### PR TITLE
Add draggable sidebar resizer

### DIFF
--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -117,6 +117,15 @@ describe("scaffold — minimal (no i18n, search only, single dark scheme)", () =
     expect(layout).not.toContain("AiChatModal");
     expect(layout).not.toContain("DocHistory");
   });
+
+  it("doc-layout does not reference sidebar resizer (disabled by default)", async () => {
+    const layout = await fs.readFile(
+      projectPath("test-minimal", "src/layouts/doc-layout.astro"),
+      "utf-8",
+    );
+    expect(layout).not.toContain("initSidebarResizer");
+    expect(layout).not.toContain("zudo-doc-sidebar-width");
+  });
 });
 
 describe("scaffold — full features (i18n, light-dark, all features)", () => {

--- a/packages/create-zudo-doc/src/constants.ts
+++ b/packages/create-zudo-doc/src/constants.ts
@@ -118,4 +118,10 @@ export const FEATURES: Feature[] = [
     hint: "Live color editor for designing schemes",
     default: false,
   },
+  {
+    value: "sidebarResizer",
+    label: "Sidebar resizer",
+    hint: "Draggable sidebar width",
+    default: false,
+  },
 ];

--- a/packages/create-zudo-doc/src/settings-gen.ts
+++ b/packages/create-zudo-doc/src/settings-gen.ts
@@ -90,6 +90,12 @@ export function generateSettingsFile(choices: UserChoices): string {
     lines.push(`  colorTweakPanel: false as boolean,`);
   }
 
+  if (choices.features.includes("sidebarResizer")) {
+    lines.push(`  sidebarResizer: true as boolean,`);
+  } else {
+    lines.push(`  sidebarResizer: false as boolean,`);
+  }
+
   lines.push(
     `  htmlPreview: undefined as HtmlPreviewConfig | undefined,`,
   );

--- a/packages/create-zudo-doc/src/strip.ts
+++ b/packages/create-zudo-doc/src/strip.ts
@@ -153,6 +153,24 @@ export async function stripFeatures(
     );
   }
 
+  // Strip sidebar resizer if not selected
+  if (!choices.features.includes("sidebarResizer")) {
+    await patchFile(
+      path.join(targetDir, "src/layouts/doc-layout.astro"),
+      [
+        // Remove head inline script block
+        [/\s*\{settings\.sidebarResizer &&[\s\S]*?applySidebarWidth[\s\S]*?<\/script>\s*\n\s*\)\}\s*\n?/g, "\n"],
+        // Remove body module script block
+        [/\s*\{settings\.sidebarResizer &&[\s\S]*?initSidebarResizer[\s\S]*?<\/script>\s*\n\s*\)\}\s*\n?/g, "\n"],
+        // Revert sidebar class to static clamp (replace the class:list with simple class)
+        [
+          /class:list=\{\[\s*\n\s*"hidden lg:block shrink-0 border-r border-muted sticky top-\[3\.5rem\] h-\[calc\(100vh-3\.5rem\)\] overflow-y-auto",\s*\n\s*settings\.sidebarResizer\s*\n\s*\? "w-\[var\(--zd-sidebar-w,clamp\(14rem,20vw,22rem\)\)\] relative"\s*\n\s*: "w-\[clamp\(14rem,20vw,22rem\)\]",\s*\n\s*\]\}/g,
+          'class="hidden lg:block w-[clamp(14rem,20vw,22rem)] shrink-0 border-r border-muted sticky top-[3.5rem] h-[calc(100vh-3.5rem)] overflow-y-auto"',
+        ],
+      ],
+    );
+  }
+
   // TODO: Strip sidebar filter when not selected
   // The sidebar filter is built into sidebar-tree.tsx — stripping requires
   // careful component surgery. For now, the filter is always included.

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -43,6 +43,7 @@ export const settings = {
   onBrokenMarkdownLinks: "warn" as "warn" | "error" | "ignore",
   aiAssistant: true as boolean,
   colorTweakPanel: true as boolean,
+  sidebarResizer: true as boolean,
   docHistory: true,
   htmlPreview: undefined as HtmlPreviewConfig | undefined,
   versions: [

--- a/src/layouts/doc-layout.astro
+++ b/src/layouts/doc-layout.astro
@@ -119,6 +119,18 @@ const contentTransition = {
         })();
       </script>
     )}
+    {settings.sidebarResizer && (
+      <script is:inline>
+        (function () {
+          function applySidebarWidth() {
+            var w = localStorage.getItem("zudo-doc-sidebar-width");
+            if (w) document.documentElement.style.setProperty("--zd-sidebar-w", w + "px");
+          }
+          applySidebarWidth();
+          document.addEventListener("astro:after-swap", applySidebarWidth);
+        })();
+      </script>
+    )}
     {settings.math && (
       <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.38/dist/katex.min.css" integrity="sha384-/L6i+LN3dyoaK2jYG5ZLh5u13cjdsPDcFOSNJeFBFa/KgVXR5kOfTdiN3ft1uMAq" crossorigin="anonymous" />
     )}
@@ -141,7 +153,12 @@ const contentTransition = {
         <aside
           id="desktop-sidebar"
           transition:persist={`sidebar-${lang}-${navSection ?? "default"}`}
-          class="hidden lg:block w-[clamp(14rem,20vw,22rem)] shrink-0 border-r border-muted sticky top-[3.5rem] h-[calc(100vh-3.5rem)] overflow-y-auto"
+          class:list={[
+            "hidden lg:block shrink-0 border-r border-muted sticky top-[3.5rem] h-[calc(100vh-3.5rem)] overflow-y-auto",
+            settings.sidebarResizer
+              ? "w-[var(--zd-sidebar-w,clamp(14rem,20vw,22rem))] relative"
+              : "w-[clamp(14rem,20vw,22rem)]",
+          ]}
         >
           <Sidebar currentSlug={currentSlug} lang={lang} navSection={navSection} currentVersion={currentVersion} />
         </aside>
@@ -199,5 +216,71 @@ const contentTransition = {
         if (el) el.scrollTop = _sidebarScrollTop;
       });
     </script>
+    {settings.sidebarResizer && (
+      <script>
+        function initSidebarResizer() {
+          const sidebar = document.getElementById("desktop-sidebar");
+          if (!sidebar || sidebar.querySelector("[data-sidebar-resizer]")) return;
+
+          const handle = document.createElement("div");
+          handle.setAttribute("data-sidebar-resizer", "");
+          Object.assign(handle.style, {
+            position: "absolute",
+            top: "0",
+            right: "0",
+            width: "6px",
+            height: "100%",
+            cursor: "col-resize",
+            zIndex: "10",
+            transition: "background 0.15s",
+          });
+
+          handle.addEventListener("mouseenter", () => {
+            if (!dragging) handle.style.background = "var(--zd-accent, rgba(128,128,128,0.3))";
+          });
+          handle.addEventListener("mouseleave", () => {
+            if (!dragging) handle.style.background = "";
+          });
+
+          let dragging = false;
+
+          handle.addEventListener("pointerdown", (e: PointerEvent) => {
+            e.preventDefault();
+            handle.setPointerCapture(e.pointerId);
+            dragging = true;
+            handle.style.background = "var(--zd-accent, rgba(128,128,128,0.3))";
+            document.documentElement.style.cursor = "col-resize";
+            document.documentElement.style.userSelect = "none";
+
+            const onMove = (ev: PointerEvent) => {
+              const rect = sidebar!.getBoundingClientRect();
+              let newWidth = ev.clientX - rect.left;
+              newWidth = Math.max(192, Math.min(448, newWidth));
+              document.documentElement.style.setProperty("--zd-sidebar-w", newWidth + "px");
+            };
+
+            const onUp = (ev: PointerEvent) => {
+              handle.releasePointerCapture(ev.pointerId);
+              dragging = false;
+              handle.style.background = "";
+              document.documentElement.style.cursor = "";
+              document.documentElement.style.userSelect = "";
+              const computed = sidebar!.getBoundingClientRect().width;
+              localStorage.setItem("zudo-doc-sidebar-width", String(Math.round(computed)));
+              handle.removeEventListener("pointermove", onMove);
+              handle.removeEventListener("pointerup", onUp);
+            };
+
+            handle.addEventListener("pointermove", onMove);
+            handle.addEventListener("pointerup", onUp);
+          });
+
+          sidebar.appendChild(handle);
+        }
+
+        initSidebarResizer();
+        document.addEventListener("astro:after-swap", initSidebarResizer);
+      </script>
+    )}
   </body>
 </html>


### PR DESCRIPTION
## Summary

- Adds opt-in `sidebarResizer` setting for a draggable sidebar width handle on desktop
- Uses inline scripts (no React) — blocking head script prevents layout shift, body module script handles pointer-drag
- Width persisted in localStorage, clamped 192–448px, survives View Transitions
- Enabled in showcase (settings.ts) for preview
- Synced create-zudo-doc generator: constants, settings-gen, strip logic, scaffold tests

## Test plan

- [ ] Verify drag handle appears on sidebar right edge at lg+ breakpoints
- [ ] Drag to resize — width clamps between 192px and 448px
- [ ] Width persists across page navigations and page reload
- [ ] Mobile sidebar overlay is unaffected
- [ ] Set `sidebarResizer: false` → no drag handle, default clamp width

🤖 Generated with [Claude Code](https://claude.com/claude-code)