### PR TITLE
fix(create-zudo-doc): handle non-TTY mode with --yes flag

### DIFF
--- a/packages/create-zudo-doc/src/index.ts
+++ b/packages/create-zudo-doc/src/index.ts
@@ -95,6 +95,9 @@ async function main() {
   let shouldInstall: boolean;
   if (args.install !== undefined) {
     shouldInstall = args.install;
+  } else if (args.yes) {
+    // In non-interactive mode, default to installing dependencies
+    shouldInstall = true;
   } else {
     const result = await p.confirm({
       message: "Install dependencies?",


### PR DESCRIPTION
## Summary

- When `--yes` is passed but `--install` is not explicitly set, default to installing dependencies (`true`) instead of calling `p.confirm()`, which requires a TTY
- This prevents `ERR_TTY_INIT_FAILED` crashes in non-interactive environments (CI, piped input, Claude Code)

Closes #109

## Test plan

- [x] `pnpm build` succeeds
- [x] `pnpm test` passes (21/21 tests)
- [x] Manual test: `node packages/create-zudo-doc/bin/create-zudo-doc.js test-project --yes` completes without TTY errors in a non-TTY environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)