### PR TITLE
feat(S4): extract shared TagNav component

### DIFF
--- a/src/components/doc-tags.astro
+++ b/src/components/doc-tags.astro
@@ -1,7 +1,6 @@
 ---
-import { settings } from "@/config/settings";
-import { t, defaultLocale, type Locale } from "@/config/i18n";
-import { withBase } from "@/utils/base";
+import TagNav from "./tag-nav.astro";
+import type { Locale } from "@/config/i18n";
 
 interface Props {
   tags: string[];
@@ -9,25 +8,6 @@ interface Props {
 }
 
 const { tags, locale = "en" } = Astro.props;
-const show = settings.docTags && tags.length > 0;
 ---
 
-{
-  show && (
-    <div class="mt-vsp-md mb-vsp-lg flex flex-wrap items-center gap-hsp-xs">
-      <span class="text-caption text-muted">{t("doc.tags", locale)}:</span>
-      {tags.map((tag) => (
-        <a
-          href={withBase(
-            locale === defaultLocale
-              ? `/docs/tags/${tag}`
-              : `/${locale}/docs/tags/${tag}`,
-          )}
-          class="inline-block px-hsp-sm py-vsp-2xs text-caption bg-surface border border-muted rounded-full text-accent hover:bg-code-bg hover:border-accent"
-        >
-          {tag}
-        </a>
-      ))}
-    </div>
-  )
-}
+<TagNav variant="page" tags={tags} locale={locale} />

--- a/src/components/tag-nav.astro
+++ b/src/components/tag-nav.astro
@@ -1,0 +1,91 @@
+---
+import { settings } from "@/config/settings";
+import { t, defaultLocale, type Locale } from "@/config/i18n";
+import { withBase } from "@/utils/base";
+import { collectTags } from "@/utils/tags";
+import { getDocsCollection } from "@/utils/get-docs-collection";
+import { toRouteSlug } from "@/utils/slug";
+import type { DocsEntry } from "@/types/docs-entry";
+
+interface Props {
+  variant: "all" | "page";
+  tags?: string[];
+  locale?: Locale;
+}
+
+const { variant, tags = [], locale = "en" } = Astro.props;
+
+let sortedTags: { tag: string; count: number }[] = [];
+
+if (settings.docTags && variant === "all") {
+  const filterDocs = (docs: DocsEntry[]) =>
+    import.meta.env.PROD
+      ? docs.filter((doc) => !doc.data.draft && !doc.data.unlisted)
+      : docs.filter((doc) => !doc.data.unlisted);
+
+  let docs: DocsEntry[];
+  if (locale === defaultLocale) {
+    const allDocs = await getDocsCollection("docs");
+    docs = filterDocs(allDocs);
+  } else {
+    const localeDocs = await getDocsCollection(`docs-${locale}`);
+    const baseDocs = await getDocsCollection("docs");
+    const filteredLocale = filterDocs(localeDocs);
+    const filteredBase = filterDocs(baseDocs);
+    const localeSlugSet = new Set(
+      filteredLocale.map((d) => d.data.slug ?? toRouteSlug(d.id)),
+    );
+    docs = [
+      ...filteredLocale,
+      ...filteredBase.filter(
+        (d) => !localeSlugSet.has(d.data.slug ?? toRouteSlug(d.id)),
+      ),
+    ];
+  }
+
+  const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));
+  sortedTags = [...tagMap.values()].sort((a, b) =>
+    a.tag.localeCompare(b.tag, locale),
+  );
+}
+
+function tagHref(tag: string) {
+  const path =
+    locale === defaultLocale
+      ? `/docs/tags/${tag}`
+      : `/${locale}/docs/tags/${tag}`;
+  return withBase(path);
+}
+---
+
+{
+  settings.docTags && variant === "all" && sortedTags.length > 0 && (
+    <div class="flex flex-wrap gap-hsp-sm">
+      {sortedTags.map(({ tag, count }) => (
+        <a
+          href={tagHref(tag)}
+          class="inline-flex items-center gap-hsp-2xs px-hsp-md py-vsp-xs bg-surface border border-muted rounded-full text-fg hover:border-accent hover:text-accent"
+        >
+          <span>{tag}</span>
+          <span class="text-caption text-muted">({count})</span>
+        </a>
+      ))}
+    </div>
+  )
+}
+
+{
+  settings.docTags && variant === "page" && tags.length > 0 && (
+    <div class="mt-vsp-md mb-vsp-lg flex flex-wrap items-center gap-hsp-xs">
+      <span class="text-caption text-muted">{t("doc.tags", locale)}:</span>
+      {tags.map((tag) => (
+        <a
+          href={tagHref(tag)}
+          class="inline-block px-hsp-sm py-vsp-2xs text-caption bg-surface border border-muted rounded-full text-accent hover:bg-code-bg hover:border-accent"
+        >
+          {tag}
+        </a>
+      ))}
+    </div>
+  )
+}

--- a/src/pages/docs/tags/index.astro
+++ b/src/pages/docs/tags/index.astro
@@ -6,15 +6,13 @@ import { toRouteSlug } from "@/utils/slug";
 import { collectTags } from "@/utils/tags";
 import { t } from "@/config/i18n";
 import { withBase } from "@/utils/base";
+import TagNav from "@/components/tag-nav.astro";
 
 const allDocs = await getCollection("docs");
 const docs = import.meta.env.PROD
   ? allDocs.filter((doc) => !doc.data.draft && !doc.data.unlisted)
   : allDocs.filter((doc) => !doc.data.unlisted);
 const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));
-const sortedTags = [...tagMap.values()].sort((a, b) =>
-  a.tag.localeCompare(b.tag),
-);
 ---
 
 <DocLayout title={t("doc.allTags")} currentSlug="tags">
@@ -27,20 +25,10 @@ const sortedTags = [...tagMap.values()].sort((a, b) =>
   />
   <h1 class="text-heading font-bold mb-vsp-lg">{t("doc.allTags")}</h1>
   {
-    sortedTags.length === 0 ? (
+    tagMap.size === 0 ? (
       <p class="text-muted">{t("doc.noTags")}</p>
     ) : (
-      <div class="flex flex-wrap gap-hsp-sm">
-        {sortedTags.map(({ tag, count }) => (
-          <a
-            href={withBase(`/docs/tags/${tag}`)}
-            class="inline-flex items-center gap-hsp-2xs px-hsp-md py-vsp-xs bg-surface border border-muted rounded-full text-fg hover:border-accent hover:text-accent"
-          >
-            <span>{tag}</span>
-            <span class="text-caption text-muted">({count})</span>
-          </a>
-        ))}
-      </div>
+      <TagNav variant="all" locale="en" />
     )
   }
 </DocLayout>

--- a/src/pages/ja/docs/tags/index.astro
+++ b/src/pages/ja/docs/tags/index.astro
@@ -6,6 +6,7 @@ import { toRouteSlug } from "@/utils/slug";
 import { collectTags } from "@/utils/tags";
 import { t } from "@/config/i18n";
 import { withBase } from "@/utils/base";
+import TagNav from "@/components/tag-nav.astro";
 import type { DocsEntry } from "@/types/docs-entry";
 
 const localeDocs = await getDocsCollection("docs-ja");
@@ -26,9 +27,6 @@ const docs = [
   ),
 ];
 const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));
-const sortedTags = [...tagMap.values()].sort((a, b) =>
-  a.tag.localeCompare(b.tag),
-);
 ---
 
 <DocLayout title={t("doc.allTags", "ja")} lang="ja" currentSlug="tags">
@@ -41,20 +39,10 @@ const sortedTags = [...tagMap.values()].sort((a, b) =>
   />
   <h1 class="text-heading font-bold mb-vsp-lg">{t("doc.allTags", "ja")}</h1>
   {
-    sortedTags.length === 0 ? (
+    tagMap.size === 0 ? (
       <p class="text-muted">{t("doc.noTags", "ja")}</p>
     ) : (
-      <div class="flex flex-wrap gap-hsp-sm">
-        {sortedTags.map(({ tag, count }) => (
-          <a
-            href={withBase(`/ja/docs/tags/${tag}`)}
-            class="inline-flex items-center gap-hsp-2xs px-hsp-md py-vsp-xs bg-surface border border-muted rounded-full text-fg hover:border-accent hover:text-accent"
-          >
-            <span>{tag}</span>
-            <span class="text-caption text-muted">({count})</span>
-          </a>
-        ))}
-      </div>
+      <TagNav variant="all" locale="ja" />
     )
   }
 </DocLayout>


### PR DESCRIPTION
## Summary

- Create `src/components/tag-nav.astro` with two variants: `all` (pills with counts, locale-aware collection fetch) and `page` (pills without counts, delegates from `DocTags`)
- Refactor `src/components/doc-tags.astro` to a thin wrapper: `<TagNav variant="page" tags={tags} locale={locale} />`
- Replace inline pill-grid JSX in `/docs/tags/index.astro` and `/ja/docs/tags/index.astro` with `<TagNav variant="all" locale="en|ja" />`, preserving existing `tagMap.size === 0` fallback

## Test plan

- [x] `pnpm check` passes (type check)
- [x] `pnpm build` succeeds
- [x] Pill classes exist only in `tag-nav.astro` (grep confirmed, no residual duplication)
- [x] `/docs/tags/` and `/ja/docs/tags/` render identically to before (breadcrumb + h1 + tag pills preserved)
- [x] `t("doc.noTags")` fallback preserved via caller-owned size-zero check

🤖 Generated with [Claude Code](https://claude.com/claude-code)