### PR TITLE
feat: T5a — shared ImageEnlarge dialog + click-to-open

### DIFF
--- a/src/components/image-enlarge.tsx
+++ b/src/components/image-enlarge.tsx
@@ -1,0 +1,123 @@
+import { useState, useEffect, useRef } from "react";
+
+interface ImageData {
+  src: string;
+  currentSrc: string;
+  srcset?: string;
+  sizes?: string;
+  alt: string;
+  naturalWidth: number;
+  naturalHeight: number;
+}
+
+export default function ImageEnlarge() {
+  const [imgData, setImgData] = useState<ImageData | null>(null);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  // Delegated click handler — T5b will add eligibility checks here before setImgData
+  useEffect(() => {
+    function handleDocumentClick(e: MouseEvent) {
+      const target = e.target as Element;
+      const btn = target.closest(".zd-enlarge-btn");
+      if (!btn) return;
+      const container = btn.closest(".zd-enlargeable");
+      if (!container) return;
+      const img = container.querySelector("img") as HTMLImageElement | null;
+      if (!img) return;
+      setImgData({
+        src: img.src,
+        currentSrc: img.currentSrc,
+        srcset: img.srcset || undefined,
+        sizes: img.sizes || undefined,
+        alt: img.alt,
+        naturalWidth: img.naturalWidth,
+        naturalHeight: img.naturalHeight,
+      });
+    }
+    document.addEventListener("click", handleDocumentClick);
+    return () => document.removeEventListener("click", handleDocumentClick);
+  }, []);
+
+  // Open dialog when imgData is set
+  useEffect(() => {
+    if (!imgData) return;
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    dialog.showModal();
+  }, [imgData]);
+
+  // Handle cancel event (ESC key)
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    function handleCancel() {
+      setImgData(null);
+    }
+    dialog.addEventListener("cancel", handleCancel);
+    return () => dialog.removeEventListener("cancel", handleCancel);
+  }, []);
+
+  // Reset state when dialog closes
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    function handleClose() {
+      setImgData(null);
+    }
+    dialog.addEventListener("close", handleClose);
+    return () => dialog.removeEventListener("close", handleClose);
+  }, []);
+
+  // Close and reset on ClientRouter navigation
+  useEffect(() => {
+    function handleAfterSwap() {
+      const dialog = dialogRef.current;
+      if (dialog?.open) dialog.close();
+      setImgData(null);
+    }
+    document.addEventListener("astro:after-swap", handleAfterSwap);
+    return () => document.removeEventListener("astro:after-swap", handleAfterSwap);
+  }, []);
+
+  function handleBackdropClick(e: React.MouseEvent) {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    const rect = dialog.getBoundingClientRect();
+    if (
+      e.clientX < rect.left ||
+      e.clientX > rect.right ||
+      e.clientY < rect.top ||
+      e.clientY > rect.bottom
+    ) {
+      dialog.close();
+    }
+  }
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onClick={handleBackdropClick}
+      className="zd-enlarge-dialog mx-auto max-h-[90vh] max-w-[90vw] overflow-hidden border border-muted bg-surface p-0"
+      style={{ position: "fixed", top: "50%", left: "50%", transform: "translate(-50%, -50%)" }}
+    >
+      {imgData && (
+        <div className="relative">
+          <img
+            src={imgData.currentSrc || imgData.src}
+            srcSet={imgData.srcset}
+            sizes={imgData.sizes}
+            alt={imgData.alt}
+            className="block max-h-[85vh] max-w-[85vw] object-contain"
+          />
+          <button
+            onClick={() => dialogRef.current?.close()}
+            className="absolute right-0 top-0 border border-muted bg-surface px-hsp-lg py-vsp-2xs text-small text-muted transition-colors hover:border-fg hover:text-fg"
+            aria-label="Close enlarged image"
+          >
+            ×
+          </button>
+        </div>
+      )}
+    </dialog>
+  );
+}

--- a/src/components/image-enlarge.tsx
+++ b/src/components/image-enlarge.tsx
@@ -105,7 +105,7 @@ export default function ImageEnlarge() {
           <img
             src={imgData.currentSrc || imgData.src}
             srcSet={imgData.srcset}
-            sizes={imgData.sizes}
+            sizes={imgData.srcset ? "100vw" : undefined}
             alt={imgData.alt}
             className="block max-h-[85vh] max-w-[85vw] object-contain"
           />

--- a/src/layouts/doc-layout.astro
+++ b/src/layouts/doc-layout.astro
@@ -26,6 +26,7 @@ import AiChatModal from "@/components/ai-chat-modal";
 import MockInit from "@/components/mock-init";
 import DesktopSidebarToggle from "@/components/desktop-sidebar-toggle";
 import FindInPageInit from "@/components/find-in-page-init";
+import ImageEnlarge from "@/components/image-enlarge";
 import { SEMANTIC_DEFAULTS, SEMANTIC_CSS_NAMES } from "@/config/color-scheme-utils";
 
 interface Props {
@@ -224,6 +225,7 @@ const contentTransition = {
     </div>
     {settings.aiAssistant && <AiChatModal basePath={withBase("/")} client:load />}
     {settings.colorTweakPanel && <ColorTweakPanel client:only="preact" />}
+    <ImageEnlarge client:load />
     <CodeBlockEnhancer />
     <TabsInit />
     {settings.mermaid && <MermaidInit />}


### PR DESCRIPTION
## Summary

- Creates `src/components/image-enlarge.tsx` — Preact island with one shared `<dialog>` per page
- Delegated click handler on `document` targets `.zd-enlarge-btn` → finds sibling `<img>` in `.zd-enlargeable` → captures image data → calls `showModal()`
- Dialog: enlarged `<img>` with `currentSrc || src`, `srcset`, `sizes="100vw"`, preserved `alt`; close button; backdrop click and ESC (cancel event) both close; `astro:after-swap` resets state on navigation
- Mounts in `doc-layout.astro` with `client:load`; T1 settings gate can wrap it once `imageEnlarge` setting is merged
- Clear extension point comment in click handler for T5b eligibility detection

## Test plan

- [ ] Verify `pnpm check` passes (no TypeScript errors)
- [ ] Confirm exactly one `<dialog class="zd-enlarge-dialog ...">` in rendered HTML
- [ ] Once T2 adds `.zd-enlarge-btn` markup, clicking it opens dialog with correct image
- [ ] ESC key closes dialog
- [ ] Backdrop click closes dialog
- [ ] Navigating with ClientRouter resets dialog state (no stale open dialog)
- [ ] No listener leaks on component unmount

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)