### PR TITLE
fix: apply content heading design to preset generator section headings

### DIFF
--- a/src/components/preset-generator.tsx
+++ b/src/components/preset-generator.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useMemo, useRef, useEffect } from "react";
 import { FEATURES, buildJson, buildCliCommand, type FormState } from "../lib/preset-generator-logic";
+import { HeadingH3 } from "./content/heading-h3";
 
 // ── Data ──
 
@@ -82,9 +83,9 @@ const PACKAGE_MANAGERS = ["pnpm", "npm", "yarn", "bun"] as const;
 
 function SectionHeading({ children }: { children: React.ReactNode }) {
   return (
-    <h3 className="mb-vsp-xs text-small font-semibold text-fg">
+    <HeadingH3 className="mb-vsp-xs">
       {children}
-    </h3>
+    </HeadingH3>
   );
 }
 


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/240

---

## Summary
After the content-component-first refactoring (#239), the preset generator page's section headings lost their styled design. This PR imports and reuses the `HeadingH3` content component in the preset generator's `SectionHeading` wrapper, restoring visual consistency with the rest of the doc site.

## Changes
- Import `HeadingH3` from `src/components/content/heading-h3.tsx` into `preset-generator.tsx`
- Replace raw `<h3>` element in `SectionHeading` with `<HeadingH3 className="mb-vsp-xs">`, gaining: `text-body` font size, `font-bold` weight, `leading-snug` line height, `pt-vsp-xs` top padding, and border-top gradient decoration
- Retain `mb-vsp-xs` bottom margin for spacing between heading and form element (flow-space doesn't apply inside Preact islands)

## Test Plan
- Verified computed styles via `/verify-ui`: font-size 19.2px, font-weight 700, border-top 2px with gradient, proper padding/margin
- Visual screenshot confirms headings match the content heading design used across other doc pages
- CI checks (type check, build, E2E)

Closes #240