### PR TITLE
fix: show ul/ol bullet and number markers via inline listStyleType

### DIFF
--- a/src/components/content/content-ol.tsx
+++ b/src/components/content/content-ol.tsx
@@ -10,8 +10,8 @@ export function ContentOl({ children, className, ...rest }: Props) {
   return (
     <ol
       {...rest}
-      className={`list-decimal${className ? ` ${className}` : ''}`}
-      style={{ paddingLeft: '2em' }}
+      className={className || undefined}
+      style={{ paddingLeft: '2em', listStyleType: 'decimal' }}
     >
       {children}
     </ol>

--- a/src/components/content/content-ul.tsx
+++ b/src/components/content/content-ul.tsx
@@ -9,8 +9,8 @@ export function ContentUl({ children, className, ...rest }: Props) {
   return (
     <ul
       {...rest}
-      className={`list-disc${className ? ` ${className}` : ''}`}
-      style={{ paddingLeft: '2em' }}
+      className={className || undefined}
+      style={{ paddingLeft: '2em', listStyleType: 'disc' }}
     >
       {children}
     </ul>


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/244

---

## Summary
Tailwind v4 doesn't generate `list-disc`/`list-decimal` CSS from these content component TSX files. The classes exist in HTML but produce no CSS rules, leaving `list-style-type: none` from preflight. Fix: use inline `listStyleType` style (same pattern as `paddingLeft`).

Note: PR #246 was merged with only the empty start commit — the actual fix was committed locally but never pushed. This PR contains the real fix.

## Changes
- `content-ul.tsx`: replace `list-disc` class with inline `listStyleType: 'disc'`
- `content-ol.tsx`: replace `list-decimal` class with inline `listStyleType: 'decimal'`

## Test Plan
- Verify disc bullet markers visible on unordered lists
- Verify decimal number markers visible on ordered lists
- Verify nested lists render correctly