### PR TITLE
image-enlarge: two-layer overlay buttons + theme tokens

### DIFF
--- a/e2e/smoke-image-enlarge.spec.ts
+++ b/e2e/smoke-image-enlarge.spec.ts
@@ -206,6 +206,68 @@ test.describe("Image Enlarge: browser behavior @local-only", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Level 4: Two-layer CSS sanity (non-@local-only — runs in CI)
+// ---------------------------------------------------------------------------
+
+// The smoke fixture's CSS is not bundled as a static asset (it lives in the
+// SSR entry). This helper injects the button token bridge and component CSS
+// that mirrors global.css so getComputedStyle resolves correctly.
+async function applyEnlargeButtonCss(page: Page) {
+  await page.addStyleTag({
+    content: `
+      :root {
+        --color-image-overlay-bg: var(--zd-image-overlay-bg);
+        --color-image-overlay-fg: var(--zd-image-overlay-fg);
+      }
+      .zd-enlarge-btn { background: transparent; }
+      .zd-enlarge-btn::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: color-mix(in oklch, var(--color-image-overlay-bg) 80%, transparent);
+      }
+      .zd-enlarge-btn > svg { color: var(--color-image-overlay-fg); }
+    `,
+  });
+}
+
+test.describe("Image Enlarge: two-layer button CSS", () => {
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test("enlarge button ::before has non-transparent background; svg color is set; button bg is transparent", async ({
+    page,
+  }) => {
+    await page.goto(PAGE, { waitUntil: "networkidle" });
+    await applyEnlargeButtonCss(page);
+    await applyImageConstraints(page);
+
+    const figure = page.locator("figure.zd-enlargeable").first();
+    const btn = figure.locator(".zd-enlarge-btn");
+    await expect(btn).toBeVisible({ timeout: 3000 });
+
+    // ::before background should be non-transparent (image-overlay-bg token via color-mix)
+    const beforeBg = await btn.evaluate((el) =>
+      getComputedStyle(el, "::before").backgroundColor,
+    );
+    expect(beforeBg).toBeTruthy();
+    expect(beforeBg).not.toBe("rgba(0, 0, 0, 0)");
+    expect(beforeBg).not.toBe("transparent");
+
+    // SVG color should be the image-overlay-fg token value (not the UA-inherited black)
+    const svgColor = await btn.evaluate((el) => {
+      const svg = el.querySelector("svg");
+      return svg ? getComputedStyle(svg).color : "";
+    });
+    expect(svgColor).toBeTruthy();
+    expect(svgColor).not.toBe("rgb(0, 0, 0)");
+
+    // Button's own background should be transparent (background lives on ::before)
+    const btnBg = await btn.evaluate((el) => getComputedStyle(el).backgroundColor);
+    expect(btnBg).toBe("rgba(0, 0, 0, 0)");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Level 4: No-JS assertions
 // ---------------------------------------------------------------------------
 

--- a/packages/create-zudo-doc/src/features/image-enlarge.ts
+++ b/packages/create-zudo-doc/src/features/image-enlarge.ts
@@ -50,6 +50,7 @@ dialog.zd-enlarge-dialog::backdrop {
 }
 
 .zd-enlarge-dialog-close {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -60,6 +61,10 @@ dialog.zd-enlarge-dialog::backdrop {
   cursor: pointer;
   z-index: 1;
   transition: opacity var(--default-transition-duration);
+}
+
+.zd-enlarge-dialog-close:hover {
+  opacity: 0.8;
 }
 
 .zd-enlarge-dialog-close::before {

--- a/packages/create-zudo-doc/src/features/image-enlarge.ts
+++ b/packages/create-zudo-doc/src/features/image-enlarge.ts
@@ -47,6 +47,37 @@ export const imageEnlargeFeature: FeatureModule = () => ({
 
 dialog.zd-enlarge-dialog::backdrop {
   background: color-mix(in oklch, var(--color-overlay) 80%, transparent);
+}
+
+.zd-enlarge-dialog-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-vsp-xs) var(--spacing-hsp-sm);
+  border: none;
+  border-radius: var(--radius-DEFAULT);
+  background: transparent;
+  cursor: pointer;
+  z-index: 1;
+  transition: opacity var(--default-transition-duration);
+}
+
+.zd-enlarge-dialog-close::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: color-mix(in oklch, var(--color-image-overlay-bg) 80%, transparent);
+  z-index: 0;
+}
+
+.zd-enlarge-dialog-close > svg {
+  position: relative;
+  z-index: 1;
+  width: var(--spacing-icon-md);
+  height: var(--spacing-icon-md);
+  color: var(--color-image-overlay-fg);
+  fill: currentColor;
 }`,
       position: "after",
     },

--- a/packages/create-zudo-doc/src/features/image-enlarge.ts
+++ b/packages/create-zudo-doc/src/features/image-enlarge.ts
@@ -56,6 +56,10 @@ export const imageEnlargeFeature: FeatureModule = () => ({
   fill: currentColor;
 }
 
+.zd-enlarge-btn:hover {
+  opacity: 0.8;
+}
+
 .zd-enlarge-btn[hidden] {
   display: none !important;
 }
@@ -65,7 +69,6 @@ dialog.zd-enlarge-dialog::backdrop {
 }
 
 .zd-enlarge-dialog-close {
-  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/create-zudo-doc/src/features/image-enlarge.ts
+++ b/packages/create-zudo-doc/src/features/image-enlarge.ts
@@ -26,19 +26,34 @@ export const imageEnlargeFeature: FeatureModule = () => ({
   position: absolute;
   top: var(--spacing-vsp-xs);
   right: var(--spacing-hsp-xs);
-  width: var(--spacing-icon-sm);
-  height: var(--spacing-icon-sm);
-  padding: 0;
-  border: none;
-  border-radius: var(--radius-DEFAULT);
-  background: color-mix(in oklch, var(--color-overlay) 80%, transparent);
-  color: var(--color-bg);
-  cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: var(--spacing-vsp-2xs) var(--spacing-hsp-sm);
+  border: none;
+  border-radius: var(--radius-DEFAULT);
+  background: transparent;
+  cursor: pointer;
   z-index: 1;
   transition: opacity var(--default-transition-duration);
+}
+
+.zd-enlarge-btn::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: color-mix(in oklch, var(--color-image-overlay-bg) 80%, transparent);
+  z-index: 0;
+}
+
+.zd-enlarge-btn > svg {
+  position: relative;
+  z-index: 1;
+  width: var(--spacing-icon-sm);
+  height: var(--spacing-icon-sm);
+  color: var(--color-image-overlay-fg);
+  fill: currentColor;
 }
 
 .zd-enlarge-btn[hidden] {

--- a/packages/create-zudo-doc/templates/base/src/config/color-scheme-utils.ts
+++ b/packages/create-zudo-doc/templates/base/src/config/color-scheme-utils.ts
@@ -22,6 +22,8 @@ export const SEMANTIC_DEFAULTS: Record<string, number> = {
   chatUserText: 9,
   chatAssistantBg: 9,
   chatAssistantText: 11,
+  imageOverlayBg: 0,
+  imageOverlayFg: 11,
 };
 
 export const SEMANTIC_CSS_NAMES: Record<string, string> = {
@@ -44,6 +46,8 @@ export const SEMANTIC_CSS_NAMES: Record<string, string> = {
   chatUserText: "--zd-chat-user-text",
   chatAssistantBg: "--zd-chat-assistant-bg",
   chatAssistantText: "--zd-chat-assistant-text",
+  imageOverlayBg: "--zd-image-overlay-bg",
+  imageOverlayFg: "--zd-image-overlay-fg",
 };
 
 export const lightDarkPairings = [
@@ -95,6 +99,8 @@ export function resolveSemanticColors(scheme: ColorScheme) {
     chatUserText: resolveColor(scheme.semantic?.chatUserText, p, p[9]),
     chatAssistantBg: resolveColor(scheme.semantic?.chatAssistantBg, p, p[9]),
     chatAssistantText: resolveColor(scheme.semantic?.chatAssistantText, p, p[11]),
+    imageOverlayBg: resolveColor(scheme.semantic?.imageOverlayBg, p, p[0]),
+    imageOverlayFg: resolveColor(scheme.semantic?.imageOverlayFg, p, p[11]),
   };
 }
 
@@ -127,6 +133,8 @@ export function schemeToCssPairs(scheme: ColorScheme): [string, string][] {
     ["--zd-chat-user-text", sem.chatUserText],
     ["--zd-chat-assistant-bg", sem.chatAssistantBg],
     ["--zd-chat-assistant-text", sem.chatAssistantText],
+    ["--zd-image-overlay-bg", sem.imageOverlayBg],
+    ["--zd-image-overlay-fg", sem.imageOverlayFg],
   ];
 }
 

--- a/packages/create-zudo-doc/templates/base/src/config/color-schemes.ts
+++ b/packages/create-zudo-doc/templates/base/src/config/color-schemes.ts
@@ -36,6 +36,9 @@ export interface ColorScheme {
     chatUserText?: ColorRef;
     chatAssistantBg?: ColorRef;
     chatAssistantText?: ColorRef;
+    /** UI chrome over user images — enlarge/close overlay buttons */
+    imageOverlayBg?: ColorRef;
+    imageOverlayFg?: ColorRef;
   };
 }
 
@@ -86,6 +89,8 @@ export const colorSchemes: Record<string, ColorScheme> = {
       danger: 1,
       warning: 3,
       info: 4,
+      imageOverlayBg: 11,
+      imageOverlayFg: 10,
     },
   },
   "Default Dark": {
@@ -112,6 +117,8 @@ export const colorSchemes: Record<string, ColorScheme> = {
       danger: 1,
       warning: 3,
       info: 4,
+      imageOverlayBg: 0,
+      imageOverlayFg: 11,
     },
   },
 };

--- a/packages/create-zudo-doc/templates/base/src/plugins/rehype-image-enlarge.ts
+++ b/packages/create-zudo-doc/templates/base/src/plugins/rehype-image-enlarge.ts
@@ -26,40 +26,46 @@ function makeEnlargeButton(): Element {
         type: "element",
         tagName: "svg",
         properties: {
-          width: "16",
-          height: "16",
-          viewBox: "0 0 24 24",
-          fill: "none",
-          stroke: "currentColor",
-          strokeWidth: "2",
-          strokeLinecap: "round",
-          strokeLinejoin: "round",
+          viewBox: "0 0 38.99 38.99",
+          fill: "currentColor",
           focusable: false,
           ariaHidden: true,
         },
         children: [
           {
             type: "element",
-            tagName: "polyline",
-            properties: { points: "15 3 21 3 21 9" },
+            tagName: "polygon",
+            properties: {
+              points:
+                "16.2 13.74 5.92 3.47 11.2 3.47 11.2 0 3.47 0 0 0 0 3.47 0 11.2 3.47 11.2 3.47 5.92 13.74 16.2 16.2 13.74",
+            },
             children: [],
           },
           {
             type: "element",
-            tagName: "polyline",
-            properties: { points: "9 21 3 21 3 15" },
+            tagName: "polygon",
+            properties: {
+              points:
+                "25.24 16.2 35.52 5.92 35.52 11.2 38.99 11.2 38.99 3.47 38.99 0 35.52 0 27.79 0 27.79 3.47 33.07 3.47 22.79 13.74 25.24 16.2",
+            },
             children: [],
           },
           {
             type: "element",
-            tagName: "line",
-            properties: { x1: "21", y1: "3", x2: "14", y2: "10" },
+            tagName: "polygon",
+            properties: {
+              points:
+                "22.79 25.24 33.07 35.52 27.79 35.52 27.79 38.99 35.52 38.99 38.99 38.99 38.99 35.52 38.99 27.79 35.52 27.79 35.52 33.07 25.24 22.79 22.79 25.24",
+            },
             children: [],
           },
           {
             type: "element",
-            tagName: "line",
-            properties: { x1: "3", y1: "21", x2: "10", y2: "14" },
+            tagName: "polygon",
+            properties: {
+              points:
+                "13.74 22.79 3.47 33.07 3.47 27.79 0 27.79 0 35.52 0 38.99 3.47 38.99 11.2 38.99 11.2 35.52 5.92 35.52 16.2 25.24 13.74 22.79",
+            },
             children: [],
           },
         ],

--- a/packages/create-zudo-doc/templates/base/src/plugins/rehype-image-enlarge.ts
+++ b/packages/create-zudo-doc/templates/base/src/plugins/rehype-image-enlarge.ts
@@ -28,7 +28,7 @@ function makeEnlargeButton(): Element {
         properties: {
           viewBox: "0 0 38.99 38.99",
           fill: "currentColor",
-          focusable: false,
+          focusable: "false",
           ariaHidden: true,
         },
         children: [

--- a/packages/create-zudo-doc/templates/base/src/styles/global.css
+++ b/packages/create-zudo-doc/templates/base/src/styles/global.css
@@ -63,6 +63,8 @@
   --color-info: var(--zd-info);
   /* Overlay is intentionally theme-independent (always dark, not scheme-driven) */
   --color-overlay: #000;
+  --color-image-overlay-bg: var(--zd-image-overlay-bg);
+  --color-image-overlay-fg: var(--zd-image-overlay-fg);
   --color-mermaid-node-bg: var(--zd-mermaid-node-bg);
   --color-mermaid-text: var(--zd-mermaid-text);
   --color-mermaid-line: var(--zd-mermaid-line);

--- a/packages/create-zudo-doc/templates/features/imageEnlarge/files/src/components/image-enlarge.tsx
+++ b/packages/create-zudo-doc/templates/features/imageEnlarge/files/src/components/image-enlarge.tsx
@@ -199,7 +199,7 @@ export default function ImageEnlarge() {
             className="zd-enlarge-dialog-close absolute right-0 top-0"
             aria-label="Close enlarged image"
           >
-            <svg viewBox="0 0 161.03 161.03" fill="currentColor" aria-hidden="true" focusable={false}>
+            <svg viewBox="0 0 161.03 161.03" fill="currentColor" aria-hidden="true" focusable="false">
               <polygon points="161.03 10.27 150.76 0 80.51 70.24 10.27 0 0 10.27 70.24 80.51 0 150.76 10.27 161.03 80.51 90.78 150.76 161.03 161.03 150.76 90.78 80.51 161.03 10.27" />
             </svg>
           </button>

--- a/packages/create-zudo-doc/templates/features/imageEnlarge/files/src/components/image-enlarge.tsx
+++ b/packages/create-zudo-doc/templates/features/imageEnlarge/files/src/components/image-enlarge.tsx
@@ -194,11 +194,14 @@ export default function ImageEnlarge() {
             className="block max-h-[85vh] max-w-[85vw] object-contain"
           />
           <button
+            type="button"
             onClick={() => dialogRef.current?.close()}
-            className="absolute right-0 top-0 border border-muted bg-surface px-hsp-lg py-vsp-2xs text-small text-muted transition-colors hover:border-fg hover:text-fg"
+            className="zd-enlarge-dialog-close absolute right-0 top-0"
             aria-label="Close enlarged image"
           >
-            ×
+            <svg viewBox="0 0 161.03 161.03" fill="currentColor" aria-hidden="true" focusable={false}>
+              <polygon points="161.03 10.27 150.76 0 80.51 70.24 10.27 0 0 10.27 70.24 80.51 0 150.76 10.27 161.03 80.51 90.78 150.76 161.03 161.03 150.76 90.78 80.51 161.03 10.27" />
+            </svg>
           </button>
         </div>
       )}

--- a/packages/md-plugins/src/__tests__/rehype-image-enlarge.test.ts
+++ b/packages/md-plugins/src/__tests__/rehype-image-enlarge.test.ts
@@ -184,7 +184,7 @@ describe("rehypeImageEnlarge", () => {
     expect(resultImg.properties?.dataFoo).toBe("bar");
   });
 
-  it("Button shape: type='button', hidden, aria-label, SVG child present", () => {
+  it("Button shape: type='button', hidden, aria-label, SVG with polygon children", () => {
     const img = makeImg();
     const tree = makeTree(makeP(img));
     runPlugin(tree);
@@ -198,6 +198,11 @@ describe("rehypeImageEnlarge", () => {
       (c) => (c as Element).tagName === "svg",
     ) as Element;
     expect(svg).toBeDefined();
-    expect(svg.children.length).toBeGreaterThan(0);
+    expect(svg.properties?.viewBox).toBe("0 0 38.99 38.99");
+    expect(svg.properties?.fill).toBe("currentColor");
+    const hasPolygon = svg.children.some(
+      (c) => (c as Element).tagName === "polygon",
+    );
+    expect(hasPolygon).toBe(true);
   });
 });

--- a/packages/md-plugins/src/__tests__/rehype-image-enlarge.test.ts
+++ b/packages/md-plugins/src/__tests__/rehype-image-enlarge.test.ts
@@ -200,9 +200,10 @@ describe("rehypeImageEnlarge", () => {
     expect(svg).toBeDefined();
     expect(svg.properties?.viewBox).toBe("0 0 38.99 38.99");
     expect(svg.properties?.fill).toBe("currentColor");
-    const hasPolygon = svg.children.some(
+    expect(svg.properties?.focusable).toBe("false");
+    const polygons = svg.children.filter(
       (c) => (c as Element).tagName === "polygon",
     );
-    expect(hasPolygon).toBe(true);
+    expect(polygons).toHaveLength(4);
   });
 });

--- a/packages/md-plugins/src/rehype-image-enlarge.ts
+++ b/packages/md-plugins/src/rehype-image-enlarge.ts
@@ -26,40 +26,46 @@ function makeEnlargeButton(): Element {
         type: "element",
         tagName: "svg",
         properties: {
-          width: "16",
-          height: "16",
-          viewBox: "0 0 24 24",
-          fill: "none",
-          stroke: "currentColor",
-          strokeWidth: "2",
-          strokeLinecap: "round",
-          strokeLinejoin: "round",
+          viewBox: "0 0 38.99 38.99",
+          fill: "currentColor",
           focusable: false,
           ariaHidden: true,
         },
         children: [
           {
             type: "element",
-            tagName: "polyline",
-            properties: { points: "15 3 21 3 21 9" },
+            tagName: "polygon",
+            properties: {
+              points:
+                "16.2 13.74 5.92 3.47 11.2 3.47 11.2 0 3.47 0 0 0 0 3.47 0 11.2 3.47 11.2 3.47 5.92 13.74 16.2 16.2 13.74",
+            },
             children: [],
           },
           {
             type: "element",
-            tagName: "polyline",
-            properties: { points: "9 21 3 21 3 15" },
+            tagName: "polygon",
+            properties: {
+              points:
+                "25.24 16.2 35.52 5.92 35.52 11.2 38.99 11.2 38.99 3.47 38.99 0 35.52 0 27.79 0 27.79 3.47 33.07 3.47 22.79 13.74 25.24 16.2",
+            },
             children: [],
           },
           {
             type: "element",
-            tagName: "line",
-            properties: { x1: "21", y1: "3", x2: "14", y2: "10" },
+            tagName: "polygon",
+            properties: {
+              points:
+                "22.79 25.24 33.07 35.52 27.79 35.52 27.79 38.99 35.52 38.99 38.99 38.99 38.99 35.52 38.99 27.79 35.52 27.79 35.52 33.07 25.24 22.79 22.79 25.24",
+            },
             children: [],
           },
           {
             type: "element",
-            tagName: "line",
-            properties: { x1: "3", y1: "21", x2: "10", y2: "14" },
+            tagName: "polygon",
+            properties: {
+              points:
+                "13.74 22.79 3.47 33.07 3.47 27.79 0 27.79 0 35.52 0 38.99 3.47 38.99 11.2 38.99 11.2 35.52 5.92 35.52 16.2 25.24 13.74 22.79",
+            },
             children: [],
           },
         ],

--- a/packages/md-plugins/src/rehype-image-enlarge.ts
+++ b/packages/md-plugins/src/rehype-image-enlarge.ts
@@ -28,7 +28,7 @@ function makeEnlargeButton(): Element {
         properties: {
           viewBox: "0 0 38.99 38.99",
           fill: "currentColor",
-          focusable: false,
+          focusable: "false",
           ariaHidden: true,
         },
         children: [

--- a/src/components/image-enlarge.tsx
+++ b/src/components/image-enlarge.tsx
@@ -199,7 +199,7 @@ export default function ImageEnlarge() {
             className="zd-enlarge-dialog-close absolute right-0 top-0"
             aria-label="Close enlarged image"
           >
-            <svg viewBox="0 0 161.03 161.03" fill="currentColor" aria-hidden="true" focusable={false}>
+            <svg viewBox="0 0 161.03 161.03" fill="currentColor" aria-hidden="true" focusable="false">
               <polygon points="161.03 10.27 150.76 0 80.51 70.24 10.27 0 0 10.27 70.24 80.51 0 150.76 10.27 161.03 80.51 90.78 150.76 161.03 161.03 150.76 90.78 80.51 161.03 10.27" />
             </svg>
           </button>

--- a/src/components/image-enlarge.tsx
+++ b/src/components/image-enlarge.tsx
@@ -194,11 +194,14 @@ export default function ImageEnlarge() {
             className="block max-h-[85vh] max-w-[85vw] object-contain"
           />
           <button
+            type="button"
             onClick={() => dialogRef.current?.close()}
-            className="absolute right-0 top-0 border border-muted bg-surface px-hsp-lg py-vsp-2xs text-small text-muted transition-colors hover:border-fg hover:text-fg"
+            className="zd-enlarge-dialog-close absolute right-0 top-0"
             aria-label="Close enlarged image"
           >
-            ×
+            <svg viewBox="0 0 161.03 161.03" fill="currentColor" aria-hidden="true" focusable={false}>
+              <polygon points="161.03 10.27 150.76 0 80.51 70.24 10.27 0 0 10.27 70.24 80.51 0 150.76 10.27 161.03 80.51 90.78 150.76 161.03 161.03 150.76 90.78 80.51 161.03 10.27" />
+            </svg>
           </button>
         </div>
       )}

--- a/src/config/color-scheme-utils.ts
+++ b/src/config/color-scheme-utils.ts
@@ -22,6 +22,8 @@ export const SEMANTIC_DEFAULTS: Record<string, number> = {
   chatUserText: 9,
   chatAssistantBg: 9,
   chatAssistantText: 11,
+  imageOverlayBg: 0,
+  imageOverlayFg: 11,
 };
 
 export const SEMANTIC_CSS_NAMES: Record<string, string> = {
@@ -44,6 +46,8 @@ export const SEMANTIC_CSS_NAMES: Record<string, string> = {
   chatUserText: "--zd-chat-user-text",
   chatAssistantBg: "--zd-chat-assistant-bg",
   chatAssistantText: "--zd-chat-assistant-text",
+  imageOverlayBg: "--zd-image-overlay-bg",
+  imageOverlayFg: "--zd-image-overlay-fg",
 };
 
 export const lightDarkPairings = [
@@ -95,6 +99,8 @@ export function resolveSemanticColors(scheme: ColorScheme) {
     chatUserText: resolveColor(scheme.semantic?.chatUserText, p, p[9]),
     chatAssistantBg: resolveColor(scheme.semantic?.chatAssistantBg, p, p[9]),
     chatAssistantText: resolveColor(scheme.semantic?.chatAssistantText, p, p[11]),
+    imageOverlayBg: resolveColor(scheme.semantic?.imageOverlayBg, p, p[0]),
+    imageOverlayFg: resolveColor(scheme.semantic?.imageOverlayFg, p, p[11]),
   };
 }
 
@@ -127,6 +133,8 @@ export function schemeToCssPairs(scheme: ColorScheme): [string, string][] {
     ["--zd-chat-user-text", sem.chatUserText],
     ["--zd-chat-assistant-bg", sem.chatAssistantBg],
     ["--zd-chat-assistant-text", sem.chatAssistantText],
+    ["--zd-image-overlay-bg", sem.imageOverlayBg],
+    ["--zd-image-overlay-fg", sem.imageOverlayFg],
   ];
 }
 

--- a/src/config/color-schemes.ts
+++ b/src/config/color-schemes.ts
@@ -36,6 +36,9 @@ export interface ColorScheme {
     chatUserText?: ColorRef;
     chatAssistantBg?: ColorRef;
     chatAssistantText?: ColorRef;
+    /** UI chrome over user images — enlarge/close overlay buttons */
+    imageOverlayBg?: ColorRef;
+    imageOverlayFg?: ColorRef;
   };
 }
 
@@ -86,6 +89,8 @@ export const colorSchemes: Record<string, ColorScheme> = {
       danger: 1,
       warning: 3,
       info: 4,
+      imageOverlayBg: 11,
+      imageOverlayFg: 10,
     },
   },
   "Default Dark": {
@@ -112,6 +117,8 @@ export const colorSchemes: Record<string, ColorScheme> = {
       danger: 1,
       warning: 3,
       info: 4,
+      imageOverlayBg: 0,
+      imageOverlayFg: 11,
     },
   },
 };

--- a/src/content/docs-ja/components/image-enlarge.mdx
+++ b/src/content/docs-ja/components/image-enlarge.mdx
@@ -50,3 +50,26 @@ export const settings = {
 ```
 
 `imageEnlarge: false` に設定すると、機能全体を無効にできます。
+
+## オーバーレイ色のカスタマイズ
+
+拡大ボタンとダイアログの閉じるボタンは、外観を制御するトークンペアを共有しています。
+
+- `image-overlay-bg` — アイコンの背後に 80% の不透明度で描画される背景レイヤーの色。
+- `image-overlay-fg` — 背景の上に 100% の不透明度で描画されるアイコンの色。
+
+適切なオーバーレイ色はコンテンツ画像に依存し、サイトによって異なります。デフォルト値はほとんどのケースで機能しますが、3 層カラー戦略（[Color](../reference/color.mdx) を参照）に従い、任意のカラースキームで上書きできます。
+
+```ts
+// src/config/color-schemes.ts
+"My Scheme": {
+  // ...palette, background, foreground, ...
+  semantic: {
+    imageOverlayBg: 0,    // palette index — deep surface
+    imageOverlayFg: 11,   // palette index — light text
+    // or a direct color string: imageOverlayBg: "#222"
+  },
+},
+```
+
+Color Tweak Panel（有効時）を使えば、コードを編集せずにこれらのトークンをライブで調整できます。

--- a/src/content/docs/components/image-enlarge.mdx
+++ b/src/content/docs/components/image-enlarge.mdx
@@ -50,3 +50,26 @@ export const settings = {
 ```
 
 Set `imageEnlarge: false` to disable the feature entirely.
+
+## Customizing overlay colors
+
+The enlarge button and the dialog's close button share a single token pair that controls their appearance:
+
+- `image-overlay-bg` — bg layer color, rendered at 80% opacity behind the icon.
+- `image-overlay-fg` — icon color, rendered at 100% opacity on top of the bg.
+
+The right overlay color depends on the content photos, which vary between sites. The default values work for most cases, but any color scheme can override them per the three-tier color strategy (see [Color](../reference/color.mdx)):
+
+```ts
+// src/config/color-schemes.ts
+"My Scheme": {
+  // ...palette, background, foreground, ...
+  semantic: {
+    imageOverlayBg: 0,    // palette index — deep surface
+    imageOverlayFg: 11,   // palette index — light text
+    // or a direct color string: imageOverlayBg: "#222"
+  },
+},
+```
+
+The Color Tweak Panel (when enabled) exposes these tokens for live tweaking without editing code.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -63,6 +63,8 @@
   --color-info: var(--zd-info);
   /* Overlay is intentionally theme-independent (always dark, not scheme-driven) */
   --color-overlay: #000;
+  --color-image-overlay-bg: var(--zd-image-overlay-bg);
+  --color-image-overlay-fg: var(--zd-image-overlay-fg);
   --color-mermaid-node-bg: var(--zd-mermaid-node-bg);
   --color-mermaid-text: var(--zd-mermaid-text);
   --color-mermaid-line: var(--zd-mermaid-line);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -835,6 +835,10 @@ pre.astro-code .line .highlighted-word {
   fill: currentColor;
 }
 
+.zd-enlarge-btn:hover {
+  opacity: 0.8;
+}
+
 .zd-enlarge-btn[hidden] {
   display: none !important;
 }
@@ -844,7 +848,6 @@ dialog.zd-enlarge-dialog::backdrop {
 }
 
 .zd-enlarge-dialog-close {
-  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -829,6 +829,7 @@ dialog.zd-enlarge-dialog::backdrop {
 }
 
 .zd-enlarge-dialog-close {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -839,6 +840,10 @@ dialog.zd-enlarge-dialog::backdrop {
   cursor: pointer;
   z-index: 1;
   transition: opacity var(--default-transition-duration);
+}
+
+.zd-enlarge-dialog-close:hover {
+  opacity: 0.8;
 }
 
 .zd-enlarge-dialog-close::before {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -828,6 +828,37 @@ dialog.zd-enlarge-dialog::backdrop {
   background: color-mix(in oklch, var(--color-overlay) 80%, transparent);
 }
 
+.zd-enlarge-dialog-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-vsp-xs) var(--spacing-hsp-sm);
+  border: none;
+  border-radius: var(--radius-DEFAULT);
+  background: transparent;
+  cursor: pointer;
+  z-index: 1;
+  transition: opacity var(--default-transition-duration);
+}
+
+.zd-enlarge-dialog-close::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: color-mix(in oklch, var(--color-image-overlay-bg) 80%, transparent);
+  z-index: 0;
+}
+
+.zd-enlarge-dialog-close > svg {
+  position: relative;
+  z-index: 1;
+  width: var(--spacing-icon-md);
+  height: var(--spacing-icon-md);
+  color: var(--color-image-overlay-fg);
+  fill: currentColor;
+}
+
 /* ========================================
  * Page transition animations
  * ======================================== */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -805,19 +805,34 @@ pre.astro-code .line .highlighted-word {
   position: absolute;
   top: var(--spacing-vsp-xs);
   right: var(--spacing-hsp-xs);
-  width: var(--spacing-icon-sm);
-  height: var(--spacing-icon-sm);
-  padding: 0;
-  border: none;
-  border-radius: var(--radius-DEFAULT);
-  background: color-mix(in oklch, var(--color-overlay) 80%, transparent);
-  color: var(--color-bg);
-  cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: var(--spacing-vsp-2xs) var(--spacing-hsp-sm);
+  border: none;
+  border-radius: var(--radius-DEFAULT);
+  background: transparent;
+  cursor: pointer;
   z-index: 1;
   transition: opacity var(--default-transition-duration);
+}
+
+.zd-enlarge-btn::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: color-mix(in oklch, var(--color-image-overlay-bg) 80%, transparent);
+  z-index: 0;
+}
+
+.zd-enlarge-btn > svg {
+  position: relative;
+  z-index: 1;
+  width: var(--spacing-icon-sm);
+  height: var(--spacing-icon-sm);
+  color: var(--color-image-overlay-fg);
+  fill: currentColor;
 }
 
 .zd-enlarge-btn[hidden] {


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/284

---

## Summary

Polishes the existing image-enlarge feature (merged via #282) by turning the enlarge button and the dialog's close button into **two visual layers** — a semi-transparent bg painted by a `::before` pseudo-element at 80% opacity, and an SVG icon on top at 100% opacity — and by exposing the two colors as new Tier 2 semantic tokens so every color scheme can own the overlay look.

- **Two-layer structure, zero extra DOM** — the `::before` paints the bg, the SVG sits on top. Opacity split is on `::before`'s `background` via `color-mix`, never on CSS `opacity:` (which would fade the icon too).
- **New semantic tokens**: `image-overlay-bg` / `image-overlay-fg`. They flow through the full three-tier pipeline — `semantic` in `color-schemes.ts`, resolution in `color-scheme-utils.ts`, `@theme` in `global.css`, and automatically surface in the Color Tweak Panel.
- **New SVG assets** — 4-corner-arrows for enlarge (viewBox `0 0 38.99 38.99`), polygon X for close (viewBox `0 0 161.03 161.03`). Both use `fill: currentColor` so CSS drives color.
- **`create-zudo-doc` generator kept in sync** — template mirrors for the rehype plugin, the Preact island, and the CSS injection all updated; `check:template-drift` stays green.

## Changes

### Tokens (T1, #285)
- `ColorScheme["semantic"]` in `src/config/color-schemes.ts` gains optional `imageOverlayBg` / `imageOverlayFg` (`ColorRef`). Default Light maps them to palette indices `11` / `10`; Default Dark maps to `0` / `11`.
- `SEMANTIC_DEFAULTS`, `SEMANTIC_CSS_NAMES`, `resolveSemanticColors`, `schemeToCssPairs` in `color-scheme-utils.ts` all extended following the `mermaid*` / `chat*` pattern.
- `@theme` in `src/styles/global.css` adds `--color-image-overlay-bg` / `--color-image-overlay-fg` next to `--color-overlay` for discoverability.

### Two-layer button CSS (T2, T4)
- `.zd-enlarge-btn` rewritten in `src/styles/global.css`: transparent button, `::before` paints the 80% bg, `> svg` sits on top at 100%. Adds `:hover { opacity: 0.8 }` to consume the existing `transition: opacity`.
- New `.zd-enlarge-dialog-close` rule mirrors the structure for the dialog close button.
- The close-button element in `src/components/image-enlarge.tsx` swaps the `×` text for an inline polygon X SVG, styled via the new class. Tailwind `absolute right-0 top-0` stays in the markup (no `position: relative` overrides it).

### Enlarge icon swap (T3)
- `packages/md-plugins/src/rehype-image-enlarge.ts` replaces the Feather-style polylines/lines with 4 `polygon` children (corner arrows). `fill="currentColor"`, `focusable="false"`, `aria-hidden="true"`.

### Template mirrors
- `packages/create-zudo-doc/templates/base/src/plugins/rehype-image-enlarge.ts`
- `packages/create-zudo-doc/templates/base/src/config/color-schemes.ts`, `color-scheme-utils.ts`, `styles/global.css`
- `packages/create-zudo-doc/templates/features/imageEnlarge/files/src/components/image-enlarge.tsx`
- `packages/create-zudo-doc/src/features/image-enlarge.ts` — injected CSS string stays byte-identical to `src/styles/global.css`.

### Docs (T7)
- `src/content/docs/components/image-enlarge.mdx` + `src/content/docs-ja/components/image-enlarge.mdx` gain a "Customizing overlay colors" section explaining the tokens and the 80/100 split, with an override snippet.

### Tests (T6)
- `packages/md-plugins/src/__tests__/rehype-image-enlarge.test.ts` — asserts `viewBox`, `fill="currentColor"`, `focusable="false"`, and exactly 4 `<polygon>` children.
- `e2e/smoke-image-enlarge.spec.ts` — new browser test reads `::before` background + SVG color via `getComputedStyle` and asserts the two-layer wiring is live.

### Post-review fixes (codex P2)
- Dropped `position: relative` from `.zd-enlarge-dialog-close`; without this, the rule cascaded over the Tailwind `absolute right-0 top-0` on the component and the close button would have ended up in normal flow instead of overlaying the image.
- SVG `focusable` attributes switched from boolean `{false}` to string `"false"` everywhere (Preact + hast) so the attribute renders reliably.

## Test plan

- [x] `pnpm check` — TypeScript / Astro check passes.
- [x] `pnpm test` (vitest, including `@zudo-doc/md-plugins`) — all passing, 59 tests.
- [ ] `pnpm test:e2e --project smoke` — new two-layer CSS assertion passes locally (CI exercises this).
- [ ] Visual pass on `pnpm dev` — confirm the enlarge button shows the bg behind the icon at 80% opacity and the icon stays crisp; dialog close button behaves the same.
- [x] `check:template-drift` — main `global.css` and template feature injection stay byte-identical (verified programmatically).