### PR TITLE
fix: Add rehype-strip-md-extension plugin

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -15,6 +15,7 @@ import { sitemapIntegration } from "./src/integrations/sitemap";
 import { rehypeCodeTitle } from "./src/plugins/rehype-code-title";
 import { rehypeHeadingLinks } from "./src/plugins/rehype-heading-links";
 import { rehypeMermaid } from "./src/plugins/rehype-mermaid";
+import { rehypeStripMdExtension } from "./src/plugins/rehype-strip-md-extension";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
 
@@ -74,6 +75,7 @@ export default defineConfig({
     rehypePlugins: [
       rehypeCodeTitle,
       rehypeHeadingLinks, // Must run before Astro's built-in heading ID plugin
+      rehypeStripMdExtension,
       ...(settings.mermaid ? [rehypeMermaid] : []),
       ...(settings.math ? [rehypeKatex] : []),
     ],

--- a/src/plugins/rehype-strip-md-extension.ts
+++ b/src/plugins/rehype-strip-md-extension.ts
@@ -1,0 +1,31 @@
+import type { Root, Element } from 'hast';
+import { visit } from 'unist-util-visit';
+
+/**
+ * Rehype plugin that strips .md and .mdx extensions from relative link hrefs.
+ *
+ * Markdown authors often write links like `[Other doc](./other-doc.md)`.
+ * In Astro's static output, the correct URL is `/docs/other-doc/` (no extension).
+ * This plugin removes the extension at build time so links work correctly.
+ */
+export function rehypeStripMdExtension() {
+  return (tree: Root) => {
+    visit(tree, 'element', (node: Element) => {
+      if (node.tagName !== 'a') return;
+      const href = node.properties?.href;
+      if (typeof href !== 'string') return;
+
+      // Only process relative links (not http://, https://, mailto:, #, etc.)
+      if (/^[a-z][a-z0-9+.-]*:/i.test(href) || href.startsWith('#')) return;
+
+      // Strip .md or .mdx extension (with optional hash fragment)
+      const replaced = href.replace(
+        /\.mdx?(#.*)?$/,
+        (_match, hash) => hash ?? '',
+      );
+      if (replaced !== href) {
+        node.properties.href = replaced;
+      }
+    });
+  };
+}


### PR DESCRIPTION
## Summary

- Add `rehype-strip-md-extension` plugin that strips `.md`/`.mdx` extensions from relative link hrefs at build time
- Authors can write `[Other doc](./other-doc.md)` and the link will resolve correctly in Astro's static output

## Changes

- New file: `src/plugins/rehype-strip-md-extension.ts`
- Updated: `astro.config.ts` — wired plugin into rehypePlugins array

## Test plan

- `pnpm build` succeeds (92 pages, no errors)
- Links like `./file.md` are converted to `./file` in built HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)