### PR TITLE
[create-zudo-doc] Strip ai-chat API route when aiAssistant disabled

### DIFF
--- a/packages/create-zudo-doc/src/strip.ts
+++ b/packages/create-zudo-doc/src/strip.ts
@@ -212,7 +212,8 @@ export async function stripFeatures(
   await removeIfExists(targetDir, "src/integrations/llms-txt.ts");
   await removeIfExists(targetDir, "src/integrations/sitemap.ts");
 
-  // Remove AI chat and MSW mock components (aiAssistant is false by default)
+  // Remove AI chat API route, components, and MSW mock (aiAssistant is false by default)
+  await removeIfExists(targetDir, "src/pages/api/ai-chat.ts");
   await removeIfExists(targetDir, "src/components/ai-chat-modal.tsx");
   await removeIfExists(targetDir, "src/components/mock-init.tsx");
   await patchFile(


### PR DESCRIPTION
Fixes NoAdapterInstalled error when building scaffolded project without aiAssistant feature. The API route `src/pages/api/ai-chat.ts` has `prerender = false` requiring a server adapter.