### PR TITLE
feat: add Components category and basic-components page

### DIFF
--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -56,6 +56,7 @@ const translations: Record<string, Record<string, string>> = {
   en: {
     "nav.gettingStarted": "Getting Started",
     "nav.guides": "Guides",
+    "nav.components": "Components",
     "nav.reference": "Reference",
     "nav.claude": "Claude",
     "nav.previous": "Previous",
@@ -82,6 +83,7 @@ const translations: Record<string, Record<string, string>> = {
   ja: {
     "nav.gettingStarted": "はじめに",
     "nav.guides": "ガイド",
+    "nav.components": "コンポーネント",
     "nav.reference": "リファレンス",
     "nav.claude": "Claude",
     "nav.previous": "前へ",
@@ -108,6 +110,7 @@ const translations: Record<string, Record<string, string>> = {
   de: {
     "nav.gettingStarted": "Erste Schritte",
     "nav.guides": "Anleitungen",
+    "nav.components": "Komponenten",
     "nav.reference": "Referenz",
     "nav.claude": "Claude",
     "nav.previous": "Zurück",

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -39,6 +39,7 @@ export const settings = {
   headerNav: [
     { label: "Getting Started", labelKey: "nav.gettingStarted", path: "/docs/getting-started", categoryMatch: "getting-started" },
     { label: "Guides", labelKey: "nav.guides", path: "/docs/guides", categoryMatch: "guides" },
+    { label: "Components", labelKey: "nav.components", path: "/docs/components", categoryMatch: "components" },
     { label: "Reference", labelKey: "nav.reference", path: "/docs/reference", categoryMatch: "reference" },
     { label: "Claude", labelKey: "nav.claude", path: "/docs/claude", categoryMatch: "claude" },
   ] satisfies HeaderNavItem[],

--- a/src/content/docs/components/basic-components.mdx
+++ b/src/content/docs/components/basic-components.mdx
@@ -1,0 +1,138 @@
+---
+title: Basic Components
+description: Standard Markdown and MDX typography elements available in documentation pages.
+sidebar_position: 1
+---
+
+These are the standard Markdown and MDX elements styled through zudo-doc's design token system. No imports are needed.
+
+## Headings
+
+Headings from `h2` to `h4` appear in the table of contents sidebar.
+
+### Heading 3
+
+#### Heading 4
+
+```mdx
+## Heading 2
+### Heading 3
+#### Heading 4
+```
+
+## Text Formatting
+
+**Bold text**, *italic text*, and ~~strikethrough~~. Combine them: ***bold and italic***.
+
+```mdx
+**Bold text**, *italic text*, and ~~strikethrough~~.
+Combine them: ***bold and italic***.
+```
+
+## Inline Code
+
+Use backticks to mark `inline code` within a sentence.
+
+```mdx
+Use backticks to mark `inline code` within a sentence.
+```
+
+## Code Blocks
+
+Fenced code blocks support syntax highlighting via Shiki. Specify the language after the opening backticks.
+
+```ts
+function greet(name: string): string {
+  return `Hello, ${name}!`;
+}
+```
+
+````mdx
+```ts
+function greet(name: string): string {
+  return `Hello, ${name}!`;
+}
+```
+````
+
+## Unordered Lists
+
+- First item
+- Second item
+  - Nested item
+  - Another nested item
+    - Deeply nested
+- Third item
+
+```mdx
+- First item
+- Second item
+  - Nested item
+  - Another nested item
+    - Deeply nested
+- Third item
+```
+
+## Ordered Lists
+
+1. First step
+2. Second step
+   1. Sub-step one
+   2. Sub-step two
+3. Third step
+
+```mdx
+1. First step
+2. Second step
+   1. Sub-step one
+   2. Sub-step two
+3. Third step
+```
+
+## Blockquotes
+
+> This is a blockquote. It can span multiple lines
+> and supports **formatting** within it.
+
+```mdx
+> This is a blockquote. It can span multiple lines
+> and supports **formatting** within it.
+```
+
+## Tables
+
+| Feature    | Status      | Notes              |
+| ---------- | ----------- | ------------------ |
+| MDX        | Supported   | Via `@astrojs/mdx` |
+| Shiki      | Built-in    | Code highlighting  |
+| Tailwind   | v4          | Token-based design |
+
+```mdx
+| Feature    | Status      | Notes              |
+| ---------- | ----------- | ------------------ |
+| MDX        | Supported   | Via `@astrojs/mdx` |
+| Shiki      | Built-in    | Code highlighting  |
+| Tailwind   | v4          | Token-based design |
+```
+
+## Links
+
+Internal link: [Getting Started](/docs/getting-started)
+
+External link: [Astro documentation](https://docs.astro.build)
+
+```mdx
+Internal link: [Getting Started](/docs/getting-started)
+
+External link: [Astro documentation](https://docs.astro.build)
+```
+
+## Horizontal Rules
+
+Use three dashes to create a horizontal rule:
+
+---
+
+```mdx
+---
+```

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -1,0 +1,9 @@
+---
+title: Components
+description: Available components and content features for use in MDX documentation files.
+sidebar_position: 2
+---
+
+Explore the components and content features available in zudo-doc.
+
+<CategoryNav category="components" />

--- a/src/content/docs/reference/index.mdx
+++ b/src/content/docs/reference/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Reference
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 Technical reference for zudo-doc's components, design system, and color architecture.


### PR DESCRIPTION
## Summary

- Add Components category (sidebar_position: 2) between Guides and Reference
- Create `basic-components.mdx` documenting standard Markdown/MDX elements with rendered examples and source code
- Add Components to headerNav in settings.ts
- Add `nav.components` i18n translations for en/ja/de
- Bump Reference sidebar_position from 2 to 3

## Test plan

- [ ] Verify Components appears between Guides and Reference in sidebar
- [ ] Verify Components nav item appears in header navigation
- [ ] Verify basic-components page renders all examples correctly
- [ ] Verify Japanese locale shows "コンポーネント" in nav

Refs #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)