### PR TITLE
fix(category-tree-nav): show disc bullets to match css-wisdom rendering

### DIFF
--- a/packages/create-zudo-doc/templates/base/src/components/category-tree-nav.astro
+++ b/packages/create-zudo-doc/templates/base/src/components/category-tree-nav.astro
@@ -41,7 +41,7 @@ const children =
 {
   children.length > 0 && (
     <nav aria-label="Category navigation" class="mt-vsp-lg mb-vsp-md">
-      <ul class="list-none m-0 p-0 pl-hsp-xl">
+      <ul class="list-disc m-0 p-0 pl-hsp-xl">
         {children.map((child) => (
           <li class="m-0 p-0">
             {child.href ? (
@@ -62,7 +62,7 @@ const children =
               </span>
             )}
             {child.children.length > 0 && (
-              <ul class="list-none m-0 p-0 pl-hsp-xl">
+              <ul class="list-disc m-0 p-0 pl-hsp-xl">
                 {child.children
                   .filter((c: NavNode) => c.hasPage || c.children.length > 0)
                   .map((grandchild: NavNode) => (
@@ -85,7 +85,7 @@ const children =
                         </span>
                       )}
                       {grandchild.children.length > 0 && (
-                        <ul class="list-none m-0 p-0 pl-hsp-xl">
+                        <ul class="list-disc m-0 p-0 pl-hsp-xl">
                           {grandchild.children
                             .filter(
                               (c: NavNode) =>

--- a/src/components/category-tree-nav.astro
+++ b/src/components/category-tree-nav.astro
@@ -41,7 +41,7 @@ const children =
 {
   children.length > 0 && (
     <nav aria-label="Category navigation" class="mt-vsp-lg mb-vsp-md">
-      <ul class="list-none m-0 p-0 pl-hsp-xl">
+      <ul class="list-disc m-0 p-0 pl-hsp-xl">
         {children.map((child) => (
           <li class="m-0 p-0">
             {child.href ? (
@@ -62,7 +62,7 @@ const children =
               </span>
             )}
             {child.children.length > 0 && (
-              <ul class="list-none m-0 p-0 pl-hsp-xl">
+              <ul class="list-disc m-0 p-0 pl-hsp-xl">
                 {child.children
                   .filter((c: NavNode) => c.hasPage || c.children.length > 0)
                   .map((grandchild: NavNode) => (
@@ -85,7 +85,7 @@ const children =
                         </span>
                       )}
                       {grandchild.children.length > 0 && (
-                        <ul class="list-none m-0 p-0 pl-hsp-xl">
+                        <ul class="list-disc m-0 p-0 pl-hsp-xl">
                           {grandchild.children
                             .filter(
                               (c: NavNode) =>


### PR DESCRIPTION
## Summary

Follow-up to #460. The previous fix added left padding but kept `list-none` on each `<ul>`, so bullets were still suppressed. `zudo-css-wisdom` shows disc bullets because its global `.zd-content :where(ul) { list-style-type: disc }` rule overrides the utility — zudo-doc removed that global rule in commit `f4bf21a`, so the `list-none` utility wins and no bullets appear.

This PR replaces `list-none` with `list-disc` on every nesting level to restore disc bullets, matching css-wisdom's rendering.

## Changes
- `src/components/category-tree-nav.astro` — `list-none` → `list-disc` on all 3 ul levels
- `packages/create-zudo-doc/templates/base/src/components/category-tree-nav.astro` — mirrored

## Test Plan
- [x] Local format hook clean
- [ ] CI: typecheck, build, drift, e2e (merging without waiting per user request)