### PR TITLE
[fix] Version-prefix header nav links when viewing versioned docs

### DIFF
--- a/src/components/header.astro
+++ b/src/components/header.astro
@@ -70,8 +70,11 @@ const activeNavPath = settings.headerNav
     {
       settings.headerNav.map((item) => {
         const isActive = item.path === activeNavPath;
+        const versionPrefix = currentVersion ? `/v/${currentVersion}` : "";
         const href = withBase(
-          isNonDefaultLocale ? `/${lang}${item.path}` : item.path,
+          isNonDefaultLocale
+            ? `/${lang}${versionPrefix}${item.path}`
+            : `${versionPrefix}${item.path}`,
         );
         return (
           <a


### PR DESCRIPTION
## Summary

- When viewing versioned docs (e.g. `/v/1.0/docs/getting-started`), header nav links now correctly point to the versioned path (e.g. `/v/1.0/docs/overview`) instead of the unversioned path (`/docs/overview`)
- Adds a `versionPrefix` derived from the existing `currentVersion` prop in `header.astro` and prepends it to nav link hrefs

## Test plan

- [ ] Visit a versioned doc page (e.g. `/v/1.0/docs/getting-started`)
- [ ] Verify header nav links include the version prefix in their href
- [ ] Visit a non-versioned (latest) doc page and verify header nav links remain unchanged
- [ ] Test with a non-default locale to confirm locale + version prefix combination works

🤖 Generated with [Claude Code](https://claude.com/claude-code)