### PR TITLE
spacing-fixes: resolve #218 (sidebar last-leaf padding) and #204 (preset-generator section spacing)

### DIFF
--- a/src/components/preset-generator.tsx
+++ b/src/components/preset-generator.tsx
@@ -265,7 +265,7 @@ export default function PresetGenerator() {
   }, []);
 
   return (
-    <div className="flex flex-col gap-y-vsp-lg">
+    <div className="flex flex-col gap-y-vsp-xl">
       {/* Project Name */}
       <section>
         <SectionHeading>Project Name</SectionHeading>

--- a/src/components/sidebar-tree.tsx
+++ b/src/components/sidebar-tree.tsx
@@ -484,8 +484,18 @@ function LeafNode({
   const isRoot = depth === 0;
   const paddingLeft = padLeft(depth, isRoot);
 
+  // For nested last leaves, add visual breathing space as margin on the outer wrapper
+  // rather than padding on the anchor — padding would grow the row box and throw off
+  // the ConnectorLines geometry (which uses bottom: 50% of the row to land the horizontal
+  // connector at the label midpoint).
+  const outerClass = isRoot
+    ? "border-t border-muted"
+    : !isRoot && isLast
+      ? "pb-vsp-md"
+      : "";
+
   return (
-    <div className={isRoot ? "border-t border-muted" : ""}>
+    <div className={outerClass}>
       <div className="relative">
         <ConnectorLines depth={depth} isLast={isLast} />
         <a
@@ -495,7 +505,7 @@ function LeafNode({
             ? `flex items-center gap-hsp-xs py-[calc(var(--spacing-vsp-xs)+0.15rem)] pr-[4px] text-small font-semibold ${
                 isActive ? "bg-fg text-bg" : "text-fg hover:underline focus:underline"
               }`
-            : `block py-vsp-2xs pr-[4px] ${isLast ? "pb-vsp-md" : ""} text-small ${
+            : `block py-vsp-2xs pr-[4px] text-small ${
                 isActive
                   ? "bg-fg font-medium text-bg"
                   : "text-muted hover:underline focus:underline"

--- a/src/components/sidebar-tree.tsx
+++ b/src/components/sidebar-tree.tsx
@@ -495,7 +495,7 @@ function LeafNode({
             ? `flex items-center gap-hsp-xs py-[calc(var(--spacing-vsp-xs)+0.15rem)] pr-[4px] text-small font-semibold ${
                 isActive ? "bg-fg text-bg" : "text-fg hover:underline focus:underline"
               }`
-            : `block py-vsp-2xs pr-[4px] ${isLast ? "pb-vsp-xs" : ""} text-small ${
+            : `block py-vsp-2xs pr-[4px] ${isLast ? "pb-vsp-md" : ""} text-small ${
                 isActive
                   ? "bg-fg font-medium text-bg"
                   : "text-muted hover:underline focus:underline"


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/219
    - https://github.com/zudolab/zudo-doc/issues/218
    - https://github.com/zudolab/zudo-doc/issues/204

---

## Summary

Fixes two small visual spacing issues in the doc site UI.

### Closes #218 — sidebar last-leaf bottom padding

In the sidebar, the last child item of a category used to look visually tight because all other items see `(bottom + next-item-top)` as visual gap, while the last item only sees its own bottom. The user confirmed `24px` of extra bottom space gives the right balance.

**Fix**: `src/components/sidebar-tree.tsx` — `LeafNode` now applies `pb-vsp-md` (24px) on the outer wrapper div when a non-root leaf is `isLast`. Originally the spacing was added as padding on the inner anchor, but codex review caught that padding there would grow the row box and throw off `ConnectorLines` (which uses `bottom: 50%` of the row to place the horizontal dashed connector at the label midpoint). Moving the extra space to the outer wrapper keeps the connector geometry intact.

### Closes #204 — preset generator section spacing

The `/docs/getting-started/setup-preset-generator/` page rendered `<PresetGenerator />` inside `.zd-content`. The `.zd-content > :where(* + *) { margin-top: … }` flow-space pattern only applies to direct children of `.zd-content`, so the component's internal form-group sections (wrapped in the component's own root div) were not getting that rhythm.

**Fix**: `src/components/preset-generator.tsx` — bumped the root wrapper from `gap-y-vsp-lg` (28px) to `gap-y-vsp-xl` (40px), matching the prose h3 section-gap token. Follows `/css-wisdom prose` guidance.

## Topic PRs

This session was built via `/x-wt-teams` with two parallel topics, merged locally into `base/spacing-fixes` before pushing. Topic branches were removed after merge (single-commit, already in base).

- topic-sidebar-padding → initial change + review fix
- topic-preset-spacing → single-class bump

## Test plan

- [x] `pnpm check` — type-check passes
- [x] `pnpm build` — full static build passes
- [x] codex-review on the combined diff (1 finding addressed: connector geometry)
- [ ] Manual sanity check: open dev server and visually confirm:
    - [ ] Sidebar last leaves have breathing space and dashed connector still lands correctly
    - [ ] setup-preset-generator page sections have comfortable rhythm