### PR TITLE
fix: apply hover underline to whole search result item

### DIFF
--- a/packages/create-zudo-doc/templates/features/search/files/src/components/search.astro
+++ b/packages/create-zudo-doc/templates/features/search/files/src/components/search.astro
@@ -550,12 +550,13 @@ const resultCountTemplate = t("search.resultCount", lang);
       title.innerHTML = highlightTerms(entry.title, this.currentQuery);
       link.appendChild(title);
 
-      // Description or body excerpt (optional, flow content inside <a>)
+      // Description or body excerpt (optional, flow content inside <a>).
+      // Underline together with the title so the whole row is clearly linked on hover/focus.
       const text = entry.description || entry.body;
       if (text) {
         const excerpt = document.createElement("p");
         excerpt.className =
-          "mt-vsp-2xs text-caption text-muted leading-relaxed";
+          "mt-vsp-2xs text-caption text-muted leading-relaxed group-hover:underline group-focus-visible:underline decoration-muted";
         const truncated = truncateExcerpt(text, this.currentQuery);
         excerpt.innerHTML = highlightTerms(truncated, this.currentQuery);
         link.appendChild(excerpt);

--- a/src/components/search.astro
+++ b/src/components/search.astro
@@ -550,12 +550,13 @@ const resultCountTemplate = t("search.resultCount", lang);
       title.innerHTML = highlightTerms(entry.title, this.currentQuery);
       link.appendChild(title);
 
-      // Description or body excerpt (optional, flow content inside <a>)
+      // Description or body excerpt (optional, flow content inside <a>).
+      // Underline together with the title so the whole row is clearly linked on hover/focus.
       const text = entry.description || entry.body;
       if (text) {
         const excerpt = document.createElement("p");
         excerpt.className =
-          "mt-vsp-2xs text-caption text-muted leading-relaxed";
+          "mt-vsp-2xs text-caption text-muted leading-relaxed group-hover:underline group-focus-visible:underline decoration-muted";
         const truncated = truncateExcerpt(text, this.currentQuery);
         excerpt.innerHTML = highlightTerms(truncated, this.currentQuery);
         link.appendChild(excerpt);


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/362

---

## Summary
Follow-up on issue #362 ([comment](https://github.com/zudolab/zudo-doc/issues/362#issuecomment-4303042415)): the hover underline on a search result row previously covered only the title. Extend it so the whole row (title + description) underlines together on hover / keyboard focus, matching the doc-card / nav-card convention.

## Changes
- `src/components/search.astro` — add `group-hover:underline group-focus-visible:underline decoration-muted` to the description `<p>` inside `renderResult`, so it underlines together with the title when the parent row `<a>` (with `group`) is hovered or focused
- `packages/create-zudo-doc/templates/features/search/files/src/components/search.astro` — mirror the same edit in the generator template to prevent drift
- No token-system or color-value changes — semantic `decoration-muted` only

## Test Plan
- `pnpm check:template-drift` — passes
- `/verify-ui` via Playwright on `pnpm dev` (light + dark):
  - before hover: `text-decoration-line: none` on both `<span>` title and `<p>` description
  - after hover of the row `<a>`: `text-decoration-line: underline` on both
- CI green (Template Drift Check, Type Check, Build Site, Build Doc History, E2E Tests)