### PR TITLE
fix(category-tree-nav): restore left indent lost when .zd-content ul rules were removed

### DIFF
--- a/packages/create-zudo-doc/templates/base/src/components/category-tree-nav.astro
+++ b/packages/create-zudo-doc/templates/base/src/components/category-tree-nav.astro
@@ -41,7 +41,7 @@ const children =
 {
   children.length > 0 && (
     <nav aria-label="Category navigation" class="mt-vsp-lg mb-vsp-md">
-      <ul class="list-none m-0 p-0">
+      <ul class="list-none m-0 p-0 pl-hsp-xl">
         {children.map((child) => (
           <li class="m-0 p-0">
             {child.href ? (
@@ -62,7 +62,7 @@ const children =
               </span>
             )}
             {child.children.length > 0 && (
-              <ul class="list-none m-0 p-0 pl-hsp-lg ml-hsp-xs">
+              <ul class="list-none m-0 p-0 pl-hsp-xl">
                 {child.children
                   .filter((c: NavNode) => c.hasPage || c.children.length > 0)
                   .map((grandchild: NavNode) => (
@@ -85,7 +85,7 @@ const children =
                         </span>
                       )}
                       {grandchild.children.length > 0 && (
-                        <ul class="list-none m-0 p-0 pl-hsp-lg ml-hsp-xs">
+                        <ul class="list-none m-0 p-0 pl-hsp-xl">
                           {grandchild.children
                             .filter(
                               (c: NavNode) =>

--- a/src/components/category-tree-nav.astro
+++ b/src/components/category-tree-nav.astro
@@ -41,7 +41,7 @@ const children =
 {
   children.length > 0 && (
     <nav aria-label="Category navigation" class="mt-vsp-lg mb-vsp-md">
-      <ul class="list-none m-0 p-0">
+      <ul class="list-none m-0 p-0 pl-hsp-xl">
         {children.map((child) => (
           <li class="m-0 p-0">
             {child.href ? (
@@ -62,7 +62,7 @@ const children =
               </span>
             )}
             {child.children.length > 0 && (
-              <ul class="list-none m-0 p-0 pl-hsp-lg ml-hsp-xs">
+              <ul class="list-none m-0 p-0 pl-hsp-xl">
                 {child.children
                   .filter((c: NavNode) => c.hasPage || c.children.length > 0)
                   .map((grandchild: NavNode) => (
@@ -85,7 +85,7 @@ const children =
                         </span>
                       )}
                       {grandchild.children.length > 0 && (
-                        <ul class="list-none m-0 p-0 pl-hsp-lg ml-hsp-xs">
+                        <ul class="list-none m-0 p-0 pl-hsp-xl">
                           {grandchild.children
                             .filter(
                               (c: NavNode) =>


### PR DESCRIPTION
## Summary

`CategoryTreeNav` lost its left indent after the typography refactor (commit `f4bf21a`) removed the `.zd-content :where(ul)` / `:where(ol)` rules from `global.css`. Those rules previously applied `padding-left: hsp-xl` to every `<ul>`/`<ol>` inside `.zd-content`, which gave the component its visual hierarchy.

The Preact `ContentUl` / `ContentOl` replacements only restore indent for **MDX-rendered** lists — Astro components like `CategoryTreeNav` were left flush-left because the Tailwind `p-0` reset was no longer offset by the global rule.

This PR reapplies the indent component-side (matching the project's component-first strategy) using `pl-hsp-xl` (1.5rem / 24px) on each `<ul>` level, matching the indent that `zudo-css-wisdom` still gets via the global rule.

## Changes

- `src/components/category-tree-nav.astro` — top-level ul: `p-0` → `p-0 pl-hsp-xl`; nested levels: `pl-hsp-lg ml-hsp-xs` → `pl-hsp-xl`
- `packages/create-zudo-doc/templates/base/src/components/category-tree-nav.astro` — same change to keep generator template in sync (no drift)

Both files remain byte-identical (verified via `diff`).

## Visual effect

| Level | Before | After |
|---|---|---|
| Top `<ul>` | 0px padding-left | 24px |
| Nested `<ul>` | 16px padding + 6px margin = 22px | 24px |
| Deeply nested `<ul>` | 22px | 24px |

Consistent 24px indent at every level (cumulative through nesting), matching `zudo-css-wisdom`'s rendering.

## Test Plan

- [x] `pnpm check` passes
- [x] `pnpm build` succeeds
- [x] Rendered HTML at `dist/client/docs/components/category-tree-nav/index.html` contains `<ul class="list-none m-0 p-0 pl-hsp-xl">` at every nesting level
- [x] CSS bundle generates `.pl-hsp-xl{padding-left:var(--spacing-hsp-xl)}` (1.5rem)
- [ ] CI: Build Site, Build Doc History, Type Check, Template Drift Check, E2E Tests