### PR TITLE
Fix sidebar resizer and collapsed category bugs

### DIFF
--- a/src/components/sidebar-tree.tsx
+++ b/src/components/sidebar-tree.tsx
@@ -289,7 +289,7 @@ function CategoryNode({
 
   // Initial state must match server render (no sessionStorage access)
   // to avoid hydration mismatch. Stored state is restored in useEffect below.
-  const [open, setOpen] = useState(node.collapsed ? false : containsCurrent);
+  const [open, setOpen] = useState(containsCurrent ? true : !node.collapsed);
 
   // Restore open state from sessionStorage after hydration
   useEffect(() => {

--- a/src/layouts/doc-layout.astro
+++ b/src/layouts/doc-layout.astro
@@ -123,8 +123,10 @@ const contentTransition = {
       <script is:inline>
         (function () {
           function applySidebarWidth() {
-            var w = localStorage.getItem("zudo-doc-sidebar-width");
-            if (w) document.documentElement.style.setProperty("--zd-sidebar-w", w + "px");
+            try {
+              var w = localStorage.getItem("zudo-doc-sidebar-width");
+              if (w && !isNaN(Number(w))) document.documentElement.style.setProperty("--zd-sidebar-w", w + "px");
+            } catch (e) {}
           }
           applySidebarWidth();
           document.addEventListener("astro:after-swap", applySidebarWidth);
@@ -274,23 +276,35 @@ const contentTransition = {
               ghost.style.left = (sidebarLeft + targetWidth) + "px";
             };
 
-            const onUp = (ev: PointerEvent) => {
-              handle.releasePointerCapture(ev.pointerId);
+            const cleanup = () => {
               dragging = false;
               handle.style.background = "";
               document.documentElement.style.cursor = "";
               document.documentElement.style.userSelect = "";
               ghost.remove();
-              if (targetWidth > 0) {
-                document.documentElement.style.setProperty("--zd-sidebar-w", targetWidth + "px");
-                localStorage.setItem("zudo-doc-sidebar-width", String(Math.round(targetWidth)));
-              }
               handle.removeEventListener("pointermove", onMove);
               handle.removeEventListener("pointerup", onUp);
+              handle.removeEventListener("pointercancel", onCancel);
+              handle.removeEventListener("lostpointercapture", onCancel);
+            };
+
+            const onUp = (ev: PointerEvent) => {
+              handle.releasePointerCapture(ev.pointerId);
+              cleanup();
+              if (targetWidth > 0) {
+                document.documentElement.style.setProperty("--zd-sidebar-w", targetWidth + "px");
+                try { localStorage.setItem("zudo-doc-sidebar-width", String(Math.round(targetWidth))); } catch (e) {}
+              }
+            };
+
+            const onCancel = () => {
+              cleanup();
             };
 
             handle.addEventListener("pointermove", onMove);
             handle.addEventListener("pointerup", onUp);
+            handle.addEventListener("pointercancel", onCancel);
+            handle.addEventListener("lostpointercapture", onCancel);
           });
 
           sidebar.appendChild(handle);


### PR DESCRIPTION
## Summary
- Fix localStorage access safety in sidebar resizer (try/catch + numeric validation)
- Fix listener leak when localStorage.setItem throws during drag end
- Add pointercancel and lostpointercapture handlers to prevent ghost element and cursor leak when drag is interrupted
- Fix collapsed category with active descendant causing hydration layout shift

## Changes

### Sidebar resizer (`doc-layout.astro`)
- **Head script**: Wrap localStorage.getItem in try/catch, validate stored value is numeric before applying
- **Body script**: Extract shared `cleanup()` function for drag state teardown
- **Body script**: Move listener removal before localStorage write so cleanup always runs
- **Body script**: Wrap localStorage.setItem in try/catch for storage-restricted environments
- **Body script**: Add `pointercancel` and `lostpointercapture` event handlers that call cleanup — prevents ghost div staying in DOM and cursor stuck on col-resize when drag is interrupted (tab switch, system notification, touch cancel)

### Collapsed categories (`sidebar-tree.tsx`)
- Change initial state from `node.collapsed ? false : containsCurrent` to `containsCurrent ? true : !node.collapsed`
- Categories containing the current page now always start open, preventing a flash where the active link is hidden on SSR then revealed after hydration

## Test plan
- [x] `pnpm build` passes (158 URLs, 130 doc-history files)
- Drag sidebar edge to resize, verify persistence across page loads
- Interrupt a drag (Ctrl+Tab or touch cancel), verify no ghost line remains
- Set a category to `collapsed: true` in sidebars config, navigate to a page inside it — should render open


🤖 Generated with [Claude Code](https://claude.com/claude-code)