### PR TITLE
tag-tweaks: tag page layout, card nav, and tag shape refresh

### DIFF
--- a/packages/create-zudo-doc/templates/base/src/components/doc-card-grid.astro
+++ b/packages/create-zudo-doc/templates/base/src/components/doc-card-grid.astro
@@ -1,0 +1,51 @@
+---
+interface Item {
+  href: string;
+  title: string;
+  description?: string;
+}
+
+interface Props {
+  items: Item[];
+  class?: string;
+}
+
+const { items, class: className } = Astro.props;
+---
+
+{
+  items.length > 0 && (
+    <nav
+      aria-label="Child pages"
+      class:list={[
+        "grid grid-cols-1 gap-x-hsp-lg gap-y-vsp-md sm:grid-cols-2",
+        className,
+      ]}
+    >
+      {items.map((item) => (
+        <a
+          href={item.href}
+          class="group block rounded border border-muted bg-surface px-hsp-lg py-vsp-md hover:border-accent"
+        >
+          <span class="flex items-center gap-hsp-xs font-medium text-accent underline group-hover:underline">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="currentColor"
+              viewBox="0 0 103.395 107.049"
+              aria-hidden="true"
+              class="w-[16px] shrink-0"
+            >
+              <path d="M5.746 5.74 0 11.49l20.987 20.96C34.126 45.572 41.963 53.45 41.948 53.523c-.012.062-9.456 9.544-20.986 21.07L0 95.55l5.714 5.715c3.142 3.143 5.748 5.715 5.79 5.715s2.63-2.563 5.75-5.696l17.939-18.001c21.867-21.94 29.443-29.599 29.443-29.768 0-.114-.665-.804-5.084-5.275C51.872 40.47 11.71.125 11.565.036 11.525.01 8.906 2.578 5.746 5.74m38.345-.066c-3.132 3.13-5.696 5.71-5.696 5.732-.001.022 2.16 2.185 4.8 4.807 2.641 2.623 8.382 8.338 12.758 12.702 15.38 15.337 23.763 23.641 24.314 24.086.19.153.346.336.346.405 0 .07-1.738 1.847-3.887 3.976a17515 17515 0 0 0-20.35 20.264 19555 19555 0 0 1-17.223 17.158c-.416.409-.757.77-.757.8 0 .083 11.415 11.485 11.457 11.445.235-.22 53.542-53.528 53.542-53.543C103.395 53.472 49.891.02 49.837 0c-.028-.01-2.613 2.543-5.746 5.674" />
+            </svg>
+            {item.title}
+          </span>
+          {item.description && (
+            <span class="mt-vsp-2xs block text-small text-muted">
+              {item.description}
+            </span>
+          )}
+        </a>
+      ))}
+    </nav>
+  )
+}

--- a/packages/create-zudo-doc/templates/base/src/components/doc-card-grid.astro
+++ b/packages/create-zudo-doc/templates/base/src/components/doc-card-grid.astro
@@ -7,16 +7,17 @@ interface Item {
 
 interface Props {
   items: Item[];
+  ariaLabel?: string;
   class?: string;
 }
 
-const { items, class: className } = Astro.props;
+const { items, ariaLabel = "Child pages", class: className } = Astro.props;
 ---
 
 {
   items.length > 0 && (
     <nav
-      aria-label="Child pages"
+      aria-label={ariaLabel}
       class:list={[
         "grid grid-cols-1 gap-x-hsp-lg gap-y-vsp-md sm:grid-cols-2",
         className,
@@ -27,17 +28,19 @@ const { items, class: className } = Astro.props;
           href={item.href}
           class="group block rounded border border-muted bg-surface px-hsp-lg py-vsp-md hover:border-accent"
         >
-          <span class="flex items-center gap-hsp-xs font-medium text-accent underline group-hover:underline">
+          <span class="flex items-center gap-hsp-xs">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               fill="currentColor"
               viewBox="0 0 103.395 107.049"
               aria-hidden="true"
-              class="w-[16px] shrink-0"
+              class="w-[16px] shrink-0 text-accent"
             >
               <path d="M5.746 5.74 0 11.49l20.987 20.96C34.126 45.572 41.963 53.45 41.948 53.523c-.012.062-9.456 9.544-20.986 21.07L0 95.55l5.714 5.715c3.142 3.143 5.748 5.715 5.79 5.715s2.63-2.563 5.75-5.696l17.939-18.001c21.867-21.94 29.443-29.599 29.443-29.768 0-.114-.665-.804-5.084-5.275C51.872 40.47 11.71.125 11.565.036 11.525.01 8.906 2.578 5.746 5.74m38.345-.066c-3.132 3.13-5.696 5.71-5.696 5.732-.001.022 2.16 2.185 4.8 4.807 2.641 2.623 8.382 8.338 12.758 12.702 15.38 15.337 23.763 23.641 24.314 24.086.19.153.346.336.346.405 0 .07-1.738 1.847-3.887 3.976a17515 17515 0 0 0-20.35 20.264 19555 19555 0 0 1-17.223 17.158c-.416.409-.757.77-.757.8 0 .083 11.415 11.485 11.457 11.445.235-.22 53.542-53.528 53.542-53.543C103.395 53.472 49.891.02 49.837 0c-.028-.01-2.613 2.543-5.746 5.674" />
             </svg>
-            {item.title}
+            <span class="font-medium text-accent group-hover:underline">
+              {item.title}
+            </span>
           </span>
           {item.description && (
             <span class="mt-vsp-2xs block text-small text-muted">

--- a/packages/create-zudo-doc/templates/base/src/components/tag-nav.astro
+++ b/packages/create-zudo-doc/templates/base/src/components/tag-nav.astro
@@ -64,13 +64,22 @@ function tagHref(tag: string) {
 ---
 
 {
+  /*
+  Pointed chip uses two stacked clip-path polygons to fake a 1px border:
+  outer span is the border color, inner span is the fill inset by 1px.
+  The inner clip-path matches the outer but offset by 1px on every edge,
+  hence `calc(100% - 17px)` (outer 16 + 1px rim) and
+  `calc(100% - 13px)` (outer 12 + 1px rim) on the page variant.
+*/
+}
+{
   settings.docTags && variant === "all" && sortedTags.length > 0 && (
     <ul class="flex flex-wrap gap-x-hsp-xs gap-y-vsp-xs">
       {sortedTags.map(({ tag, count }) => (
         <li class="inline-flex whitespace-nowrap">
           <a
             href={tagHref(tag)}
-            aria-label={`Docs tagged ${tag}`}
+            aria-label={`${t("doc.taggedWith", locale)}: ${tag}`}
             class="group relative inline-flex no-underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
           >
             <span
@@ -98,7 +107,7 @@ function tagHref(tag: string) {
       {tags.map((tag) => (
         <a
           href={tagHref(tag)}
-          aria-label={`Docs tagged ${tag}`}
+          aria-label={`${t("doc.taggedWith", locale)}: ${tag}`}
           class="group relative inline-flex no-underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
         >
           <span

--- a/packages/create-zudo-doc/templates/base/src/components/tag-nav.astro
+++ b/packages/create-zudo-doc/templates/base/src/components/tag-nav.astro
@@ -65,30 +65,52 @@ function tagHref(tag: string) {
 
 {
   settings.docTags && variant === "all" && sortedTags.length > 0 && (
-    <div class="flex flex-wrap gap-hsp-sm">
+    <ul class="flex flex-wrap gap-x-hsp-xs gap-y-vsp-xs">
       {sortedTags.map(({ tag, count }) => (
-        <a
-          href={tagHref(tag)}
-          class="inline-flex items-center gap-hsp-2xs px-hsp-md py-vsp-xs bg-surface border border-muted rounded-full text-fg hover:border-accent hover:text-accent"
-        >
-          <span>{tag}</span>
-          <span class="text-caption text-muted">({count})</span>
-        </a>
+        <li class="inline-flex whitespace-nowrap">
+          <a
+            href={tagHref(tag)}
+            aria-label={`Docs tagged ${tag}`}
+            class="group relative inline-flex no-underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+          >
+            <span
+              class="absolute inset-0 bg-muted group-hover:bg-fg"
+              style="clip-path: polygon(0 0, calc(100% - 16px) 0, 100% 50%, calc(100% - 16px) 100%, 0 100%)"
+            />
+            <span
+              class="relative inline-flex items-center text-small text-fg bg-bg pl-hsp-sm pr-hsp-xl py-vsp-2xs group-hover:text-bg group-hover:bg-fg"
+              style="clip-path: polygon(1px 1px, calc(100% - 17px) 1px, calc(100% - 1px) 50%, calc(100% - 17px) calc(100% - 1px), 1px calc(100% - 1px))"
+            >
+              <span>#{tag}</span>
+              <span class="text-caption opacity-60">&nbsp;({count})</span>
+            </span>
+          </a>
+        </li>
       ))}
-    </div>
+    </ul>
   )
 }
 
 {
   settings.docTags && variant === "page" && tags.length > 0 && (
-    <div class="flex flex-wrap items-center gap-hsp-xs">
+    <div class="flex flex-wrap items-center gap-x-hsp-xs gap-y-vsp-xs">
       <span class="text-caption text-muted">{t("doc.tags", locale)}:</span>
       {tags.map((tag) => (
         <a
           href={tagHref(tag)}
-          class="inline-block px-hsp-sm py-vsp-2xs text-caption bg-surface border border-muted rounded-full text-accent hover:bg-code-bg hover:border-accent"
+          aria-label={`Docs tagged ${tag}`}
+          class="group relative inline-flex no-underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
         >
-          {tag}
+          <span
+            class="absolute inset-0 bg-muted group-hover:bg-fg"
+            style="clip-path: polygon(0 0, calc(100% - 12px) 0, 100% 50%, calc(100% - 12px) 100%, 0 100%)"
+          />
+          <span
+            class="relative inline-flex items-center text-caption text-fg bg-bg pl-hsp-sm pr-hsp-lg py-vsp-2xs group-hover:text-bg group-hover:bg-fg"
+            style="clip-path: polygon(1px 1px, calc(100% - 13px) 1px, calc(100% - 1px) 50%, calc(100% - 13px) calc(100% - 1px), 1px calc(100% - 1px))"
+          >
+            #{tag}
+          </span>
         </a>
       ))}
     </div>

--- a/packages/create-zudo-doc/templates/base/src/pages/docs/tags/[tag].astro
+++ b/packages/create-zudo-doc/templates/base/src/pages/docs/tags/[tag].astro
@@ -28,7 +28,12 @@ const countText =
     : t("doc.pageCount").replace("{count}", String(tagInfo.count));
 ---
 
-<DocLayout title={`${t("doc.taggedWith")}: ${tag}`} currentSlug={`tags/${tag}`}>
+<DocLayout
+  title={`${t("doc.taggedWith")}: ${tag}`}
+  currentSlug={`tags/${tag}`}
+  hideSidebar={true}
+  hideToc={true}
+>
   <Breadcrumb
     slot="breadcrumb"
     items={[

--- a/packages/create-zudo-doc/templates/base/src/pages/docs/tags/[tag].astro
+++ b/packages/create-zudo-doc/templates/base/src/pages/docs/tags/[tag].astro
@@ -47,6 +47,7 @@ const countText =
   <p class="text-muted mb-vsp-lg">{countText}</p>
 
   <DocCardGrid
+    ariaLabel={`${t("doc.taggedWith")}: ${tag}`}
     items={tagInfo.docs.map((doc) => ({
       href: docsUrl(doc.slug, "en"),
       title: doc.title,

--- a/packages/create-zudo-doc/templates/base/src/pages/docs/tags/[tag].astro
+++ b/packages/create-zudo-doc/templates/base/src/pages/docs/tags/[tag].astro
@@ -2,6 +2,7 @@
 import { getCollection } from "astro:content";
 import DocLayout from "@/layouts/doc-layout.astro";
 import Breadcrumb from "@/components/breadcrumb.astro";
+import DocCardGrid from "@/components/doc-card-grid.astro";
 import { toRouteSlug } from "@/utils/slug";
 import { collectTags } from "@/utils/tags";
 import { t } from "@/config/i18n";
@@ -40,23 +41,11 @@ const countText =
   <h1 class="text-heading font-bold mb-vsp-xs">{t("doc.taggedWith")}: {tag}</h1>
   <p class="text-muted mb-vsp-lg">{countText}</p>
 
-  <nav class="grid grid-cols-1 gap-y-vsp-md">
-    {
-      tagInfo.docs.map((doc) => (
-        <a
-          href={docsUrl(doc.slug, "en")}
-          class="group block border border-muted bg-surface px-hsp-lg py-vsp-md hover:border-accent"
-        >
-          <span class="font-medium text-accent underline group-hover:underline">
-            {doc.title}
-          </span>
-          {doc.description && (
-            <span class="mt-vsp-2xs block text-small text-muted group-hover:underline decoration-muted">
-              {doc.description}
-            </span>
-          )}
-        </a>
-      ))
-    }
-  </nav>
+  <DocCardGrid
+    items={tagInfo.docs.map((doc) => ({
+      href: docsUrl(doc.slug, "en"),
+      title: doc.title,
+      description: doc.description,
+    }))}
+  />
 </DocLayout>

--- a/packages/create-zudo-doc/templates/base/src/pages/docs/tags/index.astro
+++ b/packages/create-zudo-doc/templates/base/src/pages/docs/tags/index.astro
@@ -15,7 +15,12 @@ const docs = import.meta.env.PROD
 const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));
 ---
 
-<DocLayout title={t("doc.allTags")} currentSlug="tags">
+<DocLayout
+  title={t("doc.allTags")}
+  currentSlug="tags"
+  hideSidebar={true}
+  hideToc={true}
+>
   <Breadcrumb
     slot="breadcrumb"
     items={[

--- a/packages/create-zudo-doc/templates/features/i18n/files/src/pages/ja/docs/tags/[tag].astro
+++ b/packages/create-zudo-doc/templates/features/i18n/files/src/pages/ja/docs/tags/[tag].astro
@@ -46,6 +46,8 @@ const countText =
   title={`${t("doc.taggedWith", "ja")}: ${tag}`}
   lang="ja"
   currentSlug={`tags/${tag}`}
+  hideSidebar={true}
+  hideToc={true}
 >
   <Breadcrumb
     slot="breadcrumb"

--- a/packages/create-zudo-doc/templates/features/i18n/files/src/pages/ja/docs/tags/[tag].astro
+++ b/packages/create-zudo-doc/templates/features/i18n/files/src/pages/ja/docs/tags/[tag].astro
@@ -2,6 +2,7 @@
 import { getDocsCollection } from "@/utils/get-docs-collection";
 import DocLayout from "@/layouts/doc-layout.astro";
 import Breadcrumb from "@/components/breadcrumb.astro";
+import DocCardGrid from "@/components/doc-card-grid.astro";
 import { toRouteSlug } from "@/utils/slug";
 import { collectTags } from "@/utils/tags";
 import { t } from "@/config/i18n";
@@ -60,23 +61,11 @@ const countText =
   </h1>
   <p class="text-muted mb-vsp-lg">{countText}</p>
 
-  <nav class="grid grid-cols-1 gap-y-vsp-md">
-    {
-      tagInfo.docs.map((doc) => (
-        <a
-          href={docsUrl(doc.slug, "ja")}
-          class="group block border border-muted bg-surface px-hsp-lg py-vsp-md hover:border-accent"
-        >
-          <span class="font-medium text-accent underline group-hover:underline">
-            {doc.title}
-          </span>
-          {doc.description && (
-            <span class="mt-vsp-2xs block text-small text-muted group-hover:underline decoration-muted">
-              {doc.description}
-            </span>
-          )}
-        </a>
-      ))
-    }
-  </nav>
+  <DocCardGrid
+    items={tagInfo.docs.map((doc) => ({
+      href: docsUrl(doc.slug, "ja"),
+      title: doc.title,
+      description: doc.description,
+    }))}
+  />
 </DocLayout>

--- a/packages/create-zudo-doc/templates/features/i18n/files/src/pages/ja/docs/tags/[tag].astro
+++ b/packages/create-zudo-doc/templates/features/i18n/files/src/pages/ja/docs/tags/[tag].astro
@@ -64,6 +64,7 @@ const countText =
   <p class="text-muted mb-vsp-lg">{countText}</p>
 
   <DocCardGrid
+    ariaLabel={`${t("doc.taggedWith", "ja")}: ${tag}`}
     items={tagInfo.docs.map((doc) => ({
       href: docsUrl(doc.slug, "ja"),
       title: doc.title,

--- a/packages/create-zudo-doc/templates/features/i18n/files/src/pages/ja/docs/tags/index.astro
+++ b/packages/create-zudo-doc/templates/features/i18n/files/src/pages/ja/docs/tags/index.astro
@@ -29,7 +29,13 @@ const docs = [
 const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));
 ---
 
-<DocLayout title={t("doc.allTags", "ja")} lang="ja" currentSlug="tags">
+<DocLayout
+  title={t("doc.allTags", "ja")}
+  lang="ja"
+  currentSlug="tags"
+  hideSidebar={true}
+  hideToc={true}
+>
   <Breadcrumb
     slot="breadcrumb"
     items={[

--- a/src/components/doc-card-grid.astro
+++ b/src/components/doc-card-grid.astro
@@ -1,0 +1,51 @@
+---
+interface Item {
+  href: string;
+  title: string;
+  description?: string;
+}
+
+interface Props {
+  items: Item[];
+  class?: string;
+}
+
+const { items, class: className } = Astro.props;
+---
+
+{
+  items.length > 0 && (
+    <nav
+      aria-label="Child pages"
+      class:list={[
+        "grid grid-cols-1 gap-x-hsp-lg gap-y-vsp-md sm:grid-cols-2",
+        className,
+      ]}
+    >
+      {items.map((item) => (
+        <a
+          href={item.href}
+          class="group block rounded border border-muted bg-surface px-hsp-lg py-vsp-md hover:border-accent"
+        >
+          <span class="flex items-center gap-hsp-xs font-medium text-accent underline group-hover:underline">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="currentColor"
+              viewBox="0 0 103.395 107.049"
+              aria-hidden="true"
+              class="w-[16px] shrink-0"
+            >
+              <path d="M5.746 5.74 0 11.49l20.987 20.96C34.126 45.572 41.963 53.45 41.948 53.523c-.012.062-9.456 9.544-20.986 21.07L0 95.55l5.714 5.715c3.142 3.143 5.748 5.715 5.79 5.715s2.63-2.563 5.75-5.696l17.939-18.001c21.867-21.94 29.443-29.599 29.443-29.768 0-.114-.665-.804-5.084-5.275C51.872 40.47 11.71.125 11.565.036 11.525.01 8.906 2.578 5.746 5.74m38.345-.066c-3.132 3.13-5.696 5.71-5.696 5.732-.001.022 2.16 2.185 4.8 4.807 2.641 2.623 8.382 8.338 12.758 12.702 15.38 15.337 23.763 23.641 24.314 24.086.19.153.346.336.346.405 0 .07-1.738 1.847-3.887 3.976a17515 17515 0 0 0-20.35 20.264 19555 19555 0 0 1-17.223 17.158c-.416.409-.757.77-.757.8 0 .083 11.415 11.485 11.457 11.445.235-.22 53.542-53.528 53.542-53.543C103.395 53.472 49.891.02 49.837 0c-.028-.01-2.613 2.543-5.746 5.674" />
+            </svg>
+            {item.title}
+          </span>
+          {item.description && (
+            <span class="mt-vsp-2xs block text-small text-muted">
+              {item.description}
+            </span>
+          )}
+        </a>
+      ))}
+    </nav>
+  )
+}

--- a/src/components/doc-card-grid.astro
+++ b/src/components/doc-card-grid.astro
@@ -7,16 +7,17 @@ interface Item {
 
 interface Props {
   items: Item[];
+  ariaLabel?: string;
   class?: string;
 }
 
-const { items, class: className } = Astro.props;
+const { items, ariaLabel = "Child pages", class: className } = Astro.props;
 ---
 
 {
   items.length > 0 && (
     <nav
-      aria-label="Child pages"
+      aria-label={ariaLabel}
       class:list={[
         "grid grid-cols-1 gap-x-hsp-lg gap-y-vsp-md sm:grid-cols-2",
         className,
@@ -27,17 +28,19 @@ const { items, class: className } = Astro.props;
           href={item.href}
           class="group block rounded border border-muted bg-surface px-hsp-lg py-vsp-md hover:border-accent"
         >
-          <span class="flex items-center gap-hsp-xs font-medium text-accent underline group-hover:underline">
+          <span class="flex items-center gap-hsp-xs">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               fill="currentColor"
               viewBox="0 0 103.395 107.049"
               aria-hidden="true"
-              class="w-[16px] shrink-0"
+              class="w-[16px] shrink-0 text-accent"
             >
               <path d="M5.746 5.74 0 11.49l20.987 20.96C34.126 45.572 41.963 53.45 41.948 53.523c-.012.062-9.456 9.544-20.986 21.07L0 95.55l5.714 5.715c3.142 3.143 5.748 5.715 5.79 5.715s2.63-2.563 5.75-5.696l17.939-18.001c21.867-21.94 29.443-29.599 29.443-29.768 0-.114-.665-.804-5.084-5.275C51.872 40.47 11.71.125 11.565.036 11.525.01 8.906 2.578 5.746 5.74m38.345-.066c-3.132 3.13-5.696 5.71-5.696 5.732-.001.022 2.16 2.185 4.8 4.807 2.641 2.623 8.382 8.338 12.758 12.702 15.38 15.337 23.763 23.641 24.314 24.086.19.153.346.336.346.405 0 .07-1.738 1.847-3.887 3.976a17515 17515 0 0 0-20.35 20.264 19555 19555 0 0 1-17.223 17.158c-.416.409-.757.77-.757.8 0 .083 11.415 11.485 11.457 11.445.235-.22 53.542-53.528 53.542-53.543C103.395 53.472 49.891.02 49.837 0c-.028-.01-2.613 2.543-5.746 5.674" />
             </svg>
-            {item.title}
+            <span class="font-medium text-accent group-hover:underline">
+              {item.title}
+            </span>
           </span>
           {item.description && (
             <span class="mt-vsp-2xs block text-small text-muted">

--- a/src/components/tag-nav.astro
+++ b/src/components/tag-nav.astro
@@ -64,13 +64,22 @@ function tagHref(tag: string) {
 ---
 
 {
+  /*
+  Pointed chip uses two stacked clip-path polygons to fake a 1px border:
+  outer span is the border color, inner span is the fill inset by 1px.
+  The inner clip-path matches the outer but offset by 1px on every edge,
+  hence `calc(100% - 17px)` (outer 16 + 1px rim) and
+  `calc(100% - 13px)` (outer 12 + 1px rim) on the page variant.
+*/
+}
+{
   settings.docTags && variant === "all" && sortedTags.length > 0 && (
     <ul class="flex flex-wrap gap-x-hsp-xs gap-y-vsp-xs">
       {sortedTags.map(({ tag, count }) => (
         <li class="inline-flex whitespace-nowrap">
           <a
             href={tagHref(tag)}
-            aria-label={`Docs tagged ${tag}`}
+            aria-label={`${t("doc.taggedWith", locale)}: ${tag}`}
             class="group relative inline-flex no-underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
           >
             <span
@@ -98,7 +107,7 @@ function tagHref(tag: string) {
       {tags.map((tag) => (
         <a
           href={tagHref(tag)}
-          aria-label={`Docs tagged ${tag}`}
+          aria-label={`${t("doc.taggedWith", locale)}: ${tag}`}
           class="group relative inline-flex no-underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
         >
           <span

--- a/src/components/tag-nav.astro
+++ b/src/components/tag-nav.astro
@@ -65,30 +65,52 @@ function tagHref(tag: string) {
 
 {
   settings.docTags && variant === "all" && sortedTags.length > 0 && (
-    <div class="flex flex-wrap gap-hsp-sm">
+    <ul class="flex flex-wrap gap-x-hsp-xs gap-y-vsp-xs">
       {sortedTags.map(({ tag, count }) => (
-        <a
-          href={tagHref(tag)}
-          class="inline-flex items-center gap-hsp-2xs px-hsp-md py-vsp-xs bg-surface border border-muted rounded-full text-fg hover:border-accent hover:text-accent"
-        >
-          <span>{tag}</span>
-          <span class="text-caption text-muted">({count})</span>
-        </a>
+        <li class="inline-flex whitespace-nowrap">
+          <a
+            href={tagHref(tag)}
+            aria-label={`Docs tagged ${tag}`}
+            class="group relative inline-flex no-underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+          >
+            <span
+              class="absolute inset-0 bg-muted group-hover:bg-fg"
+              style="clip-path: polygon(0 0, calc(100% - 16px) 0, 100% 50%, calc(100% - 16px) 100%, 0 100%)"
+            />
+            <span
+              class="relative inline-flex items-center text-small text-fg bg-bg pl-hsp-sm pr-hsp-xl py-vsp-2xs group-hover:text-bg group-hover:bg-fg"
+              style="clip-path: polygon(1px 1px, calc(100% - 17px) 1px, calc(100% - 1px) 50%, calc(100% - 17px) calc(100% - 1px), 1px calc(100% - 1px))"
+            >
+              <span>#{tag}</span>
+              <span class="text-caption opacity-60">&nbsp;({count})</span>
+            </span>
+          </a>
+        </li>
       ))}
-    </div>
+    </ul>
   )
 }
 
 {
   settings.docTags && variant === "page" && tags.length > 0 && (
-    <div class="flex flex-wrap items-center gap-hsp-xs">
+    <div class="flex flex-wrap items-center gap-x-hsp-xs gap-y-vsp-xs">
       <span class="text-caption text-muted">{t("doc.tags", locale)}:</span>
       {tags.map((tag) => (
         <a
           href={tagHref(tag)}
-          class="inline-block px-hsp-sm py-vsp-2xs text-caption bg-surface border border-muted rounded-full text-accent hover:bg-code-bg hover:border-accent"
+          aria-label={`Docs tagged ${tag}`}
+          class="group relative inline-flex no-underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
         >
-          {tag}
+          <span
+            class="absolute inset-0 bg-muted group-hover:bg-fg"
+            style="clip-path: polygon(0 0, calc(100% - 12px) 0, 100% 50%, calc(100% - 12px) 100%, 0 100%)"
+          />
+          <span
+            class="relative inline-flex items-center text-caption text-fg bg-bg pl-hsp-sm pr-hsp-lg py-vsp-2xs group-hover:text-bg group-hover:bg-fg"
+            style="clip-path: polygon(1px 1px, calc(100% - 13px) 1px, calc(100% - 1px) 50%, calc(100% - 13px) calc(100% - 1px), 1px calc(100% - 1px))"
+          >
+            #{tag}
+          </span>
         </a>
       ))}
     </div>

--- a/src/pages/docs/tags/[tag].astro
+++ b/src/pages/docs/tags/[tag].astro
@@ -28,7 +28,12 @@ const countText =
     : t("doc.pageCount").replace("{count}", String(tagInfo.count));
 ---
 
-<DocLayout title={`${t("doc.taggedWith")}: ${tag}`} currentSlug={`tags/${tag}`}>
+<DocLayout
+  title={`${t("doc.taggedWith")}: ${tag}`}
+  currentSlug={`tags/${tag}`}
+  hideSidebar={true}
+  hideToc={true}
+>
   <Breadcrumb
     slot="breadcrumb"
     items={[

--- a/src/pages/docs/tags/[tag].astro
+++ b/src/pages/docs/tags/[tag].astro
@@ -47,6 +47,7 @@ const countText =
   <p class="text-muted mb-vsp-lg">{countText}</p>
 
   <DocCardGrid
+    ariaLabel={`${t("doc.taggedWith")}: ${tag}`}
     items={tagInfo.docs.map((doc) => ({
       href: docsUrl(doc.slug, "en"),
       title: doc.title,

--- a/src/pages/docs/tags/[tag].astro
+++ b/src/pages/docs/tags/[tag].astro
@@ -2,6 +2,7 @@
 import { getCollection } from "astro:content";
 import DocLayout from "@/layouts/doc-layout.astro";
 import Breadcrumb from "@/components/breadcrumb.astro";
+import DocCardGrid from "@/components/doc-card-grid.astro";
 import { toRouteSlug } from "@/utils/slug";
 import { collectTags } from "@/utils/tags";
 import { t } from "@/config/i18n";
@@ -40,23 +41,11 @@ const countText =
   <h1 class="text-heading font-bold mb-vsp-xs">{t("doc.taggedWith")}: {tag}</h1>
   <p class="text-muted mb-vsp-lg">{countText}</p>
 
-  <nav class="grid grid-cols-1 gap-y-vsp-md">
-    {
-      tagInfo.docs.map((doc) => (
-        <a
-          href={docsUrl(doc.slug, "en")}
-          class="group block border border-muted bg-surface px-hsp-lg py-vsp-md hover:border-accent"
-        >
-          <span class="font-medium text-accent underline group-hover:underline">
-            {doc.title}
-          </span>
-          {doc.description && (
-            <span class="mt-vsp-2xs block text-small text-muted group-hover:underline decoration-muted">
-              {doc.description}
-            </span>
-          )}
-        </a>
-      ))
-    }
-  </nav>
+  <DocCardGrid
+    items={tagInfo.docs.map((doc) => ({
+      href: docsUrl(doc.slug, "en"),
+      title: doc.title,
+      description: doc.description,
+    }))}
+  />
 </DocLayout>

--- a/src/pages/docs/tags/index.astro
+++ b/src/pages/docs/tags/index.astro
@@ -15,7 +15,12 @@ const docs = import.meta.env.PROD
 const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));
 ---
 
-<DocLayout title={t("doc.allTags")} currentSlug="tags">
+<DocLayout
+  title={t("doc.allTags")}
+  currentSlug="tags"
+  hideSidebar={true}
+  hideToc={true}
+>
   <Breadcrumb
     slot="breadcrumb"
     items={[

--- a/src/pages/ja/docs/tags/[tag].astro
+++ b/src/pages/ja/docs/tags/[tag].astro
@@ -46,6 +46,8 @@ const countText =
   title={`${t("doc.taggedWith", "ja")}: ${tag}`}
   lang="ja"
   currentSlug={`tags/${tag}`}
+  hideSidebar={true}
+  hideToc={true}
 >
   <Breadcrumb
     slot="breadcrumb"

--- a/src/pages/ja/docs/tags/[tag].astro
+++ b/src/pages/ja/docs/tags/[tag].astro
@@ -2,6 +2,7 @@
 import { getDocsCollection } from "@/utils/get-docs-collection";
 import DocLayout from "@/layouts/doc-layout.astro";
 import Breadcrumb from "@/components/breadcrumb.astro";
+import DocCardGrid from "@/components/doc-card-grid.astro";
 import { toRouteSlug } from "@/utils/slug";
 import { collectTags } from "@/utils/tags";
 import { t } from "@/config/i18n";
@@ -60,23 +61,11 @@ const countText =
   </h1>
   <p class="text-muted mb-vsp-lg">{countText}</p>
 
-  <nav class="grid grid-cols-1 gap-y-vsp-md">
-    {
-      tagInfo.docs.map((doc) => (
-        <a
-          href={docsUrl(doc.slug, "ja")}
-          class="group block border border-muted bg-surface px-hsp-lg py-vsp-md hover:border-accent"
-        >
-          <span class="font-medium text-accent underline group-hover:underline">
-            {doc.title}
-          </span>
-          {doc.description && (
-            <span class="mt-vsp-2xs block text-small text-muted group-hover:underline decoration-muted">
-              {doc.description}
-            </span>
-          )}
-        </a>
-      ))
-    }
-  </nav>
+  <DocCardGrid
+    items={tagInfo.docs.map((doc) => ({
+      href: docsUrl(doc.slug, "ja"),
+      title: doc.title,
+      description: doc.description,
+    }))}
+  />
 </DocLayout>

--- a/src/pages/ja/docs/tags/[tag].astro
+++ b/src/pages/ja/docs/tags/[tag].astro
@@ -64,6 +64,7 @@ const countText =
   <p class="text-muted mb-vsp-lg">{countText}</p>
 
   <DocCardGrid
+    ariaLabel={`${t("doc.taggedWith", "ja")}: ${tag}`}
     items={tagInfo.docs.map((doc) => ({
       href: docsUrl(doc.slug, "ja"),
       title: doc.title,

--- a/src/pages/ja/docs/tags/index.astro
+++ b/src/pages/ja/docs/tags/index.astro
@@ -29,7 +29,13 @@ const docs = [
 const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));
 ---
 
-<DocLayout title={t("doc.allTags", "ja")} lang="ja" currentSlug="tags">
+<DocLayout
+  title={t("doc.allTags", "ja")}
+  lang="ja"
+  currentSlug="tags"
+  hideSidebar={true}
+  hideToc={true}
+>
   <Breadcrumb
     slot="breadcrumb"
     items={[


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/326

---

## Summary

Refreshes the tag system based on #325/#326:

- **Tag page layout (#327)** — tag index (`/docs/tags/`) and tag leaf pages (`/docs/tags/<tag>/`) now use the hide-both layout (no left sidebar, no right TOC), matching `guides/layout-demos/hide-both`. EN + JA.
- **Tag leaf card grid (#328)** — tag leaf pages render docs with the same two-column card grid as category top pages, via a new shared `doc-card-grid.astro` component (arrow SVG + title + optional description, `hover:border-accent`). EN + JA.
- **Zpaper-style pointed tag chips (#329)** — `tag-nav.astro` now renders both the `variant="all"` index chips and the `variant="page"` inline chips with a clip-path polygon pointed shape. Two stacked spans fake a 1px border; hover inverts fg/bg; `:focus-visible` adds an accent outline for keyboard users.

All `src/` changes mirror into `packages/create-zudo-doc/templates/...` so downstream scaffolds stay in sync.

## Changes

- `src/pages/docs/tags/index.astro`, `src/pages/docs/tags/[tag].astro` (+ JA mirrors): pass `hideSidebar={true}` and `hideToc={true}` to `<DocLayout>`
- `src/components/doc-card-grid.astro` (new): generic card-grid nav (title / description) with an `ariaLabel` prop so callers can pass localized labels
- `src/pages/docs/tags/[tag].astro` (+ JA mirror): render docs via `<DocCardGrid>` with a locale-aware `${t("doc.taggedWith", locale)}: ${tag}` aria-label
- `src/components/tag-nav.astro`: rewrite both variants to the zpaper pointed-chip clip-path design; use `t("doc.taggedWith", locale)` for aria-labels so JA announces correctly; add a code comment documenting the 1px rim technique
- Create-zudo-doc mirrors updated for every file above — `diff -q` confirms byte-identical parity

### Review-loop fixes (post-merge deep review)

- Replaced hardcoded English `aria-label`s with locale-threaded `t("doc.taggedWith", locale)` on both tag-nav variants and `doc-card-grid.astro`
- Fixed an always-on `underline` on `doc-card-grid` title that made `group-hover:underline` dead — now only hover underlines, matching `nav-card-grid`
- Restructured `doc-card-grid` title to an inner span (svg sibling) so underline decoration applies only to text, mirroring the existing `nav-card-grid` pattern
- Added a short block comment in `tag-nav.astro` explaining why the inner clip-path polygon is inset by 1px on every edge

## Test Plan

- [x] `pnpm check:template-drift` — manual `diff -q` on all 6 file pairs (EN ↔ base template, JA ↔ i18n template): all in sync (bash 3.2 on this Mac can't run the official script)
- [x] `pnpm check` (astro sync + tsc --noEmit)
- [x] `pnpm build` — 192 URLs, 146 doc-history files, no warnings
- [x] CI green (6/6): Template Drift, Type Check, Build Site, Build Doc History, E2E Tests, Preview Deploy
- [x] Visual verification by child agents via headless-browser screenshots at 1280×800 on `/docs/tags/`, `/docs/tags/<tag>/`, and `variant="page"` doc pages — EN and JA
- [ ] Hover state inverts fg/bg on pointed chips (spot-check)
- [ ] Tab-navigate tag chips to confirm `:focus-visible` outline is perceivable
- [ ] `/docs/tags/` → `/docs/tags/<tag>/` → linked doc transitions without layout jump