### PR TITLE
[create-zudo-doc] Fix default color scheme names

### DIFF
--- a/packages/create-zudo-doc/src/index.ts
+++ b/packages/create-zudo-doc/src/index.ts
@@ -60,8 +60,8 @@ async function main() {
     prefilled.defaultLang ??= "en";
     prefilled.colorSchemeMode ??= "light-dark";
     if (prefilled.colorSchemeMode === "light-dark") {
-      prefilled.lightScheme ??= "GitHub Light";
-      prefilled.darkScheme ??= "GitHub Dark";
+      prefilled.lightScheme ??= "Default Light";
+      prefilled.darkScheme ??= "Default Dark";
       prefilled.defaultMode ??= "dark";
       prefilled.respectPrefersColorScheme ??= true;
     } else {


### PR DESCRIPTION
The `--yes` defaults used 'GitHub Light'/'GitHub Dark' but only 'Default Light'/'Default Dark' exist. Caused build failure.