### PR TITLE
[fix] Add header nav overflow, fix SiteTreeNav leaf icon

### DIFF
--- a/src/components/header.astro
+++ b/src/components/header.astro
@@ -29,10 +29,15 @@ const pathWithoutBase = stripBase(currentPath);
 const pathForMatch = isNonDefaultLocale
   ? pathWithoutBase.replace(new RegExp(`^/${lang}`), "")
   : pathWithoutBase;
+
+const activeNavPath = settings.headerNav
+  .filter((item) => pathForMatch.startsWith(item.path))
+  .sort((a, b) => b.path.length - a.path.length)[0]?.path;
 ---
 
 <header
   class="sticky top-0 z-50 flex h-[3.5rem] items-center border-b border-muted bg-surface px-hsp-lg"
+  data-header
 >
   <SidebarToggle client:media="(max-width: 1023px)">
     <slot name="sidebar" />
@@ -51,47 +56,62 @@ const pathForMatch = isNonDefaultLocale
 
   <a
     href={withBase(isNonDefaultLocale ? `/${lang}/` : "/")}
-    class="whitespace-nowrap text-subheading font-bold text-fg hover:underline focus:underline"
+    class="whitespace-nowrap text-subheading font-bold text-fg hover:underline focus:underline shrink-0"
+    data-header-logo
   >
     {settings.siteName}
   </a>
 
   <nav
     aria-label="Main"
-    class="ml-hsp-xl hidden items-center gap-x-hsp-2xs whitespace-nowrap lg:flex"
+    class="ml-hsp-xl hidden items-center gap-x-hsp-2xs whitespace-nowrap lg:flex min-w-0"
+    data-header-nav
   >
     {
-      (() => {
-        // Longest-prefix match: only highlight the most specific nav item
-        const activeNavPath = settings.headerNav
-          .filter((item) => pathForMatch.startsWith(item.path))
-          .sort((a, b) => b.path.length - a.path.length)[0]?.path;
-
-        return settings.headerNav.map((item) => {
-          const isActive = item.path === activeNavPath;
-          const href = withBase(
-            isNonDefaultLocale ? `/${lang}${item.path}` : item.path,
-          );
-          return (
-            <a
-              href={href}
-              aria-current={isActive ? "page" : undefined}
-              class:list={[
-                "px-hsp-md py-vsp-2xs text-small font-medium transition-colors",
-                isActive
-                  ? "bg-fg text-bg"
-                  : "text-muted hover:underline focus:underline",
-              ]}
-            >
-              {item.labelKey ? t(item.labelKey, lang) : item.label}
-            </a>
-          );
-        });
-      })()
+      settings.headerNav.map((item) => {
+        const isActive = item.path === activeNavPath;
+        const href = withBase(
+          isNonDefaultLocale ? `/${lang}${item.path}` : item.path,
+        );
+        return (
+          <a
+            href={href}
+            aria-current={isActive ? "page" : undefined}
+            data-nav-item
+            class:list={[
+              "px-hsp-md py-vsp-2xs text-small font-medium transition-colors shrink-0",
+              isActive
+                ? "bg-fg text-bg"
+                : "text-muted hover:underline focus:underline",
+            ]}
+          >
+            {item.labelKey ? t(item.labelKey, lang) : item.label}
+          </a>
+        );
+      })
     }
+
+    <div class="relative shrink-0" data-nav-more style="display:none">
+      <button
+        type="button"
+        class="px-hsp-md py-vsp-2xs text-small font-medium text-muted hover:underline cursor-pointer"
+        data-nav-more-toggle
+        aria-expanded="false"
+      >
+        &middot;&middot;&middot;
+      </button>
+      <ul
+        class="absolute right-0 top-full z-10 mt-vsp-3xs hidden min-w-[8rem] border border-muted rounded bg-surface shadow-lg whitespace-nowrap"
+        data-nav-more-menu
+      >
+      </ul>
+    </div>
   </nav>
 
-  <div class="ml-auto flex items-center gap-x-hsp-md">
+  <div
+    class="ml-auto flex shrink-0 items-center gap-x-hsp-md"
+    data-header-right
+  >
     {
       settings.colorTweakPanel && (
         <button
@@ -145,18 +165,6 @@ const pathForMatch = isNonDefaultLocale
         </button>
       )
     }
-    <Search />
-    <div class="hidden lg:flex items-center gap-x-hsp-md">
-      {
-        settings.colorMode && (
-          <ThemeToggle
-            defaultMode={settings.colorMode.defaultMode}
-            client:load
-          />
-        )
-      }
-      {lang && locales.length > 1 && <LanguageSwitcher lang={lang} />}
-    </div>
     {
       settings.versions && (
         <div class="hidden lg:block">
@@ -170,5 +178,188 @@ const pathForMatch = isNonDefaultLocale
         </div>
       )
     }
+    <Search />
+    <div class="hidden lg:flex items-center gap-x-hsp-md">
+      {
+        settings.colorMode && (
+          <ThemeToggle
+            defaultMode={settings.colorMode.defaultMode}
+            client:load
+          />
+        )
+      }
+      {lang && locales.length > 1 && <LanguageSwitcher lang={lang} />}
+    </div>
   </div>
 </header>
+
+<script>
+  let cleanupNavOverflow: (() => void) | null = null;
+
+  function initNavOverflow() {
+    cleanupNavOverflow?.();
+
+    const header = document.querySelector<HTMLElement>("[data-header]");
+    const logo = document.querySelector<HTMLElement>("[data-header-logo]");
+    const nav = document.querySelector<HTMLElement>("[data-header-nav]");
+    const rightGroup = document.querySelector<HTMLElement>(
+      "[data-header-right]",
+    );
+    const moreContainer =
+      document.querySelector<HTMLElement>("[data-nav-more]");
+    const moreMenu = document.querySelector<HTMLElement>(
+      "[data-nav-more-menu]",
+    );
+    const moreToggle = document.querySelector<HTMLButtonElement>(
+      "[data-nav-more-toggle]",
+    );
+    if (
+      !header ||
+      !logo ||
+      !nav ||
+      !rightGroup ||
+      !moreContainer ||
+      !moreMenu ||
+      !moreToggle
+    )
+      return;
+
+    const items = Array.from(
+      nav.querySelectorAll<HTMLAnchorElement>(":scope > [data-nav-item]"),
+    );
+    if (items.length === 0) return;
+
+    // Measure each item's natural width once (all visible, before any hiding)
+    const itemWidths: number[] = [];
+    items.forEach((el) => {
+      el.style.display = "";
+    });
+    moreContainer.style.display = "none";
+    items.forEach((el) => {
+      itemWidths.push(el.offsetWidth);
+    });
+
+    // Measure the "..." button width
+    moreContainer.style.display = "";
+    const moreWidth = moreContainer.offsetWidth;
+    moreContainer.style.display = "none";
+
+    // Get the nav gap from computed style
+    const navGap = parseFloat(getComputedStyle(nav).columnGap) || 0;
+
+    // Get header horizontal padding
+    const headerStyle = getComputedStyle(header);
+    const headerPadX =
+      parseFloat(headerStyle.paddingLeft) +
+      parseFloat(headerStyle.paddingRight);
+
+    // Get nav left margin
+    const navMarginLeft = parseFloat(getComputedStyle(nav).marginLeft) || 0;
+
+    const controller = new AbortController();
+
+    function update() {
+      // Reset: show all items, hide "..."
+      items.forEach((el) => {
+        el.style.display = "";
+      });
+      moreContainer!.style.display = "none";
+      moreMenu!.innerHTML = "";
+      moreMenu!.classList.add("hidden");
+      moreToggle!.setAttribute("aria-expanded", "false");
+
+      // Calculate available width for nav items
+      const headerW = header!.clientWidth;
+      const logoW = logo!.offsetWidth;
+      const rightW = rightGroup!.offsetWidth;
+      const available = headerW - headerPadX - logoW - navMarginLeft - rightW;
+
+      if (available <= 0) return;
+
+      // Greedy fill: add items until budget exhausted
+      let used = 0;
+      let cutoffIndex = items.length; // all fit by default
+
+      for (let i = 0; i < items.length; i++) {
+        const w = itemWidths[i] + (i > 0 ? navGap : 0);
+        // Check if this item fits. If not all items will fit, reserve space for "..."
+        const remaining = items.length - i - 1;
+        const needMore = remaining > 0;
+        const budget = needMore ? available - moreWidth - navGap : available;
+
+        if (used + w > budget) {
+          cutoffIndex = i;
+          break;
+        }
+        used += w;
+      }
+
+      if (cutoffIndex >= items.length) return; // all fit
+
+      // Hide overflowed items
+      for (let i = cutoffIndex; i < items.length; i++) {
+        items[i].style.display = "none";
+      }
+
+      // Show "..." and populate dropdown
+      moreContainer!.style.display = "";
+      for (let i = cutoffIndex; i < items.length; i++) {
+        const el = items[i];
+        const li = document.createElement("li");
+        const a = document.createElement("a");
+        a.href = el.href;
+        a.textContent = el.textContent?.trim() || "";
+        a.className =
+          "block px-hsp-md py-vsp-3xs text-small hover:bg-accent/10 text-fg";
+        if (el.getAttribute("aria-current") === "page") {
+          a.className += " font-bold text-accent";
+        }
+        li.appendChild(a);
+        moreMenu!.appendChild(li);
+      }
+    }
+
+    // Toggle dropdown
+    moreToggle.addEventListener(
+      "click",
+      () => {
+        const isOpen = !moreMenu.classList.contains("hidden");
+        moreMenu.classList.toggle("hidden", isOpen);
+        moreToggle.setAttribute("aria-expanded", String(!isOpen));
+      },
+      { signal: controller.signal },
+    );
+
+    document.addEventListener(
+      "click",
+      (e) => {
+        if (!moreContainer.contains(e.target as Node)) {
+          moreMenu.classList.add("hidden");
+          moreToggle.setAttribute("aria-expanded", "false");
+        }
+      },
+      { signal: controller.signal },
+    );
+
+    document.addEventListener(
+      "keydown",
+      (e) => {
+        if (e.key === "Escape" && !moreMenu.classList.contains("hidden")) {
+          moreMenu.classList.add("hidden");
+          moreToggle.setAttribute("aria-expanded", "false");
+          moreToggle.focus();
+        }
+      },
+      { signal: controller.signal },
+    );
+
+    window.addEventListener("resize", update, { signal: controller.signal });
+
+    update();
+
+    cleanupNavOverflow = () => controller.abort();
+  }
+
+  initNavOverflow();
+  document.addEventListener("astro:after-swap", initNavOverflow);
+</script>

--- a/src/components/site-tree-nav.tsx
+++ b/src/components/site-tree-nav.tsx
@@ -196,11 +196,12 @@ function LeafNode({
         <a
           href={node.href}
           className={isRoot
-            ? "block py-[calc(var(--spacing-vsp-xs)+0.15rem)] text-small font-semibold text-fg hover:text-accent hover:underline focus:underline"
+            ? "flex items-center gap-hsp-xs py-[calc(var(--spacing-vsp-xs)+0.15rem)] text-small font-semibold text-fg hover:text-accent hover:underline focus:underline"
             : `block py-vsp-2xs ${isLast ? "pb-vsp-xs" : ""} text-small text-fg hover:text-accent hover:underline focus:underline`
           }
           style={{ paddingLeft }}
         >
+          {isRoot && <CategoryLinkIcon className="w-[18px] 2xl:w-[24px]" />}
           {node.label}
         </a>
       </div>


### PR DESCRIPTION
## Summary

- **Header nav overflow**: Added width-budget mechanism that measures available header space and collapses extra nav items into a "..." dropdown when they don't fit. Uses data attributes for JS measurement, `shrink-0`/`min-w-0` for proper flex behavior, and AbortController for cleanup on `astro:after-swap`.
- **Version switcher position**: Moved version switcher before Search icon in the header right group (matching mdx-formatter). PR #120 already made `currentSlug` optional so it shows on all pages.
- **SiteTreeNav leaf icon**: Root-level leaf nodes (depth 0, no children) now render with `CategoryLinkIcon` and flex layout, matching the visual style of CategoryNode at the same depth.

Ported from mdx-formatter doc site improvements.

## Test plan

- [ ] Verify header nav items collapse into "..." dropdown when window is narrow
- [ ] Verify "..." dropdown opens/closes on click, outside-click, and Escape
- [ ] Verify all nav items show when window is wide enough
- [ ] Verify version switcher appears before the search icon
- [ ] Verify root-level leaf nodes in SiteTreeNav show the category link icon
- [ ] Verify build succeeds (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)