### PR TITLE
Add underline to breadcrumbs linked items

### DIFF
--- a/src/components/breadcrumb.astro
+++ b/src/components/breadcrumb.astro
@@ -19,7 +19,7 @@ const { items } = Astro.props;
             </svg>
           )}
           {item.href ? (
-            <a href={item.href} class="text-muted hover:text-fg hover:underline flex items-center gap-x-hsp-2xs">
+            <a href={item.href} class="text-muted underline hover:text-fg flex items-center gap-x-hsp-2xs">
               {i === 0 && (
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-[1.575rem] w-[1.575rem] shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-4 0a1 1 0 01-1-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 01-1 1h-2z" />


### PR DESCRIPTION
## Summary
- Add persistent underline to linked breadcrumb items instead of only showing underline on hover

## Changes
- `src/components/breadcrumb.astro`: Added `underline` class to breadcrumb `<a>` elements (replaced `hover:underline` with always-on `underline`)

## Test Plan
- Visual inspection of breadcrumb links on doc pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)