### PR TITLE
Add link checker documentation

### DIFF
--- a/src/content/docs-ja/develop/link-checker.mdx
+++ b/src/content/docs-ja/develop/link-checker.mdx
@@ -76,7 +76,7 @@ pnpm check:links --strict
 
 ### CI内での実行
 
-リンクチェッカーはPRチェック（`pr-checks.yml`）と本番デプロイ（`main-deploy.yml`）の両ワークフローの`build-site`ジョブで、`pnpm build`の直後に実行されます。
+リンクチェッカーはPRチェックワークフロー（`pr-checks.yml`）の`build-site`ジョブで、`pnpm build`の直後に実行されます。
 
 ## 出力
 
@@ -110,4 +110,4 @@ Checking links (base: /pj/zudo-doc/)...
 
 - **`base`** — サイトのベースパス。リンク解決時のプレフィックス除去に使用
 - **`docsDir`** — MDXソーススキャンのプライマリコンテンツディレクトリ
-- **`docsJaDir`**（およびその他のロケールディレクトリ） — MDXソーススキャンの追加コンテンツディレクトリ
+- **`locales`** — ロケール設定。`dir`フィールドでMDXソーススキャンの追加コンテンツディレクトリを指定（例：`locales: { ja: { dir: "src/content/docs-ja" } }`）

--- a/src/content/docs/develop/link-checker.mdx
+++ b/src/content/docs/develop/link-checker.mdx
@@ -76,7 +76,7 @@ The link checker runs as Step 4 of 5 in the pre-push validation (`pnpm b4push`):
 
 ### In CI
 
-The link checker runs in the `build-site` job of both the PR checks (`pr-checks.yml`) and production deploy (`main-deploy.yml`) workflows, immediately after `pnpm build`.
+The link checker runs in the `build-site` job of the PR checks workflow (`pr-checks.yml`), immediately after `pnpm build`.
 
 ## Output
 
@@ -110,4 +110,4 @@ The link checker reads its configuration from `src/config/settings.ts`:
 
 - **`base`** — The site's base path, used to strip prefixes when resolving links
 - **`docsDir`** — Primary content directory for MDX source scanning
-- **`docsJaDir`** (and other locale dirs) — Additional content directories for MDX source scanning
+- **`locales`** — Locale configurations with `dir` fields pointing to additional content directories for MDX source scanning (e.g., `locales: { ja: { dir: "src/content/docs-ja" } }`)


### PR DESCRIPTION
## Summary
- Add dedicated documentation pages for the link checker feature (`scripts/check-links.js`) in both English and Japanese
- Covers both check modes (built HTML scan and MDX source scan), how to run it, output format, and CI integration

## Changes
- `src/content/docs/develop/link-checker.mdx` — English documentation page
- `src/content/docs-ja/develop/link-checker.mdx` — Japanese translation
- Documents: what the link checker validates, how to run standalone / via b4push / in CI, output examples, and configuration

## Test Plan
- Verify pages render correctly at `/docs/develop/link-checker` and `/ja/docs/develop/link-checker`
- Confirm sidebar shows the new page under the Develop category

🤖 Generated with [Claude Code](https://claude.com/claude-code)