### PR TITLE
[create-zudo-doc] Fix: strip claudeResources import when feature not selected

### DIFF
--- a/packages/create-zudo-doc/src/strip.ts
+++ b/packages/create-zudo-doc/src/strip.ts
@@ -101,6 +101,16 @@ export async function stripFeatures(
   // Strip Claude Resources if not selected
   if (!choices.features.includes("claudeResources")) {
     await removeIfExists(targetDir, "src/integrations/claude-resources");
+    await patchFile(path.join(targetDir, "astro.config.ts"), [
+      [
+        /import \{ claudeResourcesIntegration \} from "\.\/src\/integrations\/claude-resources";\n/g,
+        "",
+      ],
+      [
+        /\s*\.\.\.\(settings\.claudeResources\s*\n?\s*\? \[claudeResourcesIntegration\(settings\.claudeResources\)\]\s*\n?\s*: \[\]\),?\n?/g,
+        "\n",
+      ],
+    ]);
   }
 
   // Strip unused theme components based on color scheme mode.


### PR DESCRIPTION
## Summary

- When `claudeResources` feature is not selected during scaffolding, the CLI now strips the `claudeResourcesIntegration` import and its usage from the generated `astro.config.ts`
- Previously, only the `src/integrations/claude-resources` directory was removed, leaving a dangling import that caused build failures ("Failed to load url ./src/integrations/claude-resources")

## Test plan

- [x] Scaffold a project WITHOUT `claudeResources` feature -- verified `astro.config.ts` has no `claudeResourcesIntegration` import or spread usage
- [x] Scaffold a project WITH `claudeResources` feature -- verified import and usage remain intact
- [x] CLI builds successfully (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)