### PR TITLE
fix: rewrite skill body reference links for doc site

### DIFF
--- a/src/integrations/claude-resources/__tests__/generate.test.ts
+++ b/src/integrations/claude-resources/__tests__/generate.test.ts
@@ -33,7 +33,7 @@ function createFixture() {
 
   fs.writeFileSync(
     path.join(skillDir, "SKILL.md"),
-    '---\nname: test-skill\ndescription: "A test skill"\n---\n\nSkill instructions here.',
+    '---\nname: test-skill\ndescription: "A test skill"\n---\n\nSkill instructions here.\n\nSee [references/guide.md](references/guide.md) for details.',
   );
   fs.writeFileSync(
     path.join(skillDir, "references", "guide.md"),
@@ -216,6 +216,23 @@ describe("generateClaudeResourcesDocs", () => {
           `Link target "test-skill--${subPage}.mdx" should exist`,
         ).toBe(true);
       }
+    });
+
+    it("skill body references/scripts/assets links are rewritten to doc site format", () => {
+      generateClaudeResourcesDocs({
+        claudeDir,
+        projectRoot: tmpDir,
+        docsDir,
+      });
+
+      const skillPage = fs.readFileSync(
+        path.join(docsDir, "claude-skills", "test-skill.mdx"),
+        "utf8",
+      );
+
+      // Body links like (references/guide.md) should be rewritten to (./ref-guide)
+      expect(skillPage).toContain("](./ref-guide)");
+      expect(skillPage).not.toContain("](references/guide.md)");
     });
 
     it("agent page has model badge", () => {

--- a/src/integrations/claude-resources/generate.ts
+++ b/src/integrations/claude-resources/generate.ts
@@ -376,9 +376,16 @@ function generateSkillsDocs(config: ClaudeResourcesConfig): SkillItem[] {
       ? description.substring(0, 200) + "..."
       : description;
 
+    // Rewrite references/scripts/assets links in skill body to match doc site URLs
+    let skillBody = parsed.content.trim();
+    skillBody = skillBody
+      .replace(/\]\(references\/([^)]+)\.md\)/g, "](./ref-$1)")
+      .replace(/\]\(scripts\/([^)]+)\.md\)/g, "](./script-$1)")
+      .replace(/\]\(assets\/([^)]+)\.md\)/g, "](./asset-$1)");
+
     const body = [
       fileStructureSection,
-      escapeForMdx(parsed.content.trim()),
+      escapeForMdx(skillBody),
     ]
       .filter(Boolean)
       .join("\n\n");


### PR DESCRIPTION
## Summary
- Skill body content containing `references/*.md`, `scripts/*.md`, or `assets/*.md` links were rendered as-is in the generated doc pages, causing broken links
- Now these links are rewritten to the doc site format (`./ref-*`, `./script-*`, `./asset-*`) before generating the MDX
- Added test coverage for the link rewriting

## Test plan
- [x] All 16 existing tests pass
- [x] New test verifies `references/guide.md` links in skill body are rewritten to `./ref-guide`

🤖 Generated with [Claude Code](https://claude.com/claude-code)