### PR TITLE
fix: add aria-current to sidebar LeafNode links

### DIFF
--- a/src/components/sidebar-tree.tsx
+++ b/src/components/sidebar-tree.tsx
@@ -456,6 +456,7 @@ function LeafNode({
         <ConnectorLines depth={depth} isLast={isLast} />
         <a
           href={node.href}
+          aria-current={isActive ? "page" : undefined}
           className={isRoot
             ? `flex items-center gap-hsp-xs py-[calc(var(--spacing-vsp-xs)+0.15rem)] pr-[4px] text-small font-semibold ${
                 isActive ? "bg-fg text-bg" : "text-fg hover:underline focus:underline"


### PR DESCRIPTION
## Summary
- Add `aria-current="page"` to active sidebar `LeafNode` links
- `CategoryLink` already had this attribute, but `LeafNode` was missing it

## Test Plan
- [ ] Navigate to a doc page and inspect the active sidebar link — should have `aria-current="page"`
- [ ] Screen reader announces the current page correctly in sidebar navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)