### PR TITLE
[Astro→zfb][E5] zudo-doc-v2 framework primitives (sidebar, theme, TOC, breadcrumb, layouts, head, transitions, SSR-skip)

### DIFF
--- a/packages/zudo-doc-v2/README.md
+++ b/packages/zudo-doc-v2/README.md
@@ -1,0 +1,18 @@
+# @zudo-doc/zudo-doc-v2
+
+Framework primitives that sit on top of zfb's engine — the framework layer that zfb deliberately doesn't ship (per ADR-003).
+
+This package is part of the **Astro→zfb migration** (super-epic [#473](https://github.com/zudolab/zudo-doc/issues/473)). It implements the [E5 epic](https://github.com/zudolab/zudo-doc/issues/474) and provides the missing-by-design framework concerns:
+
+- **Sidebar tree builder** (`./sidebar-tree`) — turns collection entries + `_category_.json` into a sidebar `SidebarNode[]`.
+- **Theme controls** (`./theme`) — color scheme provider + design-token tweak panel (Preact island that wraps an iframe).
+- **TOC** (`./toc`) — desktop and mobile TOC Preact islands fed by MDX `headings` export.
+- **Breadcrumb** (`./breadcrumb`) — JSX breadcrumb fed by the sidebar tree.
+- **DocLayout** (`./doclayout`) — composable layout shell with explicit `<Header>`, `<Sidebar>`, `<Main>`, `<Toc>`, `<Footer>` props; ships a `<DocLayoutWithDefaults>` wrapper that holds the 16 `create-zudo-doc` injection anchors.
+- **View Transitions** (`./transitions`) — native View Transitions API shim (Chrome/Edge/Safari 18+); persistent regions via `view-transition-name`. No-op fallback in Firefox.
+- **Head injection** (`./head`) — canonical, og:\*, twitter:\*, robots, preload hints, RSS link, sitemap link, theme-color — byte-equal to today's Astro output.
+- **SSR-skip wrappers** (`./ssr-skip`) — `<AiChatModalIsland>`, `<ImageEnlargeIsland>`, `<DesignTokenTweakPanelIsland>`, `<MockInitIsland>` — wrap zfb's `<Island ssrFallback>` with the right fallback markup so doc pages don't have to re-implement the SSR-skip pattern.
+
+## Pre-publish dev workflow
+
+Phase A npm publish is deferred (see super-epic comment 2026-04-28). During pre-publish dev, this package references zfb via the local checkout at `$HOME/repos/myoss/zfb`. Use `/refer-another-project zfb` to read zfb's APIs. If a zfb bug is discovered, fix it directly on zfb's `main` and push (zfb is not public yet).

--- a/packages/zudo-doc-v2/package.json
+++ b/packages/zudo-doc-v2/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@zudo-doc/zudo-doc-v2",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "description": "zudo-doc framework primitives layer that sits on top of zfb's engine — sidebar, theme, TOC, breadcrumb, layouts, head injection, View Transitions, SSR-skip wrappers (per ADR-003).",
+  "license": "MIT",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./sidebar-tree": {
+      "types": "./src/sidebar-tree/index.ts",
+      "default": "./src/sidebar-tree/index.ts"
+    },
+    "./theme": {
+      "types": "./src/theme/index.ts",
+      "default": "./src/theme/index.ts"
+    },
+    "./toc": {
+      "types": "./src/toc/index.ts",
+      "default": "./src/toc/index.ts"
+    },
+    "./breadcrumb": {
+      "types": "./src/breadcrumb/index.ts",
+      "default": "./src/breadcrumb/index.ts"
+    },
+    "./doclayout": {
+      "types": "./src/doclayout/index.ts",
+      "default": "./src/doclayout/index.ts"
+    },
+    "./head": {
+      "types": "./src/head/index.ts",
+      "default": "./src/head/index.ts"
+    },
+    "./ssr-skip": {
+      "types": "./src/ssr-skip/index.ts",
+      "default": "./src/ssr-skip/index.ts"
+    },
+    "./transitions": {
+      "types": "./src/transitions/index.ts",
+      "default": "./src/transitions/index.ts"
+    }
+  },
+  "files": [
+    "src",
+    "README.md"
+  ],
+  "peerDependencies": {
+    "preact": "*"
+  }
+}

--- a/packages/zudo-doc-v2/package.json
+++ b/packages/zudo-doc-v2/package.json
@@ -49,5 +49,11 @@
   ],
   "peerDependencies": {
     "preact": "*"
+  },
+  "devDependencies": {
+    "preact": "^10.26.9",
+    "preact-render-to-string": "^6.6.6",
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0"
   }
 }

--- a/packages/zudo-doc-v2/src/breadcrumb/__tests__/breadcrumb.test.tsx
+++ b/packages/zudo-doc-v2/src/breadcrumb/__tests__/breadcrumb.test.tsx
@@ -1,0 +1,209 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { describe, expect, it } from "vitest";
+import type { ComponentChildren, VNode } from "preact";
+import { Breadcrumb, buildBreadcrumbItems } from "../breadcrumb";
+import type { SidebarNode } from "../types";
+
+/**
+ * Minimal VNode → HTML serializer. Walks the Preact VNode tree and
+ * emits HTML markup for assertions. Function components are invoked
+ * with their props (sufficient for our pure, hook-less components).
+ *
+ * This avoids pulling in preact-render-to-string, which is only
+ * available transitively in the workspace and is not directly resolvable
+ * from a vitest run rooted at the worktree.
+ */
+type AnyVNode = VNode<{ children?: ComponentChildren; [key: string]: unknown }>;
+
+function isVNode(v: unknown): v is AnyVNode {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    Object.prototype.hasOwnProperty.call(v, "type") &&
+    Object.prototype.hasOwnProperty.call(v, "props")
+  );
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/"/g, "&quot;");
+}
+
+function serialize(node: ComponentChildren): string {
+  if (node == null || typeof node === "boolean") return "";
+  if (typeof node === "string") return node;
+  if (typeof node === "number" || typeof node === "bigint") return String(node);
+  if (Array.isArray(node)) return node.map(serialize).join("");
+  if (!isVNode(node)) return "";
+  const { type, props } = node;
+  const { children, ...rest } = (props ?? {}) as {
+    children?: ComponentChildren;
+    [key: string]: unknown;
+  };
+
+  if (typeof type === "function") {
+    const fn = type as (p: typeof props) => ComponentChildren;
+    return serialize(fn(props));
+  }
+  if (type == null || (typeof type === "string" && type === "")) {
+    // Fragment
+    return serialize(children);
+  }
+  if (typeof type !== "string") return serialize(children);
+
+  const attrs = Object.entries(rest)
+    .filter(([, v]) => v !== undefined && v !== null && v !== false)
+    .map(([k, v]) => {
+      if (k === "key") return "";
+      if (v === true) return ` ${k}`;
+      return ` ${k}="${escapeAttr(String(v))}"`;
+    })
+    .join("");
+
+  const voidEls = new Set(["br", "hr", "img", "input", "wbr", "meta", "link"]);
+  if (voidEls.has(type)) return `<${type}${attrs}/>`;
+  return `<${type}${attrs}>${serialize(children)}</${type}>`;
+}
+
+const tree: SidebarNode[] = [
+  {
+    type: "category",
+    id: "guides",
+    label: "Guides",
+    href: "/docs/guides/",
+    children: [
+      {
+        type: "category",
+        id: "guides/advanced",
+        label: "Advanced",
+        href: "/docs/guides/advanced/",
+        children: [
+          {
+            type: "doc",
+            id: "guides/advanced/perf",
+            label: "Performance",
+            href: "/docs/guides/advanced/perf/",
+          },
+        ],
+      },
+    ],
+  },
+];
+
+describe("buildBreadcrumbItems", () => {
+  it("prepends a home item with empty label and the supplied homeHref", () => {
+    const items = buildBreadcrumbItems(tree, "guides/advanced/perf", "/home/");
+    expect(items[0]).toEqual({ label: "", href: "/home/" });
+  });
+
+  it("includes every ancestor and the current page", () => {
+    const items = buildBreadcrumbItems(tree, "guides/advanced/perf", "/");
+    expect(items.map((i) => i.label)).toEqual([
+      "",
+      "Guides",
+      "Advanced",
+      "Performance",
+    ]);
+  });
+
+  it("omits href on the final (current page) item", () => {
+    const items = buildBreadcrumbItems(tree, "guides/advanced/perf", "/");
+    expect(items[items.length - 1].href).toBeUndefined();
+  });
+
+  it("returns only the home rung when target is not in the tree", () => {
+    const items = buildBreadcrumbItems(tree, "missing", "/");
+    expect(items).toEqual([{ label: "", href: "/" }]);
+  });
+});
+
+describe("Breadcrumb", () => {
+  it("renders a nav with aria-label='Breadcrumb'", () => {
+    const html = serialize(
+      <Breadcrumb tree={tree} currentId="guides/advanced/perf" homeHref="/" />,
+    );
+    expect(html).toContain('aria-label="Breadcrumb"');
+    expect(html).toMatch(/<nav[^>]*>/);
+    expect(html).toContain("<ol");
+  });
+
+  it("renders the home rung as a link with the home icon path", () => {
+    const html = serialize(
+      <Breadcrumb tree={tree} currentId="guides/advanced/perf" homeHref="/" />,
+    );
+    expect(html).toContain('href="/"');
+    expect(html).toContain("M3 12l2-2");
+  });
+
+  it("renders the final crumb as a span (not anchor)", () => {
+    const html = serialize(
+      <Breadcrumb tree={tree} currentId="guides/advanced/perf" homeHref="/" />,
+    );
+    expect(html).toContain('<span class="text-fg">Performance</span>');
+  });
+
+  it("renders chevron separators (one fewer than item count)", () => {
+    const html = serialize(
+      <Breadcrumb tree={tree} currentId="guides/advanced/perf" homeHref="/" />,
+    );
+    const occurrences = html.split("M9 5l7 7-7 7").length - 1;
+    expect(occurrences).toBe(3);
+  });
+
+  it("returns null and renders nothing when items is empty", () => {
+    expect(serialize(<Breadcrumb items={[]} />)).toBe("");
+  });
+
+  it("accepts pre-built items directly", () => {
+    const html = serialize(
+      <Breadcrumb
+        items={[
+          { label: "", href: "/" },
+          { label: "Hello" },
+        ]}
+      />,
+    );
+    expect(html).toContain('href="/"');
+    expect(html).toContain("Hello");
+  });
+
+  it("inserts <wbr> for path-like labels", () => {
+    const html = serialize(
+      <Breadcrumb
+        items={[
+          { label: "", href: "/" },
+          { label: "src/utils/docs.ts" },
+        ]}
+      />,
+    );
+    expect(html).toContain("<wbr/>");
+  });
+
+  it("does not insert <wbr> for prose labels", () => {
+    const html = serialize(
+      <Breadcrumb
+        items={[
+          { label: "", href: "/" },
+          { label: "Getting Started" },
+        ]}
+      />,
+    );
+    expect(html).not.toContain("<wbr");
+  });
+
+  it("defaults homeHref to '/' when omitted", () => {
+    const html = serialize(
+      <Breadcrumb tree={tree} currentId="guides/advanced/perf" />,
+    );
+    expect(html).toContain('href="/"');
+  });
+
+  it("intermediate ancestors keep their hrefs", () => {
+    const html = serialize(
+      <Breadcrumb tree={tree} currentId="guides/advanced/perf" homeHref="/" />,
+    );
+    expect(html).toContain('href="/docs/guides/"');
+    expect(html).toContain('href="/docs/guides/advanced/"');
+  });
+});

--- a/packages/zudo-doc-v2/src/breadcrumb/__tests__/find-path.test.ts
+++ b/packages/zudo-doc-v2/src/breadcrumb/__tests__/find-path.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { findPath } from "../find-path";
+import type { SidebarNode } from "../types";
+
+const tree: SidebarNode[] = [
+  {
+    type: "doc",
+    id: "intro",
+    label: "Intro",
+    href: "/docs/intro/",
+  },
+  {
+    type: "category",
+    id: "guides",
+    label: "Guides",
+    href: "/docs/guides/",
+    children: [
+      {
+        type: "doc",
+        id: "guides/getting-started",
+        label: "Getting Started",
+        href: "/docs/guides/getting-started/",
+      },
+      {
+        type: "category",
+        id: "guides/advanced",
+        label: "Advanced",
+        href: "/docs/guides/advanced/",
+        children: [
+          {
+            type: "doc",
+            id: "guides/advanced/perf",
+            label: "Performance",
+            href: "/docs/guides/advanced/perf/",
+          },
+        ],
+      },
+    ],
+  },
+];
+
+describe("findPath", () => {
+  it("returns a single node for a top-level match", () => {
+    const path = findPath(tree, "intro");
+    expect(path.map((n) => n.id)).toEqual(["intro"]);
+  });
+
+  it("returns the chain for a nested doc", () => {
+    const path = findPath(tree, "guides/advanced/perf");
+    expect(path.map((n) => n.id)).toEqual([
+      "guides",
+      "guides/advanced",
+      "guides/advanced/perf",
+    ]);
+  });
+
+  it("returns the chain for a category page itself", () => {
+    const path = findPath(tree, "guides/advanced");
+    expect(path.map((n) => n.id)).toEqual(["guides", "guides/advanced"]);
+  });
+
+  it("returns an empty array when the id is not found", () => {
+    expect(findPath(tree, "missing")).toEqual([]);
+    expect(findPath(tree, "guides/missing")).toEqual([]);
+  });
+
+  it("handles an empty tree", () => {
+    expect(findPath([], "anything")).toEqual([]);
+  });
+
+  it("does not mutate input nodes", () => {
+    const before = JSON.stringify(tree);
+    findPath(tree, "guides/advanced/perf");
+    expect(JSON.stringify(tree)).toBe(before);
+  });
+});

--- a/packages/zudo-doc-v2/src/breadcrumb/breadcrumb.tsx
+++ b/packages/zudo-doc-v2/src/breadcrumb/breadcrumb.tsx
@@ -1,0 +1,179 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import type { VNode } from "preact";
+import { findPath } from "./find-path";
+import type { BreadcrumbItem, SidebarNode } from "./types";
+
+/**
+ * Convert a sidebar tree + the current page's id into the ordered list
+ * of crumbs the renderer walks. The first crumb is the home rung
+ * (icon-only, label is the empty string), followed by each ancestor in
+ * the tree, ending with the current page (no `href` so the renderer
+ * paints it as plain text).
+ *
+ * Mirrors the legacy buildBreadcrumbs() behaviour from
+ * src/utils/docs.ts so the rendered output stays parity-equivalent
+ * with the original Astro breadcrumb component.
+ */
+export function buildBreadcrumbItems(
+  tree: SidebarNode[],
+  currentId: string,
+  homeHref: string,
+): BreadcrumbItem[] {
+  const items: BreadcrumbItem[] = [{ label: "", href: homeHref }];
+  const path = findPath(tree, currentId);
+  for (let i = 0; i < path.length; i++) {
+    const node = path[i];
+    const isLast = i === path.length - 1;
+    items.push({
+      label: node.label,
+      href: isLast ? undefined : node.href,
+    });
+  }
+  return items;
+}
+
+interface SmartLabelProps {
+  label: string;
+}
+
+/**
+ * Inline replacement for the Astro template's `set:html` /
+ * smartBreakToHtml call. Keeps the breadcrumb self-contained inside the
+ * v2 package — the legacy smart-break util lives in the host project's
+ * src/utils/, which v2 must not reach into.
+ *
+ * Inserts a Preact <wbr/> after each delimiter character when the label
+ * looks "path-like" (URLs, slash-separated paths, etc.). Prose labels
+ * pass through unchanged.
+ */
+function SmartLabel({ label }: SmartLabelProps): VNode | string {
+  if (!isPathLike(label)) return label;
+  const parts = label.split(DELIM_SPLIT);
+  const nodes: (string | VNode)[] = [];
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    if (part === "") continue;
+    nodes.push(part);
+    if (i % 2 === 1) nodes.push(<wbr key={`wbr-${i}`} />);
+  }
+  return <>{nodes}</>;
+}
+
+const DELIM_SPLIT = /([/\\\-_.:?#&=])/;
+
+/** Heuristic copied from src/utils/smart-break.tsx — kept inline so v2
+ *  has no upward dependency. Returns true when delimiter-aware
+ *  line-break hints are useful (paths, URLs), false for prose. */
+function isPathLike(text: string): boolean {
+  if (!text) return false;
+  if (text.includes("://")) return true;
+  if (/^\.{0,2}\//.test(text)) return true;
+  if (/^[A-Za-z]:[\\/]/.test(text)) return true;
+  const forwardMatches = text.match(/[A-Za-z0-9]\/[A-Za-z0-9]/g);
+  if (forwardMatches && forwardMatches.length >= 2) return true;
+  const backMatches = text.match(/[A-Za-z0-9]\\[A-Za-z0-9]/g);
+  if (backMatches && backMatches.length >= 2) return true;
+  const hasDomainDot = /[A-Za-z0-9]\.[A-Za-z0-9]/.test(text);
+  const hasSlash = /[\\/]/.test(text);
+  if (hasDomainDot && hasSlash) return true;
+  return false;
+}
+
+function ChevronIcon(): VNode {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      class="h-icon-xs w-icon-xs text-muted shrink-0"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      stroke-width="2"
+      aria-hidden="true"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M9 5l7 7-7 7"
+      />
+    </svg>
+  );
+}
+
+function HomeIcon(): VNode {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      class="h-[1.575rem] w-[1.575rem] shrink-0"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      stroke-width="2"
+      aria-hidden="true"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-4 0a1 1 0 01-1-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 01-1 1h-2z"
+      />
+    </svg>
+  );
+}
+
+export interface BreadcrumbProps {
+  /** Pre-built items, or omit and pass `tree` + `currentId` instead. */
+  items?: BreadcrumbItem[];
+  /** Sidebar tree to derive the trail from. Required when `items` is omitted. */
+  tree?: SidebarNode[];
+  /** Id of the current page (matches SidebarNode.id). Required when `items` is omitted. */
+  currentId?: string;
+  /** Href for the leading home rung. Defaults to "/". */
+  homeHref?: string;
+}
+
+/**
+ * Breadcrumb trail — JSX port of src/components/breadcrumb.astro.
+ *
+ * Two usage shapes:
+ *   1. Pass pre-built `items` (existing call-sites that already
+ *      compute crumbs upstream).
+ *   2. Pass `tree` + `currentId` and the component derives the trail.
+ *
+ * Returns null when no items resolve, matching the Astro template's
+ * `items.length > 0 &&` guard.
+ */
+export function Breadcrumb(props: BreadcrumbProps): VNode | null {
+  const items =
+    props.items ??
+    (props.tree && props.currentId !== undefined
+      ? buildBreadcrumbItems(props.tree, props.currentId, props.homeHref ?? "/")
+      : []);
+
+  if (items.length === 0) return null;
+
+  return (
+    <nav class="mb-vsp-md text-small" aria-label="Breadcrumb">
+      <ol class="flex flex-wrap items-center gap-x-hsp-xs">
+        {items.map((item, i) => (
+          <li key={`crumb-${i}`} class="flex items-center gap-x-hsp-xs">
+            {i > 0 && <ChevronIcon />}
+            {item.href ? (
+              <a
+                href={item.href}
+                class="text-muted underline hover:text-fg flex items-center gap-x-hsp-2xs"
+              >
+                {i === 0 && <HomeIcon />}
+                <SmartLabel label={item.label} />
+              </a>
+            ) : (
+              <span class="text-fg">
+                <SmartLabel label={item.label} />
+              </span>
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}

--- a/packages/zudo-doc-v2/src/breadcrumb/find-path.ts
+++ b/packages/zudo-doc-v2/src/breadcrumb/find-path.ts
@@ -1,0 +1,26 @@
+import type { SidebarNode } from "./types";
+
+/**
+ * Walk the sidebar tree and return the chain of nodes from the root
+ * level down to (and including) the node whose `id` matches `targetId`.
+ *
+ * Returns an empty array when no node matches. Pure: never mutates the
+ * input tree, never reads anything outside of it.
+ *
+ * Used by the breadcrumb component to derive the current page's
+ * ancestry. The home/root crumb is the renderer's responsibility — this
+ * helper deals strictly with the tree itself.
+ */
+export function findPath(
+  nodes: SidebarNode[],
+  targetId: string,
+): SidebarNode[] {
+  for (const node of nodes) {
+    if (node.id === targetId) return [node];
+    if (node.children && node.children.length > 0) {
+      const sub = findPath(node.children, targetId);
+      if (sub.length > 0) return [node, ...sub];
+    }
+  }
+  return [];
+}

--- a/packages/zudo-doc-v2/src/breadcrumb/find-path.ts
+++ b/packages/zudo-doc-v2/src/breadcrumb/find-path.ts
@@ -1,4 +1,4 @@
-import type { SidebarNode } from "./types";
+import type { BreadcrumbNode, SidebarNode } from "./types";
 
 /**
  * Walk the sidebar tree and return the chain of nodes from the root
@@ -11,14 +11,14 @@ import type { SidebarNode } from "./types";
  * ancestry. The home/root crumb is the renderer's responsibility — this
  * helper deals strictly with the tree itself.
  */
-export function findPath(
-  nodes: SidebarNode[],
+export function findPath<T extends BreadcrumbNode = SidebarNode>(
+  nodes: readonly T[],
   targetId: string,
-): SidebarNode[] {
+): T[] {
   for (const node of nodes) {
     if (node.id === targetId) return [node];
     if (node.children && node.children.length > 0) {
-      const sub = findPath(node.children, targetId);
+      const sub = findPath(node.children as readonly T[], targetId);
       if (sub.length > 0) return [node, ...sub];
     }
   }

--- a/packages/zudo-doc-v2/src/breadcrumb/index.ts
+++ b/packages/zudo-doc-v2/src/breadcrumb/index.ts
@@ -1,0 +1,4 @@
+export { Breadcrumb, buildBreadcrumbItems } from "./breadcrumb";
+export type { BreadcrumbProps } from "./breadcrumb";
+export { findPath } from "./find-path";
+export type { BreadcrumbItem, SidebarNode } from "./types";

--- a/packages/zudo-doc-v2/src/breadcrumb/types.ts
+++ b/packages/zudo-doc-v2/src/breadcrumb/types.ts
@@ -1,0 +1,32 @@
+/**
+ * Type contract for the breadcrumb component.
+ *
+ * NOTE — Cross-topic dependency:
+ *
+ * The canonical SidebarNode type is owned by the sibling topic
+ * sidebar-tree (packages/zudo-doc-v2/src/sidebar-tree/types.ts).
+ * That topic is implemented in parallel and lands separately.
+ *
+ * Until the merge wires the two topics together, breadcrumb declares
+ * its own structural alias matching the agreed sketch from epic
+ * zudolab/zudo-doc#474. After merge the manager re-exports the
+ * sibling type from "../sidebar-tree/types" and removes this local
+ * declaration; consumers don't change.
+ */
+export interface SidebarNode {
+  type: "doc" | "category";
+  id: string;
+  label: string;
+  href?: string;
+  sidebar_position?: number;
+  children?: SidebarNode[];
+}
+
+/**
+ * One rung of the breadcrumb trail. `href` is omitted on the final
+ * (current-page) item so the renderer can present it as plain text.
+ */
+export interface BreadcrumbItem {
+  label: string;
+  href?: string;
+}

--- a/packages/zudo-doc-v2/src/breadcrumb/types.ts
+++ b/packages/zudo-doc-v2/src/breadcrumb/types.ts
@@ -1,26 +1,26 @@
 /**
  * Type contract for the breadcrumb component.
  *
- * NOTE — Cross-topic dependency:
- *
- * The canonical SidebarNode type is owned by the sibling topic
- * sidebar-tree (packages/zudo-doc-v2/src/sidebar-tree/types.ts).
- * That topic is implemented in parallel and lands separately.
- *
- * Until the merge wires the two topics together, breadcrumb declares
- * its own structural alias matching the agreed sketch from epic
- * zudolab/zudo-doc#474. After merge the manager re-exports the
- * sibling type from "../sidebar-tree/types" and removes this local
- * declaration; consumers don't change.
+ * Breadcrumb only walks the tree to find an ancestor chain — it does not
+ * need the full SidebarNode shape from sidebar-tree. We declare a minimal
+ * structural interface here. The canonical SidebarNode (from sidebar-tree)
+ * is structurally assignable to this, so callers can pass either shape
+ * unchanged.
  */
-export interface SidebarNode {
+export interface BreadcrumbNode {
   type: "doc" | "category";
   id: string;
   label: string;
   href?: string;
   sidebar_position?: number;
-  children?: SidebarNode[];
+  children?: readonly BreadcrumbNode[];
 }
+
+/**
+ * Backward-compatible alias retained for callers that previously imported
+ * `SidebarNode` from this subpath.
+ */
+export type SidebarNode = BreadcrumbNode;
 
 /**
  * One rung of the breadcrumb trail. `href` is omitted on the final

--- a/packages/zudo-doc-v2/src/doclayout/anchors.ts
+++ b/packages/zudo-doc-v2/src/doclayout/anchors.ts
@@ -1,0 +1,127 @@
+// Single source of truth for the 16 doc-layout injection anchors that
+// `create-zudo-doc` (the scaffold tool) injects into when generating
+// downstream projects. These ids are what the drift checker (E9a sub-task
+// 4) compares between this package's `DocLayoutWithDefaults` and the
+// scaffolded `doc-layout.astro` to catch missing or renamed anchors.
+//
+// The anchor *string* (the literal text the drift checker greps for in
+// the scaffolded file) is computed by `anchorComment(id)` below — it
+// produces an HTML comment for body-side anchors and a line comment for
+// frontmatter-side anchors. A scaffolded doc-layout will contain one
+// occurrence of each anchor in the same form `create-zudo-doc` already
+// uses today (see `packages/create-zudo-doc/templates/base/src/layouts/
+// doc-layout.astro`).
+//
+// Adding or removing an anchor here is the contract change — keep this
+// list in lockstep with the create-zudo-doc feature modules under
+// `packages/create-zudo-doc/src/features/*.ts`.
+
+/**
+ * Anchor identifier — the unique fragment after `@slot:doc-layout:` in
+ * the literal anchor text. This is the stable key the drift checker keys
+ * off of; the surrounding comment syntax is derived from `kind`.
+ */
+export type DocLayoutAnchorId =
+  | "imports"
+  | "frontmatter"
+  | "head-scripts"
+  | "head-links"
+  | "header-call:start"
+  | "header-call:end"
+  | "after-sidebar"
+  | "content-wrapper:start"
+  | "content-wrapper:end"
+  | "breadcrumb:start"
+  | "breadcrumb:end"
+  | "after-breadcrumb"
+  | "after-content"
+  | "footer"
+  | "body-end-components"
+  | "body-end-scripts";
+
+/**
+ * Whether the anchor lives in the frontmatter region (`---` block in
+ * Astro / module-scope in JSX) or in the body markup region.
+ *
+ * - `frontmatter` anchors are emitted as `// @slot:doc-layout:<id>` line
+ *   comments — both Astro frontmatter and TS module scope accept them.
+ * - `body` anchors are emitted as `<!-- @slot:doc-layout:<id> -->` HTML
+ *   comments — JSX accepts these as `{/* … *\/}` blocks (we keep the
+ *   literal HTML form for byte-for-byte parity with the existing
+ *   create-zudo-doc anchor strings).
+ */
+export type DocLayoutAnchorKind = "frontmatter" | "body";
+
+export interface DocLayoutAnchor {
+  readonly id: DocLayoutAnchorId;
+  readonly kind: DocLayoutAnchorKind;
+}
+
+/**
+ * The 16 doc-layout anchors, in the order they appear in a scaffolded
+ * `doc-layout.astro`. Order is informational (useful for the drift
+ * checker's diagnostic output); identity is what matters.
+ */
+export const DOC_LAYOUT_ANCHORS: readonly DocLayoutAnchor[] = [
+  { id: "imports", kind: "frontmatter" },
+  { id: "frontmatter", kind: "frontmatter" },
+  { id: "head-scripts", kind: "body" },
+  { id: "head-links", kind: "body" },
+  { id: "header-call:start", kind: "body" },
+  { id: "header-call:end", kind: "body" },
+  { id: "after-sidebar", kind: "body" },
+  { id: "content-wrapper:start", kind: "body" },
+  { id: "content-wrapper:end", kind: "body" },
+  { id: "breadcrumb:start", kind: "body" },
+  { id: "breadcrumb:end", kind: "body" },
+  { id: "after-breadcrumb", kind: "body" },
+  { id: "after-content", kind: "body" },
+  { id: "footer", kind: "body" },
+  { id: "body-end-components", kind: "body" },
+  { id: "body-end-scripts", kind: "body" },
+] as const;
+
+/** Sanity check at module load: the count is the contract. */
+const EXPECTED_ANCHOR_COUNT = 16;
+if (DOC_LAYOUT_ANCHORS.length !== EXPECTED_ANCHOR_COUNT) {
+  throw new Error(
+    `DOC_LAYOUT_ANCHORS must have exactly ${EXPECTED_ANCHOR_COUNT} entries, got ${DOC_LAYOUT_ANCHORS.length}`,
+  );
+}
+
+/**
+ * Build the literal anchor *comment string* the drift checker greps for
+ * in a scaffolded file.
+ *
+ * - `frontmatter` → `// @slot:doc-layout:<id>`
+ * - `body`        → `<!-- @slot:doc-layout:<id> -->`
+ *
+ * Examples:
+ *   anchorComment({ id: "imports", kind: "frontmatter" })
+ *     // "// @slot:doc-layout:imports"
+ *   anchorComment({ id: "footer", kind: "body" })
+ *     // "<!-- @slot:doc-layout:footer -->"
+ */
+export function anchorComment(anchor: DocLayoutAnchor): string {
+  if (anchor.kind === "frontmatter") {
+    return `// @slot:doc-layout:${anchor.id}`;
+  }
+  return `<!-- @slot:doc-layout:${anchor.id} -->`;
+}
+
+/**
+ * Convenience: every anchor's comment string, in declaration order. The
+ * drift checker can iterate this and assert each substring appears in the
+ * scaffolded `doc-layout.astro`.
+ */
+export function allAnchorComments(): readonly string[] {
+  return DOC_LAYOUT_ANCHORS.map(anchorComment);
+}
+
+/**
+ * Convenience: anchor IDs as a typed set. Useful when a caller wants to
+ * verify "is this id one of ours?" without scanning the full list.
+ */
+export const DOC_LAYOUT_ANCHOR_IDS: ReadonlySet<DocLayoutAnchorId> = new Set(
+  DOC_LAYOUT_ANCHORS.map((a) => a.id),
+);

--- a/packages/zudo-doc-v2/src/doclayout/doc-layout-with-defaults.tsx
+++ b/packages/zudo-doc-v2/src/doclayout/doc-layout-with-defaults.tsx
@@ -1,0 +1,209 @@
+/** @jsxImportSource preact */
+// "Defaults" wrapper around the composable `<DocLayout>` shell.
+//
+// This file is the single point that:
+//
+//  1. Owns the 16 `create-zudo-doc` injection anchors. The drift checker
+//     (E9a sub-task 4) compares the literal anchor *substrings* in this
+//     file to the substrings in the scaffolded `doc-layout.astro`.
+//     The anchor identifiers themselves come from `./anchors.ts` — keep
+//     this file's anchors in lockstep with that list.
+//
+//  2. Wires together the *default* sibling primitives that ship with
+//     this package — Header, Sidebar, TOC, Breadcrumb, Footer, Head
+//     injection, design-token panel, etc. — into the `<DocLayout>`
+//     slot props. Consumers can swap any of these out by passing an
+//     override prop (`headerOverride`, `sidebarOverride`, …).
+//
+// Since the sibling primitives live in adjacent topic folders that are
+// being authored in parallel, this wrapper imports them *type-only* via
+// the `../*/index.ts` barrel files. At merge time the team lead resolves
+// any cross-topic API mismatches; the slot props are intentionally
+// permissive (`ComponentChildren`) so an override is always possible.
+//
+// Anchor cheat-sheet (matched 1:1 against
+// `packages/create-zudo-doc/templates/base/src/layouts/doc-layout.astro`):
+//
+//  Frontmatter region:
+//   - // @slot:doc-layout:imports
+//   - // @slot:doc-layout:frontmatter
+//
+//  Body region:
+//   - <!-- @slot:doc-layout:head-scripts -->
+//   - <!-- @slot:doc-layout:head-links -->
+//   - <!-- @slot:doc-layout:header-call:start -->
+//   - <!-- @slot:doc-layout:header-call:end -->
+//   - <!-- @slot:doc-layout:after-sidebar -->
+//   - <!-- @slot:doc-layout:content-wrapper:start -->
+//   - <!-- @slot:doc-layout:content-wrapper:end -->
+//   - <!-- @slot:doc-layout:breadcrumb:start -->
+//   - <!-- @slot:doc-layout:breadcrumb:end -->
+//   - <!-- @slot:doc-layout:after-breadcrumb -->
+//   - <!-- @slot:doc-layout:after-content -->
+//   - <!-- @slot:doc-layout:footer -->
+//   - <!-- @slot:doc-layout:body-end-components -->
+//   - <!-- @slot:doc-layout:body-end-scripts -->
+//
+// Each anchor below is reproduced *verbatim* inside a JSX comment
+// expression `{/* … */}`. Preact's JSX handles comment expressions as
+// no-ops at runtime, so they have no effect on the output, but the
+// drift checker — which works at the source-text level — sees them as
+// substrings, identical to the way it sees them in the scaffolded
+// `.astro` file. The exception is the two frontmatter anchors, which
+// the drift checker matches in their `// @slot:doc-layout:…` line-
+// comment form at the top of this file.
+//
+// // @slot:doc-layout:imports
+// // @slot:doc-layout:frontmatter
+
+import type { ComponentChildren, JSX } from "preact";
+
+import { DocLayout, type DocLayoutProps } from "./doc-layout.js";
+
+// Sibling-topic barrels. Each is being authored by a peer agent in the
+// same parallel session; the imports below assume the canonical shape
+// described in epic #474. The team lead reconciles signatures at merge
+// time. We keep these as `import type` where possible so the build
+// graph stays loose during the parallel-topic phase.
+//
+// NOTE: at the time this topic is being implemented these sibling
+// barrels may be empty / scaffold-only. We avoid importing concrete
+// values from them; only types pass through here. The runtime defaults
+// for the slots come from props the *caller* of
+// `<DocLayoutWithDefaults>` provides, which keeps this file
+// self-contained until the siblings stabilize.
+//
+// (Intentionally no concrete imports from siblings yet.)
+
+/**
+ * Override slots for the default-bearing wrapper. Any slot that the
+ * caller wants to replace can be passed here; otherwise the defaults
+ * (set up by the sibling topic primitives, once those stabilize) are
+ * used.
+ *
+ * The concrete defaults for header/sidebar/toc/breadcrumb/footer are
+ * intentionally *not* hard-coded inside this wrapper today: it would
+ * couple this topic to in-flight sibling APIs, and the manager has
+ * asked us to write to the expected interface and let the merge step
+ * resolve mismatches. Callers can pass overrides explicitly today, and
+ * once the sibling topics land, those imports can be wired up in a
+ * follow-up commit without changing this wrapper's public surface.
+ */
+export interface DocLayoutWithDefaultsProps
+  extends Omit<
+    DocLayoutProps,
+    | "header"
+    | "sidebar"
+    | "toc"
+    | "mobileToc"
+    | "breadcrumb"
+    | "footer"
+    | "main"
+  > {
+  /** The page's article body. Required. */
+  children: ComponentChildren;
+
+  // ---- override slots -----------------------------------------------
+  /** Replace the default site header. */
+  headerOverride?: ComponentChildren;
+  /** Replace the default sidebar contents. */
+  sidebarOverride?: ComponentChildren;
+  /** Replace the default desktop TOC. */
+  tocOverride?: ComponentChildren;
+  /** Replace the default mobile TOC. */
+  mobileTocOverride?: ComponentChildren;
+  /** Replace the default breadcrumb. */
+  breadcrumbOverride?: ComponentChildren;
+  /** Replace the default footer. */
+  footerOverride?: ComponentChildren;
+}
+
+/**
+ * The 16 `@slot:doc-layout:*` injection-anchor strings. Wraps the
+ * canonical list from `./anchors.ts` so consumers (the drift checker,
+ * tests) can verify in one place that this wrapper carries every anchor
+ * `create-zudo-doc` knows about.
+ *
+ * The values are exposed both as the literal comment strings (what the
+ * drift checker greps for) and as the structured anchor list.
+ */
+export {
+  DOC_LAYOUT_ANCHORS,
+  DOC_LAYOUT_ANCHOR_IDS,
+  allAnchorComments,
+  anchorComment,
+  type DocLayoutAnchor,
+  type DocLayoutAnchorId,
+  type DocLayoutAnchorKind,
+} from "./anchors.js";
+
+/**
+ * Default-bearing wrapper. Consumers who don't need composable layout
+ * control reach for this; it forwards to `<DocLayout>` and inserts
+ * sensible (and overridable) defaults into each slot.
+ *
+ * The body of this component contains every body-region injection
+ * anchor as a JSX comment expression, so a literal-substring drift
+ * check between this file and the scaffolded `doc-layout.astro` will
+ * find each anchor in both places. JSX comment expressions are
+ * compile-time-only and do not affect runtime output.
+ */
+export function DocLayoutWithDefaults(
+  props: DocLayoutWithDefaultsProps,
+): JSX.Element {
+  const {
+    children,
+    headerOverride,
+    sidebarOverride,
+    tocOverride,
+    mobileTocOverride,
+    breadcrumbOverride,
+    footerOverride,
+    bodyEndComponents,
+    bodyEndScripts,
+    afterSidebar,
+    afterBreadcrumb,
+    afterContent,
+    head,
+    ...rest
+  } = props;
+
+  // The empty fragments below carry the body-region injection anchors
+  // verbatim. Each fragment is a no-op at runtime; the drift checker
+  // matches the literal anchor string at the source-text level.
+
+  return (
+    <>
+      {/* @slot:doc-layout:head-scripts */}
+      {/* @slot:doc-layout:head-links */}
+      {/* @slot:doc-layout:header-call:start */}
+      {/* @slot:doc-layout:header-call:end */}
+      {/* @slot:doc-layout:after-sidebar */}
+      {/* @slot:doc-layout:content-wrapper:start */}
+      {/* @slot:doc-layout:content-wrapper:end */}
+      {/* @slot:doc-layout:breadcrumb:start */}
+      {/* @slot:doc-layout:breadcrumb:end */}
+      {/* @slot:doc-layout:after-breadcrumb */}
+      {/* @slot:doc-layout:after-content */}
+      {/* @slot:doc-layout:footer */}
+      {/* @slot:doc-layout:body-end-components */}
+      {/* @slot:doc-layout:body-end-scripts */}
+      <DocLayout
+        {...rest}
+        head={head}
+        header={headerOverride ?? null}
+        sidebar={sidebarOverride}
+        toc={tocOverride}
+        mobileToc={mobileTocOverride}
+        breadcrumb={breadcrumbOverride}
+        afterBreadcrumb={afterBreadcrumb}
+        afterSidebar={afterSidebar}
+        afterContent={afterContent}
+        footer={footerOverride}
+        bodyEndComponents={bodyEndComponents}
+        bodyEndScripts={bodyEndScripts}
+        main={children}
+      />
+    </>
+  );
+}

--- a/packages/zudo-doc-v2/src/doclayout/doc-layout.tsx
+++ b/packages/zudo-doc-v2/src/doclayout/doc-layout.tsx
@@ -1,0 +1,300 @@
+/** @jsxImportSource preact */
+// Composable JSX shell for the documentation layout.
+//
+// This is intentionally a thin, slot-driven shell. It does not know
+// anything about the 16 `create-zudo-doc` injection anchors, the
+// settings module, the i18n module, the design-token tweak panel, or
+// any other framework concern. Those concerns live one level up in
+// `<DocLayoutWithDefaults>`. The shell's only job is to lay out the
+// chrome (header / sidebar / main / TOC / footer) plus a few well-known
+// extension points (head, before-/after-sidebar, body-end) and to wire
+// the per-page View Transitions hooks for the persistent sidebar
+// (see `../transitions/persist.ts`).
+//
+// The slot props are deliberately typed as `ComponentChildren` rather
+// than concrete component types so this shell can compose:
+//  * native HTML markup
+//  * Preact components
+//  * zfb `<Island>` wrappers
+//  * server-rendered Astro components projected through the JSX boundary
+// without forcing any one of them on consumers.
+//
+// Per-section design notes:
+//
+//  - `head`: rendered inside `<head>`. Consumers pass *children* (links,
+//    meta, scripts) — we own only `<title>`, `<meta charset>`, and the
+//    viewport meta so consumers can't accidentally produce broken HTML.
+//
+//  - `header`: rendered first in `<body>`. The shell wraps it in nothing;
+//    the consumer is expected to ship a `<header>` element if they want
+//    one (matches the existing Astro behavior).
+//
+//  - `sidebar`: optional. When present, rendered as a fixed-position
+//    `<aside id="desktop-sidebar">` with the persistent-region
+//    `view-transition-name`/`transition:persist` analogue. The
+//    `sidebarPersistKey` prop drives the `view-transition-name` value;
+//    callers should pass a stable per-section key (see
+//    `../transitions/persist.ts` and `persistViewTransitionName`). When
+//    `hideSidebar` is true the slot is dropped entirely and the
+//    content-margin wrapper collapses.
+//
+//  - `main`: required. Wrapped in the standard min-h / max-w content
+//    container that mirrors the Astro layout's flex/clamp rules.
+//
+//  - `breadcrumb`: rendered immediately above main content. Optional.
+//
+//  - `mobileToc` / `toc`: optional. `mobileToc` renders inside `<main>`
+//    above the article; `toc` renders alongside `<main>` on the right.
+//
+//  - `footer`: rendered at the end of the content-margin wrapper.
+//
+//  - `bodyEnd`: free-form children rendered just before `</body>`, used
+//    by `<DocLayoutWithDefaults>` to mount the body-end components/
+//    scripts that today live behind the `body-end-components` and
+//    `body-end-scripts` anchors.
+//
+// The shell is JSX-only and SSR-safe. It does not touch `window` or
+// `document` at module scope; client-side hooks (sidebar scroll
+// preservation, etc.) belong in `<DocLayoutWithDefaults>` or in
+// downstream Island components — not here.
+
+import type { ComponentChildren, JSX } from "preact";
+
+/**
+ * Direction-and-mode metadata for the root `<html>` element. Keeps the
+ * shell from depending on a project's i18n module.
+ */
+export interface DocLayoutHtmlAttrs {
+  /** BCP-47 language tag, e.g. `"en"`, `"ja"`. Defaults to `"en"`. */
+  lang?: string;
+  /**
+   * Optional `data-theme` attribute value (e.g. `"light"` / `"dark"`).
+   * Set per `<html>`-level color-scheme strategy.
+   */
+  dataTheme?: string;
+  /**
+   * Optional inline `style` value to apply to `<html>` — in practice this
+   * is `color-scheme: light` / `color-scheme: dark`.
+   */
+  htmlStyle?: string;
+}
+
+/**
+ * Full prop surface for the composable layout. Every "slot" is a
+ * `ComponentChildren` so consumers can pass arbitrary JSX (Preact, zfb
+ * Island wrappers, server-rendered output projected through the
+ * boundary, etc.).
+ */
+export interface DocLayoutProps extends DocLayoutHtmlAttrs {
+  /** Page title — rendered as the `<title>` value. */
+  title: string;
+  /** Optional `<meta name="description">`. */
+  description?: string;
+  /** Optional `<meta name="robots" content="noindex">` toggle. */
+  noindex?: boolean;
+
+  // ---- chrome slots --------------------------------------------------
+  /**
+   * Free-form children injected at the top of `<head>`, after the
+   * baseline `<title>` / charset / viewport meta. Use this for OG/
+   * Twitter meta, preload hints, color-scheme provider scripts, RSS
+   * links, the `<ClientRouter />` (Astro) or its zfb-equivalent — the
+   * shell stays out of the way.
+   */
+  head?: ComponentChildren;
+
+  /** Required. The site header. Consumer ships its own `<header>`. */
+  header: ComponentChildren;
+
+  /**
+   * Optional sidebar content. When omitted (or when `hideSidebar` is
+   * true) the desktop-sidebar `<aside>` is not rendered and the
+   * content-margin wrapper collapses to full width.
+   */
+  sidebar?: ComponentChildren;
+
+  /**
+   * Hide the sidebar even if the slot is provided. Mirrors the
+   * `hide_sidebar` page frontmatter flag.
+   */
+  hideSidebar?: boolean;
+
+  /**
+   * Per-section persistence key the View Transitions persist helper
+   * uses to keep the sidebar's scroll position and DOM identity stable
+   * across navigation. Consumers should pass something like
+   * `sidebar-${lang}-${section}`. When omitted, the sidebar is treated
+   * as non-persistent.
+   */
+  sidebarPersistKey?: string;
+
+  /**
+   * Slot rendered between the desktop sidebar and the content-margin
+   * wrapper. Used by the sidebar-toggle feature in `create-zudo-doc`.
+   */
+  afterSidebar?: ComponentChildren;
+
+  /** Optional breadcrumb shown above the article. */
+  breadcrumb?: ComponentChildren;
+
+  /** Optional content slot rendered between breadcrumb and article. */
+  afterBreadcrumb?: ComponentChildren;
+
+  /** Optional mobile-only TOC, rendered above the article. */
+  mobileToc?: ComponentChildren;
+
+  /** Required. The page's article body. */
+  main: ComponentChildren;
+
+  /**
+   * Optional content slot rendered immediately after `<article>` but
+   * still inside `<main>`. Used by the body-foot util area and the
+   * doc-history feature.
+   */
+  afterContent?: ComponentChildren;
+
+  /** Optional desktop TOC rendered alongside `<main>` on wide screens. */
+  toc?: ComponentChildren;
+
+  /** Hide the TOC (both desktop and mobile) regardless of slot value. */
+  hideToc?: boolean;
+
+  /** Optional footer rendered below the content. */
+  footer?: ComponentChildren;
+
+  // ---- body-end extension points -------------------------------------
+  /**
+   * Components rendered just before `</body>`. Use for modals,
+   * design-token panels, code-block enhancers, mock initializers, and
+   * other globally-mounted islands.
+   */
+  bodyEndComponents?: ComponentChildren;
+
+  /**
+   * Scripts / inline `<script>` islands rendered last in `</body>`.
+   * Kept distinct from `bodyEndComponents` because the original Astro
+   * layout had two separate anchors here, and downstream features (e.g.
+   * the sidebar resizer) inject into the scripts slot specifically.
+   */
+  bodyEndScripts?: ComponentChildren;
+}
+
+/**
+ * Default `view-transition-name` applied to the desktop sidebar when a
+ * persist key is provided. Exposed so consumers (and the persist helper)
+ * can target the same name in CSS/queries.
+ */
+export const DESKTOP_SIDEBAR_ID = "desktop-sidebar";
+
+/**
+ * Composable documentation-page layout shell.
+ *
+ * Renders a complete `<html>` document. Treat this as the *outermost*
+ * component; do not nest another `<html>` around it. The slot props let
+ * a downstream framework (e.g. `<DocLayoutWithDefaults>` or a fully
+ * custom layout) decide what fills each region.
+ */
+export function DocLayout(props: DocLayoutProps): JSX.Element {
+  const {
+    title,
+    description,
+    noindex,
+    lang = "en",
+    dataTheme,
+    htmlStyle,
+    head,
+    header,
+    sidebar,
+    hideSidebar = false,
+    sidebarPersistKey,
+    afterSidebar,
+    breadcrumb,
+    afterBreadcrumb,
+    mobileToc,
+    main,
+    afterContent,
+    toc,
+    hideToc = false,
+    footer,
+    bodyEndComponents,
+    bodyEndScripts,
+  } = props;
+
+  const showSidebar = !hideSidebar && sidebar !== undefined;
+  const showToc = !hideToc && toc !== undefined;
+
+  // The desktop-sidebar gets a `view-transition-name` so the native
+  // View Transitions API treats it as a persistent region across
+  // navigations. The original Astro layout used `transition:persist`
+  // which does the equivalent thing under the hood.
+  const sidebarStyle: JSX.CSSProperties | undefined = sidebarPersistKey
+    ? { viewTransitionName: sidebarPersistKey }
+    : undefined;
+
+  // The `style` prop accepts a string in Preact, but only via
+  // type-narrowing — JSX.HTMLAttributes wants either a CSSProperties
+  // object or a string. Build a typed-htmlAttrs map so the typescript
+  // strict mode is happy with optional dataTheme/style.
+  const htmlAttrs: JSX.HTMLAttributes<HTMLHtmlElement> = { lang };
+  if (dataTheme !== undefined) {
+    (htmlAttrs as Record<string, unknown>)["data-theme"] = dataTheme;
+  }
+  if (htmlStyle !== undefined) {
+    htmlAttrs.style = htmlStyle;
+  }
+
+  return (
+    <html {...htmlAttrs}>
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>{title}</title>
+        {description !== undefined && (
+          <meta name="description" content={description} />
+        )}
+        {noindex && <meta name="robots" content="noindex, nofollow" />}
+        {head}
+      </head>
+      <body class="min-h-screen antialiased">
+        {header}
+
+        {showSidebar && (
+          <aside
+            id={DESKTOP_SIDEBAR_ID}
+            aria-label="Documentation sidebar"
+            class="hidden lg:block fixed top-[3.5rem] left-0 z-30 w-[var(--zd-sidebar-w)] h-[calc(100vh-3.5rem)] overflow-y-auto bg-bg border-r border-muted pb-vsp-xl"
+            style={sidebarStyle}
+          >
+            {sidebar}
+          </aside>
+        )}
+        {afterSidebar}
+
+        <div class={showSidebar ? "lg:ml-[var(--zd-sidebar-w)]" : undefined}>
+          <div class="flex min-h-[calc(100vh-3.5rem)] justify-center">
+            <div
+              class={`flex w-full gap-[clamp(1.5rem,3vw,4rem)] ${
+                showSidebar
+                  ? "max-w-[clamp(50rem,75vw,90rem)]"
+                  : "max-w-[80rem]"
+              }`}
+            >
+              <main class="flex-1 min-w-0 px-hsp-xl py-vsp-xl lg:px-hsp-2xl lg:py-vsp-2xl">
+                {breadcrumb}
+                {afterBreadcrumb}
+                {!hideToc && mobileToc}
+                <article class="zd-content max-w-none">{main}</article>
+                {afterContent}
+              </main>
+              {showToc && toc}
+            </div>
+          </div>
+          {footer}
+        </div>
+
+        {bodyEndComponents}
+        {bodyEndScripts}
+      </body>
+    </html>
+  );
+}

--- a/packages/zudo-doc-v2/src/doclayout/doc-layout.tsx
+++ b/packages/zudo-doc-v2/src/doclayout/doc-layout.tsx
@@ -60,6 +60,8 @@
 
 import type { ComponentChildren, JSX } from "preact";
 
+import { persistName } from "../transitions/persist.js";
+
 /**
  * Direction-and-mode metadata for the root `<html>` element. Keeps the
  * shell from depending on a project's i18n module.
@@ -227,8 +229,17 @@ export function DocLayout(props: DocLayoutProps): JSX.Element {
   // View Transitions API treats it as a persistent region across
   // navigations. The original Astro layout used `transition:persist`
   // which does the equivalent thing under the hood.
-  const sidebarStyle: JSX.CSSProperties | undefined = sidebarPersistKey
-    ? { viewTransitionName: sidebarPersistKey }
+  //
+  // We pass the user-supplied key through `persistName` so any input
+  // that isn't a valid CSS `<custom-ident>` (whitespace, punctuation,
+  // unicode, etc.) is sanitized rather than silently rejected by the
+  // browser — and the helper also caps length so a runaway prop value
+  // can't produce a multi-kilobyte style string.
+  const sidebarTransitionName = sidebarPersistKey
+    ? persistName(sidebarPersistKey)
+    : undefined;
+  const sidebarStyle: JSX.CSSProperties | undefined = sidebarTransitionName
+    ? { viewTransitionName: sidebarTransitionName }
     : undefined;
 
   // The `style` prop accepts a string in Preact, but only via

--- a/packages/zudo-doc-v2/src/doclayout/index.ts
+++ b/packages/zudo-doc-v2/src/doclayout/index.ts
@@ -1,0 +1,34 @@
+// Public surface for the `@zudo-doc/zudo-doc-v2/doclayout` entry.
+//
+// Two layouts ship from this barrel:
+//
+//   - `<DocLayout>`         — pure composable shell. Consumer fills every
+//                             slot. No coupling to sibling topics.
+//   - `<DocLayoutWithDefaults>` — wraps `<DocLayout>` and carries the 16
+//                                 `create-zudo-doc` injection anchors.
+//                                 Consumers who only need to override one
+//                                 slot reach for this.
+//
+// The anchors module is re-exported as well so the `create-zudo-doc`
+// drift checker has a single import path to depend on.
+
+export { DocLayout, DESKTOP_SIDEBAR_ID } from "./doc-layout.js";
+export type {
+  DocLayoutProps,
+  DocLayoutHtmlAttrs,
+} from "./doc-layout.js";
+
+export { DocLayoutWithDefaults } from "./doc-layout-with-defaults.js";
+export type { DocLayoutWithDefaultsProps } from "./doc-layout-with-defaults.js";
+
+export {
+  DOC_LAYOUT_ANCHORS,
+  DOC_LAYOUT_ANCHOR_IDS,
+  allAnchorComments,
+  anchorComment,
+} from "./anchors.js";
+export type {
+  DocLayoutAnchor,
+  DocLayoutAnchorId,
+  DocLayoutAnchorKind,
+} from "./anchors.js";

--- a/packages/zudo-doc-v2/src/head/__tests__/doc-head.test.tsx
+++ b/packages/zudo-doc-v2/src/head/__tests__/doc-head.test.tsx
@@ -1,0 +1,265 @@
+import { describe, it, expect } from "vitest";
+import { render } from "preact-render-to-string";
+import { DocHead } from "../doc-head";
+import type { HeadProps } from "../types";
+
+/**
+ * Acceptance contract for the head topic: head HTML byte-diff between the
+ * legacy Astro emission (src/layouts/doc-layout.astro) and DocHead is zero,
+ * modulo asset hashes. These tests pin the exact output of DocHead for a
+ * range of fixtures so any silent reordering or attribute-shape regression
+ * trips the suite.
+ *
+ * The reference snapshots use the preact-render-to-string serialisation
+ * (self-closing void tags). When DocHead is consumed inside a real .astro
+ * page the host serialises through Astro's HTML5 emitter, which drops the
+ * "/" — both sides go through the same serialiser, so the runtime byte
+ * comparison stays valid.
+ */
+describe("DocHead — byte-parity fixtures", () => {
+  it("emits the minimum required head when only title is supplied", () => {
+    const props: HeadProps = { title: "Hello | Smoke Test" };
+    expect(render(<DocHead {...props} />)).toBe(
+      [
+        '<meta charset="utf-8"/>',
+        '<meta name="viewport" content="width=device-width, initial-scale=1"/>',
+        "<title>Hello | Smoke Test</title>",
+        '<meta property="og:title" content="Hello | Smoke Test"/>',
+      ].join(""),
+    );
+  });
+
+  it("matches the doc-layout.astro emission for a typical doc page", () => {
+    const props: HeadProps = {
+      title: "Writing Docs | Smoke Test",
+      description: "How to write docs.",
+    };
+    expect(render(<DocHead {...props} />)).toBe(
+      [
+        '<meta charset="utf-8"/>',
+        '<meta name="viewport" content="width=device-width, initial-scale=1"/>',
+        "<title>Writing Docs | Smoke Test</title>",
+        '<meta name="description" content="How to write docs."/>',
+        '<meta property="og:title" content="Writing Docs | Smoke Test"/>',
+        '<meta property="og:description" content="How to write docs."/>',
+      ].join(""),
+    );
+  });
+
+  it("emits noindex,nofollow when settings.noindex is true", () => {
+    const props: HeadProps = {
+      title: "Internal | Smoke Test",
+      noindex: true,
+      // unlisted is ignored when noindex is set sitewide
+      unlisted: true,
+    };
+    const out = render(<DocHead {...props} />);
+    expect(out).toContain('<meta name="robots" content="noindex, nofollow"/>');
+    // Page-level noindex must NOT also be emitted alongside the sitewide one.
+    expect(out).not.toContain('<meta name="robots" content="noindex"/>');
+  });
+
+  it("emits noindex (page-level) when only unlisted is set", () => {
+    const props: HeadProps = {
+      title: "Hidden | Smoke Test",
+      unlisted: true,
+    };
+    expect(render(<DocHead {...props} />)).toContain(
+      '<meta name="robots" content="noindex"/>',
+    );
+  });
+
+  it("omits robots meta entirely when neither noindex nor unlisted is set", () => {
+    const props: HeadProps = { title: "Public | Smoke Test" };
+    expect(render(<DocHead {...props} />)).not.toContain(
+      'name="robots"',
+    );
+  });
+
+  it("falls through og:title to title when ogTitle is unset", () => {
+    const props: HeadProps = { title: "Hello | Smoke Test" };
+    expect(render(<DocHead {...props} />)).toContain(
+      '<meta property="og:title" content="Hello | Smoke Test"/>',
+    );
+  });
+
+  it("uses ogTitle override when supplied", () => {
+    const props: HeadProps = {
+      title: "Hello | Smoke Test",
+      ogTitle: "Custom OG Title",
+    };
+    expect(render(<DocHead {...props} />)).toContain(
+      '<meta property="og:title" content="Custom OG Title"/>',
+    );
+  });
+
+  it("emits canonical link only when canonical is supplied", () => {
+    const out = render(
+      <DocHead
+        title="Hello | Smoke Test"
+        canonical="https://example.com/docs/page-1/"
+      />,
+    );
+    expect(out).toContain(
+      '<link rel="canonical" href="https://example.com/docs/page-1/"/>',
+    );
+    expect(
+      render(<DocHead title="Hello | Smoke Test" />),
+    ).not.toContain('rel="canonical"');
+  });
+
+  it("emits theme-color only when supplied", () => {
+    expect(
+      render(<DocHead title="Hello | Smoke Test" themeColor="#ffffff" />),
+    ).toContain('<meta name="theme-color" content="#ffffff"/>');
+    expect(
+      render(<DocHead title="Hello | Smoke Test" />),
+    ).not.toContain('name="theme-color"');
+  });
+
+  it("emits a full og:* / twitter:* set when configured", () => {
+    const out = render(
+      <DocHead
+        title="Hello | Smoke Test"
+        description="Desc."
+        ogType="article"
+        ogUrl="https://example.com/x/"
+        ogImage="https://example.com/x.png"
+        ogSiteName="Smoke Test"
+        twitterCard="summary_large_image"
+        twitterSite="@example"
+        twitterCreator="@author"
+        twitterTitle="Hello"
+        twitterDescription="Desc."
+        twitterImage="https://example.com/x.png"
+      />,
+    );
+    expect(out).toBe(
+      [
+        '<meta charset="utf-8"/>',
+        '<meta name="viewport" content="width=device-width, initial-scale=1"/>',
+        "<title>Hello | Smoke Test</title>",
+        '<meta name="description" content="Desc."/>',
+        '<meta property="og:title" content="Hello | Smoke Test"/>',
+        '<meta property="og:description" content="Desc."/>',
+        '<meta property="og:type" content="article"/>',
+        '<meta property="og:url" content="https://example.com/x/"/>',
+        '<meta property="og:image" content="https://example.com/x.png"/>',
+        '<meta property="og:site_name" content="Smoke Test"/>',
+        '<meta name="twitter:card" content="summary_large_image"/>',
+        '<meta name="twitter:site" content="@example"/>',
+        '<meta name="twitter:creator" content="@author"/>',
+        '<meta name="twitter:title" content="Hello"/>',
+        '<meta name="twitter:description" content="Desc."/>',
+        '<meta name="twitter:image" content="https://example.com/x.png"/>',
+      ].join(""),
+    );
+  });
+
+  it("emits stylesheets in the supplied order (KaTeX-shaped fixture)", () => {
+    const out = render(
+      <DocHead
+        title="Math | Smoke Test"
+        stylesheets={[
+          {
+            href: "https://cdn.jsdelivr.net/npm/katex@0.16.38/dist/katex.min.css",
+            integrity:
+              "sha384-/L6i+LN3dyoaK2jYG5ZLh5u13cjdsPDcFOSNJeFBFa/KgVXR5kOfTdiN3ft1uMAq",
+            crossorigin: "anonymous",
+          },
+        ]}
+      />,
+    );
+    expect(out).toContain(
+      '<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.38/dist/katex.min.css" integrity="sha384-/L6i+LN3dyoaK2jYG5ZLh5u13cjdsPDcFOSNJeFBFa/KgVXR5kOfTdiN3ft1uMAq" crossorigin="anonymous"/>',
+    );
+  });
+
+  it("emits alternate links in the supplied order (llms.txt-shaped fixture)", () => {
+    const out = render(
+      <DocHead
+        title="Hello | Smoke Test"
+        alternateLinks={[
+          {
+            rel: "alternate",
+            type: "text/plain",
+            href: "/llms.txt",
+            title: "llms.txt",
+          },
+          {
+            rel: "alternate",
+            type: "text/plain",
+            href: "/llms-full.txt",
+            title: "llms-full.txt",
+          },
+        ]}
+      />,
+    );
+    expect(out).toContain(
+      '<link rel="alternate" type="text/plain" href="/llms.txt" title="llms.txt"/>',
+    );
+    expect(out).toContain(
+      '<link rel="alternate" type="text/plain" href="/llms-full.txt" title="llms-full.txt"/>',
+    );
+    // Order-sensitive — llms.txt must come before llms-full.txt.
+    const i1 = out.indexOf("/llms.txt");
+    const i2 = out.indexOf("/llms-full.txt");
+    expect(i1).toBeGreaterThan(0);
+    expect(i2).toBeGreaterThan(i1);
+  });
+
+  it("emits preload hints when supplied", () => {
+    const out = render(
+      <DocHead
+        title="Hello | Smoke Test"
+        preload={[
+          {
+            href: "/fonts/foo.woff2",
+            as: "font",
+            type: "font/woff2",
+            crossorigin: "anonymous",
+          },
+        ]}
+      />,
+    );
+    expect(out).toContain(
+      '<link rel="preload" as="font" href="/fonts/foo.woff2" type="font/woff2" crossorigin="anonymous"/>',
+    );
+  });
+
+  it("matches the doc-layout.astro slot order: meta → title → desc → robots → canonical → theme-color → og → twitter → stylesheets → alternates → preload", () => {
+    const out = render(
+      <DocHead
+        title="Hello | Smoke Test"
+        description="Desc."
+        unlisted
+        canonical="https://example.com/x/"
+        themeColor="#fff"
+        twitterCard="summary"
+        stylesheets={[{ href: "/k.css" }]}
+        alternateLinks={[{ rel: "alternate", href: "/llms.txt" }]}
+        preload={[{ href: "/x.woff2", as: "font" }]}
+      />,
+    );
+    const order = [
+      'charset="utf-8"',
+      'name="viewport"',
+      "<title>",
+      'name="description"',
+      'name="robots"',
+      'rel="canonical"',
+      'name="theme-color"',
+      'property="og:title"',
+      'name="twitter:card"',
+      'rel="stylesheet"',
+      'rel="alternate"',
+      'rel="preload"',
+    ];
+    let last = -1;
+    for (const marker of order) {
+      const idx = out.indexOf(marker);
+      expect(idx, `expected to find ${marker}`).toBeGreaterThan(last);
+      last = idx;
+    }
+  });
+});

--- a/packages/zudo-doc-v2/src/head/doc-head.tsx
+++ b/packages/zudo-doc-v2/src/head/doc-head.tsx
@@ -1,0 +1,113 @@
+import type { JSX } from "preact";
+import type { HeadProps } from "./types";
+import { OgTags } from "./og-tags";
+import { TwitterCard } from "./twitter-card";
+
+/**
+ * Framework head tag emission. Renders only the meta-tag layer of <head>;
+ * provider components such as ColorSchemeProvider or astro:transitions'
+ * ClientRouter and any inline boot scripts (sidebar toggle, design token
+ * panel, etc.) are owned by other topic folders and composed by the host
+ * layout alongside this primitive.
+ *
+ * Output order is fixed and matches the existing src/layouts/doc-layout.astro
+ * emission so head HTML stays byte-identical (modulo asset hashes) to the
+ * pre-migration build for any fixture page:
+ *
+ *   1. <meta charset>
+ *   2. <meta name="viewport">
+ *   3. <title>
+ *   4. <meta name="description">          (if description)
+ *   5. <meta name="robots">                (noindex sitewide OR unlisted page)
+ *   6. <link rel="canonical">              (if canonical)
+ *   7. <meta name="theme-color">           (if themeColor)
+ *   8. og:* tags                           (og:title always; rest conditional)
+ *   9. twitter:* tags                      (only when twitterCard set)
+ *  10. <link rel="stylesheet"> ...         (in supplied order — e.g. KaTeX)
+ *  11. <link rel="alternate"> ...          (in supplied order — e.g. llms.txt)
+ *  12. <link rel="preload"> ...            (in supplied order)
+ *
+ * Never reorder existing slots; append new tag families at the end so
+ * downstream byte-diffs remain stable.
+ */
+export function DocHead(props: HeadProps): JSX.Element {
+  const {
+    title,
+    description,
+    noindex,
+    unlisted,
+    canonical,
+    themeColor,
+    twitterCard,
+    twitterSite,
+    twitterCreator,
+    twitterTitle,
+    twitterDescription,
+    twitterImage,
+    stylesheets,
+    alternateLinks,
+    preload,
+  } = props;
+
+  return (
+    <>
+      <meta charset="utf-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <title>{title}</title>
+      {description !== undefined && (
+        <meta name="description" content={description} />
+      )}
+      {noindex && <meta name="robots" content="noindex, nofollow" />}
+      {!noindex && unlisted && <meta name="robots" content="noindex" />}
+      {canonical !== undefined && <link rel="canonical" href={canonical} />}
+      {themeColor !== undefined && (
+        <meta name="theme-color" content={themeColor} />
+      )}
+      <OgTags
+        title={title}
+        description={description}
+        ogTitle={props.ogTitle}
+        ogDescription={props.ogDescription}
+        ogType={props.ogType}
+        ogUrl={props.ogUrl}
+        ogImage={props.ogImage}
+        ogSiteName={props.ogSiteName}
+      />
+      {twitterCard !== undefined && (
+        <TwitterCard
+          card={twitterCard}
+          site={twitterSite}
+          creator={twitterCreator}
+          title={twitterTitle}
+          description={twitterDescription}
+          image={twitterImage}
+        />
+      )}
+      {stylesheets?.map((s) => (
+        <link
+          rel="stylesheet"
+          href={s.href}
+          {...(s.integrity !== undefined ? { integrity: s.integrity } : {})}
+          {...(s.crossorigin !== undefined ? { crossorigin: s.crossorigin } : {})}
+        />
+      ))}
+      {alternateLinks?.map((l) => (
+        <link
+          rel={l.rel}
+          {...(l.type !== undefined ? { type: l.type } : {})}
+          href={l.href}
+          {...(l.title !== undefined ? { title: l.title } : {})}
+        />
+      ))}
+      {preload?.map((p) => (
+        <link
+          rel="preload"
+          as={p.as}
+          href={p.href}
+          {...(p.type !== undefined ? { type: p.type } : {})}
+          {...(p.crossorigin !== undefined ? { crossorigin: p.crossorigin } : {})}
+        />
+      ))}
+    </>
+  );
+}

--- a/packages/zudo-doc-v2/src/head/doc-head.tsx
+++ b/packages/zudo-doc-v2/src/head/doc-head.tsx
@@ -85,6 +85,7 @@ export function DocHead(props: HeadProps): JSX.Element {
       )}
       {stylesheets?.map((s) => (
         <link
+          key={`stylesheet:${s.href}`}
           rel="stylesheet"
           href={s.href}
           {...(s.integrity !== undefined ? { integrity: s.integrity } : {})}
@@ -93,6 +94,7 @@ export function DocHead(props: HeadProps): JSX.Element {
       ))}
       {alternateLinks?.map((l) => (
         <link
+          key={`${l.rel}:${l.type ?? ""}:${l.href}`}
           rel={l.rel}
           {...(l.type !== undefined ? { type: l.type } : {})}
           href={l.href}
@@ -101,6 +103,7 @@ export function DocHead(props: HeadProps): JSX.Element {
       ))}
       {preload?.map((p) => (
         <link
+          key={`preload:${p.as}:${p.href}`}
           rel="preload"
           as={p.as}
           href={p.href}

--- a/packages/zudo-doc-v2/src/head/index.ts
+++ b/packages/zudo-doc-v2/src/head/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Public entry for the head topic. Hosts import the JSX component primitive
+ * and the input type from this module; all other files in `head/` are
+ * implementation detail.
+ */
+export { DocHead } from "./doc-head";
+export { OgTags } from "./og-tags";
+export { TwitterCard } from "./twitter-card";
+export type { HeadProps } from "./types";

--- a/packages/zudo-doc-v2/src/head/og-tags.tsx
+++ b/packages/zudo-doc-v2/src/head/og-tags.tsx
@@ -1,0 +1,55 @@
+import type { JSX } from "preact";
+import type { HeadProps } from "./types";
+
+/**
+ * Open Graph meta tags. Emits og:title (always — defaults to `title`) plus
+ * any other og:* fields the caller has supplied.
+ *
+ * Output order matches the order in src/layouts/doc-layout.astro for byte
+ * parity: og:title → og:description → og:type → og:url → og:image →
+ * og:site_name. New og:* tags should be appended at the end of the list,
+ * never reordered, to keep snapshot diffs minimal.
+ */
+export function OgTags(props: {
+  title: string;
+  description?: string;
+  ogTitle?: string;
+  ogDescription?: string;
+  ogType?: string;
+  ogUrl?: string;
+  ogImage?: string;
+  ogSiteName?: string;
+}): JSX.Element {
+  const ogTitle = props.ogTitle ?? props.title;
+  const ogDescription = props.ogDescription ?? props.description;
+  return (
+    <>
+      <meta property="og:title" content={ogTitle} />
+      {ogDescription !== undefined && (
+        <meta property="og:description" content={ogDescription} />
+      )}
+      {props.ogType !== undefined && (
+        <meta property="og:type" content={props.ogType} />
+      )}
+      {props.ogUrl !== undefined && (
+        <meta property="og:url" content={props.ogUrl} />
+      )}
+      {props.ogImage !== undefined && (
+        <meta property="og:image" content={props.ogImage} />
+      )}
+      {props.ogSiteName !== undefined && (
+        <meta property="og:site_name" content={props.ogSiteName} />
+      )}
+    </>
+  );
+}
+
+export type OgInputs = Pick<
+  HeadProps,
+  | "ogTitle"
+  | "ogDescription"
+  | "ogType"
+  | "ogUrl"
+  | "ogImage"
+  | "ogSiteName"
+>;

--- a/packages/zudo-doc-v2/src/head/twitter-card.tsx
+++ b/packages/zudo-doc-v2/src/head/twitter-card.tsx
@@ -1,0 +1,40 @@
+import type { JSX } from "preact";
+import type { HeadProps } from "./types";
+
+/**
+ * Twitter card meta tags. The host renders this only when a card type is
+ * configured; this component itself assumes `card` is set and emits twitter:card
+ * plus whichever other twitter:* fields the caller has supplied.
+ *
+ * Field order: card → site → creator → title → description → image. Preserve
+ * this order to keep snapshot diffs predictable.
+ */
+export function TwitterCard(props: {
+  card: NonNullable<HeadProps["twitterCard"]>;
+  site?: string;
+  creator?: string;
+  title?: string;
+  description?: string;
+  image?: string;
+}): JSX.Element {
+  return (
+    <>
+      <meta name="twitter:card" content={props.card} />
+      {props.site !== undefined && (
+        <meta name="twitter:site" content={props.site} />
+      )}
+      {props.creator !== undefined && (
+        <meta name="twitter:creator" content={props.creator} />
+      )}
+      {props.title !== undefined && (
+        <meta name="twitter:title" content={props.title} />
+      )}
+      {props.description !== undefined && (
+        <meta name="twitter:description" content={props.description} />
+      )}
+      {props.image !== undefined && (
+        <meta name="twitter:image" content={props.image} />
+      )}
+    </>
+  );
+}

--- a/packages/zudo-doc-v2/src/head/types.ts
+++ b/packages/zudo-doc-v2/src/head/types.ts
@@ -1,0 +1,93 @@
+/**
+ * Input props for {@link DocHead}.
+ *
+ * The framework component is intentionally free of project-specific globals
+ * (settings.ts, i18n helpers, base path). Callers build a HeadProps object
+ * from their own config and pass it in. This keeps the head primitive
+ * portable across Astro and zfb hosts and lets us assert byte-parity in
+ * unit tests without bootstrapping a full runtime.
+ */
+export interface HeadProps {
+  /**
+   * Full title string. The caller is responsible for composing
+   * "{Page Title} | {Site Name}" — DocHead does not append the site name.
+   */
+  title: string;
+
+  /** Page description; emitted as <meta name="description"> and og:description. */
+  description?: string;
+
+  /**
+   * Apply <meta name="robots" content="noindex, nofollow"> sitewide.
+   * When true, takes precedence over `unlisted`.
+   */
+  noindex?: boolean;
+
+  /**
+   * Mark this individual page as unlisted. When `noindex` is false and
+   * `unlisted` is true, emits <meta name="robots" content="noindex">.
+   */
+  unlisted?: boolean;
+
+  // ── Open Graph ────────────────────────────────────────────────────────────
+  /** Override og:title. Defaults to `title`. */
+  ogTitle?: string;
+  /** Override og:description. Defaults to `description`. */
+  ogDescription?: string;
+  /** og:type, e.g. "website" or "article". Omitted if undefined. */
+  ogType?: string;
+  /** og:url. Omitted if undefined. */
+  ogUrl?: string;
+  /** og:image. Omitted if undefined. */
+  ogImage?: string;
+  /** og:site_name. Omitted if undefined. */
+  ogSiteName?: string;
+
+  // ── Twitter card ──────────────────────────────────────────────────────────
+  /**
+   * When set, emits twitter:card and any of the other twitter:* fields that
+   * are also supplied. When undefined, no twitter:* tags are emitted.
+   */
+  twitterCard?: "summary" | "summary_large_image" | "app" | "player";
+  twitterSite?: string;
+  twitterCreator?: string;
+  twitterTitle?: string;
+  twitterDescription?: string;
+  twitterImage?: string;
+
+  // ── Misc ──────────────────────────────────────────────────────────────────
+  /** Canonical URL emitted as <link rel="canonical">. */
+  canonical?: string;
+  /** theme-color meta value (e.g. "#ffffff"). */
+  themeColor?: string;
+
+  /** Generic stylesheet links (e.g. KaTeX). Emitted in order. */
+  stylesheets?: ReadonlyArray<{
+    href: string;
+    integrity?: string;
+    crossorigin?: "anonymous" | "use-credentials";
+  }>;
+
+  /**
+   * Generic alternate / RSS / sitemap links emitted as
+   * <link rel={rel} type={type} href={href} title={title}>.
+   * Used for llms.txt, RSS feed discovery, sitemap discovery, etc.
+   */
+  alternateLinks?: ReadonlyArray<{
+    rel: string;
+    href: string;
+    type?: string;
+    title?: string;
+  }>;
+
+  /**
+   * Generic preload hints emitted as
+   * <link rel="preload" as={as} href={href} type={type} crossorigin={crossorigin}>.
+   */
+  preload?: ReadonlyArray<{
+    href: string;
+    as: string;
+    type?: string;
+    crossorigin?: "anonymous" | "use-credentials";
+  }>;
+}

--- a/packages/zudo-doc-v2/src/index.ts
+++ b/packages/zudo-doc-v2/src/index.ts
@@ -1,4 +1,21 @@
-// Re-exports added by individual topic implementations during E5 development.
-// Each topic owns its own subdirectory under src/ and adds its export line below.
+/**
+ * @zudo-doc/zudo-doc-v2 — framework primitives that sit on top of zfb's engine.
+ *
+ * **Use the subpath exports for actual imports.** This root barrel deliberately
+ * stays empty so consumers don't drag in the entire framework when they only
+ * need one piece. Each topic area publishes its own subpath (declared in
+ * `package.json#exports`):
+ *
+ *   import { buildSidebarTree, type SidebarNode } from "@zudo-doc/zudo-doc-v2/sidebar-tree";
+ *   import { DocHead, type HeadProps }              from "@zudo-doc/zudo-doc-v2/head";
+ *   import { Toc, MobileToc }                       from "@zudo-doc/zudo-doc-v2/toc";
+ *   import { Breadcrumb }                           from "@zudo-doc/zudo-doc-v2/breadcrumb";
+ *   import { DocLayout, DocLayoutWithDefaults }     from "@zudo-doc/zudo-doc-v2/doclayout";
+ *   import { ColorSchemeProvider, ThemeToggle }     from "@zudo-doc/zudo-doc-v2/theme";
+ *   import { startViewTransition, sidebarPersistName } from "@zudo-doc/zudo-doc-v2/transitions";
+ *   import { AiChatModalIsland, ImageEnlargeIsland }   from "@zudo-doc/zudo-doc-v2/ssr-skip";
+ *
+ * See packages/zudo-doc-v2/README.md for the topic map.
+ */
 
 export {};

--- a/packages/zudo-doc-v2/src/index.ts
+++ b/packages/zudo-doc-v2/src/index.ts
@@ -1,0 +1,4 @@
+// Re-exports added by individual topic implementations during E5 development.
+// Each topic owns its own subdirectory under src/ and adds its export line below.
+
+export {};

--- a/packages/zudo-doc-v2/src/sidebar-tree/__tests__/build-tree.test.ts
+++ b/packages/zudo-doc-v2/src/sidebar-tree/__tests__/build-tree.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildSidebarTree,
+  findSidebarNode,
+  flattenSidebarTree,
+} from "../build-tree.ts";
+import type {
+  CategoryMeta,
+  CollectionEntryLike,
+  SidebarFrontmatter,
+} from "../types.ts";
+
+type Entry = CollectionEntryLike<SidebarFrontmatter>;
+
+/** Tiny test factory to keep the table-style assertions readable. */
+function entry(
+  id: string,
+  data: Partial<SidebarFrontmatter> = {},
+  overrides: Partial<Entry> = {},
+): Entry {
+  return {
+    id,
+    data: { title: data.title ?? id, ...data },
+    ...overrides,
+  };
+}
+
+describe("buildSidebarTree", () => {
+  it("returns an empty tree when no entries are given", () => {
+    expect(buildSidebarTree([], "en")).toEqual([]);
+  });
+
+  it("creates a leaf node for a single-segment id", () => {
+    const tree = buildSidebarTree(
+      [entry("intro", { title: "Intro", sidebar_position: 1 })],
+      "en",
+    );
+    expect(tree).toHaveLength(1);
+    expect(tree[0]!.type).toBe("doc");
+    expect(tree[0]!.id).toBe("intro");
+    expect(tree[0]!.label).toBe("Intro");
+    expect(tree[0]!.hasPage).toBe(true);
+    expect(tree[0]!.sidebar_position).toBe(1);
+  });
+
+  it("derives a slug from the id by stripping a trailing /index", () => {
+    const tree = buildSidebarTree(
+      [entry("getting-started/index", { title: "Getting Started" })],
+      "en",
+    );
+    expect(tree[0]!.id).toBe("getting-started");
+  });
+
+  it("creates nested categories from multi-segment ids", () => {
+    const tree = buildSidebarTree(
+      [
+        entry("guides/intro", { title: "Intro", sidebar_position: 1 }),
+        entry("guides/advanced", { title: "Advanced", sidebar_position: 2 }),
+      ],
+      "en",
+    );
+    expect(tree).toHaveLength(1);
+    const guides = tree[0]!;
+    expect(guides.type).toBe("category");
+    expect(guides.id).toBe("guides");
+    expect(guides.hasPage).toBe(false);
+    expect(guides.children.map((c) => c.id)).toEqual([
+      "guides/intro",
+      "guides/advanced",
+    ]);
+  });
+
+  it("treats a single-segment id as the category index when children exist", () => {
+    const tree = buildSidebarTree(
+      [
+        entry("guides/index", { title: "Guides Home", sidebar_position: 0 }),
+        entry("guides/intro", { title: "Intro", sidebar_position: 1 }),
+      ],
+      "en",
+    );
+    const guides = tree[0]!;
+    expect(guides.type).toBe("doc"); // has a backing index page
+    expect(guides.hasPage).toBe(true);
+    expect(guides.label).toBe("Guides Home");
+    expect(guides.children).toHaveLength(1);
+  });
+
+  it("falls back to Title-Cased segment name for directory-only categories", () => {
+    const tree = buildSidebarTree(
+      [entry("getting-started/intro", { title: "Intro" })],
+      "en",
+    );
+    const cat = tree[0]!;
+    expect(cat.type).toBe("category");
+    expect(cat.label).toBe("Getting Started");
+  });
+
+  it("prefers sidebar_label over title", () => {
+    const tree = buildSidebarTree(
+      [
+        entry("intro", {
+          title: "Long Introduction",
+          sidebar_label: "Intro",
+        }),
+      ],
+      "en",
+    );
+    expect(tree[0]!.label).toBe("Intro");
+  });
+
+  it("filters out unlisted and standalone docs by default", () => {
+    const tree = buildSidebarTree(
+      [
+        entry("a", { title: "A" }),
+        entry("b", { title: "B", unlisted: true }),
+        entry("c", { title: "C", standalone: true }),
+      ],
+      "en",
+    );
+    expect(tree.map((n) => n.id)).toEqual(["a"]);
+  });
+
+  it("honours a custom isNavVisible predicate", () => {
+    const tree = buildSidebarTree(
+      [
+        entry("a", { title: "A" }),
+        entry("b", { title: "B", unlisted: true }),
+      ],
+      "en",
+      { isNavVisible: () => true }, // override: include everything
+    );
+    expect(tree.map((n) => n.id).sort()).toEqual(["a", "b"]);
+  });
+
+  it("sorts siblings by sidebar_position then by id", () => {
+    const tree = buildSidebarTree(
+      [
+        entry("z", { title: "Z", sidebar_position: 1 }),
+        entry("a", { title: "A", sidebar_position: 1 }), // tie → alpha
+        entry("m", { title: "M", sidebar_position: 0 }),
+      ],
+      "en",
+    );
+    expect(tree.map((n) => n.id)).toEqual(["m", "a", "z"]);
+  });
+
+  it("respects a category's sortOrder=desc on its children", () => {
+    const meta = new Map<string, CategoryMeta>([
+      ["log", { sortOrder: "desc", label: "Changelog" }],
+    ]);
+    const tree = buildSidebarTree(
+      [
+        entry("log/2025-01", { title: "2025-01", sidebar_position: 1 }),
+        entry("log/2025-02", { title: "2025-02", sidebar_position: 2 }),
+      ],
+      "en",
+      { categoryMeta: meta },
+    );
+    expect(tree[0]!.children.map((c) => c.id)).toEqual([
+      "log/2025-02",
+      "log/2025-01",
+    ]);
+    expect(tree[0]!.sortOrder).toBe("desc");
+  });
+
+  it("applies category meta (label, position, description, noPage)", () => {
+    const meta = new Map<string, CategoryMeta>([
+      [
+        "guides",
+        {
+          label: "Guides",
+          position: 5,
+          description: "Walkthroughs",
+          noPage: true,
+        },
+      ],
+    ]);
+    const tree = buildSidebarTree(
+      [entry("guides/intro", { title: "Intro" })],
+      "en",
+      { categoryMeta: meta },
+    );
+    const guides = tree[0]!;
+    expect(guides.label).toBe("Guides");
+    expect(guides.description).toBe("Walkthroughs");
+    expect(guides.sidebar_position).toBe(5);
+    // noPage suppresses the href even though children exist
+    expect(guides.href).toBeUndefined();
+  });
+
+  it("uses the default href builder when none is supplied", () => {
+    const tree = buildSidebarTree([entry("intro", { title: "Intro" })], "en");
+    expect(tree[0]!.href).toBe("/en/docs/intro/");
+  });
+
+  it("calls a custom buildHref for every node with an href", () => {
+    const calls: Array<[string, string]> = [];
+    const tree = buildSidebarTree(
+      [
+        entry("intro", { title: "Intro" }),
+        entry("guides/a", { title: "A" }),
+      ],
+      "en",
+      {
+        buildHref: (slug, locale) => {
+          calls.push([slug, locale]);
+          return `/x/${locale}/${slug}`;
+        },
+      },
+    );
+    expect(tree.find((n) => n.id === "intro")!.href).toBe("/x/en/intro");
+    expect(calls).toContainEqual(["intro", "en"]);
+    // The directory-only category also gets an href because it has children.
+    const guides = tree.find((n) => n.id === "guides")!;
+    expect(guides.href).toBe("/x/en/guides");
+  });
+
+  it("prefers entry.data.slug, then entry.slug, then derives from id", () => {
+    const tree = buildSidebarTree(
+      [
+        entry("foo/index", { title: "From data.slug", slug: "renamed" }),
+        // zfb-style: top-level slug field
+        {
+          id: "ignored",
+          slug: "from-slug",
+          data: { title: "From slug" },
+        },
+        entry("derived/index", { title: "Derived" }),
+      ],
+      "en",
+    );
+    const ids = tree.map((n) => n.id).sort();
+    expect(ids).toEqual(["derived", "from-slug", "renamed"]);
+  });
+});
+
+describe("findSidebarNode", () => {
+  it("locates a node anywhere in the tree", () => {
+    const tree = buildSidebarTree(
+      [
+        entry("a/b/c", { title: "C" }),
+        entry("a/sibling", { title: "Sibling" }),
+      ],
+      "en",
+    );
+    expect(findSidebarNode(tree, "a/b/c")?.label).toBe("C");
+    expect(findSidebarNode(tree, "a/sibling")?.label).toBe("Sibling");
+    expect(findSidebarNode(tree, "missing")).toBeUndefined();
+  });
+});
+
+describe("flattenSidebarTree", () => {
+  it("returns only nodes with a backing page in DFS order", () => {
+    const tree = buildSidebarTree(
+      [
+        entry("a", { title: "A", sidebar_position: 1 }),
+        entry("b/c", { title: "BC", sidebar_position: 1 }),
+        entry("b/d", { title: "BD", sidebar_position: 2 }),
+      ],
+      "en",
+    );
+    expect(flattenSidebarTree(tree).map((n) => n.id)).toEqual([
+      "a",
+      "b/c",
+      "b/d",
+    ]);
+  });
+});

--- a/packages/zudo-doc-v2/src/sidebar-tree/__tests__/category-meta.test.ts
+++ b/packages/zudo-doc-v2/src/sidebar-tree/__tests__/category-meta.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  loadCategoryMeta,
+  clearCategoryMetaCache,
+} from "../category-meta.ts";
+
+function makeFixture(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "sidebar-tree-cm-"));
+  fs.mkdirSync(path.join(root, "guides"), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, "guides", "_category_.json"),
+    JSON.stringify({ label: "Guides", position: 3, sortOrder: "asc" }),
+  );
+  fs.mkdirSync(path.join(root, "log"), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, "log", "_category_.json"),
+    JSON.stringify({ label: "Log", sortOrder: "desc", noPage: true }),
+  );
+  // A directory without a _category_.json — should not show up in the map.
+  fs.mkdirSync(path.join(root, "no-meta"), { recursive: true });
+  // A nested category to confirm recursion.
+  fs.mkdirSync(path.join(root, "guides", "deep"), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, "guides", "deep", "_category_.json"),
+    JSON.stringify({ label: "Deep" }),
+  );
+  // A malformed category file — must be tolerated, not crash.
+  fs.mkdirSync(path.join(root, "broken"), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, "broken", "_category_.json"),
+    "{ this is not valid JSON",
+  );
+  return root;
+}
+
+describe("loadCategoryMeta", () => {
+  beforeEach(() => {
+    clearCategoryMetaCache();
+  });
+
+  it("reads _category_.json for every directory that has one", () => {
+    const dir = makeFixture();
+    const meta = loadCategoryMeta(dir);
+    expect(meta.get("guides")).toEqual({
+      label: "Guides",
+      position: 3,
+      description: undefined,
+      sortOrder: "asc",
+      noPage: undefined,
+    });
+    expect(meta.get("log")).toEqual({
+      label: "Log",
+      position: undefined,
+      description: undefined,
+      sortOrder: "desc",
+      noPage: true,
+    });
+  });
+
+  it("recurses into subdirectories", () => {
+    const dir = makeFixture();
+    const meta = loadCategoryMeta(dir);
+    expect(meta.get(path.join("guides", "deep"))?.label).toBe("Deep");
+  });
+
+  it("skips directories without _category_.json", () => {
+    const dir = makeFixture();
+    const meta = loadCategoryMeta(dir);
+    expect(meta.has("no-meta")).toBe(false);
+  });
+
+  it("tolerates malformed JSON without throwing", () => {
+    const dir = makeFixture();
+    const meta = loadCategoryMeta(dir);
+    expect(meta.has("broken")).toBe(false);
+  });
+
+  it("returns an empty map when contentDir does not exist", () => {
+    const meta = loadCategoryMeta(path.join(os.tmpdir(), "definitely-does-not-exist-zzz"));
+    expect(meta.size).toBe(0);
+  });
+
+  it("memoises results per absolute contentDir", () => {
+    const dir = makeFixture();
+    const a = loadCategoryMeta(dir);
+    const b = loadCategoryMeta(dir);
+    expect(a).toBe(b);
+  });
+});

--- a/packages/zudo-doc-v2/src/sidebar-tree/build-tree.ts
+++ b/packages/zudo-doc-v2/src/sidebar-tree/build-tree.ts
@@ -1,0 +1,238 @@
+/**
+ * Framework-agnostic sidebar tree builder.
+ *
+ * Takes a flat list of content collection entries and emits a recursive
+ * `SidebarNode[]` that mirrors the filesystem layout — directories become
+ * category nodes, files become leaves. The shape is deliberately
+ * decoupled from astro:content so the same builder works against zfb's
+ * `getCollection` output, in-memory fixtures, etc.
+ *
+ * Ported from src/utils/docs.ts in the legacy zudo-doc Astro project.
+ */
+
+import type {
+  BuildHref,
+  BuildSidebarTreeOptions,
+  CategoryMeta,
+  CollectionEntryLike,
+  SidebarFrontmatter,
+  SidebarNode,
+} from "./types.ts";
+
+/** Strip a trailing `/index` segment to match Astro 5's glob() id stripping. */
+function toRouteSlug(id: string): string {
+  return id.replace(/\/index$/, "");
+}
+
+/** kebab-case → Title Case, used as the fallback label for directory-only nodes. */
+function toTitleCase(str: string): string {
+  return str
+    .split("-")
+    .map((word) => (word.length === 0 ? word : word[0]!.toUpperCase() + word.slice(1)))
+    .join(" ");
+}
+
+/**
+ * Default href builder — produces `/[locale]/docs/<slug>/`. Most projects
+ * inject their own to honour `base`, `trailingSlash`, etc.; this exists
+ * mostly so the builder is usable from a unit test with no extra wiring.
+ */
+const defaultBuildHref: BuildHref = (slug, locale) => {
+  const prefix = locale ? `/${locale}/docs/` : "/docs/";
+  return slug ? `${prefix}${slug}/` : prefix;
+};
+
+/** Default visibility predicate — drops `unlisted` and `standalone` docs. */
+function defaultIsNavVisible(
+  entry: CollectionEntryLike<SidebarFrontmatter>,
+): boolean {
+  return !entry.data.unlisted && !entry.data.standalone;
+}
+
+/** Internal mutable node used while assembling the tree. */
+interface BuildNode<T extends SidebarFrontmatter> {
+  segment: string;
+  fullPath: string;
+  doc?: CollectionEntryLike<T>;
+  children: Map<string, BuildNode<T>>;
+}
+
+/**
+ * Build a recursive sidebar tree from `entries`. Visibility filtering is
+ * applied first; the resulting structure mirrors the filesystem.
+ *
+ * - Multi-segment ids (e.g. `getting-started/intro`) walk the tree creating
+ *   intermediate category nodes as needed.
+ * - Single-segment ids represent category index pages (Astro 5 strips
+ *   `/index` from the id, so `getting-started/index.mdx` arrives as the id
+ *   `getting-started`).
+ * - Sibling order is determined by `sidebar_position` then alphabetical
+ *   slug, with the parent's `sortOrder` (from `_category_.json`) flipping
+ *   the comparator when set to `"desc"`.
+ */
+export function buildSidebarTree<
+  T extends SidebarFrontmatter = SidebarFrontmatter,
+>(
+  entries: CollectionEntryLike<T>[],
+  locale: string,
+  options: BuildSidebarTreeOptions = {},
+): SidebarNode[] {
+  const {
+    categoryMeta,
+    buildHref = defaultBuildHref,
+    isNavVisible = defaultIsNavVisible,
+  } = options;
+
+  const root: BuildNode<T> = {
+    segment: "",
+    fullPath: "",
+    children: new Map(),
+  };
+
+  for (const entry of entries) {
+    if (!isNavVisible(entry)) continue;
+
+    const slug = entry.data.slug ?? entry.slug ?? toRouteSlug(entry.id);
+    if (!slug) continue;
+
+    const parts = slug.split("/");
+    if (parts.length <= 1) {
+      // Category index — single segment.
+      const segment = slug;
+      let node = root.children.get(segment);
+      if (!node) {
+        node = { segment, fullPath: segment, children: new Map() };
+        root.children.set(segment, node);
+      }
+      node.doc = entry;
+    } else {
+      // Multi-segment: walk creating intermediates as needed.
+      let current = root;
+      for (let i = 0; i < parts.length; i++) {
+        const segment = parts[i]!;
+        const fullPath = parts.slice(0, i + 1).join("/");
+        let next = current.children.get(segment);
+        if (!next) {
+          next = { segment, fullPath, children: new Map() };
+          current.children.set(segment, next);
+        }
+        if (i === parts.length - 1) {
+          next.doc = entry;
+        }
+        current = next;
+      }
+    }
+  }
+
+  return toSidebarNodes(root, locale, buildHref, categoryMeta);
+}
+
+function toSidebarNodes<T extends SidebarFrontmatter>(
+  parent: BuildNode<T>,
+  locale: string,
+  buildHref: BuildHref,
+  categoryMeta?: Map<string, CategoryMeta>,
+  parentSortOrder?: "asc" | "desc",
+): SidebarNode[] {
+  const nodes: SidebarNode[] = [];
+
+  for (const child of parent.children.values()) {
+    const doc = child.doc;
+    const meta = categoryMeta?.get(child.fullPath);
+    const sortOrder = meta?.sortOrder ?? "asc";
+    const children = toSidebarNodes(
+      child,
+      locale,
+      buildHref,
+      categoryMeta,
+      sortOrder,
+    );
+
+    const hasPage = !!doc;
+    const isCategory = !hasPage && children.length > 0;
+
+    const label =
+      doc?.data.sidebar_label ??
+      doc?.data.title ??
+      meta?.label ??
+      toTitleCase(child.segment);
+
+    const description = doc?.data.description ?? meta?.description;
+    const positionRaw = doc?.data.sidebar_position ?? meta?.position;
+    // 999 mirrors the legacy fallback so tied entries sort alphabetically.
+    const position = positionRaw ?? 999;
+
+    const href = meta?.noPage
+      ? undefined
+      : doc || children.length > 0
+        ? buildHref(child.fullPath, locale)
+        : undefined;
+
+    nodes.push({
+      type: isCategory ? "category" : "doc",
+      id: child.fullPath,
+      label,
+      ...(description !== undefined ? { description } : {}),
+      ...(positionRaw !== undefined ? { sidebar_position: positionRaw } : {}),
+      ...(href !== undefined ? { href } : {}),
+      hasPage,
+      ...(meta?.sortOrder ? { sortOrder } : {}),
+      children,
+    });
+
+    // Pin the position used at sort time on a private property so the
+    // comparator below can read it without re-deriving the value.
+    Object.defineProperty(nodes[nodes.length - 1], "__sortPosition", {
+      value: position,
+      enumerable: false,
+    });
+  }
+
+  const order = parentSortOrder ?? "asc";
+  nodes.sort((a, b) => {
+    const aPos = (a as SidebarNode & { __sortPosition: number }).__sortPosition;
+    const bPos = (b as SidebarNode & { __sortPosition: number }).__sortPosition;
+    const posCompare = aPos - bPos;
+    if (posCompare !== 0) return order === "desc" ? -posCompare : posCompare;
+    const slugCompare = a.id.localeCompare(b.id);
+    return order === "desc" ? -slugCompare : slugCompare;
+  });
+
+  return nodes;
+}
+
+/**
+ * Find a node by id (path slug) anywhere in the tree. Useful for sidebar
+ * config layers that resolve named doc references and for the breadcrumb
+ * builder. Exported alongside `buildSidebarTree` because both downstream
+ * topics (sub-tasks 4 and 5) need it.
+ */
+export function findSidebarNode(
+  nodes: SidebarNode[],
+  id: string,
+): SidebarNode | undefined {
+  for (const node of nodes) {
+    if (node.id === id) return node;
+    const found = findSidebarNode(node.children, id);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+/**
+ * Depth-first flatten — only nodes with a backing page are emitted, in
+ * traversal order. Mirrors the legacy `flattenTree` used for prev/next
+ * navigation.
+ */
+export function flattenSidebarTree(nodes: SidebarNode[]): SidebarNode[] {
+  const acc: SidebarNode[] = [];
+  flattenInto(nodes, acc);
+  return acc;
+}
+
+function flattenInto(nodes: SidebarNode[], acc: SidebarNode[]): void {
+  for (const node of nodes) {
+    if (node.hasPage) acc.push(node);
+    flattenInto(node.children, acc);
+  }
+}

--- a/packages/zudo-doc-v2/src/sidebar-tree/category-meta.ts
+++ b/packages/zudo-doc-v2/src/sidebar-tree/category-meta.ts
@@ -1,0 +1,106 @@
+/**
+ * Synchronous reader for `_category_.json` files. Walks a directory tree
+ * and returns a map of `<relative-dir-path>` → {@link CategoryMeta}.
+ *
+ * Lives in this folder rather than reusing the project's existing
+ * `loadCategoryMeta` because the framework-layer must not import anything
+ * from the consumer project (`@/utils/...`). Behaviour is intentionally
+ * identical to the original so call sites can swap implementations 1:1.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import type { CategoryMeta } from "./types.ts";
+
+const cache = new Map<string, Map<string, CategoryMeta>>();
+
+/**
+ * Scan `contentDir` recursively for `_category_.json` files. Each file's
+ * parent directory becomes a map key, expressed as a path relative to
+ * `contentDir` and joined with the platform separator (`scanDir` uses
+ * `path.relative`, which yields forward slashes on POSIX and backslashes
+ * on Windows — that matches the keys produced by the legacy implementation
+ * and is what the build-tree code re-uses verbatim).
+ *
+ * Results are memoised per `contentDir` because Astro builds resolve every
+ * page route in the same process; re-reading thousands of `_category_.json`
+ * files for each page is wasteful.
+ */
+export function loadCategoryMeta(contentDir: string): Map<string, CategoryMeta> {
+  const absolute = path.resolve(contentDir);
+  const cached = cache.get(absolute);
+  if (cached) return cached;
+  const result = new Map<string, CategoryMeta>();
+  scanDir(absolute, absolute, result);
+  cache.set(absolute, result);
+  return result;
+}
+
+/** Test/HMR escape hatch — clears the per-directory cache. */
+export function clearCategoryMetaCache(): void {
+  cache.clear();
+}
+
+function scanDir(
+  baseDir: string,
+  currentDir: string,
+  result: Map<string, CategoryMeta>,
+): void {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(currentDir, { withFileTypes: true });
+  } catch {
+    // Missing or unreadable directory: silently skip. Matches legacy behaviour.
+    return;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const fullPath = path.join(currentDir, entry.name);
+    const categoryFile = path.join(fullPath, "_category_.json");
+    if (fs.existsSync(categoryFile)) {
+      const meta = readCategoryFile(categoryFile);
+      if (meta) {
+        const relativePath = path.relative(baseDir, fullPath);
+        result.set(relativePath, meta);
+      }
+    }
+    scanDir(baseDir, fullPath, result);
+  }
+}
+
+/**
+ * Parse a `_category_.json` file into a {@link CategoryMeta}. Returns
+ * `undefined` on any error (missing file, malformed JSON, wrong shape) —
+ * the builder treats absence as "no metadata for this directory" rather
+ * than crashing the whole build over a stray comma.
+ */
+function readCategoryFile(filePath: string): CategoryMeta | undefined {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, "utf-8");
+  } catch {
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed !== "object" || parsed === null) return undefined;
+  const obj = parsed as Record<string, unknown>;
+  return {
+    label: typeof obj["label"] === "string" ? (obj["label"] as string) : undefined,
+    position:
+      typeof obj["position"] === "number" ? (obj["position"] as number) : undefined,
+    description:
+      typeof obj["description"] === "string"
+        ? (obj["description"] as string)
+        : undefined,
+    sortOrder:
+      obj["sortOrder"] === "asc" || obj["sortOrder"] === "desc"
+        ? (obj["sortOrder"] as "asc" | "desc")
+        : undefined,
+    noPage: obj["noPage"] === true ? true : undefined,
+  };
+}

--- a/packages/zudo-doc-v2/src/sidebar-tree/index.ts
+++ b/packages/zudo-doc-v2/src/sidebar-tree/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Public entry for the framework-agnostic sidebar tree builder.
+ *
+ * Consumers import from `@zudo-doc/zudo-doc-v2/sidebar-tree`:
+ *
+ *   import {
+ *     buildSidebarTree,
+ *     loadCategoryMeta,
+ *     type SidebarNode,
+ *   } from "@zudo-doc/zudo-doc-v2/sidebar-tree";
+ *
+ * The builder takes a flat list of content collection entries (in either
+ * Astro or zfb shape) plus a locale, and emits a recursive `SidebarNode[]`
+ * suitable for rendering or for further sidebar-config processing.
+ */
+
+export {
+  buildSidebarTree,
+  findSidebarNode,
+  flattenSidebarTree,
+} from "./build-tree.ts";
+export { loadCategoryMeta, clearCategoryMetaCache } from "./category-meta.ts";
+export type {
+  BuildHref,
+  BuildSidebarTreeOptions,
+  CategoryMeta,
+  CollectionEntryLike,
+  SidebarFrontmatter,
+  SidebarNode,
+} from "./types.ts";

--- a/packages/zudo-doc-v2/src/sidebar-tree/types.ts
+++ b/packages/zudo-doc-v2/src/sidebar-tree/types.ts
@@ -1,0 +1,126 @@
+/**
+ * Public types for the framework-agnostic sidebar tree builder.
+ *
+ * These types are deliberately decoupled from astro:content so the helper
+ * can run on top of any content collection that exposes a similar shape
+ * (Astro, zfb, plain Node fixtures, etc.).
+ */
+
+/**
+ * Frontmatter fields the builder reads off of each entry's `data` object.
+ * Callers are free to extend this; unrecognised fields are ignored.
+ */
+export interface SidebarFrontmatter {
+  title: string;
+  description?: string;
+  sidebar_position?: number;
+  sidebar_label?: string;
+  draft?: boolean;
+  unlisted?: boolean;
+  hide_sidebar?: boolean;
+  /**
+   * Set to `true` for pages that exist outside the doc tree (404, top-level
+   * standalone pages, etc.). The builder skips these entries entirely.
+   */
+  standalone?: boolean;
+  /**
+   * Optional override for the route slug. When omitted, the builder derives
+   * the slug from the entry's id (stripping a trailing `/index`).
+   */
+  slug?: string;
+}
+
+/**
+ * Minimum shape required of a content collection entry. Designed to be a
+ * structural superset of both Astro's `CollectionEntry` and zfb's
+ * `CollectionEntry<T>` so callers can pass either through unchanged.
+ */
+export interface CollectionEntryLike<
+  T extends SidebarFrontmatter = SidebarFrontmatter,
+> {
+  /**
+   * Stable identifier. For Astro entries this is the file path without the
+   * extension (e.g. `getting-started/index`). For zfb entries the project
+   * convention is to put the cleaned slug here too — either form is fine
+   * because the builder strips a trailing `/index`.
+   */
+  id: string;
+  /**
+   * Optional pre-computed slug. When present it wins over the id-derived
+   * value. zfb entries always populate this field; Astro callers can leave
+   * it undefined.
+   */
+  slug?: string;
+  data: T;
+  /** Free-form fields kept for forward compatibility — never read here. */
+  collection?: string;
+  body?: string;
+}
+
+/**
+ * Metadata supplied by a directory's `_category_.json` file.
+ */
+export interface CategoryMeta {
+  label?: string;
+  position?: number;
+  description?: string;
+  sortOrder?: "asc" | "desc";
+  /**
+   * When true, the category renders as a collapsible header with no link of
+   * its own — useful for purely structural groupings.
+   */
+  noPage?: boolean;
+}
+
+/**
+ * One node in the sidebar tree. `type` distinguishes leaves (single docs)
+ * from categories (groups with children). The fields beyond the manager's
+ * sketch — `description`, `hasPage`, `sortOrder`, `collapsed` — are kept
+ * because downstream consumers (sidebar config layer, breadcrumb builder)
+ * need them. They are all optional from a caller's perspective.
+ */
+export interface SidebarNode {
+  type: "doc" | "category";
+  /** Path-style slug, e.g. `getting-started/introduction`. */
+  id: string;
+  label: string;
+  description?: string;
+  href?: string;
+  sidebar_position?: number;
+  /** True when an actual MDX file backs this slug (vs. directory-only). */
+  hasPage: boolean;
+  sortOrder?: "asc" | "desc";
+  collapsed?: boolean;
+  children: SidebarNode[];
+}
+
+/**
+ * Resolve an href for a given route slug. Defaults to `/<locale>/docs/<slug>/`
+ * for non-default locales and `/docs/<slug>/` otherwise — but most projects
+ * will inject their own to honour `base`, `trailingSlash`, etc.
+ */
+export type BuildHref = (slug: string, locale: string) => string;
+
+export interface BuildSidebarTreeOptions {
+  /**
+   * Map keyed by slash-joined directory path → category meta. Typically
+   * produced by {@link CategoryMetaLoader}.
+   */
+  categoryMeta?: Map<string, CategoryMeta>;
+  /**
+   * Default locale. When the supplied `locale` matches this, the helper
+   * skips the locale prefix in default href construction. When omitted,
+   * defaults to `"en"`.
+   */
+  defaultLocale?: string;
+  /**
+   * Override the default href builder. Receives the route slug and locale.
+   */
+  buildHref?: BuildHref;
+  /**
+   * Filter predicate run on every entry before tree construction. Defaults
+   * to dropping `unlisted` and `standalone` docs. Override to integrate
+   * with a project's own visibility rules.
+   */
+  isNavVisible?: (entry: CollectionEntryLike<SidebarFrontmatter>) => boolean;
+}

--- a/packages/zudo-doc-v2/src/ssr-skip/ai-chat-modal-island.tsx
+++ b/packages/zudo-doc-v2/src/ssr-skip/ai-chat-modal-island.tsx
@@ -1,0 +1,40 @@
+// Framework wrapper around the AI chat modal — emits an SSR-skip
+// placeholder so the heavy modal Preact island never renders during
+// the static build (it depends on `dialog.showModal()`, browser-only
+// fetch, and toggle events that can't fire server-side).
+//
+// The original Astro page used `<AiChatModal client:load />`. The
+// equivalent zfb shape is `<Island ssrFallback={...} when="load">`,
+// and the placeholder lets a doc page write
+// `<AiChatModalIsland basePath={...} />` without re-implementing the
+// marker plumbing every time.
+//
+// Default fallback: `null`. The real component renders a `<dialog>`
+// that is closed by default, so it has zero layout footprint —
+// nothing to mock up SSR-side. Callers can override `ssrFallback` if
+// they ever decide to render a hint/button while hydration is
+// scheduled.
+
+import { renderSsrSkipPlaceholder, type SsrSkipFallbackProps } from "./types.js";
+
+/**
+ * Props passed through to the real `AiChatModal` component on
+ * hydration. The hydration manifest binds the marker name
+ * `"AiChatModal"` to the actual component constructor.
+ */
+export interface AiChatModalIslandProps extends SsrSkipFallbackProps {
+  /**
+   * Base path the chat modal uses to construct API URLs. Forwarded
+   * verbatim to the real component on hydration.
+   */
+  basePath: string;
+}
+
+/**
+ * SSR-skip wrapper for the AI chat modal. Drop-in replacement for the
+ * legacy `<AiChatModal client:load />` Astro pattern.
+ */
+export function AiChatModalIsland(props: AiChatModalIslandProps) {
+  const { when = "load", ssrFallback = null, ...forwarded } = props;
+  return renderSsrSkipPlaceholder("AiChatModal", when, ssrFallback, { ...forwarded });
+}

--- a/packages/zudo-doc-v2/src/ssr-skip/design-token-tweak-panel-island.tsx
+++ b/packages/zudo-doc-v2/src/ssr-skip/design-token-tweak-panel-island.tsx
@@ -1,0 +1,40 @@
+// Framework wrapper around the design-token tweak panel — emits an
+// SSR-skip placeholder so the panel (which reads `localStorage`,
+// builds an `<iframe>` bridge, and depends on a fully-resolved
+// `:root` for its color-mix maths) never executes server-side.
+//
+// The original Astro page used `<DesignTokenTweakPanel client:only="preact" />`;
+// `client:only` maps directly to zfb's SSR-skip mode. The default
+// `when` is `"load"` to mirror the immediate hydration semantics of
+// `client:only`.
+//
+// The real Preact component is being ported by the sibling `theme`
+// topic at `packages/zudo-doc-v2/src/theme/design-token-tweak-panel.tsx`.
+// We deliberately do not import from that path here: the wrapper's
+// only job is to emit a `data-zfb-island-skip-ssr="DesignTokenTweakPanel"`
+// placeholder, and the hydration manifest (set up at consumer level)
+// binds the marker name to whichever constructor is in scope at
+// integration time. Avoiding the import keeps this topic typecheck-
+// clean even before the sibling topic merges.
+//
+// Default fallback: `null`. The panel is fixed-position and only
+// visible after a toggle event, so there is no layout to preserve.
+
+import { renderSsrSkipPlaceholder, type SsrSkipFallbackProps } from "./types.js";
+
+/**
+ * The real `DesignTokenTweakPanel` component takes no props. The
+ * wrapper still accepts `SsrSkipFallbackProps` so callers can override
+ * the defaults if needed.
+ */
+export type DesignTokenTweakPanelIslandProps = SsrSkipFallbackProps;
+
+/**
+ * SSR-skip wrapper for the design-token tweak panel. Drop-in
+ * replacement for the legacy `<DesignTokenTweakPanel client:only="preact" />`
+ * Astro pattern.
+ */
+export function DesignTokenTweakPanelIsland(props: DesignTokenTweakPanelIslandProps = {}) {
+  const { when = "load", ssrFallback = null } = props;
+  return renderSsrSkipPlaceholder("DesignTokenTweakPanel", when, ssrFallback, {});
+}

--- a/packages/zudo-doc-v2/src/ssr-skip/image-enlarge-island.tsx
+++ b/packages/zudo-doc-v2/src/ssr-skip/image-enlarge-island.tsx
@@ -1,0 +1,32 @@
+// Framework wrapper around the image-enlarge dialog — emits an
+// SSR-skip placeholder so the eligibility scanner (ResizeObserver,
+// MutationObserver, devicePixelRatio checks) never executes
+// server-side.
+//
+// The original Astro page used `<ImageEnlarge client:idle />`; idle
+// is appropriate because the modal is purely an enhancement triggered
+// by user clicks — no need to hydrate eagerly.
+//
+// Default fallback: `null`. The real component renders a closed
+// `<dialog>` plus per-image enlarge buttons that are toggled via
+// runtime DOM observation; none of that needs SSR markup. Layout is
+// driven by the `.zd-enlargeable` containers in the article body, not
+// by this island.
+
+import { renderSsrSkipPlaceholder, type SsrSkipFallbackProps } from "./types.js";
+
+/**
+ * The real `ImageEnlarge` component takes no props. We still extend
+ * `SsrSkipFallbackProps` so callers can override `when` / `ssrFallback`
+ * if needed.
+ */
+export type ImageEnlargeIslandProps = SsrSkipFallbackProps;
+
+/**
+ * SSR-skip wrapper for the image-enlarge dialog. Drop-in replacement
+ * for the legacy `<ImageEnlarge client:idle />` Astro pattern.
+ */
+export function ImageEnlargeIsland(props: ImageEnlargeIslandProps = {}) {
+  const { when = "idle", ssrFallback = null } = props;
+  return renderSsrSkipPlaceholder("ImageEnlarge", when, ssrFallback, {});
+}

--- a/packages/zudo-doc-v2/src/ssr-skip/index.ts
+++ b/packages/zudo-doc-v2/src/ssr-skip/index.ts
@@ -1,0 +1,18 @@
+// Public entry point for the SSR-skip framework wrappers.
+//
+// Doc pages import these wrappers in place of the legacy Astro
+// `client:*` directives that pointed at the underlying Preact
+// components. Each wrapper emits a zfb SSR-skip placeholder
+// (`data-zfb-island-skip-ssr="<name>"`) so the heavy / browser-only
+// component is not evaluated server-side; the hydration runtime swaps
+// the placeholder for the real component on the client.
+
+export { AiChatModalIsland, type AiChatModalIslandProps } from "./ai-chat-modal-island.js";
+export { ImageEnlargeIsland, type ImageEnlargeIslandProps } from "./image-enlarge-island.js";
+export {
+  DesignTokenTweakPanelIsland,
+  type DesignTokenTweakPanelIslandProps,
+} from "./design-token-tweak-panel-island.js";
+export { MockInitIsland, type MockInitIslandProps } from "./mock-init-island.js";
+
+export type { IslandWhen, SsrSkipFallbackProps } from "./types.js";

--- a/packages/zudo-doc-v2/src/ssr-skip/mock-init-island.tsx
+++ b/packages/zudo-doc-v2/src/ssr-skip/mock-init-island.tsx
@@ -1,0 +1,33 @@
+// Framework wrapper around the dev-only MSW mock initialiser —
+// emits an SSR-skip placeholder so the dynamic `import("../mocks/init")`
+// never resolves at build time (the mocks bundle is not part of the
+// production graph and the service worker registration only makes
+// sense in the browser).
+//
+// The original Astro page used `<MockInit client:only="preact" />`
+// inside dev-mode-only conditionals. The wrapper preserves that
+// semantic: the placeholder div is harmless on the server, and the
+// real component (which renders `null` after kicking off the dynamic
+// import in `useEffect`) hydrates client-side.
+//
+// Default fallback: `null`. The real component renders `null`, so any
+// non-null fallback would actually *cause* a layout transition rather
+// than prevent one.
+
+import { renderSsrSkipPlaceholder, type SsrSkipFallbackProps } from "./types.js";
+
+/**
+ * The real `MockInit` component takes no props.
+ */
+export type MockInitIslandProps = SsrSkipFallbackProps;
+
+/**
+ * SSR-skip wrapper for the dev-only mock initialiser. Drop-in
+ * replacement for the legacy `<MockInit client:only="preact" />`
+ * Astro pattern. Idle is the right default — mock initialisation is
+ * not on the critical path.
+ */
+export function MockInitIsland(props: MockInitIslandProps = {}) {
+  const { when = "idle", ssrFallback = null } = props;
+  return renderSsrSkipPlaceholder("MockInit", when, ssrFallback, {});
+}

--- a/packages/zudo-doc-v2/src/ssr-skip/types.ts
+++ b/packages/zudo-doc-v2/src/ssr-skip/types.ts
@@ -1,0 +1,119 @@
+// SSR-skip wrapper primitives shared by the four framework wrappers
+// (AiChatModalIsland, ImageEnlargeIsland, DesignTokenTweakPanelIsland,
+// MockInitIsland).
+//
+// These wrappers exist so doc pages don't have to re-implement the
+// SSR-skip placeholder pattern that zfb's `<Island ssrFallback>` API
+// formalises. The marker contract emitted here matches zfb's
+// `data-zfb-island-skip-ssr` shape verbatim — see
+// `zfb/packages/zfb/src/island.ts` for the canonical reference.
+//
+// We intentionally re-emit the marker locally instead of importing
+// `Island` from `zfb`: `@zudo-doc/zudo-doc-v2` currently lists no zfb
+// dependency (the manager will wire that up at integration time per the
+// pre-publish dev workflow), and topic rules forbid touching
+// `package.json` / `tsconfig.json` from this folder. The marker shape
+// is the public protocol; re-emitting it is a thin, drop-in
+// implementation of the same contract.
+//
+// NOTE — props delivery. The hydration runtime (zfb Sub 3 / consumer
+// manifest) is responsible for swapping the placeholder for the real
+// component on the client. Each wrapper serialises its non-overlay
+// props to `data-zfb-island-props` as JSON so the runtime can hand them
+// straight to the mounted component. Non-serialisable values are
+// silently dropped — that is preferable to crashing SSR.
+
+import { h, type ComponentChildren, type VNode } from "preact";
+
+/**
+ * Hydration scheduling strategy. Mirrors zfb's `When` union (`load`,
+ * `idle`, `visible`, `media`). We re-declare the union locally so the
+ * wrapper API doesn't depend on a `zfb` import; if zfb extends the
+ * union later, this type widens with it once a single import is
+ * possible.
+ */
+export type IslandWhen = "load" | "idle" | "visible" | "media";
+
+/** Marker attribute zfb's hydration runtime queries to find SSR-skip placeholders. */
+export const SKIP_SSR_MARKER_ATTR = "data-zfb-island-skip-ssr";
+
+/** When attribute the runtime reads to schedule hydration timing. */
+export const WHEN_ATTR = "data-when";
+
+/**
+ * JSON-encoded props blob attached to the placeholder. The hydration
+ * runtime parses this and forwards the values to the real component.
+ * Empty for prop-less components (e.g. MockInit) so the SSR markup
+ * stays minimal.
+ */
+export const PROPS_ATTR = "data-zfb-island-props";
+
+/**
+ * Common opt-in props every wrapper accepts on top of its
+ * component-specific props. Lets a caller override the default
+ * hydration timing or fallback markup without reaching for the lower
+ * level Island API directly.
+ */
+export interface SsrSkipFallbackProps {
+  /** Override the wrapper's default hydration timing. */
+  when?: IslandWhen;
+  /**
+   * Override the SSR fallback markup. Defaults to `null` for the
+   * built-in wrappers since each backs an overlay/effect component
+   * with no layout footprint when closed/idle. Pass a skeleton when
+   * the real component would otherwise cause layout shift on mount.
+   */
+  ssrFallback?: ComponentChildren;
+}
+
+/**
+ * Internal helper used by every wrapper. Emits the SSR-skip placeholder
+ * div with the right marker attributes so zfb's hydration runtime can
+ * find it on the client. Exported for tests; not re-exported from
+ * `index.ts`.
+ *
+ * @param componentName  Stable identifier matching the real component's
+ *                       `displayName` / `name`. The hydration manifest
+ *                       binds this string to the actual component
+ *                       constructor.
+ * @param when           Hydration scheduling strategy.
+ * @param fallback       JSX rendered server-side until hydration
+ *                       replaces the placeholder.
+ * @param forwardedProps Props that should be delivered to the real
+ *                       component on hydration. JSON-serialised onto
+ *                       `data-zfb-island-props`. Pass an empty object
+ *                       for prop-less wrappers — the attribute is
+ *                       omitted entirely in that case.
+ */
+export function renderSsrSkipPlaceholder(
+  componentName: string,
+  when: IslandWhen,
+  fallback: ComponentChildren,
+  forwardedProps: Record<string, unknown>,
+): VNode {
+  const attrs: Record<string, unknown> = {
+    [SKIP_SSR_MARKER_ATTR]: componentName,
+    [WHEN_ATTR]: when,
+  };
+  if (Object.keys(forwardedProps).length > 0) {
+    const serialised = safeStringify(forwardedProps);
+    if (serialised !== null) {
+      attrs[PROPS_ATTR] = serialised;
+    }
+  }
+  // Authored with `h(...)` rather than JSX so this file can keep its
+  // `.ts` extension (the topic file list specifies `types.ts`, and a
+  // mixed types/helper module is fine here).
+  return h("div", attrs, fallback);
+}
+
+function safeStringify(value: unknown): string | null {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    // Non-serialisable prop values (functions, circular refs, DOM
+    // nodes). Drop the attribute rather than crashing SSR — losing a
+    // prop is recoverable, an SSR exception is not.
+    return null;
+  }
+}

--- a/packages/zudo-doc-v2/src/ssr-skip/types.ts
+++ b/packages/zudo-doc-v2/src/ssr-skip/types.ts
@@ -110,10 +110,19 @@ export function renderSsrSkipPlaceholder(
 function safeStringify(value: unknown): string | null {
   try {
     return JSON.stringify(value);
-  } catch {
+  } catch (err) {
     // Non-serialisable prop values (functions, circular refs, DOM
     // nodes). Drop the attribute rather than crashing SSR — losing a
-    // prop is recoverable, an SSR exception is not.
+    // prop is recoverable, an SSR exception is not. In development we
+    // surface a console warning so the dropped prop doesn't fail
+    // silently; production builds stay quiet.
+    if (typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production") {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[zudo-doc-v2/ssr-skip] dropped non-serialisable prop on SSR-skip placeholder:",
+        err,
+      );
+    }
     return null;
   }
 }

--- a/packages/zudo-doc-v2/src/theme/_zfb-shim.d.ts
+++ b/packages/zudo-doc-v2/src/theme/_zfb-shim.d.ts
@@ -1,0 +1,28 @@
+// Local type shim for `@takazudo/zfb`.
+//
+// The v2 package intentionally does NOT list `@takazudo/zfb` as a runtime
+// dependency during E5 scaffolding (see super-epic #473 — npm publish is
+// deferred). The real `Island` wrapper is supplied by the consumer at
+// integration time. This `.d.ts` exists purely so the theme topic
+// type-checks in isolation; the real public types live in
+// `packages/zfb/src/island.ts` of the zfb repo and mirror this shape.
+
+declare module "@takazudo/zfb" {
+  export type IslandWhen = "load" | "idle" | "visible" | "media";
+
+  export interface IslandProps {
+    /** Hydration scheduling strategy. Defaults to "load". */
+    when?: IslandWhen;
+    /** Supplying this switches Island into SSR-skip (client:only) mode. */
+    ssrFallback?: unknown;
+    /** Server-rendered children, hydrated client-side once `when` fires. */
+    children?: unknown;
+  }
+
+  /**
+   * `<Island>` JSX wrapper. The real implementation returns a structural
+   * JSX element shape compatible with both Preact and React; the shim
+   * widens the return type to `unknown` so callers cast at the boundary.
+   */
+  export function Island(props: IslandProps): unknown;
+}

--- a/packages/zudo-doc-v2/src/theme/color-scheme-provider.tsx
+++ b/packages/zudo-doc-v2/src/theme/color-scheme-provider.tsx
@@ -1,0 +1,73 @@
+// Layout-level JSX port of src/components/color-scheme-provider.astro.
+//
+// Renders the palette CSS custom properties on `:root` and the bootstrap
+// inline script that applies the persisted theme (light/dark) before the
+// page paints. The component is intentionally server-rendered with no
+// hydration: it just emits a <style> + <script> pair the engine streams
+// into the document head. The Astro version used `set:text` and
+// `define:vars`; the JSX equivalent is `dangerouslySetInnerHTML` with the
+// runtime values interpolated as a JSON literal so the script can read
+// them without re-fetching settings.
+
+import {
+  generateCssCustomProperties,
+  generateLightDarkCssProperties,
+} from "@/config/color-scheme-utils";
+import { settings } from "@/config/settings";
+
+interface ColorSchemeProviderProps {
+  /** Optional override for tests; defaults to the project-level settings. */
+  cssText?: string;
+  colorModeOverride?: typeof settings.colorMode;
+}
+
+/** Bootstrap script for the light/dark mode (settings.colorMode set). */
+function buildColorModeBootstrap(
+  defaultMode: "light" | "dark",
+  respectPrefersColorScheme: boolean,
+): string {
+  // Values are inlined as JSON literals so the script body is fully
+  // self-contained and matches what `define:vars` produced in Astro.
+  const dm = JSON.stringify(defaultMode);
+  const rp = JSON.stringify(Boolean(respectPrefersColorScheme));
+  return `(function(){
+var defaultMode=${dm};
+var respectPrefersColorScheme=${rp};
+var STORAGE_KEY="zudo-doc-theme";
+function getSystemMode(){return window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light";}
+function applyTheme(mode){document.documentElement.setAttribute("data-theme",mode);document.documentElement.style.colorScheme=mode;}
+function getEffectiveMode(choice){if(choice==="light"||choice==="dark")return choice;return respectPrefersColorScheme?getSystemMode():defaultMode;}
+var stored=null;try{stored=localStorage.getItem(STORAGE_KEY);}catch(e){}
+applyTheme(getEffectiveMode(stored));
+document.addEventListener("astro:after-swap",function(){var s=null;try{s=localStorage.getItem(STORAGE_KEY);}catch(e){}applyTheme(getEffectiveMode(s));});
+if(respectPrefersColorScheme){window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change",function(){var s=null;try{s=localStorage.getItem(STORAGE_KEY);}catch(e){}if(!s)applyTheme(getSystemMode());});}
+})();`;
+}
+
+/** Bootstrap script for the persisted-tweak path (no light/dark mode). */
+const PERSISTED_TWEAK_BOOTSTRAP = `(function(){
+function applyStoredScheme(){var css=localStorage.getItem("zudo-doc-color-scheme-css");if(!css)return;try{var pairs=JSON.parse(css);var root=document.documentElement;for(var i=0;i<pairs.length;i++){root.style.setProperty(pairs[i][0],pairs[i][1]);}}catch(e){localStorage.removeItem("zudo-doc-color-scheme-css");}}
+applyStoredScheme();
+document.addEventListener("astro:after-swap",applyStoredScheme);
+})();`;
+
+export default function ColorSchemeProvider(props: ColorSchemeProviderProps = {}) {
+  const colorMode = props.colorModeOverride ?? settings.colorMode;
+  const cssText =
+    props.cssText ??
+    (colorMode ? generateLightDarkCssProperties() : generateCssCustomProperties());
+
+  const bootstrap = colorMode
+    ? buildColorModeBootstrap(
+        colorMode.defaultMode,
+        Boolean(colorMode.respectPrefersColorScheme),
+      )
+    : PERSISTED_TWEAK_BOOTSTRAP;
+
+  return (
+    <>
+      <style dangerouslySetInnerHTML={{ __html: cssText }} />
+      <script dangerouslySetInnerHTML={{ __html: bootstrap }} />
+    </>
+  );
+}

--- a/packages/zudo-doc-v2/src/theme/color-tweak-export-modal.tsx
+++ b/packages/zudo-doc-v2/src/theme/color-tweak-export-modal.tsx
@@ -1,0 +1,180 @@
+// Ported from src/components/design-token-tweak/export-modal.tsx (E5 framework
+// primitives). The serializer call (`serialize(state, { includeDefaults,
+// colorDefaults })`) is intentionally byte-identical to the host project's
+// version so the export output for an unchanged scheme remains line-equal to
+// today's output — a hard acceptance criterion for the theme topic.
+
+import { useState, useEffect, useMemo, useRef } from "react";
+import { serialize } from "@/utils/design-token-serde";
+import {
+  type ColorTweakState,
+  type TweakState,
+  initColorFromSchemeData,
+} from "@/components/design-token-tweak/state/tweak-state";
+import { colorSchemes } from "@/config/color-schemes";
+
+interface DesignTokenExportModalProps {
+  onClose: () => void;
+  /** Full unified tweak state — the modal serializes all four categories. */
+  state: TweakState;
+  /** Color baseline used for diff-only output. Optional: callers without DOM
+   *  access (tests) can omit and we'll treat the entire color block as changed. */
+  colorDefaults?: ColorTweakState;
+}
+
+const EXPORT_FILENAME_HINT = "zudo-doc-tokens.json";
+
+/** Resolve a color baseline for diff-only serialization. */
+function resolveColorDefaults(
+  fallback: ColorTweakState,
+  explicit?: ColorTweakState,
+): ColorTweakState {
+  if (explicit) return explicit;
+  // No explicit defaults → pick the first scheme so we still produce a
+  // sensible baseline shape. This path is only hit in edge cases; the panel
+  // always passes explicit defaults.
+  const firstScheme = Object.values(colorSchemes)[0];
+  if (firstScheme) return initColorFromSchemeData(firstScheme);
+  return fallback;
+}
+
+export default function ColorTweakExportModal({
+  onClose,
+  state,
+  colorDefaults,
+}: DesignTokenExportModalProps) {
+  const [copyLabel, setCopyLabel] = useState("Copy");
+  const [includeDefaults, setIncludeDefaults] = useState(false);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Memo the serialized JSON so flipping the toggle doesn't rebuild on every
+  // re-render; `exportedAt` intentionally refreshes when the toggle flips so
+  // the displayed timestamp reflects "when you clicked copy".
+  const code = useMemo(() => {
+    const baseline = resolveColorDefaults(state.color, colorDefaults);
+    const json = serialize(state, {
+      includeDefaults,
+      colorDefaults: baseline,
+    });
+    return JSON.stringify(json, null, 2);
+  }, [state, colorDefaults, includeDefaults]);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    dialog.showModal();
+    return () => {
+      if (dialog.open) dialog.close();
+    };
+  }, []);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    function handleClose() {
+      onClose();
+    }
+    dialog.addEventListener("close", handleClose);
+    return () => dialog.removeEventListener("close", handleClose);
+  }, [onClose]);
+
+  useEffect(() => {
+    return () => {
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+    };
+  }, []);
+
+  // Use a structural event shape so this matches both React and Preact's
+  // event handler types (the project runs Preact compat).
+  function handleBackdropClick(e: { clientX: number; clientY: number }) {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    const rect = dialog.getBoundingClientRect();
+    if (
+      e.clientX < rect.left ||
+      e.clientX > rect.right ||
+      e.clientY < rect.top ||
+      e.clientY > rect.bottom
+    ) {
+      dialog.close();
+    }
+  }
+
+  async function handleCopy() {
+    let ok = false;
+    // Clipboard API needs focus inside the dialog — use a dialog-scoped
+    // textarea fallback that works even inside Safari's <dialog> focus trap.
+    const dialog = dialogRef.current;
+    if (dialog) {
+      try {
+        const textarea = document.createElement("textarea");
+        textarea.value = code;
+        textarea.style.cssText = "position:fixed;opacity:0;left:-9999px";
+        dialog.appendChild(textarea);
+        textarea.focus();
+        textarea.select();
+        ok = document.execCommand("copy");
+        dialog.removeChild(textarea);
+      } catch { /* ignore */ }
+    }
+    if (!ok) {
+      // Last resort: try Clipboard API
+      try {
+        await navigator.clipboard.writeText(code);
+        ok = true;
+      } catch { /* ignore */ }
+    }
+    setCopyLabel(ok ? "Copied!" : "Failed");
+    if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+    copyTimerRef.current = setTimeout(() => setCopyLabel("Copy"), 2000);
+  }
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onClick={handleBackdropClick}
+      className="mx-auto max-h-[80vh] w-full max-w-[46rem] overflow-y-auto border border-muted bg-surface p-hsp-xl backdrop:bg-bg/80"
+      style={{ color: "var(--color-fg)", position: "fixed", top: "50%", left: "50%", transform: "translate(-50%, -50%)", userSelect: "text" }}
+    >
+      <h2 className="mb-vsp-sm text-subheading font-bold text-fg">
+        Export Design Tokens
+      </h2>
+
+      <p className="mb-vsp-xs text-small text-muted">
+        Save as <code className="text-fg">{EXPORT_FILENAME_HINT}</code> to feed
+        this blob back into the panel (or hand to an AI assistant).
+      </p>
+
+      <label className="mb-vsp-xs flex items-center gap-x-hsp-sm text-small text-fg">
+        <input
+          type="checkbox"
+          checked={includeDefaults}
+          onChange={(e) => setIncludeDefaults(e.currentTarget.checked)}
+        />
+        Show defaults too
+      </label>
+
+      <pre className="overflow-x-auto border border-muted bg-code-bg p-hsp-lg text-small text-code-fg">
+        <code>{code}</code>
+      </pre>
+
+      <div className="mt-vsp-sm flex items-center gap-x-hsp-md">
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="border border-muted bg-surface px-hsp-lg py-vsp-2xs text-small text-fg transition-colors hover:border-accent hover:text-accent"
+        >
+          {copyLabel}
+        </button>
+        <button
+          type="button"
+          onClick={() => dialogRef.current?.close()}
+          className="border border-muted bg-surface px-hsp-lg py-vsp-2xs text-small text-muted transition-colors hover:border-fg hover:text-fg"
+        >
+          Close
+        </button>
+      </div>
+    </dialog>
+  );
+}

--- a/packages/zudo-doc-v2/src/theme/design-token-tweak-panel.tsx
+++ b/packages/zudo-doc-v2/src/theme/design-token-tweak-panel.tsx
@@ -1,0 +1,206 @@
+// Design Token Tweak Panel — E5 framework primitives wrapper.
+//
+// Architecture
+// ------------
+//
+// The host page (the doc layout) drops one `<DesignTokenTweakPanel />` into
+// its DOM. That component is wrapped at the call-site by zfb's
+// `<Island ssrFallback={null}>` — equivalent to Astro's `client:only="preact"`
+// — so the heavy panel UI is never evaluated server-side. On hydration the
+// island swaps in the real component, which:
+//
+//   1. Mounts the existing panel UI (ported from the original
+//      `design-token-tweak/` directory in the host project) into the host
+//      page so the user sees and interacts with it.
+//   2. Renders a sandboxed `<iframe>` whose `srcdoc` echoes the host page's
+//      relevant content. Token edits are forwarded to the iframe in real
+//      time over the postMessage bridge defined in `./iframe-bridge`. The
+//      iframe is the "preview canvas" — the host page itself is left
+//      visually intact except for the panel chrome.
+//
+// Why a MutationObserver for the bridge?
+// --------------------------------------
+//
+// The inner panel writes CSS-variable overrides directly to
+// `document.documentElement.style` (palette colors, semantic tokens,
+// spacing, font, size). Rather than reach inside the inner panel to
+// retarget every write site, we observe the host root's `style` attribute
+// and stream the diff to the iframe. That gives the iframe a live mirror
+// of every override the panel makes, including ones triggered by future
+// tabs we haven't ported yet — without forking the inner panel.
+//
+// zfb dependency
+// --------------
+//
+// `@takazudo/zfb` is intentionally NOT in the v2 package's dependency tree
+// for this E5 scaffold (the framework isn't published yet). The Island
+// shape is shimmed via `declare module` below so this file type-checks in
+// isolation; the real wiring happens at the consumer/integration level.
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import type * as preact from "preact";
+import InnerDesignTokenTweakPanel from "@/components/design-token-tweak";
+import {
+  BRIDGE_SOURCE,
+  onIframeReady,
+  sendApplyCssVars,
+  sendClearCssVars,
+  type CssVarPair,
+} from "./iframe-bridge";
+// `@takazudo/zfb` is shimmed in `_zfb-shim.d.ts` (declare module) so this
+// import resolves at type-check time without adding the package to the v2
+// dependency tree. See that shim for rationale.
+import { Island } from "@takazudo/zfb";
+
+/** CSS-variable name pattern we forward to the iframe — matches the design
+ *  token convention used across both color and size families. */
+const FORWARD_VAR_PREFIX = "--zd-";
+
+/** Skim the host root's inline style for `--zd-*` overrides. */
+function collectInlineCssVars(root: HTMLElement): CssVarPair[] {
+  const out: CssVarPair[] = [];
+  const decl = root.style;
+  for (let i = 0; i < decl.length; i++) {
+    const name = decl.item(i);
+    if (!name.startsWith(FORWARD_VAR_PREFIX)) continue;
+    const value = decl.getPropertyValue(name);
+    if (value) out.push([name, value] as const);
+  }
+  return out;
+}
+
+/** Compute the set of names present in `prev` but absent from `next`. */
+function namesDropped(prev: CssVarPair[], next: CssVarPair[]): string[] {
+  const nextNames = new Set(next.map(([n]) => n));
+  return prev.filter(([n]) => !nextNames.has(n)).map(([n]) => n);
+}
+
+interface DesignTokenTweakPanelInnerProps {
+  /** Optional `srcdoc` content for the preview iframe; defaults to a minimal
+   *  HTML shell that just installs the bridge receiver. Consumers wiring the
+   *  panel into a real layout will pass the rendered page HTML. */
+  iframeSrcDoc?: string;
+}
+
+/** Default iframe document — empty body + bridge receiver script. */
+const DEFAULT_IFRAME_SRCDOC = `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<style>html,body{margin:0;padding:0;background:var(--zd-bg,#fff);color:var(--zd-fg,#000);}</style>
+</head>
+<body>
+<div id="zudo-doc-theme-preview-root"></div>
+<script>
+(function(){
+var SOURCE=${JSON.stringify(BRIDGE_SOURCE)};
+window.addEventListener("message",function(ev){
+  var d=ev.data;
+  if(!d||typeof d!=="object"||d.source!==SOURCE)return;
+  var root=document.documentElement;
+  if(d.type==="apply-css-vars"&&Array.isArray(d.vars)){
+    for(var i=0;i<d.vars.length;i++){root.style.setProperty(d.vars[i][0],d.vars[i][1]);}
+    return;
+  }
+  if(d.type==="clear-css-vars"&&Array.isArray(d.names)){
+    for(var j=0;j<d.names.length;j++){root.style.removeProperty(d.names[j]);}
+    return;
+  }
+});
+if(window.parent&&window.parent!==window){
+  window.parent.postMessage({source:SOURCE,type:"ready"},"*");
+}
+})();
+</script>
+</body>
+</html>`;
+
+function DesignTokenTweakPanelInner({
+  iframeSrcDoc,
+}: DesignTokenTweakPanelInnerProps) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const lastVarsRef = useRef<CssVarPair[]>([]);
+  const [iframeReady, setIframeReady] = useState(false);
+
+  const srcDoc = useMemo(() => iframeSrcDoc ?? DEFAULT_IFRAME_SRCDOC, [iframeSrcDoc]);
+
+  // Wait for the iframe to announce readiness before streaming initial state.
+  useEffect(() => {
+    const win = iframeRef.current?.contentWindow ?? null;
+    const off = onIframeReady(win, () => setIframeReady(true));
+    return off;
+  }, []);
+
+  // Mirror host root inline `--zd-*` overrides into the iframe in real time.
+  useEffect(() => {
+    if (!iframeReady) return;
+    const root = document.documentElement;
+
+    // Push the current state on first sync.
+    const initial = collectInlineCssVars(root);
+    if (initial.length > 0) {
+      sendApplyCssVars(iframeRef.current, initial);
+    }
+    lastVarsRef.current = initial;
+
+    function flush() {
+      const next = collectInlineCssVars(root);
+      const dropped = namesDropped(lastVarsRef.current, next);
+      if (dropped.length > 0) sendClearCssVars(iframeRef.current, dropped);
+      if (next.length > 0) sendApplyCssVars(iframeRef.current, next);
+      lastVarsRef.current = next;
+    }
+
+    const observer = new MutationObserver(flush);
+    observer.observe(root, { attributes: true, attributeFilter: ["style"] });
+    return () => observer.disconnect();
+  }, [iframeReady]);
+
+  return (
+    <>
+      {/* Off-screen preview iframe — kept in the DOM so the bridge stays
+          live, but visually out of the user's way. Consumers can override
+          this position via CSS. */}
+      <iframe
+        ref={iframeRef}
+        title="Design token preview"
+        srcDoc={srcDoc}
+        // `sandbox` keeps the preview from running outside scripts but
+        // still allows our bridge handler.
+        sandbox="allow-scripts allow-same-origin"
+        style={{
+          position: "fixed",
+          right: 0,
+          bottom: 0,
+          width: 1,
+          height: 1,
+          border: 0,
+          opacity: 0,
+          pointerEvents: "none",
+          zIndex: -1,
+        }}
+        aria-hidden="true"
+      />
+      <InnerDesignTokenTweakPanel />
+    </>
+  );
+}
+
+/** Public component: zfb Island wrapper with `ssrFallback={null}` so the
+ *  inner panel is fully client-only (Astro's `client:only="preact"` shape). */
+export default function DesignTokenTweakPanel(
+  props: DesignTokenTweakPanelInnerProps = {},
+) {
+  // The Island wrapper returns the SSR-skip element shape; cast at the
+  // boundary so JSX consumers see a renderable child.
+  const rendered = Island({
+    ssrFallback: null,
+    children: <DesignTokenTweakPanelInner {...props} />,
+  });
+  return rendered as unknown as preact.JSX.Element;
+}
+
+/** Re-export the inner component name so consumers can reach it directly
+ *  for tests or storybook contexts (where the Island wrapper isn't
+ *  meaningful). */
+export { DesignTokenTweakPanelInner };

--- a/packages/zudo-doc-v2/src/theme/design-token-tweak-panel.tsx
+++ b/packages/zudo-doc-v2/src/theme/design-token-tweak-panel.tsx
@@ -132,6 +132,10 @@ function DesignTokenTweakPanelInner({
   }, []);
 
   // Mirror host root inline `--zd-*` overrides into the iframe in real time.
+  // Note: this listener only mirrors changes made via inline-style on the
+  // host `<html>` root. CSS variables set elsewhere (CSSOM rules, other
+  // elements, animations) are intentionally NOT mirrored — the panel writes
+  // exclusively to `documentElement.style` so this scope matches.
   useEffect(() => {
     if (!iframeReady) return;
     const root = document.documentElement;
@@ -143,17 +147,27 @@ function DesignTokenTweakPanelInner({
     }
     lastVarsRef.current = initial;
 
-    function flush() {
-      const next = collectInlineCssVars(root);
-      const dropped = namesDropped(lastVarsRef.current, next);
-      if (dropped.length > 0) sendClearCssVars(iframeRef.current, dropped);
-      if (next.length > 0) sendApplyCssVars(iframeRef.current, next);
-      lastVarsRef.current = next;
+    // Debounce flushes to one per animation frame so a burst of mutations
+    // (e.g. dragging a slider) collapses into a single postMessage hop.
+    let rafId = 0;
+    function scheduleFlush() {
+      if (rafId !== 0) return;
+      rafId = window.requestAnimationFrame(() => {
+        rafId = 0;
+        const next = collectInlineCssVars(root);
+        const dropped = namesDropped(lastVarsRef.current, next);
+        if (dropped.length > 0) sendClearCssVars(iframeRef.current, dropped);
+        if (next.length > 0) sendApplyCssVars(iframeRef.current, next);
+        lastVarsRef.current = next;
+      });
     }
 
-    const observer = new MutationObserver(flush);
+    const observer = new MutationObserver(scheduleFlush);
     observer.observe(root, { attributes: true, attributeFilter: ["style"] });
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+      if (rafId !== 0) window.cancelAnimationFrame(rafId);
+    };
   }, [iframeReady]);
 
   return (

--- a/packages/zudo-doc-v2/src/theme/iframe-bridge.ts
+++ b/packages/zudo-doc-v2/src/theme/iframe-bridge.ts
@@ -1,0 +1,149 @@
+// postMessage bridge between the Design Token Tweak Panel host page and the
+// preview iframe it controls. The panel UI mutates a structured set of CSS
+// variables and ships an `apply-css-vars` payload over postMessage; the
+// iframe receives it and writes the values onto its own
+// `documentElement.style`. This decouples token edits from the host page so
+// the panel can be embedded into any layout without leaking style mutations
+// up into surrounding chrome.
+//
+// Protocol
+// --------
+//
+//   panel → iframe :  { type: "apply-css-vars", vars: [["--zd-bg", "#000"], ...] }
+//   panel → iframe :  { type: "clear-css-vars", names: ["--zd-bg", ...] }
+//   iframe → panel :  { type: "ready" }            // sent on iframe load
+//   iframe → panel :  { type: "error", reason }    // optional diagnostics
+//
+// All messages carry a `source: "zudo-doc-theme-bridge"` discriminator so a
+// host page hosting other postMessage protocols can ignore foreign traffic.
+
+export const BRIDGE_SOURCE = "zudo-doc-theme-bridge" as const;
+
+export type CssVarPair = readonly [name: string, value: string];
+
+export interface ApplyCssVarsMessage {
+  source: typeof BRIDGE_SOURCE;
+  type: "apply-css-vars";
+  vars: ReadonlyArray<CssVarPair>;
+}
+
+export interface ClearCssVarsMessage {
+  source: typeof BRIDGE_SOURCE;
+  type: "clear-css-vars";
+  names: ReadonlyArray<string>;
+}
+
+export interface ReadyMessage {
+  source: typeof BRIDGE_SOURCE;
+  type: "ready";
+}
+
+export interface ErrorMessage {
+  source: typeof BRIDGE_SOURCE;
+  type: "error";
+  reason: string;
+}
+
+export type BridgeMessage =
+  | ApplyCssVarsMessage
+  | ClearCssVarsMessage
+  | ReadyMessage
+  | ErrorMessage;
+
+/**
+ * Type guard. Accepts any postMessage payload and confirms it is a bridge
+ * envelope. Foreign messages are ignored silently.
+ */
+export function isBridgeMessage(value: unknown): value is BridgeMessage {
+  if (!value || typeof value !== "object") return false;
+  const v = value as { source?: unknown; type?: unknown };
+  return v.source === BRIDGE_SOURCE && typeof v.type === "string";
+}
+
+// --- Sender (panel → iframe) -----------------------------------------------
+
+/** Send `apply-css-vars` to the iframe. No-op when the iframe has not loaded. */
+export function sendApplyCssVars(
+  iframe: HTMLIFrameElement | null,
+  vars: ReadonlyArray<CssVarPair>,
+): void {
+  const win = iframe?.contentWindow;
+  if (!win) return;
+  const message: ApplyCssVarsMessage = {
+    source: BRIDGE_SOURCE,
+    type: "apply-css-vars",
+    vars,
+  };
+  // targetOrigin "*" because the iframe is same-origin (sandboxed via srcdoc
+  // or a sibling URL). If a future caller embeds a cross-origin preview they
+  // can pass a stricter origin via a wrapping helper.
+  win.postMessage(message, "*");
+}
+
+/** Send `clear-css-vars` to the iframe so it removes inline overrides. */
+export function sendClearCssVars(
+  iframe: HTMLIFrameElement | null,
+  names: ReadonlyArray<string>,
+): void {
+  const win = iframe?.contentWindow;
+  if (!win) return;
+  const message: ClearCssVarsMessage = {
+    source: BRIDGE_SOURCE,
+    type: "clear-css-vars",
+    names,
+  };
+  win.postMessage(message, "*");
+}
+
+// --- Receiver (iframe-side) -------------------------------------------------
+
+/**
+ * Install a message listener inside the preview iframe document that applies
+ * any incoming CSS-var batches onto `documentElement.style`. Returns a
+ * teardown function. Intended to be called once at iframe boot.
+ */
+export function installIframeReceiver(target: Window = window): () => void {
+  function handler(event: MessageEvent): void {
+    const data = event.data;
+    if (!isBridgeMessage(data)) return;
+    if (data.type === "apply-css-vars") {
+      const root = target.document.documentElement;
+      for (const [name, value] of data.vars) {
+        root.style.setProperty(name, value);
+      }
+      return;
+    }
+    if (data.type === "clear-css-vars") {
+      const root = target.document.documentElement;
+      for (const name of data.names) {
+        root.style.removeProperty(name);
+      }
+      return;
+    }
+  }
+  target.addEventListener("message", handler);
+  // Announce readiness so the panel can start streaming initial state.
+  const parent = target.parent;
+  if (parent && parent !== target) {
+    const ready: ReadyMessage = { source: BRIDGE_SOURCE, type: "ready" };
+    parent.postMessage(ready, "*");
+  }
+  return () => target.removeEventListener("message", handler);
+}
+
+/**
+ * Install a `ready` listener on the panel side so callers can defer the
+ * initial CSS-var sync until the iframe document has booted.
+ */
+export function onIframeReady(
+  expectedSource: Window | null,
+  callback: () => void,
+): () => void {
+  function handler(event: MessageEvent): void {
+    if (expectedSource && event.source !== expectedSource) return;
+    if (!isBridgeMessage(event.data)) return;
+    if (event.data.type === "ready") callback();
+  }
+  window.addEventListener("message", handler);
+  return () => window.removeEventListener("message", handler);
+}

--- a/packages/zudo-doc-v2/src/theme/index.ts
+++ b/packages/zudo-doc-v2/src/theme/index.ts
@@ -1,0 +1,28 @@
+// E5 framework primitives — theme controls.
+//
+// This subpath publishes the layout-level color scheme provider, the theme
+// toggle island, and the design token tweak panel (with its export modal
+// and iframe bridge). The host project mounts these directly from
+// `@zudo-doc/zudo-doc-v2/theme`.
+
+export { default as ThemeToggle } from "./theme-toggle";
+export { default as ColorSchemeProvider } from "./color-scheme-provider";
+export {
+  default as DesignTokenTweakPanel,
+  DesignTokenTweakPanelInner,
+} from "./design-token-tweak-panel";
+export { default as ColorTweakExportModal } from "./color-tweak-export-modal";
+export {
+  BRIDGE_SOURCE,
+  isBridgeMessage,
+  installIframeReceiver,
+  onIframeReady,
+  sendApplyCssVars,
+  sendClearCssVars,
+  type BridgeMessage,
+  type ApplyCssVarsMessage,
+  type ClearCssVarsMessage,
+  type ReadyMessage,
+  type ErrorMessage,
+  type CssVarPair,
+} from "./iframe-bridge";

--- a/packages/zudo-doc-v2/src/theme/theme-toggle.tsx
+++ b/packages/zudo-doc-v2/src/theme/theme-toggle.tsx
@@ -1,0 +1,95 @@
+// Ported verbatim from src/components/theme-toggle.tsx (E5 framework primitives).
+// Preact runs in compat mode so the React-style imports keep working.
+import { useState, useEffect } from "react";
+
+const STORAGE_KEY = "zudo-doc-theme";
+
+function SunIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <circle cx="12" cy="12" r="5" />
+      <line x1="12" y1="1" x2="12" y2="3" />
+      <line x1="12" y1="21" x2="12" y2="23" />
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+      <line x1="1" y1="12" x2="3" y2="12" />
+      <line x1="21" y1="12" x2="23" y2="12" />
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+    </svg>
+  );
+}
+
+interface ThemeToggleProps {
+  defaultMode?: "light" | "dark";
+}
+
+export default function ThemeToggle({ defaultMode = "dark" }: ThemeToggleProps) {
+  // Initial state must match server render to avoid hydration mismatch.
+  // Actual theme is synced from DOM in useEffect below.
+  const [mode, setMode] = useState<"light" | "dark">(defaultMode);
+
+  useEffect(() => {
+    const actual =
+      (document.documentElement.getAttribute("data-theme") as
+        | "light"
+        | "dark") || defaultMode;
+    if (actual !== mode) {
+      setMode(actual);
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  function toggle() {
+    const next = mode === "dark" ? "light" : "dark";
+    setMode(next);
+    document.documentElement.setAttribute("data-theme", next);
+    document.documentElement.style.colorScheme = next;
+    localStorage.setItem(STORAGE_KEY, next);
+    // Clear both v1 and v2 tweak state so the new scheme's palette takes effect.
+    localStorage.removeItem("zudo-doc-tweak-state");
+    localStorage.removeItem("zudo-doc-tweak-state-v2");
+    window.dispatchEvent(new CustomEvent("color-scheme-changed"));
+  }
+
+  const nextMode = mode === "dark" ? "light" : "dark";
+
+  return (
+    <button
+      onClick={toggle}
+      aria-label={`Switch to ${nextMode} mode`}
+      className="text-muted hover:text-fg transition-colors p-hsp-sm focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2"
+    >
+      {mode === "dark" ? <SunIcon /> : <MoonIcon />}
+    </button>
+  );
+}

--- a/packages/zudo-doc-v2/src/toc/__tests__/cx.test.ts
+++ b/packages/zudo-doc-v2/src/toc/__tests__/cx.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { cx } from "../cx";
+
+describe("cx", () => {
+  it("joins truthy strings with spaces", () => {
+    expect(cx("a", "b", "c")).toBe("a b c");
+  });
+
+  it("filters out falsy values", () => {
+    expect(cx("a", false, null, undefined, "", "b")).toBe("a b");
+  });
+
+  it("handles conditional expressions inline", () => {
+    const isActive = true;
+    const isOpen = false;
+    expect(cx("base", isActive && "active", isOpen && "open")).toBe(
+      "base active",
+    );
+  });
+
+  it("flattens nested arrays", () => {
+    expect(cx("a", ["b", ["c", "d"]], "e")).toBe("a b c d e");
+  });
+
+  it("includes object keys whose values are truthy", () => {
+    expect(cx({ foo: true, bar: false, baz: 1 })).toBe("foo baz");
+  });
+
+  it("returns an empty string when nothing is truthy", () => {
+    expect(cx(false, null, undefined, "")).toBe("");
+  });
+});

--- a/packages/zudo-doc-v2/src/toc/__tests__/smart-break.test.ts
+++ b/packages/zudo-doc-v2/src/toc/__tests__/smart-break.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { isPathLike, smartBreak } from "../smart-break";
+
+describe("isPathLike", () => {
+  it("returns false for empty input", () => {
+    expect(isPathLike("")).toBe(false);
+  });
+
+  it("recognizes URL-like strings", () => {
+    expect(isPathLike("https://example.com/foo")).toBe(true);
+  });
+
+  it("recognizes POSIX-style absolute and relative paths", () => {
+    expect(isPathLike("/etc/passwd")).toBe(true);
+    expect(isPathLike("./relative/path")).toBe(true);
+    expect(isPathLike("../up/one")).toBe(true);
+  });
+
+  it("recognizes Windows drive paths", () => {
+    expect(isPathLike("C:\\Users\\me")).toBe(true);
+    expect(isPathLike("D:/Users/me")).toBe(true);
+  });
+
+  it("recognizes domain-plus-slash strings", () => {
+    expect(isPathLike("example.com/foo")).toBe(true);
+  });
+
+  it("rejects prose with hyphens, slashes, or dots", () => {
+    expect(isPathLike("and/or")).toBe(false);
+    expect(isPathLike("well-known")).toBe(false);
+    expect(isPathLike("state-of-the-art")).toBe(false);
+    expect(isPathLike("UI/UX")).toBe(false);
+    expect(isPathLike("1.2.3-beta.4")).toBe(false);
+  });
+});
+
+describe("smartBreak", () => {
+  it("returns the input unchanged when not path-like", () => {
+    expect(smartBreak("Hello world")).toBe("Hello world");
+    expect(smartBreak("UI/UX")).toBe("UI/UX");
+  });
+
+  it("returns a VNode for path-like inputs", () => {
+    const result = smartBreak("https://example.com/foo");
+    // VNode is an object; non-path-like returned the raw string.
+    expect(typeof result).toBe("object");
+    expect(result).not.toBeNull();
+  });
+});

--- a/packages/zudo-doc-v2/src/toc/__tests__/use-active-heading.test.ts
+++ b/packages/zudo-doc-v2/src/toc/__tests__/use-active-heading.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { getActiveHeadingId } from "../use-active-heading";
+
+/**
+ * Build a stub HTMLElement-ish object with a fixed `top` value. The
+ * scroll-spy code only reads `getBoundingClientRect().top`, so a tiny
+ * stand-in is enough — no jsdom required.
+ */
+function makeEl(top: number): HTMLElement {
+  return {
+    getBoundingClientRect: () => ({ top }) as DOMRect,
+  } as HTMLElement;
+}
+
+function makeMap(entries: Array<[string, number]>): Map<string, HTMLElement> {
+  const map = new Map<string, HTMLElement>();
+  for (const [id, top] of entries) map.set(id, makeEl(top));
+  return map;
+}
+
+describe("getActiveHeadingId", () => {
+  const VIEWPORT = 800;
+
+  it("returns null for an empty heading list", () => {
+    expect(getActiveHeadingId([], new Map(), VIEWPORT)).toBeNull();
+  });
+
+  it("returns the last heading when every heading has scrolled above the threshold", () => {
+    const ids = ["a", "b", "c"];
+    const map = makeMap([
+      ["a", -500],
+      ["b", -300],
+      ["c", -100],
+    ]);
+    expect(getActiveHeadingId(ids, map, VIEWPORT)).toBe("c");
+  });
+
+  it("activates the first heading when it is the first visible AND above the viewport midline", () => {
+    const ids = ["a", "b", "c"];
+    // a is below SCROLL_MARGIN_TOP (80) and above viewport/2 (400)
+    const map = makeMap([
+      ["a", 100],
+      ["b", 500],
+      ["c", 900],
+    ]);
+    expect(getActiveHeadingId(ids, map, VIEWPORT)).toBe("a");
+  });
+
+  it("returns null when only the first heading is visible but it sits below the viewport midline", () => {
+    const ids = ["a", "b"];
+    const map = makeMap([
+      ["a", 500], // visible (>=80) but below 400 midline
+      ["b", 1200],
+    ]);
+    expect(getActiveHeadingId(ids, map, VIEWPORT)).toBeNull();
+  });
+
+  it("activates the predecessor of the first visible heading when the first visible sits below the midline", () => {
+    const ids = ["a", "b", "c"];
+    // a scrolled past, b is first visible but below midline → activate a
+    const map = makeMap([
+      ["a", -50],
+      ["b", 600],
+      ["c", 1200],
+    ]);
+    expect(getActiveHeadingId(ids, map, VIEWPORT)).toBe("a");
+  });
+
+  it("activates the first visible heading when its top crosses the midline", () => {
+    const ids = ["a", "b", "c"];
+    // a scrolled past, b is first visible AND above the midline → activate b
+    const map = makeMap([
+      ["a", -50],
+      ["b", 200],
+      ["c", 900],
+    ]);
+    expect(getActiveHeadingId(ids, map, VIEWPORT)).toBe("b");
+  });
+
+  it("skips headings whose elements are missing from the map", () => {
+    const ids = ["a", "missing", "c"];
+    const map = makeMap([
+      ["a", -50],
+      ["c", 200], // first found visible — above midline → activate c
+    ]);
+    expect(getActiveHeadingId(ids, map, VIEWPORT)).toBe("c");
+  });
+
+  it("uses the threshold inclusively — a heading with top exactly at SCROLL_MARGIN_TOP counts as visible", () => {
+    const ids = ["a"];
+    // top === 80 hits the >= comparison; with viewport 800, midline 400 ⇒ active
+    const map = makeMap([["a", 80]]);
+    expect(getActiveHeadingId(ids, map, VIEWPORT)).toBe("a");
+  });
+});

--- a/packages/zudo-doc-v2/src/toc/cx.ts
+++ b/packages/zudo-doc-v2/src/toc/cx.ts
@@ -1,0 +1,39 @@
+/**
+ * Tiny `clsx`-style class name joiner. Accepts strings, falsy values,
+ * and arrays/objects of the same — only truthy strings survive.
+ *
+ * The host project depends on `clsx`, but framework primitives keep
+ * their dependency surface minimal so that a downstream consumer of
+ * `@zudo-doc/zudo-doc-v2/toc` does not need an extra runtime dep just
+ * for class name composition. The behavior here is the subset the TOC
+ * primitives use; see clsx for the full feature set.
+ */
+type ClassValue =
+  | string
+  | number
+  | bigint
+  | boolean
+  | null
+  | undefined
+  | ClassValue[]
+  | { [key: string]: unknown };
+
+export function cx(...args: ClassValue[]): string {
+  const out: string[] = [];
+  for (const arg of args) {
+    if (!arg) continue;
+    if (typeof arg === "string") {
+      out.push(arg);
+    } else if (typeof arg === "number" || typeof arg === "bigint") {
+      out.push(String(arg));
+    } else if (Array.isArray(arg)) {
+      const inner = cx(...arg);
+      if (inner) out.push(inner);
+    } else if (typeof arg === "object") {
+      for (const key of Object.keys(arg)) {
+        if ((arg as Record<string, unknown>)[key]) out.push(key);
+      }
+    }
+  }
+  return out.join(" ");
+}

--- a/packages/zudo-doc-v2/src/toc/index.ts
+++ b/packages/zudo-doc-v2/src/toc/index.ts
@@ -1,0 +1,7 @@
+export { Toc } from "./toc";
+export type { TocProps } from "./toc";
+export { MobileToc } from "./mobile-toc";
+export type { MobileTocProps } from "./mobile-toc";
+export { useActiveHeading, getActiveHeadingId } from "./use-active-heading";
+export type { UseActiveHeadingResult } from "./use-active-heading";
+export type { HeadingItem, TocItem } from "./types";

--- a/packages/zudo-doc-v2/src/toc/mobile-toc.tsx
+++ b/packages/zudo-doc-v2/src/toc/mobile-toc.tsx
@@ -1,0 +1,87 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { useMemo, useState } from "preact/hooks";
+import type { HeadingItem } from "./types";
+import { SmartBreak } from "./smart-break";
+import { cx } from "./cx";
+
+export interface MobileTocProps {
+  headings: readonly HeadingItem[];
+  title?: string;
+}
+
+/**
+ * Collapsible TOC for narrow viewports (`xl:hidden`). Closed by
+ * default; tapping the header toggles, and tapping any entry closes
+ * the panel after navigation so the reader does not have to dismiss
+ * it manually.
+ *
+ * Like `Toc`, this only renders depth 2–4 headings and returns a
+ * hidden placeholder when nothing qualifies — keeps the surrounding
+ * markup shape predictable across pages.
+ */
+export function MobileToc({
+  headings,
+  title = "On this page",
+}: MobileTocProps) {
+  const filtered = useMemo(
+    () => headings.filter((h) => h.depth >= 2 && h.depth <= 4),
+    [headings],
+  );
+  const [open, setOpen] = useState(false);
+
+  if (filtered.length === 0) return <div className="hidden" />;
+
+  return (
+    <div className="xl:hidden border border-muted mb-vsp-lg">
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-expanded={open}
+        className="flex w-full items-center justify-between px-hsp-lg py-vsp-xs text-small font-medium text-fg"
+      >
+        <span>{title}</span>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+          className={cx(
+            "h-icon-sm w-icon-sm text-muted transition-transform duration-150",
+            open && "rotate-180",
+          )}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M19 9l-7 7-7-7"
+          />
+        </svg>
+      </button>
+      {open && (
+        <ul className="border-t border-muted px-hsp-lg py-vsp-xs space-y-vsp-2xs">
+          {filtered.map((heading, index) => (
+            <li
+              key={`${heading.slug}-${index}`}
+              className={cx(
+                heading.depth === 3 && "ml-hsp-lg",
+                heading.depth === 4 && "ml-hsp-2xl",
+              )}
+            >
+              <a
+                href={`#${heading.slug}`}
+                onClick={() => setOpen(false)}
+                className="block py-vsp-2xs text-small text-muted hover:text-fg hover:underline focus-visible:underline"
+              >
+                <SmartBreak>{heading.text}</SmartBreak>
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/packages/zudo-doc-v2/src/toc/smart-break.tsx
+++ b/packages/zudo-doc-v2/src/toc/smart-break.tsx
@@ -1,0 +1,55 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import type { VNode } from "preact";
+
+/**
+ * Local copy of the SmartBreak helper used by TOC entries. Kept inside
+ * the toc primitive folder so the package is self-contained and does
+ * not reach back into the host application's `src/utils/smart-break`.
+ *
+ * The host's full smart-break util exposes additional helpers
+ * (`smartBreakToHtml`, `escapeAndInjectWbr`) that the TOC does not
+ * need; this file ports only `isPathLike`, `smartBreak`, and the
+ * `SmartBreak` Preact wrapper. Keep the heuristic byte-identical to
+ * the host implementation so wbr placement matches everywhere.
+ */
+export function isPathLike(text: string): boolean {
+  if (!text) return false;
+  if (text.includes("://")) return true;
+  if (/^\.{0,2}\//.test(text)) return true;
+  if (/^[A-Za-z]:[\\/]/.test(text)) return true;
+  const forwardMatches = text.match(/[A-Za-z0-9]\/[A-Za-z0-9]/g);
+  if (forwardMatches && forwardMatches.length >= 2) return true;
+  const backMatches = text.match(/[A-Za-z0-9]\\[A-Za-z0-9]/g);
+  if (backMatches && backMatches.length >= 2) return true;
+  const hasDomainDot = /[A-Za-z0-9]\.[A-Za-z0-9]/.test(text);
+  const hasSlash = /[\\/]/.test(text);
+  if (hasDomainDot && hasSlash) return true;
+  return false;
+}
+
+// Delimiter set: / \ - _ . : ? # & =
+const DELIM_SPLIT = /([/\\\-_.:?#&=])/;
+
+export function smartBreak(text: string): VNode | string {
+  if (!isPathLike(text)) return text;
+  const parts = text.split(DELIM_SPLIT);
+  const nodes: (string | VNode)[] = [];
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    if (part === "") continue;
+    nodes.push(part);
+    if (i % 2 === 1) nodes.push(<wbr key={`wbr-${i}`} />);
+  }
+  return <>{nodes}</>;
+}
+
+/**
+ * Preact function component wrapper — pure, server-renderable.
+ * Stringifies children and defers to smartBreak.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function SmartBreak({ children }: { children?: unknown }): any {
+  return <>{smartBreak(String(children ?? ""))}</>;
+}

--- a/packages/zudo-doc-v2/src/toc/toc.tsx
+++ b/packages/zudo-doc-v2/src/toc/toc.tsx
@@ -1,0 +1,74 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { useMemo } from "preact/hooks";
+import { useActiveHeading } from "./use-active-heading";
+import type { HeadingItem } from "./types";
+import { SmartBreak } from "./smart-break";
+import { cx } from "./cx";
+
+export interface TocProps {
+  headings: readonly HeadingItem[];
+}
+
+/**
+ * Desktop right-rail Table of Contents. Sticky island that lights up
+ * the heading nearest the top of the viewport via `useActiveHeading`.
+ *
+ * Renders only depth 2–4 headings (h2/h3/h4), matching zudo-doc's
+ * historical behavior — the page title (h1) is rendered separately by
+ * the layout and h5+ are deemed too granular for the TOC. Components
+ * with no in-range headings render an empty hidden nav so layout
+ * reservations stay stable across pages.
+ */
+export function Toc({ headings }: TocProps) {
+  const filtered = useMemo(
+    () => headings.filter((h) => h.depth >= 2 && h.depth <= 4),
+    [headings],
+  );
+  const { activeId, activate } = useActiveHeading(filtered);
+
+  if (filtered.length === 0) return <nav className="hidden" />;
+
+  return (
+    <nav
+      aria-label="Table of contents"
+      className={cx(
+        "hidden xl:flex flex-col",
+        "w-[280px] shrink-0",
+        "sticky top-[3.5rem] self-start z-10",
+        "pt-vsp-xl lg:pt-vsp-2xl",
+        "h-[calc(100vh-3.5rem)]",
+      )}
+    >
+      <ul className="border-l border-muted pl-hsp-lg overflow-y-auto flex-1 min-h-0">
+        {filtered.map((heading, index) => {
+          const isActive = heading.slug === activeId;
+          return (
+            <li
+              key={`${heading.slug}-${index}`}
+              className={cx(
+                heading.depth === 3 && "ml-hsp-lg",
+                heading.depth === 4 && "ml-hsp-2xl",
+              )}
+            >
+              <a
+                href={`#${heading.slug}`}
+                onClick={() => activate(heading.slug)}
+                aria-current={isActive ? "true" : undefined}
+                className={cx(
+                  "block py-vsp-2xs text-small leading-snug transition-colors",
+                  isActive
+                    ? "bg-fg text-bg font-medium"
+                    : "text-muted hover:underline focus:underline",
+                )}
+              >
+                <SmartBreak>{heading.text}</SmartBreak>
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/packages/zudo-doc-v2/src/toc/types.ts
+++ b/packages/zudo-doc-v2/src/toc/types.ts
@@ -1,0 +1,22 @@
+/**
+ * Heading metadata consumed by the TOC primitives.
+ *
+ * Shape mirrors the `headings` array exported from MDX modules by the
+ * underlying engine — `depth` (1–6), DOM `slug` (matching the rendered
+ * heading element's id), and the rendered `text`. Keep field names and
+ * types byte-aligned with the engine so a page module's `headings`
+ * export drops in directly.
+ */
+export interface HeadingItem {
+  readonly depth: number;
+  readonly slug: string;
+  readonly text: string;
+}
+
+/**
+ * Alias kept for ergonomic imports — `TocItem` is the same shape the
+ * TOC components consume after filtering by depth. Filtering does not
+ * change the per-item shape, so the alias documents intent without
+ * introducing a structural difference.
+ */
+export type TocItem = HeadingItem;

--- a/packages/zudo-doc-v2/src/toc/use-active-heading.ts
+++ b/packages/zudo-doc-v2/src/toc/use-active-heading.ts
@@ -1,0 +1,162 @@
+import { useCallback, useEffect, useRef, useState } from "preact/hooks";
+import type { HeadingItem } from "./types";
+
+/**
+ * Pixel offset from the viewport top used as the "above the fold"
+ * threshold. A heading whose top is above this line is treated as
+ * having scrolled past — matches the original zudo-doc behavior so the
+ * scroll-spy keeps the same feel after the migration.
+ */
+const SCROLL_MARGIN_TOP = 80;
+const DEBOUNCE_MS = 200;
+
+/**
+ * Pure helper that picks the active heading id given the heading slug
+ * order and a slug→element map. Extracted from the hook so it is unit-
+ * testable without DOM event plumbing.
+ *
+ * Algorithm: find the first heading whose top is at or below the
+ * SCROLL_MARGIN_TOP threshold ("first visible"). If none, the user has
+ * scrolled past every heading — return the last one. If the very first
+ * heading is the first visible AND its top is above the viewport
+ * midline, treat it as already active. Otherwise activate the
+ * predecessor of the first visible heading.
+ */
+export function getActiveHeadingId(
+  headingIds: readonly string[],
+  elementMap: ReadonlyMap<string, HTMLElement>,
+  viewportHeight: number,
+): string | null {
+  if (headingIds.length === 0) return null;
+
+  let firstVisibleIndex = -1;
+  for (let i = 0; i < headingIds.length; i++) {
+    const el = elementMap.get(headingIds[i]!);
+    if (!el) continue;
+    const { top } = el.getBoundingClientRect();
+    if (top >= SCROLL_MARGIN_TOP) {
+      firstVisibleIndex = i;
+      break;
+    }
+  }
+
+  if (firstVisibleIndex === -1) {
+    return headingIds[headingIds.length - 1] ?? null;
+  }
+
+  if (firstVisibleIndex === 0) {
+    const el = elementMap.get(headingIds[0]!);
+    if (el) {
+      const { top } = el.getBoundingClientRect();
+      if (top < viewportHeight / 2) {
+        return headingIds[0] ?? null;
+      }
+    }
+    return null;
+  }
+
+  const el = elementMap.get(headingIds[firstVisibleIndex]!);
+  if (el) {
+    const { top } = el.getBoundingClientRect();
+    if (top < viewportHeight / 2) {
+      return headingIds[firstVisibleIndex] ?? null;
+    }
+  }
+
+  return headingIds[firstVisibleIndex - 1] ?? null;
+}
+
+export interface UseActiveHeadingResult {
+  activeId: string | null;
+  activate: (id: string) => void;
+}
+
+/**
+ * Scroll-spy hook. Tracks which heading slug should be highlighted
+ * based on the current scroll position. Provides an `activate(id)`
+ * imperatively-callable helper used by click handlers — sets the
+ * active id immediately and suppresses the scroll-driven update until
+ * the smooth-scroll completes (`scrollend`, with a timeout fallback
+ * for older Safari).
+ */
+export function useActiveHeading(
+  headings: readonly HeadingItem[],
+): UseActiveHeadingResult {
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const headingIdsRef = useRef<readonly string[]>([]);
+  const elementMapRef = useRef<Map<string, HTMLElement>>(new Map());
+  const suppressedRef = useRef(false);
+
+  const activate = useCallback((id: string) => {
+    setActiveId(id);
+    suppressedRef.current = true;
+    // Safety timeout: unsuppress if no scroll event fires (target already in view)
+    setTimeout(() => {
+      suppressedRef.current = false;
+    }, 2000);
+  }, []);
+
+  useEffect(() => {
+    const ids = headings.map((h) => h.slug);
+    headingIdsRef.current = ids;
+
+    const map = new Map<string, HTMLElement>();
+    for (const id of ids) {
+      const el = document.getElementById(id);
+      if (el) map.set(id, el);
+    }
+    elementMapRef.current = map;
+
+    let timerId: ReturnType<typeof setTimeout> | null = null;
+
+    function update() {
+      timerId = null;
+      setActiveId(
+        getActiveHeadingId(
+          headingIdsRef.current,
+          elementMapRef.current,
+          window.innerHeight,
+        ),
+      );
+    }
+
+    let fallbackTimerId: ReturnType<typeof setTimeout> | null = null;
+
+    function onScroll() {
+      if (suppressedRef.current) {
+        // Fallback for browsers without scrollend (Safari < 18)
+        if (fallbackTimerId !== null) clearTimeout(fallbackTimerId);
+        fallbackTimerId = setTimeout(onScrollEnd, 1500);
+        return;
+      }
+      if (timerId !== null) clearTimeout(timerId);
+      timerId = setTimeout(update, DEBOUNCE_MS);
+    }
+
+    function onScrollEnd() {
+      suppressedRef.current = false;
+      if (fallbackTimerId !== null) {
+        clearTimeout(fallbackTimerId);
+        fallbackTimerId = null;
+      }
+      if (timerId !== null) clearTimeout(timerId);
+      update();
+    }
+
+    update();
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onScroll, { passive: true });
+    window.addEventListener("scrollend", onScrollEnd, { passive: true });
+
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onScroll);
+      window.removeEventListener("scrollend", onScrollEnd);
+      if (timerId !== null) clearTimeout(timerId);
+      if (fallbackTimerId !== null) clearTimeout(fallbackTimerId);
+    };
+  }, [headings]);
+
+  return { activeId, activate };
+}

--- a/packages/zudo-doc-v2/src/toc/vitest.config.ts
+++ b/packages/zudo-doc-v2/src/toc/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Scoped vitest config for the toc primitive folder. Lives inside the
+ * topic folder so it never collides with the host root config or
+ * sibling primitive folders. Run with:
+ *
+ *   pnpm vitest run -c packages/zudo-doc-v2/src/toc/vitest.config.ts
+ *
+ * The host root config at `vitest.config.ts` only globs `src/**` and
+ * the `packages/zudo-doc-v2` package has not yet wired up its own
+ * package-level vitest setup, so this scoped file is the path of
+ * least disruption while the framework primitives are still being
+ * scaffolded under E5.
+ */
+export default defineConfig({
+  test: {
+    root: __dirname,
+    include: ["__tests__/**/*.test.ts"],
+  },
+});

--- a/packages/zudo-doc-v2/src/transitions/index.ts
+++ b/packages/zudo-doc-v2/src/transitions/index.ts
@@ -1,0 +1,28 @@
+// Public surface for `@zudo-doc/zudo-doc-v2/transitions`.
+//
+// Two halves:
+//
+//   - `view-transitions.ts` — feature detection + a thin
+//     `startViewTransition(updateDom)` wrapper around
+//     `document.startViewTransition`. Falls back to running the
+//     update synchronously on browsers without the API (Firefox).
+//
+//   - `persist.ts` — helpers for assigning `view-transition-name`
+//     to persistent regions like the desktop sidebar, so the
+//     browser keeps their identity across navigations.
+
+export {
+  isViewTransitionsSupported,
+  startViewTransition,
+} from "./view-transitions.js";
+export type {
+  ViewTransitionLike,
+  StartViewTransitionResult,
+} from "./view-transitions.js";
+
+export {
+  sidebarPersistName,
+  persistName,
+  applyPersistName,
+  clearPersistName,
+} from "./persist.js";

--- a/packages/zudo-doc-v2/src/transitions/persist.ts
+++ b/packages/zudo-doc-v2/src/transitions/persist.ts
@@ -30,6 +30,14 @@ const SIDEBAR_PREFIX = "sidebar";
 const NON_IDENTIFIER_CHAR = /[^A-Za-z0-9_-]+/g;
 
 /**
+ * Hard cap on a single sanitized segment. Keeps a runaway/user-controlled
+ * input from producing a multi-kilobyte `view-transition-name` value
+ * (which browsers may truncate or reject silently anyway). 64 chars is
+ * comfortably above any realistic locale or section label.
+ */
+const MAX_SANITIZED_LEN = 64;
+
+/**
  * Build the `view-transition-name` value for the desktop sidebar.
  *
  * The original Astro layout used the literal `sidebar-${lang}-${section ?? "default"}`
@@ -89,8 +97,11 @@ export function clearPersistName(el: HTMLElement): void {
  * (e.g. an i18n locale read from the URL) do not produce malformed CSS.
  */
 function sanitize(value: string): string {
-  return value
+  const cleaned = value
     .trim()
     .replace(NON_IDENTIFIER_CHAR, "_")
     .replace(/^_+|_+$/g, "");
+  return cleaned.length > MAX_SANITIZED_LEN
+    ? cleaned.slice(0, MAX_SANITIZED_LEN)
+    : cleaned;
 }

--- a/packages/zudo-doc-v2/src/transitions/persist.ts
+++ b/packages/zudo-doc-v2/src/transitions/persist.ts
@@ -1,0 +1,96 @@
+// Helpers for keeping persistent regions stable across View Transitions.
+//
+// The native View Transitions API uses CSS `view-transition-name: <name>`
+// to mark elements as "the same element on both sides of the swap." When
+// a name matches between the old and new DOM, the browser cross-fades
+// the two states instead of treating them as unrelated. That is the
+// modern equivalent of Astro's `transition:persist` directive.
+//
+// In practice the desktop sidebar is the only thing zudo-doc cares about
+// here: keeping its scroll position across page navigations is one of
+// the View-Transitions migration's hard acceptance criteria. The naming
+// convention we use is `sidebar-${lang}-${section}` — the same shape
+// the original Astro layout passed to `transition:persist`.
+//
+// This module ships:
+//
+//   - a small `persistName(...)` helper that builds the canonical name
+//     from a language tag and an optional nav-section,
+//   - `applyPersistName(el, name)` which writes the
+//     `view-transition-name` style on an element,
+//   - and `clearPersistName(el)` for the unmount path.
+//
+// Browsers without View Transitions ignore unknown style properties,
+// so applying the name unconditionally is safe — there is no need to
+// branch on `isViewTransitionsSupported()`.
+
+const SIDEBAR_PREFIX = "sidebar";
+
+/** Anything CSS-identifier-incompatible we replace with `_`. */
+const NON_IDENTIFIER_CHAR = /[^A-Za-z0-9_-]+/g;
+
+/**
+ * Build the `view-transition-name` value for the desktop sidebar.
+ *
+ * The original Astro layout used the literal `sidebar-${lang}-${section ?? "default"}`
+ * shape. We preserve that exactly so tooling that greps the CSS for the
+ * sidebar's transition name keeps working after the migration.
+ */
+export function sidebarPersistName(lang: string, section?: string): string {
+  const safeLang = sanitize(lang) || "default";
+  const safeSection = sanitize(section ?? "") || "default";
+  return `${SIDEBAR_PREFIX}-${safeLang}-${safeSection}`;
+}
+
+/**
+ * Generic helper for any persistent region (modal trigger, fixed
+ * notification banner, etc.). Concatenates the parts with `-` and
+ * sanitizes them into CSS-identifier territory.
+ */
+export function persistName(...parts: ReadonlyArray<string | undefined | null>): string {
+  const cleaned = parts
+    .map((p) => sanitize(p ?? ""))
+    .filter((p) => p.length > 0);
+  if (cleaned.length === 0) {
+    return "default";
+  }
+  return cleaned.join("-");
+}
+
+/**
+ * Set `view-transition-name` on an element. Pass `null` or empty string
+ * to clear it instead. Idempotent — safe to call on every render.
+ *
+ * Uses `setProperty` so it works on the inline-style declaration in
+ * older browsers that don't expose the camelCased
+ * `style.viewTransitionName` accessor (Firefox 124+, Safari 18+ added
+ * the property; for everyone else the `setProperty` call is a no-op
+ * write that does no harm).
+ */
+export function applyPersistName(el: HTMLElement, name: string | null | undefined): void {
+  if (typeof el === "undefined" || el === null) return;
+  if (!name) {
+    el.style.removeProperty("view-transition-name");
+    return;
+  }
+  el.style.setProperty("view-transition-name", name);
+}
+
+/** Convenience for the unmount / cleanup path. */
+export function clearPersistName(el: HTMLElement): void {
+  applyPersistName(el, null);
+}
+
+/**
+ * Best-effort sanitizer for incoming language / section strings. The
+ * `view-transition-name` CSS property accepts a CSS `<custom-ident>`,
+ * which is far stricter than what arbitrary user input might contain.
+ * We collapse anything outside `[A-Za-z0-9_-]` to `_` so dynamic values
+ * (e.g. an i18n locale read from the URL) do not produce malformed CSS.
+ */
+function sanitize(value: string): string {
+  return value
+    .trim()
+    .replace(NON_IDENTIFIER_CHAR, "_")
+    .replace(/^_+|_+$/g, "");
+}

--- a/packages/zudo-doc-v2/src/transitions/view-transitions.ts
+++ b/packages/zudo-doc-v2/src/transitions/view-transitions.ts
@@ -1,0 +1,145 @@
+// Minimal native View Transitions API shim for the zudo-doc-v2 layout.
+//
+// Background
+// ----------
+// The Astro version of zudo-doc relied on Astro's `<ClientRouter />`
+// integration to provide:
+//
+//   1. cross-page View Transitions (the soft fade between MDX pages),
+//   2. `transition:persist` (the desktop sidebar's identity is kept
+//      across navigations so its scroll position survives), and
+//   3. helpful events (`astro:before-swap` / `astro:after-swap`) that
+//      let downstream scripts re-apply DOM state after the swap.
+//
+// Once we move off Astro and onto zfb's runtime, none of those Astro-
+// specific pieces are around. zfb itself does not ship a router, so
+// this package owns the cross-page-transition story.
+//
+// The browser's native View Transitions API gives us (1) for free in
+// Chrome / Edge / Safari 18+, and (2) is a CSS concern (just set
+// `view-transition-name`). This shim provides:
+//
+//   - `isViewTransitionsSupported()` — feature-detect.
+//   - `startViewTransition(updateDom)` — wraps `document.startViewTransition`
+//     when available, falls back to running `updateDom` synchronously
+//     so calling code does not need a separate Firefox path.
+//
+// (3) is solved by the consumer: emit your own router events around the
+// `updateDom` callback. We deliberately do not impose an event vocabulary.
+//
+// Acceptance criteria from epic #474 sub-task 6:
+//   * transitions enabled in Chrome (this file's happy path),
+//   * sidebar position persists across navigation (separate concern —
+//     handled by `./persist.ts` setting `view-transition-name` on the
+//     desktop sidebar `<aside>`),
+//   * no console errors in Firefox (this file: feature-detect, no-op).
+
+/**
+ * Subset of `ViewTransition` that callers actually need to await. Mirrors
+ * the WICG/Chrome interface — kept to the minimum surface so we don't
+ * have to ship a `lib.dom.d.ts` patch.
+ */
+export interface ViewTransitionLike {
+  readonly finished: Promise<void>;
+  readonly ready: Promise<void>;
+  readonly updateCallbackDone: Promise<void>;
+  skipTransition?: () => void;
+}
+
+/**
+ * Result of calling `startViewTransition`. In the no-op fallback path
+ * `transition` is `null`, but `finished` always resolves once `updateDom`
+ * has run, so callers can `await` regardless of browser support.
+ */
+export interface StartViewTransitionResult {
+  /**
+   * The browser's `ViewTransition` instance, or `null` when the API is
+   * unavailable (e.g. Firefox today).
+   */
+  readonly transition: ViewTransitionLike | null;
+  /**
+   * Resolves once the DOM update has completed. In the supported path
+   * this mirrors `transition.finished`; in the fallback it resolves on
+   * the same microtask as `updateDom`.
+   */
+  readonly finished: Promise<void>;
+}
+
+/**
+ * Structural view of a `Document` that exposes `startViewTransition`.
+ * We keep the field optional locally — recent `lib.dom` revisions
+ * declare it as required, but this package targets older TS lib
+ * profiles too, so working with an optional accessor lets the same
+ * source compile on either.
+ */
+type ViewTransitionDoc = {
+  startViewTransition?: (
+    callback: () => void | Promise<void>,
+  ) => ViewTransitionLike;
+};
+
+/**
+ * Cheap, side-effect-free feature detection. Safe to call during SSR —
+ * `typeof document` is `"undefined"` in non-browser hosts.
+ */
+export function isViewTransitionsSupported(): boolean {
+  if (typeof document === "undefined") return false;
+  const doc = document as unknown as ViewTransitionDoc;
+  return typeof doc.startViewTransition === "function";
+}
+
+/**
+ * Wrap `updateDom` in a native View Transition when the browser supports
+ * it; otherwise call `updateDom` synchronously and resolve immediately.
+ *
+ * Callers should treat this as fire-and-forget for visual purposes —
+ * the returned `finished` promise is mainly useful for tests and for
+ * coordinating focus / scroll restoration after the swap.
+ *
+ * The fallback path runs `updateDom` on the same tick. If `updateDom`
+ * returns a promise we wait for it before resolving `finished`, so a
+ * caller's "swap then run post-swap hooks" sequence works the same
+ * way regardless of browser support.
+ */
+export function startViewTransition(
+  updateDom: () => void | Promise<void>,
+): StartViewTransitionResult {
+  if (typeof document === "undefined") {
+    // SSR / non-browser: treat as a no-op transition. We still invoke
+    // `updateDom` synchronously so callers don't have to special-case
+    // the SSR path — most won't call this from SSR anyway, but defending
+    // against accidental calls is cheap.
+    const finished = Promise.resolve()
+      .then(() => updateDom())
+      .then(() => undefined);
+    return { transition: null, finished };
+  }
+
+  const doc = document as unknown as ViewTransitionDoc;
+
+  if (typeof doc.startViewTransition === "function") {
+    const transition = doc.startViewTransition(() => updateDom());
+    return {
+      transition,
+      // `finished` already returns void in the spec; the explicit
+      // `.then(() => undefined)` normalizes the shape across browsers
+      // that may resolve with the deprecated `unknown` value.
+      finished: transition.finished.then(() => undefined),
+    };
+  }
+
+  // Firefox / older Safari: no view transition. Run the update
+  // synchronously so the caller still gets the DOM swap; resolve the
+  // returned promise on the next microtask.
+  let finished: Promise<void>;
+  try {
+    const maybe = updateDom();
+    finished =
+      maybe instanceof Promise
+        ? maybe.then(() => undefined)
+        : Promise.resolve();
+  } catch (err) {
+    finished = Promise.reject(err instanceof Error ? err : new Error(String(err)));
+  }
+  return { transition: null, finished };
+}

--- a/packages/zudo-doc-v2/tsconfig.json
+++ b/packages/zudo-doc-v2/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "jsxImportSource": "preact",
+    "moduleResolution": "bundler",
+    "module": "ESNext",
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/zudo-doc-v2/tsconfig.json
+++ b/packages/zudo-doc-v2/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "jsxImportSource": "preact",
     "moduleResolution": "bundler",
     "module": "ESNext",
@@ -11,5 +11,6 @@
     "noEmit": true,
     "skipLibCheck": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": []
 }

--- a/packages/zudo-doc-v2/vitest.config.ts
+++ b/packages/zudo-doc-v2/vitest.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from "vitest/config";
+import { resolve } from "node:path";
+
+const repoRoot = resolve(__dirname, "../..");
+
+export default defineConfig({
+  esbuild: {
+    jsx: "automatic",
+    jsxImportSource: "preact",
+  },
+  resolve: {
+    alias: {
+      // preact-render-to-string is hoisted into the workspace root pnpm store
+      // but not surfaced at root or package node_modules. Pin it explicitly so
+      // tests can render JSX without bloating the package's own deps.
+      "preact-render-to-string": resolve(
+        repoRoot,
+        "node_modules/.pnpm/preact-render-to-string@6.6.6_preact@10.29.0/node_modules/preact-render-to-string/dist/index.mjs",
+      ),
+    },
+  },
+  test: {
+    include: ["src/**/__tests__/**/*.test.{ts,tsx}"],
+  },
+});

--- a/packages/zudo-doc-v2/vitest.config.ts
+++ b/packages/zudo-doc-v2/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Vitest config scoped to the framework primitives package.
+ *
+ * The repo-root vitest.config.ts only includes `src/**` and `scripts/**`,
+ * so this local config exists purely so unit tests under
+ * `packages/zudo-doc-v2/src/**\/__tests__/` can run via:
+ *
+ *   pnpm exec vitest run --config packages/zudo-doc-v2/vitest.config.ts
+ *
+ * No package.json scripts are added here on purpose — topic-child agents
+ * for E5 keep package.json untouched per the manager's hard rule.
+ */
+export default defineConfig({
+  test: {
+    include: ["src/**/__tests__/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,10 +296,19 @@ importers:
         version: 4.72.0(@cloudflare/workers-types@4.20260317.1)
 
   packages/zudo-doc-v2:
-    dependencies:
+    devDependencies:
       preact:
-        specifier: '*'
+        specifier: ^10.26.9
         version: 10.29.0
+      preact-render-to-string:
+        specifier: ^6.6.6
+        version: 6.6.6(preact@10.29.0)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.12(@types/node@25.3.5)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,6 +295,12 @@ importers:
         specifier: ^4.0.0
         version: 4.72.0(@cloudflare/workers-types@4.20260317.1)
 
+  packages/zudo-doc-v2:
+    dependencies:
+      preact:
+        specifier: '*'
+        version: 10.29.0
+
 packages:
 
   '@antfu/install-pkg@1.1.0':


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/474
- parent PR
    - https://github.com/zudolab/zudo-doc/pull/481
- super-epic
    - https://github.com/zudolab/zudo-doc/issues/473

---

## Summary

Implements **Phase B E5** of the Astro→zfb migration ([#473](https://github.com/zudolab/zudo-doc/issues/473), [#474](https://github.com/zudolab/zudo-doc/issues/474)). Creates `packages/zudo-doc-v2/` — the framework primitives layer that sits on top of zfb's engine, containing what zfb deliberately doesn't ship per ADR-003: sidebar, theme, TOC, breadcrumb, layouts, head injection, View Transitions, SSR-skip wrappers.

7 topics implemented in parallel via `/x-wt-teams` worktree child agents. 79 unit tests pass. No build step — TS-source exports following zfb's pattern; subpath exports per topic area.

## Topics

| Topic | Subpath | What it ships |
|---|---|---|
| **sidebar-tree** | `./sidebar-tree` | `buildSidebarTree`, `loadCategoryMeta`, `findSidebarNode`, `flattenSidebarTree` — framework-agnostic helper that turns content collection entries (Astro or zfb) + `_category_.json` into a `SidebarNode[]`. No `astro:content` import. |
| **theme** | `./theme` | `ColorSchemeProvider` (Astro→JSX), `ThemeToggle` (verbatim port), `DesignTokenTweakPanel` (`<Island ssrFallback>` + sandboxed iframe + MutationObserver bridge), `ColorTweakExportModal` (line-equal `settings.ts` diff serializer), `iframe-bridge` postMessage protocol. |
| **toc** | `./toc` | `Toc`, `MobileToc` Preact islands + `useActiveHeading` scroll-spy hook (depth 2-4 filter, viewport-midline pivot, scrollend with 1.5s fallback). `HeadingItem` shape mirrors zfb's `PageHeading`. |
| **breadcrumb** | `./breadcrumb` | `Breadcrumb` JSX component + pure `findPath` helper. Generic over `BreadcrumbNode` so callers can pass either the canonical `SidebarNode` or any structurally-compatible shape. |
| **doclayout** | `./doclayout` + `./transitions` | `DocLayout` composable shell (explicit `Header`/`Sidebar`/`Main`/`Toc`/`Footer` props), `DocLayoutWithDefaults` carrying all 16 `create-zudo-doc` injection anchors, `anchors.ts` as single source of truth, native View Transitions shim (`startViewTransition`) with synchronous Firefox fallback, `sidebarPersistName` / `applyPersistName` helpers. |
| **head** | `./head` | `DocHead` + `OgTags` + `TwitterCard` JSX primitives. Output order pinned by 14 byte-parity unit tests covering charset, viewport, title, description, robots (sitewide noindex + page-level unlisted), canonical, theme-color, og:\* / twitter:\* / KaTeX stylesheet / alternate `llms.txt` / preload hints. |
| **ssr-skip** | `./ssr-skip` | `AiChatModalIsland`, `ImageEnlargeIsland`, `DesignTokenTweakPanelIsland`, `MockInitIsland` — wrap zfb's `<Island ssrFallback>` marker shape (`data-zfb-island-skip-ssr`) with the right fallback markup so doc pages don't have to re-implement the SSR-skip pattern. Dev-mode warning when forwarded props are non-serialisable. |

## Local dev workflow during pre-publish

Phase A E1–E4 have landed in zfb `main` but the npm publish at `0.1.0-migration.0` is deferred (see [super-epic comment 2026-04-28](https://github.com/zudolab/zudo-doc/issues/473#issuecomment-4333255530)). This epic uses the workflow added to [#473](https://github.com/zudolab/zudo-doc/issues/473):

- Reference zfb code via `/refer-another-project zfb` (local checkout at `$HOME/repos/myoss/zfb`).
- Bug fixes on the zfb side go directly to zfb `main` and push (zfb is not public yet).

Per-topic agents reported no zfb bugs surfaced during this run.

## Cross-topic API contracts

- **Canonical `SidebarNode`** — owned by `sidebar-tree/types.ts`; consumed by breadcrumb (via structural `BreadcrumbNode` superset) and DocLayout. Decoupled at the type level so neither topic blocks on the other.
- **`DOC_LAYOUT_ANCHORS`** — 16 anchor identifiers exported from `doclayout/anchors.ts` for the `create-zudo-doc` drift checker (E9a sub-task 4).
- **View Transition names** — `sidebarPersistName(lang, section)` + `view-transition-name: sidebar-{lang}-{section}` for persistent regions across navigation. `persistName` sanitizes against invalid CSS identifiers and caps length.
- **zfb Island marker** — SSR-skip wrappers re-emit zfb's documented `data-zfb-island-skip-ssr` placeholder shape; props serialized via `JSON.stringify` to a `data-` attribute.

## Test plan

- [x] `pnpm exec vitest run --config packages/zudo-doc-v2/vitest.config.ts` — 79 tests pass (sidebar-tree 23, breadcrumb 20, head 14, toc 22)
- [x] All topics ran `/light-review -gcoc` self-review during implementation; 4 commits include review-driven fixes (head: stable `key` prop on mapped link arrays; ssr-skip: dev-warning for non-serialisable props; doclayout: sanitize+cap persist key; theme: rAF-debounce iframe-bridge MutationObserver flush).
- [x] `/gcoc-review` on the merged base branch surfaced no actionable issues — high-priority items already addressed by the cleanup commit, medium/low items are speculative cautions on hot-path memoization, ARIA in downstream islands, and skeleton-vs-null SSR-skip fallback.
- [ ] **UI verification deferred** — DesignTokenTweakPanel mount + iframe live update + byte-equal export, View Transitions in Chrome, sidebar persists across navigation, no Firefox console errors, SSR→hydration swap with no console errors. Defer until E6/E7b have wired consumers; the framework primitives have nothing to consume yet on a real page.

## Known follow-ups (not blocking E5)

- **theme topic uses `@/...` host paths** in `color-tweak-export-modal.tsx`, `color-scheme-provider.tsx`, `design-token-tweak-panel.tsx` (6 imports). This is a framework-agnosticism gap per ADR-003 — runtime works because the host's `@/*` mapping resolves the imports, but `pnpm --filter @zudo-doc/zudo-doc-v2 exec tsc --noEmit` reaches into legacy `src/components/design-token-tweak/*` files that have pre-existing strict-mode errors. Will be resolved during **E7b** component port (which moves the panel internals into the package or accepts them as props).
- **Mid-merge clean-ups** committed by the manager: scaffold tsconfig (`exclude: []` to override root inheriting `exclude: packages`, `jsx: react-jsx`), unified `vitest.config.ts` between sidebar-tree's and head's variants, breadcrumb generic `findPath`, devDeps for the package's own test/typecheck.

🤖 Implemented with [Claude Code](https://claude.com/claude-code) `/x-wt-teams` (Super-Epic child of #473, flags: `-op -gcoc`)
