### PR TITLE
fix(tags): drop broken /docs/ href from tags breadcrumb (#430)

### DIFF
--- a/packages/create-zudo-doc/templates/base/src/pages/docs/tags/[tag].astro
+++ b/packages/create-zudo-doc/templates/base/src/pages/docs/tags/[tag].astro
@@ -38,7 +38,7 @@ const countText =
   <Breadcrumb
     slot="breadcrumb"
     items={[
-      { label: "Docs", href: withBase("/docs") },
+      { label: "Docs" },
       { label: t("doc.allTags"), href: withBase("/docs/tags") },
       { label: tag },
     ]}

--- a/packages/create-zudo-doc/templates/base/src/pages/docs/tags/index.astro
+++ b/packages/create-zudo-doc/templates/base/src/pages/docs/tags/index.astro
@@ -5,7 +5,6 @@ import Breadcrumb from "@/components/breadcrumb.astro";
 import { toRouteSlug } from "@/utils/slug";
 import { collectTags } from "@/utils/tags";
 import { defaultLocale, t } from "@/config/i18n";
-import { withBase } from "@/utils/base";
 import TagNav from "@/components/tag-nav.astro";
 
 const allDocs = await getCollection("docs");
@@ -23,10 +22,7 @@ const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));
 >
   <Breadcrumb
     slot="breadcrumb"
-    items={[
-      { label: "Docs", href: withBase("/docs") },
-      { label: t("doc.allTags") },
-    ]}
+    items={[{ label: "Docs" }, { label: t("doc.allTags") }]}
   />
   <h1 class="text-heading font-bold mb-vsp-lg">{t("doc.allTags")}</h1>
   {

--- a/packages/create-zudo-doc/templates/features/i18n/files/src/pages/[locale]/docs/tags/[tag].astro
+++ b/packages/create-zudo-doc/templates/features/i18n/files/src/pages/[locale]/docs/tags/[tag].astro
@@ -56,7 +56,7 @@ const countText =
   <Breadcrumb
     slot="breadcrumb"
     items={[
-      { label: "Docs", href: withBase(`/${lang}/docs`) },
+      { label: "Docs" },
       { label: t("doc.allTags", lang), href: withBase(`/${lang}/docs/tags`) },
       { label: tag },
     ]}

--- a/packages/create-zudo-doc/templates/features/i18n/files/src/pages/[locale]/docs/tags/index.astro
+++ b/packages/create-zudo-doc/templates/features/i18n/files/src/pages/[locale]/docs/tags/index.astro
@@ -6,7 +6,6 @@ import { collectTags } from "@/utils/tags";
 import { settings } from "@/config/settings";
 import { t, type Locale } from "@/config/i18n";
 import { loadLocaleDocs } from "@/utils/locale-docs";
-import { withBase } from "@/utils/base";
 import TagNav from "@/components/tag-nav.astro";
 import type { DocsEntry } from "@/types/docs-entry";
 
@@ -37,10 +36,7 @@ const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));
 >
   <Breadcrumb
     slot="breadcrumb"
-    items={[
-      { label: "Docs", href: withBase(`/${lang}/docs`) },
-      { label: t("doc.allTags", lang) },
-    ]}
+    items={[{ label: "Docs" }, { label: t("doc.allTags", lang) }]}
   />
   <h1 class="text-heading font-bold mb-vsp-lg">{t("doc.allTags", lang)}</h1>
   {

--- a/src/pages/[locale]/docs/tags/[tag].astro
+++ b/src/pages/[locale]/docs/tags/[tag].astro
@@ -56,7 +56,7 @@ const countText =
   <Breadcrumb
     slot="breadcrumb"
     items={[
-      { label: "Docs", href: withBase(`/${lang}/docs`) },
+      { label: "Docs" },
       { label: t("doc.allTags", lang), href: withBase(`/${lang}/docs/tags`) },
       { label: tag },
     ]}

--- a/src/pages/[locale]/docs/tags/index.astro
+++ b/src/pages/[locale]/docs/tags/index.astro
@@ -6,7 +6,6 @@ import { collectTags } from "@/utils/tags";
 import { settings } from "@/config/settings";
 import { t, type Locale } from "@/config/i18n";
 import { loadLocaleDocs } from "@/utils/locale-docs";
-import { withBase } from "@/utils/base";
 import TagNav from "@/components/tag-nav.astro";
 import type { DocsEntry } from "@/types/docs-entry";
 
@@ -37,10 +36,7 @@ const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));
 >
   <Breadcrumb
     slot="breadcrumb"
-    items={[
-      { label: "Docs", href: withBase(`/${lang}/docs`) },
-      { label: t("doc.allTags", lang) },
-    ]}
+    items={[{ label: "Docs" }, { label: t("doc.allTags", lang) }]}
   />
   <h1 class="text-heading font-bold mb-vsp-lg">{t("doc.allTags", lang)}</h1>
   {

--- a/src/pages/docs/tags/[tag].astro
+++ b/src/pages/docs/tags/[tag].astro
@@ -38,7 +38,7 @@ const countText =
   <Breadcrumb
     slot="breadcrumb"
     items={[
-      { label: "Docs", href: withBase("/docs") },
+      { label: "Docs" },
       { label: t("doc.allTags"), href: withBase("/docs/tags") },
       { label: tag },
     ]}

--- a/src/pages/docs/tags/index.astro
+++ b/src/pages/docs/tags/index.astro
@@ -5,7 +5,6 @@ import Breadcrumb from "@/components/breadcrumb.astro";
 import { toRouteSlug } from "@/utils/slug";
 import { collectTags } from "@/utils/tags";
 import { defaultLocale, t } from "@/config/i18n";
-import { withBase } from "@/utils/base";
 import TagNav from "@/components/tag-nav.astro";
 
 const allDocs = await getCollection("docs");
@@ -23,10 +22,7 @@ const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));
 >
   <Breadcrumb
     slot="breadcrumb"
-    items={[
-      { label: "Docs", href: withBase("/docs") },
-      { label: t("doc.allTags") },
-    ]}
+    items={[{ label: "Docs" }, { label: t("doc.allTags") }]}
   />
   <h1 class="text-heading font-bold mb-vsp-lg">{t("doc.allTags")}</h1>
   {


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/430

---

## Summary

- The `docs/tags/` index and `docs/tags/[tag]` detail pages rendered a breadcrumb item `{ label: "Docs", href: "/docs" }`, but no `docs/index.astro` landing page ships in this project or in the scaffold templates.
- Under `trailingSlash: true`, strict link check flagged `/pj/<base>/docs/` as broken on every tags page (and its Japanese mirror when i18n is enabled).
- Drop the `href` from the "Docs" breadcrumb item so it renders as a plain text label, matching the existing "no-link text-only item" convention used by the leaf breadcrumb item on the same line. Implements fix option (b) from #430 — the minimal surgical fix.

## Changes

Main repo (fixes the bug on the live docs site):
- `src/pages/docs/tags/index.astro` — drop href, remove now-unused `withBase` import.
- `src/pages/docs/tags/[tag].astro` — drop href (keep `withBase` for the remaining `/docs/tags` href on the next breadcrumb item).
- `src/pages/[locale]/docs/tags/index.astro` — same as default-locale index.
- `src/pages/[locale]/docs/tags/[tag].astro` — same as default-locale [tag].

Scaffold templates (prevents the bug from shipping to downstream projects generated by `create-zudo-doc`):
- `packages/create-zudo-doc/templates/base/src/pages/docs/tags/index.astro`
- `packages/create-zudo-doc/templates/base/src/pages/docs/tags/[tag].astro`
- `packages/create-zudo-doc/templates/features/i18n/files/src/pages/[locale]/docs/tags/index.astro`
- `packages/create-zudo-doc/templates/features/i18n/files/src/pages/[locale]/docs/tags/[tag].astro`

## Test Plan

- [x] `pnpm check` passes
- [x] `SKIP_DOC_HISTORY=1 pnpm build` passes
- [x] `pnpm check:links --strict` reports **0** broken links rooted at `dist/client/docs/tags/**` (other pre-existing broken links on `main` are unrelated to #430)
- [x] Template Drift Check (CI) — green; main-repo pages and scaffold template mirrors stay in sync
- [x] CI green (Build Site, Build Doc History, Type Check, Template Drift Check, E2E Tests, Preview Deploy)

Closes #430