### PR TITLE
fix(create-zudo-doc): add missing site-tree-nav-demo.astro to scaffold template

### DIFF
--- a/packages/create-zudo-doc/templates/base/src/components/site-tree-nav-demo.astro
+++ b/packages/create-zudo-doc/templates/base/src/components/site-tree-nav-demo.astro
@@ -1,0 +1,26 @@
+---
+import { buildNavTree, groupSatelliteNodes, isNavVisible } from "@/utils/docs";
+import { loadLocaleDocs } from "@/utils/locale-docs";
+import { stripBase } from "@/utils/base";
+import { detectLocaleFromPath, type Locale } from "@/config/i18n";
+import { settings } from "@/config/settings";
+import { getCategoryOrder } from "@/utils/nav-scope";
+import SiteTreeNav from "@/components/site-tree-nav.tsx";
+
+const currentPath = Astro.url.pathname;
+const pathWithoutBase = stripBase(currentPath);
+const lang: Locale = detectLocaleFromPath(pathWithoutBase);
+
+const categoryOrder = getCategoryOrder();
+const { allDocs, categoryMeta } = await loadLocaleDocs(lang);
+const navDocs = allDocs.filter(isNavVisible);
+const tree = buildNavTree(navDocs, lang, categoryMeta);
+const groupedTree = groupSatelliteNodes(tree, categoryOrder);
+---
+
+<SiteTreeNav
+  tree={groupedTree}
+  categoryOrder={categoryOrder}
+  categoryIgnore={["inbox"]}
+  client:visible
+/>

--- a/packages/create-zudo-doc/templates/base/src/components/site-tree-nav-demo.astro
+++ b/packages/create-zudo-doc/templates/base/src/components/site-tree-nav-demo.astro
@@ -3,7 +3,6 @@ import { buildNavTree, groupSatelliteNodes, isNavVisible } from "@/utils/docs";
 import { loadLocaleDocs } from "@/utils/locale-docs";
 import { stripBase } from "@/utils/base";
 import { detectLocaleFromPath, type Locale } from "@/config/i18n";
-import { settings } from "@/config/settings";
 import { getCategoryOrder } from "@/utils/nav-scope";
 import SiteTreeNav from "@/components/site-tree-nav.tsx";
 

--- a/src/components/site-tree-nav-demo.astro
+++ b/src/components/site-tree-nav-demo.astro
@@ -3,7 +3,6 @@ import { buildNavTree, groupSatelliteNodes, isNavVisible } from "@/utils/docs";
 import { loadLocaleDocs } from "@/utils/locale-docs";
 import { stripBase } from "@/utils/base";
 import { detectLocaleFromPath, type Locale } from "@/config/i18n";
-import { settings } from "@/config/settings";
 import { getCategoryOrder } from "@/utils/nav-scope";
 import SiteTreeNav from "@/components/site-tree-nav.tsx";
 


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/255

---

## Summary
- Add missing `site-tree-nav-demo.astro` to the scaffold base template, fixing build failure in all newly scaffolded projects
- Remove unused `settings` import from the component (both source and scaffold copy)

## Changes
- **`packages/create-zudo-doc/templates/base/src/components/site-tree-nav-demo.astro`** — New file. Copied from the main project's `src/components/` directory. This Astro wrapper renders `SiteTreeNav` with live data for use as a global MDX component in documentation pages.
- **`src/components/site-tree-nav-demo.astro`** — Removed unused `import { settings } from "@/config/settings"` (review cleanup)

## Test Plan
- Run `create-zudo-doc` to scaffold a new project → verify `site-tree-nav-demo.astro` exists in `src/components/`
- Run `pnpm build` in the scaffolded project → verify no import resolution errors
- Run `pnpm build` in the main zudo-doc project → verify no regression from removed import

Closes #255