### PR TITLE
ci: replace upload-artifact with cache for inter-job data transfer

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -3,8 +3,12 @@
 # Triggered on every push to `main`. The pipeline:
 #   1. Builds the Astro static site (shallow clone, skips doc history)
 #   2. Builds doc history JSONs (full clone, standalone server package)
-#   3. Merges both artifacts and deploys to Cloudflare Pages (production)
+#   3. Merges both build outputs and deploys to Cloudflare Pages (production)
 #   4. Sends IFTTT notification with deploy status
+#
+# Inter-job data sharing uses actions/cache (not upload-artifact) to avoid
+# Actions storage accumulation. Cache keys are scoped to github.run_id so
+# each run gets a fresh, unique cache that won't be reused by other runs.
 #
 # Concurrency: only one production deploy runs at a time.
 # We do NOT cancel in-progress runs -- the earlier deploy should finish.
@@ -56,12 +60,11 @@ jobs:
         env:
           SKIP_DOC_HISTORY: "1"
 
-      - name: Upload build artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+      - name: Cache site build output
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
-          name: dist-out
           path: dist/
-          retention-days: 1
+          key: dist-${{ github.run_id }}
 
   # ---------------------------------------------------------------------------
   # Job 2: Build doc history JSONs (full clone — only this job needs it)
@@ -97,12 +100,11 @@ jobs:
             --locale ja:../../src/content/docs-ja \
             --out-dir ../../doc-history-out
 
-      - name: Upload doc history artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+      - name: Cache doc history output
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
-          name: doc-history-out
           path: doc-history-out/
-          retention-days: 1
+          key: doc-history-${{ github.run_id }}
 
   # ---------------------------------------------------------------------------
   # Job 3: Deploy to Cloudflare Pages (production)
@@ -114,27 +116,27 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - name: Download site artifact
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+      - name: Restore site build cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
-          name: dist-out
-          path: dist-out/
+          path: dist/
+          key: dist-${{ github.run_id }}
+          fail-on-cache-miss: true
 
-      - name: Download doc history artifact
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+      - name: Restore doc history cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
-          name: doc-history-out
           path: doc-history-out/
-        continue-on-error: true
+          key: doc-history-${{ github.run_id }}
 
       - name: Prepare deploy directory
         run: |
           mkdir -p deploy/pj/zudo-doc
           # When aiAssistant is enabled, Astro outputs static files to dist/client/
-          if [ -d dist-out/client ]; then
-            cp -r dist-out/client/. deploy/pj/zudo-doc/
+          if [ -d dist/client ]; then
+            cp -r dist/client/. deploy/pj/zudo-doc/
           else
-            cp -r dist-out/. deploy/pj/zudo-doc/
+            cp -r dist/. deploy/pj/zudo-doc/
           fi
           # Merge doc history JSONs into the deploy directory (if available)
           if [ -d doc-history-out ] && [ "$(ls -A doc-history-out 2>/dev/null)" ]; then

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,8 +6,12 @@
 #   2. Build the Astro docs site (shallow clone, skips doc history)
 #   3. Build doc history JSONs (full clone, standalone server package)
 #   4. E2E & smoke tests (Playwright)
-#   5. Merge artifacts and deploy a preview to Cloudflare Pages
+#   5. Merge build outputs and deploy a preview to Cloudflare Pages
 #   6. Post the preview URL as a PR comment
+#
+# Inter-job data sharing uses actions/cache (not upload-artifact) to avoid
+# Actions storage accumulation. Cache keys are scoped to github.run_id so
+# each run gets a fresh, unique cache that won't be reused by other runs.
 #
 # Concurrency: cancel in-progress runs for the same PR to save resources.
 
@@ -90,12 +94,11 @@ jobs:
       - name: Check links
         run: pnpm run check:links
 
-      - name: Upload build artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+      - name: Cache site build output
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
-          name: dist-out
           path: dist/
-          retention-days: 1
+          key: dist-${{ github.run_id }}
 
   # ---------------------------------------------------------------------------
   # Job 3: Build doc history JSONs (full clone — only this job needs it)
@@ -131,12 +134,11 @@ jobs:
             --locale ja:../../src/content/docs-ja \
             --out-dir ../../doc-history-out
 
-      - name: Upload doc history artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+      - name: Cache doc history output
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
-          name: doc-history-out
           path: doc-history-out/
-          retention-days: 1
+          key: doc-history-${{ github.run_id }}
 
   # ---------------------------------------------------------------------------
   # Job 4: E2E & smoke tests
@@ -176,12 +178,12 @@ jobs:
         run: pnpm test:e2e:ci
 
       - name: Upload test results
-        if: ${{ !cancelled() }}
+        if: ${{ failure() }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: playwright-report
           path: playwright-report/
-          retention-days: 7
+          retention-days: 1
 
   # ---------------------------------------------------------------------------
   # Job 5: Deploy preview and comment on PR
@@ -193,27 +195,27 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - name: Download site artifact
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+      - name: Restore site build cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
-          name: dist-out
-          path: dist-out/
+          path: dist/
+          key: dist-${{ github.run_id }}
+          fail-on-cache-miss: true
 
-      - name: Download doc history artifact
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+      - name: Restore doc history cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
-          name: doc-history-out
           path: doc-history-out/
-        continue-on-error: true
+          key: doc-history-${{ github.run_id }}
 
       - name: Prepare deploy directory
         run: |
           mkdir -p deploy/pj/zudo-doc
           # When aiAssistant is enabled, Astro outputs static files to dist/client/
-          if [ -d dist-out/client ]; then
-            cp -r dist-out/client/. deploy/pj/zudo-doc/
+          if [ -d dist/client ]; then
+            cp -r dist/client/. deploy/pj/zudo-doc/
           else
-            cp -r dist-out/. deploy/pj/zudo-doc/
+            cp -r dist/. deploy/pj/zudo-doc/
           fi
           # Merge doc history JSONs into the deploy directory (if available)
           if [ -d doc-history-out ] && [ "$(ls -A doc-history-out 2>/dev/null)" ]; then


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/216

---

## Summary

- Replaces `actions/upload-artifact` + `actions/download-artifact` with `actions/cache/save` + `actions/cache/restore` (keyed by `github.run_id`) for the `dist/` and `doc-history-out/` build outputs in `pr-checks.yml` and `main-deploy.yml`.
- Cache does NOT count against the zudolab org's Actions storage billing (it has its own separate per-repo cache quota), so this stops the storage drain caused by accumulating artifacts.
- Each run gets a fresh, unique cache via `github.run_id`, so caches never collide across runs.
- Reduces the `playwright-report` upload to failure-only (`if: failure()`) with `retention-days: 1`, so successful runs no longer leave reports behind.

## Changes

**`.github/workflows/pr-checks.yml`**
- `build-site` job — replace `Upload build artifact` (`dist-out`) with `Cache site build output` (`actions/cache/save@v4`, key `dist-${{ github.run_id }}`).
- `build-history` job — replace `Upload doc history artifact` (`doc-history-out`) with `Cache doc history output` (`actions/cache/save@v4`, key `doc-history-${{ github.run_id }}`).
- `e2e` job — `Upload test results` (`playwright-report`) now runs `if: failure()` only, with `retention-days: 1` (was `if: !cancelled()` retention 7d).
- `preview` job — replace both `download-artifact` steps with `actions/cache/restore@v4`. `dist/` restore uses `fail-on-cache-miss: true`; `doc-history-out/` restore omits it (matches the original `continue-on-error: true` semantics). The `Prepare deploy directory` script now reads from `dist/` instead of `dist-out/`.
- Header comment updated to document the cache-based inter-job data sharing.

**`.github/workflows/main-deploy.yml`**
- `build-site` job — same `actions/cache/save` swap as above.
- `build-history` job — same `actions/cache/save` swap as above.
- `deploy` job — same `actions/cache/restore` swap as above; `Prepare deploy directory` now reads from `dist/` instead of `dist-out/`.
- Header comment updated to document the cache-based inter-job data sharing.

**Pattern reference**: This mirrors [zudolab/zudo-paper](https://github.com/zudolab/zudo-paper/blob/main/.github/workflows/main-deploy.yml)'s already-adopted pattern; the `actions/cache` SHA pin matches.

## Test Plan
- [x] `actionlint` clean on both workflow files
- [x] PR Checks workflow passes end-to-end on this PR (Type Check, Build Site, Build Doc History, E2E Tests, Preview Deploy — all 5 ✓)
- [x] Preview deploy succeeds and produces a working `pr-217.zudo-doc.pages.dev` preview (verified via successful Preview Deploy job)
- [ ] Production deploy (`main-deploy.yml`) will run on merge — same pattern, expected to pass

Closes #216