### PR TITLE
open-issues: close #426 (versions locale) and #427 (generator-tester skill drift)

### DIFF
--- a/.claude/skills/l-generator-cli-tester/SKILL.md
+++ b/.claude/skills/l-generator-cli-tester/SKILL.md
@@ -212,18 +212,18 @@ Check that expected files exist or don't exist in `__inbox/generator-test-<patte
 
 Use these tables to verify. Check each file with `test -e <path>`.
 
+> **Note on `theme-toggle.tsx`**: this component always ships on disk as part of the base template — whether it renders at runtime is gated by the `colorMode` setting. The expectation tables below therefore only assert PRESENT for the `light-dark` and `all-features` patterns and do not assert ABSENT elsewhere.
+
 **barebone** — minimal, everything stripped:
 
 | File | Expected |
 |------|----------|
 | `src/components/search.astro` | ABSENT |
 | `src/components/language-switcher.astro` | ABSENT |
-| `src/pages/ja/` | ABSENT |
+| `src/pages/[locale]/` | ABSENT |
 | `src/content/docs-ja/` | ABSENT |
 | `src/integrations/claude-resources/` | ABSENT |
-| `src/components/theme-toggle.tsx` | ABSENT |
-| `src/components/design-token-tweak/index.tsx` | ABSENT |
-| `src/components/color-tweak-export-modal.tsx` | ABSENT |
+| `src/components/design-token-tweak/` | ABSENT |
 | `src/components/doc-history.tsx` | ABSENT |
 | `src/components/ai-chat-modal.tsx` | ABSENT |
 | `src/integrations/doc-history.ts` | ABSENT |
@@ -241,8 +241,7 @@ Use these tables to verify. Check each file with `test -e <path>`.
 | `src/components/search.astro` | PRESENT |
 | `src/components/language-switcher.astro` | ABSENT |
 | `src/integrations/claude-resources/` | ABSENT |
-| `src/components/theme-toggle.tsx` | ABSENT |
-| `src/components/design-token-tweak/index.tsx` | ABSENT |
+| `src/components/design-token-tweak/` | ABSENT |
 
 **i18n:**
 
@@ -250,11 +249,10 @@ Use these tables to verify. Check each file with `test -e <path>`.
 |------|----------|
 | `src/components/search.astro` | ABSENT |
 | `src/components/language-switcher.astro` | PRESENT |
-| `src/pages/ja/` | PRESENT |
+| `src/pages/[locale]/` | PRESENT |
 | `src/content/docs-ja/` | PRESENT |
 | `src/integrations/claude-resources/` | ABSENT |
-| `src/components/theme-toggle.tsx` | ABSENT |
-| `src/components/design-token-tweak/index.tsx` | ABSENT |
+| `src/components/design-token-tweak/` | ABSENT |
 
 **sidebar-filter:**
 
@@ -263,8 +261,7 @@ Use these tables to verify. Check each file with `test -e <path>`.
 | `src/components/search.astro` | ABSENT |
 | `src/components/sidebar-tree.tsx` | PRESENT |
 | `src/components/language-switcher.astro` | ABSENT |
-| `src/components/theme-toggle.tsx` | ABSENT |
-| `src/components/design-token-tweak/index.tsx` | ABSENT |
+| `src/components/design-token-tweak/` | ABSENT |
 
 **claude-resources:**
 
@@ -273,21 +270,19 @@ Use these tables to verify. Check each file with `test -e <path>`.
 | `src/integrations/claude-resources/` | PRESENT |
 | `src/components/search.astro` | ABSENT |
 | `src/components/language-switcher.astro` | ABSENT |
-| `src/components/theme-toggle.tsx` | ABSENT |
-| `src/components/design-token-tweak/index.tsx` | ABSENT |
+| `src/components/design-token-tweak/` | ABSENT |
 
 **design-token-panel:**
 
 | File | Expected |
 |------|----------|
 | `src/components/design-token-tweak/index.tsx` | PRESENT |
-| `src/components/color-tweak-export-modal.tsx` | PRESENT |
+| `src/components/design-token-tweak/export-modal.tsx` | PRESENT |
 | `src/config/color-tweak-presets.ts` | PRESENT |
 | `src/utils/color-convert.ts` | PRESENT |
-| `src/utils/export-code.ts` | PRESENT |
+| `src/utils/design-token-serde.ts` | PRESENT |
 | `src/components/search.astro` | ABSENT |
 | `src/components/language-switcher.astro` | ABSENT |
-| `src/components/theme-toggle.tsx` | ABSENT |
 
 **light-dark:**
 
@@ -296,7 +291,7 @@ Use these tables to verify. Check each file with `test -e <path>`.
 | `src/components/theme-toggle.tsx` | PRESENT |
 | `src/components/search.astro` | ABSENT |
 | `src/components/language-switcher.astro` | ABSENT |
-| `src/components/design-token-tweak/index.tsx` | ABSENT |
+| `src/components/design-token-tweak/` | ABSENT |
 
 **lang-ja:**
 
@@ -304,7 +299,6 @@ Use these tables to verify. Check each file with `test -e <path>`.
 |------|----------|
 | `src/components/search.astro` | ABSENT |
 | `src/components/language-switcher.astro` | ABSENT |
-| `src/components/theme-toggle.tsx` | ABSENT |
 | `src/pages/docs/` | PRESENT |
 | `src/content/docs/` | PRESENT |
 
@@ -314,12 +308,12 @@ Use these tables to verify. Check each file with `test -e <path>`.
 |------|----------|
 | `src/components/search.astro` | PRESENT |
 | `src/components/language-switcher.astro` | PRESENT |
-| `src/pages/ja/` | PRESENT |
+| `src/pages/[locale]/` | PRESENT |
 | `src/content/docs-ja/` | PRESENT |
 | `src/integrations/claude-resources/` | PRESENT |
 | `src/components/theme-toggle.tsx` | PRESENT |
 | `src/components/design-token-tweak/index.tsx` | PRESENT |
-| `src/components/color-tweak-export-modal.tsx` | PRESENT |
+| `src/components/design-token-tweak/export-modal.tsx` | PRESENT |
 | `src/config/color-tweak-presets.ts` | PRESENT |
 
 ## Step 7: Verify Settings

--- a/packages/create-zudo-doc/templates/features/versioning/files/src/pages/docs/versions.astro
+++ b/packages/create-zudo-doc/templates/features/versioning/files/src/pages/docs/versions.astro
@@ -1,9 +1,9 @@
 ---
 import DocLayout from "@/layouts/doc-layout.astro";
 import VersionsPageContent from "@/components/versions-page-content.astro";
-import { t } from "@/config/i18n";
+import { defaultLocale, t } from "@/config/i18n";
 
-const lang = "en";
+const lang = defaultLocale;
 ---
 
 <DocLayout

--- a/src/pages/docs/versions.astro
+++ b/src/pages/docs/versions.astro
@@ -1,9 +1,9 @@
 ---
 import DocLayout from "@/layouts/doc-layout.astro";
 import VersionsPageContent from "@/components/versions-page-content.astro";
-import { t } from "@/config/i18n";
+import { defaultLocale, t } from "@/config/i18n";
 
-const lang = "en";
+const lang = defaultLocale;
 ---
 
 <DocLayout


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/428
    - https://github.com/zudolab/zudo-doc/issues/426
    - https://github.com/zudolab/zudo-doc/issues/427

---

## Summary

- Closes #426 — replace hardcoded `const lang = "en"` in `src/pages/docs/versions.astro` (and its `create-zudo-doc` versioning template mirror) with `defaultLocale` from `@/config/i18n`, extending the Sub #421 pattern to the versioning feature.
- Closes #427 — refresh three categories of stale expectations in `.claude/skills/l-generator-cli-tester/SKILL.md` so the skill accurately reflects the current scaffolder output.

## Changes

### versions-locale (closes #426)
- `src/pages/docs/versions.astro`: import `defaultLocale` alongside `t` from `@/config/i18n`, set `const lang = defaultLocale` instead of the string literal.
- `packages/create-zudo-doc/templates/features/versioning/files/src/pages/docs/versions.astro`: identical change so `check:template-drift` stays clean.
- No-op for the main project (`defaultLocale` is `"en"`), and enables the versions page to respect `settings.defaultLocale` for downstream generated projects.

### tester-skill-drift (closes #427)
Updates to `.claude/skills/l-generator-cli-tester/SKILL.md`:

1. **i18n pages directory**: replace `src/pages/ja/` with `src/pages/[locale]/` in the `barebone`, `i18n`, and `all-features` expectation tables, matching the i18n feature refactor landed in sub #422 of epic #419.
2. **theme-toggle.tsx runtime gating**: remove the `ABSENT` assertions from every non-`light-dark` pattern (the component always ships on disk and is gated at runtime by `colorMode`). Add a short clarifying note above the tables so future readers understand why the assertion only appears for `light-dark` and `all-features`.
3. **design-token-panel paths**: point the `design-token-panel` and `all-features` tables at the current files:
   - `src/components/color-tweak-export-modal.tsx` → `src/components/design-token-tweak/export-modal.tsx`
   - `src/utils/export-code.ts` → `src/utils/design-token-serde.ts`
   - Collapsed a few redundant `src/components/design-token-tweak/index.tsx ABSENT` rows to `src/components/design-token-tweak/ ABSENT` where the whole directory is absent.

## Test Plan

- `pnpm check:template-drift` — passes (base page and versioning template mirror stay byte-identical).
- `pnpm check` — Astro type-check passes.
- `/gcoc-review` on the merged diff — no findings (see run log in cclogs).
- CI on this PR covers: Template Drift Check, Build Site, Build Doc History, E2E Tests, Type Check.
- Generated URLs for the versions page remain byte-identical in the base project (defaultLocale is still `"en"`).