### PR TITLE
fix: remove crossorigin from KaTeX CSS to fix preload warnings

### DIFF
--- a/src/layouts/doc-layout.astro
+++ b/src/layouts/doc-layout.astro
@@ -116,7 +116,7 @@ const contentTransition = {
       </script>
     )}
     {settings.math && (
-      <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.38/dist/katex.min.css" crossorigin="anonymous" />
+      <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.38/dist/katex.min.css" />
     )}
     {settings.llmsTxt && (
       <Fragment>


### PR DESCRIPTION
## Summary
- Remove unnecessary `crossorigin="anonymous"` from the KaTeX CSS CDN link in doc-layout
- Fixes browser console warnings about preloaded resources with credential mode mismatch

## Changes
- Removed `crossorigin="anonymous"` attribute from the KaTeX CSS `<link>` tag in `src/layouts/doc-layout.astro`
- Root cause: Astro's ClientRouter creates `<link rel="preload">` without copying the `crossorigin` attribute during view transitions, causing the browser to double-fetch the resource due to credential mode mismatch
- Safe to remove because no Subresource Integrity (`integrity`) attribute is used

## Test Plan
- Visit the docs site and navigate between pages using view transitions
- Open browser DevTools Console and verify no "preloaded using link preload but not used" warnings for KaTeX CSS
- Verify math equations still render correctly on pages that use them (e.g., `/docs/components/math-equations`)