### PR TITLE
feat: add locale switcher and theme toggle to mobile sidebar footer

### DIFF
--- a/src/components/sidebar-tree.tsx
+++ b/src/components/sidebar-tree.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import type { NavNode } from "@/utils/docs";
 import { INDENT, BASE_PAD, connectorLeft, ConnectorLines, CategoryLinkIcon } from "./tree-nav-shared";
+import ThemeToggle from "@/components/theme-toggle";
 
 function ToggleChevron({ isExpanded, className }: { isExpanded: boolean; className?: string }) {
   return (
@@ -142,14 +143,42 @@ function RootMenuItemEntry({ item }: { item: RootMenuItem }) {
   );
 }
 
+interface LocaleLink {
+  label: string;
+  href: string;
+  active: boolean;
+}
+
 interface SidebarTreeProps {
   nodes: NavNode[];
   currentSlug?: string;
   rootMenuItems?: RootMenuItem[];
   backToMenuLabel?: string;
+  localeLinks?: LocaleLink[];
+  themeDefaultMode?: "light" | "dark";
 }
 
-export default function SidebarTree({ nodes, currentSlug, rootMenuItems, backToMenuLabel }: SidebarTreeProps) {
+function SidebarFooter({ links, themeDefaultMode }: { links?: LocaleLink[]; themeDefaultMode?: "light" | "dark" }) {
+  return (
+    <div className="lg:hidden flex items-center gap-hsp-md border-t border-muted px-hsp-sm py-vsp-xs pb-[200px] text-small">
+      {themeDefaultMode && <ThemeToggle defaultMode={themeDefaultMode} />}
+      {links && links.map((link, i) => (
+        <span key={link.href} className="flex items-center gap-hsp-xs">
+          {i > 0 && <span className="text-muted">/</span>}
+          {link.active ? (
+            <span className="font-medium text-fg">{link.label}</span>
+          ) : (
+            <a href={link.href} className="text-muted hover:text-fg">
+              {link.label}
+            </a>
+          )}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export default function SidebarTree({ nodes, currentSlug, rootMenuItems, backToMenuLabel, localeLinks, themeDefaultMode }: SidebarTreeProps) {
   const activeSlug = useActiveSlug(nodes, currentSlug);
   const [query, setQuery] = useState("");
   const [showingRootMenu, setShowingRootMenu] = useState(false);
@@ -201,6 +230,7 @@ export default function SidebarTree({ nodes, currentSlug, rootMenuItems, backToM
         {rootMenuItems.map((item) => (
           <RootMenuItemEntry key={item.href} item={item} />
         ))}
+        {(localeLinks || themeDefaultMode) && <SidebarFooter links={localeLinks} themeDefaultMode={themeDefaultMode} />}
       </nav>
     );
   }
@@ -213,6 +243,7 @@ export default function SidebarTree({ nodes, currentSlug, rootMenuItems, backToM
         {rootMenuItems.map((item) => (
           <RootMenuItemEntry key={item.href} item={item} />
         ))}
+        {(localeLinks || themeDefaultMode) && <SidebarFooter links={localeLinks} themeDefaultMode={themeDefaultMode} />}
       </nav>
     );
   }
@@ -252,6 +283,7 @@ export default function SidebarTree({ nodes, currentSlug, rootMenuItems, backToM
         depth={0}
         forceOpen={!!query}
       />
+      {(localeLinks || themeDefaultMode) && <SidebarFooter links={localeLinks} themeDefaultMode={themeDefaultMode} />}
     </nav>
   );
 }

--- a/src/components/sidebar.astro
+++ b/src/components/sidebar.astro
@@ -1,8 +1,14 @@
 ---
 import SidebarTree from "@/components/sidebar-tree";
 import { buildSidebarForSection } from "@/utils/sidebar";
-import { defaultLocale, t, type Locale } from "@/config/i18n";
-import { withBase, versionedDocsUrl } from "@/utils/base";
+import {
+  defaultLocale,
+  locales,
+  t,
+  getLocaleLabel,
+  type Locale,
+} from "@/config/i18n";
+import { withBase, stripBase, versionedDocsUrl } from "@/utils/base";
 import { loadLocaleDocs } from "@/utils/locale-docs";
 import { isNavVisible, type NavNode } from "@/utils/docs";
 import { settings } from "@/config/settings";
@@ -80,6 +86,26 @@ const rawNodes = buildSidebarForSection(docs, lang, navSection, categoryMeta);
 const nodes = currentVersion
   ? remapVersionedHrefs(rawNodes, currentVersion, lang)
   : rawNodes;
+
+// Build locale switcher links for mobile sidebar
+const currentPath = Astro.url.pathname;
+const localeLinks =
+  locales.length > 1
+    ? locales.map((code) => {
+        let relativePath = stripBase(currentPath);
+        if (lang !== defaultLocale) {
+          relativePath = relativePath.replace(new RegExp(`^/${lang}/`), "/");
+        }
+        if (code !== defaultLocale) {
+          relativePath = `/${code}${relativePath}`;
+        }
+        return {
+          label: getLocaleLabel(code),
+          href: withBase(relativePath),
+          active: code === lang,
+        };
+      })
+    : undefined;
 ---
 
 <SidebarTree
@@ -87,5 +113,9 @@ const nodes = currentVersion
   currentSlug={currentSlug}
   rootMenuItems={rootMenuItems}
   backToMenuLabel={backToMenuLabel}
+  localeLinks={localeLinks}
+  themeDefaultMode={settings.colorMode
+    ? settings.colorMode.defaultMode
+    : undefined}
   client:load
 />


### PR DESCRIPTION
## Summary
- Add `SidebarFooter` component to mobile sidebar showing locale links and theme toggle
- Ported from zudo-css where this UX improvement has been in use
- Shows at the bottom of all 3 sidebar render paths (root menu, top page, main doc view)
- Only visible on mobile (`lg:hidden`) — desktop header already has these controls

## Changes
- **`src/components/sidebar-tree.tsx`**: Add `LocaleLink` interface, `SidebarFooter` component, new props (`localeLinks`, `themeDefaultMode`), render footer in 3 render paths
- **`src/components/sidebar.astro`**: Build locale links from `Astro.url.pathname`, pass `localeLinks` and `themeDefaultMode` to `SidebarTree`

## Test Plan
- [ ] Open mobile sidebar — locale links and theme toggle should appear at the bottom
- [ ] Locale links should show current locale as bold text, others as clickable links
- [ ] Theme toggle should switch between light/dark modes
- [ ] Footer should be hidden on desktop (lg+ breakpoint)
- [ ] All 3 sidebar views (root menu, top page, doc page) should show the footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)