### PR TITLE
preset-generator: sync UI with CLI, add headerRightItems config, document new options

### DIFF
--- a/packages/create-zudo-doc/src/__tests__/preset.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/preset.test.ts
@@ -119,6 +119,14 @@ describe("validatePreset — headerRightItems (sub #440)", () => {
     ).toMatch(/component must be a string/);
   });
 
+  it("rejects items where trigger is not a string", () => {
+    expect(
+      validatePreset({
+        headerRightItems: [{ type: "trigger", trigger: 42 }],
+      }),
+    ).toMatch(/trigger must be a string/);
+  });
+
   it("rejects non-object items", () => {
     expect(
       validatePreset({ headerRightItems: ["theme-toggle"] }),

--- a/packages/create-zudo-doc/src/__tests__/preset.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/preset.test.ts
@@ -33,3 +33,116 @@ describe("validatePreset — cjkFriendly", () => {
     );
   });
 });
+
+describe("validatePreset — headerRightItems (sub #440)", () => {
+  it("accepts a valid mix of component and trigger items", () => {
+    expect(
+      validatePreset({
+        headerRightItems: [
+          { type: "component", component: "theme-toggle" },
+          { type: "trigger", trigger: "design-token-panel" },
+          { type: "component", component: "github-link" },
+          { type: "trigger", trigger: "ai-chat" },
+          { type: "component", component: "search" },
+          { type: "component", component: "version-switcher" },
+          { type: "component", component: "language-switcher" },
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  it("accepts an empty array (user wants no items)", () => {
+    expect(validatePreset({ headerRightItems: [] })).toBeNull();
+  });
+
+  it("accepts the field being omitted entirely", () => {
+    expect(validatePreset({})).toBeNull();
+  });
+
+  it("rejects non-array values", () => {
+    expect(validatePreset({ headerRightItems: "nope" })).toMatch(
+      /headerRightItems.*must be an array/,
+    );
+  });
+
+  it("rejects an unknown component name", () => {
+    expect(
+      validatePreset({
+        headerRightItems: [{ type: "component", component: "not-a-real-thing" }],
+      }),
+    ).toMatch(/unknown component "not-a-real-thing"/);
+  });
+
+  it("rejects an unknown trigger name", () => {
+    expect(
+      validatePreset({
+        headerRightItems: [{ type: "trigger", trigger: "imaginary-trigger" }],
+      }),
+    ).toMatch(/unknown trigger "imaginary-trigger"/);
+  });
+
+  it("rejects link items in v1 of preset support", () => {
+    expect(
+      validatePreset({
+        headerRightItems: [
+          {
+            type: "link",
+            href: "https://example.com",
+            label: "Custom",
+          },
+        ],
+      }),
+    ).toMatch(/type "link" is not supported in presets/);
+  });
+
+  it("rejects html items in v1 of preset support", () => {
+    expect(
+      validatePreset({
+        headerRightItems: [{ type: "html", html: "<span>x</span>" }],
+      }),
+    ).toMatch(/type "html" is not supported in presets/);
+  });
+
+  it("rejects items missing a discriminating type field", () => {
+    expect(
+      validatePreset({
+        headerRightItems: [{ component: "theme-toggle" }],
+      }),
+    ).toMatch(/must have type "component" or "trigger"/);
+  });
+
+  it("rejects items where component is not a string", () => {
+    expect(
+      validatePreset({
+        headerRightItems: [{ type: "component", component: 42 }],
+      }),
+    ).toMatch(/component must be a string/);
+  });
+
+  it("rejects non-object items", () => {
+    expect(
+      validatePreset({ headerRightItems: ["theme-toggle"] }),
+    ).toMatch(/must be an object/);
+  });
+});
+
+describe("presetToChoices — headerRightItems (sub #440)", () => {
+  it("forwards a valid headerRightItems array", () => {
+    const items = [
+      { type: "component" as const, component: "theme-toggle" as const },
+      { type: "trigger" as const, trigger: "design-token-panel" as const },
+    ];
+    const choices = presetToChoices({ headerRightItems: items });
+    expect(choices.headerRightItems).toEqual(items);
+  });
+
+  it("leaves headerRightItems undefined when omitted", () => {
+    const choices = presetToChoices({});
+    expect(choices.headerRightItems).toBeUndefined();
+  });
+
+  it("forwards an empty array as-is", () => {
+    const choices = presetToChoices({ headerRightItems: [] });
+    expect(choices.headerRightItems).toEqual([]);
+  });
+});

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -604,6 +604,36 @@ describe("scaffold — headerRightItems preset override (sub #440)", () => {
     expect(content).not.toContain('trigger: "ai-chat"');
   });
 
+  it("honors an explicit empty headerRightItems array (no items)", async () => {
+    // Empty array means "user wants no header-right items at all" — must not
+    // silently fall back to the hardcoded default. validatePreset accepts [],
+    // and presetToChoices forwards it; settings-gen must honor it too.
+    const choices: UserChoices = {
+      projectName: "test-hri-empty",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search", "designTokenPanel"],
+      packageManager: "pnpm",
+      headerRightItems: [],
+    };
+    await scaffold(choices);
+    const content = await fs.readFile(
+      projectPath("test-hri-empty", "src/config/settings.ts"),
+      "utf-8",
+    );
+    const match = content.match(
+      /headerRightItems:\s*\[([\s\S]*?)\]\s*as\s+HeaderRightItem\[\],/,
+    );
+    expect(match).toBeTruthy();
+    // Block should be empty (whitespace only) — no fallback entries leaked in.
+    expect(match![1].trim()).toBe("");
+    // Specifically, the legacy fallback's design-token-panel trigger must not
+    // appear even though designTokenPanel is in the features list.
+    expect(content).not.toContain('trigger: "design-token-panel"');
+    expect(content).not.toContain('component: "github-link"');
+  });
+
   it("emits ai-chat verbatim when explicitly listed in the preset", async () => {
     // The runtime filter (filterHeaderRightItems) hides ai-chat when
     // aiAssistant is false in the scaffold, but emission must still preserve

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -541,6 +541,95 @@ describe("scaffold — docHistory feature", () => {
   });
 });
 
+describe("scaffold — headerRightItems preset override (sub #440)", () => {
+  it("emits user-supplied headerRightItems verbatim and in chosen order", async () => {
+    const choices: UserChoices = {
+      projectName: "test-hri-override",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search"],
+      packageManager: "pnpm",
+      headerRightItems: [
+        { type: "component", component: "theme-toggle" },
+        { type: "trigger", trigger: "design-token-panel" },
+        { type: "component", component: "github-link" },
+        { type: "trigger", trigger: "ai-chat" },
+        { type: "component", component: "search" },
+      ],
+    };
+    await scaffold(choices);
+    const content = await fs.readFile(
+      projectPath("test-hri-override", "src/config/settings.ts"),
+      "utf-8",
+    );
+    // Extract the headerRightItems block to assert exact order.
+    const blockMatch = content.match(
+      /headerRightItems:\s*\[([\s\S]*?)\]\s*as\s+HeaderRightItem\[\],/,
+    );
+    expect(blockMatch).not.toBeNull();
+    const block = blockMatch![1]!;
+    const lines = block
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean);
+    expect(lines).toEqual([
+      `{ type: "component", component: "theme-toggle" },`,
+      `{ type: "trigger", trigger: "design-token-panel" },`,
+      `{ type: "component", component: "github-link" },`,
+      `{ type: "trigger", trigger: "ai-chat" },`,
+      `{ type: "component", component: "search" },`,
+    ]);
+  });
+
+  it("falls back to hardcoded default when headerRightItems is omitted", async () => {
+    const choices: UserChoices = {
+      projectName: "test-hri-fallback",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search", "designTokenPanel"],
+      packageManager: "pnpm",
+    };
+    await scaffold(choices);
+    const content = await fs.readFile(
+      projectPath("test-hri-fallback", "src/config/settings.ts"),
+      "utf-8",
+    );
+    // The legacy hardcoded fallback gates designTokenPanel on the feature.
+    expect(content).toContain('trigger: "design-token-panel"');
+    expect(content).toContain('component: "github-link"');
+    expect(content).toContain('component: "theme-toggle"');
+    // ai-chat is not in the legacy fallback path.
+    expect(content).not.toContain('trigger: "ai-chat"');
+  });
+
+  it("emits ai-chat verbatim when explicitly listed in the preset", async () => {
+    // The runtime filter (filterHeaderRightItems) hides ai-chat when
+    // aiAssistant is false in the scaffold, but emission must still preserve
+    // the entry so the preset round-trips and so users can flip aiAssistant
+    // later without re-editing headerRightItems.
+    const choices: UserChoices = {
+      projectName: "test-hri-aichat",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search"],
+      packageManager: "pnpm",
+      headerRightItems: [
+        { type: "trigger", trigger: "ai-chat" },
+        { type: "component", component: "theme-toggle" },
+      ],
+    };
+    await scaffold(choices);
+    const content = await fs.readFile(
+      projectPath("test-hri-aichat", "src/config/settings.ts"),
+      "utf-8",
+    );
+    expect(content).toContain('trigger: "ai-chat"');
+  });
+});
+
 describe("scaffold — llmsTxt feature", () => {
   it("settings have llmsTxt: true when enabled", async () => {
     const choices: UserChoices = {

--- a/packages/create-zudo-doc/src/preset.ts
+++ b/packages/create-zudo-doc/src/preset.ts
@@ -2,6 +2,51 @@ import fs from "fs";
 import { FEATURES, SINGLE_SCHEMES, SUPPORTED_LANGS } from "./constants.js";
 import type { PartialChoices } from "./prompts.js";
 
+/**
+ * Header-right item shapes accepted in v1 of preset support. Mirrors
+ * `HeaderRightComponentItem` and `HeaderRightTriggerItem` from
+ * `src/config/settings-types.ts`. The wider `link`/`html` variants are
+ * intentionally rejected for now — they need free-text fields that pollute
+ * the JSON preset schema and the generator UI.
+ */
+export type PresetHeaderRightComponentName =
+  | "theme-toggle"
+  | "language-switcher"
+  | "version-switcher"
+  | "github-link"
+  | "search";
+
+export type PresetHeaderRightTriggerName =
+  | "design-token-panel"
+  | "ai-chat";
+
+export interface PresetHeaderRightComponentItem {
+  type: "component";
+  component: PresetHeaderRightComponentName;
+}
+
+export interface PresetHeaderRightTriggerItem {
+  type: "trigger";
+  trigger: PresetHeaderRightTriggerName;
+}
+
+export type PresetHeaderRightItem =
+  | PresetHeaderRightComponentItem
+  | PresetHeaderRightTriggerItem;
+
+const VALID_HEADER_RIGHT_COMPONENTS = new Set<PresetHeaderRightComponentName>([
+  "theme-toggle",
+  "language-switcher",
+  "version-switcher",
+  "github-link",
+  "search",
+]);
+
+const VALID_HEADER_RIGHT_TRIGGERS = new Set<PresetHeaderRightTriggerName>([
+  "design-token-panel",
+  "ai-chat",
+]);
+
 export interface PresetJson {
   projectName?: string;
   defaultLang?: string;
@@ -15,6 +60,7 @@ export interface PresetJson {
   githubUrl?: string;
   cjkFriendly?: boolean;
   packageManager?: "pnpm" | "npm" | "yarn" | "bun";
+  headerRightItems?: PresetHeaderRightItem[];
 }
 
 export function loadPreset(pathOrStdin: string): PartialChoices {
@@ -69,6 +115,48 @@ export function validatePreset(json: unknown): string | null {
   if (p.cjkFriendly !== undefined && typeof p.cjkFriendly !== "boolean") {
     return `"cjkFriendly" must be a boolean in preset`;
   }
+  if (p.headerRightItems !== undefined) {
+    if (!Array.isArray(p.headerRightItems)) {
+      return `"headerRightItems" must be an array in preset`;
+    }
+    for (let i = 0; i < p.headerRightItems.length; i++) {
+      const item = p.headerRightItems[i] as unknown;
+      if (item === null || typeof item !== "object" || Array.isArray(item)) {
+        return `headerRightItems[${i}] must be an object`;
+      }
+      const t = (item as { type?: unknown }).type;
+      if (t === "link" || t === "html") {
+        return `headerRightItems[${i}] type "${t}" is not supported in presets (v1) — edit settings.ts after scaffold`;
+      }
+      if (t === "component") {
+        const component = (item as { component?: unknown }).component;
+        if (typeof component !== "string") {
+          return `headerRightItems[${i}].component must be a string`;
+        }
+        if (!VALID_HEADER_RIGHT_COMPONENTS.has(
+          component as PresetHeaderRightComponentName,
+        )) {
+          return `headerRightItems[${i}] unknown component "${component}". Allowed: ${[
+            ...VALID_HEADER_RIGHT_COMPONENTS,
+          ].join(", ")}`;
+        }
+      } else if (t === "trigger") {
+        const trigger = (item as { trigger?: unknown }).trigger;
+        if (typeof trigger !== "string") {
+          return `headerRightItems[${i}].trigger must be a string`;
+        }
+        if (!VALID_HEADER_RIGHT_TRIGGERS.has(
+          trigger as PresetHeaderRightTriggerName,
+        )) {
+          return `headerRightItems[${i}] unknown trigger "${trigger}". Allowed: ${[
+            ...VALID_HEADER_RIGHT_TRIGGERS,
+          ].join(", ")}`;
+        }
+      } else {
+        return `headerRightItems[${i}] must have type "component" or "trigger" (got ${JSON.stringify(t)})`;
+      }
+    }
+  }
   // Cross-field validation
   if (p.colorSchemeMode === "single" && (p.lightScheme || p.darkScheme)) {
     return `lightScheme/darkScheme are only valid with colorSchemeMode "light-dark"`;
@@ -97,6 +185,9 @@ export function presetToChoices(json: PresetJson): PartialChoices {
   if (json.packageManager) choices.packageManager = json.packageManager;
   if (json.githubUrl !== undefined) choices.githubUrl = json.githubUrl;
   if (json.cjkFriendly !== undefined) choices.cjkFriendly = json.cjkFriendly;
+  if (json.headerRightItems !== undefined) {
+    choices.headerRightItems = json.headerRightItems;
+  }
 
   if (json.features) {
     // Warn about unrecognized feature names

--- a/packages/create-zudo-doc/src/prompts.ts
+++ b/packages/create-zudo-doc/src/prompts.ts
@@ -1,5 +1,6 @@
 import * as p from "@clack/prompts";
 import { LIGHT_DARK_PAIRINGS, SINGLE_SCHEMES, FEATURES, SUPPORTED_LANGS } from "./constants.js";
+import type { PresetHeaderRightItem } from "./preset.js";
 
 export interface UserChoices {
   projectName: string;
@@ -22,6 +23,11 @@ export interface UserChoices {
   cjkFriendly?: boolean;
   // Package manager
   packageManager: "pnpm" | "npm" | "yarn" | "bun";
+  // Header-right items override. Preset-only — no interactive prompt because
+  // the array-of-discriminated-union shape does not fit `--flag` style prompts
+  // or CLI args. When omitted, settings-gen.ts emits the existing hardcoded
+  // fallback.
+  headerRightItems?: PresetHeaderRightItem[];
 }
 
 export interface PartialChoices {
@@ -37,6 +43,7 @@ export interface PartialChoices {
   githubUrl?: string;
   cjkFriendly?: boolean;
   packageManager?: "pnpm" | "npm" | "yarn" | "bun";
+  headerRightItems?: PresetHeaderRightItem[];
 }
 
 export async function runPrompts(
@@ -280,5 +287,6 @@ export async function runPrompts(
     githubUrl,
     cjkFriendly: prefilled.cjkFriendly,
     packageManager,
+    headerRightItems: prefilled.headerRightItems,
   };
 }

--- a/packages/create-zudo-doc/src/settings-gen.ts
+++ b/packages/create-zudo-doc/src/settings-gen.ts
@@ -233,16 +233,35 @@ export function generateSettingsFile(choices: UserChoices): string {
   }
   lines.push(`  ] as HeaderNavItem[],`);
   lines.push(`  headerRightItems: [`);
-  if (choices.features.includes("designTokenPanel")) {
-    lines.push(`    { type: "trigger", trigger: "design-token-panel" },`);
-  }
-  if (choices.features.includes("versioning")) {
-    lines.push(`    { type: "component", component: "version-switcher" },`);
-  }
-  lines.push(`    { type: "component", component: "github-link" },`);
-  lines.push(`    { type: "component", component: "theme-toggle" },`);
-  if (choices.features.includes("i18n")) {
-    lines.push(`    { type: "component", component: "language-switcher" },`);
+  if (choices.headerRightItems && choices.headerRightItems.length > 0) {
+    // User-supplied override: emit each entry verbatim, in the chosen order.
+    // filterHeaderRightItems (src/utils/header-right-items.ts) handles runtime
+    // hiding of items whose feature is disabled — no need to gate emission
+    // here on choices.features.
+    for (const item of choices.headerRightItems) {
+      if (item.type === "trigger") {
+        lines.push(
+          `    { type: "trigger", trigger: ${JSON.stringify(item.trigger)} },`,
+        );
+      } else {
+        lines.push(
+          `    { type: "component", component: ${JSON.stringify(item.component)} },`,
+        );
+      }
+    }
+  } else {
+    // Default fallback: hardcoded order, gated on selected features.
+    if (choices.features.includes("designTokenPanel")) {
+      lines.push(`    { type: "trigger", trigger: "design-token-panel" },`);
+    }
+    if (choices.features.includes("versioning")) {
+      lines.push(`    { type: "component", component: "version-switcher" },`);
+    }
+    lines.push(`    { type: "component", component: "github-link" },`);
+    lines.push(`    { type: "component", component: "theme-toggle" },`);
+    if (choices.features.includes("i18n")) {
+      lines.push(`    { type: "component", component: "language-switcher" },`);
+    }
   }
   lines.push(`  ] as HeaderRightItem[],`);
   lines.push(`};`);

--- a/packages/create-zudo-doc/src/settings-gen.ts
+++ b/packages/create-zudo-doc/src/settings-gen.ts
@@ -233,8 +233,9 @@ export function generateSettingsFile(choices: UserChoices): string {
   }
   lines.push(`  ] as HeaderNavItem[],`);
   lines.push(`  headerRightItems: [`);
-  if (choices.headerRightItems && choices.headerRightItems.length > 0) {
-    // User-supplied override: emit each entry verbatim, in the chosen order.
+  if (choices.headerRightItems !== undefined) {
+    // User-supplied override (including empty array): emit each entry verbatim,
+    // in the chosen order. An empty array means "no header-right items" — honor it.
     // filterHeaderRightItems (src/utils/header-right-items.ts) handles runtime
     // hiding of items whose feature is disabled — no need to gate emission
     // here on choices.features.

--- a/src/__tests__/preset-generator-logic.test.ts
+++ b/src/__tests__/preset-generator-logic.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { FEATURES, buildJson, buildCliCommand, type FormState } from "../lib/preset-generator-logic";
+import {
+  FEATURES,
+  buildJson,
+  buildCliCommand,
+  DEFAULT_HEADER_RIGHT_ITEMS,
+  type FormState,
+  type HeaderRightItemSpec,
+} from "../lib/preset-generator-logic";
 
 function makeState(overrides: Partial<FormState> = {}): FormState {
   return {
@@ -12,7 +19,9 @@ function makeState(overrides: Partial<FormState> = {}): FormState {
     defaultMode: "dark",
     respectPrefersColorScheme: true,
     features: [],
+    cjkFriendly: false,
     packageManager: "pnpm",
+    headerRightItems: [...DEFAULT_HEADER_RIGHT_ITEMS],
     ...overrides,
   };
 }
@@ -142,13 +151,94 @@ describe("buildCliCommand", () => {
     expect(cmd).toContain('"my docs"');
   });
 
-  it("command ends with --yes", () => {
+  it("command line ends with --yes (before the trailing comment line)", () => {
     const cmd = buildCliCommand(makeState());
-    expect(cmd).toMatch(/--yes$/);
+    // The command itself ends with --yes; a documentation comment line about
+    // headerRightItems may follow on a separate shell-comment line.
+    const firstLine = cmd.split("\n")[0]!;
+    expect(firstLine).toMatch(/--yes$/);
+  });
+
+  it("includes a trailing # comment about headerRightItems being preset-only", () => {
+    const cmd = buildCliCommand(makeState());
+    expect(cmd).toContain(
+      "# headerRightItems: use a JSON preset (--preset) — array configs are not expressible as CLI flags",
+    );
   });
 
   it("includes --pm flag", () => {
     const cmd = buildCliCommand(makeState({ packageManager: "npm" }));
     expect(cmd).toContain("--pm npm");
+  });
+});
+
+describe("headerRightItems — DEFAULT_HEADER_RIGHT_ITEMS", () => {
+  it("matches the canonical default order from src/config/settings.ts", () => {
+    // This is the live default from src/config/settings.ts and the user-facing
+    // guide at src/content/docs/guides/header-right-items.mdx. Keep both sides
+    // in sync — preset-generator drift here would surprise scaffold users.
+    expect(DEFAULT_HEADER_RIGHT_ITEMS).toEqual([
+      { kind: "component", name: "version-switcher" },
+      { kind: "trigger", name: "design-token-panel" },
+      { kind: "trigger", name: "ai-chat" },
+      { kind: "component", name: "github-link" },
+      { kind: "component", name: "theme-toggle" },
+      { kind: "component", name: "search" },
+      { kind: "component", name: "language-switcher" },
+    ]);
+  });
+});
+
+describe("buildJson — headerRightItems mapping", () => {
+  it("maps {kind: 'component'} → {type: 'component', component: <name>}", () => {
+    const items: HeaderRightItemSpec[] = [
+      { kind: "component", name: "github-link" },
+    ];
+    const json = buildJson(makeState({ headerRightItems: items }));
+    expect(json.headerRightItems).toEqual([
+      { type: "component", component: "github-link" },
+    ]);
+  });
+
+  it("maps {kind: 'trigger'} → {type: 'trigger', trigger: <name>}", () => {
+    const items: HeaderRightItemSpec[] = [
+      { kind: "trigger", name: "ai-chat" },
+    ];
+    const json = buildJson(makeState({ headerRightItems: items }));
+    expect(json.headerRightItems).toEqual([
+      { type: "trigger", trigger: "ai-chat" },
+    ]);
+  });
+
+  it("emits the canonical default headerRightItems for the default state", () => {
+    const json = buildJson(makeState());
+    expect(json.headerRightItems).toEqual([
+      { type: "component", component: "version-switcher" },
+      { type: "trigger", trigger: "design-token-panel" },
+      { type: "trigger", trigger: "ai-chat" },
+      { type: "component", component: "github-link" },
+      { type: "component", component: "theme-toggle" },
+      { type: "component", component: "search" },
+      { type: "component", component: "language-switcher" },
+    ]);
+  });
+
+  it("preserves reordered items in the JSON output", () => {
+    const reordered: HeaderRightItemSpec[] = [
+      { kind: "component", name: "theme-toggle" },
+      { kind: "component", name: "github-link" },
+      { kind: "trigger", name: "design-token-panel" },
+    ];
+    const json = buildJson(makeState({ headerRightItems: reordered }));
+    expect(json.headerRightItems).toEqual([
+      { type: "component", component: "theme-toggle" },
+      { type: "component", component: "github-link" },
+      { type: "trigger", trigger: "design-token-panel" },
+    ]);
+  });
+
+  it("emits headerRightItems even when it equals the default (always present)", () => {
+    const json = buildJson(makeState());
+    expect(json).toHaveProperty("headerRightItems");
   });
 });

--- a/src/__tests__/preset-generator-roundtrip.test.ts
+++ b/src/__tests__/preset-generator-roundtrip.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { FEATURES, buildCliCommand, type FormState } from "../lib/preset-generator-logic";
+import {
+  FEATURES,
+  buildCliCommand,
+  DEFAULT_HEADER_RIGHT_ITEMS,
+  type FormState,
+} from "../lib/preset-generator-logic";
 import { parseArgs } from "../../packages/create-zudo-doc/src/cli";
 
 /**
@@ -8,11 +13,19 @@ import { parseArgs } from "../../packages/create-zudo-doc/src/cli";
  * Strips the leading "{pm} create zudo-doc" prefix (3 tokens).
  */
 function cliCommandToArgv(command: string): string[] {
+  // Strip trailing/leading shell-comment lines (e.g. the headerRightItems
+  // documentation hint) — these are documentation only, not parsable args.
+  const commandLine = command
+    .split("\n")
+    .filter((line) => !line.trimStart().startsWith("#"))
+    .join(" ")
+    .trim();
+
   const tokens: string[] = [];
   let current = "";
   let inQuotes = false;
 
-  for (const ch of command) {
+  for (const ch of commandLine) {
     if (ch === '"') {
       inQuotes = !inQuotes;
     } else if (ch === " " && !inQuotes) {
@@ -39,7 +52,9 @@ function makeState(overrides: Partial<FormState> = {}): FormState {
     defaultMode: "dark",
     respectPrefersColorScheme: true,
     features: FEATURES.filter((f) => f.default).map((f) => f.value),
+    cjkFriendly: false,
     packageManager: "pnpm",
+    headerRightItems: [...DEFAULT_HEADER_RIGHT_ITEMS],
     ...overrides,
   };
 }

--- a/src/components/preset-generator.tsx
+++ b/src/components/preset-generator.tsx
@@ -1,5 +1,12 @@
 import { useState, useCallback, useMemo, useRef, useEffect } from "react";
-import { FEATURES, buildJson, buildCliCommand, type FormState } from "../lib/preset-generator-logic";
+import {
+  FEATURES,
+  buildJson,
+  buildCliCommand,
+  DEFAULT_HEADER_RIGHT_ITEMS,
+  type FormState,
+  type HeaderRightItemSpec,
+} from "../lib/preset-generator-logic";
 import { HeadingH3 } from "./content/heading-h3";
 
 // ── Data ──
@@ -78,6 +85,24 @@ const SUPPORTED_LANGS = [
 ] as const;
 
 const PACKAGE_MANAGERS = ["pnpm", "npm", "yarn", "bun"] as const;
+
+// Display labels for header-right items. Keep in sync with the canonical names
+// defined in src/config/settings-types.ts (HeaderRightComponentName /
+// HeaderRightTriggerName). Order does not matter here — the user reorders
+// state.headerRightItems directly.
+const HEADER_RIGHT_LABELS: Record<string, string> = {
+  "version-switcher": "Version switcher",
+  "design-token-panel": "Design token panel (trigger)",
+  "ai-chat": "AI chat (trigger)",
+  "github-link": "GitHub link",
+  "theme-toggle": "Theme toggle",
+  search: "Search",
+  "language-switcher": "Language switcher",
+};
+
+function headerRightItemKey(item: HeaderRightItemSpec): string {
+  return `${item.kind}:${item.name}`;
+}
 
 // ── Sub-components ──
 
@@ -246,6 +271,7 @@ export default function PresetGenerator() {
     features: FEATURES.filter((f) => f.default).map((f) => f.value),
     cjkFriendly: true,
     packageManager: "pnpm",
+    headerRightItems: [...DEFAULT_HEADER_RIGHT_ITEMS],
   });
 
   const [modalState, setModalState] = useState<FormState | null>(null);
@@ -264,6 +290,52 @@ export default function PresetGenerator() {
         : [...prev.features, value];
       return { ...prev, features };
     });
+  }, []);
+
+  // Header-right items: present rows in user-chosen order, support per-row
+  // checkbox (off removes the item entirely from state), arrow buttons to
+  // reorder, and a Reset-to-default button. The presence/absence of an item is
+  // the single source of truth — there is no "shadow off-list" to merge back.
+  const toggleHeaderRightItem = useCallback((spec: HeaderRightItemSpec) => {
+    setState((prev) => {
+      const key = headerRightItemKey(spec);
+      const existsAt = prev.headerRightItems.findIndex(
+        (item) => headerRightItemKey(item) === key,
+      );
+      if (existsAt >= 0) {
+        return {
+          ...prev,
+          headerRightItems: prev.headerRightItems.filter((_, i) => i !== existsAt),
+        };
+      }
+      // Re-adding: append at the end. Users can reorder afterwards.
+      return {
+        ...prev,
+        headerRightItems: [...prev.headerRightItems, spec],
+      };
+    });
+  }, []);
+
+  const moveHeaderRightItem = useCallback(
+    (index: number, direction: -1 | 1) => {
+      setState((prev) => {
+        const target = index + direction;
+        if (target < 0 || target >= prev.headerRightItems.length) return prev;
+        const next = [...prev.headerRightItems];
+        const tmp = next[index]!;
+        next[index] = next[target]!;
+        next[target] = tmp;
+        return { ...prev, headerRightItems: next };
+      });
+    },
+    [],
+  );
+
+  const resetHeaderRightItems = useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      headerRightItems: [...DEFAULT_HEADER_RIGHT_ITEMS],
+    }));
   }, []);
 
   return (
@@ -467,6 +539,120 @@ export default function PresetGenerator() {
             />
             AI Assistant (under development)
           </label>
+        </div>
+      </section>
+
+      {/* Header right items */}
+      <section>
+        <SectionHeading>Header right items</SectionHeading>
+        <p className="mb-vsp-xs text-caption text-muted">
+          Choose which items appear in the header right cluster and in what
+          order. Disabled items are dropped from the preset entirely. The
+          ai-chat trigger is shown for forward-compatibility but the scaffold
+          hardcodes <code>aiAssistant: false</code> so it never renders.
+        </p>
+        <ul className="flex flex-col gap-y-vsp-2xs">
+          {(() => {
+            const allSpecs: HeaderRightItemSpec[] = [
+              ...DEFAULT_HEADER_RIGHT_ITEMS,
+            ];
+            // Show items in current state order first, then any default items
+            // that the user has removed (so they can be re-enabled).
+            const presentKeys = new Set(
+              state.headerRightItems.map(headerRightItemKey),
+            );
+            const missing = allSpecs.filter(
+              (spec) => !presentKeys.has(headerRightItemKey(spec)),
+            );
+            const ordered: Array<{ spec: HeaderRightItemSpec; index: number }> =
+              state.headerRightItems.map((spec, index) => ({ spec, index }));
+
+            return (
+              <>
+                {ordered.map(({ spec, index }) => {
+                  const key = headerRightItemKey(spec);
+                  const label = HEADER_RIGHT_LABELS[spec.name] ?? spec.name;
+                  const isAiChat = spec.name === "ai-chat";
+                  return (
+                    <li
+                      key={key}
+                      className="flex items-center gap-x-hsp-xs text-small text-fg"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={true}
+                        onChange={() => toggleHeaderRightItem(spec)}
+                        aria-label={`Include ${label}`}
+                        className="accent-accent"
+                      />
+                      <span className="flex-1">
+                        {label}
+                        {isAiChat && (
+                          <span className="ml-hsp-xs text-caption text-muted">
+                            (requires aiAssistant — disabled in scaffold)
+                          </span>
+                        )}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => moveHeaderRightItem(index, -1)}
+                        disabled={index === 0}
+                        aria-label={`Move ${label} up`}
+                        className="border border-muted bg-surface px-hsp-xs py-vsp-2xs text-caption text-fg transition-colors hover:border-accent hover:text-accent disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        ↑
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => moveHeaderRightItem(index, 1)}
+                        disabled={index === ordered.length - 1}
+                        aria-label={`Move ${label} down`}
+                        className="border border-muted bg-surface px-hsp-xs py-vsp-2xs text-caption text-fg transition-colors hover:border-accent hover:text-accent disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        ↓
+                      </button>
+                    </li>
+                  );
+                })}
+                {missing.map((spec) => {
+                  const key = headerRightItemKey(spec);
+                  const label = HEADER_RIGHT_LABELS[spec.name] ?? spec.name;
+                  const isAiChat = spec.name === "ai-chat";
+                  return (
+                    <li
+                      key={key}
+                      className="flex items-center gap-x-hsp-xs text-small text-muted"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={false}
+                        onChange={() => toggleHeaderRightItem(spec)}
+                        aria-label={`Include ${label}`}
+                        className="accent-accent"
+                      />
+                      <span className="flex-1">
+                        {label}
+                        {isAiChat && (
+                          <span className="ml-hsp-xs text-caption text-muted">
+                            (requires aiAssistant — disabled in scaffold)
+                          </span>
+                        )}
+                      </span>
+                    </li>
+                  );
+                })}
+              </>
+            );
+          })()}
+        </ul>
+        <div className="mt-vsp-xs">
+          <button
+            type="button"
+            onClick={resetHeaderRightItems}
+            className="border border-muted bg-surface px-hsp-md py-vsp-2xs text-small text-muted transition-colors hover:border-fg hover:text-fg"
+          >
+            Reset to default
+          </button>
         </div>
       </section>
 

--- a/src/content/docs-ja/getting-started/setup-preset-generator.mdx
+++ b/src/content/docs-ja/getting-started/setup-preset-generator.mdx
@@ -9,3 +9,19 @@ import PresetGenerator from '@/components/preset-generator';
 このインタラクティブツールを使って、zudo-docプロジェクトのオプションを設定し、セットアッププリセットを生成できます。出力はプログラマティックAPI用のJSON、またはターミナル用のCLIコマンドとしてコピーできます。
 
 <PresetGenerator client:load />
+
+## ヘッダー右側アイテム
+
+「Header right items」セクションは `settings.headerRightItems` — サイトヘッダー右側のクラスタ(テーマ切替、言語スイッチャー、バージョンスイッチャー、GitHub リンク、Design Token Panel / AI Chat トリガー)を構成します。各アイテムのオン・オフを切り替え、上下ボタンで描画順を変更できます。
+
+2 種類のアイテム — `link`(任意の外部リンク)と `html`(生 HTML)— は、意図的に UI に出していません。これらを使う場合はスキャフォールド後に `settings.ts` を直接編集してください。discriminated union のスキーマと使用例は [ヘッダー右側アイテム](../guides/header-right-items.mdx) を参照してください。
+
+## 新しく追加された機能
+
+Features セクションには、いくつか押さえておきたい新項目があります。
+
+- **Image enlarge** — コンテンツ画像のクリック拡大。デフォルトで有効。
+- **Tag governance** — タグの語彙ルール監査。デフォルトで有効。詳細は [タグガバナンス](../guides/tag-governance.mdx)。
+- **Body foot util area** — 記事本文の末尾にタグリストやフィードバックリンクなどのユーティリティを差し込めるスロット。詳細は [Body foot util area](../guides/body-foot-util-area.mdx)。
+- **Footer taglist** — サイトフッターにグローバルタグクラウドを表示します。詳細は [Footer taglist](../guides/footer-taglist.mdx)。
+- **Design Token Panel** — 旧称「Color tweak panel」を改称。設定キーは `designTokenPanel`。互換のため `colorTweakPanel` も引き続きエイリアスとして使えます。

--- a/src/content/docs/getting-started/setup-preset-generator.mdx
+++ b/src/content/docs/getting-started/setup-preset-generator.mdx
@@ -9,3 +9,19 @@ import PresetGenerator from '@/components/preset-generator';
 Use this interactive tool to configure your zudo-doc project options and generate a setup preset. You can copy the output as JSON for the programmatic API, or as a CLI command for terminal usage.
 
 <PresetGenerator client:load />
+
+## Header right items
+
+The "Header right items" section configures `settings.headerRightItems` — the right-side cluster of the site header (theme toggle, language switcher, version switcher, GitHub link, and the Design Token Panel / AI Chat triggers). Toggle each item on or off, and use the up/down buttons to change render order.
+
+Two item kinds — `link` (custom external link) and `html` (raw HTML) — are intentionally not exposed in the UI. Add those by editing `settings.ts` directly after scaffolding. See [Header Right Items](../guides/header-right-items.mdx) for the full discriminated-union schema and examples.
+
+## Newly available features
+
+The Features section now includes a few additions worth calling out:
+
+- **Image enlarge** — click-to-zoom for content images. Enabled by default.
+- **Tag governance** — vocabulary-rule audit for tags. Enabled by default. See [Tag governance](../guides/tag-governance.mdx).
+- **Body foot util area** — slot at the bottom of the article body for util widgets like a tag list or feedback link. See [Body foot util area](../guides/body-foot-util-area.mdx).
+- **Footer taglist** — render the global tag cloud in the site footer. See [Footer taglist](../guides/footer-taglist.mdx).
+- **Design Token Panel** — renamed from "Color tweak panel". The setting key is `designTokenPanel`; the legacy `colorTweakPanel` still works as an alias.

--- a/src/lib/preset-generator-logic.ts
+++ b/src/lib/preset-generator-logic.ts
@@ -1,5 +1,51 @@
 // Keep in sync with packages/create-zudo-doc/src/constants.ts
 
+import type {
+  HeaderRightComponentName,
+  HeaderRightTriggerName,
+  HeaderRightItem,
+} from "../config/settings-types";
+
+export type { HeaderRightComponentName, HeaderRightTriggerName };
+
+/**
+ * UI-internal representation of a header-right item. The preset generator UI
+ * benefits from a uniform `{ kind, name }` handle while the user is reordering
+ * and toggling rows, but the JSON output uses the canonical `HeaderRightItem`
+ * discriminated union (`type` + `trigger | component`) from
+ * `src/config/settings-types.ts`. v1 of preset support intentionally rejects
+ * `link`/`html` items (they need free-text fields).
+ */
+export type HeaderRightItemSpec =
+  | { kind: "trigger"; name: HeaderRightTriggerName }
+  | { kind: "component"; name: HeaderRightComponentName };
+
+/**
+ * Canonical default order, mirrored from `src/config/settings.ts`. Editing
+ * either side without the other will desync the preset generator from the
+ * project's own scaffold.
+ */
+export const DEFAULT_HEADER_RIGHT_ITEMS: readonly HeaderRightItemSpec[] = [
+  { kind: "component", name: "version-switcher" },
+  { kind: "trigger", name: "design-token-panel" },
+  { kind: "trigger", name: "ai-chat" },
+  { kind: "component", name: "github-link" },
+  { kind: "component", name: "theme-toggle" },
+  { kind: "component", name: "search" },
+  { kind: "component", name: "language-switcher" },
+];
+
+/**
+ * Map a UI-internal {@link HeaderRightItemSpec} to the canonical
+ * `HeaderRightItem` shape consumed by `settings.ts`.
+ */
+export function specToHeaderRightItem(spec: HeaderRightItemSpec): HeaderRightItem {
+  if (spec.kind === "trigger") {
+    return { type: "trigger", trigger: spec.name };
+  }
+  return { type: "component", component: spec.name };
+}
+
 export const FEATURES = [
   { value: "i18n", label: "i18n (multi-language)", cliFlag: "i18n", default: false },
   { value: "search", label: "Pagefind search", cliFlag: "search", default: true },
@@ -37,6 +83,7 @@ export interface FormState {
   features: string[];
   cjkFriendly: boolean;
   packageManager: string;
+  headerRightItems: HeaderRightItemSpec[];
 }
 
 export function buildJson(state: FormState): Record<string, unknown> {
@@ -58,6 +105,9 @@ export function buildJson(state: FormState): Record<string, unknown> {
   base.features = state.features;
   base.cjkFriendly = state.cjkFriendly;
   base.packageManager = state.packageManager;
+  // Always emit the canonical {type, trigger|component} shape (not the internal
+  // kind/name shape) — self-documents the preset for users who copy-paste.
+  base.headerRightItems = state.headerRightItems.map(specToHeaderRightItem);
   return base;
 }
 
@@ -91,5 +141,11 @@ export function buildCliCommand(state: FormState): string {
   parts.push(`--pm ${pm}`);
   parts.push("--yes");
 
-  return parts.join(" ");
+  // Trailing comment: headerRightItems is an array of discriminated unions
+  // that does not fit the --flag CLI model. Surfaced as a shell comment line
+  // so users know to use a JSON preset (--preset) for header-right ordering.
+  const trailingNote =
+    "\n# headerRightItems: use a JSON preset (--preset) — array configs are not expressible as CLI flags";
+
+  return parts.join(" ") + trailingNote;
 }

--- a/src/lib/preset-generator-logic.ts
+++ b/src/lib/preset-generator-logic.ts
@@ -6,17 +6,21 @@ export const FEATURES = [
   { value: "sidebarFilter", label: "Sidebar filter", cliFlag: "sidebar-filter", default: true },
   { value: "claudeResources", label: "Claude Resources", cliFlag: "claude-resources", default: false },
   { value: "claudeSkills", label: "Claude skills (user-facing)", cliFlag: "claude-skills", default: false },
-  { value: "colorTweakPanel", label: "Color tweak panel", cliFlag: "color-tweak-panel", default: false },
+  { value: "designTokenPanel", label: "Design Token Panel", cliFlag: "design-token-panel", default: false },
   { value: "sidebarResizer", label: "Sidebar resizer", cliFlag: "sidebar-resizer", default: false },
   { value: "sidebarToggle", label: "Sidebar toggle", cliFlag: "sidebar-toggle", default: false },
   { value: "versioning", label: "Versioning", cliFlag: "versioning", default: false },
   { value: "docHistory", label: "Document history", cliFlag: "doc-history", default: false },
+  { value: "bodyFootUtil", label: "Body foot util area", cliFlag: "body-foot-util", default: false },
   { value: "llmsTxt", label: "llms.txt", cliFlag: "llms-txt", default: false },
   { value: "skillSymlinker", label: "Skill symlinker", cliFlag: "skill-symlinker", default: false },
   { value: "tauri", label: "Tauri desktop app", cliFlag: "tauri", default: false },
   { value: "footerNavGroup", label: "Footer nav group", cliFlag: "footer-nav-group", default: false },
+  { value: "imageEnlarge", label: "Image enlarge", cliFlag: "image-enlarge", default: true },
   { value: "footerCopyright", label: "Footer copyright", cliFlag: "footer-copyright", default: false },
   { value: "changelog", label: "Changelog", cliFlag: "changelog", default: false },
+  { value: "tagGovernance", label: "Tag governance", cliFlag: "tag-governance", default: true },
+  { value: "footerTaglist", label: "Footer taglist", cliFlag: "footer-taglist", default: false },
 ] as const;
 
 export type ColorSchemeMode = "single" | "light-dark";


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/437

---

## Summary

- Sync the interactive Preset Generator UI (`src/lib/preset-generator-logic.ts`, `src/components/preset-generator.tsx`) with the CLI generator constants in `packages/create-zudo-doc/src/constants.ts` — 20 features both sides, same value order, labels, defaults, and CLI flags.
- Rename `colorTweakPanel` → `designTokenPanel` in the UI (CLI generator already used the new name; runtime alias in `settings.ts` continues to work).
- Add four feature checkboxes that were missing from the UI: `bodyFootUtil`, `imageEnlarge` (default on), `tagGovernance` (default on), `footerTaglist`.
- Add a Header Right Items configurator: per-item checkbox + up/down reorder + reset-to-default. Items emit in the JSON preset using the canonical `{ type, trigger | component }` discriminated-union shape from `src/config/settings-types.ts`. `link` and `html` item kinds are intentionally not surfaced in v1.
- Update `packages/create-zudo-doc`: add `headerRightItems?: PresetHeaderRightItem[]` to `PresetJson` / `PartialChoices` / `UserChoices`; `validatePreset` rejects unknown component/trigger names and rejects `link`/`html` types; `settings-gen.ts` honors the user-supplied array verbatim, including an explicit empty array.
- Document the new options in the bilingual `setup-preset-generator.mdx` (EN + JA), cross-linking to `../guides/header-right-items.mdx`.

## Sub-issues

- #438 — Sync FEATURES list with CLI generator (drift fix)
- #440 — Add headerRightItems configuration to preset generator
- #443 — Document new preset generator options (EN + JA)

## Implementation notes

- The drift-detection unit test `src/__tests__/preset-generator-features-sync.test.ts` (the acceptance gate from #438) now passes with 25/25 cases.
- Default behavior is byte-identical to the prior output when no `headerRightItems` override is supplied — existing scaffold tests stay green.
- The empty-array case (`headerRightItems: []` in a preset) was originally silently falling back to the hardcoded default; review caught the bug. Fixed in commit 024c065 by gating on `!== undefined` instead of `length > 0`. Locked in by a new scaffold test.

## Review

Combined review per `-co -gcoc` (Codex + GitHub Copilot Cheap):

- Codex was rate-limited at run time → silent fallback to two `code-reviewer` Opus subagents (per skill policy).
- GCOC (`gpt-4.1`) ran cleanly.
- All findings consolidated; the empty-array bug was fixed; symmetric `trigger must be a string` validator test added; other findings (intentional always-emit design from #440 spec, type duplication, future link/html label key collision) deferred as out of scope.

## Test Plan

- `pnpm test:unit` (root) — 381/381 pass on the merged base; one tags-audit test was a load-related flake that passes in isolation.
- `pnpm --filter create-zudo-doc test` — 119/119 pass for preset/scaffold/header-right validation.
- `pnpm check` (Astro typecheck) — clean.
- `pnpm format:md` — no diff on either bilingual mdx file.
- CI on this PR is green (6/6 checks at HEAD = 024c065).
- Manual smoke (recommended before merge): open `/docs/getting-started/setup-preset-generator/` in dev, confirm Body foot util area, Image enlarge (checked), Tag governance (checked), Footer taglist, and Design Token Panel (no longer "Color tweak panel") all appear; reorder a few header-right items and verify the generated JSON reflects the chosen order.