### PR TITLE
Frontmatter Preview: render frontmatter as a table on each doc page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ e2e/fixtures/*/src/config/color-schemes.ts
 e2e/fixtures/*/src/config/color-tweak-presets.ts
 e2e/fixtures/*/src/config/i18n.ts
 e2e/fixtures/*/src/config/settings-types.ts
+e2e/fixtures/*/src/config/frontmatter-preview-defaults.ts
 e2e/fixtures/*/src/config/sidebars.ts
 e2e/fixtures/*/astro.config.ts
 e2e/fixtures/*/.astro

--- a/e2e/fixtures/smoke/src/config/settings.ts
+++ b/e2e/fixtures/smoke/src/config/settings.ts
@@ -3,6 +3,7 @@ import type {
   ColorModeConfig,
   HtmlPreviewConfig,
   LocaleConfig,
+  FrontmatterPreviewConfig,
 } from "./settings-types";
 
 export const settings = {
@@ -24,6 +25,7 @@ export const settings = {
   aiAssistant: true as boolean,
   colorTweakPanel: true as boolean,
   imageEnlarge: true as boolean,
+  frontmatterPreview: {} as FrontmatterPreviewConfig,
   docHistory: true,
   htmlPreview: {
     css: `.global-test { border: 3px solid rgb(255, 0, 0); }`,

--- a/e2e/fixtures/smoke/src/content/docs/auto-index-category/child-page.mdx
+++ b/e2e/fixtures/smoke/src/content/docs/auto-index-category/child-page.mdx
@@ -1,0 +1,6 @@
+---
+title: Child Page
+sidebar_position: 1
+---
+
+This page belongs to a category that has no `index.mdx`, so its parent renders as an auto-generated index page.

--- a/e2e/fixtures/smoke/src/content/docs/guides/frontmatter-preview-test.mdx
+++ b/e2e/fixtures/smoke/src/content/docs/guides/frontmatter-preview-test.mdx
@@ -1,0 +1,8 @@
+---
+title: Frontmatter Preview Test
+sidebar_position: 99
+author: smoke-test
+status: verified
+---
+
+This page has custom frontmatter fields (`author` and `status`) that should appear in the frontmatter preview table.

--- a/e2e/smoke-frontmatter-preview.spec.ts
+++ b/e2e/smoke-frontmatter-preview.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * E2E smoke tests for the frontmatter-preview block rendered-vs-hidden behavior.
+ *
+ * Three scenarios:
+ * 1. System-only frontmatter → block absent.
+ * 2. Custom frontmatter → block visible with correct rows (and ignored keys absent).
+ * 3. Auto-index category page → block absent (no entry, auto-generated).
+ *
+ * Fixture content:
+ * - /docs/getting-started — system-only frontmatter (title, sidebar_position)
+ * - /docs/guides/frontmatter-preview-test — custom fields: author, status
+ * - /docs/auto-index-category — auto-generated index (no index.mdx)
+ */
+
+test.describe("Frontmatter Preview: rendered-vs-hidden behavior", () => {
+  test("system-only frontmatter → block absent", async ({ page }) => {
+    await page.goto("/docs/getting-started", { waitUntil: "load" });
+
+    const block = page.locator('[data-testid="frontmatter-preview"]');
+    await expect(block).not.toBeAttached();
+  });
+
+  test("custom frontmatter → block visible with correct rows", async ({
+    page,
+  }) => {
+    await page.goto("/docs/guides/frontmatter-preview-test", {
+      waitUntil: "load",
+    });
+
+    // Block must be present
+    const block = page.locator('[data-testid="frontmatter-preview"]');
+    await expect(block).toBeVisible();
+
+    // Custom field rows must appear
+    const tbody = block.locator("tbody");
+    await expect(tbody.locator("tr")).toHaveCount(2);
+
+    const keyTexts = await tbody.locator("td:first-child").allTextContents();
+    expect(keyTexts).toContain("author");
+    expect(keyTexts).toContain("status");
+
+    // System-managed keys must NOT appear
+    expect(keyTexts).not.toContain("title");
+    expect(keyTexts).not.toContain("sidebar_position");
+  });
+
+  test("auto-index category page → block absent", async ({ page }) => {
+    await page.goto("/docs/auto-index-category", { waitUntil: "load" });
+
+    const block = page.locator('[data-testid="frontmatter-preview"]');
+    await expect(block).not.toBeAttached();
+  });
+});

--- a/packages/create-zudo-doc/src/__tests__/content-config-gen.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/content-config-gen.test.ts
@@ -60,6 +60,11 @@ describe("generateContentConfig", () => {
     expect(result).toContain("slug: z.string().optional()");
   });
 
+  it("preserves unknown frontmatter keys via .passthrough()", () => {
+    const result = generateContentConfig(baseChoices);
+    expect(result).toContain(".passthrough()");
+  });
+
   it("includes version locale variants in version collections", () => {
     const choices = { ...baseChoices, features: ["versioning"] };
     const result = generateContentConfig(choices);

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -956,6 +956,66 @@ describe("scaffold — CLAUDE.md generation", () => {
   });
 });
 
+describe("scaffold — frontmatterPreview setting", () => {
+  it("generated settings.ts contains frontmatterPreview: false by default", async () => {
+    const choices: UserChoices = {
+      projectName: "test-fp-default",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search"],
+      packageManager: "pnpm",
+    };
+    await scaffold(choices);
+    const content = await fs.readFile(
+      projectPath("test-fp-default", "src/config/settings.ts"),
+      "utf-8",
+    );
+    expect(content).toContain("frontmatterPreview:");
+    expect(content).toContain("FrontmatterPreviewConfig | false");
+  });
+
+  it("frontmatter-preview.astro component exists in base template", async () => {
+    const choices: UserChoices = {
+      projectName: "test-fp-component",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search"],
+      packageManager: "pnpm",
+    };
+    await scaffold(choices);
+    expect(
+      await fs.pathExists(
+        projectPath(
+          "test-fp-component",
+          "src/components/frontmatter-preview.astro",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("frontmatter-preview-defaults.ts exists in base template", async () => {
+    const choices: UserChoices = {
+      projectName: "test-fp-defaults",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search"],
+      packageManager: "pnpm",
+    };
+    await scaffold(choices);
+    expect(
+      await fs.pathExists(
+        projectPath(
+          "test-fp-defaults",
+          "src/config/frontmatter-preview-defaults.ts",
+        ),
+      ),
+    ).toBe(true);
+  });
+});
+
 describe("scaffold — imageEnlarge feature", () => {
   it("settings have imageEnlarge: true when enabled", async () => {
     const choices: UserChoices = {

--- a/packages/create-zudo-doc/src/content-config-gen.ts
+++ b/packages/create-zudo-doc/src/content-config-gen.ts
@@ -42,7 +42,7 @@ export function generateContentConfig(choices: UserChoices): string {
   lines.push(`  standalone: z.boolean().optional(),`);
   lines.push(`  slug: z.string().optional(),`);
   lines.push(`  generated: z.boolean().optional(),`);
-  lines.push(`});`);
+  lines.push(`}).passthrough();`);
   lines.push(``);
 
   // --- Base docs collection ---

--- a/packages/create-zudo-doc/src/settings-gen.ts
+++ b/packages/create-zudo-doc/src/settings-gen.ts
@@ -10,6 +10,7 @@ export function generateSettingsFile(choices: UserChoices): string {
   lines.push(`  HeaderNavItem,`);
   lines.push(`  ColorModeConfig,`);
   lines.push(`  HtmlPreviewConfig,`);
+  lines.push(`  FrontmatterPreviewConfig,`);
   lines.push(`  LocaleConfig,`);
   lines.push(`  VersionConfig,`);
   lines.push(`  FooterConfig,`);
@@ -18,6 +19,7 @@ export function generateSettingsFile(choices: UserChoices): string {
   lines.push(`  HeaderNavItem,`);
   lines.push(`  ColorModeConfig,`);
   lines.push(`  HtmlPreviewConfig,`);
+  lines.push(`  FrontmatterPreviewConfig,`);
   lines.push(`  LocaleConfig,`);
   lines.push(`  VersionConfig,`);
   lines.push(`  FooterConfig,`);
@@ -78,6 +80,9 @@ export function generateSettingsFile(choices: UserChoices): string {
   lines.push(`  sitemap: false,`);
   lines.push(`  docMetainfo: false,`);
   lines.push(`  docTags: false,`);
+  lines.push(
+    `  frontmatterPreview: false as FrontmatterPreviewConfig | false,`,
+  );
   if (choices.features.includes("llmsTxt")) {
     lines.push(`  llmsTxt: true,`);
   } else {

--- a/packages/create-zudo-doc/templates/base/src/components/frontmatter-preview.astro
+++ b/packages/create-zudo-doc/templates/base/src/components/frontmatter-preview.astro
@@ -1,0 +1,87 @@
+---
+import { settings } from "@/config/settings";
+import { DEFAULT_FRONTMATTER_IGNORE_KEYS } from "@/config/frontmatter-preview-defaults";
+import { t, type Locale } from "@/config/i18n";
+
+interface Props {
+  data: Record<string, unknown>;
+  locale?: Locale;
+}
+
+const { data, locale = "en" } = Astro.props;
+
+// Resolve effective ignore list
+const cfg = settings.frontmatterPreview;
+
+// If feature is disabled, render nothing
+const ignoreSet: Set<string> = (() => {
+  if (cfg === false) return new Set<string>();
+  if (cfg.ignoreKeys) return new Set(cfg.ignoreKeys);
+  const keys = [
+    ...DEFAULT_FRONTMATTER_IGNORE_KEYS,
+    ...(cfg.extraIgnoreKeys ?? []),
+  ];
+  return new Set(keys);
+})();
+
+// Filter entries: skip ignored keys and null/undefined values
+const entries = Object.entries(data).filter(
+  ([key, value]) =>
+    !ignoreSet.has(key) && value !== null && value !== undefined,
+);
+
+function renderValue(v: unknown): { text?: string; code?: string } {
+  if (typeof v === "string") return { text: v };
+  if (typeof v === "number") return { text: String(v) };
+  if (typeof v === "boolean") return { text: v ? "true" : "false" };
+  if (Array.isArray(v) && v.every((item) => typeof item === "string")) {
+    return { text: (v as string[]).join(", ") };
+  }
+  return { code: JSON.stringify(v) };
+}
+---
+
+{
+  cfg !== false && entries.length > 0 && (
+    <div data-testid="frontmatter-preview" class="my-vsp-lg">
+      <p class="text-caption text-muted mb-vsp-2xs">
+        {t("frontmatter.preview.title", locale)}
+      </p>
+      <div class="overflow-x-auto">
+        <table class="w-full border-collapse text-caption">
+          <thead>
+            <tr>
+              <th class="text-left font-semibold px-hsp-md py-vsp-2xs border-b-2 border-muted text-fg">
+                {t("frontmatter.preview.keyCol", locale)}
+              </th>
+              <th class="text-left font-semibold px-hsp-md py-vsp-2xs border-b-2 border-muted text-fg">
+                {t("frontmatter.preview.valueCol", locale)}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map(([key, value]) => {
+              const rendered = renderValue(value);
+              return (
+                <tr class="border-b border-muted">
+                  <td class="px-hsp-md py-vsp-2xs text-muted font-mono align-top">
+                    {key}
+                  </td>
+                  <td class="px-hsp-md py-vsp-2xs text-fg break-words align-top">
+                    {rendered.code !== undefined ? (
+                      <code class="bg-code-bg text-code-fg px-hsp-xs py-0 rounded text-micro font-mono">
+                        {rendered.code}
+                      </code>
+                    ) : (
+                      rendered.text
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/packages/create-zudo-doc/templates/base/src/config/frontmatter-preview-defaults.ts
+++ b/packages/create-zudo-doc/templates/base/src/config/frontmatter-preview-defaults.ts
@@ -1,0 +1,23 @@
+/**
+ * Schema-managed frontmatter keys that are handled by the framework and
+ * should be hidden from the frontmatter preview by default.
+ * These correspond to every field defined in the docsSchema in src/content.config.ts.
+ */
+export const DEFAULT_FRONTMATTER_IGNORE_KEYS: string[] = [
+  "title",
+  "description",
+  "category",
+  "sidebar_position",
+  "sidebar_label",
+  "tags",
+  "search_exclude",
+  "pagination_next",
+  "pagination_prev",
+  "draft",
+  "unlisted",
+  "hide_sidebar",
+  "hide_toc",
+  "standalone",
+  "slug",
+  "generated",
+];

--- a/packages/create-zudo-doc/templates/base/src/config/i18n.ts
+++ b/packages/create-zudo-doc/templates/base/src/config/i18n.ts
@@ -82,6 +82,9 @@ const translations: Record<string, Record<string, string>> = {
     "nav.backToMenu": "Back to main menu",
     "doc.fallbackNotice":
       "This page has not been translated yet and is shown in the original language.",
+    "frontmatter.preview.title": "Frontmatter",
+    "frontmatter.preview.keyCol": "Key",
+    "frontmatter.preview.valueCol": "Value",
     "version.latest": "Latest",
     "version.switcher.label": "Version",
     "version.banner.unmaintained":
@@ -133,6 +136,9 @@ const translations: Record<string, Record<string, string>> = {
     "nav.backToMenu": "メインメニューに戻る",
     "doc.fallbackNotice":
       "このページはまだ翻訳されていません。原文のまま表示しています。",
+    "frontmatter.preview.title": "フロントマター",
+    "frontmatter.preview.keyCol": "キー",
+    "frontmatter.preview.valueCol": "値",
     "version.latest": "最新",
     "version.switcher.label": "バージョン",
     "version.banner.unmaintained":
@@ -184,6 +190,9 @@ const translations: Record<string, Record<string, string>> = {
     "doc.pageCountSingle": "{count} Seite",
     "doc.fallbackNotice":
       "Diese Seite wurde noch nicht übersetzt und wird in der Originalsprache angezeigt.",
+    "frontmatter.preview.title": "Frontmatter",
+    "frontmatter.preview.keyCol": "Schlüssel",
+    "frontmatter.preview.valueCol": "Wert",
     "version.latest": "Neueste",
     "version.switcher.label": "Version",
     "version.banner.unmaintained":

--- a/packages/create-zudo-doc/templates/base/src/config/settings-types.ts
+++ b/packages/create-zudo-doc/templates/base/src/config/settings-types.ts
@@ -48,6 +48,19 @@ export interface HtmlPreviewConfig {
   js?: string;
 }
 
+export interface FrontmatterPreviewConfig {
+  /**
+   * Completely replaces the default ignore list.
+   * When set, `extraIgnoreKeys` is ignored.
+   */
+  ignoreKeys?: string[];
+  /**
+   * Additional keys to ignore on top of the defaults.
+   * Has no effect when `ignoreKeys` is also set.
+   */
+  extraIgnoreKeys?: string[];
+}
+
 export interface VersionConfig {
   /** Version identifier, used in URL path (e.g., "1.0", "v1") */
   slug: string;

--- a/packages/create-zudo-doc/templates/base/src/pages/docs/[...slug].astro
+++ b/packages/create-zudo-doc/templates/base/src/pages/docs/[...slug].astro
@@ -34,6 +34,7 @@ import { docsUrl } from "@/utils/base";
 import EditLink from "@/components/edit-link.astro";
 import DocMetainfo from "@/components/doc-metainfo.astro";
 import DocTags from "@/components/doc-tags.astro";
+import FrontmatterPreview from "@/components/frontmatter-preview.astro";
 
 export async function getStaticPaths() {
   const allDocs = await getCollection("docs");
@@ -191,6 +192,10 @@ const slug = autoIndex
         )}
 
         {entry?.data?.tags && <DocTags tags={entry.data.tags} locale="en" />}
+
+        {settings.frontmatterPreview && entry && (
+          <FrontmatterPreview data={entry.data} locale="en" />
+        )}
 
         <Content components={components} />
 

--- a/packages/create-zudo-doc/templates/features/i18n/files/src/pages/ja/docs/[...slug].astro
+++ b/packages/create-zudo-doc/templates/features/i18n/files/src/pages/ja/docs/[...slug].astro
@@ -35,6 +35,7 @@ import EditLink from "@/components/edit-link.astro";
 import { settings } from "@/config/settings";
 import DocMetainfo from "@/components/doc-metainfo.astro";
 import DocTags from "@/components/doc-tags.astro";
+import FrontmatterPreview from "@/components/frontmatter-preview.astro";
 import type { DocsEntry } from "@/types/docs-entry";
 
 export async function getStaticPaths() {
@@ -242,6 +243,10 @@ const slug = autoIndex
         )}
 
         {entry?.data?.tags && <DocTags tags={entry.data.tags} locale="ja" />}
+
+        {settings.frontmatterPreview && entry && (
+          <FrontmatterPreview data={entry.data} locale="ja" />
+        )}
 
         <Content components={components} />
 

--- a/packages/create-zudo-doc/templates/features/versioning/files/src/pages/v/[version]/docs/[...slug].astro
+++ b/packages/create-zudo-doc/templates/features/versioning/files/src/pages/v/[version]/docs/[...slug].astro
@@ -34,6 +34,7 @@ import { settings } from "@/config/settings";
 import { versionedDocsUrl } from "@/utils/base";
 import DocMetainfo from "@/components/doc-metainfo.astro";
 import DocTags from "@/components/doc-tags.astro";
+import FrontmatterPreview from "@/components/frontmatter-preview.astro";
 import EditLink from "@/components/edit-link.astro";
 import type { VersionConfig } from "@/config/settings-types";
 
@@ -221,6 +222,10 @@ const slug = autoIndex
         )}
 
         {entry?.data?.tags && <DocTags tags={entry.data.tags} locale="en" />}
+
+        {settings.frontmatterPreview && entry && (
+          <FrontmatterPreview data={entry.data} locale="en" />
+        )}
 
         <Content components={components} />
 

--- a/packages/create-zudo-doc/templates/features/versioning/files/src/pages/v/[version]/ja/docs/[...slug].astro
+++ b/packages/create-zudo-doc/templates/features/versioning/files/src/pages/v/[version]/ja/docs/[...slug].astro
@@ -34,6 +34,7 @@ import { settings } from "@/config/settings";
 import { versionedDocsUrl } from "@/utils/base";
 import DocMetainfo from "@/components/doc-metainfo.astro";
 import DocTags from "@/components/doc-tags.astro";
+import FrontmatterPreview from "@/components/frontmatter-preview.astro";
 import EditLink from "@/components/edit-link.astro";
 import type { VersionConfig } from "@/config/settings-types";
 import type { DocsEntry } from "@/types/docs-entry";
@@ -285,6 +286,10 @@ const slug = autoIndex
         )}
 
         {entry?.data?.tags && <DocTags tags={entry.data.tags} locale="ja" />}
+
+        {settings.frontmatterPreview && entry && (
+          <FrontmatterPreview data={entry.data} locale="ja" />
+        )}
 
         <Content components={components} />
 

--- a/src/components/frontmatter-preview.astro
+++ b/src/components/frontmatter-preview.astro
@@ -1,0 +1,87 @@
+---
+import { settings } from "@/config/settings";
+import { DEFAULT_FRONTMATTER_IGNORE_KEYS } from "@/config/frontmatter-preview-defaults";
+import { t, type Locale } from "@/config/i18n";
+
+interface Props {
+  data: Record<string, unknown>;
+  locale?: Locale;
+}
+
+const { data, locale = "en" } = Astro.props;
+
+// Resolve effective ignore list
+const cfg = settings.frontmatterPreview;
+
+// If feature is disabled, render nothing
+const ignoreSet: Set<string> = (() => {
+  if (cfg === false) return new Set<string>();
+  if (cfg.ignoreKeys) return new Set(cfg.ignoreKeys);
+  const keys = [
+    ...DEFAULT_FRONTMATTER_IGNORE_KEYS,
+    ...(cfg.extraIgnoreKeys ?? []),
+  ];
+  return new Set(keys);
+})();
+
+// Filter entries: skip ignored keys and null/undefined values
+const entries = Object.entries(data).filter(
+  ([key, value]) =>
+    !ignoreSet.has(key) && value !== null && value !== undefined,
+);
+
+function renderValue(v: unknown): { text?: string; code?: string } {
+  if (typeof v === "string") return { text: v };
+  if (typeof v === "number") return { text: String(v) };
+  if (typeof v === "boolean") return { text: v ? "true" : "false" };
+  if (Array.isArray(v) && v.every((item) => typeof item === "string")) {
+    return { text: (v as string[]).join(", ") };
+  }
+  return { code: JSON.stringify(v) };
+}
+---
+
+{
+  cfg !== false && entries.length > 0 && (
+    <div data-testid="frontmatter-preview" class="my-vsp-lg">
+      <p class="text-caption text-muted mb-vsp-2xs">
+        {t("frontmatter.preview.title", locale)}
+      </p>
+      <div class="overflow-x-auto">
+        <table class="w-full border-collapse text-caption">
+          <thead>
+            <tr>
+              <th class="text-left font-semibold px-hsp-md py-vsp-2xs border-b-2 border-muted text-fg">
+                {t("frontmatter.preview.keyCol", locale)}
+              </th>
+              <th class="text-left font-semibold px-hsp-md py-vsp-2xs border-b-2 border-muted text-fg">
+                {t("frontmatter.preview.valueCol", locale)}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map(([key, value]) => {
+              const rendered = renderValue(value);
+              return (
+                <tr class="border-b border-muted">
+                  <td class="px-hsp-md py-vsp-2xs text-muted font-mono align-top">
+                    {key}
+                  </td>
+                  <td class="px-hsp-md py-vsp-2xs text-fg break-words align-top">
+                    {rendered.code !== undefined ? (
+                      <code class="bg-code-bg text-code-fg px-hsp-xs py-0 rounded text-micro font-mono">
+                        {rendered.code}
+                      </code>
+                    ) : (
+                      rendered.text
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/src/config/frontmatter-preview-defaults.ts
+++ b/src/config/frontmatter-preview-defaults.ts
@@ -1,0 +1,23 @@
+/**
+ * Schema-managed frontmatter keys that are handled by the framework and
+ * should be hidden from the frontmatter preview by default.
+ * These correspond to every field defined in the docsSchema in src/content.config.ts.
+ */
+export const DEFAULT_FRONTMATTER_IGNORE_KEYS: string[] = [
+  "title",
+  "description",
+  "category",
+  "sidebar_position",
+  "sidebar_label",
+  "tags",
+  "search_exclude",
+  "pagination_next",
+  "pagination_prev",
+  "draft",
+  "unlisted",
+  "hide_sidebar",
+  "hide_toc",
+  "standalone",
+  "slug",
+  "generated",
+];

--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -82,6 +82,9 @@ const translations: Record<string, Record<string, string>> = {
     "nav.backToMenu": "Back to main menu",
     "doc.fallbackNotice":
       "This page has not been translated yet and is shown in the original language.",
+    "frontmatter.preview.title": "Frontmatter",
+    "frontmatter.preview.keyCol": "Key",
+    "frontmatter.preview.valueCol": "Value",
     "version.latest": "Latest",
     "version.switcher.label": "Version",
     "version.banner.unmaintained":
@@ -133,6 +136,9 @@ const translations: Record<string, Record<string, string>> = {
     "nav.backToMenu": "メインメニューに戻る",
     "doc.fallbackNotice":
       "このページはまだ翻訳されていません。原文のまま表示しています。",
+    "frontmatter.preview.title": "フロントマター",
+    "frontmatter.preview.keyCol": "キー",
+    "frontmatter.preview.valueCol": "値",
     "version.latest": "最新",
     "version.switcher.label": "バージョン",
     "version.banner.unmaintained":
@@ -184,6 +190,9 @@ const translations: Record<string, Record<string, string>> = {
     "doc.pageCountSingle": "{count} Seite",
     "doc.fallbackNotice":
       "Diese Seite wurde noch nicht übersetzt und wird in der Originalsprache angezeigt.",
+    "frontmatter.preview.title": "Frontmatter",
+    "frontmatter.preview.keyCol": "Schlüssel",
+    "frontmatter.preview.valueCol": "Wert",
     "version.latest": "Neueste",
     "version.switcher.label": "Version",
     "version.banner.unmaintained":

--- a/src/config/settings-types.ts
+++ b/src/config/settings-types.ts
@@ -48,6 +48,19 @@ export interface HtmlPreviewConfig {
   js?: string;
 }
 
+export interface FrontmatterPreviewConfig {
+  /**
+   * Completely replaces the default ignore list.
+   * When set, `extraIgnoreKeys` is ignored.
+   */
+  ignoreKeys?: string[];
+  /**
+   * Additional keys to ignore on top of the defaults.
+   * Has no effect when `ignoreKeys` is also set.
+   */
+  extraIgnoreKeys?: string[];
+}
+
 export interface VersionConfig {
   /** Version identifier, used in URL path (e.g., "1.0", "v1") */
   slug: string;

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -6,6 +6,7 @@ export type {
   LocaleConfig,
   VersionConfig,
   FooterConfig,
+  FrontmatterPreviewConfig,
 } from "./settings-types";
 import type {
   HeaderNavItem,
@@ -14,6 +15,7 @@ import type {
   LocaleConfig,
   VersionConfig,
   FooterConfig,
+  FrontmatterPreviewConfig,
 } from "./settings-types";
 
 export const settings = {
@@ -48,6 +50,7 @@ export const settings = {
   sidebarResizer: true as boolean,
   sidebarToggle: true as boolean,
   imageEnlarge: true as boolean,
+  frontmatterPreview: {} satisfies FrontmatterPreviewConfig as FrontmatterPreviewConfig | false,
   docHistory: true,
   htmlPreview: undefined as HtmlPreviewConfig | undefined,
   versions: [

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -3,24 +3,26 @@ import { z } from "astro/zod";
 import { glob } from "astro/loaders";
 import { settings } from "./config/settings";
 
-const docsSchema = z.object({
-  title: z.string(),
-  description: z.string().optional(),
-  category: z.string().optional(),
-  sidebar_position: z.number().optional(),
-  sidebar_label: z.string().optional(),
-  tags: z.array(z.string()).optional(),
-  search_exclude: z.boolean().optional(),
-  pagination_next: z.string().nullable().optional(), // doc slug or null to hide
-  pagination_prev: z.string().nullable().optional(), // doc slug or null to hide
-  draft: z.boolean().optional(), // Exclude from build entirely
-  unlisted: z.boolean().optional(), // Built but noindexed, hidden from sidebar/nav
-  hide_sidebar: z.boolean().optional(), // Hide the left sidebar, center content
-  hide_toc: z.boolean().optional(), // Hide the right-side table of contents
-  standalone: z.boolean().optional(), // Hidden from sidebar nav but still indexed (unlike unlisted)
-  slug: z.string().optional(), // Custom URL slug override
-  generated: z.boolean().optional(), // Build-time generated content (skip translation)
-});
+const docsSchema = z
+  .object({
+    title: z.string(),
+    description: z.string().optional(),
+    category: z.string().optional(),
+    sidebar_position: z.number().optional(),
+    sidebar_label: z.string().optional(),
+    tags: z.array(z.string()).optional(),
+    search_exclude: z.boolean().optional(),
+    pagination_next: z.string().nullable().optional(), // doc slug or null to hide
+    pagination_prev: z.string().nullable().optional(), // doc slug or null to hide
+    draft: z.boolean().optional(), // Exclude from build entirely
+    unlisted: z.boolean().optional(), // Built but noindexed, hidden from sidebar/nav
+    hide_sidebar: z.boolean().optional(), // Hide the left sidebar, center content
+    hide_toc: z.boolean().optional(), // Hide the right-side table of contents
+    standalone: z.boolean().optional(), // Hidden from sidebar nav but still indexed (unlike unlisted)
+    slug: z.string().optional(), // Custom URL slug override
+    generated: z.boolean().optional(), // Build-time generated content (skip translation)
+  })
+  .passthrough(); // Allow custom frontmatter keys (e.g. author, status) to pass through for frontmatter preview
 
 const docs = defineCollection({
   loader: glob({ pattern: "**/*.{md,mdx}", base: `./${settings.docsDir}` }),

--- a/src/content/docs-ja/guides/configuration.mdx
+++ b/src/content/docs-ja/guides/configuration.mdx
@@ -35,6 +35,7 @@ export const settings = {
   colorTweakPanel: true,
   docMetainfo: true,
   docTags: true,
+  frontmatterPreview: {},
   math: true,
   docHistory: true,
   claudeResources: {
@@ -294,6 +295,40 @@ llmsTxt: true,
 ドキュメントページのタグサポートを有効にします。`true`の場合、ページは`tags`フロントマターフィールドを使用でき、タグインデックスページが`/docs/tags/`に生成されます。
 
 デフォルト：`true`
+
+### frontmatterPreview
+
+カスタムフロントマターフィールドをページタイトルの直下にコンパクトなキー/値テーブルとして表示します。フレームワーク管理のキー（`title`、`description`、`sidebar_position` など）はデフォルトで非表示になるため、プロジェクト固有のメタデータのみが表示されます。すべてのページでブロックを無効にするには `false` を設定します。
+
+型：`FrontmatterPreviewConfig | false`
+
+デフォルト：`{}`（組み込み無視リストで有効）
+
+`FrontmatterPreviewConfig` オブジェクトは以下を受け入れます：
+
+| プロパティ | 型 | 説明 |
+|----------|------|-------------|
+| `ignoreKeys` | `string[]`（オプション） | デフォルトの無視リストを完全に置き換えます。設定すると `extraIgnoreKeys` は無視されます |
+| `extraIgnoreKeys` | `string[]`（オプション） | デフォルトに加えて無視する追加キーです。`ignoreKeys` が設定されている場合は効果がありません |
+
+```ts
+// Extend the default list:
+frontmatterPreview: {
+  extraIgnoreKeys: ["reviewed_by", "internal_id"],
+},
+// Replace the default list entirely:
+frontmatterPreview: {
+  ignoreKeys: ["title", "description", "sidebar_position"],
+},
+// Disable:
+frontmatterPreview: false,
+```
+
+<Tip>
+
+完全なデフォルト無視リストとライブデモについては、[フロントマタープレビューリファレンス](../reference/frontmatter-preview.mdx) を参照してください。
+
+</Tip>
 
 ### colorTweakPanel
 

--- a/src/content/docs-ja/reference/frontmatter-preview.mdx
+++ b/src/content/docs-ja/reference/frontmatter-preview.mdx
@@ -1,0 +1,103 @@
+---
+title: フロントマタープレビュー
+description: カスタムフロントマターフィールドをページタイトルの下にメタデータテーブルとして自動表示します。
+sidebar_position: 7
+author: zudo-doc
+status: stable
+---
+
+フロントマタープレビューブロックは、ドキュメントに無視されていないフロントマターキーが含まれている場合、ページタイトルの下に自動的に表示されます。カスタムフィールドをコンパクトなキー/値テーブルとしてレンダリングし、著者情報、ステータス、バージョンなどのドキュメントメタデータを本文中に埋め込まずに表示するのに便利です。
+
+このページ自体がその機能のデモです。上部に表示されている `author` と `status` フィールドは、このページ自身のフロントマターで宣言されています。
+
+## ブロックが表示される条件
+
+フィルタリングを経て少なくとも1つのフロントマターキーが残った場合のみブロックが表示されます。フレームワーク管理のキー（`title`、`description`、`sidebar_position`、`tags` など）はデフォルトで除外されます。すべてのキーが無視リストに含まれている場合は何も表示されません。
+
+`src/config/settings.ts` で `frontmatterPreview: false` を設定すると、すべてのページでこの機能を無効にできます。
+
+## デフォルト無視リスト
+
+以下のキーはデフォルトで無視されます。これらはコンテンツスキームで定義されたすべてのフィールドに対応しており、再表示しても冗長になるだけです。
+
+| キー | 理由 |
+|-----|------|
+| `title` | ページの `h1` としてレンダリング |
+| `description` | タイトルの下にサブタイトルとして表示 |
+| `sidebar_position` | ナビゲーション内部メタデータ |
+| `sidebar_label` | ナビゲーション内部メタデータ |
+| `category` | ナビゲーション内部メタデータ |
+| `tags` | タグバッジとして別途レンダリング |
+| `search_exclude` | ビルド時フラグ |
+| `pagination_next` | ビルド時フラグ |
+| `pagination_prev` | ビルド時フラグ |
+| `draft` | ビルド時フラグ |
+| `unlisted` | ビルド時フラグ |
+| `hide_sidebar` | レイアウトフラグ |
+| `hide_toc` | レイアウトフラグ |
+| `standalone` | レイアウトフラグ |
+| `slug` | URL オーバーライド |
+| `generated` | ビルド時フラグ |
+
+このリストにないキーは自動的に表示されます。
+
+## 無視リストのカスタマイズ
+
+`src/config/settings.ts` の `frontmatterPreview` 設定には、互いに排他的な2つの設定があります。
+
+### `extraIgnoreKeys` — デフォルトを拡張する
+
+デフォルト設定を破棄せずにキーを無視リストに追加します。プロジェクト全体で非表示にしたいカスタムフロントマターフィールドがある場合に使用します。
+
+```ts
+frontmatterPreview: {
+  extraIgnoreKeys: ["reviewed_by", "internal_id"],
+},
+```
+
+### `ignoreKeys` — デフォルトを置き換える
+
+組み込みの無視リストを完全に置き換えます。非表示にするキーを完全に制御したい場合に使用します。`ignoreKeys` が存在する場合、`extraIgnoreKeys` は無視されます。
+
+```ts
+frontmatterPreview: {
+  ignoreKeys: ["title", "description", "sidebar_position"],
+},
+```
+
+<Warning>
+
+`ignoreKeys` を使用する際に標準スキーマキーを含めないと、`draft` や `unlisted` などのフレームワーク内部フィールドがテーブルに表示される可能性があります。ほとんどの場合、`extraIgnoreKeys` を使用する方が安全です。
+
+</Warning>
+
+## 機能を無効にする
+
+`frontmatterPreview: false` を設定すると、すべてのページからブロックを一括削除できます。
+
+```ts
+frontmatterPreview: false,
+```
+
+## 使用例
+
+次のフロントマターは `author` と `status` が表示されるプレビューテーブルを生成します。`title`、`description`、`sidebar_position` はフィルタリングされます。
+
+```mdx
+---
+title: My Release Notes
+description: What changed in v2.
+sidebar_position: 5
+author: Jane Doe
+status: released
+---
+```
+
+レンダリングされたテーブル：
+
+| キー | 値 |
+|-----|---|
+| `author` | Jane Doe |
+| `status` | released |
+
+完全な設定リファレンスについては、[設定 — frontmatterPreview](../guides/configuration.mdx#frontmatterpreview) を参照してください。

--- a/src/content/docs/guides/configuration.mdx
+++ b/src/content/docs/guides/configuration.mdx
@@ -35,6 +35,7 @@ export const settings = {
   colorTweakPanel: true,
   docMetainfo: true,
   docTags: true,
+  frontmatterPreview: {},
   math: true,
   docHistory: true,
   claudeResources: {
@@ -294,6 +295,40 @@ Default: `true`
 Enables tag support for documentation pages. When `true`, pages can use the `tags` frontmatter field, and tag index pages are generated at `/docs/tags/`.
 
 Default: `true`
+
+### frontmatterPreview
+
+Displays custom frontmatter fields as a compact key/value table directly beneath the page title. Framework-managed keys (`title`, `description`, `sidebar_position`, etc.) are hidden by default so only project-specific metadata is shown. Set to `false` to disable the block on all pages.
+
+Type: `FrontmatterPreviewConfig | false`
+
+Default: `{}` (enabled with built-in ignore list)
+
+The `FrontmatterPreviewConfig` object accepts:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `ignoreKeys` | `string[]` (optional) | Completely replaces the default ignore list. When set, `extraIgnoreKeys` is ignored |
+| `extraIgnoreKeys` | `string[]` (optional) | Additional keys to ignore on top of the defaults. Has no effect when `ignoreKeys` is also set |
+
+```ts
+// Extend the default list:
+frontmatterPreview: {
+  extraIgnoreKeys: ["reviewed_by", "internal_id"],
+},
+// Replace the default list entirely:
+frontmatterPreview: {
+  ignoreKeys: ["title", "description", "sidebar_position"],
+},
+// Disable:
+frontmatterPreview: false,
+```
+
+<Tip>
+
+See the [Frontmatter Preview reference](../reference/frontmatter-preview.mdx) for the full default ignore list and a live demo.
+
+</Tip>
 
 ### colorTweakPanel
 

--- a/src/content/docs/reference/frontmatter-preview.mdx
+++ b/src/content/docs/reference/frontmatter-preview.mdx
@@ -1,0 +1,103 @@
+---
+title: Frontmatter Preview
+description: Automatically display custom frontmatter fields as a metadata table beneath the page title.
+sidebar_position: 7
+author: zudo-doc
+status: stable
+---
+
+The frontmatter preview block appears automatically below the page title whenever a document contains non-ignored frontmatter keys. It renders those custom fields as a compact key/value table — useful for surfacing document metadata such as authorship, status, or version without embedding it inline in the prose.
+
+This very page demonstrates the feature: the `author` and `status` fields you see rendered above were declared in its own frontmatter.
+
+## When the Block Appears
+
+The block appears only when at least one frontmatter key survives filtering. Framework-managed keys (`title`, `description`, `sidebar_position`, `tags`, etc.) are stripped by default. If every key is on the ignore list, nothing is rendered.
+
+Set `frontmatterPreview: false` in `src/config/settings.ts` to disable the feature entirely for all pages.
+
+## Default Ignore List
+
+The following keys are ignored by default. They correspond to every field defined in the content schema and would be redundant to show again:
+
+| Key | Reason |
+|-----|--------|
+| `title` | Rendered as the page `h1` |
+| `description` | Shown as a subtitle below the title |
+| `sidebar_position` | Internal navigation metadata |
+| `sidebar_label` | Internal navigation metadata |
+| `category` | Internal navigation metadata |
+| `tags` | Rendered separately as tag badges |
+| `search_exclude` | Build-time flag |
+| `pagination_next` | Build-time flag |
+| `pagination_prev` | Build-time flag |
+| `draft` | Build-time flag |
+| `unlisted` | Build-time flag |
+| `hide_sidebar` | Layout flag |
+| `hide_toc` | Layout flag |
+| `standalone` | Layout flag |
+| `slug` | URL override |
+| `generated` | Build-time flag |
+
+Any key not in this list will be shown automatically.
+
+## Customizing the Ignore List
+
+The `frontmatterPreview` setting in `src/config/settings.ts` accepts two mutually exclusive knobs.
+
+### `extraIgnoreKeys` — extend the defaults
+
+Add keys to the ignore list without discarding the defaults. Use this when you have a project-wide custom frontmatter field that should remain hidden everywhere:
+
+```ts
+frontmatterPreview: {
+  extraIgnoreKeys: ["reviewed_by", "internal_id"],
+},
+```
+
+### `ignoreKeys` — replace the defaults
+
+Completely replaces the built-in ignore list. Use this when you want full control over which keys are hidden. When `ignoreKeys` is present, `extraIgnoreKeys` is ignored.
+
+```ts
+frontmatterPreview: {
+  ignoreKeys: ["title", "description", "sidebar_position"],
+},
+```
+
+<Warning>
+
+Using `ignoreKeys` without including the standard schema keys can expose framework-internal fields like `draft` or `unlisted` in the rendered table. In most cases, `extraIgnoreKeys` is the safer choice.
+
+</Warning>
+
+## Disable the Feature
+
+Set `frontmatterPreview: false` to remove the block from all pages at once:
+
+```ts
+frontmatterPreview: false,
+```
+
+## Example
+
+The following frontmatter produces a preview table with `author` and `status` visible, while `title`, `description`, and `sidebar_position` are filtered out:
+
+```mdx
+---
+title: My Release Notes
+description: What changed in v2.
+sidebar_position: 5
+author: Jane Doe
+status: released
+---
+```
+
+The rendered table shows:
+
+| Key | Value |
+|-----|-------|
+| `author` | Jane Doe |
+| `status` | released |
+
+For the full configuration reference, see [Configuration — frontmatterPreview](../guides/configuration.mdx#frontmatterpreview).

--- a/src/pages/docs/[...slug].astro
+++ b/src/pages/docs/[...slug].astro
@@ -34,6 +34,7 @@ import { docsUrl } from "@/utils/base";
 import EditLink from "@/components/edit-link.astro";
 import DocMetainfo from "@/components/doc-metainfo.astro";
 import DocTags from "@/components/doc-tags.astro";
+import FrontmatterPreview from "@/components/frontmatter-preview.astro";
 
 export async function getStaticPaths() {
   const allDocs = await getCollection("docs");
@@ -191,6 +192,10 @@ const slug = autoIndex
         )}
 
         {entry?.data?.tags && <DocTags tags={entry.data.tags} locale="en" />}
+
+        {settings.frontmatterPreview && entry && (
+          <FrontmatterPreview data={entry.data} locale="en" />
+        )}
 
         <Content components={components} />
 

--- a/src/pages/ja/docs/[...slug].astro
+++ b/src/pages/ja/docs/[...slug].astro
@@ -35,6 +35,7 @@ import EditLink from "@/components/edit-link.astro";
 import { settings } from "@/config/settings";
 import DocMetainfo from "@/components/doc-metainfo.astro";
 import DocTags from "@/components/doc-tags.astro";
+import FrontmatterPreview from "@/components/frontmatter-preview.astro";
 import type { DocsEntry } from "@/types/docs-entry";
 
 export async function getStaticPaths() {
@@ -242,6 +243,10 @@ const slug = autoIndex
         )}
 
         {entry?.data?.tags && <DocTags tags={entry.data.tags} locale="ja" />}
+
+        {settings.frontmatterPreview && entry && (
+          <FrontmatterPreview data={entry.data} locale="ja" />
+        )}
 
         <Content components={components} />
 

--- a/src/pages/v/[version]/docs/[...slug].astro
+++ b/src/pages/v/[version]/docs/[...slug].astro
@@ -34,6 +34,7 @@ import { settings } from "@/config/settings";
 import { versionedDocsUrl } from "@/utils/base";
 import DocMetainfo from "@/components/doc-metainfo.astro";
 import DocTags from "@/components/doc-tags.astro";
+import FrontmatterPreview from "@/components/frontmatter-preview.astro";
 import EditLink from "@/components/edit-link.astro";
 import type { VersionConfig } from "@/config/settings-types";
 
@@ -221,6 +222,10 @@ const slug = autoIndex
         )}
 
         {entry?.data?.tags && <DocTags tags={entry.data.tags} locale="en" />}
+
+        {settings.frontmatterPreview && entry && (
+          <FrontmatterPreview data={entry.data} locale="en" />
+        )}
 
         <Content components={components} />
 

--- a/src/pages/v/[version]/ja/docs/[...slug].astro
+++ b/src/pages/v/[version]/ja/docs/[...slug].astro
@@ -34,6 +34,7 @@ import { settings } from "@/config/settings";
 import { versionedDocsUrl } from "@/utils/base";
 import DocMetainfo from "@/components/doc-metainfo.astro";
 import DocTags from "@/components/doc-tags.astro";
+import FrontmatterPreview from "@/components/frontmatter-preview.astro";
 import EditLink from "@/components/edit-link.astro";
 import type { VersionConfig } from "@/config/settings-types";
 import type { DocsEntry } from "@/types/docs-entry";
@@ -285,6 +286,10 @@ const slug = autoIndex
         )}
 
         {entry?.data?.tags && <DocTags tags={entry.data.tags} locale="ja" />}
+
+        {settings.frontmatterPreview && entry && (
+          <FrontmatterPreview data={entry.data} locale="ja" />
+        )}
 
         <Content components={components} />
 


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/296

---

## Summary

Adds the `frontmatterPreview` feature — a GitHub-style table rendered between a doc's title area and its MDX content that surfaces custom frontmatter fields (e.g. `author`, `status`) while hiding every schema-managed key by default. When nothing remains after filtering (or on auto-index pages), the block renders nothing. Mirrored into `create-zudo-doc`.

## Changes

### Feature (main project)

- **Settings & types** (#297) — `FrontmatterPreviewConfig` with `ignoreKeys` (replace) and `extraIgnoreKeys` (extend); `DEFAULT_FRONTMATTER_IGNORE_KEYS` covers every schema field. Default `frontmatterPreview: {}` so the feature is on but filtered.
- **Component** (#298) — `src/components/frontmatter-preview.astro`, server-rendered (no client JS), design-token styling, `data-testid="frontmatter-preview"`, empty-filter ⇒ no markup.
- **Page wiring** (#299) — mounted in all four doc-page routes (EN / JA × normal / versioned), gated by `settings.frontmatterPreview && entry`, never on auto-index pages.
- **i18n** (#300) — `frontmatter.preview.title / keyCol / valueCol` in EN / JA / DE.
- **Docs** (#301) — new `/docs/reference/frontmatter-preview/` (and JA mirror), plus a `### frontmatterPreview` subsection in the configuration reference.
- **E2E smoke test** (#302) — `e2e/smoke-frontmatter-preview.spec.ts` covers (a) system-only frontmatter hides the block, (b) custom `author`/`status` surfaces, (c) auto-index pages hide the block. **Also fixed a latent bug:** `src/content.config.ts` was missing `.passthrough()` on `docsSchema`, so custom frontmatter keys were silently dropped.

### Generator sync (#303 + review fix)

- Mirrored the whole feature into `packages/create-zudo-doc/`: settings, types, defaults, component, page wiring (base + i18n + versioning templates), i18n keys, scaffold tests.
- **Review fix:** `content-config-gen.ts` was emitting `z.object({...})` without `.passthrough()`, so scaffolded projects would hit the same silent key-stripping bug. Added `.passthrough()` + regression test.

## Test Plan

- [x] `pnpm check` (typecheck)
- [x] `pnpm build` (static build)
- [x] `pnpm --filter create-zudo-doc test` (153/153)
- [x] E2E smoke tests pass
- [x] `pnpm check:template-drift` clean for touched files
- [ ] CI on PR #304