### PR TITLE
fix(home-hero): port responsive layout to [locale]/index.astro and i18n template

### DIFF
--- a/packages/create-zudo-doc/templates/features/i18n/files/src/pages/[locale]/index.astro
+++ b/packages/create-zudo-doc/templates/features/i18n/files/src/pages/[locale]/index.astro
@@ -41,7 +41,9 @@ const tagCount = collectTags(
 <DocLayout title={settings.siteName} lang={lang} hideSidebar hideToc>
   <!-- Hero: logo left, title+desc+links right, block centered -->
   <div class="flex justify-center mb-vsp-xl">
-    <div class="flex items-center gap-hsp-xl">
+    <div
+      class="flex flex-col items-center text-center gap-hsp-md lg:flex-row lg:text-left lg:gap-hsp-xl"
+    >
       <div
         class="w-[80%] aspect-square lg:h-[10.5rem] lg:w-[10.5rem] bg-fg shrink-0"
         style={`-webkit-mask: url(${logoUrl}) center/contain no-repeat; mask: url(${logoUrl}) center/contain no-repeat;`}
@@ -53,7 +55,9 @@ const tagCount = collectTags(
         <p class="text-muted text-small mb-vsp-sm">
           {settings.siteDescription}
         </p>
-        <div class="flex items-center gap-hsp-md text-small">
+        <div
+          class="flex items-center justify-center lg:justify-start gap-hsp-md text-small"
+        >
           {
             overview && (
               <>
@@ -66,9 +70,18 @@ const tagCount = collectTags(
           }
           <a
             href="https://github.com/zudolab/zudo-doc"
-            class="text-fg underline hover:text-accent"
+            class="inline-flex items-center gap-[0.3em] text-fg underline hover:text-accent"
             target="_blank"
-            rel="noopener noreferrer">GitHub</a
+            rel="noopener noreferrer"
+            ><svg
+              viewBox="0 0 16 16"
+              aria-hidden="true"
+              class="w-[1em] h-[1em] shrink-0"
+              ><path
+                fill="currentColor"
+                d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"
+              ></path></svg
+            >GitHub</a
           >
           <span class="text-muted">/</span>
           <a

--- a/src/pages/[locale]/index.astro
+++ b/src/pages/[locale]/index.astro
@@ -41,7 +41,9 @@ const tagCount = collectTags(
 <DocLayout title={settings.siteName} lang={lang} hideSidebar hideToc>
   <!-- Hero: logo left, title+desc+links right, block centered -->
   <div class="flex justify-center mb-vsp-xl">
-    <div class="flex items-center gap-hsp-xl">
+    <div
+      class="flex flex-col items-center text-center gap-hsp-md lg:flex-row lg:text-left lg:gap-hsp-xl"
+    >
       <div
         class="w-[80%] aspect-square lg:h-[10.5rem] lg:w-[10.5rem] bg-fg shrink-0"
         style={`-webkit-mask: url(${logoUrl}) center/contain no-repeat; mask: url(${logoUrl}) center/contain no-repeat;`}
@@ -53,7 +55,9 @@ const tagCount = collectTags(
         <p class="text-muted text-small mb-vsp-sm">
           {settings.siteDescription}
         </p>
-        <div class="flex items-center gap-hsp-md text-small">
+        <div
+          class="flex items-center justify-center lg:justify-start gap-hsp-md text-small"
+        >
           {
             overview && (
               <>
@@ -66,9 +70,18 @@ const tagCount = collectTags(
           }
           <a
             href="https://github.com/zudolab/zudo-doc"
-            class="text-fg underline hover:text-accent"
+            class="inline-flex items-center gap-[0.3em] text-fg underline hover:text-accent"
             target="_blank"
-            rel="noopener noreferrer">GitHub</a
+            rel="noopener noreferrer"
+            ><svg
+              viewBox="0 0 16 16"
+              aria-hidden="true"
+              class="w-[1em] h-[1em] shrink-0"
+              ><path
+                fill="currentColor"
+                d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"
+              ></path></svg
+            >GitHub</a
           >
           <span class="text-muted">/</span>
           <a


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/433

---

## Summary
- Port the responsive `flex-col` → `lg:flex-row` hero layout from `src/pages/index.astro` to `src/pages/[locale]/index.astro` so non-default locales (e.g. `/ja/`) stack the logo above the title on narrow viewports instead of overflowing.
- Center the link row on mobile and switch to left-align at `lg` (`justify-center lg:justify-start`).
- Add the inline GitHub icon next to the "GitHub" link to match the canonical root variant.
- Mirror the same fix to the `create-zudo-doc` i18n template counterpart so generated projects ship the responsive layout.

## Changes
- `src/pages/[locale]/index.astro` — inner flex wrapper, link row alignment, GitHub icon+text variant.
- `packages/create-zudo-doc/templates/features/i18n/files/src/pages/[locale]/index.astro` — same diff applied to the generator template (avoids template drift).

## Test Plan
- `pnpm check:template-drift` — passes (no drift).
- `pnpm check` — typecheck passes.
- `pnpm dev` and visit `/pj/zudo-doc/ja/` at 400px viewport: hero stacks (logo above title), no horizontal overflow.
- Same page at 1200px viewport: hero is side-by-side, link row left-aligned, GitHub icon visible next to label.
- Compare with the default locale `/`: hero markup is now identical aside from i18n glue.

Closes #433