### PR TITLE
Document HTML support in footer copyright

### DIFF
--- a/src/content/docs-ja/guides/footer.mdx
+++ b/src/content/docs-ja/guides/footer.mdx
@@ -27,7 +27,7 @@ footer: {
       ],
     },
   ],
-  copyright: `Copyright © ${new Date().getFullYear()} zudolab. Built with zudo-doc.`,
+  copyright: `Copyright © ${new Date().getFullYear()} <a href="https://example.com">Your Name</a>. Built with <a href="https://zudo-doc.pages.dev/">zudo-doc</a>.`,
 } satisfies FooterConfig as FooterConfig | false,
 ```
 
@@ -56,6 +56,12 @@ footer: {
 ### copyright
 
 リンクカラムの下にセンタリングされて表示されるオプションの著作権テキストです。リンクカラムが存在する場合、著作権テキストは上部ボーダーで区切られます。リンクが設定されていない場合は、ボーダーなしで表示されます。
+
+著作権フィールドは**HTMLコンテンツ**をサポートしています。`<a>`タグを使用してリンクを含めることができます。著作権内のリンクは自動的に`text-accent`カラーとアンダーラインでスタイリングされます。
+
+```ts
+copyright: `Copyright © ${new Date().getFullYear()} <a href="https://example.com">Your Name</a>. Built with <a href="https://zudo-doc.pages.dev/">zudo-doc</a>.`,
+```
 
 ## カラムの追加
 
@@ -86,7 +92,7 @@ footer: {
       ],
     },
   ],
-  copyright: `Copyright © ${new Date().getFullYear()} My Project.`,
+  copyright: `Copyright © ${new Date().getFullYear()} <a href="https://example.com">My Project</a>.`,
 },
 ```
 

--- a/src/content/docs/guides/footer.mdx
+++ b/src/content/docs/guides/footer.mdx
@@ -27,7 +27,7 @@ footer: {
       ],
     },
   ],
-  copyright: `Copyright © ${new Date().getFullYear()} zudolab. Built with zudo-doc.`,
+  copyright: `Copyright © ${new Date().getFullYear()} <a href="https://example.com">Your Name</a>. Built with <a href="https://zudo-doc.pages.dev/">zudo-doc</a>.`,
 } satisfies FooterConfig as FooterConfig | false,
 ```
 
@@ -56,6 +56,12 @@ External links (URLs starting with `http://` or `https://`) automatically open i
 ### copyright
 
 Optional copyright text displayed centered below the link columns. When link columns are present, the copyright is separated from them by a top border. When no links are configured, the copyright displays without a border.
+
+The copyright field supports **HTML content** — you can include `<a>` tags for links. Links in the copyright are automatically styled with `text-accent` color and underlined.
+
+```ts
+copyright: `Copyright © ${new Date().getFullYear()} <a href="https://example.com">Your Name</a>. Built with <a href="https://zudo-doc.pages.dev/">zudo-doc</a>.`,
+```
 
 ## Adding Columns
 
@@ -86,7 +92,7 @@ footer: {
       ],
     },
   ],
-  copyright: `Copyright © ${new Date().getFullYear()} My Project.`,
+  copyright: `Copyright © ${new Date().getFullYear()} <a href="https://example.com">My Project</a>.`,
 },
 ```
 


### PR DESCRIPTION
## Summary
- Update footer guide (EN + JA) to document that the `copyright` field supports HTML content
- Update code examples to show `<a>` tags in copyright, matching actual `settings.ts` usage
- Add note about automatic `text-accent` color and underline styling for copyright links

## Test Plan
- [ ] Verify footer guide renders correctly on dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)