### PR TITLE
fix: proper spacing for preset generator page

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -277,8 +277,10 @@ body {
 
 /* Reset prose heading decorations inside preset generator */
 .zd-preset-gen :where(h3) {
+  --flow-space: initial;
   font-size: var(--text-small);
   font-weight: var(--font-weight-semibold);
+  line-height: var(--leading-relaxed);
   padding-top: 0;
   border-top: none;
   border-image: none;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -265,9 +265,23 @@ body {
   margin-top: 0;
 }
 
+/* astro-island uses display:contents which absorbs margin — give it a box */
+.zd-content > :where(astro-island) {
+  display: block;
+}
+
 /* Flow spacing inside nested sections (e.g., preset generator) */
 .zd-content .zd-preset-gen :where(section) > :where(* + *) {
   margin-top: var(--flow-space, var(--spacing-vsp-md));
+}
+
+/* Reset prose heading decorations inside preset generator */
+.zd-preset-gen :where(h3) {
+  font-size: var(--text-small);
+  font-weight: var(--font-weight-semibold);
+  padding-top: 0;
+  border-top: none;
+  border-image: none;
 }
 
 /* ── Heading auto-links ── */


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/223

---

## Summary
- Fix missing flow spacing between introductory paragraph and preset generator form caused by Astro's `display: contents` on `<astro-island>` elements
- Reset prose heading decorations (font-size, border, padding) leaking into form section labels

## Changes
- Override `astro-island` to `display: block` inside `.zd-content` so the flow spacing rule's `margin-top` renders on a real box
- Reset `.zd-preset-gen h3` prose styles: font-size (19.2px -> 16px), font-weight (bold -> semibold), line-height, padding-top, border-top, border-image, and --flow-space

## Root Cause
Astro injects `astro-island { display: contents }` which removes the element's box. The CSS flow spacing rule `.zd-content > :where(* + *)` matches the `astro-island` element but the computed `margin-top: 24px` has no box to render on, resulting in zero spacing. Additionally, the unlayered prose heading rules (`.zd-content :where(h3)`) override Tailwind's layered utility classes, causing form labels to render with document heading decorations.

## Test Plan
- Verify `astro-island` has `display: block` and `margin-top: 24px` (computed styles)
- Verify form h3 has `font-size: 16px`, `padding-top: 0px`, no border-top
- Visual check: proper spacing between paragraph and form in both light and dark themes
- Regression check: other doc pages unaffected (no astro-islands inside `.zd-content` on other pages)

Closes #223