### PR TITLE
feat(image-enlarge): --spacing-image-overlay-inset token + figure flow-space

### DIFF
--- a/packages/create-zudo-doc/src/features/image-enlarge.ts
+++ b/packages/create-zudo-doc/src/features/image-enlarge.ts
@@ -42,7 +42,6 @@ export const imageEnlargeFeature: FeatureModule = () => ({
   content: "";
   position: absolute;
   inset: 0;
-  border-radius: inherit;
   background: color-mix(in oklch, var(--color-image-overlay-bg) 80%, transparent);
   z-index: 0;
 }
@@ -88,7 +87,6 @@ dialog.zd-enlarge-dialog::backdrop {
   content: "";
   position: absolute;
   inset: 0;
-  border-radius: inherit;
   background: color-mix(in oklch, var(--color-image-overlay-bg) 80%, transparent);
   z-index: 0;
 }

--- a/packages/create-zudo-doc/src/features/image-enlarge.ts
+++ b/packages/create-zudo-doc/src/features/image-enlarge.ts
@@ -13,7 +13,8 @@ export const imageEnlargeFeature: FeatureModule = () => ({
 .zd-enlargeable {
   position: relative;
   display: block;
-  margin: 0;
+  margin-inline: 0;
+  margin-block-end: 0;
 }
 
 .zd-enlargeable img {
@@ -24,14 +25,13 @@ export const imageEnlargeFeature: FeatureModule = () => ({
 
 .zd-enlarge-btn {
   position: absolute;
-  top: var(--spacing-vsp-xs);
-  right: var(--spacing-hsp-xs);
+  top: var(--spacing-image-overlay-inset);
+  right: var(--spacing-image-overlay-inset);
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: var(--spacing-vsp-2xs) var(--spacing-hsp-sm);
+  padding: var(--spacing-image-overlay-inset);
   border: none;
-  border-radius: var(--radius-DEFAULT);
   background: transparent;
   cursor: pointer;
   z-index: 1;
@@ -72,9 +72,8 @@ dialog.zd-enlarge-dialog::backdrop {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: var(--spacing-vsp-xs) var(--spacing-hsp-sm);
+  padding: var(--spacing-image-overlay-inset);
   border: none;
-  border-radius: var(--radius-DEFAULT);
   background: transparent;
   cursor: pointer;
   z-index: 1;

--- a/packages/create-zudo-doc/templates/base/src/styles/global.css
+++ b/packages/create-zudo-doc/templates/base/src/styles/global.css
@@ -104,6 +104,9 @@
   --spacing-icon-md: 1.25rem;    /* 20px — medium emphasis icons */
   --spacing-icon-lg: 1.5rem;     /* 24px — large / mobile icons */
 
+  /* Image overlay button chrome */
+  --spacing-image-overlay-inset: 0.5rem;  /* 8px — overlay button corner inset + internal padding */
+
   /* ========================================
    * Typography
    * ======================================== */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -824,7 +824,6 @@ pre.astro-code .line .highlighted-word {
   content: "";
   position: absolute;
   inset: 0;
-  border-radius: inherit;
   background: color-mix(in oklch, var(--color-image-overlay-bg) 80%, transparent);
   z-index: 0;
 }
@@ -870,7 +869,6 @@ dialog.zd-enlarge-dialog::backdrop {
   content: "";
   position: absolute;
   inset: 0;
-  border-radius: inherit;
   background: color-mix(in oklch, var(--color-image-overlay-bg) 80%, transparent);
   z-index: 0;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -107,6 +107,9 @@
   --spacing-icon-md: 1.25rem;    /* 20px — medium emphasis icons */
   --spacing-icon-lg: 1.5rem;     /* 24px — large / mobile icons */
 
+  /* Image overlay button chrome */
+  --spacing-image-overlay-inset: 0.5rem;  /* 8px — overlay button corner inset + internal padding */
+
   /* ========================================
    * Typography
    * ======================================== */
@@ -792,7 +795,8 @@ pre.astro-code .line .highlighted-word {
 .zd-enlargeable {
   position: relative;
   display: block;
-  margin: 0;
+  margin-inline: 0;
+  margin-block-end: 0;
 }
 
 .zd-enlargeable img {
@@ -803,14 +807,13 @@ pre.astro-code .line .highlighted-word {
 
 .zd-enlarge-btn {
   position: absolute;
-  top: var(--spacing-vsp-xs);
-  right: var(--spacing-hsp-xs);
+  top: var(--spacing-image-overlay-inset);
+  right: var(--spacing-image-overlay-inset);
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: var(--spacing-vsp-2xs) var(--spacing-hsp-sm);
+  padding: var(--spacing-image-overlay-inset);
   border: none;
-  border-radius: var(--radius-DEFAULT);
   background: transparent;
   cursor: pointer;
   z-index: 1;
@@ -851,9 +854,8 @@ dialog.zd-enlarge-dialog::backdrop {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: var(--spacing-vsp-xs) var(--spacing-hsp-sm);
+  padding: var(--spacing-image-overlay-inset);
   border: none;
-  border-radius: var(--radius-DEFAULT);
   background: transparent;
   cursor: pointer;
   z-index: 1;


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/293
    - https://github.com/zudolab/zudo-doc/issues/294

---

## Summary

Polish pass on the image-enlarge overlay buttons (follow-up to #292) plus a design-token tier correction.

- Add one Tier 1 theme token `--spacing-image-overlay-inset: 0.5rem` (8 px) capturing the "overlay-button chrome" design decision. Shared by 2 components today (enlarge trigger + dialog close).
- Use it for both the corner inset (`top`/`right` on the enlarge trigger) and internal padding on `.zd-enlarge-btn` and `.zd-enlarge-dialog-close`. Replaces `hsp-*`/`vsp-*` uses, which were a tier mismatch — axis-based rhythm tokens are not the right semantic for a 2D corner inset.
- Drop `border-radius` on both overlay buttons → sharp corners per spec.
- Release `margin-block-start` on `.zd-enlargeable` (`margin: 0` → `margin-inline: 0; margin-block-end: 0`) so prose flow-space applies to figures against preceding paragraphs.

Also drops two dead `border-radius: inherit` lines on the `::before` pill pseudos that became no-ops once the parent radius was removed (flagged by `/deep-review`).

## Changes

**`src/styles/global.css`**
- Add `--spacing-image-overlay-inset: 0.5rem` in `@theme` next to the `--spacing-icon-*` block.
- `.zd-enlargeable`: `margin: 0` → `margin-inline: 0; margin-block-end: 0`.
- `.zd-enlarge-btn`: `top` and `right` use the new token; `padding: var(--spacing-image-overlay-inset)`; `border-radius` removed.
- `.zd-enlarge-dialog-close`: `padding: var(--spacing-image-overlay-inset)`; `border-radius` removed.
- Both `::before` pseudos: drop `border-radius: inherit` (dead code after parent radius removal).

**`packages/create-zudo-doc/templates/base/src/styles/global.css`**
- Mirror the new `--spacing-image-overlay-inset` token (always-on in base, matches the `--color-image-overlay-bg/fg` precedent from #292).

**`packages/create-zudo-doc/src/features/image-enlarge.ts`**
- Byte-identical edits to the three injected rule blocks so `pnpm check:template-drift` stays clean.

## Out of scope

- `src/components/image-enlarge.tsx`, `packages/md-plugins/src/rehype-image-enlarge.ts`, MDX docs, E2E specs, unit tests — all unchanged (the new token is internal chrome, value-agnostic for asserted fields).

## Test plan

- [ ] `pnpm check:template-drift` passes (CI gate).
- [ ] `pnpm check` passes (Astro typecheck).
- [ ] `pnpm test` passes (vitest, all packages — existing `rehype-image-enlarge.test.ts` asserts SVG attributes only).
- [ ] `pnpm test:e2e --project smoke` passes `smoke-image-enlarge.spec.ts` without modification (reads colors + visibility, not padding/border-radius/margin).
- [ ] `pnpm build` succeeds.
- [ ] Visual check on `/docs/components/image-enlarge`:
  - Enlarge trigger: `top: 8px; right: 8px; padding: 8px; border-radius: 0`.
  - Dialog close: 36×36 (`icon-md` 20 px + 2·8 px padding), `border-radius: 0`.
  - Figures have visible top margin against preceding paragraphs.

## References

- Predecessor PR (two-layer overlay button structure + image-overlay color tokens): #292
- Two-tier size strategy: https://takazudomodular.com/pj/zcss/docs/methodology/design-systems/two-tier-size-strategy/