### PR TITLE
Fix z-index stacking of doc history panel and TOC

### DIFF
--- a/src/components/toc.tsx
+++ b/src/components/toc.tsx
@@ -22,7 +22,7 @@ export function Toc({ headings }: TocProps) {
       className={clsx(
         "hidden xl:block",
         "w-[280px] shrink-0",
-        "sticky top-[3.5rem] self-start",
+        "sticky top-[3.5rem] self-start z-10",
         "pt-vsp-xl lg:pt-vsp-2xl",
         "max-h-[calc(100vh-3.5rem)] overflow-y-auto",
       )}


### PR DESCRIPTION
## Summary
- Fix z-index stacking issue where the sticky TOC overlaps the doc history panel

## Changes
- `src/components/toc.tsx`: Added `z-10` to the sticky TOC nav to keep it below the history panel's `z-40` backdrop and `z-50` panel

## Test Plan
- Open doc history panel, verify TOC does not overlap it

🤖 Generated with [Claude Code](https://claude.com/claude-code)