### PR TITLE
refactor: move content typography from global CSS to Preact component overrides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Minimal documentation framework built with Astro 6, MDX, Tailwind CSS v4, and Pr
 - **Astro 6** — static site generator with Content Collections
 - **MDX** — via `@astrojs/mdx`, content directory configurable via `docsDir` setting
 - **Tailwind CSS v4** — via `@tailwindcss/vite` (not `@astrojs/tailwind`)
-- **Preact** — for interactive islands only (TOC scroll spy, sidebar toggle, collapsible categories), with compat mode for React API compatibility
+- **Preact** — for interactive islands (TOC scroll spy, sidebar toggle, collapsible categories) and server-rendered content typography components, with compat mode for React API compatibility
 - **Shiki** — built-in code highlighting, theme set from active color scheme
 - **TypeScript** — strict mode via `astro/tsconfigs/strict`
 
@@ -34,7 +34,8 @@ packages/
 
 src/
 ├── components/          # Astro + Preact components
-│   └── admonitions/     # Note, Tip, Info, Warning, Danger
+│   ├── admonitions/     # Note, Tip, Info, Warning, Danger
+│   └── content/         # MDX element overrides (server-rendered, no client JS)
 ├── config/              # Settings, color schemes
 ├── content/
 │   ├── docs/            # English MDX content
@@ -56,6 +57,7 @@ src/
 - Use **Preact islands** (`client:load`) only when client-side interactivity is needed
 - Preact runs in compat mode (`@astrojs/preact` with `compat: true`), so components can use React-style imports and APIs
 - Current Preact islands: `toc.tsx`, `mobile-toc.tsx`, `sidebar-toggle.tsx`, `sidebar-tree.tsx`, `theme-toggle.tsx`, `doc-history.tsx`, `color-tweak-panel.tsx`, `color-tweak-export-modal.tsx`
+- Content typography components (`src/components/content/`): Preact function components (no `client:` directive — server-rendered, zero JS) that override HTML elements in MDX via `<Content components={...} />`. Includes: headings (h2-h4), paragraph, link, strong, blockquote, lists (ul/ol), table.
 
 ### Content Collections
 

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -97,6 +97,6 @@ Element dimensions (icons, toggles, etc.) follow a two-tier approach:
 - Before writing or editing CSS, Tailwind classes, color tokens, or component markup, invoke `/zudo-doc-design-system` to load project-specific rules
 - Tailwind v4: imports `tailwindcss/preflight` + `tailwindcss/utilities` (no default theme)
 - No `--*: initial` resets needed — default theme is simply not imported
-- Content typography: `.zd-content` class in `global.css` (no prose plugin — direct element styling with `:where()` selectors)
+- Content typography: component-first approach — major HTML elements (h2-h4, p, a, strong, blockquote, ul, ol, table) are overridden via Preact components in `src/components/content/` registered through `component-map.ts`. Minor elements (li, th/td, code, pre, hr, img, h5/h6, dt/dd, etc.) and structural rules (flow-space, consecutive heading tightening, hash-links) remain in `.zd-content` in `global.css`.
 - **Component-first strategy**: always use Tailwind utility classes directly in component markup — never create CSS module files or custom CSS class names. The component itself is the abstraction.
 - **Tight token strategy**: prefer existing spacing (`hsp-*`, `vsp-*`), typography (`text-caption`, `text-small`, etc.), and color tokens. Avoid arbitrary values (`text-[0.8rem]`, `py-[0.35rem]`) when an existing token is close enough.

--- a/src/components/content/component-map.ts
+++ b/src/components/content/component-map.ts
@@ -1,0 +1,23 @@
+import { HeadingH2 } from './heading-h2';
+import { HeadingH3 } from './heading-h3';
+import { HeadingH4 } from './heading-h4';
+import { ContentParagraph } from './content-paragraph';
+import { ContentLink } from './content-link';
+import { ContentStrong } from './content-strong';
+import { ContentBlockquote } from './content-blockquote';
+import { ContentUl } from './content-ul';
+import { ContentOl } from './content-ol';
+import { ContentTable } from './content-table';
+
+export const htmlOverrides = {
+  h2: HeadingH2,
+  h3: HeadingH3,
+  h4: HeadingH4,
+  p: ContentParagraph,
+  a: ContentLink,
+  strong: ContentStrong,
+  blockquote: ContentBlockquote,
+  ul: ContentUl,
+  ol: ContentOl,
+  table: ContentTable,
+};

--- a/src/components/content/content-blockquote.tsx
+++ b/src/components/content/content-blockquote.tsx
@@ -1,0 +1,16 @@
+type Props = {
+  children?: React.ReactNode;
+  className?: string;
+  [key: string]: any;
+};
+
+export function ContentBlockquote({ children, className, ...rest }: Props) {
+  return (
+    <blockquote
+      className={`border-l-[3px] border-muted pl-hsp-lg text-muted italic${className ? ` ${className}` : ''}`}
+      {...rest}
+    >
+      {children}
+    </blockquote>
+  );
+}

--- a/src/components/content/content-link.tsx
+++ b/src/components/content/content-link.tsx
@@ -6,8 +6,9 @@ type Props = {
 };
 
 export function ContentLink({ href, className, children, ...rest }: Props) {
-  // Block links should render without content link styling
-  if (className && className.split(' ').includes('block')) {
+  // Block links and hash-links (heading anchors) should render without content link styling
+  const classes = className ? className.split(' ') : [];
+  if (classes.includes('block') || classes.includes('hash-link')) {
     return (
       <a href={href} className={className} {...rest}>
         {children}

--- a/src/components/content/content-link.tsx
+++ b/src/components/content/content-link.tsx
@@ -1,0 +1,27 @@
+type Props = {
+  href?: string;
+  className?: string;
+  children?: React.ReactNode;
+  [key: string]: any;
+};
+
+export function ContentLink({ href, className, children, ...rest }: Props) {
+  // Block links should render without content link styling
+  if (className && className.split(' ').includes('block')) {
+    return (
+      <a href={href} className={className} {...rest}>
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <a
+      href={href}
+      className={`text-accent underline hover:text-accent-hover${className ? ` ${className}` : ''}`}
+      {...rest}
+    >
+      {children}
+    </a>
+  );
+}

--- a/src/components/content/content-ol.tsx
+++ b/src/components/content/content-ol.tsx
@@ -1,0 +1,15 @@
+type Props = {
+  children?: React.ReactNode;
+  [key: string]: any;
+};
+
+export function ContentOl({ children, ...rest }: Props) {
+  return (
+    <ol
+      className="list-decimal pl-[calc(var(--spacing-hsp-xl)+4px)]"
+      {...rest}
+    >
+      {children}
+    </ol>
+  );
+}

--- a/src/components/content/content-ol.tsx
+++ b/src/components/content/content-ol.tsx
@@ -1,12 +1,14 @@
 type Props = {
   children?: React.ReactNode;
+  className?: string;
   [key: string]: any;
 };
 
-export function ContentOl({ children, ...rest }: Props) {
+// +4px nudge: hsp-xl (24px) is slightly too tight for disc/decimal markers (#222)
+export function ContentOl({ children, className, ...rest }: Props) {
   return (
     <ol
-      className="list-decimal pl-[calc(var(--spacing-hsp-xl)+4px)]"
+      className={`list-decimal pl-[calc(var(--spacing-hsp-xl)+4px)]${className ? ` ${className}` : ''}`}
       {...rest}
     >
       {children}

--- a/src/components/content/content-paragraph.tsx
+++ b/src/components/content/content-paragraph.tsx
@@ -1,0 +1,8 @@
+type Props = {
+  children?: React.ReactNode;
+  [key: string]: any;
+};
+
+export function ContentParagraph({ children, ...rest }: Props) {
+  return <p {...rest}>{children}</p>;
+}

--- a/src/components/content/content-paragraph.tsx
+++ b/src/components/content/content-paragraph.tsx
@@ -3,6 +3,8 @@ type Props = {
   [key: string]: any;
 };
 
+// Passthrough: no custom styles needed for <p> (inherits from .zd-content base).
+// Override claimed to enable future Tailwind utilities without CSS cascade conflicts.
 export function ContentParagraph({ children, ...rest }: Props) {
   return <p {...rest}>{children}</p>;
 }

--- a/src/components/content/content-strong.tsx
+++ b/src/components/content/content-strong.tsx
@@ -1,0 +1,16 @@
+type Props = {
+  children?: React.ReactNode;
+  className?: string;
+  [key: string]: any;
+};
+
+export function ContentStrong({ children, className, ...rest }: Props) {
+  return (
+    <strong
+      className={`font-bold text-fg${className ? ` ${className}` : ''}`}
+      {...rest}
+    >
+      {children}
+    </strong>
+  );
+}

--- a/src/components/content/content-table.tsx
+++ b/src/components/content/content-table.tsx
@@ -1,0 +1,17 @@
+type Props = {
+  children?: React.ReactNode;
+  [key: string]: any;
+};
+
+export function ContentTable({ children, ...rest }: Props) {
+  return (
+    <div className="overflow-x-auto">
+      <table
+        className="w-full border-collapse text-small"
+        {...rest}
+      >
+        {children}
+      </table>
+    </div>
+  );
+}

--- a/src/components/content/content-table.tsx
+++ b/src/components/content/content-table.tsx
@@ -1,13 +1,14 @@
 type Props = {
   children?: React.ReactNode;
+  className?: string;
   [key: string]: any;
 };
 
-export function ContentTable({ children, ...rest }: Props) {
+export function ContentTable({ children, className, ...rest }: Props) {
   return (
     <div className="overflow-x-auto">
       <table
-        className="w-full border-collapse text-small"
+        className={`w-full border-collapse text-small${className ? ` ${className}` : ''}`}
         {...rest}
       >
         {children}

--- a/src/components/content/content-ul.tsx
+++ b/src/components/content/content-ul.tsx
@@ -1,0 +1,15 @@
+type Props = {
+  children?: React.ReactNode;
+  [key: string]: any;
+};
+
+export function ContentUl({ children, ...rest }: Props) {
+  return (
+    <ul
+      className="list-disc pl-[calc(var(--spacing-hsp-xl)+4px)]"
+      {...rest}
+    >
+      {children}
+    </ul>
+  );
+}

--- a/src/components/content/content-ul.tsx
+++ b/src/components/content/content-ul.tsx
@@ -1,12 +1,14 @@
 type Props = {
   children?: React.ReactNode;
+  className?: string;
   [key: string]: any;
 };
 
-export function ContentUl({ children, ...rest }: Props) {
+// +4px nudge: hsp-xl (24px) is slightly too tight for disc/decimal markers (#222)
+export function ContentUl({ children, className, ...rest }: Props) {
   return (
     <ul
-      className="list-disc pl-[calc(var(--spacing-hsp-xl)+4px)]"
+      className={`list-disc pl-[calc(var(--spacing-hsp-xl)+4px)]${className ? ` ${className}` : ''}`}
       {...rest}
     >
       {children}

--- a/src/components/content/heading-h2.tsx
+++ b/src/components/content/heading-h2.tsx
@@ -1,0 +1,25 @@
+import type { CSSProperties, ReactNode } from 'react';
+
+type Props = {
+  id?: string;
+  children?: ReactNode;
+  [key: string]: any;
+};
+
+export function HeadingH2({ id, children, ...rest }: Props) {
+  return (
+    <h2
+      id={id}
+      className="text-subheading font-bold leading-tight pt-vsp-sm border-t-[3px] border-transparent"
+      style={
+        {
+          '--flow-space': 'var(--spacing-vsp-2xl)',
+          borderImage: 'linear-gradient(to right, var(--color-fg), transparent) 1',
+        } as CSSProperties
+      }
+      {...rest}
+    >
+      {children}
+    </h2>
+  );
+}

--- a/src/components/content/heading-h2.tsx
+++ b/src/components/content/heading-h2.tsx
@@ -2,15 +2,16 @@ import type { CSSProperties, ReactNode } from 'react';
 
 type Props = {
   id?: string;
+  className?: string;
   children?: ReactNode;
   [key: string]: any;
 };
 
-export function HeadingH2({ id, children, ...rest }: Props) {
+export function HeadingH2({ id, children, className, ...rest }: Props) {
   return (
     <h2
       id={id}
-      className="text-subheading font-bold leading-tight pt-vsp-sm border-t-[3px] border-transparent"
+      className={`text-subheading font-bold leading-tight pt-vsp-sm border-t-[3px] border-transparent${className ? ` ${className}` : ''}`}
       style={
         {
           borderImage: 'linear-gradient(to right, var(--color-fg), transparent) 1',

--- a/src/components/content/heading-h2.tsx
+++ b/src/components/content/heading-h2.tsx
@@ -13,7 +13,6 @@ export function HeadingH2({ id, children, ...rest }: Props) {
       className="text-subheading font-bold leading-tight pt-vsp-sm border-t-[3px] border-transparent"
       style={
         {
-          '--flow-space': 'var(--spacing-vsp-2xl)',
           borderImage: 'linear-gradient(to right, var(--color-fg), transparent) 1',
         } as CSSProperties
       }

--- a/src/components/content/heading-h3.tsx
+++ b/src/components/content/heading-h3.tsx
@@ -1,0 +1,25 @@
+import type { CSSProperties, ReactNode } from 'react';
+
+type Props = {
+  id?: string;
+  children?: ReactNode;
+  [key: string]: any;
+};
+
+export function HeadingH3({ id, children, ...rest }: Props) {
+  return (
+    <h3
+      id={id}
+      className="text-body font-bold leading-snug pt-vsp-xs border-t-[2px] border-transparent"
+      style={
+        {
+          '--flow-space': 'var(--spacing-vsp-xl)',
+          borderImage: 'linear-gradient(to right, var(--color-muted), transparent) 1',
+        } as CSSProperties
+      }
+      {...rest}
+    >
+      {children}
+    </h3>
+  );
+}

--- a/src/components/content/heading-h3.tsx
+++ b/src/components/content/heading-h3.tsx
@@ -13,7 +13,6 @@ export function HeadingH3({ id, children, ...rest }: Props) {
       className="text-body font-bold leading-snug pt-vsp-xs border-t-[2px] border-transparent"
       style={
         {
-          '--flow-space': 'var(--spacing-vsp-xl)',
           borderImage: 'linear-gradient(to right, var(--color-muted), transparent) 1',
         } as CSSProperties
       }

--- a/src/components/content/heading-h3.tsx
+++ b/src/components/content/heading-h3.tsx
@@ -2,15 +2,16 @@ import type { CSSProperties, ReactNode } from 'react';
 
 type Props = {
   id?: string;
+  className?: string;
   children?: ReactNode;
   [key: string]: any;
 };
 
-export function HeadingH3({ id, children, ...rest }: Props) {
+export function HeadingH3({ id, children, className, ...rest }: Props) {
   return (
     <h3
       id={id}
-      className="text-body font-bold leading-snug pt-vsp-xs border-t-[2px] border-transparent"
+      className={`text-body font-bold leading-snug pt-vsp-xs border-t-[2px] border-transparent${className ? ` ${className}` : ''}`}
       style={
         {
           borderImage: 'linear-gradient(to right, var(--color-muted), transparent) 1',

--- a/src/components/content/heading-h4.tsx
+++ b/src/components/content/heading-h4.tsx
@@ -13,7 +13,6 @@ export function HeadingH4({ id, children, ...rest }: Props) {
       className="text-body font-semibold leading-snug pt-vsp-xs border-t border-transparent"
       style={
         {
-          '--flow-space': 'var(--spacing-vsp-lg)',
           borderImage: 'linear-gradient(to right, var(--color-muted), transparent) 1',
         } as CSSProperties
       }

--- a/src/components/content/heading-h4.tsx
+++ b/src/components/content/heading-h4.tsx
@@ -1,0 +1,25 @@
+import type { CSSProperties, ReactNode } from 'react';
+
+type Props = {
+  id?: string;
+  children?: ReactNode;
+  [key: string]: any;
+};
+
+export function HeadingH4({ id, children, ...rest }: Props) {
+  return (
+    <h4
+      id={id}
+      className="text-body font-semibold leading-snug pt-vsp-xs border-t border-transparent"
+      style={
+        {
+          '--flow-space': 'var(--spacing-vsp-lg)',
+          borderImage: 'linear-gradient(to right, var(--color-muted), transparent) 1',
+        } as CSSProperties
+      }
+      {...rest}
+    >
+      {children}
+    </h4>
+  );
+}

--- a/src/components/content/heading-h4.tsx
+++ b/src/components/content/heading-h4.tsx
@@ -2,15 +2,16 @@ import type { CSSProperties, ReactNode } from 'react';
 
 type Props = {
   id?: string;
+  className?: string;
   children?: ReactNode;
   [key: string]: any;
 };
 
-export function HeadingH4({ id, children, ...rest }: Props) {
+export function HeadingH4({ id, children, className, ...rest }: Props) {
   return (
     <h4
       id={id}
-      className="text-body font-semibold leading-snug pt-vsp-xs border-t border-transparent"
+      className={`text-body font-semibold leading-snug pt-vsp-xs border-t border-transparent${className ? ` ${className}` : ''}`}
       style={
         {
           borderImage: 'linear-gradient(to right, var(--color-muted), transparent) 1',

--- a/src/pages/docs/[...slug].astro
+++ b/src/pages/docs/[...slug].astro
@@ -13,6 +13,7 @@ import Tabs from "@/components/tabs.astro";
 import TabItem from "@/components/tab-item.astro";
 import Details from "@/components/details.astro";
 import HtmlPreview from "@/components/html-preview-wrapper.astro";
+import { htmlOverrides } from "@/components/content/component-map";
 import Breadcrumb from "@/components/breadcrumb.astro";
 import { toRouteSlug } from "@/utils/slug";
 import {
@@ -105,6 +106,7 @@ export async function getStaticPaths() {
 const { entry, breadcrumbs = [], prev, next, autoIndex } = Astro.props;
 
 const components = {
+  ...htmlOverrides,
   Note,
   Tip,
   Info,

--- a/src/pages/ja/docs/[...slug].astro
+++ b/src/pages/ja/docs/[...slug].astro
@@ -14,6 +14,7 @@ import Tabs from "@/components/tabs.astro";
 import TabItem from "@/components/tab-item.astro";
 import Details from "@/components/details.astro";
 import HtmlPreview from "@/components/html-preview-wrapper.astro";
+import { htmlOverrides } from "@/components/content/component-map";
 import Breadcrumb from "@/components/breadcrumb.astro";
 import { toRouteSlug } from "@/utils/slug";
 import {
@@ -149,6 +150,7 @@ const {
 } = Astro.props;
 
 const components = {
+  ...htmlOverrides,
   Note,
   Tip,
   Info,

--- a/src/pages/v/[version]/docs/[...slug].astro
+++ b/src/pages/v/[version]/docs/[...slug].astro
@@ -14,6 +14,7 @@ import Tabs from "@/components/tabs.astro";
 import TabItem from "@/components/tab-item.astro";
 import Details from "@/components/details.astro";
 import HtmlPreview from "@/components/html-preview-wrapper.astro";
+import { htmlOverrides } from "@/components/content/component-map";
 import Breadcrumb from "@/components/breadcrumb.astro";
 import { toRouteSlug } from "@/utils/slug";
 import {
@@ -131,6 +132,7 @@ const { entry, version, breadcrumbs = [], prev, next, autoIndex } = Astro.props;
 const versionConfig = version as VersionConfig;
 
 const components = {
+  ...htmlOverrides,
   Note,
   Tip,
   Info,

--- a/src/pages/v/[version]/ja/docs/[...slug].astro
+++ b/src/pages/v/[version]/ja/docs/[...slug].astro
@@ -14,6 +14,7 @@ import Tabs from "@/components/tabs.astro";
 import TabItem from "@/components/tab-item.astro";
 import Details from "@/components/details.astro";
 import HtmlPreview from "@/components/html-preview-wrapper.astro";
+import { htmlOverrides } from "@/components/content/component-map";
 import Breadcrumb from "@/components/breadcrumb.astro";
 import { toRouteSlug } from "@/utils/slug";
 import {
@@ -187,6 +188,7 @@ const {
 const versionConfig = version as VersionConfig;
 
 const components = {
+  ...htmlOverrides,
   Note,
   Tip,
   Info,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -213,34 +213,18 @@ body {
 
 /* ── Headings ── */
 
+/* Heading flow-space (structural — consumed by flow spacing system) */
+
 .zd-content :where(h2) {
   --flow-space: var(--spacing-vsp-2xl);
-  font-size: var(--text-subheading);
-  font-weight: var(--font-weight-bold);
-  line-height: var(--leading-tight);
-  padding-top: var(--spacing-vsp-sm);
-  border-top: 3px solid transparent;
-  border-image: linear-gradient(to right, var(--color-fg), transparent) 1;
 }
 
 .zd-content :where(h3) {
   --flow-space: var(--spacing-vsp-xl);
-  font-size: var(--text-body);
-  font-weight: var(--font-weight-bold);
-  line-height: var(--leading-snug);
-  padding-top: var(--spacing-vsp-xs);
-  border-top: 2px solid transparent;
-  border-image: linear-gradient(to right, var(--color-muted), transparent) 1;
 }
 
 .zd-content :where(h4) {
   --flow-space: var(--spacing-vsp-lg);
-  font-size: var(--text-body);
-  font-weight: var(--font-weight-semibold);
-  line-height: var(--leading-snug);
-  padding-top: var(--spacing-vsp-xs);
-  border-top: 1px solid transparent;
-  border-image: linear-gradient(to right, var(--color-muted), transparent) 1;
 }
 
 .zd-content :where(h5, h6) {
@@ -301,34 +285,13 @@ body {
 
 /* ── Links ── */
 
-.zd-content :where(a:not(.block):not([data-site-nav] *)) {
-  color: var(--color-accent);
-  text-decoration: underline;
-}
-
-.zd-content :where(a:not(.block):not([data-site-nav] *):hover) {
-  color: var(--color-accent-hover);
-}
-
-/* ── Bold / Strong ── */
-
-.zd-content :where(strong) {
-  font-weight: var(--font-weight-bold);
-  color: var(--color-fg);
+/* Link reset inside site-nav (component can't detect ancestor context) */
+.zd-content [data-site-nav] a {
+  color: inherit;
+  text-decoration: none;
 }
 
 /* ── Lists ── */
-/* +4px nudge: hsp-xl (24px) is slightly too tight for disc/decimal markers (#222) */
-
-.zd-content :where(ul) {
-  list-style-type: disc;
-  padding-left: calc(var(--spacing-hsp-xl) + 4px);
-}
-
-.zd-content :where(ol) {
-  list-style-type: decimal;
-  padding-left: calc(var(--spacing-hsp-xl) + 4px);
-}
 
 .zd-content :where(li) {
   margin-bottom: var(--spacing-vsp-xs);
@@ -344,13 +307,8 @@ body {
 }
 
 /* ── Blockquotes ── */
-
-.zd-content :where(blockquote) {
-  border-left: 3px solid var(--color-muted);
-  padding-left: var(--spacing-hsp-lg);
-  color: var(--color-muted);
-  font-style: italic;
-}
+/* blockquote base styles live in ContentBlockquote component; keep nested p rule
+   here because MDX renders <p> children independently (component can't style them) */
 
 .zd-content :where(blockquote p) {
   margin-bottom: var(--spacing-vsp-xs);
@@ -387,12 +345,6 @@ body {
 }
 
 /* ── Tables ── */
-
-.zd-content :where(table) {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: var(--text-small);
-}
 
 .zd-content :where(th),
 .zd-content :where(td) {


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/232

---

## Summary

- Replace `.zd-content :where(h2, h3, ...)` CSS rules with Preact component overrides via `<Content components={...} />`, eliminating cascade conflicts where Tailwind v4 layered utilities are beaten by unlayered global CSS
- Create 10 server-rendered Preact components in `src/components/content/` for headings (h2-h4), paragraph, link, strong, blockquote, lists (ul/ol), and table
- Wire components into all 4 page templates via a central `component-map.ts` registry
- Remove 56 lines of redundant global CSS while keeping structural rules (flow-space, consecutive heading tightening, hash-links, minor elements)

## Changes

### New components (`src/components/content/`)

- `heading-h2.tsx`, `heading-h3.tsx`, `heading-h4.tsx` — heading visual styles via Tailwind + inline borderImage gradient
- `content-paragraph.tsx` — passthrough placeholder for future override use
- `content-link.tsx` — accent/underline styling with `.block` and `.hash-link` exclusions
- `content-strong.tsx` — bold + fg color (defensive for blockquote context)
- `content-blockquote.tsx` — left border, italic, muted color
- `content-ul.tsx`, `content-ol.tsx` — disc/decimal lists with +4px marker nudge (#222)
- `content-table.tsx` — full-width table wrapped in `overflow-x-auto` scroll container
- `component-map.ts` — central registry mapping HTML tags to component overrides

### Modified files

- **4 page templates** — import `htmlOverrides` and spread into `components` prop
- **`global.css`** — removed element-specific CSS rules replaced by components; kept structural flow-space rules for headings, consecutive heading tightening, hash-link auto-links, and minor element styling (li, th/td, code, pre, hr, img, h5/h6, dt/dd)
- **`CLAUDE.md`** — documented component-first content typography architecture

### Design decisions

- `--flow-space` stays as CSS structural rules (not inline style) to preserve consecutive-heading spacing overrides
- Site-nav link reset (`[data-site-nav] a`) stays in global CSS since components can't detect ancestor context
- `blockquote p` margin stays in global CSS since components can't style MDX children
- th/td, li, and other minor elements stay in global CSS (low-conflict, not standard MDX overrides)

## Test Plan

- [x] `pnpm build` passes (134 pages)
- [x] `pnpm check` — no type errors
- [x] Computed style verification: h2/h3/h4 font-size, weight, border, padding, margin match original CSS
- [x] Preset generator h3 confirmed independent (16px/600/0px border — no cascade leak)
- [x] Full-page visual screenshot confirms correct rendering
- [x] All className props properly merged (review fix applied)