### PR TITLE
fix: restore adequate left indent for ul/ol list markers

### DIFF
--- a/src/components/content/content-ol.tsx
+++ b/src/components/content/content-ol.tsx
@@ -5,12 +5,13 @@ type Props = {
 };
 
 // 2em indent: enough room for 2-digit markers like "66." (#244)
+// Inline style — Tailwind v4 does not generate arbitrary values from these TSX files
 export function ContentOl({ children, className, ...rest }: Props) {
   return (
     <ol
+      {...rest}
       className={`list-decimal${className ? ` ${className}` : ''}`}
       style={{ paddingLeft: '2em' }}
-      {...rest}
     >
       {children}
     </ol>

--- a/src/components/content/content-ol.tsx
+++ b/src/components/content/content-ol.tsx
@@ -4,11 +4,12 @@ type Props = {
   [key: string]: any;
 };
 
-// +4px nudge: hsp-xl (24px) is slightly too tight for disc/decimal markers (#222)
+// 2em indent: enough room for 2-digit markers like "66." (#244)
 export function ContentOl({ children, className, ...rest }: Props) {
   return (
     <ol
-      className={`list-decimal pl-[calc(var(--spacing-hsp-xl)+4px)]${className ? ` ${className}` : ''}`}
+      className={`list-decimal${className ? ` ${className}` : ''}`}
+      style={{ paddingLeft: '2em' }}
       {...rest}
     >
       {children}

--- a/src/components/content/content-ul.tsx
+++ b/src/components/content/content-ul.tsx
@@ -4,13 +4,13 @@ type Props = {
   [key: string]: any;
 };
 
-// 2em indent: enough room for 2-digit markers like "66." (#244)
+// 2em indent via inline style — Tailwind v4 does not generate arbitrary values from these TSX files (#244)
 export function ContentUl({ children, className, ...rest }: Props) {
   return (
     <ul
+      {...rest}
       className={`list-disc${className ? ` ${className}` : ''}`}
       style={{ paddingLeft: '2em' }}
-      {...rest}
     >
       {children}
     </ul>

--- a/src/components/content/content-ul.tsx
+++ b/src/components/content/content-ul.tsx
@@ -4,11 +4,12 @@ type Props = {
   [key: string]: any;
 };
 
-// +4px nudge: hsp-xl (24px) is slightly too tight for disc/decimal markers (#222)
+// 2em indent: enough room for 2-digit markers like "66." (#244)
 export function ContentUl({ children, className, ...rest }: Props) {
   return (
     <ul
-      className={`list-disc pl-[calc(var(--spacing-hsp-xl)+4px)]${className ? ` ${className}` : ''}`}
+      className={`list-disc${className ? ` ${className}` : ''}`}
+      style={{ paddingLeft: '2em' }}
       {...rest}
     >
       {children}


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/244

---

## Summary
- Restore `padding-left` on `<ul>` and `<ol>` content components, which was lost when global CSS rules were moved to components but Tailwind v4 failed to generate the arbitrary value classes
- Use inline `style={{ paddingLeft: '2em' }}` instead of Tailwind arbitrary values, since Tailwind v4 does not generate classes from these server-rendered Preact TSX files
- Fix prop spread order to prevent `{...rest}` from silently overriding the padding style

## Changes
- `content-ul.tsx`: Replace non-functional `pl-[calc(var(--spacing-hsp-xl)+4px)]` Tailwind class with inline `style={{ paddingLeft: '2em' }}`, move `{...rest}` before `style`/`className` to prevent override
- `content-ol.tsx`: Same fix as above

## Root Cause
Commit `f4bf21a` refactored typography rules from `.zd-content` in `global.css` into Preact content components. The `ul`/`ol` padding-left was moved to a Tailwind arbitrary value `pl-[calc(var(--spacing-hsp-xl)+4px)]`, but Tailwind v4 never generated this class from the TSX files, resulting in `padding-left: 0px`.

## Test Plan
- Verified `padding-left: 38.4px` (2em at 19.2px body text) via Playwright computed style check
- Visual verification: unordered and ordered lists show proper left indentation with markers well-spaced
- Build passes, all CI checks pass (Type Check, Build Site, Build Doc History, Preview Deploy, E2E Tests)