### PR TITLE
Fix version switcher header layout and top page visibility

### DIFF
--- a/src/components/header.astro
+++ b/src/components/header.astro
@@ -93,19 +93,6 @@ const pathForMatch = isNonDefaultLocale
 
   <div class="ml-auto flex items-center gap-x-hsp-md">
     {
-      settings.versions && currentSlug && (
-        <div class="hidden lg:block">
-          <VersionSwitcher
-            currentVersion={currentVersion}
-            currentSlug={currentSlug}
-            lang={lang}
-            availability={versionAvailability}
-            idSuffix="header"
-          />
-        </div>
-      )
-    }
-    {
       settings.colorTweakPanel && (
         <button
           id="color-tweak-trigger"
@@ -170,5 +157,18 @@ const pathForMatch = isNonDefaultLocale
       }
       {lang && locales.length > 1 && <LanguageSwitcher lang={lang} />}
     </div>
+    {
+      settings.versions && (
+        <div class="hidden lg:block">
+          <VersionSwitcher
+            currentVersion={currentVersion}
+            currentSlug={currentSlug}
+            lang={lang}
+            availability={versionAvailability}
+            idSuffix="header"
+          />
+        </div>
+      )
+    }
   </div>
 </header>

--- a/src/components/version-switcher.astro
+++ b/src/components/version-switcher.astro
@@ -6,7 +6,7 @@ import type { VersionAvailability } from "@/utils/version-availability";
 
 interface Props {
   currentVersion?: string;
-  currentSlug: string;
+  currentSlug?: string;
   lang?: Locale;
   availability?: VersionAvailability;
   idSuffix?: string;
@@ -31,7 +31,7 @@ const isNonDefaultLocale = lang !== defaultLocale;
 const versionsPageUrl = withBase(
   isNonDefaultLocale ? `/${lang}/docs/versions` : "/docs/versions",
 );
-const latestUrl = docsUrl(currentSlug, lang);
+const latestUrl = currentSlug ? docsUrl(currentSlug, lang) : versionsPageUrl;
 const isLatest = !currentVersion;
 ---
 
@@ -84,10 +84,14 @@ const isLatest = !currentVersion;
     </li>
     {
       versions.map((v) => {
-        const vUrl = versionedDocsUrl(currentSlug, v.slug, lang);
+        const vUrl = currentSlug
+          ? versionedDocsUrl(currentSlug, v.slug, lang)
+          : versionsPageUrl;
         const isActive = currentVersion === v.slug;
         const isAvailable =
-          !availability || (availability[v.slug]?.has(currentSlug) ?? false);
+          !currentSlug ||
+          !availability ||
+          (availability[v.slug]?.has(currentSlug) ?? false);
         return (
           <li>
             {isAvailable ? (


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/118
    - https://github.com/zudolab/zudo-doc/issues/119

---

## Summary

Fixes two version switcher bugs:
- The dropdown was positioned before the right-side icon group in the header, pushing icons off the right edge (#118). Moved it to the end of the group.
- The dropdown required `currentSlug` to render, so it was hidden on the landing/top page (#119). Made `currentSlug` optional; when absent, version links fall back to the versions overview page.

## Changes

- `header.astro`: Move version switcher from before the icon group to after it (last item in the `ml-auto` flex container). Remove `currentSlug` guard so it renders on all pages.
- `version-switcher.astro`: Make `currentSlug` optional. When no slug is available, `latestUrl` and versioned URLs fall back to the versions overview page, and all versions are treated as available.

## Test Plan

- `pnpm build` passes (all pages render including landing page with version switcher)
- Verify on a doc page: version switcher appears in header after icons, dropdown links to versioned doc pages
- Verify on landing page: version switcher appears in header, dropdown links to versions overview page