### PR TITLE
fix: restore heading designs in preset generator and gitignore cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ src/content/docs/claude-commands/
 src/content/docs/claude-skills/
 src/content/docs/claude-agents/
 test-results/
+.playwright-cli/
 
 # E2E fixture symlinks and generated files
 e2e/fixtures/*/node_modules

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -275,17 +275,6 @@ body {
   margin-top: var(--flow-space, var(--spacing-vsp-md));
 }
 
-/* Reset prose heading decorations inside preset generator */
-.zd-preset-gen :where(h3) {
-  --flow-space: initial;
-  font-size: var(--text-small);
-  font-weight: var(--font-weight-semibold);
-  line-height: var(--leading-relaxed);
-  padding-top: 0;
-  border-top: none;
-  border-image: none;
-}
-
 /* ── Heading auto-links ── */
 
 .zd-content :where(h2, h3, h4, h5, h6) .hash-link {


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/223

---

## Summary
- Restore heading designs in preset generator that were stripped by PR #230's over-aggressive CSS reset
- Add `.playwright-cli/` to `.gitignore`

## Changes

### Heading design fix (`src/styles/global.css`)
Remove the `.zd-preset-gen :where(h3)` CSS override that was added in PR #230. This rule stripped all heading decoration (border-top gradient, font-size, padding) from h3 elements inside the preset generator, making them appear as plain bold text.

The spacing fix from PR #230 (astro-island `display: block` and section flow spacing rules) already handles the original #223 spacing issue. The h3 override was unnecessary and caused a visual regression. Without it, headings get their border-top gradient decoration from `.zd-content :where(h3)` base styles.

**Root cause note**: The deeper architectural issue is that `.zd-content :where(h3)` (unlayered) always beats Tailwind utility classes (layered via `@import "tailwindcss/utilities"`). This will be properly addressed by #232 (Content Component First refactoring).

### Gitignore (`.gitignore`)
Add `.playwright-cli/` directory (Playwright CLI cache with screenshots, console logs, YAML snapshots) to `.gitignore`.

## Test Plan
- Verify preset generator headings have gradient border-top decoration (not just bold text)
- Verify `.playwright-cli/` no longer appears in `git status`
- Verify spacing on preset generator page is still correct (no regression from PR #230's fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)