### PR TITLE
feat(frontmatter-preview): add FrontmatterPreview component (#298)

### DIFF
--- a/src/components/frontmatter-preview.astro
+++ b/src/components/frontmatter-preview.astro
@@ -1,0 +1,87 @@
+---
+import { settings } from "@/config/settings";
+import { DEFAULT_FRONTMATTER_IGNORE_KEYS } from "@/config/frontmatter-preview-defaults";
+import { t, type Locale } from "@/config/i18n";
+
+interface Props {
+  data: Record<string, unknown>;
+  locale?: Locale;
+}
+
+const { data, locale = "en" } = Astro.props;
+
+// Resolve effective ignore list
+const cfg = settings.frontmatterPreview;
+
+// If feature is disabled, render nothing
+const ignoreSet: Set<string> = (() => {
+  if (cfg === false) return new Set<string>();
+  if (cfg.ignoreKeys) return new Set(cfg.ignoreKeys);
+  const keys = [
+    ...DEFAULT_FRONTMATTER_IGNORE_KEYS,
+    ...(cfg.extraIgnoreKeys ?? []),
+  ];
+  return new Set(keys);
+})();
+
+// Filter entries: skip ignored keys and null/undefined values
+const entries = Object.entries(data).filter(
+  ([key, value]) =>
+    !ignoreSet.has(key) && value !== null && value !== undefined,
+);
+
+function renderValue(v: unknown): { text?: string; code?: string } {
+  if (typeof v === "string") return { text: v };
+  if (typeof v === "number") return { text: String(v) };
+  if (typeof v === "boolean") return { text: v ? "true" : "false" };
+  if (Array.isArray(v) && v.every((item) => typeof item === "string")) {
+    return { text: (v as string[]).join(", ") };
+  }
+  return { code: JSON.stringify(v) };
+}
+---
+
+{
+  cfg !== false && entries.length > 0 && (
+    <div data-testid="frontmatter-preview" class="my-vsp-lg">
+      <p class="text-caption text-muted mb-vsp-2xs">
+        {t("frontmatter.preview.title", locale)}
+      </p>
+      <div class="overflow-x-auto">
+        <table class="w-full border-collapse text-caption">
+          <thead>
+            <tr>
+              <th class="text-left font-semibold px-hsp-md py-vsp-2xs border-b-2 border-muted text-fg">
+                {t("frontmatter.preview.keyCol", locale)}
+              </th>
+              <th class="text-left font-semibold px-hsp-md py-vsp-2xs border-b-2 border-muted text-fg">
+                {t("frontmatter.preview.valueCol", locale)}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map(([key, value]) => {
+              const rendered = renderValue(value);
+              return (
+                <tr class="border-b border-muted">
+                  <td class="px-hsp-md py-vsp-2xs text-muted font-mono align-top">
+                    {key}
+                  </td>
+                  <td class="px-hsp-md py-vsp-2xs text-fg break-words align-top">
+                    {rendered.code !== undefined ? (
+                      <code class="bg-code-bg text-code-fg px-hsp-xs py-0 rounded text-micro font-mono">
+                        {rendered.code}
+                      </code>
+                    ) : (
+                      rendered.text
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/src/config/frontmatter-preview-defaults.ts
+++ b/src/config/frontmatter-preview-defaults.ts
@@ -1,0 +1,23 @@
+/**
+ * Schema-managed frontmatter keys that are handled by the framework and
+ * should be hidden from the frontmatter preview by default.
+ * These correspond to every field defined in the docsSchema in src/content.config.ts.
+ */
+export const DEFAULT_FRONTMATTER_IGNORE_KEYS: string[] = [
+  "title",
+  "description",
+  "category",
+  "sidebar_position",
+  "sidebar_label",
+  "tags",
+  "search_exclude",
+  "pagination_next",
+  "pagination_prev",
+  "draft",
+  "unlisted",
+  "hide_sidebar",
+  "hide_toc",
+  "standalone",
+  "slug",
+  "generated",
+];

--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -82,6 +82,9 @@ const translations: Record<string, Record<string, string>> = {
     "nav.backToMenu": "Back to main menu",
     "doc.fallbackNotice":
       "This page has not been translated yet and is shown in the original language.",
+    "frontmatter.preview.title": "Frontmatter",
+    "frontmatter.preview.keyCol": "Key",
+    "frontmatter.preview.valueCol": "Value",
     "version.latest": "Latest",
     "version.switcher.label": "Version",
     "version.banner.unmaintained":
@@ -133,6 +136,9 @@ const translations: Record<string, Record<string, string>> = {
     "nav.backToMenu": "メインメニューに戻る",
     "doc.fallbackNotice":
       "このページはまだ翻訳されていません。原文のまま表示しています。",
+    "frontmatter.preview.title": "フロントマター",
+    "frontmatter.preview.keyCol": "キー",
+    "frontmatter.preview.valueCol": "値",
     "version.latest": "最新",
     "version.switcher.label": "バージョン",
     "version.banner.unmaintained":
@@ -184,6 +190,9 @@ const translations: Record<string, Record<string, string>> = {
     "doc.pageCountSingle": "{count} Seite",
     "doc.fallbackNotice":
       "Diese Seite wurde noch nicht übersetzt und wird in der Originalsprache angezeigt.",
+    "frontmatter.preview.title": "Frontmatter",
+    "frontmatter.preview.keyCol": "Schlüssel",
+    "frontmatter.preview.valueCol": "Wert",
     "version.latest": "Neueste",
     "version.switcher.label": "Version",
     "version.banner.unmaintained":

--- a/src/config/settings-types.ts
+++ b/src/config/settings-types.ts
@@ -48,6 +48,19 @@ export interface HtmlPreviewConfig {
   js?: string;
 }
 
+export interface FrontmatterPreviewConfig {
+  /**
+   * Completely replaces the default ignore list.
+   * When set, `extraIgnoreKeys` is ignored.
+   */
+  ignoreKeys?: string[];
+  /**
+   * Additional keys to ignore on top of the defaults.
+   * Has no effect when `ignoreKeys` is also set.
+   */
+  extraIgnoreKeys?: string[];
+}
+
 export interface VersionConfig {
   /** Version identifier, used in URL path (e.g., "1.0", "v1") */
   slug: string;

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -6,6 +6,7 @@ export type {
   LocaleConfig,
   VersionConfig,
   FooterConfig,
+  FrontmatterPreviewConfig,
 } from "./settings-types";
 import type {
   HeaderNavItem,
@@ -14,6 +15,7 @@ import type {
   LocaleConfig,
   VersionConfig,
   FooterConfig,
+  FrontmatterPreviewConfig,
 } from "./settings-types";
 
 export const settings = {
@@ -48,6 +50,7 @@ export const settings = {
   sidebarResizer: true as boolean,
   sidebarToggle: true as boolean,
   imageEnlarge: true as boolean,
+  frontmatterPreview: {} satisfies FrontmatterPreviewConfig as FrontmatterPreviewConfig | false,
   docHistory: true,
   htmlPreview: undefined as HtmlPreviewConfig | undefined,
   versions: [


### PR DESCRIPTION
## Summary

- Implements `src/components/frontmatter-preview.astro` — server-rendered, zero client JS
- Resolves effective ignore list from `settings.frontmatterPreview`: uses `ignoreKeys` as-is when provided, otherwise merges `DEFAULT_FRONTMATTER_IGNORE_KEYS` with any `extraIgnoreKeys`
- Filters out ignored keys and null/undefined values; renders nothing (empty fragment) when filtered list is empty
- Renders a plain `<table>` with heading (`t("frontmatter.preview.title")`) and key/value columns using i18n strings from #300
- Attaches `data-testid="frontmatter-preview"` on outer wrapper for E2E test in #302
- Value rendering: `string`/`number`/`boolean` → text, `string[]` → comma-joined, other arrays/objects → `<code>{JSON.stringify(v)}</code>`
- All styling uses project design tokens (`text-caption`, `text-muted`, `text-fg`, `bg-code-bg`, `text-code-fg`, `border-muted`, `hsp-*`, `vsp-*`) — no hardcoded colors

## Test plan

- [ ] `pnpm check` passes (verified locally)
- [ ] Component renders nothing when `settings.frontmatterPreview === false`
- [ ] Component renders nothing when all keys are filtered out
- [ ] Table appears with correct heading and columns for a doc with visible frontmatter keys
- [ ] E2E test in #302 can locate `[data-testid="frontmatter-preview"]`

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)