### PR TITLE
Template drift guard: automated detection and sync for create-zudo-doc templates

### DIFF
--- a/.claude/skills/l-update-generator/SKILL.md
+++ b/.claude/skills/l-update-generator/SKILL.md
@@ -24,6 +24,8 @@ The generator uses **additive composition** — not copy-then-strip:
 - Periodically to verify generator health
 - User says "update generator", "sync generator", "check generator drift", "l-update-generator", or the old name "l-sync-create-zudo-doc"
 
+**Quick pre-check**: Run `pnpm check:template-drift` first to get an automated summary of base template drift. Then proceed with the full workflow below for settings, dependency, astro config, and feature composition drift.
+
 ## Step 1: Analyze Drift
 
 Compare the main project's source files with what the generator produces.
@@ -81,6 +83,10 @@ Compare shared files between the main project and the base template:
 - **Template**: `packages/create-zudo-doc/templates/base/`
 
 Check that non-feature-specific files in the base template reflect the latest changes from the main project (layout updates, plugin changes, utility functions, type definitions, etc.).
+
+**Automated first check**: Run `pnpm check:template-drift` before doing manual analysis. This runs `scripts/check-template-drift.sh` and quickly identifies files that differ between the main project and the base template.
+
+**Allowlist note**: Some files are listed in `.template-drift-allowlist` (e.g., `global.css`, `header.astro`, `doc-layout.astro`) and are skipped entirely by the automated script because they contain slot sections that intentionally differ. These files **still require manual review** — check that any non-slot-section changes in the main project are reflected in the template counterpart.
 
 ## Step 2: Report Findings
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,6 +2,7 @@
 #
 # Triggered on PRs targeting `main`. The pipeline mirrors the local
 # `pnpm b4push` script:
+#   0. Template drift check (no install needed — pure shell)
 #   1. Type checking (astro check)
 #   2. Build the Astro docs site (shallow clone, skips doc history)
 #   3. Build doc history JSONs (full clone, standalone server package)

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -32,6 +32,19 @@ permissions:
 
 jobs:
   # ---------------------------------------------------------------------------
+  # Job 0: Template drift check (lightweight, no pnpm install needed)
+  # ---------------------------------------------------------------------------
+  check-template-drift:
+    name: Template Drift Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - name: Check template drift
+        run: bash scripts/check-template-drift.sh
+
+  # ---------------------------------------------------------------------------
   # Job 1: Type checking
   # ---------------------------------------------------------------------------
   typecheck:

--- a/.template-drift-allowlist
+++ b/.template-drift-allowlist
@@ -1,0 +1,14 @@
+# Plugin re-exports — generated projects use inline implementations,
+# production re-exports from @zudo-doc/md-plugins
+src/plugins/rehype-code-title.ts
+src/plugins/rehype-heading-links.ts
+src/plugins/rehype-mermaid.ts
+src/plugins/rehype-strip-md-extension.ts
+src/plugins/remark-admonitions.ts
+src/plugins/remark-resolve-markdown-links.ts
+
+# Slot-based files — templates use @slot: injection anchors,
+# production has features inlined
+src/components/header.astro
+src/layouts/doc-layout.astro
+src/styles/global.css

--- a/.template-drift-allowlist
+++ b/.template-drift-allowlist
@@ -7,6 +7,11 @@ src/plugins/rehype-strip-md-extension.ts
 src/plugins/remark-admonitions.ts
 src/plugins/remark-resolve-markdown-links.ts
 
+# Plugin utilities — template-only files (production uses @zudo-doc/md-plugins)
+src/plugins/docs-source-map.ts
+src/plugins/hast-utils.ts
+src/plugins/url-utils.ts
+
 # Slot-based files — templates use @slot: injection anchors,
 # production has features inlined
 src/components/header.astro

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Minimal documentation framework built with Astro 6, MDX, Tailwind CSS v4, and Pr
 - `pnpm dev:network` — Astro dev server with `--host 0.0.0.0` for LAN access
 - `pnpm build` — static HTML export to `dist/`
 - `pnpm check` — Astro type checking
-- `pnpm b4push` — pre-push validation: format check → typecheck → build → link check → E2E tests
+- `pnpm b4push` — pre-push validation: format check → template drift check → typecheck → build → link check → E2E tests
 
 ## Key Directories
 
@@ -177,6 +177,8 @@ When adding or removing a feature from zudo-doc, update the `create-zudo-doc` ge
 6. **`packages/create-zudo-doc/src/scaffold.ts`** — Add/remove dependencies in `generatePackageJson()`
 7. **`packages/create-zudo-doc/src/__tests__/scaffold.test.ts`** — Update tests
 8. Run `/l-update-generator` to verify no drift remains
+
+**Important**: This checklist also applies to incremental improvements (CSS token migrations, icon sizing, spacing changes, etc.) — not just new features. If you change a file that has a template counterpart, update the template too. Run `pnpm check:template-drift` to verify (note: allowlisted files like `global.css`, `header.astro`, and `doc-layout.astro` are excluded from automated checks and need manual review).
 
 ## Design Tokens & CSS
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "setup:doc-skill": "bash scripts/setup-doc-skill.sh",
     "setup:zudo-doc-wisdom": "bash scripts/setup-zudo-doc-wisdom.sh",
     "// ── Linting ─────────────────────────────────────": "",
-    "lint:tokens": "design-token-lint"
+    "lint:tokens": "design-token-lint",
+    "check:template-drift": "bash scripts/check-template-drift.sh"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/packages/create-zudo-doc/templates/base/src/components/admonitions/admonition.astro
+++ b/packages/create-zudo-doc/templates/base/src/components/admonitions/admonition.astro
@@ -27,7 +27,7 @@ const titleColor = `var(--color-${c.semanticColor})`;
 ---
 
 <div
-  class="my-vsp-md border-l-[4px] px-hsp-lg pt-vsp-md pb-vsp-2xs"
+  class="mt-vsp-md border-l-[4px] px-hsp-lg pt-vsp-md pb-vsp-2xs"
   data-admonition={type}
   style={`border-color: ${borderColor}; background-color: ${bgColor};`}
 >
@@ -35,7 +35,7 @@ const titleColor = `var(--color-${c.semanticColor})`;
     <span class="mr-hsp-2xs">{c.icon}</span>
     {displayTitle}
   </p>
-  <div class="text-small text-fg [&>p]:my-vsp-2xs">
+  <div class="text-small text-fg [&>*+*]:mt-vsp-2xs">
     <slot />
   </div>
 </div>

--- a/packages/create-zudo-doc/templates/base/src/components/breadcrumb.astro
+++ b/packages/create-zudo-doc/templates/base/src/components/breadcrumb.astro
@@ -17,7 +17,7 @@ const { items } = Astro.props;
             {i > 0 && (
               <svg
                 xmlns="http://www.w3.org/2000/svg"
-                class="h-[0.75rem] w-[0.75rem] text-muted shrink-0"
+                class="h-icon-xs w-icon-xs text-muted shrink-0"
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke="currentColor"

--- a/packages/create-zudo-doc/templates/base/src/components/content/component-map.ts
+++ b/packages/create-zudo-doc/templates/base/src/components/content/component-map.ts
@@ -1,0 +1,23 @@
+import { HeadingH2 } from './heading-h2';
+import { HeadingH3 } from './heading-h3';
+import { HeadingH4 } from './heading-h4';
+import { ContentParagraph } from './content-paragraph';
+import { ContentLink } from './content-link';
+import { ContentStrong } from './content-strong';
+import { ContentBlockquote } from './content-blockquote';
+import { ContentUl } from './content-ul';
+import { ContentOl } from './content-ol';
+import { ContentTable } from './content-table';
+
+export const htmlOverrides = {
+  h2: HeadingH2,
+  h3: HeadingH3,
+  h4: HeadingH4,
+  p: ContentParagraph,
+  a: ContentLink,
+  strong: ContentStrong,
+  blockquote: ContentBlockquote,
+  ul: ContentUl,
+  ol: ContentOl,
+  table: ContentTable,
+};

--- a/packages/create-zudo-doc/templates/base/src/components/content/content-blockquote.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/content/content-blockquote.tsx
@@ -1,0 +1,16 @@
+type Props = {
+  children?: React.ReactNode;
+  className?: string;
+  [key: string]: any;
+};
+
+export function ContentBlockquote({ children, className, ...rest }: Props) {
+  return (
+    <blockquote
+      className={`border-l-[3px] border-muted pl-hsp-lg text-muted italic${className ? ` ${className}` : ''}`}
+      {...rest}
+    >
+      {children}
+    </blockquote>
+  );
+}

--- a/packages/create-zudo-doc/templates/base/src/components/content/content-link.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/content/content-link.tsx
@@ -1,0 +1,28 @@
+type Props = {
+  href?: string;
+  className?: string;
+  children?: React.ReactNode;
+  [key: string]: any;
+};
+
+export function ContentLink({ href, className, children, ...rest }: Props) {
+  // Block links and hash-links (heading anchors) should render without content link styling
+  const classes = className ? className.split(' ') : [];
+  if (classes.includes('block') || classes.includes('hash-link')) {
+    return (
+      <a href={href} className={className} {...rest}>
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <a
+      href={href}
+      className={`text-accent underline hover:text-accent-hover${className ? ` ${className}` : ''}`}
+      {...rest}
+    >
+      {children}
+    </a>
+  );
+}

--- a/packages/create-zudo-doc/templates/base/src/components/content/content-ol.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/content/content-ol.tsx
@@ -1,0 +1,19 @@
+type Props = {
+  children?: React.ReactNode;
+  className?: string;
+  [key: string]: any;
+};
+
+// 2em indent: enough room for 2-digit markers like "66." (#244)
+// Inline style — Tailwind v4 does not generate arbitrary values from these TSX files
+export function ContentOl({ children, className, ...rest }: Props) {
+  return (
+    <ol
+      {...rest}
+      className={className || undefined}
+      style={{ paddingLeft: '2em', listStyleType: 'decimal' }}
+    >
+      {children}
+    </ol>
+  );
+}

--- a/packages/create-zudo-doc/templates/base/src/components/content/content-paragraph.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/content/content-paragraph.tsx
@@ -1,0 +1,10 @@
+type Props = {
+  children?: React.ReactNode;
+  [key: string]: any;
+};
+
+// Passthrough: no custom styles needed for <p> (inherits from .zd-content base).
+// Override claimed to enable future Tailwind utilities without CSS cascade conflicts.
+export function ContentParagraph({ children, ...rest }: Props) {
+  return <p {...rest}>{children}</p>;
+}

--- a/packages/create-zudo-doc/templates/base/src/components/content/content-strong.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/content/content-strong.tsx
@@ -1,0 +1,16 @@
+type Props = {
+  children?: React.ReactNode;
+  className?: string;
+  [key: string]: any;
+};
+
+export function ContentStrong({ children, className, ...rest }: Props) {
+  return (
+    <strong
+      className={`font-bold text-fg${className ? ` ${className}` : ''}`}
+      {...rest}
+    >
+      {children}
+    </strong>
+  );
+}

--- a/packages/create-zudo-doc/templates/base/src/components/content/content-table.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/content/content-table.tsx
@@ -1,0 +1,18 @@
+type Props = {
+  children?: React.ReactNode;
+  className?: string;
+  [key: string]: any;
+};
+
+export function ContentTable({ children, className, ...rest }: Props) {
+  return (
+    <div className="overflow-x-auto">
+      <table
+        className={`w-full border-collapse text-small${className ? ` ${className}` : ''}`}
+        {...rest}
+      >
+        {children}
+      </table>
+    </div>
+  );
+}

--- a/packages/create-zudo-doc/templates/base/src/components/content/content-ul.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/content/content-ul.tsx
@@ -1,0 +1,18 @@
+type Props = {
+  children?: React.ReactNode;
+  className?: string;
+  [key: string]: any;
+};
+
+// 2em indent via inline style — Tailwind v4 does not generate arbitrary values from these TSX files (#244)
+export function ContentUl({ children, className, ...rest }: Props) {
+  return (
+    <ul
+      {...rest}
+      className={className || undefined}
+      style={{ paddingLeft: '2em', listStyleType: 'disc' }}
+    >
+      {children}
+    </ul>
+  );
+}

--- a/packages/create-zudo-doc/templates/base/src/components/content/heading-h2.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/content/heading-h2.tsx
@@ -1,0 +1,25 @@
+import type { CSSProperties, ReactNode } from 'react';
+
+type Props = {
+  id?: string;
+  className?: string;
+  children?: ReactNode;
+  [key: string]: any;
+};
+
+export function HeadingH2({ id, children, className, ...rest }: Props) {
+  return (
+    <h2
+      id={id}
+      className={`text-subheading font-bold leading-tight pt-vsp-sm border-t-[3px] border-transparent${className ? ` ${className}` : ''}`}
+      style={
+        {
+          borderImage: 'linear-gradient(to right, var(--color-fg), transparent) 1',
+        } as CSSProperties
+      }
+      {...rest}
+    >
+      {children}
+    </h2>
+  );
+}

--- a/packages/create-zudo-doc/templates/base/src/components/content/heading-h3.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/content/heading-h3.tsx
@@ -1,0 +1,25 @@
+import type { CSSProperties, ReactNode } from 'react';
+
+type Props = {
+  id?: string;
+  className?: string;
+  children?: ReactNode;
+  [key: string]: any;
+};
+
+export function HeadingH3({ id, children, className, ...rest }: Props) {
+  return (
+    <h3
+      id={id}
+      className={`text-body font-bold leading-snug pt-vsp-xs border-t-[2px] border-transparent${className ? ` ${className}` : ''}`}
+      style={
+        {
+          borderImage: 'linear-gradient(to right, var(--color-muted), transparent) 1',
+        } as CSSProperties
+      }
+      {...rest}
+    >
+      {children}
+    </h3>
+  );
+}

--- a/packages/create-zudo-doc/templates/base/src/components/content/heading-h4.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/content/heading-h4.tsx
@@ -1,0 +1,25 @@
+import type { CSSProperties, ReactNode } from 'react';
+
+type Props = {
+  id?: string;
+  className?: string;
+  children?: ReactNode;
+  [key: string]: any;
+};
+
+export function HeadingH4({ id, children, className, ...rest }: Props) {
+  return (
+    <h4
+      id={id}
+      className={`text-body font-semibold leading-snug pt-vsp-xs border-t border-transparent${className ? ` ${className}` : ''}`}
+      style={
+        {
+          borderImage: 'linear-gradient(to right, var(--color-muted), transparent) 1',
+        } as CSSProperties
+      }
+      {...rest}
+    >
+      {children}
+    </h4>
+  );
+}

--- a/packages/create-zudo-doc/templates/base/src/components/doc-metainfo.astro
+++ b/packages/create-zudo-doc/templates/base/src/components/doc-metainfo.astro
@@ -22,7 +22,7 @@ const hasInfo = gitInfo && (gitInfo.createdAt || gitInfo.updatedAt);
         <span class="inline-flex items-center gap-hsp-2xs">
           <svg
             xmlns="http://www.w3.org/2000/svg"
-            class="h-[0.75rem] w-[0.75rem]"
+            class="h-icon-xs w-icon-xs"
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
@@ -43,7 +43,7 @@ const hasInfo = gitInfo && (gitInfo.createdAt || gitInfo.updatedAt);
         <span class="inline-flex items-center gap-hsp-2xs">
           <svg
             xmlns="http://www.w3.org/2000/svg"
-            class="h-[0.75rem] w-[0.75rem]"
+            class="h-icon-xs w-icon-xs"
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
@@ -64,7 +64,7 @@ const hasInfo = gitInfo && (gitInfo.createdAt || gitInfo.updatedAt);
         <span class="inline-flex items-center gap-hsp-2xs">
           <svg
             xmlns="http://www.w3.org/2000/svg"
-            class="h-[0.75rem] w-[0.75rem]"
+            class="h-icon-xs w-icon-xs"
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"

--- a/packages/create-zudo-doc/templates/base/src/components/mobile-toc.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/mobile-toc.tsx
@@ -29,7 +29,7 @@ export function MobileToc({ headings, title = "On this page" }: MobileTocProps) 
           xmlns="http://www.w3.org/2000/svg"
           aria-hidden="true"
           className={clsx(
-            "h-[1rem] w-[1rem] text-muted transition-transform duration-150",
+            "h-icon-sm w-icon-sm text-muted transition-transform duration-150",
             open && "rotate-180",
           )}
           fill="none"

--- a/packages/create-zudo-doc/templates/base/src/components/page-loading-overlay.astro
+++ b/packages/create-zudo-doc/templates/base/src/components/page-loading-overlay.astro
@@ -14,7 +14,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: rgba(0, 0, 0, 0.6);
+    background: color-mix(in oklch, var(--color-overlay) 60%, transparent);
     opacity: 0;
     pointer-events: none;
     transition: opacity 150ms ease-out;

--- a/packages/create-zudo-doc/templates/base/src/components/sidebar-toggle.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/sidebar-toggle.tsx
@@ -39,7 +39,7 @@ export default function SidebarToggle({ children }: SidebarToggleProps) {
         {open ? (
           <svg
             xmlns="http://www.w3.org/2000/svg"
-            className="h-[1.5rem] w-[1.5rem]"
+            className="h-icon-lg w-icon-lg"
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
@@ -54,7 +54,7 @@ export default function SidebarToggle({ children }: SidebarToggleProps) {
         ) : (
           <svg
             xmlns="http://www.w3.org/2000/svg"
-            className="h-[1.5rem] w-[1.5rem]"
+            className="h-icon-lg w-icon-lg"
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
@@ -72,8 +72,7 @@ export default function SidebarToggle({ children }: SidebarToggleProps) {
       {/* Backdrop overlay - mobile only */}
       {open && (
         <div
-          className="fixed inset-0 z-30 lg:hidden"
-          style={{ backgroundColor: "rgba(0, 0, 0, 0.3)" }}
+          className="fixed inset-0 z-30 bg-overlay/30 lg:hidden"
           onClick={() => setOpen(false)}
         />
       )}

--- a/packages/create-zudo-doc/templates/base/src/components/sidebar-tree.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/sidebar-tree.tsx
@@ -224,7 +224,7 @@ export default function SidebarTree({ nodes, currentSlug, rootMenuItems, backToM
           onClick={() => setShowingRootMenu(false)}
           className="flex w-full items-center gap-hsp-xs px-hsp-sm py-vsp-xs text-small text-muted hover:text-fg border-b border-muted"
         >
-          <svg className="h-[1rem] w-[1rem] shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <svg className="h-icon-sm w-icon-sm shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
           </svg>
           {backToMenuLabel ?? "Back to main menu"}
@@ -258,7 +258,7 @@ export default function SidebarTree({ nodes, currentSlug, rootMenuItems, backToM
           onClick={() => setShowingRootMenu(true)}
           className="lg:hidden flex w-full items-center gap-hsp-xs px-hsp-sm py-vsp-xs text-small text-muted hover:text-fg border-b border-muted"
         >
-          <svg className="h-[1rem] w-[1rem] shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <svg className="h-icon-sm w-icon-sm shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
           </svg>
           {backToMenuLabel ?? "Back to main menu"}
@@ -484,8 +484,18 @@ function LeafNode({
   const isRoot = depth === 0;
   const paddingLeft = padLeft(depth, isRoot);
 
+  // For nested last leaves, add visual breathing space as margin on the outer wrapper
+  // rather than padding on the anchor — padding would grow the row box and throw off
+  // the ConnectorLines geometry (which uses bottom: 50% of the row to land the horizontal
+  // connector at the label midpoint).
+  const outerClass = isRoot
+    ? "border-t border-muted"
+    : !isRoot && isLast
+      ? "pb-vsp-md"
+      : "";
+
   return (
-    <div className={isRoot ? "border-t border-muted" : ""}>
+    <div className={outerClass}>
       <div className="relative">
         <ConnectorLines depth={depth} isLast={isLast} />
         <a
@@ -495,7 +505,7 @@ function LeafNode({
             ? `flex items-center gap-hsp-xs py-[calc(var(--spacing-vsp-xs)+0.15rem)] pr-[4px] text-small font-semibold ${
                 isActive ? "bg-fg text-bg" : "text-fg hover:underline focus:underline"
               }`
-            : `block py-vsp-2xs pr-[4px] ${isLast ? "pb-vsp-xs" : ""} text-small ${
+            : `block py-vsp-2xs pr-[4px] text-small ${
                 isActive
                   ? "bg-fg font-medium text-bg"
                   : "text-muted hover:underline focus:underline"

--- a/packages/create-zudo-doc/templates/base/src/components/site-tree-nav.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/site-tree-nav.tsx
@@ -152,7 +152,7 @@ function CategoryNode({
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
-              className={`h-[0.75rem] w-[0.75rem] transition-transform duration-150 ${open ? "rotate-90" : ""} text-muted`}
+              className={`h-icon-xs w-icon-xs transition-transform duration-150 ${open ? "rotate-90" : ""} text-muted`}
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"

--- a/packages/create-zudo-doc/templates/base/src/components/toc.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/toc.tsx
@@ -20,14 +20,14 @@ export function Toc({ headings }: TocProps) {
     <nav
       aria-label="Table of contents"
       className={clsx(
-        "hidden xl:block",
+        "hidden xl:flex flex-col",
         "w-[280px] shrink-0",
         "sticky top-[3.5rem] self-start z-10",
         "pt-vsp-xl lg:pt-vsp-2xl",
-        "max-h-[calc(100vh-3.5rem)] overflow-y-auto",
+        "h-[calc(100vh-3.5rem)]",
       )}
     >
-      <ul className="border-l border-muted pl-hsp-lg">
+      <ul className="border-l border-muted pl-hsp-lg overflow-y-auto flex-1 min-h-0">
         {filtered.map((heading, index) => {
           const isActive = heading.slug === activeId;
           return (

--- a/packages/create-zudo-doc/templates/base/src/config/color-scheme-utils.ts
+++ b/packages/create-zudo-doc/templates/base/src/config/color-scheme-utils.ts
@@ -18,6 +18,10 @@ export const SEMANTIC_DEFAULTS: Record<string, number> = {
   mermaidLine: 8,
   mermaidLabelBg: 10,
   mermaidNoteBg: 0,
+  chatUserBg: 5,
+  chatUserText: 9,
+  chatAssistantBg: 9,
+  chatAssistantText: 11,
 };
 
 export const SEMANTIC_CSS_NAMES: Record<string, string> = {
@@ -36,6 +40,10 @@ export const SEMANTIC_CSS_NAMES: Record<string, string> = {
   mermaidLine: "--zd-mermaid-line",
   mermaidLabelBg: "--zd-mermaid-label-bg",
   mermaidNoteBg: "--zd-mermaid-note-bg",
+  chatUserBg: "--zd-chat-user-bg",
+  chatUserText: "--zd-chat-user-text",
+  chatAssistantBg: "--zd-chat-assistant-bg",
+  chatAssistantText: "--zd-chat-assistant-text",
 };
 
 export const lightDarkPairings = [
@@ -83,6 +91,10 @@ export function resolveSemanticColors(scheme: ColorScheme) {
     mermaidLine: resolveColor(scheme.semantic?.mermaidLine, p, p[8]),
     mermaidLabelBg: resolveColor(scheme.semantic?.mermaidLabelBg, p, p[10]),
     mermaidNoteBg: resolveColor(scheme.semantic?.mermaidNoteBg, p, p[0]),
+    chatUserBg: resolveColor(scheme.semantic?.chatUserBg, p, p[5]),
+    chatUserText: resolveColor(scheme.semantic?.chatUserText, p, p[9]),
+    chatAssistantBg: resolveColor(scheme.semantic?.chatAssistantBg, p, p[9]),
+    chatAssistantText: resolveColor(scheme.semantic?.chatAssistantText, p, p[11]),
   };
 }
 
@@ -111,6 +123,10 @@ export function schemeToCssPairs(scheme: ColorScheme): [string, string][] {
     ["--zd-mermaid-line", sem.mermaidLine],
     ["--zd-mermaid-label-bg", sem.mermaidLabelBg],
     ["--zd-mermaid-note-bg", sem.mermaidNoteBg],
+    ["--zd-chat-user-bg", sem.chatUserBg],
+    ["--zd-chat-user-text", sem.chatUserText],
+    ["--zd-chat-assistant-bg", sem.chatAssistantBg],
+    ["--zd-chat-assistant-text", sem.chatAssistantText],
   ];
 }
 

--- a/packages/create-zudo-doc/templates/base/src/config/color-schemes.ts
+++ b/packages/create-zudo-doc/templates/base/src/config/color-schemes.ts
@@ -32,6 +32,10 @@ export interface ColorScheme {
     mermaidLine?: ColorRef;
     mermaidLabelBg?: ColorRef;
     mermaidNoteBg?: ColorRef;
+    chatUserBg?: ColorRef;
+    chatUserText?: ColorRef;
+    chatAssistantBg?: ColorRef;
+    chatAssistantText?: ColorRef;
   };
 }
 

--- a/packages/create-zudo-doc/templates/base/src/pages/docs/[...slug].astro
+++ b/packages/create-zudo-doc/templates/base/src/pages/docs/[...slug].astro
@@ -13,6 +13,7 @@ import Tabs from "@/components/tabs.astro";
 import TabItem from "@/components/tab-item.astro";
 import Details from "@/components/details.astro";
 import HtmlPreview from "@/components/html-preview-wrapper.astro";
+import { htmlOverrides } from "@/components/content/component-map";
 import Breadcrumb from "@/components/breadcrumb.astro";
 import { toRouteSlug } from "@/utils/slug";
 import {
@@ -105,6 +106,7 @@ export async function getStaticPaths() {
 const { entry, breadcrumbs = [], prev, next, autoIndex } = Astro.props;
 
 const components = {
+  ...htmlOverrides,
   Note,
   Tip,
   Info,

--- a/packages/create-zudo-doc/templates/base/src/styles/global.css
+++ b/packages/create-zudo-doc/templates/base/src/styles/global.css
@@ -61,6 +61,8 @@
   --color-danger: var(--zd-danger);
   --color-warning: var(--zd-warning);
   --color-info: var(--zd-info);
+  /* Overlay is intentionally theme-independent (always dark, not scheme-driven) */
+  --color-overlay: #000;
   --color-mermaid-node-bg: var(--zd-mermaid-node-bg);
   --color-mermaid-text: var(--zd-mermaid-text);
   --color-mermaid-line: var(--zd-mermaid-line);
@@ -93,16 +95,25 @@
   --spacing-vsp-2xl: 3.5rem;     /* 56px — page-level gap */
 
   /* ========================================
+   * Element sizes — semantic icon dimensions
+   * ======================================== */
+  --spacing-icon-xs: 0.75rem;    /* 12px — inline meta icons, chevrons */
+  --spacing-icon-sm: 1rem;       /* 16px — standard UI icons */
+  --spacing-icon-md: 1.25rem;    /* 20px — medium emphasis icons */
+  --spacing-icon-lg: 1.5rem;     /* 24px — large / mobile icons */
+
+  /* ========================================
    * Typography
    * ======================================== */
 
-  /* Font sizes (6 steps) */
-  --text-caption: 0.875rem;      /* 14px — labels, timestamps */
-  --text-small: 1rem;            /* 16px — secondary text, nav items */
-  --text-body: 1.2rem;           /* 19.2px — paragraphs, default */
-  --text-subheading: 1.4rem;     /* 22.4px — card titles, section labels */
-  --text-heading: 3rem;          /* 48px — page headings */
-  --text-display: 3.75rem;       /* 60px — hero text */
+  /* ── Tier 2: Semantic font-size tokens (reference Tier 1 scale only) ── */
+  --text-micro:      var(--text-scale-2xs);  /* 12px — compact panel labels, color swatch annotations */
+  --text-caption:    var(--text-scale-xs);   /* labels, timestamps */
+  --text-small:      var(--text-scale-sm);   /* secondary text, nav items */
+  --text-body:       var(--text-scale-md);   /* paragraphs, default */
+  --text-subheading: var(--text-scale-lg);   /* card titles, section labels */
+  --text-heading:    var(--text-scale-xl);   /* page headings */
+  --text-display:    var(--text-scale-2xl);  /* hero text */
 
   /* Font families */
   --font-sans: system-ui, sans-serif;
@@ -138,6 +149,16 @@
 :root {
   /* Default responsive range; sidebar-resizer.ts allows 192–448px for explicit resizing */
   --zd-sidebar-w: clamp(14rem, 20vw, 22rem);
+
+  /* ── Tier 1: Abstract font-size scale (raw values — NOT for direct component use) ── */
+  /* Used only as a source of truth for Tier 2 semantic tokens above. */
+  --text-scale-2xs: 0.75rem;    /* 12px */
+  --text-scale-xs:  0.875rem;   /* 14px */
+  --text-scale-sm:  1rem;       /* 16px */
+  --text-scale-md:  1.2rem;     /* 19.2px */
+  --text-scale-lg:  1.4rem;     /* 22.4px */
+  --text-scale-xl:  3rem;       /* 48px */
+  --text-scale-2xl: 3.75rem;    /* 60px */
 }
 
 /* ========================================
@@ -183,8 +204,8 @@ body {
 
 /* ── Flow spacing (vertical rhythm) ── */
 
-.zd-content :where(> * + *) {
-  margin-top: var(--spacing-vsp-md);
+.zd-content > :where(* + *) {
+  margin-top: var(--flow-space, var(--spacing-vsp-md));
 }
 
 /* ── Headings ── */

--- a/packages/create-zudo-doc/templates/base/src/utils/docs.ts
+++ b/packages/create-zudo-doc/templates/base/src/utils/docs.ts
@@ -41,14 +41,33 @@ interface BuildNode {
 const categoryMetaCache = new Map<string, Map<string, CategoryMeta>>();
 const navTreeCache = new Map<string, NavNode[]>();
 
-/** Build a cache key from docs array + locale + category meta. */
+/** Build a cache key from docs array + locale + category meta.
+ *  Includes nav-affecting frontmatter so HMR picks up changes. */
 function navTreeCacheKey(
   docs: DocsEntry[],
   lang: Locale,
   categoryMeta?: Map<string, CategoryMeta>,
 ): string {
-  const metaKey = categoryMeta ? [...categoryMeta.keys()].sort().join(";") : "_";
-  return `${lang}:${metaKey}:${docs.map((d) => d.id).sort().join(",")}`;
+  const metaKey = categoryMeta
+    ? JSON.stringify([...categoryMeta.entries()].sort(([a], [b]) => a.localeCompare(b)))
+    : "_";
+  return `${lang}:${metaKey}:${docs
+    .map((d) => {
+      const { sidebar_position, sidebar_label, title, description, unlisted, standalone, slug } =
+        d.data;
+      return JSON.stringify([
+        d.id,
+        sidebar_position,
+        sidebar_label,
+        title,
+        description,
+        unlisted,
+        standalone,
+        slug,
+      ]);
+    })
+    .sort()
+    .join(",")}`;
 }
 
 /**

--- a/packages/create-zudo-doc/templates/base/tsconfig.json
+++ b/packages/create-zudo-doc/templates/base/tsconfig.json
@@ -6,5 +6,5 @@
       "@/*": ["src/*"]
     }
   },
-  "exclude": ["dist", "e2e/fixtures", "packages", "worktrees", "src/**/__tests__", "vitest.config.ts"]
+  "exclude": ["dist", "e2e/fixtures", "packages", "worktrees", "vendor", "src/**/__tests__", "vitest.config.ts"]
 }

--- a/packages/create-zudo-doc/templates/features/docHistory/files/src/components/doc-history.tsx
+++ b/packages/create-zudo-doc/templates/features/docHistory/files/src/components/doc-history.tsx
@@ -29,7 +29,7 @@ function HistoryIcon() {
       strokeWidth={2}
       strokeLinecap="round"
       strokeLinejoin="round"
-      className="h-[1.25rem] w-[1.25rem]"
+      className="h-icon-md w-icon-md"
     >
       <circle cx="12" cy="12" r="10" />
       <polyline points="12 6 12 12 16 14" />
@@ -47,7 +47,7 @@ function CloseIcon() {
       strokeWidth={2}
       strokeLinecap="round"
       strokeLinejoin="round"
-      className="h-[1.25rem] w-[1.25rem]"
+      className="h-icon-md w-icon-md"
     >
       <path d="M18 6L6 18M6 6l12 12" />
     </svg>
@@ -64,7 +64,7 @@ function ArrowLeftIcon() {
       strokeWidth={2}
       strokeLinecap="round"
       strokeLinejoin="round"
-      className="h-[1rem] w-[1rem]"
+      className="h-icon-sm w-icon-sm"
     >
       <path d="M19 12H5M12 19l-7-7 7-7" />
     </svg>

--- a/packages/create-zudo-doc/templates/features/i18n/files/src/pages/ja/docs/[...slug].astro
+++ b/packages/create-zudo-doc/templates/features/i18n/files/src/pages/ja/docs/[...slug].astro
@@ -14,6 +14,7 @@ import Tabs from "@/components/tabs.astro";
 import TabItem from "@/components/tab-item.astro";
 import Details from "@/components/details.astro";
 import HtmlPreview from "@/components/html-preview-wrapper.astro";
+import { htmlOverrides } from "@/components/content/component-map";
 import Breadcrumb from "@/components/breadcrumb.astro";
 import { toRouteSlug } from "@/utils/slug";
 import {
@@ -149,6 +150,7 @@ const {
 } = Astro.props;
 
 const components = {
+  ...htmlOverrides,
   Note,
   Tip,
   Info,

--- a/packages/create-zudo-doc/templates/features/search/files/src/components/search.astro
+++ b/packages/create-zudo-doc/templates/features/search/files/src/components/search.astro
@@ -32,7 +32,7 @@ import { withBase } from "@/utils/base";
 
   <dialog
     data-search-dialog
-    class="m-0 h-full w-full max-w-none border-none bg-transparent p-0 backdrop:bg-[rgba(0,0,0,0.6)] sm:mx-auto sm:my-[10vh] sm:h-auto sm:max-h-[80vh] sm:max-w-[52rem] sm:rounded-lg"
+    class="m-0 h-full w-full max-w-none border-none bg-transparent p-0 backdrop:bg-overlay/60 sm:mx-auto sm:my-[10vh] sm:h-auto sm:max-h-[80vh] sm:max-w-[52rem] sm:rounded-lg"
   >
     <div
       class="flex h-full flex-col overflow-hidden bg-surface sm:rounded-lg sm:border sm:border-muted"

--- a/packages/create-zudo-doc/templates/features/sidebarToggle/files/src/components/desktop-sidebar-toggle.tsx
+++ b/packages/create-zudo-doc/templates/features/sidebarToggle/files/src/components/desktop-sidebar-toggle.tsx
@@ -42,7 +42,7 @@ export default function DesktopSidebarToggle() {
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"
-        className="h-[1rem] w-[1rem]"
+        className="h-icon-sm w-icon-sm"
         aria-hidden="true"
         fill="none"
         viewBox="0 0 24 24"

--- a/packages/create-zudo-doc/templates/features/tauri/files/src/components/find-bar.tsx
+++ b/packages/create-zudo-doc/templates/features/tauri/files/src/components/find-bar.tsx
@@ -57,10 +57,10 @@ export function FindBar({ visible, onClose, findInPage, containerSelector }: Fin
   if (!visible) return null;
 
   return (
-    <div className="fixed top-[3.5rem] right-0 z-50 flex items-center gap-2 py-1.5 px-3 bg-surface border-b border-l border-muted rounded-bl-lg shadow-md">
+    <div className="fixed top-[3.5rem] right-0 z-50 flex items-center gap-hsp-sm py-hsp-xs px-hsp-md bg-surface border-b border-l border-muted rounded-bl-lg shadow-md">
       <input
         ref={inputRef}
-        className="w-48 py-1 px-2 rounded text-small bg-bg border border-muted text-fg outline-none focus:border-accent"
+        className="w-48 py-[4px] px-hsp-sm rounded text-small bg-bg border border-muted text-fg outline-none focus:border-accent"
         type="text"
         value={query}
         placeholder="Find in page..."
@@ -76,7 +76,7 @@ export function FindBar({ visible, onClose, findInPage, containerSelector }: Fin
       </span>
       <button
         type="button"
-        className="py-0.5 px-2 rounded text-caption bg-bg border border-muted text-fg hover:bg-surface"
+        className="py-hsp-2xs px-hsp-sm rounded text-caption bg-bg border border-muted text-fg hover:bg-surface"
         onClick={() => {
           const result = findInPage.prev();
           setMatchInfo(toMatchInfo(result));
@@ -87,7 +87,7 @@ export function FindBar({ visible, onClose, findInPage, containerSelector }: Fin
       </button>
       <button
         type="button"
-        className="py-0.5 px-2 rounded text-caption bg-bg border border-muted text-fg hover:bg-surface"
+        className="py-hsp-2xs px-hsp-sm rounded text-caption bg-bg border border-muted text-fg hover:bg-surface"
         onClick={() => {
           const result = findInPage.next();
           setMatchInfo(toMatchInfo(result));
@@ -98,7 +98,7 @@ export function FindBar({ visible, onClose, findInPage, containerSelector }: Fin
       </button>
       <button
         type="button"
-        className="py-0.5 px-2 rounded text-caption bg-bg border border-muted text-fg hover:bg-surface"
+        className="py-hsp-2xs px-hsp-sm rounded text-caption bg-bg border border-muted text-fg hover:bg-surface"
         onClick={onClose}
         title="Close (Esc)"
       >

--- a/packages/create-zudo-doc/templates/features/versioning/files/src/pages/v/[version]/docs/[...slug].astro
+++ b/packages/create-zudo-doc/templates/features/versioning/files/src/pages/v/[version]/docs/[...slug].astro
@@ -14,6 +14,7 @@ import Tabs from "@/components/tabs.astro";
 import TabItem from "@/components/tab-item.astro";
 import Details from "@/components/details.astro";
 import HtmlPreview from "@/components/html-preview-wrapper.astro";
+import { htmlOverrides } from "@/components/content/component-map";
 import Breadcrumb from "@/components/breadcrumb.astro";
 import { toRouteSlug } from "@/utils/slug";
 import {
@@ -131,6 +132,7 @@ const { entry, version, breadcrumbs = [], prev, next, autoIndex } = Astro.props;
 const versionConfig = version as VersionConfig;
 
 const components = {
+  ...htmlOverrides,
   Note,
   Tip,
   Info,

--- a/packages/create-zudo-doc/templates/features/versioning/files/src/pages/v/[version]/ja/docs/[...slug].astro
+++ b/packages/create-zudo-doc/templates/features/versioning/files/src/pages/v/[version]/ja/docs/[...slug].astro
@@ -14,6 +14,7 @@ import Tabs from "@/components/tabs.astro";
 import TabItem from "@/components/tab-item.astro";
 import Details from "@/components/details.astro";
 import HtmlPreview from "@/components/html-preview-wrapper.astro";
+import { htmlOverrides } from "@/components/content/component-map";
 import Breadcrumb from "@/components/breadcrumb.astro";
 import { toRouteSlug } from "@/utils/slug";
 import {
@@ -187,6 +188,7 @@ const {
 const versionConfig = version as VersionConfig;
 
 const components = {
+  ...htmlOverrides,
   Note,
   Tip,
   Info,

--- a/scripts/check-template-drift.sh
+++ b/scripts/check-template-drift.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if ((BASH_VERSINFO[0] < 4)); then
+  echo "Error: bash 4+ is required (found bash $BASH_VERSION)." >&2
+  echo "On macOS, install via: brew install bash" >&2
+  exit 1
+fi
+
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 ALLOWLIST="$ROOT_DIR/.template-drift-allowlist"
 
@@ -49,7 +55,7 @@ BASE_DIR="$ROOT_DIR/packages/create-zudo-doc/templates/base"
 while IFS= read -r -d '' template_file; do
   prod_path="${template_file#"$BASE_DIR/"}"
   check_pair "$template_file" "$prod_path"
-done < <(find "$BASE_DIR" -type f -print0)
+done < <(find "$BASE_DIR" -type f -print0 | sort -z)
 
 echo "Checking feature template files..."
 
@@ -62,7 +68,7 @@ for feature_dir in "$FEATURES_DIR"/*/; do
   while IFS= read -r -d '' template_file; do
     prod_path="${template_file#"$files_dir/"}"
     check_pair "$template_file" "$prod_path"
-  done < <(find "$files_dir" -type f -print0)
+  done < <(find "$files_dir" -type f -print0 | sort -z)
 done
 
 echo ""

--- a/scripts/check-template-drift.sh
+++ b/scripts/check-template-drift.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+ALLOWLIST="$ROOT_DIR/.template-drift-allowlist"
+
+# Load allowlist into an associative array
+declare -A ALLOWED
+if [[ -f "$ALLOWLIST" ]]; then
+  while IFS= read -r line; do
+    # Skip blank lines and comments
+    [[ -z "$line" || "$line" == \#* ]] && continue
+    ALLOWED["$line"]=1
+  done < "$ALLOWLIST"
+fi
+
+DRIFTED=()
+
+check_pair() {
+  local template_file="$1"
+  local prod_path="$2" # relative to repo root
+
+  # Skip if in allowlist
+  if [[ -n "${ALLOWED[$prod_path]+_}" ]]; then
+    return
+  fi
+
+  local prod_file="$ROOT_DIR/$prod_path"
+
+  if [[ ! -f "$prod_file" ]]; then
+    echo "  [MISSING IN PROD] $prod_path"
+    DRIFTED+=("$prod_path")
+    return
+  fi
+
+  diff -q "$template_file" "$prod_file" >/dev/null 2>&1 && diff_exit=0 || diff_exit=$?
+  if [[ $diff_exit -eq 1 ]]; then
+    echo "  [DIFF] $prod_path"
+    DRIFTED+=("$prod_path")
+  elif [[ $diff_exit -ne 0 ]]; then
+    echo "  [ERROR] diff failed (exit $diff_exit) for $prod_path" >&2
+    DRIFTED+=("$prod_path")
+  fi
+}
+
+echo "Checking base template files..."
+
+BASE_DIR="$ROOT_DIR/packages/create-zudo-doc/templates/base"
+while IFS= read -r -d '' template_file; do
+  prod_path="${template_file#"$BASE_DIR/"}"
+  check_pair "$template_file" "$prod_path"
+done < <(find "$BASE_DIR" -type f -print0)
+
+echo "Checking feature template files..."
+
+FEATURES_DIR="$ROOT_DIR/packages/create-zudo-doc/templates/features"
+for feature_dir in "$FEATURES_DIR"/*/; do
+  files_dir="${feature_dir}files"
+  if [[ ! -d "$files_dir" ]]; then
+    continue
+  fi
+  while IFS= read -r -d '' template_file; do
+    prod_path="${template_file#"$files_dir/"}"
+    check_pair "$template_file" "$prod_path"
+  done < <(find "$files_dir" -type f -print0)
+done
+
+echo ""
+if [[ ${#DRIFTED[@]} -eq 0 ]]; then
+  echo "✅ No template drift detected."
+  exit 0
+else
+  echo "❌ ${#DRIFTED[@]} file(s) have unexpected drift:"
+  for f in "${DRIFTED[@]}"; do
+    echo "   - $f"
+  done
+  exit 1
+fi

--- a/scripts/run-b4push.sh
+++ b/scripts/run-b4push.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 START_TIME=$(date +%s)
 FAILURES=()
-TOTAL_STEPS=6
+TOTAL_STEPS=7
 CURRENT_STEP=0
 
 step() {
@@ -27,7 +27,15 @@ else
   fail "Format check"
 fi
 
-# ── Step 2: Design token lint ───────────────────────
+# ── Step 2: Template drift check ─────────────────────
+step "Template drift check"
+if (cd "$ROOT_DIR" && bash scripts/check-template-drift.sh); then
+  pass "Template drift check passed"
+else
+  fail "Template drift check"
+fi
+
+# ── Step 3: Design token lint ───────────────────────
 step "Design token lint"
 if (cd "$ROOT_DIR" && pnpm lint:tokens); then
   pass "Design token lint passed"
@@ -35,7 +43,7 @@ else
   fail "Design token lint"
 fi
 
-# ── Step 3: Type checking ────────────────────────────
+# ── Step 4: Type checking ────────────────────────────
 step "Type checking (astro check)"
 if (cd "$ROOT_DIR" && pnpm check); then
   pass "Type checking passed"
@@ -43,7 +51,7 @@ else
   fail "Type checking"
 fi
 
-# ── Step 4: Build ────────────────────────────────────
+# ── Step 5: Build ────────────────────────────────────
 step "Build (astro build)"
 if (cd "$ROOT_DIR" && pnpm build); then
   pass "Build passed"
@@ -51,7 +59,7 @@ else
   fail "Build"
 fi
 
-# ── Step 5: Link check ────────────────────────────────
+# ── Step 6: Link check ────────────────────────────────
 step "Link check (check-links)"
 if (cd "$ROOT_DIR" && pnpm run check:links); then
   pass "Link check passed"
@@ -59,7 +67,7 @@ else
   fail "Link check"
 fi
 
-# ── Step 6: E2E & smoke tests ────────────────────────
+# ── Step 7: E2E & smoke tests ────────────────────────
 step "E2E & smoke tests (playwright)"
 if (cd "$ROOT_DIR" && pnpm test:e2e); then
   pass "E2E & smoke tests passed"


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/258

---

## Summary

- Add automated template drift detection (`check-template-drift.sh`) that compares `create-zudo-doc` template files against production counterparts
- Sync 24 drifted template files (17 base + 7 feature) covering icon tokens, overlay colors, content components, design tokens, and spacing
- Enforce drift checks in CI (`pr-checks.yml`) and local pre-push validation (`b4push`)
- Update documentation and `/l-update-generator` skill with drift guard references

## Changes

### Drift detection script
- `scripts/check-template-drift.sh` — compares base and feature template files against production, reports diffs, respects allowlist
- `.template-drift-allowlist` — lists intentionally-different files (plugin re-exports, slot-based files, template-only utilities)
- `package.json` — added `check:template-drift` script
- Includes bash 4+ version guard for macOS compatibility and deterministic output ordering

### CI and pre-push enforcement
- `.github/workflows/pr-checks.yml` — new `Template Drift Check` job (lightweight, no pnpm install)
- `scripts/run-b4push.sh` — added drift check as Step 2 (7 total steps)

### Base template sync (17 items)
- Icon sizing: migrated `h-[Xrem] w-[Xrem]` → `h-icon-* w-icon-*` tokens across 6 components
- Overlay colors: migrated `rgba(0,0,0,...)` → `bg-overlay/*` and `color-mix()` in 2 components
- Component improvements: admonition spacing, sidebar-tree padding, TOC scrollability, docs.ts cache key
- Content component overrides: added `htmlOverrides` to `[...slug].astro` + 11 new content component files
- Design tokens: icon sizes, Tier 1 font-size scale, overlay color, flow spacing in `global.css`
- Color scheme: chat semantic tokens in `color-scheme-utils.ts` and `color-schemes.ts`
- Misc: `vendor` exclude in `tsconfig.json`

### Feature template sync (7 items)
- Icon tokens in `doc-history.tsx`, `desktop-sidebar-toggle.tsx`
- Overlay color in `search.astro`
- `htmlOverrides` in 3 versioning/i18n slug pages
- Spacing tokens in `find-bar.tsx`

### Documentation
- `CLAUDE.md` — updated b4push description, added incremental improvement note to Feature Change Checklist
- `.claude/skills/l-update-generator/SKILL.md` — added drift check references and allowlist guidance

## Test Plan
- [ ] `pnpm check:template-drift` passes (0 drift detected)
- [ ] CI `Template Drift Check` job passes
- [ ] `pnpm b4push` runs drift check as step 2
- [ ] `cd packages/create-zudo-doc && pnpm build && pnpm test` passes
- [ ] Full CI pipeline passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)