### PR TITLE
fix: use consistent y-padding for header nav dropdown items

### DIFF
--- a/src/components/header.astro
+++ b/src/components/header.astro
@@ -353,7 +353,7 @@ function isNavItemActive(item: (typeof settings.headerNav)[number]): boolean {
             a.textContent =
               parentLink.textContent?.trim().replace(/\s+/g, " ") || "";
             a.className =
-              "block px-hsp-md py-vsp-3xs text-small font-bold hover:bg-accent/10 text-fg";
+              "block px-hsp-md py-vsp-2xs text-small font-bold hover:bg-accent/10 text-fg";
             if (parentLink.getAttribute("aria-current") === "page") {
               a.className += " text-accent";
             }
@@ -367,8 +367,8 @@ function isNavItemActive(item: (typeof settings.headerNav)[number]): boolean {
             a.textContent = child.textContent?.trim() || "";
             const isChildActive = child.hasAttribute("data-active");
             a.className = isChildActive
-              ? "block pl-hsp-xl pr-hsp-md py-vsp-3xs text-small font-bold text-accent hover:bg-accent/10"
-              : "block pl-hsp-xl pr-hsp-md py-vsp-3xs text-small text-muted hover:bg-accent/10 hover:text-fg";
+              ? "block pl-hsp-xl pr-hsp-md py-vsp-2xs text-small font-bold text-accent hover:bg-accent/10"
+              : "block pl-hsp-xl pr-hsp-md py-vsp-2xs text-small text-muted hover:bg-accent/10 hover:text-fg";
             li.appendChild(a);
             moreMenu!.appendChild(li);
           });
@@ -380,7 +380,7 @@ function isNavItemActive(item: (typeof settings.headerNav)[number]): boolean {
           a.href = anchor.href;
           a.textContent = anchor.textContent?.trim() || "";
           a.className =
-            "block px-hsp-md py-vsp-3xs text-small hover:bg-accent/10 text-fg";
+            "block px-hsp-md py-vsp-2xs text-small hover:bg-accent/10 text-fg";
           if (anchor.getAttribute("aria-current") === "page") {
             a.className += " font-bold text-accent";
           }


### PR DESCRIPTION
## Summary
- Header nav overflow menu items used `py-vsp-3xs` which is not a defined spacing token, while regular dropdown items use `py-vsp-2xs`
- Align all overflow menu item padding to `py-vsp-2xs` to match the regular dropdown items

## Changes
- Update overflow menu items in header.astro from `py-vsp-3xs` to `py-vsp-2xs`

## Test Plan
- Verify header nav dropdown items have consistent vertical padding
- Test overflow menu behavior at narrower viewport widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)