### PR TITLE
Long Text Proper Break: smart-break utility + 10 integrations

### DIFF
--- a/docs/smart-break-dynamic-inventory.md
+++ b/docs/smart-break-dynamic-inventory.md
@@ -1,0 +1,67 @@
+# Smart-break dynamic/non-MDX surfaces — audit inventory
+
+Scope: issue #376 — audit statically-rendered strings in dynamic/non-MDX
+components and apply smart-break (SmartBreak / smartBreakToHtml) to path-like
+text sites. `isPathLike` is conservative by design — non-path prose passes
+through untouched — so applying SmartBreak to borderline call sites is
+cheap and safe.
+
+## Surface matrix
+
+| # | File | Text site | Decision | Reason |
+|---|---|---|---|---|
+| 1 | `src/components/doc-history.tsx` | `entry.message` (commit subject) | **Applied** (`<SmartBreak>`) | Commit messages commonly reference paths, URLs, or file names. |
+| 2 | `src/components/doc-history.tsx` | `entry.hash.slice(0, 7)` | Not-path-like | 7-char git short SHA. No delimiters, never path-like. |
+| 3 | `src/components/doc-history.tsx` | `entry.author` | Not-path-like | Author display name. |
+| 4 | `src/components/doc-history.tsx` | `row.leftLine` / `row.rightLine` (diff body) | **Deferred** | Diff is shown in a horizontally-scrollable fixed-layout table, one line per `<td>`. Diff bodies are code, not headers / labels, and users expect horizontal scroll for long lines; wbr injection is orthogonal and would introduce visual drift vs. the original file. |
+| 5 | `src/components/toc.tsx` | `heading.text` | **Applied** (`<SmartBreak>`) | Heading text is usually prose, but can contain filenames (e.g. "Configuring settings.ts") or URLs. Cheap safety net. |
+| 6 | `src/components/mobile-toc.tsx` | `heading.text` | **Applied** (`<SmartBreak>`) | Same reasoning as toc.tsx; the mobile variant mirrors the same data. |
+| 7 | `src/components/ai-chat-modal.tsx` | User message (`{msg.content}` plain text) | **Applied** (`<SmartBreak>`) | User-typed content may contain URLs or paths; rendered as plain text so a wrapper is trivial. |
+| 8 | `src/components/ai-chat-modal.tsx` | Assistant message (`dangerouslySetInnerHTML` from `renderMarkdown`) | **Deferred** | `renderMarkdown` is a self-contained HTML renderer that does not reuse the MDX component-override pipeline. Integrating smart-break would require injecting wbr post-tokenization or rewriting the renderer; the vast majority of path-like text in assistant replies already appears inside `<code>` / fenced code blocks, which wrap via monospace CSS. Out of scope for this audit — worth a follow-up if real overflow is observed. |
+| 9 | `src/components/ai-chat-modal.tsx` | Header text "AI Assistant", placeholder, status text ("Thinking…", "Ask a question…") | Not-path-like | Static English prose / UI labels. |
+| 10 | `src/components/frontmatter-preview.astro` | `rendered?.text` (string/number/bool/array-of-strings values) | **Applied** (`smartBreakToHtml` via `set:html`) | Frontmatter values include file paths (e.g. `image`, `slug`, `permalink`), URLs, and arrays of tags. `smartBreakToHtml` is a no-op for non-path prose and booleans/numbers. |
+| 11 | `src/components/frontmatter-preview.astro` | `key` column (`{key}`) | Not-path-like | Keys are always short field names (e.g. `title`, `tags`); delimiters are rare. |
+| 12 | `src/components/frontmatter-preview.astro` | `rendered?.code` (JSON fallback) | Not-path-like | Already wrapped in `<code>` with `break-words`; JSON is not the target of the "path-like" heuristic. |
+| 13 | `src/components/theme-toggle.tsx` | aria-label, no visible path text | Not-path-like | Labels like "Switch to dark mode". |
+| 14 | `src/components/design-token-tweak/export-modal.tsx` | exported CSS in a `<textarea>` | Not-path-like | Text lives inside a `<textarea>`; wbr has no effect there. |
+| 15 | `src/components/design-token-tweak/**` | token labels, hex value inputs | Not-path-like | All short labels / input boxes. |
+
+## Template mirror updates
+
+The following base/feature template files mirror the edited source files and
+must be kept in lockstep (checked by `pnpm check:template-drift`):
+
+- `packages/create-zudo-doc/templates/features/docHistory/files/src/components/doc-history.tsx`
+- `packages/create-zudo-doc/templates/base/src/components/toc.tsx`
+- `packages/create-zudo-doc/templates/base/src/components/mobile-toc.tsx`
+- `packages/create-zudo-doc/templates/base/src/components/frontmatter-preview.astro`
+
+`ai-chat-modal.tsx` does not have a template counterpart — no mirror needed.
+
+## Incidental fix — `SmartBreak` return type
+
+The foundation from #371 declared `SmartBreak` as returning Preact's `VNode`.
+TypeScript treats Preact's `VNode` and React's `JSX.Element` as distinct types,
+so `.tsx` files that `import ... from "react"` (e.g. `toc.tsx`, `mobile-toc.tsx`,
+`doc-history.tsx`, `ai-chat-modal.tsx`) could not use `<SmartBreak>` as a JSX
+child without a type error:
+
+```
+Type 'VNode<{}>' is not assignable to type 'ReactNode | Promise<ReactNode>'.
+```
+
+At runtime, `@astrojs/preact` with `compat: true` aliases React calls to Preact
+so this is a pure typing gap. Fix: widen `SmartBreak`'s declared return type
+from `VNode` to `any`. The internal `smartBreak()` and `smartBreakToHtml()`
+functions keep their precise return types. All 41 existing smart-break unit
+tests continue to pass.
+
+Mirrored into `packages/create-zudo-doc/templates/base/src/utils/smart-break.tsx`
+so downstream scaffolded projects get the same permissive signature.
+
+## Verification
+
+- `pnpm check` — typecheck clean after edits.
+- `pnpm vitest run src/utils/__tests__/smart-break.test.ts` — 41/41 passing.
+- No new runtime dependencies; every edit is a wrapper around an existing
+  text-node render site.

--- a/e2e/fixtures/smoke/src/content/docs/guides/smart-break-test.mdx
+++ b/e2e/fixtures/smoke/src/content/docs/guides/smart-break-test.mdx
@@ -2,7 +2,7 @@
 title: Smart Break Test
 sidebar_position: 15
 sidebar_label: src/components/very/long/path/to/some/module/file-name.ts
-description: Fixture page for smart-break (<wbr>) visual, a11y, and copy-paste verification.
+description: Fixture page for smart-break visual, a11y, and copy-paste verification.
 ---
 
 ## Inline code wrapping

--- a/e2e/fixtures/smoke/src/content/docs/guides/smart-break-test.mdx
+++ b/e2e/fixtures/smoke/src/content/docs/guides/smart-break-test.mdx
@@ -1,0 +1,31 @@
+---
+title: Smart Break Test
+sidebar_position: 15
+sidebar_label: src/components/very/long/path/to/some/module/file-name.ts
+description: Fixture page for smart-break (<wbr>) visual, a11y, and copy-paste verification.
+---
+
+## Inline code wrapping
+
+Visit this resource at `https://example.com/very/long/path/to/some/resource/that-should-wrap-on-narrow.html` to see how inline code wraps on narrow viewports.
+
+Another path example: `packages/doc-history-server/src/cli/generate-history.ts` which should also wrap.
+
+## Table cell wrapping
+
+| Key | URL |
+| --- | --- |
+| docs | https://example.com/very/long/path/to/some/resource/that-should-wrap-in-table-cell.html |
+| api | https://api.example.com/v1/endpoints/users/profiles/settings/preferences.json |
+
+## Link wrapping
+
+See the reference at [https://example.com/very/long/path/to/some/documentation/page-about-everything.html](https://example.com/very/long/path/to/some/documentation/page-about-everything.html) for more.
+
+## Fenced code block regression
+
+The fenced block below must NOT wrap unless the user toggles word wrap:
+
+```ts
+const longVariable = "this is a deliberately long line that must NOT wrap unless the user toggles word-wrap explicitly, so the regression guard catches any accidental overflow-wrap on pre.astro-code";
+```

--- a/e2e/smoke-smart-break.spec.ts
+++ b/e2e/smoke-smart-break.spec.ts
@@ -1,0 +1,406 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * E2E tests for smart-break (<wbr>) injection across all surfaces.
+ *
+ * Covers epic #370 sub-issues #372-#377: smart-break must visually wrap
+ * path-like text at narrow widths, must be invisible to copy-paste
+ * (byte-identical clipboard content), and must not pollute the
+ * accessibility tree (no phantom word boundaries).
+ *
+ * Narrow viewport (375×900) is used for the visual wrap and overflow
+ * assertions so the mobile sidebar panel is reachable via hamburger.
+ */
+
+const NARROW = { width: 375, height: 900 } as const;
+const TEST_PAGE = "/docs/guides/smart-break-test";
+const SIDEBAR_LABEL =
+  "src/components/very/long/path/to/some/module/file-name.ts";
+const INLINE_CODE =
+  "https://example.com/very/long/path/to/some/resource/that-should-wrap-on-narrow.html";
+const LINK_URL =
+  "https://example.com/very/long/path/to/some/documentation/page-about-everything.html";
+
+/**
+ * Assign a data-test-id to a DOM element chosen by a predicate and
+ * return the id. Keeps subsequent locator queries stable across the
+ * Preact islands that re-render after hydration.
+ */
+async function tagFirst(
+  page: Page,
+  rootSelector: string,
+  predicateSrc: string,
+  id: string,
+): Promise<void> {
+  await page.evaluate(
+    ({ rootSelector, predicateSrc, id }) => {
+      const predicate = new Function("el", predicateSrc) as (
+        el: Element,
+      ) => boolean;
+      const nodes = Array.from(document.querySelectorAll(rootSelector));
+      const match = nodes.find((n) => predicate(n));
+      if (!match) throw new Error(`No element matched: ${rootSelector}`);
+      (match as HTMLElement).setAttribute("data-test-id", id);
+    },
+    { rootSelector, predicateSrc, id },
+  );
+}
+
+/**
+ * Select all text inside the element (via Range) and return what the
+ * browser would put on the clipboard. <wbr> is a void element and must
+ * not contribute any characters to selection.toString().
+ */
+async function selectionTextOf(page: Page, selector: string): Promise<string> {
+  return await page.evaluate((sel) => {
+    const el = document.querySelector(sel);
+    if (!el) throw new Error(`Element not found: ${sel}`);
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    const sel_ = window.getSelection();
+    if (!sel_) throw new Error("getSelection() returned null");
+    sel_.removeAllRanges();
+    sel_.addRange(range);
+    const text = sel_.toString();
+    sel_.removeAllRanges();
+    return text;
+  }, selector);
+}
+
+async function wbrCount(page: Page, selector: string): Promise<number> {
+  return await page.evaluate((sel) => {
+    const el = document.querySelector(sel);
+    return el ? el.querySelectorAll("wbr").length : 0;
+  }, selector);
+}
+
+// --------------------------------------------------------------------------
+// Visual wrap: sidebar / inline code / table / link
+// --------------------------------------------------------------------------
+
+test.describe("smart-break: visual wrapping on narrow viewports", () => {
+  test("sidebar label with long path wraps across multiple lines (#372)", async ({
+    page,
+  }) => {
+    await page.setViewportSize(NARROW);
+    await page.goto(TEST_PAGE, { waitUntil: "load" });
+
+    // Open mobile sidebar (desktop sidebar is hidden at lg:hidden/<1024px).
+    await page.locator('button[aria-label="Open sidebar"]').click();
+    await expect(
+      page.locator('button[aria-label="Close sidebar"]'),
+    ).toBeVisible();
+
+    const link = page.locator(
+      `header aside a[href$="/docs/guides/smart-break-test"]`,
+    );
+    await expect(link).toBeVisible();
+
+    // <wbr> must actually have been injected into the label span.
+    const count = await link.evaluate(
+      (a) => a.querySelectorAll("wbr").length,
+    );
+    expect(count, "expected <wbr> injected into sidebar label").toBeGreaterThan(
+      0,
+    );
+
+    // Height check: label wraps beyond a single line.
+    const { height, lineHeight } = await link.evaluate((el) => {
+      const rect = el.getBoundingClientRect();
+      const cs = window.getComputedStyle(el);
+      return {
+        height: rect.height,
+        lineHeight: parseFloat(cs.lineHeight) || 20,
+      };
+    });
+    expect(height).toBeGreaterThan(lineHeight * 1.5);
+  });
+
+  test("inline code with long URL wraps and contains <wbr> (#373)", async ({
+    page,
+  }) => {
+    await page.setViewportSize(NARROW);
+    await page.goto(TEST_PAGE, { waitUntil: "load" });
+
+    await tagFirst(
+      page,
+      "main code",
+      `return !!el.textContent && el.textContent.includes("wrap-on-narrow");`,
+      "sb-inline-code",
+    );
+    const sel = '[data-test-id="sb-inline-code"]';
+    expect(await wbrCount(page, sel)).toBeGreaterThan(0);
+
+    const { width, scrollWidth } = await page.evaluate((s) => {
+      const el = document.querySelector(s) as HTMLElement;
+      return {
+        width: el.getBoundingClientRect().width,
+        scrollWidth: el.scrollWidth,
+      };
+    }, sel);
+    // No horizontal overflow inside the inline code box.
+    expect(scrollWidth).toBeLessThanOrEqual(Math.ceil(width) + 1);
+  });
+
+  test("table cell with long URL wraps within its cell (#375)", async ({
+    page,
+  }) => {
+    await page.setViewportSize(NARROW);
+    await page.goto(TEST_PAGE, { waitUntil: "load" });
+
+    await tagFirst(
+      page,
+      "main table td",
+      `return !!el.textContent && el.textContent.includes("wrap-in-table-cell");`,
+      "sb-table-cell",
+    );
+    const sel = '[data-test-id="sb-table-cell"]';
+
+    // Primary assertion: the document itself does not scroll horizontally
+    // (the table may be inside an overflow-x-auto wrapper, which is fine).
+    const bodyScroll = await page.evaluate(() => ({
+      bodyScrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+    }));
+    expect(bodyScroll.bodyScrollWidth).toBeLessThanOrEqual(
+      bodyScroll.clientWidth + 1,
+    );
+
+    // Secondary assertion: the cell's content fits its own width — smart
+    // break / overflow-wrap kicks in so there is no horizontal overflow
+    // inside the cell itself.
+    const { width, scrollWidth } = await page.evaluate((s) => {
+      const el = document.querySelector(s) as HTMLElement;
+      return {
+        width: el.getBoundingClientRect().width,
+        scrollWidth: el.scrollWidth,
+      };
+    }, sel);
+    expect(scrollWidth).toBeLessThanOrEqual(Math.ceil(width) + 1);
+  });
+
+  test("link text with long URL wraps across multiple lines (#374)", async ({
+    page,
+  }) => {
+    await page.setViewportSize(NARROW);
+    await page.goto(TEST_PAGE, { waitUntil: "load" });
+
+    await tagFirst(
+      page,
+      "main a",
+      `return !!el.textContent && el.textContent.includes("page-about-everything");`,
+      "sb-link",
+    );
+    const sel = '[data-test-id="sb-link"]';
+
+    expect(await wbrCount(page, sel)).toBeGreaterThan(0);
+
+    const { height, lineHeight } = await page.evaluate((s) => {
+      const el = document.querySelector(s) as HTMLElement;
+      const rect = el.getBoundingClientRect();
+      const cs = window.getComputedStyle(el);
+      return {
+        height: rect.height,
+        lineHeight: parseFloat(cs.lineHeight) || 20,
+      };
+    }, sel);
+    expect(height).toBeGreaterThan(lineHeight * 1.5);
+  });
+});
+
+// --------------------------------------------------------------------------
+// Regression: fenced code blocks must still render unwrapped
+// --------------------------------------------------------------------------
+
+test.describe("smart-break: regression guards", () => {
+  test("fenced code blocks render unwrapped (smart-break skips Shiki output)", async ({
+    page,
+  }) => {
+    await page.setViewportSize(NARROW);
+    await page.goto(TEST_PAGE, { waitUntil: "load" });
+
+    const pre = page.locator("main pre.astro-code").first();
+    await expect(pre).toBeVisible();
+
+    // The pre may show a horizontal scrollbar (overflow-x: auto) — the
+    // content is wider than the visible box but stays on one physical line.
+    // If smart-break had polluted Shiki spans with <wbr>, the long line
+    // would wrap instead of overflowing, and scrollWidth would equal
+    // clientWidth.
+    const { scrollWidth, clientWidth, wbrInsideCode } = await pre.evaluate(
+      (el) => {
+        const code = el.querySelector("code");
+        return {
+          scrollWidth: (el as HTMLElement).scrollWidth,
+          clientWidth: (el as HTMLElement).clientWidth,
+          wbrInsideCode: code ? code.querySelectorAll("wbr").length : -1,
+        };
+      },
+    );
+    expect(wbrInsideCode).toBe(0);
+    expect(scrollWidth).toBeGreaterThan(clientWidth);
+  });
+});
+
+// --------------------------------------------------------------------------
+// Copy-paste byte-identity (critical acceptance criterion)
+// --------------------------------------------------------------------------
+
+test.describe("smart-break: copy-paste byte-identity", () => {
+  test("sidebar label copies as original string without <wbr> artifacts (#372)", async ({
+    page,
+  }) => {
+    await page.setViewportSize(NARROW);
+    await page.goto(TEST_PAGE, { waitUntil: "load" });
+
+    await page.locator('button[aria-label="Open sidebar"]').click();
+    await expect(
+      page.locator('button[aria-label="Close sidebar"]'),
+    ).toBeVisible();
+
+    // Select the smart-broken label span inside the test-page link.
+    await tagFirst(
+      page,
+      `header aside a[href$="/docs/guides/smart-break-test"] span`,
+      `return el.querySelectorAll("wbr").length > 0;`,
+      "sb-sidebar-label",
+    );
+    const sel = '[data-test-id="sb-sidebar-label"]';
+    expect(await wbrCount(page, sel)).toBeGreaterThan(0);
+
+    const text = await selectionTextOf(page, sel);
+    expect(text).toBe(SIDEBAR_LABEL);
+    expect(text).not.toContain("<wbr>");
+    expect(text).not.toMatch(/​/); // no zero-width space either
+  });
+
+  test("inline code copies as original string without <wbr> artifacts (#373)", async ({
+    page,
+  }) => {
+    await page.goto(TEST_PAGE, { waitUntil: "load" });
+
+    await tagFirst(
+      page,
+      "main code",
+      `return !!el.textContent && el.textContent.includes("wrap-on-narrow");`,
+      "sb-inline-code-copy",
+    );
+    const sel = '[data-test-id="sb-inline-code-copy"]';
+    expect(await wbrCount(page, sel)).toBeGreaterThan(0);
+
+    const text = await selectionTextOf(page, sel);
+    expect(text).toBe(INLINE_CODE);
+    expect(text).not.toContain("<wbr>");
+  });
+
+  test("link text copies as original URL without <wbr> artifacts (#374)", async ({
+    page,
+  }) => {
+    await page.goto(TEST_PAGE, { waitUntil: "load" });
+
+    await tagFirst(
+      page,
+      "main a",
+      `return !!el.textContent && el.textContent.includes("page-about-everything");`,
+      "sb-link-copy",
+    );
+    const sel = '[data-test-id="sb-link-copy"]';
+    expect(await wbrCount(page, sel)).toBeGreaterThan(0);
+
+    const text = await selectionTextOf(page, sel);
+    expect(text).toBe(LINK_URL);
+    expect(text).not.toContain("<wbr>");
+  });
+
+  test("search result row (path-like hit) has no <wbr> artifacts in selection (#375)", async ({
+    page,
+  }) => {
+    await page.setViewportSize(NARROW);
+    await page.goto(TEST_PAGE, { waitUntil: "load" });
+
+    await page.keyboard.press("Control+k");
+    const input = page.locator("[data-search-input]");
+    await expect(input).toBeFocused({ timeout: 3000 });
+
+    // Query text that definitely appears in the fixture body.
+    await input.fill("Smart Break");
+    const results = page.locator("[data-search-results] article");
+    await expect(results.first()).toBeVisible({ timeout: 10000 });
+
+    await page.evaluate(() => {
+      const first = document.querySelector(
+        "[data-search-results] article",
+      ) as HTMLElement | null;
+      if (first) first.setAttribute("data-test-id", "sb-search-result");
+    });
+    const sel = '[data-test-id="sb-search-result"]';
+
+    // The article may include wbr injections on path-like tokens inside
+    // excerpt/title. Either way, selection.toString() must not expose them.
+    const text = await selectionTextOf(page, sel);
+    expect(text).not.toContain("<wbr>");
+    expect(text).not.toContain("&lt;wbr&gt;");
+
+    // Dialog overflow guard: first result's width does not exceed its
+    // own bounding box (smart-break should have wrapped any long token).
+    const { articleScrollWidth, articleWidth } = await page.evaluate((s) => {
+      const a = document.querySelector(s) as HTMLElement;
+      return {
+        articleScrollWidth: a.scrollWidth,
+        articleWidth: a.getBoundingClientRect().width,
+      };
+    }, sel);
+    expect(articleScrollWidth).toBeLessThanOrEqual(Math.ceil(articleWidth) + 1);
+  });
+});
+
+// --------------------------------------------------------------------------
+// Accessibility: <wbr> must not pollute accessible names / textContent
+// --------------------------------------------------------------------------
+
+test.describe("smart-break: accessibility", () => {
+  test("link accessible name matches raw URL (no <wbr> text leakage)", async ({
+    page,
+  }) => {
+    await page.goto(TEST_PAGE, { waitUntil: "load" });
+
+    await tagFirst(
+      page,
+      "main a",
+      `return !!el.textContent && el.textContent.includes("page-about-everything");`,
+      "sb-link-a11y",
+    );
+    const link = page.locator('[data-test-id="sb-link-a11y"]');
+
+    // 1. textContent across wbr injections must equal the raw URL.
+    //    (<wbr> is a void element; it contributes no characters to the
+    //    text layer, so this is effectively the string a screen reader
+    //    would announce.)
+    const textContent = await link.evaluate((el) => el.textContent ?? "");
+    expect(textContent).toBe(LINK_URL);
+    expect(textContent).not.toContain("<wbr>");
+
+    // 2. Computed accessible name (same path ATs use) must also be the
+    //    raw URL — proving <wbr> is not injected into the accessible
+    //    name tree.
+    await expect(link).toHaveAccessibleName(LINK_URL);
+  });
+
+  test("inline code textContent equals raw path (no phantom characters)", async ({
+    page,
+  }) => {
+    await page.goto(TEST_PAGE, { waitUntil: "load" });
+
+    await tagFirst(
+      page,
+      "main code",
+      `return !!el.textContent && el.textContent.includes("wrap-on-narrow");`,
+      "sb-inline-code-a11y",
+    );
+    const code = page.locator('[data-test-id="sb-inline-code-a11y"]');
+    const textContent = await code.evaluate((el) => el.textContent ?? "");
+    expect(textContent).toBe(INLINE_CODE);
+    expect(textContent).not.toContain("<wbr>");
+    expect(textContent).not.toMatch(/​/); // no zero-width space
+  });
+});

--- a/packages/create-zudo-doc/templates/base/src/components/breadcrumb.astro
+++ b/packages/create-zudo-doc/templates/base/src/components/breadcrumb.astro
@@ -1,6 +1,6 @@
 ---
 import type { BreadcrumbItem } from "@/utils/docs";
-import { smartBreakToHtml } from "@/utils/smart-break";
+import { isPathLike, smartBreakToHtml } from "@/utils/smart-break";
 
 interface Props {
   items: BreadcrumbItem[];
@@ -54,10 +54,16 @@ const { items } = Astro.props;
                     />
                   </svg>
                 )}
-                <span set:html={smartBreakToHtml(item.label)} />
+                {isPathLike(item.label) ? (
+                  <span set:html={smartBreakToHtml(item.label)} />
+                ) : (
+                  item.label
+                )}
               </a>
-            ) : (
+            ) : isPathLike(item.label) ? (
               <span class="text-fg" set:html={smartBreakToHtml(item.label)} />
+            ) : (
+              <span class="text-fg">{item.label}</span>
             )}
           </li>
         ))}

--- a/packages/create-zudo-doc/templates/base/src/components/breadcrumb.astro
+++ b/packages/create-zudo-doc/templates/base/src/components/breadcrumb.astro
@@ -1,5 +1,6 @@
 ---
 import type { BreadcrumbItem } from "@/utils/docs";
+import { smartBreakToHtml } from "@/utils/smart-break";
 
 interface Props {
   items: BreadcrumbItem[];
@@ -53,10 +54,10 @@ const { items } = Astro.props;
                     />
                   </svg>
                 )}
-                {item.label}
+                <span set:html={smartBreakToHtml(item.label)} />
               </a>
             ) : (
-              <span class="text-fg">{item.label}</span>
+              <span class="text-fg" set:html={smartBreakToHtml(item.label)} />
             )}
           </li>
         ))}

--- a/packages/create-zudo-doc/templates/base/src/components/content/component-map.ts
+++ b/packages/create-zudo-doc/templates/base/src/components/content/component-map.ts
@@ -8,6 +8,7 @@ import { ContentBlockquote } from './content-blockquote';
 import { ContentUl } from './content-ul';
 import { ContentOl } from './content-ol';
 import { ContentTable } from './content-table';
+import { ContentCode } from './content-code';
 
 export const htmlOverrides = {
   h2: HeadingH2,
@@ -20,4 +21,5 @@ export const htmlOverrides = {
   ul: ContentUl,
   ol: ContentOl,
   table: ContentTable,
+  code: ContentCode,
 };

--- a/packages/create-zudo-doc/templates/base/src/components/content/content-code.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/content/content-code.tsx
@@ -1,0 +1,43 @@
+import { SmartBreak as SmartBreakImpl } from '@/utils/smart-break';
+
+// Preact VNode vs React.ReactNode type mismatch under compat mode; cast so the
+// content override type-checks. Runtime is fine since @astrojs/preact compat is on.
+const SmartBreak = SmartBreakImpl as unknown as (props: {
+  children?: unknown;
+}) => any;
+
+type Props = {
+  children?: React.ReactNode;
+  className?: string;
+  [key: string]: any;
+};
+
+/**
+ * Override for inline `<code>` in MDX. Wraps text-only inline code with
+ * <SmartBreak> so that path/URL-like strings (e.g. `src/foo/bar.ts`) can
+ * break at delimiters on narrow viewports.
+ *
+ * Block code inside a fenced block is processed by Shiki, which emits a
+ * <code> element with class "language-*" containing a tree of <span>
+ * nodes (not a plain string). We detect those and render untouched so
+ * syntax highlighting is never disturbed.
+ */
+export function ContentCode({ children, className, ...rest }: Props) {
+  const isShikiBlock =
+    typeof className === 'string' && /(^|\s)language-/.test(className);
+  const isInlineText = typeof children === 'string';
+
+  if (isShikiBlock || !isInlineText) {
+    return (
+      <code className={className} {...rest}>
+        {children}
+      </code>
+    );
+  }
+
+  return (
+    <code className={className} {...rest}>
+      <SmartBreak>{children}</SmartBreak>
+    </code>
+  );
+}

--- a/packages/create-zudo-doc/templates/base/src/components/content/content-code.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/content/content-code.tsx
@@ -21,13 +21,19 @@ type Props = {
  * <code> element with class "language-*" containing a tree of <span>
  * nodes (not a plain string). We detect those and render untouched so
  * syntax highlighting is never disturbed.
+ *
+ * Astro 6 passes pure-text MDX children wrapped in a `StaticHtml` Preact
+ * component whose text lives in `props.value`, not as a string child.
+ * `extractText` unwraps that so the heuristic works regardless of MDX's
+ * internal wrapping.
  */
 export function ContentCode({ children, className, ...rest }: Props) {
   const isShikiBlock =
     typeof className === 'string' && /(^|\s)language-/.test(className);
-  const isInlineText = typeof children === 'string';
 
-  if (isShikiBlock || !isInlineText) {
+  const textFromChildren = isShikiBlock ? null : extractText(children);
+
+  if (textFromChildren === null) {
     return (
       <code className={className} {...rest}>
         {children}
@@ -37,7 +43,75 @@ export function ContentCode({ children, className, ...rest }: Props) {
 
   return (
     <code className={className} {...rest}>
-      <SmartBreak>{children}</SmartBreak>
+      <SmartBreak>{textFromChildren}</SmartBreak>
     </code>
   );
+}
+
+/**
+ * Walk a React/Preact children value and return a concatenated plain
+ * string when the entire subtree is text-only. Returns null if any
+ * non-text node (other than the StaticHtml wrapper Astro uses for pure
+ * text MDX content) is found — that signals inline markup inside the
+ * code span and means we must not inject <wbr>.
+ */
+function extractText(children: unknown): string | null {
+  if (typeof children === 'string') return children;
+  if (typeof children === 'number') return String(children);
+  // Only accept a single VNode whose `props.value` is text (the Astro
+  // StaticHtml wrapper used for pure-text MDX children). Deliberately do
+  // NOT recurse into arbitrary VNode trees — that would match Shiki's
+  // <span>-based block code output and inject <wbr> into syntax-highlighted
+  // tokens, breaking block code rendering.
+  if (children && typeof children === 'object' && !Array.isArray(children)) {
+    const v = children as { props?: { value?: unknown } };
+    if (v.props && v.props.value != null) {
+      if (
+        typeof v.props.value === 'string' ||
+        v.props.value instanceof String ||
+        (typeof v.props.value === 'object' && typeof (v.props.value as object).toString === 'function')
+      ) {
+        const s = String(v.props.value);
+        if (!s || s.startsWith('[object')) return null;
+        // Shiki block-code output also arrives as a StaticHtml wrapper, but
+        // its value is escaped HTML (e.g. "&lt;span class=...&gt;"). Inline
+        // code's value is the plain text of the backtick span (no HTML
+        // markup). If the value looks like HTML, refuse to unwrap — the
+        // block path below falls through to a plain <code> passthrough.
+        if (looksLikeHtmlMarkup(s)) return null;
+        return decodeEntities(s);
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Detect whether a string is the HTML-escaped rendering of a Shiki block
+ * (with nested <span> tokens) rather than the plain text of an inline
+ * `<code>` span. The presence of an escaped HTML-tag opener (`&lt;span`,
+ * `&lt;code`, etc.) is a reliable signal; plain URL/path inline code
+ * never contains those escaped sequences.
+ */
+function looksLikeHtmlMarkup(s: string): boolean {
+  return /&lt;(span|code|pre|div|br|i|b|em|strong)\b/i.test(s) || /<(span|code|pre)\s/i.test(s);
+}
+
+/**
+ * Minimal HTML entity decoder for the set MDX produces for inline text
+ * (`&amp;`, `&lt;`, `&gt;`, `&quot;`, `&#39;`, numeric). Keeps the
+ * result visually identical to the authored source so downstream
+ * SmartBreak operates on the original characters.
+ */
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#x27;/gi, "'")
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, n) => String.fromCodePoint(parseInt(n, 16)))
+    .replace(/&amp;/g, '&');
 }

--- a/packages/create-zudo-doc/templates/base/src/components/content/content-link.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/content/content-link.tsx
@@ -4,7 +4,7 @@ import { SmartBreak as SmartBreakBase } from '../../utils/smart-break';
 // components type children as React.ReactNode. Cast to a React-compatible
 // signature; at runtime Preact compat unifies the two.
 const SmartBreak = SmartBreakBase as unknown as (props: {
-  children?: unknown;
+  children?: React.ReactNode;
 }) => React.ReactElement;
 
 type Props = {

--- a/packages/create-zudo-doc/templates/base/src/components/content/content-link.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/content/content-link.tsx
@@ -25,8 +25,16 @@ export function ContentLink({ href, className, children, ...rest }: Props) {
     );
   }
 
+  // Astro 6 wraps pure-text MDX children in a `StaticHtml` Preact component
+  // whose text lives in `props.value`, not as a direct string child. Unwrap
+  // when possible so path-like text gets smart-break treatment.
+  const textFromChildren = extractText(children);
   const content =
-    typeof children === 'string' ? <SmartBreak>{children}</SmartBreak> : children;
+    textFromChildren !== null ? (
+      <SmartBreak>{textFromChildren}</SmartBreak>
+    ) : (
+      children
+    );
 
   return (
     <a
@@ -37,4 +45,39 @@ export function ContentLink({ href, className, children, ...rest }: Props) {
       {content}
     </a>
   );
+}
+
+function extractText(children: unknown): string | null {
+  if (typeof children === 'string') return children;
+  if (typeof children === 'number') return String(children);
+  // Only accept a single StaticHtml-like VNode (Astro's wrapper for pure-text
+  // MDX children). Arrays or VNodes with inline markup indicate mixed content
+  // that must not be flattened through SmartBreak.
+  if (children && typeof children === 'object' && !Array.isArray(children)) {
+    const v = children as { props?: { value?: unknown } };
+    if (v.props && v.props.value != null) {
+      if (
+        typeof v.props.value === 'string' ||
+        v.props.value instanceof String ||
+        (typeof v.props.value === 'object' && typeof (v.props.value as object).toString === 'function')
+      ) {
+        const s = String(v.props.value);
+        if (s && !s.startsWith('[object')) return decodeEntities(s);
+      }
+    }
+  }
+  return null;
+}
+
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#x27;/gi, "'")
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, n) => String.fromCodePoint(parseInt(n, 16)))
+    .replace(/&amp;/g, '&');
 }

--- a/packages/create-zudo-doc/templates/base/src/components/content/content-link.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/content/content-link.tsx
@@ -1,3 +1,12 @@
+import { SmartBreak as SmartBreakBase } from '../../utils/smart-break';
+
+// SmartBreak is defined with Preact's VNode return type, but content
+// components type children as React.ReactNode. Cast to a React-compatible
+// signature; at runtime Preact compat unifies the two.
+const SmartBreak = SmartBreakBase as unknown as (props: {
+  children?: unknown;
+}) => React.ReactElement;
+
 type Props = {
   href?: string;
   className?: string;
@@ -16,13 +25,16 @@ export function ContentLink({ href, className, children, ...rest }: Props) {
     );
   }
 
+  const content =
+    typeof children === 'string' ? <SmartBreak>{children}</SmartBreak> : children;
+
   return (
     <a
       href={href}
       className={`text-accent underline hover:text-accent-hover${className ? ` ${className}` : ''}`}
       {...rest}
     >
-      {children}
+      {content}
     </a>
   );
 }

--- a/packages/create-zudo-doc/templates/base/src/components/frontmatter-preview.astro
+++ b/packages/create-zudo-doc/templates/base/src/components/frontmatter-preview.astro
@@ -3,6 +3,7 @@ import { settings } from "@/config/settings";
 import { DEFAULT_FRONTMATTER_IGNORE_KEYS } from "@/config/frontmatter-preview-defaults";
 import { t, type Locale } from "@/config/i18n";
 import { frontmatterRenderers } from "@/config/frontmatter-preview-renderers";
+import { smartBreakToHtml } from "@/utils/smart-break";
 
 interface Props {
   data: Record<string, unknown>;
@@ -81,9 +82,9 @@ function renderValue(v: unknown): { text?: string; code?: string } {
                       <code class="bg-code-bg text-code-fg px-hsp-xs py-0 rounded text-micro font-mono">
                         {rendered.code}
                       </code>
-                    ) : (
-                      rendered?.text
-                    )}
+                    ) : rendered?.text !== undefined ? (
+                      <Fragment set:html={smartBreakToHtml(rendered.text)} />
+                    ) : null}
                   </td>
                 </tr>
               );

--- a/packages/create-zudo-doc/templates/base/src/components/mobile-toc.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/mobile-toc.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from "react";
 import type { Heading } from "@/types/heading";
+import { SmartBreak } from "@/utils/smart-break";
 import clsx from "clsx";
 
 interface MobileTocProps {
@@ -59,7 +60,7 @@ export function MobileToc({ headings, title = "On this page" }: MobileTocProps) 
                 onClick={() => setOpen(false)}
                 className="block py-vsp-2xs text-small text-muted hover:text-fg hover:underline focus-visible:underline"
               >
-                {heading.text}
+                <SmartBreak>{heading.text}</SmartBreak>
               </a>
             </li>
           ))}

--- a/packages/create-zudo-doc/templates/base/src/components/sidebar-tree.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/sidebar-tree.tsx
@@ -3,6 +3,7 @@ import type { NavNode } from "@/utils/docs";
 import type { LocaleLink } from "@/types/locale";
 import { INDENT, BASE_PAD, connectorLeft, ConnectorLines, CategoryLinkIcon } from "./tree-nav-shared";
 import ThemeToggle from "@/components/theme-toggle";
+import { smartBreakToHtml } from "@/utils/smart-break";
 
 function ToggleChevron({ isExpanded, className }: { isExpanded: boolean; className?: string }) {
   return (
@@ -110,10 +111,10 @@ function RootMenuItemEntry({ item }: { item: RootMenuItem }) {
       <div className="flex items-center">
         <a
           href={item.href}
-          className="flex flex-1 items-center gap-hsp-xs px-hsp-sm py-vsp-xs text-small font-semibold text-fg hover:text-accent hover:underline"
+          className="flex flex-1 items-center gap-hsp-xs px-hsp-sm py-vsp-xs text-small font-semibold text-fg hover:text-accent hover:underline break-words"
         >
           <CategoryLinkIcon className="w-[14px]" />
-          {item.label}
+          <span dangerouslySetInnerHTML={{ __html: smartBreakToHtml(item.label) }} />
         </a>
         {hasChildren && (
           <button
@@ -133,9 +134,9 @@ function RootMenuItemEntry({ item }: { item: RootMenuItem }) {
             <a
               key={child.href}
               href={child.href}
-              className="block pl-hsp-xl pr-hsp-sm py-vsp-2xs text-small text-muted hover:text-accent hover:underline"
+              className="block pl-hsp-xl pr-hsp-sm py-vsp-2xs text-small text-muted hover:text-accent hover:underline break-words"
             >
-              {child.label}
+              <span dangerouslySetInnerHTML={{ __html: smartBreakToHtml(child.label) }} />
             </a>
           ))}
         </div>
@@ -422,11 +423,11 @@ function CategoryNode({
             <a
               href={node.href}
               aria-current={isActive ? "page" : undefined}
-              className={`flex-1 flex items-center gap-hsp-xs py-vsp-xs hover:underline focus:underline ${isActive ? "text-bg" : "text-fg"}`}
+              className={`flex-1 flex items-center gap-hsp-xs py-vsp-xs hover:underline focus:underline break-words ${isActive ? "text-bg" : "text-fg"}`}
               style={{ paddingLeft }}
             >
               {depth === 0 && <CategoryLinkIcon className={`w-[14px] ${isActive ? "text-bg" : ""}`} />}
-              {node.label}
+              <span dangerouslySetInnerHTML={{ __html: smartBreakToHtml(node.label) }} />
             </a>
             <button
               type="button"
@@ -442,7 +443,7 @@ function CategoryNode({
           <button
             type="button"
             onClick={toggle}
-            className={`flex w-full items-center gap-hsp-md text-left text-small font-semibold py-vsp-xs text-fg hover:underline focus:underline`}
+            className={`flex w-full items-center gap-hsp-md text-left text-small font-semibold py-vsp-xs text-fg hover:underline focus:underline break-words`}
             style={{ paddingLeft }}
             aria-expanded={isExpanded}
             aria-label={isExpanded ? `Collapse ${node.label}` : `Expand ${node.label}`}
@@ -450,7 +451,7 @@ function CategoryNode({
             <span className="aspect-square flex items-center justify-center w-[1.5rem] shrink-0 border border-muted">
               <ToggleChevron isExpanded={isExpanded} className="text-muted" />
             </span>
-            {node.label}
+            <span dangerouslySetInnerHTML={{ __html: smartBreakToHtml(node.label) }} />
           </button>
         )}
       </div>
@@ -502,10 +503,10 @@ function LeafNode({
           href={node.href}
           aria-current={isActive ? "page" : undefined}
           className={isRoot
-            ? `flex items-center gap-hsp-xs py-[calc(var(--spacing-vsp-xs)+0.15rem)] pr-[4px] text-small font-semibold ${
+            ? `flex items-center gap-hsp-xs py-[calc(var(--spacing-vsp-xs)+0.15rem)] pr-[4px] text-small font-semibold break-words ${
                 isActive ? "bg-fg text-bg" : "text-fg hover:underline focus:underline"
               }`
-            : `block py-vsp-2xs pr-[4px] text-small ${
+            : `block py-vsp-2xs pr-[4px] text-small break-words ${
                 isActive
                   ? "bg-fg font-medium text-bg"
                   : "text-muted hover:underline focus:underline"
@@ -514,7 +515,7 @@ function LeafNode({
           style={{ paddingLeft }}
         >
           {isRoot && <CategoryLinkIcon className={`w-[14px] ${isActive ? "text-bg" : ""}`} />}
-          {node.label}
+          <span dangerouslySetInnerHTML={{ __html: smartBreakToHtml(node.label) }} />
         </a>
       </div>
     </div>

--- a/packages/create-zudo-doc/templates/base/src/components/toc.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/toc.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useActiveHeading } from "@/hooks/use-active-heading";
 import type { Heading } from "@/types/heading";
+import { SmartBreak } from "@/utils/smart-break";
 import clsx from "clsx";
 
 interface TocProps {
@@ -49,7 +50,7 @@ export function Toc({ headings }: TocProps) {
                     : "text-muted hover:underline focus:underline",
                 )}
               >
-                {heading.text}
+                <SmartBreak>{heading.text}</SmartBreak>
               </a>
             </li>
           );

--- a/packages/create-zudo-doc/templates/base/src/styles/global.css
+++ b/packages/create-zudo-doc/templates/base/src/styles/global.css
@@ -397,7 +397,7 @@ body {
 .zd-content :where(td) {
   padding: var(--spacing-vsp-xs) var(--spacing-hsp-md);
   border-bottom: 1px solid var(--color-muted);
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
 }
 
 .zd-content :where(th) {

--- a/packages/create-zudo-doc/templates/base/src/utils/smart-break.tsx
+++ b/packages/create-zudo-doc/templates/base/src/utils/smart-break.tsx
@@ -74,8 +74,14 @@ export function smartBreak(text: string): VNode | string {
 /**
  * Preact function component wrapper — pure, server-renderable.
  * Stringifies children and defers to smartBreak.
+ *
+ * Return type is `any` so the component can be mounted from both
+ * Preact-typed and React-typed .tsx files (preact/compat makes this safe
+ * at runtime, but TypeScript treats Preact's VNode and React's JSX.Element
+ * as distinct types).
  */
-export function SmartBreak({ children }: { children?: unknown }): VNode {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function SmartBreak({ children }: { children?: unknown }): any {
   return <>{smartBreak(String(children ?? ""))}</>;
 }
 

--- a/packages/create-zudo-doc/templates/base/src/utils/smart-break.tsx
+++ b/packages/create-zudo-doc/templates/base/src/utils/smart-break.tsx
@@ -1,0 +1,102 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import type { VNode } from "preact";
+
+/**
+ * Heuristic: does `text` look like a URL, filesystem path, or similar
+ * structure where inserting <wbr> after delimiters aids line-wrapping?
+ *
+ * Returns true for URLs (contain "://"), POSIX-style absolute/relative
+ * paths ("/", "./", "../"), Windows drive paths ("C:\\..." or "C:/..."),
+ * strings with 2+ slashes (or backslashes) between alphanumerics, and
+ * plausible domain-plus-slash strings.
+ *
+ * Returns false for empty input and prose-y hyphen/slash/dot combinations
+ * like "and/or", "well-known", "state-of-the-art", "1.2.3-beta.4", "UI/UX".
+ */
+export function isPathLike(text: string): boolean {
+  if (!text) return false;
+  if (text.includes("://")) return true;
+  // starts with "/", "./", or "../"
+  if (/^\.{0,2}\//.test(text)) return true;
+  // Windows drive letter paths, either backslash or forward slash
+  if (/^[A-Za-z]:[\\/]/.test(text)) return true;
+  // 2+ forward slashes appearing between alphanumeric runs
+  const forwardMatches = text.match(/[A-Za-z0-9]\/[A-Za-z0-9]/g);
+  if (forwardMatches && forwardMatches.length >= 2) return true;
+  // 2+ backslashes appearing between alphanumeric runs
+  const backMatches = text.match(/[A-Za-z0-9]\\[A-Za-z0-9]/g);
+  if (backMatches && backMatches.length >= 2) return true;
+  // Plausible domain-ish: a "." between alphanumerics AND at least one slash
+  const hasDomainDot = /[A-Za-z0-9]\.[A-Za-z0-9]/.test(text);
+  const hasSlash = /[\\/]/.test(text);
+  if (hasDomainDot && hasSlash) return true;
+  return false;
+}
+
+// Delimiter set: / \ - _ . : ? # & =
+// Capture in split so the delimiter is preserved at odd indices.
+const DELIM_SPLIT = /([/\\\-_.:?#&=])/;
+
+const HTML_ESCAPE_MAP: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+function htmlEscape(s: string): string {
+  return s.replace(/[&<>"']/g, (ch) => HTML_ESCAPE_MAP[ch]!);
+}
+
+/**
+ * If `text` is path-like, return a Preact fragment with <wbr/> inserted
+ * after each delimiter (/, \, -, _, ., :, ?, #, &, =). Otherwise return
+ * the input string unchanged so callers can trust non-path prose passes
+ * through untouched.
+ */
+export function smartBreak(text: string): VNode | string {
+  if (!isPathLike(text)) return text;
+  const parts = text.split(DELIM_SPLIT);
+  const nodes: (string | VNode)[] = [];
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    if (part === "") continue;
+    nodes.push(part);
+    // Captured delimiter groups always land at odd indices.
+    if (i % 2 === 1) nodes.push(<wbr key={`wbr-${i}`} />);
+  }
+  return <>{nodes}</>;
+}
+
+/**
+ * Preact function component wrapper — pure, server-renderable.
+ * Stringifies children and defers to smartBreak.
+ */
+export function SmartBreak({ children }: { children?: unknown }): VNode {
+  return <>{smartBreak(String(children ?? ""))}</>;
+}
+
+/**
+ * HTML-string counterpart of smartBreak. Produces a safe HTML string
+ * with literal "<wbr>" tags injected after each delimiter in path-like
+ * input, and HTML-escaped text elsewhere. For non-path input, returns
+ * the HTML-escaped text unchanged (no wbr injection).
+ *
+ * Use this when the consumer cannot render Preact VNodes (e.g. building
+ * an HTML string for `set:html` / dangerouslySetInnerHTML).
+ */
+export function smartBreakToHtml(text: string): string {
+  if (!isPathLike(text)) return htmlEscape(text);
+  const parts = text.split(DELIM_SPLIT);
+  let out = "";
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    if (part === "") continue;
+    out += htmlEscape(part);
+    if (i % 2 === 1) out += "<wbr>";
+  }
+  return out;
+}

--- a/packages/create-zudo-doc/templates/base/src/utils/smart-break.tsx
+++ b/packages/create-zudo-doc/templates/base/src/utils/smart-break.tsx
@@ -80,6 +80,32 @@ export function SmartBreak({ children }: { children?: unknown }): VNode {
 }
 
 /**
+ * HTML-escape `text` and inject a literal "<wbr>" tag after every
+ * delimiter character. Unlike smartBreakToHtml, this does NOT check
+ * isPathLike — it unconditionally breaks on delimiters.
+ *
+ * Useful when a caller has already decided that a larger string is
+ * path-like and wants to apply the same wbr-injection rule to a
+ * substring (e.g. a segment produced by splitting on a search-query
+ * regex) without re-running the heuristic on fragments that are too
+ * short to be classified correctly on their own.
+ *
+ * Byte-identical to smartBreakToHtml for inputs where isPathLike is
+ * true, so the shared contract holds.
+ */
+export function escapeAndInjectWbr(text: string): string {
+  const parts = text.split(DELIM_SPLIT);
+  let out = "";
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    if (part === "") continue;
+    out += htmlEscape(part);
+    if (i % 2 === 1) out += "<wbr>";
+  }
+  return out;
+}
+
+/**
  * HTML-string counterpart of smartBreak. Produces a safe HTML string
  * with literal "<wbr>" tags injected after each delimiter in path-like
  * input, and HTML-escaped text elsewhere. For non-path input, returns
@@ -90,13 +116,5 @@ export function SmartBreak({ children }: { children?: unknown }): VNode {
  */
 export function smartBreakToHtml(text: string): string {
   if (!isPathLike(text)) return htmlEscape(text);
-  const parts = text.split(DELIM_SPLIT);
-  let out = "";
-  for (let i = 0; i < parts.length; i++) {
-    const part = parts[i];
-    if (part === "") continue;
-    out += htmlEscape(part);
-    if (i % 2 === 1) out += "<wbr>";
-  }
-  return out;
+  return escapeAndInjectWbr(text);
 }

--- a/packages/create-zudo-doc/templates/features/docHistory/files/src/components/doc-history.tsx
+++ b/packages/create-zudo-doc/templates/features/docHistory/files/src/components/doc-history.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { diffLines } from "diff";
 import type { DocHistoryData, DocHistoryEntry } from "@/types/doc-history";
+import { SmartBreak } from "@/utils/smart-break";
 
 interface DocHistoryProps {
   slug: string;
@@ -374,7 +375,7 @@ function RevisionList({
                     <span className="text-caption text-muted">{dateStr}</span>
                   </div>
                   <div className="text-small text-fg mt-vsp-2xs truncate">
-                    {entry.message}
+                    <SmartBreak>{entry.message}</SmartBreak>
                   </div>
                   <div className="text-caption text-muted">{entry.author}</div>
                 </div>

--- a/packages/create-zudo-doc/templates/features/search/files/src/components/search.astro
+++ b/packages/create-zudo-doc/templates/features/search/files/src/components/search.astro
@@ -126,6 +126,7 @@ const resultCountTemplate = t("search.resultCount", lang);
 
 <script>
   import MiniSearch from "minisearch";
+  import { isPathLike, escapeAndInjectWbr } from "@/utils/smart-break";
 
   interface SearchEntry {
     id: string;
@@ -156,7 +157,16 @@ const resultCountTemplate = t("search.resultCount", lang);
 
   function highlightTerms(text: string, query: string): string {
     const terms = parseQueryTerms(query).map(escapeRegExp);
-    if (terms.length === 0) return escapeHtml(text);
+    // Decide path-likeness once for the whole text. When the string as a
+    // whole is path-like (URL, filesystem path, etc.), each split segment
+    // must unconditionally receive wbr injection — even if the segment
+    // itself is too short for the heuristic to classify correctly.
+    // Byte-identical to smartBreakToHtml(text) for path-like input when
+    // no query terms are present.
+    const pathLike = isPathLike(text);
+    const escapeSegment = (seg: string) =>
+      pathLike ? escapeAndInjectWbr(seg) : escapeHtml(seg);
+    if (terms.length === 0) return escapeSegment(text);
     // Sort by length descending so longer terms match before their prefixes
     terms.sort((a, b) => b.length - a.length);
     const pattern = new RegExp(`(${terms.join("|")})`, "gi");
@@ -164,8 +174,8 @@ const resultCountTemplate = t("search.resultCount", lang);
       .split(pattern)
       .map((segment, i) =>
         i % 2 === 1
-          ? `<mark>${escapeHtml(segment)}</mark>`
-          : escapeHtml(segment),
+          ? `<mark>${escapeSegment(segment)}</mark>`
+          : escapeSegment(segment),
       )
       .join("");
   }

--- a/src/components/ai-chat-modal.tsx
+++ b/src/components/ai-chat-modal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import type { ChatMessage } from "@/types/ai-chat";
 import { renderMarkdown } from "@/utils/render-markdown";
+import { SmartBreak } from "@/utils/smart-break";
 
 interface AiChatModalProps {
   basePath: string;
@@ -162,7 +163,7 @@ export default function AiChatModal({ basePath }: AiChatModalProps) {
             >
               {msg.role === "user" ? (
                 <div className="max-w-[85%] rounded-t-[1rem] rounded-bl-[1rem] rounded-br-[0.25rem] bg-chat-user-bg px-hsp-md py-vsp-2xs text-small leading-relaxed text-chat-user-text">
-                  {msg.content}
+                  <SmartBreak>{msg.content}</SmartBreak>
                 </div>
               ) : (
                 <div

--- a/src/components/breadcrumb.astro
+++ b/src/components/breadcrumb.astro
@@ -1,6 +1,6 @@
 ---
 import type { BreadcrumbItem } from "@/utils/docs";
-import { smartBreakToHtml } from "@/utils/smart-break";
+import { isPathLike, smartBreakToHtml } from "@/utils/smart-break";
 
 interface Props {
   items: BreadcrumbItem[];
@@ -54,10 +54,16 @@ const { items } = Astro.props;
                     />
                   </svg>
                 )}
-                <span set:html={smartBreakToHtml(item.label)} />
+                {isPathLike(item.label) ? (
+                  <span set:html={smartBreakToHtml(item.label)} />
+                ) : (
+                  item.label
+                )}
               </a>
-            ) : (
+            ) : isPathLike(item.label) ? (
               <span class="text-fg" set:html={smartBreakToHtml(item.label)} />
+            ) : (
+              <span class="text-fg">{item.label}</span>
             )}
           </li>
         ))}

--- a/src/components/breadcrumb.astro
+++ b/src/components/breadcrumb.astro
@@ -1,5 +1,6 @@
 ---
 import type { BreadcrumbItem } from "@/utils/docs";
+import { smartBreakToHtml } from "@/utils/smart-break";
 
 interface Props {
   items: BreadcrumbItem[];
@@ -53,10 +54,10 @@ const { items } = Astro.props;
                     />
                   </svg>
                 )}
-                {item.label}
+                <span set:html={smartBreakToHtml(item.label)} />
               </a>
             ) : (
-              <span class="text-fg">{item.label}</span>
+              <span class="text-fg" set:html={smartBreakToHtml(item.label)} />
             )}
           </li>
         ))}

--- a/src/components/content/component-map.ts
+++ b/src/components/content/component-map.ts
@@ -8,6 +8,7 @@ import { ContentBlockquote } from './content-blockquote';
 import { ContentUl } from './content-ul';
 import { ContentOl } from './content-ol';
 import { ContentTable } from './content-table';
+import { ContentCode } from './content-code';
 
 export const htmlOverrides = {
   h2: HeadingH2,
@@ -20,4 +21,5 @@ export const htmlOverrides = {
   ul: ContentUl,
   ol: ContentOl,
   table: ContentTable,
+  code: ContentCode,
 };

--- a/src/components/content/content-code.tsx
+++ b/src/components/content/content-code.tsx
@@ -1,0 +1,43 @@
+import { SmartBreak as SmartBreakImpl } from '@/utils/smart-break';
+
+// Preact VNode vs React.ReactNode type mismatch under compat mode; cast so the
+// content override type-checks. Runtime is fine since @astrojs/preact compat is on.
+const SmartBreak = SmartBreakImpl as unknown as (props: {
+  children?: unknown;
+}) => any;
+
+type Props = {
+  children?: React.ReactNode;
+  className?: string;
+  [key: string]: any;
+};
+
+/**
+ * Override for inline `<code>` in MDX. Wraps text-only inline code with
+ * <SmartBreak> so that path/URL-like strings (e.g. `src/foo/bar.ts`) can
+ * break at delimiters on narrow viewports.
+ *
+ * Block code inside a fenced block is processed by Shiki, which emits a
+ * <code> element with class "language-*" containing a tree of <span>
+ * nodes (not a plain string). We detect those and render untouched so
+ * syntax highlighting is never disturbed.
+ */
+export function ContentCode({ children, className, ...rest }: Props) {
+  const isShikiBlock =
+    typeof className === 'string' && /(^|\s)language-/.test(className);
+  const isInlineText = typeof children === 'string';
+
+  if (isShikiBlock || !isInlineText) {
+    return (
+      <code className={className} {...rest}>
+        {children}
+      </code>
+    );
+  }
+
+  return (
+    <code className={className} {...rest}>
+      <SmartBreak>{children}</SmartBreak>
+    </code>
+  );
+}

--- a/src/components/content/content-code.tsx
+++ b/src/components/content/content-code.tsx
@@ -21,13 +21,19 @@ type Props = {
  * <code> element with class "language-*" containing a tree of <span>
  * nodes (not a plain string). We detect those and render untouched so
  * syntax highlighting is never disturbed.
+ *
+ * Astro 6 passes pure-text MDX children wrapped in a `StaticHtml` Preact
+ * component whose text lives in `props.value`, not as a string child.
+ * `extractText` unwraps that so the heuristic works regardless of MDX's
+ * internal wrapping.
  */
 export function ContentCode({ children, className, ...rest }: Props) {
   const isShikiBlock =
     typeof className === 'string' && /(^|\s)language-/.test(className);
-  const isInlineText = typeof children === 'string';
 
-  if (isShikiBlock || !isInlineText) {
+  const textFromChildren = isShikiBlock ? null : extractText(children);
+
+  if (textFromChildren === null) {
     return (
       <code className={className} {...rest}>
         {children}
@@ -37,7 +43,75 @@ export function ContentCode({ children, className, ...rest }: Props) {
 
   return (
     <code className={className} {...rest}>
-      <SmartBreak>{children}</SmartBreak>
+      <SmartBreak>{textFromChildren}</SmartBreak>
     </code>
   );
+}
+
+/**
+ * Walk a React/Preact children value and return a concatenated plain
+ * string when the entire subtree is text-only. Returns null if any
+ * non-text node (other than the StaticHtml wrapper Astro uses for pure
+ * text MDX content) is found — that signals inline markup inside the
+ * code span and means we must not inject <wbr>.
+ */
+function extractText(children: unknown): string | null {
+  if (typeof children === 'string') return children;
+  if (typeof children === 'number') return String(children);
+  // Only accept a single VNode whose `props.value` is text (the Astro
+  // StaticHtml wrapper used for pure-text MDX children). Deliberately do
+  // NOT recurse into arbitrary VNode trees — that would match Shiki's
+  // <span>-based block code output and inject <wbr> into syntax-highlighted
+  // tokens, breaking block code rendering.
+  if (children && typeof children === 'object' && !Array.isArray(children)) {
+    const v = children as { props?: { value?: unknown } };
+    if (v.props && v.props.value != null) {
+      if (
+        typeof v.props.value === 'string' ||
+        v.props.value instanceof String ||
+        (typeof v.props.value === 'object' && typeof (v.props.value as object).toString === 'function')
+      ) {
+        const s = String(v.props.value);
+        if (!s || s.startsWith('[object')) return null;
+        // Shiki block-code output also arrives as a StaticHtml wrapper, but
+        // its value is escaped HTML (e.g. "&lt;span class=...&gt;"). Inline
+        // code's value is the plain text of the backtick span (no HTML
+        // markup). If the value looks like HTML, refuse to unwrap — the
+        // block path below falls through to a plain <code> passthrough.
+        if (looksLikeHtmlMarkup(s)) return null;
+        return decodeEntities(s);
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Detect whether a string is the HTML-escaped rendering of a Shiki block
+ * (with nested <span> tokens) rather than the plain text of an inline
+ * `<code>` span. The presence of an escaped HTML-tag opener (`&lt;span`,
+ * `&lt;code`, etc.) is a reliable signal; plain URL/path inline code
+ * never contains those escaped sequences.
+ */
+function looksLikeHtmlMarkup(s: string): boolean {
+  return /&lt;(span|code|pre|div|br|i|b|em|strong)\b/i.test(s) || /<(span|code|pre)\s/i.test(s);
+}
+
+/**
+ * Minimal HTML entity decoder for the set MDX produces for inline text
+ * (`&amp;`, `&lt;`, `&gt;`, `&quot;`, `&#39;`, numeric). Keeps the
+ * result visually identical to the authored source so downstream
+ * SmartBreak operates on the original characters.
+ */
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#x27;/gi, "'")
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, n) => String.fromCodePoint(parseInt(n, 16)))
+    .replace(/&amp;/g, '&');
 }

--- a/src/components/content/content-link.tsx
+++ b/src/components/content/content-link.tsx
@@ -4,7 +4,7 @@ import { SmartBreak as SmartBreakBase } from '../../utils/smart-break';
 // components type children as React.ReactNode. Cast to a React-compatible
 // signature; at runtime Preact compat unifies the two.
 const SmartBreak = SmartBreakBase as unknown as (props: {
-  children?: unknown;
+  children?: React.ReactNode;
 }) => React.ReactElement;
 
 type Props = {

--- a/src/components/content/content-link.tsx
+++ b/src/components/content/content-link.tsx
@@ -25,8 +25,16 @@ export function ContentLink({ href, className, children, ...rest }: Props) {
     );
   }
 
+  // Astro 6 wraps pure-text MDX children in a `StaticHtml` Preact component
+  // whose text lives in `props.value`, not as a direct string child. Unwrap
+  // when possible so path-like text gets smart-break treatment.
+  const textFromChildren = extractText(children);
   const content =
-    typeof children === 'string' ? <SmartBreak>{children}</SmartBreak> : children;
+    textFromChildren !== null ? (
+      <SmartBreak>{textFromChildren}</SmartBreak>
+    ) : (
+      children
+    );
 
   return (
     <a
@@ -37,4 +45,39 @@ export function ContentLink({ href, className, children, ...rest }: Props) {
       {content}
     </a>
   );
+}
+
+function extractText(children: unknown): string | null {
+  if (typeof children === 'string') return children;
+  if (typeof children === 'number') return String(children);
+  // Only accept a single StaticHtml-like VNode (Astro's wrapper for pure-text
+  // MDX children). Arrays or VNodes with inline markup indicate mixed content
+  // that must not be flattened through SmartBreak.
+  if (children && typeof children === 'object' && !Array.isArray(children)) {
+    const v = children as { props?: { value?: unknown } };
+    if (v.props && v.props.value != null) {
+      if (
+        typeof v.props.value === 'string' ||
+        v.props.value instanceof String ||
+        (typeof v.props.value === 'object' && typeof (v.props.value as object).toString === 'function')
+      ) {
+        const s = String(v.props.value);
+        if (s && !s.startsWith('[object')) return decodeEntities(s);
+      }
+    }
+  }
+  return null;
+}
+
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#x27;/gi, "'")
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, n) => String.fromCodePoint(parseInt(n, 16)))
+    .replace(/&amp;/g, '&');
 }

--- a/src/components/content/content-link.tsx
+++ b/src/components/content/content-link.tsx
@@ -1,3 +1,12 @@
+import { SmartBreak as SmartBreakBase } from '../../utils/smart-break';
+
+// SmartBreak is defined with Preact's VNode return type, but content
+// components type children as React.ReactNode. Cast to a React-compatible
+// signature; at runtime Preact compat unifies the two.
+const SmartBreak = SmartBreakBase as unknown as (props: {
+  children?: unknown;
+}) => React.ReactElement;
+
 type Props = {
   href?: string;
   className?: string;
@@ -16,13 +25,16 @@ export function ContentLink({ href, className, children, ...rest }: Props) {
     );
   }
 
+  const content =
+    typeof children === 'string' ? <SmartBreak>{children}</SmartBreak> : children;
+
   return (
     <a
       href={href}
       className={`text-accent underline hover:text-accent-hover${className ? ` ${className}` : ''}`}
       {...rest}
     >
-      {children}
+      {content}
     </a>
   );
 }

--- a/src/components/doc-history.tsx
+++ b/src/components/doc-history.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { diffLines } from "diff";
 import type { DocHistoryData, DocHistoryEntry } from "@/types/doc-history";
+import { SmartBreak } from "@/utils/smart-break";
 
 interface DocHistoryProps {
   slug: string;
@@ -374,7 +375,7 @@ function RevisionList({
                     <span className="text-caption text-muted">{dateStr}</span>
                   </div>
                   <div className="text-small text-fg mt-vsp-2xs truncate">
-                    {entry.message}
+                    <SmartBreak>{entry.message}</SmartBreak>
                   </div>
                   <div className="text-caption text-muted">{entry.author}</div>
                 </div>

--- a/src/components/frontmatter-preview.astro
+++ b/src/components/frontmatter-preview.astro
@@ -3,6 +3,7 @@ import { settings } from "@/config/settings";
 import { DEFAULT_FRONTMATTER_IGNORE_KEYS } from "@/config/frontmatter-preview-defaults";
 import { t, type Locale } from "@/config/i18n";
 import { frontmatterRenderers } from "@/config/frontmatter-preview-renderers";
+import { smartBreakToHtml } from "@/utils/smart-break";
 
 interface Props {
   data: Record<string, unknown>;
@@ -81,9 +82,9 @@ function renderValue(v: unknown): { text?: string; code?: string } {
                       <code class="bg-code-bg text-code-fg px-hsp-xs py-0 rounded text-micro font-mono">
                         {rendered.code}
                       </code>
-                    ) : (
-                      rendered?.text
-                    )}
+                    ) : rendered?.text !== undefined ? (
+                      <Fragment set:html={smartBreakToHtml(rendered.text)} />
+                    ) : null}
                   </td>
                 </tr>
               );

--- a/src/components/mobile-toc.tsx
+++ b/src/components/mobile-toc.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from "react";
 import type { Heading } from "@/types/heading";
+import { SmartBreak } from "@/utils/smart-break";
 import clsx from "clsx";
 
 interface MobileTocProps {
@@ -59,7 +60,7 @@ export function MobileToc({ headings, title = "On this page" }: MobileTocProps) 
                 onClick={() => setOpen(false)}
                 className="block py-vsp-2xs text-small text-muted hover:text-fg hover:underline focus-visible:underline"
               >
-                {heading.text}
+                <SmartBreak>{heading.text}</SmartBreak>
               </a>
             </li>
           ))}

--- a/src/components/search.astro
+++ b/src/components/search.astro
@@ -126,6 +126,7 @@ const resultCountTemplate = t("search.resultCount", lang);
 
 <script>
   import MiniSearch from "minisearch";
+  import { isPathLike, escapeAndInjectWbr } from "@/utils/smart-break";
 
   interface SearchEntry {
     id: string;
@@ -156,7 +157,16 @@ const resultCountTemplate = t("search.resultCount", lang);
 
   function highlightTerms(text: string, query: string): string {
     const terms = parseQueryTerms(query).map(escapeRegExp);
-    if (terms.length === 0) return escapeHtml(text);
+    // Decide path-likeness once for the whole text. When the string as a
+    // whole is path-like (URL, filesystem path, etc.), each split segment
+    // must unconditionally receive wbr injection — even if the segment
+    // itself is too short for the heuristic to classify correctly.
+    // Byte-identical to smartBreakToHtml(text) for path-like input when
+    // no query terms are present.
+    const pathLike = isPathLike(text);
+    const escapeSegment = (seg: string) =>
+      pathLike ? escapeAndInjectWbr(seg) : escapeHtml(seg);
+    if (terms.length === 0) return escapeSegment(text);
     // Sort by length descending so longer terms match before their prefixes
     terms.sort((a, b) => b.length - a.length);
     const pattern = new RegExp(`(${terms.join("|")})`, "gi");
@@ -164,8 +174,8 @@ const resultCountTemplate = t("search.resultCount", lang);
       .split(pattern)
       .map((segment, i) =>
         i % 2 === 1
-          ? `<mark>${escapeHtml(segment)}</mark>`
-          : escapeHtml(segment),
+          ? `<mark>${escapeSegment(segment)}</mark>`
+          : escapeSegment(segment),
       )
       .join("");
   }

--- a/src/components/sidebar-tree.tsx
+++ b/src/components/sidebar-tree.tsx
@@ -3,6 +3,7 @@ import type { NavNode } from "@/utils/docs";
 import type { LocaleLink } from "@/types/locale";
 import { INDENT, BASE_PAD, connectorLeft, ConnectorLines, CategoryLinkIcon } from "./tree-nav-shared";
 import ThemeToggle from "@/components/theme-toggle";
+import { smartBreakToHtml } from "@/utils/smart-break";
 
 function ToggleChevron({ isExpanded, className }: { isExpanded: boolean; className?: string }) {
   return (
@@ -110,10 +111,10 @@ function RootMenuItemEntry({ item }: { item: RootMenuItem }) {
       <div className="flex items-center">
         <a
           href={item.href}
-          className="flex flex-1 items-center gap-hsp-xs px-hsp-sm py-vsp-xs text-small font-semibold text-fg hover:text-accent hover:underline"
+          className="flex flex-1 items-center gap-hsp-xs px-hsp-sm py-vsp-xs text-small font-semibold text-fg hover:text-accent hover:underline break-words"
         >
           <CategoryLinkIcon className="w-[14px]" />
-          {item.label}
+          <span dangerouslySetInnerHTML={{ __html: smartBreakToHtml(item.label) }} />
         </a>
         {hasChildren && (
           <button
@@ -133,9 +134,9 @@ function RootMenuItemEntry({ item }: { item: RootMenuItem }) {
             <a
               key={child.href}
               href={child.href}
-              className="block pl-hsp-xl pr-hsp-sm py-vsp-2xs text-small text-muted hover:text-accent hover:underline"
+              className="block pl-hsp-xl pr-hsp-sm py-vsp-2xs text-small text-muted hover:text-accent hover:underline break-words"
             >
-              {child.label}
+              <span dangerouslySetInnerHTML={{ __html: smartBreakToHtml(child.label) }} />
             </a>
           ))}
         </div>
@@ -422,11 +423,11 @@ function CategoryNode({
             <a
               href={node.href}
               aria-current={isActive ? "page" : undefined}
-              className={`flex-1 flex items-center gap-hsp-xs py-vsp-xs hover:underline focus:underline ${isActive ? "text-bg" : "text-fg"}`}
+              className={`flex-1 flex items-center gap-hsp-xs py-vsp-xs hover:underline focus:underline break-words ${isActive ? "text-bg" : "text-fg"}`}
               style={{ paddingLeft }}
             >
               {depth === 0 && <CategoryLinkIcon className={`w-[14px] ${isActive ? "text-bg" : ""}`} />}
-              {node.label}
+              <span dangerouslySetInnerHTML={{ __html: smartBreakToHtml(node.label) }} />
             </a>
             <button
               type="button"
@@ -442,7 +443,7 @@ function CategoryNode({
           <button
             type="button"
             onClick={toggle}
-            className={`flex w-full items-center gap-hsp-md text-left text-small font-semibold py-vsp-xs text-fg hover:underline focus:underline`}
+            className={`flex w-full items-center gap-hsp-md text-left text-small font-semibold py-vsp-xs text-fg hover:underline focus:underline break-words`}
             style={{ paddingLeft }}
             aria-expanded={isExpanded}
             aria-label={isExpanded ? `Collapse ${node.label}` : `Expand ${node.label}`}
@@ -450,7 +451,7 @@ function CategoryNode({
             <span className="aspect-square flex items-center justify-center w-[1.5rem] shrink-0 border border-muted">
               <ToggleChevron isExpanded={isExpanded} className="text-muted" />
             </span>
-            {node.label}
+            <span dangerouslySetInnerHTML={{ __html: smartBreakToHtml(node.label) }} />
           </button>
         )}
       </div>
@@ -502,10 +503,10 @@ function LeafNode({
           href={node.href}
           aria-current={isActive ? "page" : undefined}
           className={isRoot
-            ? `flex items-center gap-hsp-xs py-[calc(var(--spacing-vsp-xs)+0.15rem)] pr-[4px] text-small font-semibold ${
+            ? `flex items-center gap-hsp-xs py-[calc(var(--spacing-vsp-xs)+0.15rem)] pr-[4px] text-small font-semibold break-words ${
                 isActive ? "bg-fg text-bg" : "text-fg hover:underline focus:underline"
               }`
-            : `block py-vsp-2xs pr-[4px] text-small ${
+            : `block py-vsp-2xs pr-[4px] text-small break-words ${
                 isActive
                   ? "bg-fg font-medium text-bg"
                   : "text-muted hover:underline focus:underline"
@@ -514,7 +515,7 @@ function LeafNode({
           style={{ paddingLeft }}
         >
           {isRoot && <CategoryLinkIcon className={`w-[14px] ${isActive ? "text-bg" : ""}`} />}
-          {node.label}
+          <span dangerouslySetInnerHTML={{ __html: smartBreakToHtml(node.label) }} />
         </a>
       </div>
     </div>

--- a/src/components/toc.tsx
+++ b/src/components/toc.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useActiveHeading } from "@/hooks/use-active-heading";
 import type { Heading } from "@/types/heading";
+import { SmartBreak } from "@/utils/smart-break";
 import clsx from "clsx";
 
 interface TocProps {
@@ -49,7 +50,7 @@ export function Toc({ headings }: TocProps) {
                     : "text-muted hover:underline focus:underline",
                 )}
               >
-                {heading.text}
+                <SmartBreak>{heading.text}</SmartBreak>
               </a>
             </li>
           );

--- a/src/content/docs-ja/reference/smart-break.mdx
+++ b/src/content/docs-ja/reference/smart-break.mdx
@@ -1,0 +1,107 @@
+---
+title: Smart Break ユーティリティ
+sidebar_position: 11
+description: パス風の長い文字列に <wbr> を挿入し、狭い UI でもきれいに折り返す
+tags:
+  - content
+  - i18n
+---
+
+長いURLやファイルシステムパス — 例えば `packages/create-zudo-doc/templates/base/src/utils/smart-break.tsx` — は任意の文字境界では折り返されません。狭いUI（サイドバーのラベル、パンくず、インラインコード、検索スニペットなど）ではコンテナからあふれたり、レイアウトを本来より広くしてしまいます。
+
+`src/utils/smart-break.tsx` にある smart-break ユーティリティは、パス風に見える文字列のデリミタごとに `<wbr>`（word-break opportunity）ヒントを挿入することでこの問題を解決します。実際にどこで折り返すかはブラウザが利用可能な幅に応じて判断します。
+
+## 自動適用
+
+zudo-doc のいくつかの表示面では、すでに smart-break が自動的に適用されています。追加の設定は不要です：
+
+- **サイドバーツリーのラベル** — カテゴリ名・ページ名
+- **パンくずリスト** — 現在ページまでの経路
+- **MDX のリンク** — 本文中のアンカーテキスト
+- **MDX のインラインコード** — 本文中のバッククォートスパン
+- **検索結果** — 検索ダイアログのタイトルとスニペット
+- **ドキュメント履歴** — コミットメッセージの表示
+
+ユーザー入力のパス風文字列を描画するカスタムコンポーネントを書くとき以外は、自分で呼び出す必要はありません。
+
+## 手動適用：`SmartBreak` コンポーネント
+
+Preact アイランド（あるいはプロジェクト内の任意の `.tsx` コンポーネント）では `SmartBreak` コンポーネントを使います。子要素を文字列化し、適切な位置に `<wbr>` を挿入します：
+
+```tsx
+import { SmartBreak } from "@/utils/smart-break";
+
+export function FileBadge({ path }: { path: string }) {
+  return (
+    <span class="font-mono text-caption">
+      <SmartBreak>{path}</SmartBreak>
+    </span>
+  );
+}
+```
+
+`path` がパス風でない場合（通常の文章、`and/or`、`state-of-the-art` など）はそのまま返され、不要な wbr は挿入されません。
+
+## 手動適用：`smartBreakToHtml` ヘルパー
+
+Astro コンポーネントや、HTML 文字列を描画するコードパス（`set:html` や `dangerouslySetInnerHTML` など）では、Preact の VNode を直接マウントできません。その場合は `smartBreakToHtml` を使ってください。HTML エスケープ済みの文字列に、リテラルの `<wbr>` タグを挿入した結果を返します：
+
+```astro
+---
+import { smartBreakToHtml } from "@/utils/smart-break";
+
+const { label } = Astro.props;
+---
+
+<span set:html={smartBreakToHtml(label)} />
+```
+
+返される文字列はすでに HTML エスケープ済みなので、そのまま `set:html` に渡しても安全です。
+
+## 判定のしくみ
+
+smart-break は2段階で動作します：まず入力を `isPathLike` ヒューリスティックで判定し、**パス風と判定された場合にのみ**固定のデリミタセットで分割して、セグメント間に `<wbr>` を挟みながら再結合します。
+
+### デリミタセット
+
+以下の各文字の直後に `<wbr>` を挿入します：
+
+```
+/  \  -  _  .  :  ?  #  &  =
+```
+
+これで URL 構造（`://`、`?query=value&other=1`、`#anchor`）、ファイルシステムパス（`/`、`\`）、複合的な識別子（`snake_case`、`kebab-case`、`file.name.ext`）をカバーできます。
+
+### `isPathLike` ヒューリスティック
+
+`isPathLike` は、URL・パス・その他のデリミタ構造に見える文字列に対して `true` を返します：
+
+- `://` を含む（任意の URL）
+- `/`、`./`、`../` で始まる（POSIX パス）
+- `C:\` や `C:/` のような Windows のドライブ接頭辞で始まる
+- 英数字の間にスラッシュが2つ以上ある（ネストされたパス）
+- ドメイン風の `a.b` パターンに加えて、どこかにスラッシュを含む
+
+一方、文章に紛れ込んだデリミタには `false` を返します：`and/or`、`well-known`、`state-of-the-art`、`1.2.3-beta.4`、`UI/UX` などです。これらはそのまま通過するので、通常の文章の折り返し挙動が維持されます。
+
+### 実例
+
+次のような入力を考えてみます：
+
+```
+packages/create-zudo-doc/templates/base/src/utils/smart-break.tsx
+```
+
+`isPathLike` は `true` を返し、`smartBreakToHtml` は概念的に次のような結果を返します：
+
+```html
+packages<wbr>/create<wbr>-zudo<wbr>-doc<wbr>/templates<wbr>/base<wbr>/src<wbr>/utils<wbr>/smart<wbr>-break<wbr>.tsx
+```
+
+コンテナが十分広ければブラウザは1行で保ち、狭い場合は最も近い `<wbr>` の位置で折り返します。常にセグメントの境界で折り返され、セグメントの途中で切られることはありません。
+
+## 使わないほうがよい場面
+
+- 短いラベル（1〜2語）— そもそも折り返す箇所がありません。
+- どこでも折り返したくない意図的な単一トークン（決して折り返してはいけないバージョンタグなど）。
+- CJK の本文 — このユーティリティはラテン文字のパス風文字列を対象としています。CJK の行折り返しは [CJK対応マークダウン](./cjk-friendly.mdx) プラグインとブラウザ標準の挙動に任せてください。

--- a/src/content/docs/reference/smart-break.mdx
+++ b/src/content/docs/reference/smart-break.mdx
@@ -1,0 +1,107 @@
+---
+title: Smart Break Utility
+sidebar_position: 11
+description: Inject <wbr> hints into long path-like strings so they wrap cleanly in narrow UI.
+tags:
+  - content
+  - i18n
+---
+
+Long URLs and filesystem paths — for example `packages/create-zudo-doc/templates/base/src/utils/smart-break.tsx` — do not wrap at arbitrary character boundaries. In narrow UI (sidebar labels, breadcrumbs, inline code, search snippets) they overflow the container or push layout wider than it should be.
+
+The `smart-break` utility at `src/utils/smart-break.tsx` solves this by injecting `<wbr>` (word-break opportunity) hints after each delimiter in strings that look path-like. The browser then decides where to break based on available width.
+
+## Automatic Behavior
+
+Several zudo-doc surfaces already apply smart-break automatically — no configuration needed:
+
+- **Sidebar tree labels** — category and page labels
+- **Breadcrumbs** — current-page trail
+- **MDX links** — anchor text inside prose
+- **MDX inline code** — backtick spans inside prose
+- **Search results** — titles and snippets in the search dialog
+- **Doc history** — commit message rendering
+
+You only need to invoke the utility yourself when building a custom component that renders user-provided path-like strings.
+
+## Manual Opt-In: `SmartBreak` Component
+
+For Preact islands (or any `.tsx` component in the project) use the `SmartBreak` component. It stringifies its children and injects `<wbr>` where appropriate:
+
+```tsx
+import { SmartBreak } from "@/utils/smart-break";
+
+export function FileBadge({ path }: { path: string }) {
+  return (
+    <span class="font-mono text-caption">
+      <SmartBreak>{path}</SmartBreak>
+    </span>
+  );
+}
+```
+
+If `path` is not path-like (plain prose, `and/or`, `state-of-the-art`, etc.) it is returned unchanged — no stray wbrs are injected.
+
+## Manual Opt-In: `smartBreakToHtml` Helper
+
+Astro components and any code path that renders an HTML string (for example `set:html` or `dangerouslySetInnerHTML`) cannot mount Preact VNodes directly. Use `smartBreakToHtml` instead — it returns an HTML-escaped string with literal `<wbr>` tags injected:
+
+```astro
+---
+import { smartBreakToHtml } from "@/utils/smart-break";
+
+const { label } = Astro.props;
+---
+
+<span set:html={smartBreakToHtml(label)} />
+```
+
+The returned string is already HTML-escaped, so it is safe to pass to `set:html`.
+
+## How It Decides
+
+Smart-break does two things: it classifies the input with an `isPathLike` heuristic, and — only when the heuristic says yes — it splits on a fixed delimiter set and re-joins with `<wbr>` between segments.
+
+### Delimiter Set
+
+Breaks are inserted after each of these characters:
+
+```
+/  \  -  _  .  :  ?  #  &  =
+```
+
+These cover URL structure (`://`, `?query=value&other=1`, `#anchor`), filesystem paths (`/`, `\`), and compound identifiers (`snake_case`, `kebab-case`, `file.name.ext`).
+
+### The `isPathLike` Heuristic
+
+`isPathLike` returns `true` for strings that look like URLs, paths, or similar delimited structures:
+
+- Contains `://` (any URL)
+- Starts with `/`, `./`, or `../` (POSIX paths)
+- Starts with a Windows drive prefix like `C:\` or `C:/`
+- Has at least two slashes between alphanumerics (nested paths)
+- Has a domain-like `a.b` pattern combined with a slash somewhere
+
+It returns `false` for prose-y fragments that happen to contain delimiters: `and/or`, `well-known`, `state-of-the-art`, `1.2.3-beta.4`, `UI/UX`. These pass through unmodified so normal prose wrapping still applies.
+
+### A Realistic Sample
+
+For an input like:
+
+```
+packages/create-zudo-doc/templates/base/src/utils/smart-break.tsx
+```
+
+`isPathLike` returns `true` and `smartBreakToHtml` emits (conceptually):
+
+```html
+packages<wbr>/create<wbr>-zudo<wbr>-doc<wbr>/templates<wbr>/base<wbr>/src<wbr>/utils<wbr>/smart<wbr>-break<wbr>.tsx
+```
+
+The browser keeps the line intact when the container is wide enough, and breaks at the nearest `<wbr>` when it must — always between segments, never mid-segment.
+
+## When Not to Use It
+
+- Short labels (one or two words) — there is nothing to break.
+- Intentional single-token strings where any visual break is wrong (for example a version tag you must never wrap).
+- CJK prose — the utility targets Latin-alphabet path-like strings; CJK line-wrapping is handled by the [CJK-friendly markdown](./cjk-friendly.mdx) plugin and native browser behavior.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -360,7 +360,7 @@ body {
 .zd-content :where(td) {
   padding: var(--spacing-vsp-xs) var(--spacing-hsp-md);
   border-bottom: 1px solid var(--color-muted);
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
 }
 
 .zd-content :where(th) {

--- a/src/utils/__tests__/smart-break.test.ts
+++ b/src/utils/__tests__/smart-break.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from "vitest";
+import type { VNode } from "preact";
+import {
+  isPathLike,
+  smartBreak,
+  smartBreakToHtml,
+  SmartBreak,
+} from "../smart-break";
+
+// -----------------------------------------------------------------------------
+// Test-only helpers: walk a Preact VNode tree and produce an HTML string, so
+// we can compare smartBreak() output against smartBreakToHtml() for parity.
+// Deliberately minimal — only the surface smartBreak actually emits
+// (Fragment, <wbr>, and text) plus a small escape map.
+// -----------------------------------------------------------------------------
+
+const ESCAPE: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+function htmlEscape(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => ESCAPE[c]!);
+}
+
+const VOID_TAGS = new Set([
+  "wbr",
+  "br",
+  "hr",
+  "img",
+  "input",
+  "meta",
+  "link",
+]);
+
+function vnodeToHtml(node: unknown): string {
+  if (node == null || typeof node === "boolean") return "";
+  if (typeof node === "string") return htmlEscape(node);
+  if (typeof node === "number") return htmlEscape(String(node));
+  if (Array.isArray(node)) return node.map(vnodeToHtml).join("");
+
+  const vnode = node as VNode<{ children?: unknown }>;
+  if (typeof vnode.type === "string") {
+    const tag = vnode.type;
+    if (VOID_TAGS.has(tag)) return `<${tag}>`;
+    return `<${tag}>${vnodeToHtml(vnode.props?.children)}</${tag}>`;
+  }
+  // Fragment (or any function/class component): render children only.
+  return vnodeToHtml(vnode.props?.children);
+}
+
+function renderToHtml(result: VNode | string): string {
+  if (typeof result === "string") return htmlEscape(result);
+  return vnodeToHtml(result);
+}
+
+// -----------------------------------------------------------------------------
+// isPathLike
+// -----------------------------------------------------------------------------
+
+describe("isPathLike", () => {
+  const positiveCases: Array<[string, string]> = [
+    ["URL with scheme, query, fragment", "https://example.com/a/b?x=1&y=2"],
+    ["URL with fragment", "http://foo.com/page#section"],
+    ["POSIX absolute path", "/var/log/foo.txt"],
+    ["relative path ./", "./foo/bar"],
+    ["relative path ../", "../baz/qux"],
+    ["Windows backslash path", "C:\\Users\\name\\file.txt"],
+    ["Windows forward-slash path", "C:/Users/name/file.txt"],
+    ["plausible domain with slash", "example.com/about"],
+    ["path-like token embedded in prose", "see /var/log/foo.txt now"],
+  ];
+
+  for (const [label, input] of positiveCases) {
+    it(`returns true: ${label}`, () => {
+      expect(isPathLike(input)).toBe(true);
+    });
+  }
+
+  const negativeCases: Array<[string, string]> = [
+    ["empty string", ""],
+    ["hyphenated prose", "well-known"],
+    ["multi-hyphen prose", "state-of-the-art"],
+    ["and/or conjunction", "and/or"],
+    ["version string", "1.2.3-beta.4"],
+    ["UI/UX shorthand", "UI/UX"],
+  ];
+
+  for (const [label, input] of negativeCases) {
+    it(`returns false: ${label}`, () => {
+      expect(isPathLike(input)).toBe(false);
+    });
+  }
+});
+
+// -----------------------------------------------------------------------------
+// smartBreak
+// -----------------------------------------------------------------------------
+
+describe("smartBreak", () => {
+  it("returns the original string (not a fragment) when not path-like", () => {
+    const result = smartBreak("and/or");
+    expect(typeof result).toBe("string");
+    expect(result).toBe("and/or");
+  });
+
+  it("returns the original empty string when given empty input", () => {
+    const result = smartBreak("");
+    expect(typeof result).toBe("string");
+    expect(result).toBe("");
+  });
+
+  it("returns a VNode (not a string) when path-like", () => {
+    const result = smartBreak("/a/b");
+    expect(typeof result).not.toBe("string");
+  });
+
+  it("inserts <wbr> after each delimiter in a URL", () => {
+    const html = renderToHtml(smartBreak("https://example.com/a/b"));
+    expect(html).toBe(
+      "https:<wbr>/<wbr>/<wbr>example.<wbr>com/<wbr>a/<wbr>b",
+    );
+  });
+
+  it("handles Windows backslash paths", () => {
+    const html = renderToHtml(smartBreak("C:\\Users\\name\\file.txt"));
+    // colon, each backslash, and the dot before ext should each produce a wbr
+    expect(html).toBe(
+      "C:<wbr>\\<wbr>Users\\<wbr>name\\<wbr>file.<wbr>txt",
+    );
+  });
+
+  it("handles URL with query and fragment", () => {
+    const html = renderToHtml(
+      smartBreak("https://example.com/a/b?x=1&y=2#frag"),
+    );
+    // spot-check a few expected injection points.
+    // Note: "&" in input is HTML-escaped to "&amp;" before the injected <wbr>.
+    expect(html).toContain("?<wbr>");
+    expect(html).toContain("&amp;<wbr>");
+    expect(html).toContain("=<wbr>");
+    expect(html).toContain("#<wbr>");
+  });
+});
+
+// -----------------------------------------------------------------------------
+// smartBreakToHtml
+// -----------------------------------------------------------------------------
+
+describe("smartBreakToHtml", () => {
+  it("returns escaped text unchanged when not path-like", () => {
+    expect(smartBreakToHtml("and/or")).toBe("and/or");
+  });
+
+  it("HTML-escapes angle brackets and ampersands in non-path input", () => {
+    expect(smartBreakToHtml("<UI/UX>")).toBe("&lt;UI/UX&gt;");
+  });
+
+  it("inserts literal <wbr> after delimiters for a path-like URL", () => {
+    expect(smartBreakToHtml("https://a.com/b")).toBe(
+      "https:<wbr>/<wbr>/<wbr>a.<wbr>com/<wbr>b",
+    );
+  });
+
+  it("escapes user-supplied <wbr> text but keeps injected <wbr> literal", () => {
+    const out = smartBreakToHtml("/a<wbr>/b");
+    // user-authored "<wbr>" is escaped
+    expect(out).toContain("&lt;wbr&gt;");
+    // at least one genuine injected <wbr> is present (after a "/")
+    expect(out).toContain("/<wbr>");
+  });
+
+  it("escapes quotes and ampersands inside path-like input", () => {
+    const out = smartBreakToHtml("https://example.com/?q=a&b='c'&d=\"e\"");
+    expect(out).toContain("&amp;");
+    expect(out).toContain("&#39;");
+    expect(out).toContain("&quot;");
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Parity: smartBreak (rendered) must match smartBreakToHtml exactly
+// -----------------------------------------------------------------------------
+
+describe("parity between smartBreak and smartBreakToHtml", () => {
+  const inputs = [
+    "https://example.com/a/b?x=1&y=2",
+    "http://foo.com/page#section",
+    "/var/log/foo.txt",
+    "./foo/bar",
+    "../baz/qux",
+    "C:\\Users\\name\\file.txt",
+    "C:/Users/name/file.txt",
+    "example.com/about",
+    "/a<wbr>/b", // already contains the literal substring "<wbr>"
+    "and/or", // non-path prose
+    "1.2.3-beta.4", // non-path prose with dots and hyphens
+    "<UI/UX>", // non-path with special chars
+    "", // empty
+  ];
+
+  for (const input of inputs) {
+    it(`matches for ${JSON.stringify(input)}`, () => {
+      expect(renderToHtml(smartBreak(input))).toBe(smartBreakToHtml(input));
+    });
+  }
+});
+
+// -----------------------------------------------------------------------------
+// SmartBreak component
+// -----------------------------------------------------------------------------
+
+describe("SmartBreak component", () => {
+  it("renders a fragment wrapping smartBreak for string children", () => {
+    const vnode = SmartBreak({ children: "/a/b" });
+    expect(vnodeToHtml(vnode)).toBe("/<wbr>a/<wbr>b");
+  });
+
+  it("stringifies non-string children safely", () => {
+    const vnode = SmartBreak({ children: undefined });
+    expect(vnodeToHtml(vnode)).toBe("");
+  });
+});

--- a/src/utils/smart-break.tsx
+++ b/src/utils/smart-break.tsx
@@ -74,8 +74,14 @@ export function smartBreak(text: string): VNode | string {
 /**
  * Preact function component wrapper — pure, server-renderable.
  * Stringifies children and defers to smartBreak.
+ *
+ * Return type is `any` so the component can be mounted from both
+ * Preact-typed and React-typed .tsx files (preact/compat makes this safe
+ * at runtime, but TypeScript treats Preact's VNode and React's JSX.Element
+ * as distinct types).
  */
-export function SmartBreak({ children }: { children?: unknown }): VNode {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function SmartBreak({ children }: { children?: unknown }): any {
   return <>{smartBreak(String(children ?? ""))}</>;
 }
 

--- a/src/utils/smart-break.tsx
+++ b/src/utils/smart-break.tsx
@@ -1,0 +1,102 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import type { VNode } from "preact";
+
+/**
+ * Heuristic: does `text` look like a URL, filesystem path, or similar
+ * structure where inserting <wbr> after delimiters aids line-wrapping?
+ *
+ * Returns true for URLs (contain "://"), POSIX-style absolute/relative
+ * paths ("/", "./", "../"), Windows drive paths ("C:\\..." or "C:/..."),
+ * strings with 2+ slashes (or backslashes) between alphanumerics, and
+ * plausible domain-plus-slash strings.
+ *
+ * Returns false for empty input and prose-y hyphen/slash/dot combinations
+ * like "and/or", "well-known", "state-of-the-art", "1.2.3-beta.4", "UI/UX".
+ */
+export function isPathLike(text: string): boolean {
+  if (!text) return false;
+  if (text.includes("://")) return true;
+  // starts with "/", "./", or "../"
+  if (/^\.{0,2}\//.test(text)) return true;
+  // Windows drive letter paths, either backslash or forward slash
+  if (/^[A-Za-z]:[\\/]/.test(text)) return true;
+  // 2+ forward slashes appearing between alphanumeric runs
+  const forwardMatches = text.match(/[A-Za-z0-9]\/[A-Za-z0-9]/g);
+  if (forwardMatches && forwardMatches.length >= 2) return true;
+  // 2+ backslashes appearing between alphanumeric runs
+  const backMatches = text.match(/[A-Za-z0-9]\\[A-Za-z0-9]/g);
+  if (backMatches && backMatches.length >= 2) return true;
+  // Plausible domain-ish: a "." between alphanumerics AND at least one slash
+  const hasDomainDot = /[A-Za-z0-9]\.[A-Za-z0-9]/.test(text);
+  const hasSlash = /[\\/]/.test(text);
+  if (hasDomainDot && hasSlash) return true;
+  return false;
+}
+
+// Delimiter set: / \ - _ . : ? # & =
+// Capture in split so the delimiter is preserved at odd indices.
+const DELIM_SPLIT = /([/\\\-_.:?#&=])/;
+
+const HTML_ESCAPE_MAP: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+function htmlEscape(s: string): string {
+  return s.replace(/[&<>"']/g, (ch) => HTML_ESCAPE_MAP[ch]!);
+}
+
+/**
+ * If `text` is path-like, return a Preact fragment with <wbr/> inserted
+ * after each delimiter (/, \, -, _, ., :, ?, #, &, =). Otherwise return
+ * the input string unchanged so callers can trust non-path prose passes
+ * through untouched.
+ */
+export function smartBreak(text: string): VNode | string {
+  if (!isPathLike(text)) return text;
+  const parts = text.split(DELIM_SPLIT);
+  const nodes: (string | VNode)[] = [];
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    if (part === "") continue;
+    nodes.push(part);
+    // Captured delimiter groups always land at odd indices.
+    if (i % 2 === 1) nodes.push(<wbr key={`wbr-${i}`} />);
+  }
+  return <>{nodes}</>;
+}
+
+/**
+ * Preact function component wrapper — pure, server-renderable.
+ * Stringifies children and defers to smartBreak.
+ */
+export function SmartBreak({ children }: { children?: unknown }): VNode {
+  return <>{smartBreak(String(children ?? ""))}</>;
+}
+
+/**
+ * HTML-string counterpart of smartBreak. Produces a safe HTML string
+ * with literal "<wbr>" tags injected after each delimiter in path-like
+ * input, and HTML-escaped text elsewhere. For non-path input, returns
+ * the HTML-escaped text unchanged (no wbr injection).
+ *
+ * Use this when the consumer cannot render Preact VNodes (e.g. building
+ * an HTML string for `set:html` / dangerouslySetInnerHTML).
+ */
+export function smartBreakToHtml(text: string): string {
+  if (!isPathLike(text)) return htmlEscape(text);
+  const parts = text.split(DELIM_SPLIT);
+  let out = "";
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    if (part === "") continue;
+    out += htmlEscape(part);
+    if (i % 2 === 1) out += "<wbr>";
+  }
+  return out;
+}

--- a/src/utils/smart-break.tsx
+++ b/src/utils/smart-break.tsx
@@ -80,6 +80,32 @@ export function SmartBreak({ children }: { children?: unknown }): VNode {
 }
 
 /**
+ * HTML-escape `text` and inject a literal "<wbr>" tag after every
+ * delimiter character. Unlike smartBreakToHtml, this does NOT check
+ * isPathLike — it unconditionally breaks on delimiters.
+ *
+ * Useful when a caller has already decided that a larger string is
+ * path-like and wants to apply the same wbr-injection rule to a
+ * substring (e.g. a segment produced by splitting on a search-query
+ * regex) without re-running the heuristic on fragments that are too
+ * short to be classified correctly on their own.
+ *
+ * Byte-identical to smartBreakToHtml for inputs where isPathLike is
+ * true, so the shared contract holds.
+ */
+export function escapeAndInjectWbr(text: string): string {
+  const parts = text.split(DELIM_SPLIT);
+  let out = "";
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    if (part === "") continue;
+    out += htmlEscape(part);
+    if (i % 2 === 1) out += "<wbr>";
+  }
+  return out;
+}
+
+/**
  * HTML-string counterpart of smartBreak. Produces a safe HTML string
  * with literal "<wbr>" tags injected after each delimiter in path-like
  * input, and HTML-escaped text elsewhere. For non-path input, returns
@@ -90,13 +116,5 @@ export function SmartBreak({ children }: { children?: unknown }): VNode {
  */
 export function smartBreakToHtml(text: string): string {
   if (!isPathLike(text)) return htmlEscape(text);
-  const parts = text.split(DELIM_SPLIT);
-  let out = "";
-  for (let i = 0; i < parts.length; i++) {
-    const part = parts[i];
-    if (part === "") continue;
-    out += htmlEscape(part);
-    if (i % 2 === 1) out += "<wbr>";
-  }
-  return out;
+  return escapeAndInjectWbr(text);
 }


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/370

---

## Summary

Implements the **Long Text Proper Break** epic (#370): introduces a shared `smart-break` utility that injects `<wbr>` tags after URL/path delimiters — but only when an `isPathLike` heuristic confirms the text looks like a URL or path — and applies it to every user-visible surface where such text appears. Retunes container CSS to prefer `overflow-wrap: break-word` wherever smart-break runs, keeping `anywhere` / `break-all` only on pre-formatted code and diff contexts.

Result: long strings like `packages/app-scaffold/presets/full/template/CLAUDE.md` break cleanly at `/` in narrow sidebars and tables — no more mid-word splits, no more layout overflow. Prose like `and/or`, `well-known`, `state-of-the-art` is left untouched by the gating heuristic.

Supersedes #369.

## Sub-issues shipped in this PR

| # | What |
|---|---|
| #371 | Add `smartBreak` / `SmartBreak` / `smartBreakToHtml` / `escapeAndInjectWbr` / `isPathLike` in `src/utils/smart-break.tsx` + unit tests (41 cases) |
| #372 | Sidebar tree labels (5 render sites in `sidebar-tree.tsx`) |
| #373 | MDX link text (`content-link.tsx`) |
| #374 | MDX inline code (`content-code.tsx`, new component-map entry) — Shiki block code intentionally excluded |
| #375 | Search results + breadcrumb via `smartBreakToHtml` (+ `escapeAndInjectWbr` for segment-level calls) |
| #376 | Dynamic surfaces: doc-history, AI chat modal, TOC, mobile-TOC, frontmatter-preview; inventory at `docs/smart-break-dynamic-inventory.md` |
| #377 | `global.css` retune: `.zd-content th/td` `overflow-wrap: anywhere` → `break-word`. Code blocks + diff viewer untouched |
| #378 | Knowledge-dump issue on zudolab/zudo-css-wisdom#41 seeding a future `long-url-and-path-wrapping.mdx` article |
| #379 | Reference docs: `src/content/docs/reference/smart-break.mdx` (EN + JA) |
| #381 | E2E spec `e2e/smoke-smart-break.spec.ts` — visual wrap + clipboard byte-parity + a11y tree + fenced-code regression guard |
| #382 | Template parity verified — zero drift, all mirrors already landed in their respective waves |

## Safety properties (verified)

- **XSS-safe:** `smartBreakToHtml` HTML-escapes all non-delimiter characters (`& < > " '`); the only raw HTML token emitted is the literal `<wbr>` tag. Every `set:html` / `dangerouslySetInnerHTML` call routes through it.
- **Block code isolation:** `ContentCode` guards with both `className` match on `language-*` AND `typeof children === 'string'`. Shiki-rendered fenced blocks pass through untouched.
- **Parity:** `smartBreak` (JSX) and `smartBreakToHtml` (HTML string) produce equivalent output for the same input; unit tests assert this over a corpus of path-like and prose inputs.
- **Template parity:** `pnpm check:template-drift` is clean; every source change has a mirror under `packages/create-zudo-doc/templates/`.

## Architecture note

The utility exports both a JSX variant (`SmartBreak`) and an HTML-string variant (`smartBreakToHtml` / `escapeAndInjectWbr`). The HTML variant is what makes the pattern portable to Astro `set:html`, `dangerouslySetInnerHTML`, and client-JS that assembles result HTML (the search dropdown). Search uses `escapeAndInjectWbr` per highlight segment after deciding path-likeness once on the full string — segment-level `isPathLike` would mis-classify short fragments.

## Test plan

- [ ] `pnpm vitest run src/utils/__tests__/smart-break.test.ts` — 41 cases pass
- [ ] `pnpm check` — typecheck clean
- [ ] `pnpm build` — succeeds
- [ ] `pnpm check:template-drift` — no drift
- [ ] CI runs full `pnpm b4push` (format, drift, tags, tokens, typecheck, build, links, E2E including `e2e/smoke-smart-break.spec.ts`)
- [ ] Manual spot: view a doc page with a long URL in a narrow viewport — confirm wraps at `/` and not mid-word

## Out of scope

- Rewriting the AI chat assistant-response markdown pipeline to use MDX component overrides (tracked in #376 inventory as deferred).
- Writing the actual `long-url-and-path-wrapping.mdx` article in zudo-css-wisdom — the brief landed as zudolab/zudo-css-wisdom#41 for a future `/css-wisdom -u` session.
