### PR TITLE
fix: Target .astro-code class for Shiki dual-theme colors

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -495,9 +495,15 @@ pre.astro-code:focus-within .code-buttons {
  * ======================================== */
 
 [data-theme] .shiki,
-[data-theme] .shiki span {
+[data-theme] .shiki span,
+[data-theme] .astro-code,
+[data-theme] .astro-code span {
   color: light-dark(var(--shiki-light), var(--shiki-dark)) !important;
   background-color: light-dark(var(--shiki-light-bg), var(--shiki-dark-bg)) !important;
+  font-style: light-dark(
+    var(--shiki-light-font-style, inherit),
+    var(--shiki-dark-font-style, inherit)
+  );
 }
 
 /* ========================================


### PR DESCRIPTION
## Summary

- Astro outputs code blocks with class `astro-code`, not `shiki`
- The CSS selector only targeted `.shiki`, so dual-theme syntax highlighting colors were never applied
- Also adds `font-style` mapping for italic tokens (e.g., comments)

## Test plan

- Code blocks show colored syntax highlighting in both light and dark modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)