### PR TITLE
[Astro→zfb][Component port A] layout shell + interactive shell + body-foot-util

### DIFF
--- a/packages/zudo-doc-v2/package.json
+++ b/packages/zudo-doc-v2/package.json
@@ -26,6 +26,10 @@
       "types": "./src/breadcrumb/index.ts",
       "default": "./src/breadcrumb/index.ts"
     },
+    "./header": {
+      "types": "./src/header/index.ts",
+      "default": "./src/header/index.ts"
+    },
     "./doclayout": {
       "types": "./src/doclayout/index.ts",
       "default": "./src/doclayout/index.ts"

--- a/packages/zudo-doc-v2/package.json
+++ b/packages/zudo-doc-v2/package.json
@@ -42,6 +42,10 @@
       "types": "./src/transitions/index.ts",
       "default": "./src/transitions/index.ts"
     },
+    "./sidebar-resizer": {
+      "types": "./src/sidebar-resizer/index.ts",
+      "default": "./src/sidebar-resizer/index.ts"
+    },
     "./integrations/doc-history": {
       "types": "./src/integrations/doc-history/index.ts",
       "default": "./src/integrations/doc-history/index.ts"

--- a/packages/zudo-doc-v2/package.json
+++ b/packages/zudo-doc-v2/package.json
@@ -38,6 +38,10 @@
       "types": "./src/ssr-skip/index.ts",
       "default": "./src/ssr-skip/index.ts"
     },
+    "./body-foot-util": {
+      "types": "./src/body-foot-util/index.ts",
+      "default": "./src/body-foot-util/index.ts"
+    },
     "./transitions": {
       "types": "./src/transitions/index.ts",
       "default": "./src/transitions/index.ts"

--- a/packages/zudo-doc-v2/package.json
+++ b/packages/zudo-doc-v2/package.json
@@ -42,6 +42,14 @@
       "types": "./src/transitions/index.ts",
       "default": "./src/transitions/index.ts"
     },
+    "./page-loading": {
+      "types": "./src/page-loading/index.ts",
+      "default": "./src/page-loading/index.ts"
+    },
+    "./tab-item": {
+      "types": "./src/tab-item/index.ts",
+      "default": "./src/tab-item/index.ts"
+    },
     "./integrations/doc-history": {
       "types": "./src/integrations/doc-history/index.ts",
       "default": "./src/integrations/doc-history/index.ts"

--- a/packages/zudo-doc-v2/package.json
+++ b/packages/zudo-doc-v2/package.json
@@ -26,6 +26,10 @@
       "types": "./src/breadcrumb/index.ts",
       "default": "./src/breadcrumb/index.ts"
     },
+    "./i18n-version": {
+      "types": "./src/i18n-version/index.ts",
+      "default": "./src/i18n-version/index.ts"
+    },
     "./doclayout": {
       "types": "./src/doclayout/index.ts",
       "default": "./src/doclayout/index.ts"

--- a/packages/zudo-doc-v2/package.json
+++ b/packages/zudo-doc-v2/package.json
@@ -26,6 +26,14 @@
       "types": "./src/breadcrumb/index.ts",
       "default": "./src/breadcrumb/index.ts"
     },
+    "./footer": {
+      "types": "./src/footer/index.ts",
+      "default": "./src/footer/index.ts"
+    },
+    "./sidebar": {
+      "types": "./src/sidebar/index.ts",
+      "default": "./src/sidebar/index.ts"
+    },
     "./doclayout": {
       "types": "./src/doclayout/index.ts",
       "default": "./src/doclayout/index.ts"

--- a/packages/zudo-doc-v2/src/body-foot-util/body-foot-util-area.tsx
+++ b/packages/zudo-doc-v2/src/body-foot-util/body-foot-util-area.tsx
@@ -1,0 +1,106 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import type { VNode } from "preact";
+import { DocHistoryIsland, type DocHistoryIslandProps } from "./doc-history-island.js";
+
+/**
+ * Default label used when the consumer doesn't pass one. The legacy
+ * Astro template translated `doc.viewSource` via the project's i18n
+ * module; v2 stays framework-agnostic, so callers resolve their
+ * translation upstream and pass the result here. The English string
+ * is mirrored verbatim from the legacy translations table so the
+ * component degrades to the original wording when no override is
+ * supplied.
+ */
+export const DEFAULT_VIEW_SOURCE_LABEL = "View source on GitHub";
+
+export interface BodyFootUtilAreaProps {
+  /**
+   * Final, pre-computed GitHub source URL. The legacy template
+   * derived this from `settings.githubUrl + contentDir + entryId`; the
+   * v2 component delegates that computation to the consumer (no
+   * upstream dependency on the project settings module).
+   *
+   * When falsy, the view-source link is suppressed.
+   */
+  sourceUrl?: string | null;
+  /**
+   * Display text for the view-source link. Defaults to
+   * `"View source on GitHub"`; pass the i18n-resolved string from
+   * upstream to localise.
+   */
+  viewSourceLabel?: string;
+  /**
+   * When provided, mounts the `DocHistoryIsland` SSR-skip wrapper.
+   * The legacy Astro template owned three gating predicates
+   * (`utilSettings.docHistory`, `currentSlug`, and the per-page /
+   * `isCategoryIndex` resolution); v2 collapses all of those into a
+   * single nullable prop so the v2 package stays oblivious to the
+   * project's settings shape.
+   *
+   * Pass `null` / `undefined` to suppress the history trigger
+   * entirely.
+   */
+  docHistory?: DocHistoryIslandProps | null;
+}
+
+/**
+ * Footer utility area shown below an article body — composes the
+ * "View source on GitHub" link and the `DocHistoryIsland` SSR-skip
+ * wrapper. JSX port of `src/components/body-foot-util-area.astro`.
+ *
+ * Returns `null` when neither slot has anything to render, mirroring
+ * the `hasContent && (...)` guard in the original template so the
+ * surrounding `<section>` (with its top border + spacing) doesn't
+ * appear as an empty band.
+ */
+export function BodyFootUtilArea(props: BodyFootUtilAreaProps): VNode | null {
+  const { sourceUrl, viewSourceLabel = DEFAULT_VIEW_SOURCE_LABEL, docHistory } =
+    props;
+
+  const showSource = Boolean(sourceUrl);
+  const showHistory = Boolean(docHistory);
+  if (!showSource && !showHistory) return null;
+
+  return (
+    <section
+      class="mt-vsp-xl border-t border-muted pt-vsp-md"
+      aria-label="Document utilities"
+    >
+      {showSource && (
+        <div class="mb-vsp-md">
+          <a
+            href={sourceUrl as string}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center gap-hsp-2xs text-small text-muted hover:text-accent"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-[0.875rem] w-[0.875rem]"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              stroke-width="2"
+              aria-hidden="true"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M14 3h7m0 0v7m0-7L10 14"
+              />
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M5 5h5m-5 0a2 2 0 00-2 2v12a2 2 0 002 2h12a2 2 0 002-2v-5"
+              />
+            </svg>
+            <span>{viewSourceLabel}</span>
+          </a>
+        </div>
+      )}
+      {showHistory && docHistory && <DocHistoryIsland {...docHistory} />}
+    </section>
+  );
+}

--- a/packages/zudo-doc-v2/src/body-foot-util/doc-history-island.tsx
+++ b/packages/zudo-doc-v2/src/body-foot-util/doc-history-island.tsx
@@ -1,0 +1,62 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+// Framework wrapper around the doc-history Preact island — emits an
+// SSR-skip placeholder so the heavy revision-history component (with
+// its diff library, dialog.showModal(), keyboard handlers, View
+// Transitions hooks, and runtime fetch) is never evaluated during the
+// static build.
+//
+// The original Astro template wired the component as
+// `<DocHistory ... client:idle />`; the v2 equivalent is the SSR-skip
+// placeholder pattern formalised in `../ssr-skip/types.ts`. This
+// wrapper sits next to the body-foot-util-area component because the
+// island is only ever mounted from there — it is part of this topic
+// rather than a generic ssr-skip primitive.
+//
+// Default fallback: `null`. The real component renders an inline
+// "History" trigger button + a closed `<dialog>`; both have zero
+// layout footprint until the user opens the panel, so there is
+// nothing meaningful to mock up server-side.
+
+import type { VNode } from "preact";
+import {
+  renderSsrSkipPlaceholder,
+  type SsrSkipFallbackProps,
+} from "../ssr-skip/types.js";
+
+/**
+ * Props delivered to the real `DocHistory` Preact component on
+ * hydration. Mirrors the constructor signature in
+ * `src/components/doc-history.tsx` so the runtime can JSON-decode
+ * `data-zfb-island-props` and forward the values straight through.
+ */
+export interface DocHistoryIslandProps extends SsrSkipFallbackProps {
+  /** Page slug used to build the history JSON fetch path. */
+  slug: string;
+  /**
+   * Locale code, omitted for the default locale. Forwarded to the
+   * fetch path resolver inside the real component.
+   */
+  locale?: string;
+  /**
+   * Site base path. Defaults to `"/"` inside the real component when
+   * omitted; explicit when the site is served from a subpath.
+   */
+  basePath?: string;
+}
+
+/**
+ * SSR-skip wrapper for the doc-history dialog. Drop-in replacement for
+ * the legacy `<DocHistory ... client:idle />` Astro pattern.
+ *
+ * The marker emitted here is `"DocHistory"` — the hydration manifest
+ * shipped by the consumer must bind that name to the real component
+ * constructor.
+ */
+export function DocHistoryIsland(props: DocHistoryIslandProps): VNode {
+  const { when = "idle", ssrFallback = null, ...forwarded } = props;
+  return renderSsrSkipPlaceholder("DocHistory", when, ssrFallback, {
+    ...forwarded,
+  });
+}

--- a/packages/zudo-doc-v2/src/body-foot-util/edit-link.tsx
+++ b/packages/zudo-doc-v2/src/body-foot-util/edit-link.tsx
@@ -1,0 +1,74 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import type { VNode } from "preact";
+
+/**
+ * Default label used when the consumer doesn't pass one. The legacy
+ * Astro template translated `doc.editPage` via the project's i18n
+ * module; v2 stays framework-agnostic and lets the caller pass the
+ * already-translated label as `label` instead. The English string is
+ * mirrored verbatim from the legacy translations table.
+ */
+export const DEFAULT_EDIT_LINK_LABEL = "Edit this page";
+
+export interface EditLinkProps {
+  /**
+   * Final, pre-computed edit URL. The legacy Astro version derived
+   * this from `settings.editUrl + contentDir + entryId`; that
+   * computation belongs in the consumer (so this v2 component has no
+   * upward dependency on the project settings module).
+   *
+   * When `null` / `undefined` / empty string the link is suppressed
+   * entirely — the component returns `null` to mirror the
+   * `editUrl && (...)` guard in the original template.
+   */
+  editUrl?: string | null;
+  /**
+   * Display text for the link. The legacy template called
+   * `t("doc.editPage", locale)`; consumers should resolve their i18n
+   * lookup upstream and pass the result here. Defaults to
+   * `"Edit this page"` so the component degrades to the original
+   * English label when no translation is provided.
+   */
+  label?: string;
+}
+
+/**
+ * "Edit this page" link — JSX port of `src/components/edit-link.astro`.
+ *
+ * The legacy component owned three concerns: URL computation, i18n
+ * lookup, and presentation. v2 keeps only presentation; URL and label
+ * are pre-resolved by the caller. This matches the breadcrumb subpath
+ * pattern of "no settings/i18n imports inside the v2 package".
+ */
+export function EditLink(props: EditLinkProps): VNode | null {
+  const { editUrl, label = DEFAULT_EDIT_LINK_LABEL } = props;
+  if (!editUrl) return null;
+
+  return (
+    <a
+      href={editUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      class="inline-flex items-center gap-hsp-2xs text-small text-muted hover:text-accent"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        class="h-[0.875rem] w-[0.875rem]"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        stroke-width="2"
+        aria-hidden="true"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+        />
+      </svg>
+      <span>{label}</span>
+    </a>
+  );
+}

--- a/packages/zudo-doc-v2/src/body-foot-util/index.ts
+++ b/packages/zudo-doc-v2/src/body-foot-util/index.ts
@@ -1,0 +1,15 @@
+// Barrel for the body-foot-util topic — JSX port of
+// `src/components/body-foot-util-area.astro` and its sibling
+// `edit-link.astro`. The DocHistory SSR-skip wrapper lives next to the
+// area component because it is only ever mounted from there.
+export {
+  BodyFootUtilArea,
+  DEFAULT_VIEW_SOURCE_LABEL,
+} from "./body-foot-util-area.js";
+export type { BodyFootUtilAreaProps } from "./body-foot-util-area.js";
+
+export { EditLink, DEFAULT_EDIT_LINK_LABEL } from "./edit-link.js";
+export type { EditLinkProps } from "./edit-link.js";
+
+export { DocHistoryIsland } from "./doc-history-island.js";
+export type { DocHistoryIslandProps } from "./doc-history-island.js";

--- a/packages/zudo-doc-v2/src/footer/footer.tsx
+++ b/packages/zudo-doc-v2/src/footer/footer.tsx
@@ -1,0 +1,146 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+// JSX port of src/components/footer.astro.
+//
+// The original Astro template mixed data-prep (settings + getDocsCollection
+// + tag-vocabulary lookups + locale overrides) with the presentational
+// footer markup. Because v2 must stay decoupled from host-only helpers,
+// only the presentational shell lives here: callers prepare the
+// already-localized, already-resolved data upstream and feed it in via
+// `linkColumns` / `tagColumns` / `copyright` props.
+//
+// Behaviour parity notes:
+//
+//  - When all three slots are empty/undefined the component returns null,
+//    matching the Astro template's "early return when !footer" guard.
+//
+//  - When at least one slot has content, a `<footer>` shell is rendered.
+//    The link/tag column grid is only emitted when at least one column is
+//    present (mirrors the Astro `hasColumns &&` guard).
+//
+//  - The copyright block is rendered as-is via `dangerouslySetInnerHTML`
+//    because the original template used `<Fragment set:html={copyright} />`
+//    to allow inline anchors. Callers are responsible for sanitising
+//    the string (the Astro version did the same — it trusted
+//    `settings.footer.copyright`).
+//
+//  - When both columns and copyright exist, the copyright block is
+//    visually separated by a top border + spacing, identical to the
+//    `mt-vsp-lg border-t border-muted pt-vsp-md` that the Astro template
+//    applied via `class:list` conditional.
+
+import type { VNode } from "preact";
+
+import type { FooterLinkColumn, FooterTagColumn } from "./types";
+
+export interface FooterProps {
+  /**
+   * Already-localized link columns. Each item's href should be
+   * base-prefixed and locale-aware; `isExternal` controls the
+   * target/rel attributes.
+   */
+  linkColumns?: FooterLinkColumn[];
+  /**
+   * Already-resolved tag columns. Empty array (or omitted) hides the
+   * taglist entirely. Each tag's href should already be base-prefixed.
+   */
+  tagColumns?: FooterTagColumn[];
+  /**
+   * Copyright HTML. Rendered via `dangerouslySetInnerHTML` so embedded
+   * anchors work. The caller is responsible for the contents.
+   */
+  copyright?: string;
+}
+
+/**
+ * Footer shell for the documentation layout.
+ *
+ * Returns null when every slot is empty so the host can place this
+ * unconditionally inside the layout's `footer` slot without producing
+ * an empty `<footer>` element.
+ */
+export function Footer(props: FooterProps): VNode | null {
+  const linkColumns = props.linkColumns ?? [];
+  const tagColumns = props.tagColumns ?? [];
+  const copyright = props.copyright ?? "";
+
+  const hasColumns = linkColumns.length > 0 || tagColumns.length > 0;
+  const hasCopyright = copyright.length > 0;
+
+  if (!hasColumns && !hasCopyright) return null;
+
+  const copyrightClass = hasColumns
+    ? "text-center text-caption text-muted [&_a]:text-accent [&_a]:underline mt-vsp-lg border-t border-muted pt-vsp-md"
+    : "text-center text-caption text-muted [&_a]:text-accent [&_a]:underline";
+
+  return (
+    <footer class="border-t border-muted bg-surface">
+      <div class="mx-auto max-w-[clamp(50rem,75vw,90rem)] px-hsp-xl py-vsp-xl lg:px-hsp-2xl lg:py-vsp-2xl">
+        {hasColumns && (
+          <div class="grid grid-cols-1 gap-vsp-lg sm:grid-cols-2 lg:grid-cols-[repeat(auto-fit,minmax(12rem,1fr))]">
+            {linkColumns.map((column, i) => (
+              <div key={`link-${i}-${column.title}`}>
+                <p class="text-small font-semibold text-fg mb-vsp-xs">
+                  {column.title}
+                </p>
+                <ul class="list-none p-0">
+                  {column.items.map((item, j) => (
+                    <li
+                      key={`item-${i}-${j}-${item.href}`}
+                      class="mb-vsp-2xs"
+                    >
+                      <a
+                        href={item.href}
+                        class="text-caption text-muted hover:text-accent hover:underline focus-visible:underline"
+                        {...(item.isExternal
+                          ? {
+                              target: "_blank",
+                              rel: "noopener noreferrer",
+                            }
+                          : {})}
+                      >
+                        {item.label}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+            {tagColumns.map((column, i) => (
+              <div
+                key={`tag-${i}-${column.group}`}
+                data-taglist-group={column.group}
+              >
+                <h2 class="text-small font-semibold text-fg mb-vsp-xs">
+                  {column.title}
+                </h2>
+                <ul class="list-none p-0">
+                  {column.tags.map(({ tag, count, href }) => (
+                    <li key={`tag-item-${tag}`} class="mb-vsp-2xs">
+                      <a
+                        href={href}
+                        class="text-caption text-muted hover:text-accent hover:underline focus-visible:underline"
+                      >
+                        #{tag}
+                        <span class="opacity-60" aria-hidden="true">
+                          &nbsp;({count})
+                        </span>
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        )}
+        {hasCopyright && (
+          <div
+            class={copyrightClass}
+            dangerouslySetInnerHTML={{ __html: copyright }}
+          />
+        )}
+      </div>
+    </footer>
+  );
+}

--- a/packages/zudo-doc-v2/src/footer/index.ts
+++ b/packages/zudo-doc-v2/src/footer/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Public entry for the framework-agnostic footer shell.
+ *
+ * Consumers import from `@zudo-doc/zudo-doc-v2/footer`:
+ *
+ *   import { Footer, type FooterProps } from "@zudo-doc/zudo-doc-v2/footer";
+ *
+ * The shell is purely presentational — see `./types.ts` for the data
+ * shapes the host project assembles upstream.
+ */
+
+export { Footer } from "./footer";
+export type { FooterProps } from "./footer";
+export type {
+  FooterLinkColumn,
+  FooterLinkItem,
+  FooterTagColumn,
+  FooterTagItem,
+} from "./types";

--- a/packages/zudo-doc-v2/src/footer/types.ts
+++ b/packages/zudo-doc-v2/src/footer/types.ts
@@ -1,0 +1,60 @@
+/**
+ * Public types for the framework-agnostic footer shell.
+ *
+ * The original Astro `footer.astro` mixed three concerns:
+ *   1. Reading `settings.footer` and applying locale overrides.
+ *   2. Loading the docs collection + tag vocabulary to build the
+ *      optional taglist columns.
+ *   3. Rendering the footer markup.
+ *
+ * Concerns (1) and (2) depend on host-side helpers (`@/config/settings`,
+ * `@/utils/get-docs-collection`, `tag-vocabulary`, etc.) that v2 must
+ * not reach into. So this package only ports concern (3): the
+ * presentational shell. Callers prepare the columns upstream and pass
+ * already-localized, already-resolved hrefs in.
+ */
+
+/** A single link rendered inside a {@link FooterLinkColumn}. */
+export interface FooterLinkItem {
+  /** Visible label (already locale-resolved by the caller). */
+  label: string;
+  /** Resolved href (already base-prefixed and locale-aware). */
+  href: string;
+  /**
+   * When true, the rendered anchor adds `target="_blank"` and
+   * `rel="noopener noreferrer"`. Callers compute this from their own
+   * external-href detector.
+   */
+  isExternal?: boolean;
+}
+
+/** One column in the footer's link grid. */
+export interface FooterLinkColumn {
+  /** Visible heading for the column (already locale-resolved). */
+  title: string;
+  items: FooterLinkItem[];
+}
+
+/** A single tag rendered inside a {@link FooterTagColumn}. */
+export interface FooterTagItem {
+  /** Canonical tag id (rendered as `#<tag>`). */
+  tag: string;
+  /** Document count shown next to the tag. */
+  count: number;
+  /** Resolved href to the tag's index page. */
+  href: string;
+}
+
+/** One column in the footer's tag grid. */
+export interface FooterTagColumn {
+  /**
+   * Group identifier — usually a vocabulary group name like `"topic"`,
+   * or the literal `"__flat__"` sentinel for the ungrouped/flat column.
+   * Surfaced as `data-taglist-group` on the rendered column wrapper so
+   * downstream tests / e2e selectors keep working.
+   */
+  group: string;
+  /** Visible heading for the column (already locale-resolved). */
+  title: string;
+  tags: FooterTagItem[];
+}

--- a/packages/zudo-doc-v2/src/header/__tests__/nav-active.test.ts
+++ b/packages/zudo-doc-v2/src/header/__tests__/nav-active.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeActiveNavPath,
+  isNavItemActive,
+  pathForMatch,
+  type NavItemLike,
+} from "../nav-active";
+
+describe("pathForMatch", () => {
+  it("returns the path unchanged when lang is undefined", () => {
+    expect(pathForMatch("/docs/intro", undefined, "en")).toBe("/docs/intro");
+  });
+
+  it("returns the path unchanged when lang equals the default locale", () => {
+    expect(pathForMatch("/docs/intro", "en", "en")).toBe("/docs/intro");
+  });
+
+  it("strips the leading locale segment for non-default locales", () => {
+    expect(pathForMatch("/ja/docs/intro", "ja", "en")).toBe("/docs/intro");
+  });
+
+  it("only strips the locale at the very start of the path", () => {
+    // A path that merely contains the locale code mid-path must be left
+    // intact — otherwise nav matching gets confused by content slugs
+    // that happen to share a prefix with a locale code.
+    expect(pathForMatch("/docs/ja-tutorial", "ja", "en")).toBe(
+      "/docs/ja-tutorial",
+    );
+  });
+
+  it("handles an empty path safely", () => {
+    expect(pathForMatch("", "ja", "en")).toBe("");
+  });
+});
+
+describe("computeActiveNavPath", () => {
+  const nav: NavItemLike[] = [
+    { path: "/docs/" },
+    {
+      path: "/learn/",
+      children: [
+        { path: "/learn/getting-started/" },
+        { path: "/learn/advanced/" },
+      ],
+    },
+    { path: "/blog/" },
+  ];
+
+  it("returns undefined when nothing matches", () => {
+    expect(computeActiveNavPath(nav, "/about/")).toBeUndefined();
+  });
+
+  it("returns the matching top-level path", () => {
+    expect(computeActiveNavPath(nav, "/docs/")).toBe("/docs/");
+  });
+
+  it("matches when the active page is nested under a top-level path", () => {
+    expect(computeActiveNavPath(nav, "/docs/intro/")).toBe("/docs/");
+  });
+
+  it("prefers the most specific (longest) child path over its parent", () => {
+    expect(
+      computeActiveNavPath(nav, "/learn/getting-started/setup/"),
+    ).toBe("/learn/getting-started/");
+  });
+
+  it("falls back to the parent when no child matches", () => {
+    expect(computeActiveNavPath(nav, "/learn/foo/")).toBe("/learn/");
+  });
+
+  it("handles items with no children at all", () => {
+    expect(computeActiveNavPath(nav, "/blog/post-1/")).toBe("/blog/");
+  });
+});
+
+describe("isNavItemActive", () => {
+  const item: NavItemLike = {
+    path: "/learn/",
+    children: [{ path: "/learn/advanced/" }, { path: "/learn/intro/" }],
+  };
+
+  it("returns true when the active path equals the item's path", () => {
+    expect(isNavItemActive(item, "/learn/")).toBe(true);
+  });
+
+  it("returns true when the active path equals one of the children", () => {
+    expect(isNavItemActive(item, "/learn/advanced/")).toBe(true);
+    expect(isNavItemActive(item, "/learn/intro/")).toBe(true);
+  });
+
+  it("returns false when no path matches", () => {
+    expect(isNavItemActive(item, "/docs/")).toBe(false);
+  });
+
+  it("returns false when the active path is undefined", () => {
+    expect(isNavItemActive(item, undefined)).toBe(false);
+  });
+
+  it("works for items with no children", () => {
+    const flat: NavItemLike = { path: "/blog/" };
+    expect(isNavItemActive(flat, "/blog/")).toBe(true);
+    expect(isNavItemActive(flat, "/docs/")).toBe(false);
+  });
+});

--- a/packages/zudo-doc-v2/src/header/_astro-content-shim.d.ts
+++ b/packages/zudo-doc-v2/src/header/_astro-content-shim.d.ts
@@ -1,0 +1,25 @@
+// Local type shim for `astro:content`.
+//
+// The host project's `@/config/i18n` re-exports a `CollectionKey` type
+// imported from Astro's virtual `astro:content` module. That virtual
+// module is materialized by Astro's tooling when running `astro check`
+// against the project root, but the v2 package's standalone `tsc --
+// noEmit` pass does not run through Astro and so the import resolves
+// to nothing.
+//
+// Mirrors the existing `theme/_zfb-shim.d.ts` pattern: provide just
+// enough surface for the v2 type-check to succeed without taking a
+// real runtime dependency on `astro:content`. The shape is intentional
+// — `CollectionKey` is "any string content collection name", and that
+// is the only export the i18n module pulls from this virtual module.
+
+declare module "astro:content" {
+  /**
+   * In the real Astro virtual module, `CollectionKey` is the union of
+   * literal collection names registered in `content.config.ts`. For
+   * the v2 package we only need it to behave as a string-like type; the
+   * branding adds no runtime weight and helps preserve the original
+   * intent if a downstream consumer ever passes the value through.
+   */
+  export type CollectionKey = string & { readonly __collectionKey?: unique symbol };
+}

--- a/packages/zudo-doc-v2/src/header/header.tsx
+++ b/packages/zudo-doc-v2/src/header/header.tsx
@@ -1,0 +1,508 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+// Layout-level JSX port of `src/components/header.astro` for the
+// zudo-doc framework primitives layer (super-epic #473, sub-issue
+// #476). The component is intentionally server-render-friendly: it
+// emits the same markup the legacy Astro template did, leaving the two
+// interactive child islands (the mobile sidebar toggle and the dropdown
+// "..." overflow controller) as either consumer-supplied slots or an
+// inline-script `<script dangerouslySetInnerHTML>`.
+//
+// Why this shape:
+//   * The Astro template embeds three Astro-only sub-components
+//     (`<LanguageSwitcher />`, `<VersionSwitcher />`, `<Search />`).
+//     None of those have a JSX equivalent yet (Task #3 ports them), so
+//     they are exposed as `languageSwitcher` / `versionSwitcher` /
+//     `search` slot props. The host project keeps using
+//     `header.astro` until the sibling ports land — this file exists
+//     so consumers of the v2 package can opt into the JSX path early.
+//   * The two Preact islands (`SidebarToggle`, `ThemeToggle`) are also
+//     accepted as slots so consumers control hydration boundaries
+//     (e.g. wrap them in zfb's `<Island when="media">` / `<Island
+//     when="load">`). The matching `<slot name="sidebar" />` in the
+//     legacy template becomes `sidebarSlot` so the mobile-sheet tree
+//     can still flow in from the layout.
+//   * Everything that derives from `settings` (siteName, headerNav,
+//     headerRightItems, githubRepoUrl) is read here directly via the
+//     `@/config` and `@/utils` aliases — same pattern as the existing
+//     `color-scheme-provider.tsx` port. Pure helpers used by the active-
+//     link logic live in `./nav-active.ts` so they stay unit-testable
+//     without booting the host config.
+//   * The inline overflow script is a pure-JS string emitted via
+//     `dangerouslySetInnerHTML` (see `./nav-overflow-script.ts`). The
+//     behaviour is identical to the original `<script>` block — only
+//     the TypeScript syntax was stripped because a raw `<script>` tag
+//     ships its body to the browser as-is.
+
+import type { ComponentChildren, JSX, VNode } from "preact";
+import { settings } from "@/config/settings";
+import { withBase, stripBase, navHref } from "@/utils/base";
+import { defaultLocale, locales, t, type Locale } from "@/config/i18n";
+import { buildGitHubRepoUrl } from "@/utils/github";
+import { filterHeaderRightItems } from "@/utils/header-right-items";
+import {
+  computeActiveNavPath,
+  isNavItemActive,
+  pathForMatch,
+} from "./nav-active.js";
+import { NAV_OVERFLOW_SCRIPT } from "./nav-overflow-script.js";
+
+/**
+ * Props for the JSX `<Header />` port. Mirrors the Astro template's
+ * `Props` interface plus a small set of slot props that replace child
+ * Astro components and named `<slot>` outlets.
+ */
+export interface HeaderProps {
+  /** Active locale; `undefined` matches the legacy "no-lang" code path. */
+  lang?: Locale;
+  /** Current page URL path (as the layout passes from `Astro.url.pathname`). */
+  currentPath?: string;
+  /** Optional active version slug. Forwarded into `navHref` for nav links. */
+  currentVersion?: string;
+
+  /**
+   * Children projected into the mobile `<SidebarToggle>` island —
+   * replaces the legacy `<slot name="sidebar" />`. Consumers pass the
+   * sidebar tree they want to surface in the mobile sheet.
+   */
+  sidebarSlot?: ComponentChildren;
+
+  /**
+   * Replacement for the `<SidebarToggle client:media="...">` element in
+   * the legacy template. Consumers wrap their preferred Preact /
+   * `<Island>` toggle (with the sidebar slot already nested inside) and
+   * the shell drops it in untouched. When omitted nothing renders in
+   * that slot — the layout is still valid (e.g. doc pages with
+   * `hide_sidebar`).
+   */
+  sidebarToggle?: ComponentChildren;
+
+  /**
+   * Replacement for `<ThemeToggle client:load />`. Rendered only when
+   * `settings.colorMode` is configured AND a `theme-toggle` entry is
+   * present in `headerRightItems` — matching the original template.
+   */
+  themeToggle?: ComponentChildren;
+
+  /** Replacement for the `<LanguageSwitcher />` Astro child. */
+  languageSwitcher?: ComponentChildren;
+
+  /** Replacement for the `<VersionSwitcher />` Astro child. */
+  versionSwitcher?: ComponentChildren;
+
+  /** Replacement for the `<Search />` Astro child. */
+  search?: ComponentChildren;
+}
+
+/**
+ * Site-header shell — JSX port of `src/components/header.astro`.
+ *
+ * Responsibilities (matching the legacy template byte-for-byte):
+ *   1. Render the sticky `<header>` with the site logo and the desktop
+ *      nav, including the dropdown-parent / overflow-bucket markup the
+ *      controller script reshapes at runtime.
+ *   2. Iterate `settings.headerRightItems`, emitting the matching
+ *      trigger button / icon link / consumer-supplied slot for each
+ *      entry. Items disabled by `filterHeaderRightItems` (e.g.
+ *      ai-chat trigger when `aiAssistant` is off) are skipped.
+ *   3. Emit the inline overflow controller script. The script wires the
+ *      "..." overflow menu, manages `aria-expanded` on dropdowns, and
+ *      re-runs after View Transitions (`astro:after-swap`).
+ */
+export function Header(props: HeaderProps): JSX.Element {
+  const {
+    lang,
+    currentPath = "",
+    currentVersion,
+    sidebarSlot,
+    sidebarToggle,
+    themeToggle,
+    languageSwitcher,
+    versionSwitcher,
+    search,
+  } = props;
+
+  const isNonDefaultLocale = lang != null && lang !== defaultLocale;
+  const pathWithoutBase = stripBase(currentPath);
+  const matchPath = pathForMatch(pathWithoutBase, lang, defaultLocale);
+
+  const activeNavPath = computeActiveNavPath(settings.headerNav, matchPath);
+  const headerRightItems = filterHeaderRightItems(
+    settings.headerRightItems ?? [],
+  );
+  const githubRepoUrl = buildGitHubRepoUrl();
+  const githubLabel = t("header.github", lang);
+
+  return (
+    <header
+      class="sticky top-0 z-50 flex h-[3.5rem] items-center border-b border-muted bg-surface px-hsp-lg"
+      data-header
+    >
+      {sidebarToggle ?? (
+        // Render an inert wrapper so consumers that omit the slot still
+        // get the named-slot semantics from the legacy template
+        // (mobile sidebar contents stay accessible to assistive tech
+        // even without the toggle island).
+        <SidebarSlotFallback>{sidebarSlot}</SidebarSlotFallback>
+      )}
+
+      <a
+        href={withBase(isNonDefaultLocale ? `/${lang}/` : "/")}
+        class="whitespace-nowrap text-subheading font-bold text-fg hover:underline focus:underline shrink-0"
+        data-header-logo
+      >
+        {settings.siteName}
+      </a>
+
+      <nav
+        aria-label="Main"
+        class="relative ml-hsp-xl hidden min-w-0 flex-1 items-center gap-x-hsp-2xs whitespace-nowrap lg:flex"
+        data-header-nav
+      >
+        {settings.headerNav.map((item) => renderNavItem(
+          item,
+          activeNavPath,
+          lang,
+          currentVersion,
+        ))}
+
+        <div class="relative shrink-0" data-nav-more style="display:none">
+          <button
+            type="button"
+            class="px-hsp-md py-vsp-2xs text-small font-medium text-muted hover:underline cursor-pointer"
+            data-nav-more-toggle
+            aria-expanded="false"
+          >
+            {"···"}
+          </button>
+          <ul
+            class="absolute right-0 top-full z-10 mt-vsp-3xs hidden min-w-[8rem] border border-muted rounded bg-surface shadow-lg whitespace-nowrap"
+            data-nav-more-menu
+          />
+        </div>
+      </nav>
+
+      <div
+        class="ml-auto flex shrink-0 items-center gap-x-hsp-md"
+        data-header-right
+      >
+        {headerRightItems.map((item, i) => renderRightItem(
+          item,
+          i,
+          {
+            lang,
+            githubRepoUrl,
+            githubLabel,
+            themeToggle,
+            languageSwitcher,
+            versionSwitcher,
+            search,
+          },
+        ))}
+      </div>
+
+      <script dangerouslySetInnerHTML={{ __html: NAV_OVERFLOW_SCRIPT }} />
+    </header>
+  );
+}
+
+/** Visually-hidden fallback container so the `<slot name="sidebar" />`
+ *  semantic is preserved even when the consumer doesn't pass an
+ *  interactive `sidebarToggle` slot. Renders nothing visible — the
+ *  legacy template only surfaces this content via the toggle island. */
+function SidebarSlotFallback({
+  children,
+}: {
+  children?: ComponentChildren;
+}): VNode | null {
+  if (children === undefined || children === null) return null;
+  return <span hidden>{children}</span>;
+}
+
+function renderNavItem(
+  item: (typeof settings.headerNav)[number],
+  activeNavPath: string | undefined,
+  lang: Locale | undefined,
+  currentVersion: string | undefined,
+): VNode {
+  const isActive = isNavItemActive(item, activeNavPath);
+  const href = navHref(item.path, lang, currentVersion);
+  const label = item.labelKey ? t(item.labelKey, lang) : item.label;
+
+  if (item.children && item.children.length > 0) {
+    return (
+      <div
+        class="group relative shrink-0"
+        data-nav-item
+        data-nav-item-dropdown
+      >
+        <a
+          href={href}
+          aria-current={isActive ? "page" : undefined}
+          aria-haspopup="true"
+          aria-expanded="false"
+          class={[
+            "flex items-center gap-x-hsp-xs px-hsp-md py-vsp-2xs text-small font-medium transition-colors",
+            isActive
+              ? "bg-fg text-bg"
+              : "text-muted hover:underline focus:underline",
+          ].join(" ")}
+        >
+          {label}
+          <svg
+            class={[
+              "h-[0.5rem] w-[0.5rem] shrink-0",
+              isActive ? "text-bg" : "text-muted",
+            ].join(" ")}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="3"
+            aria-hidden="true"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M19 9l-7 7-7-7"
+            />
+          </svg>
+        </a>
+        <div class="absolute left-0 top-full z-50 hidden group-hover:block group-focus-within:block pt-vsp-3xs">
+          <div class="min-w-[10rem] border border-muted rounded bg-surface shadow-lg py-vsp-3xs">
+            {item.children.map((child) => {
+              const childHref = navHref(child.path, lang, currentVersion);
+              const childLabel = child.labelKey
+                ? t(child.labelKey, lang)
+                : child.label;
+              const childActive = activeNavPath === child.path;
+              return (
+                <a
+                  href={childHref}
+                  data-active={childActive ? "" : undefined}
+                  class={[
+                    "block px-hsp-md py-vsp-2xs text-small hover:bg-accent/10 hover:underline",
+                    childActive ? "font-bold text-accent" : "text-fg",
+                  ].join(" ")}
+                >
+                  {childLabel}
+                </a>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <a
+      href={href}
+      aria-current={isActive ? "page" : undefined}
+      data-nav-item
+      class={[
+        "px-hsp-md py-vsp-2xs text-small font-medium transition-colors shrink-0",
+        isActive
+          ? "bg-fg text-bg"
+          : "text-muted hover:underline focus:underline",
+      ].join(" ")}
+    >
+      {label}
+    </a>
+  );
+}
+
+interface RightItemContext {
+  lang: Locale | undefined;
+  githubRepoUrl: string | null;
+  githubLabel: string;
+  themeToggle: ComponentChildren;
+  languageSwitcher: ComponentChildren;
+  versionSwitcher: ComponentChildren;
+  search: ComponentChildren;
+}
+
+function renderRightItem(
+  item: (ReturnType<typeof filterHeaderRightItems>)[number],
+  index: number,
+  ctx: RightItemContext,
+): VNode | null {
+  if (item.type === "trigger" && item.trigger === "design-token-panel") {
+    // The legacy template used an inline `onclick` attribute string. We
+    // preserve that DOM-level behaviour by spreading the attribute via a
+    // plain object — Preact's typed JSX rejects a string-valued
+    // `onclick` prop because it expects an event handler function, but
+    // the underlying renderer happily forwards the literal attribute
+    // when the prop arrives through a spread.
+    const inlineOnclick: Record<string, string> = {
+      onclick:
+        "window.dispatchEvent(new CustomEvent('toggle-design-token-panel'))",
+    };
+    return (
+      <button
+        key={`right-${index}`}
+        id="design-token-trigger"
+        type="button"
+        class="flex items-center justify-center text-muted transition-colors hover:text-fg"
+        aria-label="Toggle design token panel"
+        {...inlineOnclick}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <circle cx="13.5" cy="6.5" r="2.5" />
+          <circle cx="17.5" cy="10.5" r="2.5" />
+          <circle cx="8.5" cy="7.5" r="2.5" />
+          <circle cx="6.5" cy="12.5" r="2.5" />
+          <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z" />
+        </svg>
+      </button>
+    );
+  }
+
+  if (item.type === "trigger" && item.trigger === "ai-chat") {
+    // See the design-token branch above for why this goes through a spread.
+    const inlineOnclick: Record<string, string> = {
+      onclick: "window.dispatchEvent(new CustomEvent('toggle-ai-chat'))",
+    };
+    return (
+      <button
+        key={`right-${index}`}
+        id="ai-chat-trigger"
+        type="button"
+        class="flex items-center justify-center text-muted transition-colors hover:text-fg"
+        aria-label="Open AI assistant"
+        {...inlineOnclick}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path d="M9.5 2.5Q10.5 11.5 18 13Q10.5 14.5 9.5 23.5Q8.5 14.5 1 13Q8.5 11.5 9.5 2.5Z" />
+          <path d="M19 0.5Q19.5 4 23.5 5Q19.5 6 19 9.5Q18.5 6 14.5 5Q18.5 4 19 0.5Z" />
+        </svg>
+      </button>
+    );
+  }
+
+  if (item.type === "component" && item.component === "version-switcher") {
+    return (
+      <div key={`right-${index}`} class="hidden lg:block">
+        {ctx.versionSwitcher}
+      </div>
+    );
+  }
+
+  if (
+    item.type === "component" &&
+    item.component === "github-link" &&
+    ctx.githubRepoUrl
+  ) {
+    return (
+      <a
+        key={`right-${index}`}
+        href={ctx.githubRepoUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="flex items-center justify-center text-muted transition-colors hover:text-fg"
+        aria-label={ctx.githubLabel}
+        title={ctx.githubLabel}
+      >
+        <span class="sr-only">{ctx.githubLabel}</span>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path d="M12 .5C5.649.5.5 5.649.5 12a11.5 11.5 0 0 0 7.86 10.915c.575.106.785-.25.785-.556 0-.274-.01-1-.016-1.962-3.198.695-3.873-1.541-3.873-1.541-.523-1.327-1.277-1.68-1.277-1.68-1.044-.714.079-.699.079-.699 1.154.082 1.761 1.186 1.761 1.186 1.026 1.758 2.692 1.25 3.348.956.104-.743.401-1.25.73-1.537-2.553-.29-5.238-1.276-5.238-5.682 0-1.255.448-2.282 1.182-3.086-.119-.29-.512-1.458.111-3.04 0 0 .964-.309 3.159 1.18A10.98 10.98 0 0 1 12 6.036c.977.005 1.963.132 2.883.387 2.193-1.49 3.155-1.18 3.155-1.18.625 1.582.232 2.75.114 3.04.736.804 1.18 1.831 1.18 3.086 0 4.417-2.689 5.389-5.25 5.673.412.355.779 1.056.779 2.129 0 1.538-.014 2.778-.014 3.156 0 .31.207.668.79.555A11.502 11.502 0 0 0 23.5 12C23.5 5.649 18.351.5 12 .5Z" />
+        </svg>
+      </a>
+    );
+  }
+
+  if (item.type === "component" && item.component === "theme-toggle") {
+    if (!settings.colorMode) return null;
+    return (
+      <div key={`right-${index}`} class="hidden lg:flex items-center">
+        {ctx.themeToggle}
+      </div>
+    );
+  }
+
+  if (item.type === "component" && item.component === "language-switcher") {
+    if (!(ctx.lang && locales.length > 1)) return null;
+    return (
+      <div key={`right-${index}`} class="hidden lg:flex items-center">
+        {ctx.languageSwitcher}
+      </div>
+    );
+  }
+
+  if (item.type === "component" && item.component === "search") {
+    return <div key={`right-${index}`}>{ctx.search}</div>;
+  }
+
+  if (item.type === "link") {
+    const label = item.label ?? item.ariaLabel;
+    const isExternal = /^https?:\/\//.test(item.href);
+    return (
+      <a
+        key={`right-${index}`}
+        href={item.href}
+        target={isExternal ? "_blank" : undefined}
+        rel={isExternal ? "noopener noreferrer" : undefined}
+        class="flex items-center justify-center text-muted transition-colors hover:text-fg"
+        aria-label={item.ariaLabel}
+        title={label}
+      >
+        {item.icon === "github" ? (
+          <>
+            {label && <span class="sr-only">{label}</span>}
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path d="M12 .5C5.649.5.5 5.649.5 12a11.5 11.5 0 0 0 7.86 10.915c.575.106.785-.25.785-.556 0-.274-.01-1-.016-1.962-3.198.695-3.873-1.541-3.873-1.541-.523-1.327-1.277-1.68-1.277-1.68-1.044-.714.079-.699.079-.699 1.154.082 1.761 1.186 1.761 1.186 1.026 1.758 2.692 1.25 3.348.956.104-.743.401-1.25.73-1.537-2.553-.29-5.238-1.276-5.238-5.682 0-1.255.448-2.282 1.182-3.086-.119-.29-.512-1.458.111-3.04 0 0 .964-.309 3.159 1.18A10.98 10.98 0 0 1 12 6.036c.977.005 1.963.132 2.883.387 2.193-1.49 3.155-1.18 3.155-1.18.625 1.582.232 2.75.114 3.04.736.804 1.18 1.831 1.18 3.086 0 4.417-2.689 5.389-5.25 5.673.412.355.779 1.056.779 2.129 0 1.538-.014 2.778-.014 3.156 0 .31.207.668.79.555A11.502 11.502 0 0 0 23.5 12C23.5 5.649 18.351.5 12 .5Z" />
+            </svg>
+          </>
+        ) : (
+          label
+        )}
+      </a>
+    );
+  }
+
+  if (item.type === "html") {
+    return (
+      <span
+        key={`right-${index}`}
+        // Mirrors `<Fragment set:html={item.html} />` from the Astro
+        // template — the legacy code already trusts this string, and
+        // this port preserves that contract.
+        dangerouslySetInnerHTML={{ __html: item.html }}
+      />
+    );
+  }
+
+  return null;
+}

--- a/packages/zudo-doc-v2/src/header/index.ts
+++ b/packages/zudo-doc-v2/src/header/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Public entry for the JSX `<Header />` port.
+ *
+ * Consumers import from `@zudo-doc/zudo-doc-v2/header`:
+ *
+ *   import { Header } from "@zudo-doc/zudo-doc-v2/header";
+ *
+ * The pure helpers used to compute active-link state are also exposed
+ * so downstream tests / custom layouts can reuse them without rebuilding
+ * the `pathForMatch` / `computeActiveNavPath` regex logic.
+ */
+
+export { Header, type HeaderProps } from "./header.js";
+export {
+  computeActiveNavPath,
+  isNavItemActive,
+  pathForMatch,
+  type NavItemLike,
+} from "./nav-active.js";
+export { NAV_OVERFLOW_SCRIPT } from "./nav-overflow-script.js";

--- a/packages/zudo-doc-v2/src/header/nav-active.ts
+++ b/packages/zudo-doc-v2/src/header/nav-active.ts
@@ -1,0 +1,73 @@
+// Pure, settings-free helpers backing the JSX <Header /> port.
+//
+// These exist as their own module so unit tests can exercise the active-
+// path resolution logic without booting the host project's @/config or
+// @/utils modules. The Header component imports from here too so the
+// runtime and the tests share a single source of truth.
+
+/** Minimal shape the active-path resolver needs from a header nav item. */
+export interface NavItemLike {
+  path: string;
+  children?: { path: string }[];
+}
+
+/**
+ * Strip the locale prefix from `pathWithoutBase` when the page is being
+ * served under a non-default locale. Mirrors the inline regex inside
+ * `header.astro` so the JSX port matches the legacy template's
+ * active-link behaviour.
+ *
+ * Examples:
+ *   pathForMatch("/ja/docs/intro", "ja", "en") === "/docs/intro"
+ *   pathForMatch("/docs/intro",   "en", "en") === "/docs/intro"
+ *   pathForMatch(null,            "ja", "en") === ""
+ */
+export function pathForMatch(
+  pathWithoutBase: string,
+  lang: string | undefined,
+  defaultLocale: string,
+): string {
+  if (lang == null || lang === defaultLocale) return pathWithoutBase;
+  return pathWithoutBase.replace(new RegExp(`^/${lang}`), "");
+}
+
+/**
+ * Pick the deepest header-nav path that the current page lives under.
+ *
+ * The legacy template flattens parent + child paths, filters by
+ * `pathForMatch.startsWith(p)`, and picks the longest match — this keeps
+ * a child link active even when its parent's path is also a prefix of
+ * the current page.
+ *
+ * Returns `undefined` when no nav entry matches; callers should treat
+ * that as "no active link."
+ */
+export function computeActiveNavPath(
+  navItems: readonly NavItemLike[],
+  pathForMatchValue: string,
+): string | undefined {
+  const allNavPaths = navItems.flatMap((item) => {
+    const paths = [item.path];
+    if (item.children) {
+      paths.push(...item.children.map((child) => child.path));
+    }
+    return paths;
+  });
+  return allNavPaths
+    .filter((p) => pathForMatchValue.startsWith(p))
+    .sort((a, b) => b.length - a.length)[0];
+}
+
+/**
+ * Active-state predicate for a top-level nav item: the item itself, or
+ * any of its children, matches the active path. Mirrors the inline
+ * `isNavItemActive` helper in the legacy template.
+ */
+export function isNavItemActive(
+  item: NavItemLike,
+  activeNavPath: string | undefined,
+): boolean {
+  if (activeNavPath === item.path) return true;
+  if (item.children?.some((child) => activeNavPath === child.path)) return true;
+  return false;
+}

--- a/packages/zudo-doc-v2/src/header/nav-overflow-script.ts
+++ b/packages/zudo-doc-v2/src/header/nav-overflow-script.ts
@@ -1,0 +1,191 @@
+// Inline-script source for the desktop-nav overflow controller.
+//
+// In the original `header.astro` template the script lived directly
+// inside a `<script>` tag (which Astro pipes through the bundler). For
+// the JSX port we emit the same logic verbatim via
+// `dangerouslySetInnerHTML`, so the value below is plain ECMAScript —
+// any TypeScript-only constructs (generic params, type casts, parameter
+// type annotations) have been dropped so the browser can parse it
+// directly.
+//
+// The behaviour is byte-for-byte equivalent to the original:
+//   1. Locate the `[data-header-nav]` flex container, its `[data-nav-more]`
+//      overflow trigger, and its dropdown menu.
+//   2. Measure each top-level nav item, then greedily hide items that
+//      would overflow and rebuild the "..." dropdown to mirror them
+//      (including the bold-parent + indented-children pattern for
+//      `[data-nav-item-dropdown]` entries).
+//   3. Wire toggle / outside-click / Escape handlers to the overflow
+//      menu and aria-expanded state to the in-place dropdowns.
+//   4. Re-run on `astro:after-swap` so the overflow stays correct after
+//      View Transitions navigation.
+//
+// Kept as a separate module (rather than inlined in `header.tsx`) so
+// the JSX file stays focused on markup and so future edits to the
+// script can be reviewed in isolation.
+
+export const NAV_OVERFLOW_SCRIPT = `(function () {
+  var cleanupNavOverflow = null;
+
+  function initNavOverflow() {
+    if (cleanupNavOverflow) cleanupNavOverflow();
+
+    var nav = document.querySelector("[data-header-nav]");
+    var moreContainer = document.querySelector("[data-nav-more]");
+    var moreMenu = document.querySelector("[data-nav-more-menu]");
+    var moreToggle = document.querySelector("[data-nav-more-toggle]");
+    if (!nav || !moreContainer || !moreMenu || !moreToggle) return;
+
+    var items = Array.from(nav.querySelectorAll(":scope > [data-nav-item]"));
+    if (items.length === 0) return;
+
+    var controller = new AbortController();
+
+    function update() {
+      items.forEach(function (el) { el.style.display = ""; });
+      moreContainer.style.display = "";
+      moreMenu.innerHTML = "";
+      moreMenu.classList.add("hidden");
+      moreToggle.setAttribute("aria-expanded", "false");
+
+      var itemWidths = items.map(function (el) { return el.offsetWidth; });
+      var moreWidth = moreContainer.offsetWidth;
+      var navGap = parseFloat(getComputedStyle(nav).columnGap) || 0;
+      var available = nav.clientWidth;
+
+      if (available <= 0) {
+        moreContainer.style.display = "none";
+        return;
+      }
+
+      var total = 0;
+      for (var i = 0; i < itemWidths.length; i++) {
+        total += itemWidths[i] + (i > 0 ? navGap : 0);
+      }
+
+      if (total <= available) {
+        moreContainer.style.display = "none";
+        return;
+      }
+
+      var used = 0;
+      var cutoffIndex = 0;
+
+      for (var i2 = 0; i2 < items.length; i2++) {
+        var w = itemWidths[i2] + (i2 > 0 ? navGap : 0);
+        if (used + w > available - moreWidth - navGap) break;
+        used += w;
+        cutoffIndex = i2 + 1;
+      }
+
+      for (var i3 = cutoffIndex; i3 < items.length; i3++) {
+        items[i3].style.display = "none";
+      }
+
+      for (var i4 = cutoffIndex; i4 < items.length; i4++) {
+        var el = items[i4];
+        var isDropdown = el.hasAttribute("data-nav-item-dropdown");
+
+        if (isDropdown) {
+          var parentLink = el.querySelector(":scope > a");
+          var childLinks = el.querySelectorAll(":scope > div a");
+          if (parentLink) {
+            var li = document.createElement("li");
+            var a = document.createElement("a");
+            a.href = parentLink.href;
+            var parentText = parentLink.textContent ? parentLink.textContent.trim().replace(/\\s+/g, " ") : "";
+            a.textContent = parentText;
+            a.className = "block px-hsp-md py-vsp-2xs text-small font-bold hover:bg-accent/10 hover:underline focus-visible:underline text-fg";
+            if (parentLink.getAttribute("aria-current") === "page") {
+              a.className += " text-accent";
+            }
+            li.appendChild(a);
+            moreMenu.appendChild(li);
+          }
+          childLinks.forEach(function (child) {
+            var li = document.createElement("li");
+            var a = document.createElement("a");
+            a.href = child.href;
+            a.textContent = child.textContent ? child.textContent.trim() : "";
+            var isChildActive = child.hasAttribute("data-active");
+            a.className = isChildActive
+              ? "block pl-hsp-xl pr-hsp-md py-vsp-2xs text-small font-bold text-accent hover:bg-accent/10 hover:underline focus-visible:underline"
+              : "block pl-hsp-xl pr-hsp-md py-vsp-2xs text-small text-muted hover:bg-accent/10 hover:text-fg hover:underline focus-visible:underline";
+            li.appendChild(a);
+            moreMenu.appendChild(li);
+          });
+        } else {
+          var anchor = el;
+          var li2 = document.createElement("li");
+          var a2 = document.createElement("a");
+          a2.href = anchor.href;
+          a2.textContent = anchor.textContent ? anchor.textContent.trim() : "";
+          a2.className = "block px-hsp-md py-vsp-2xs text-small hover:bg-accent/10 hover:underline focus-visible:underline text-fg";
+          if (anchor.getAttribute("aria-current") === "page") {
+            a2.className += " font-bold text-accent";
+          }
+          li2.appendChild(a2);
+          moreMenu.appendChild(li2);
+        }
+      }
+    }
+
+    moreToggle.addEventListener("click", function () {
+      var isOpen = !moreMenu.classList.contains("hidden");
+      moreMenu.classList.toggle("hidden", isOpen);
+      moreToggle.setAttribute("aria-expanded", String(!isOpen));
+    }, { signal: controller.signal });
+
+    document.addEventListener("click", function (e) {
+      if (!moreContainer.contains(e.target)) {
+        moreMenu.classList.add("hidden");
+        moreToggle.setAttribute("aria-expanded", "false");
+      }
+    }, { signal: controller.signal });
+
+    document.addEventListener("keydown", function (e) {
+      if (e.key !== "Escape") return;
+      if (!moreMenu.classList.contains("hidden")) {
+        moreMenu.classList.add("hidden");
+        moreToggle.setAttribute("aria-expanded", "false");
+        moreToggle.focus();
+        return;
+      }
+      var active = document.activeElement;
+      var dropdown = active && active.closest ? active.closest("[data-nav-item-dropdown]") : null;
+      if (dropdown && active && active.blur) {
+        active.blur();
+      }
+    }, { signal: controller.signal });
+
+    var dropdowns = nav.querySelectorAll("[data-nav-item-dropdown]");
+    dropdowns.forEach(function (dd) {
+      var trigger = dd.querySelector(":scope > a");
+      if (!trigger) return;
+      function setExpanded(v) {
+        trigger.setAttribute("aria-expanded", String(v));
+      }
+      dd.addEventListener("mouseenter", function () { setExpanded(true); }, { signal: controller.signal });
+      dd.addEventListener("mouseleave", function () { setExpanded(false); }, { signal: controller.signal });
+      dd.addEventListener("focusin", function () { setExpanded(true); }, { signal: controller.signal });
+      dd.addEventListener("focusout", function (e) {
+        if (!dd.contains(e.relatedTarget)) {
+          setExpanded(false);
+        }
+      }, { signal: controller.signal });
+    });
+
+    var ro = new ResizeObserver(update);
+    ro.observe(nav);
+    controller.signal.addEventListener("abort", function () { ro.disconnect(); });
+
+    document.fonts.ready.then(update);
+
+    update();
+
+    cleanupNavOverflow = function () { controller.abort(); };
+  }
+
+  initNavOverflow();
+  document.addEventListener("astro:after-swap", initNavOverflow);
+})();`;

--- a/packages/zudo-doc-v2/src/i18n-version/__tests__/language-switcher.test.tsx
+++ b/packages/zudo-doc-v2/src/i18n-version/__tests__/language-switcher.test.tsx
@@ -1,0 +1,100 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { describe, expect, it } from "vitest";
+import type { ComponentChildren, VNode } from "preact";
+import { LanguageSwitcher } from "../language-switcher";
+import type { LocaleLink } from "../types";
+
+// Minimal VNode → HTML serializer (mirrors the helper used in
+// breadcrumb.test.tsx — kept inline so the test runs without a render
+// dependency).
+type AnyVNode = VNode<{ children?: ComponentChildren; [key: string]: unknown }>;
+
+function isVNode(v: unknown): v is AnyVNode {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    Object.prototype.hasOwnProperty.call(v, "type") &&
+    Object.prototype.hasOwnProperty.call(v, "props")
+  );
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/"/g, "&quot;");
+}
+
+function serialize(node: ComponentChildren): string {
+  if (node == null || typeof node === "boolean") return "";
+  if (typeof node === "string") return node;
+  if (typeof node === "number" || typeof node === "bigint") return String(node);
+  if (Array.isArray(node)) return node.map(serialize).join("");
+  if (!isVNode(node)) return "";
+  const { type, props } = node;
+  const { children, ...rest } = (props ?? {}) as {
+    children?: ComponentChildren;
+    [key: string]: unknown;
+  };
+
+  if (typeof type === "function") {
+    const fn = type as (p: typeof props) => ComponentChildren;
+    return serialize(fn(props));
+  }
+  if (type == null || (typeof type === "string" && type === "")) {
+    return serialize(children);
+  }
+  if (typeof type !== "string") return serialize(children);
+
+  const attrs = Object.entries(rest)
+    .filter(([, v]) => v !== undefined && v !== null && v !== false)
+    .map(([k, v]) => {
+      if (k === "key") return "";
+      if (v === true) return ` ${k}`;
+      return ` ${k}="${escapeAttr(String(v))}"`;
+    })
+    .join("");
+
+  const voidEls = new Set(["br", "hr", "img", "input", "wbr", "meta", "link"]);
+  if (voidEls.has(type)) return `<${type}${attrs}/>`;
+  return `<${type}${attrs}>${serialize(children)}</${type}>`;
+}
+
+const enJa: LocaleLink[] = [
+  { code: "en", label: "EN", href: "/docs/", active: true },
+  { code: "ja", label: "JA", href: "/ja/docs/", active: false },
+];
+
+describe("LanguageSwitcher", () => {
+  it("returns null when there is one or fewer links (matches the Astro guard)", () => {
+    const noneRendered =
+      LanguageSwitcher({ links: [] as LocaleLink[] }) === null;
+    const oneRendered =
+      LanguageSwitcher({ links: [enJa[0]] }) === null;
+    expect(noneRendered).toBe(true);
+    expect(oneRendered).toBe(true);
+  });
+
+  it("renders a span (not an anchor) for the active locale with aria-current", () => {
+    const html = serialize(<LanguageSwitcher links={enJa} />);
+    expect(html).toContain('<span aria-current="true"');
+    expect(html).toContain(">EN</span>");
+  });
+
+  it("renders an anchor with the lang attribute for inactive locales", () => {
+    const html = serialize(<LanguageSwitcher links={enJa} />);
+    expect(html).toContain('href="/ja/docs/"');
+    expect(html).toContain('lang="ja"');
+    expect(html).toContain(">JA</a>");
+  });
+
+  it("inserts a slash separator between every pair of links", () => {
+    const enJaFr: LocaleLink[] = [
+      ...enJa,
+      { code: "fr", label: "FR", href: "/fr/docs/", active: false },
+    ];
+    const html = serialize(<LanguageSwitcher links={enJaFr} />);
+    // Two separators for three links.
+    const slashCount = (html.match(/<span class="text-muted">\/<\/span>/g) ?? []).length;
+    expect(slashCount).toBe(2);
+  });
+});

--- a/packages/zudo-doc-v2/src/i18n-version/__tests__/version-switcher.test.tsx
+++ b/packages/zudo-doc-v2/src/i18n-version/__tests__/version-switcher.test.tsx
@@ -1,0 +1,182 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { describe, expect, it } from "vitest";
+import type { ComponentChildren, VNode } from "preact";
+import {
+  VersionSwitcher,
+  VERSION_SWITCHER_INIT_SCRIPT,
+} from "../version-switcher";
+import type { VersionEntry, VersionSwitcherLabels } from "../types";
+
+type AnyVNode = VNode<{ children?: ComponentChildren; [key: string]: unknown }>;
+
+function isVNode(v: unknown): v is AnyVNode {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    Object.prototype.hasOwnProperty.call(v, "type") &&
+    Object.prototype.hasOwnProperty.call(v, "props")
+  );
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/"/g, "&quot;");
+}
+
+function serialize(node: ComponentChildren): string {
+  if (node == null || typeof node === "boolean") return "";
+  if (typeof node === "string") return node;
+  if (typeof node === "number" || typeof node === "bigint") return String(node);
+  if (Array.isArray(node)) return node.map(serialize).join("");
+  if (!isVNode(node)) return "";
+  const { type, props } = node;
+  const { children, ...rest } = (props ?? {}) as {
+    children?: ComponentChildren;
+    [key: string]: unknown;
+  };
+
+  if (typeof type === "function") {
+    const fn = type as (p: typeof props) => ComponentChildren;
+    return serialize(fn(props));
+  }
+  if (type == null || (typeof type === "string" && type === "")) {
+    return serialize(children);
+  }
+  if (typeof type !== "string") return serialize(children);
+
+  const attrs = Object.entries(rest)
+    .filter(([, v]) => v !== undefined && v !== null && v !== false)
+    .map(([k, v]) => {
+      if (k === "key") return "";
+      if (v === true) return ` ${k}`;
+      return ` ${k}="${escapeAttr(String(v))}"`;
+    })
+    .join("");
+
+  const voidEls = new Set(["br", "hr", "img", "input", "wbr", "meta", "link"]);
+  if (voidEls.has(type)) return `<${type}${attrs}/>`;
+  return `<${type}${attrs}>${serialize(children)}</${type}>`;
+}
+
+const labels: VersionSwitcherLabels = {
+  latest: "Latest",
+  switcher: "Version",
+  unavailable: "Not available",
+  allVersions: "All versions",
+};
+
+const versions: VersionEntry[] = [
+  { slug: "v2", label: "v2.0" },
+  { slug: "v1", label: "v1.x" },
+];
+
+const versionUrls: Record<string, string> = {
+  v2: "/v/v2/docs/intro/",
+  v1: "/v/v1/docs/intro/",
+};
+
+describe("VersionSwitcher", () => {
+  it("renders the data-version-switcher root, toggle, and menu", () => {
+    const html = serialize(
+      <VersionSwitcher
+        versions={versions}
+        latestUrl="/docs/intro/"
+        versionsPageUrl="/docs/versions/"
+        versionUrls={versionUrls}
+        labels={labels}
+      />,
+    );
+    expect(html).toContain("data-version-switcher");
+    expect(html).toContain("data-version-toggle");
+    expect(html).toContain("data-version-menu");
+    expect(html).toContain('id="version-menu"');
+  });
+
+  it("appends idSuffix to the menu id and aria-controls", () => {
+    const html = serialize(
+      <VersionSwitcher
+        versions={versions}
+        latestUrl="/docs/intro/"
+        versionsPageUrl="/docs/versions/"
+        versionUrls={versionUrls}
+        labels={labels}
+        idSuffix="header"
+      />,
+    );
+    expect(html).toContain('id="version-menu-header"');
+    expect(html).toContain('aria-controls="version-menu-header"');
+  });
+
+  it("marks the Latest entry as the active row when no currentVersion is set", () => {
+    const html = serialize(
+      <VersionSwitcher
+        versions={versions}
+        latestUrl="/docs/intro/"
+        versionsPageUrl="/docs/versions/"
+        versionUrls={versionUrls}
+        labels={labels}
+      />,
+    );
+    // Latest link gets aria-current="page" + bold/accent class.
+    expect(html).toMatch(/<a[^>]*href="\/docs\/intro\/"[^>]*aria-current="page"/);
+    expect(html).toContain("font-bold text-accent");
+  });
+
+  it("renders the matching version entry as active when currentVersion is set", () => {
+    const html = serialize(
+      <VersionSwitcher
+        versions={versions}
+        currentVersion="v1"
+        latestUrl="/docs/intro/"
+        versionsPageUrl="/docs/versions/"
+        versionUrls={versionUrls}
+        labels={labels}
+      />,
+    );
+    // The trigger label reflects the current version.
+    expect(html).toContain(">v1.x</span>");
+    // The v1 list item carries aria-current="page".
+    expect(html).toMatch(/href="\/v\/v1\/docs\/intro\/"[^>]*aria-current="page"/);
+    // Latest no longer carries it.
+    expect(html).not.toMatch(/href="\/docs\/intro\/"[^>]*aria-current="page"/);
+  });
+
+  it("renders unavailable versions as disabled, non-interactive links", () => {
+    const html = serialize(
+      <VersionSwitcher
+        versions={versions}
+        latestUrl="/docs/intro/"
+        versionsPageUrl="/docs/versions/"
+        versionUrls={versionUrls}
+        unavailableVersions={new Set(["v1"])}
+        labels={labels}
+      />,
+    );
+    expect(html).toContain('aria-disabled="true"');
+    expect(html).toContain("pointer-events-none");
+    expect(html).toContain('title="Not available"');
+  });
+
+  it("falls back to versionsPageUrl when versionUrls lacks an entry", () => {
+    const html = serialize(
+      <VersionSwitcher
+        versions={[{ slug: "v0", label: "v0" }]}
+        latestUrl="/docs/intro/"
+        versionsPageUrl="/docs/versions/"
+        versionUrls={{}}
+        labels={labels}
+      />,
+    );
+    // Two anchors point at versionsPageUrl: the v0 row and the footer
+    // "All versions" link.
+    const matches = html.match(/href="\/docs\/versions\/"/g) ?? [];
+    expect(matches.length).toBe(2);
+  });
+
+  it("VERSION_SWITCHER_INIT_SCRIPT is non-empty and contains the after-swap rebind", () => {
+    expect(VERSION_SWITCHER_INIT_SCRIPT).toContain('astro:after-swap');
+    expect(VERSION_SWITCHER_INIT_SCRIPT).toContain('AbortController');
+    expect(VERSION_SWITCHER_INIT_SCRIPT).toContain('data-version-switcher');
+  });
+});

--- a/packages/zudo-doc-v2/src/i18n-version/index.ts
+++ b/packages/zudo-doc-v2/src/i18n-version/index.ts
@@ -1,0 +1,33 @@
+// E5 framework primitives — i18n + version chrome.
+//
+// This subpath publishes the layout-level locale and version switchers.
+// Both are pure presentational components: the host project pre-builds
+// the data they need (locale links, version URLs, availability sets,
+// label strings) so v2 stays free of any settings/i18n/utils coupling.
+//
+// Usage from the host project:
+//
+//   import {
+//     LanguageSwitcher,
+//     VersionSwitcher,
+//     VERSION_SWITCHER_INIT_SCRIPT,
+//   } from "@zudo-doc/zudo-doc-v2/i18n-version";
+//
+// Mount the version-switcher init script once per page (e.g. in the
+// layout's body-end scripts slot) — it idempotently re-binds after
+// View Transitions navigation.
+
+export { LanguageSwitcher } from "./language-switcher";
+export type { LanguageSwitcherProps } from "./language-switcher";
+
+export {
+  VersionSwitcher,
+  VERSION_SWITCHER_INIT_SCRIPT,
+} from "./version-switcher";
+export type { VersionSwitcherProps } from "./version-switcher";
+
+export type {
+  LocaleLink,
+  VersionEntry,
+  VersionSwitcherLabels,
+} from "./types";

--- a/packages/zudo-doc-v2/src/i18n-version/language-switcher.tsx
+++ b/packages/zudo-doc-v2/src/i18n-version/language-switcher.tsx
@@ -1,0 +1,72 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+// JSX port of src/components/language-switcher.astro.
+//
+// Pure presentational component: the host project pre-builds the
+// `LocaleLink[]` (using its own settings/i18n modules and the active
+// `Astro.url.pathname`) and passes them in. The v2 package itself stays
+// agnostic about how locales are configured.
+//
+// Astro → JSX deltas:
+//   * `<slot />` not used (no children).
+//   * `Astro.props` → typed `LanguageSwitcherProps`.
+//   * `class=` → `class=` (Preact accepts both `class` and `className` in
+//     compat mode; we follow the convention used by the rest of v2 and
+//     keep `class` to match adjacent files like breadcrumb.tsx).
+//   * The Astro template's top-level guard (`localeLinks.length > 1 &&`)
+//     becomes an early `return null`.
+
+import type { VNode } from "preact";
+import { Fragment } from "preact";
+import type { LocaleLink } from "./types";
+
+export interface LanguageSwitcherProps {
+  /**
+   * Pre-built locale links, ordered as they should appear in the bar.
+   * The host project typically derives this with its own
+   * `buildLocaleLinks(currentPath, currentLang)` helper before passing.
+   */
+  links: LocaleLink[];
+}
+
+/**
+ * Inline locale switcher rendered in the header / sidebar footer.
+ *
+ * Returns `null` when there is one locale or fewer (matches the Astro
+ * template's `localeLinks.length > 1 &&` guard so call-sites can mount
+ * the component unconditionally).
+ */
+export function LanguageSwitcher({ links }: LanguageSwitcherProps): VNode | null {
+  if (links.length <= 1) return null;
+
+  return (
+    <div class="flex items-center gap-x-hsp-xs text-small">
+      {links.map((link, i) => (
+        // Fragment is keyed via the locale code so the reconciler keeps
+        // the active/inactive nodes paired correctly across re-renders
+        // (e.g. when the active locale flips after navigation).
+        <Fragment key={link.code}>
+          {i > 0 && <span class="text-muted">/</span>}
+          {link.active ? (
+            <span aria-current="true" class="font-medium text-fg">
+              {link.label}
+            </span>
+          ) : (
+            <a
+              href={link.href}
+              lang={link.code}
+              class="text-muted hover:text-fg"
+            >
+              {link.label}
+            </a>
+          )}
+        </Fragment>
+      ))}
+    </div>
+  );
+}
+
+// Re-export the type so consumers can import LocaleLink from this module
+// without reaching into ./types directly.
+export type { LocaleLink };

--- a/packages/zudo-doc-v2/src/i18n-version/types.ts
+++ b/packages/zudo-doc-v2/src/i18n-version/types.ts
@@ -1,0 +1,50 @@
+// Shared types for the language- and version-switcher v2 ports.
+//
+// These are presentational primitives: every value the components need to
+// render comes in via props. The package never reaches into the host
+// project's settings/i18n/utils — keeping v2 fully decoupled from the
+// legacy Astro src/ tree.
+
+/**
+ * Single link in the language-switcher's ordered list.
+ *
+ * Mirrors the shape of `LocaleLink` from src/types/locale.ts so existing
+ * call-sites can pass their already-built links straight through.
+ */
+export interface LocaleLink {
+  /** BCP-47 code, e.g. "en", "ja". Rendered as the anchor's `lang` attribute. */
+  code: string;
+  /** Display label (typically the uppercased code). */
+  label: string;
+  /** Pre-resolved href for the locale (already prefixed with the configured base). */
+  href: string;
+  /** True for the currently-active locale — rendered as plain text, not a link. */
+  active: boolean;
+}
+
+/**
+ * Single entry in the version-switcher's drop-down list.
+ *
+ * Slug is the URL-segment identifier; label is the user-visible string
+ * (e.g. "v2.0", "1.x").
+ */
+export interface VersionEntry {
+  slug: string;
+  label: string;
+}
+
+/**
+ * UI strings the version-switcher renders. Kept as a labels bag rather
+ * than wired to a host-side i18n module so the v2 package stays
+ * locale-system agnostic.
+ */
+export interface VersionSwitcherLabels {
+  /** Label for the "latest" entry, e.g. "Latest" / "最新". */
+  latest: string;
+  /** Trigger-button prefix, e.g. "Version" / "バージョン". */
+  switcher: string;
+  /** `title` attribute for unavailable items, e.g. "Not available". */
+  unavailable: string;
+  /** Footer link label, e.g. "All versions". */
+  allVersions: string;
+}

--- a/packages/zudo-doc-v2/src/i18n-version/version-switcher.tsx
+++ b/packages/zudo-doc-v2/src/i18n-version/version-switcher.tsx
@@ -1,0 +1,255 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+// JSX port of src/components/version-switcher.astro.
+//
+// Like the language-switcher, this is a pure presentational component:
+// every URL, label, and availability flag the host project would derive
+// from `settings.versions`, `t()`, and the version-availability map is
+// passed in as a prop. The v2 package itself stays free of any
+// settings/i18n/utils coupling.
+//
+// The Astro version shipped a `<script>` in the same file that wired up
+// click-toggle / outside-click / Escape-key behavior on every
+// `[data-version-switcher]` instance, idempotently re-binding after
+// `astro:after-swap`. The JSX port emits the same data-attributes and
+// markup, but the script lives separately as `VERSION_SWITCHER_INIT_SCRIPT`
+// so consumers mount it once at body-end (matching how
+// color-scheme-provider's bootstrap is structured). That keeps the
+// component itself SSR-safe and side-effect-free, while letting the host
+// page wire up exactly one global listener regardless of how many
+// switchers are on the page.
+//
+// Astro → JSX deltas:
+//   * `Astro.props` → typed `VersionSwitcherProps`.
+//   * `class:list={[...]}` → manual class concatenation in `cls(...)`.
+//   * `aria-current={isLatest ? "page" : undefined}` is preserved verbatim
+//     (Preact omits the attribute when the value is `undefined`).
+//   * The `<svg>` chevron stays inline so consumers don't need to import
+//     an icon library.
+//   * The `<script>` block in the .astro source is hoisted out into the
+//     exported `VERSION_SWITCHER_INIT_SCRIPT` constant.
+
+import type { VNode } from "preact";
+import type { VersionEntry, VersionSwitcherLabels } from "./types";
+
+export interface VersionSwitcherProps {
+  /**
+   * All known versions, in display order (latest at top of the dropdown
+   * is rendered separately via `latestUrl` — this list is the
+   * non-latest versions only).
+   */
+  versions: VersionEntry[];
+
+  /** Current version slug, or undefined when the page is on "latest". */
+  currentVersion?: string;
+
+  /** Pre-resolved href for the "Latest" entry. */
+  latestUrl: string;
+
+  /** Pre-resolved href for the "All versions" footer link. */
+  versionsPageUrl: string;
+
+  /**
+   * Map of `version slug` → pre-resolved href to that version of the
+   * current page (or the versions index page when no slug is in scope).
+   * Pass an empty object when the current page is not a versionable doc.
+   */
+  versionUrls: Record<string, string>;
+
+  /**
+   * Slugs of versions where the current page is NOT available. Renders
+   * those entries as muted, non-interactive links with the
+   * `unavailable` title attribute. Omit (or pass `undefined`) when no
+   * availability data is in scope — every entry is then treated as
+   * available, matching the Astro template's `!availability` branch.
+   */
+  unavailableVersions?: ReadonlySet<string>;
+
+  /** UI strings — see `VersionSwitcherLabels` for the field list. */
+  labels: VersionSwitcherLabels;
+
+  /**
+   * Optional suffix appended to the menu's DOM id. Used when more than
+   * one version-switcher is rendered on the same page (e.g. one in the
+   * header, one in the sidebar) so each `aria-controls` reference stays
+   * unique.
+   */
+  idSuffix?: string;
+}
+
+/** Concatenate Tailwind class strings, dropping falsy entries. */
+function cls(...parts: (string | false | null | undefined)[]): string {
+  return parts.filter(Boolean).join(" ");
+}
+
+function ChevronDownIcon(): VNode {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      class="h-[0.875rem] w-[0.875rem]"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      stroke-width="2"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M19 9l-7 7-7-7"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Drop-down version switcher rendered in the header.
+ *
+ * The toggle / outside-click / Escape-key behavior lives in
+ * `VERSION_SWITCHER_INIT_SCRIPT` — mount it once at body-end on any
+ * page that includes a `<VersionSwitcher>`.
+ */
+export function VersionSwitcher(props: VersionSwitcherProps): VNode {
+  const {
+    versions,
+    currentVersion,
+    latestUrl,
+    versionsPageUrl,
+    versionUrls,
+    unavailableVersions,
+    labels,
+    idSuffix = "",
+  } = props;
+
+  const menuId = `version-menu${idSuffix ? `-${idSuffix}` : ""}`;
+  const isLatest = !currentVersion;
+  const triggerLabel = isLatest
+    ? labels.latest
+    : (versions.find((v) => v.slug === currentVersion)?.label ?? currentVersion);
+
+  return (
+    <div class="version-switcher relative" data-version-switcher>
+      <button
+        type="button"
+        class="flex items-center gap-hsp-2xs border border-muted rounded px-hsp-sm py-vsp-3xs text-small text-muted hover:border-accent hover:text-accent transition-colors cursor-pointer whitespace-nowrap"
+        aria-expanded="false"
+        aria-controls={menuId}
+        data-version-toggle
+      >
+        <span class="text-caption">{labels.switcher}:</span>
+        <span class="font-medium">{triggerLabel}</span>
+        <ChevronDownIcon />
+      </button>
+
+      <ul
+        id={menuId}
+        class="absolute right-0 top-full z-10 mt-vsp-3xs hidden min-w-[8rem] border border-muted rounded bg-surface shadow-lg whitespace-nowrap py-vsp-3xs"
+        data-version-menu
+      >
+        <li>
+          <a
+            href={latestUrl}
+            aria-current={isLatest ? "page" : undefined}
+            class={cls(
+              "block px-hsp-md py-vsp-2xs text-small hover:bg-accent/10 hover:underline focus-visible:underline",
+              isLatest ? "font-bold text-accent" : "text-fg",
+            )}
+          >
+            {labels.latest}
+          </a>
+        </li>
+        {versions.map((v) => {
+          const vUrl = versionUrls[v.slug] ?? versionsPageUrl;
+          const isActive = currentVersion === v.slug;
+          // The Astro source treated "no availability info" as
+          // "everything available" (`!availability || (...has(slug))`).
+          // We mirror that: when the consumer doesn't pass
+          // `unavailableVersions`, treat every entry as available.
+          const isAvailable = !unavailableVersions || !unavailableVersions.has(v.slug);
+          return (
+            <li key={v.slug}>
+              {isAvailable ? (
+                <a
+                  href={vUrl}
+                  aria-current={isActive ? "page" : undefined}
+                  class={cls(
+                    "block px-hsp-md py-vsp-2xs text-small hover:bg-accent/10 hover:underline focus-visible:underline",
+                    isActive ? "font-bold text-accent" : "text-fg",
+                  )}
+                >
+                  {v.label}
+                </a>
+              ) : (
+                <a
+                  href={vUrl}
+                  aria-disabled="true"
+                  tabindex={-1}
+                  class="block px-hsp-md py-vsp-2xs text-small text-muted/50 cursor-not-allowed pointer-events-none"
+                  title={labels.unavailable}
+                >
+                  {v.label}
+                </a>
+              )}
+            </li>
+          );
+        })}
+        <li class="border-t border-muted">
+          <a
+            href={versionsPageUrl}
+            class="block px-hsp-md py-vsp-2xs text-small text-muted hover:bg-accent/10 hover:text-fg hover:underline focus-visible:underline"
+          >
+            {labels.allVersions}
+          </a>
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+/**
+ * Self-contained init script for the version-switcher's interactive
+ * behavior. Mount once per page (e.g. inside the layout's body-end
+ * scripts slot) — it idempotently re-binds after `astro:after-swap`
+ * via an AbortController, so multiple switchers on the page share a
+ * single event-listener generation.
+ *
+ * Lifted verbatim from the `<script>` block of the original
+ * version-switcher.astro so behavior is bit-for-bit identical.
+ */
+export const VERSION_SWITCHER_INIT_SCRIPT = `(function(){
+var cleanupController=null;
+function initVersionSwitcher(){
+if(cleanupController)cleanupController.abort();
+cleanupController=new AbortController();
+var signal=cleanupController.signal;
+document.querySelectorAll("[data-version-switcher]").forEach(function(switcher){
+var toggle=switcher.querySelector("[data-version-toggle]");
+var menu=switcher.querySelector("[data-version-menu]");
+if(!toggle||!menu)return;
+toggle.addEventListener("click",function(){
+var isOpen=!menu.classList.contains("hidden");
+menu.classList.toggle("hidden",isOpen);
+toggle.setAttribute("aria-expanded",String(!isOpen));
+},{signal:signal});
+document.addEventListener("click",function(e){
+if(!switcher.contains(e.target)){
+menu.classList.add("hidden");
+toggle.setAttribute("aria-expanded","false");
+}
+},{signal:signal});
+document.addEventListener("keydown",function(e){
+if(e.key==="Escape"&&!menu.classList.contains("hidden")){
+menu.classList.add("hidden");
+toggle.setAttribute("aria-expanded","false");
+toggle.focus();
+}
+},{signal:signal});
+});
+}
+initVersionSwitcher();
+document.addEventListener("astro:after-swap",initVersionSwitcher);
+})();`;
+
+// Re-export the data types so consumers can import everything they need
+// from this single module.
+export type { VersionEntry, VersionSwitcherLabels };

--- a/packages/zudo-doc-v2/src/index.ts
+++ b/packages/zudo-doc-v2/src/index.ts
@@ -13,6 +13,7 @@
  *   import { DocLayout, DocLayoutWithDefaults }     from "@zudo-doc/zudo-doc-v2/doclayout";
  *   import { ColorSchemeProvider, ThemeToggle }     from "@zudo-doc/zudo-doc-v2/theme";
  *   import { startViewTransition, sidebarPersistName } from "@zudo-doc/zudo-doc-v2/transitions";
+ *   import { initSidebarResizer }                      from "@zudo-doc/zudo-doc-v2/sidebar-resizer";
  *   import { AiChatModalIsland, ImageEnlargeIsland }   from "@zudo-doc/zudo-doc-v2/ssr-skip";
  *
  * See packages/zudo-doc-v2/README.md for the topic map.

--- a/packages/zudo-doc-v2/src/page-loading/__tests__/page-loading-overlay.test.tsx
+++ b/packages/zudo-doc-v2/src/page-loading/__tests__/page-loading-overlay.test.tsx
@@ -1,0 +1,55 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { describe, expect, it } from "vitest";
+import { render } from "preact-render-to-string";
+import {
+  AFTER_NAVIGATE_EVENT,
+  BEFORE_NAVIGATE_EVENT,
+} from "../../transitions/page-events";
+import PageLoadingOverlay, {
+  PAGE_LOADING_OVERLAY_ID,
+  buildPageLoadingOverlayBootstrap,
+} from "../page-loading-overlay";
+
+describe("buildPageLoadingOverlayBootstrap", () => {
+  it("inlines the overlay id and routes through the v2 transitions vocabulary", () => {
+    const script = buildPageLoadingOverlayBootstrap("custom-id");
+    expect(script).toContain('var id="custom-id";');
+    // Event names come from the shim, not raw `astro:*` literals in the
+    // component file — the assertion fixes that contract.
+    expect(script).toContain(JSON.stringify(BEFORE_NAVIGATE_EVENT));
+    expect(script).toContain(JSON.stringify(AFTER_NAVIGATE_EVENT));
+    expect(script).toMatch(/document\.addEventListener\(/);
+  });
+
+  it("escapes the overlay id via JSON to defend against quote injection", () => {
+    const script = buildPageLoadingOverlayBootstrap('id"; alert(1); //');
+    // JSON.stringify yields a safely escaped literal; we just check the
+    // raw quote isn't present unescaped in the body.
+    expect(script).not.toMatch(/var id="id"; alert\(1\)/);
+    expect(script).toContain(JSON.stringify('id"; alert(1); //'));
+  });
+});
+
+describe("<PageLoadingOverlay />", () => {
+  it("renders the overlay element with the default id and aria-hidden", () => {
+    const html = render(<PageLoadingOverlay />);
+    expect(html).toContain(`id="${PAGE_LOADING_OVERLAY_ID}"`);
+    expect(html).toContain('aria-hidden="true"');
+    expect(html).toContain('class="page-loading-overlay"');
+    expect(html).toContain('class="page-loading-spinner"');
+  });
+
+  it("emits both the overlay style block and the bootstrap script", () => {
+    const html = render(<PageLoadingOverlay />);
+    expect(html).toMatch(/<style>[\s\S]*\.page-loading-overlay/);
+    expect(html).toMatch(/<script>[\s\S]*addEventListener/);
+  });
+
+  it("honors a custom id on both the element and the bootstrap script", () => {
+    const html = render(<PageLoadingOverlay id="custom-overlay" />);
+    expect(html).toContain('id="custom-overlay"');
+    expect(html).toContain('var id="custom-overlay";');
+  });
+});

--- a/packages/zudo-doc-v2/src/page-loading/index.ts
+++ b/packages/zudo-doc-v2/src/page-loading/index.ts
@@ -1,0 +1,11 @@
+// E5 framework primitives — page-loading overlay.
+//
+// Subpath: `@zudo-doc/zudo-doc-v2/page-loading`. JSX port of
+// `src/components/page-loading-overlay.astro` from the host project.
+
+export {
+  default as PageLoadingOverlay,
+  PAGE_LOADING_OVERLAY_ID,
+  buildPageLoadingOverlayBootstrap,
+  type PageLoadingOverlayProps,
+} from "./page-loading-overlay";

--- a/packages/zudo-doc-v2/src/page-loading/page-loading-overlay.tsx
+++ b/packages/zudo-doc-v2/src/page-loading/page-loading-overlay.tsx
@@ -1,0 +1,143 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+// Server-rendered, zero-hydration full-page loading overlay.
+//
+// JSX port of src/components/page-loading-overlay.astro.
+//
+// Renders three things into the document:
+//
+//   1. A fixed-position overlay `<div>` with a centered spinner. Hidden
+//      by default (`opacity: 0; pointer-events: none;`) and made
+//      visible by adding `data-visible` to it.
+//   2. A `<style>` block that owns the overlay + spinner CSS plus the
+//      `prefers-reduced-motion` fallback. Inlined via
+//      `dangerouslySetInnerHTML` (matching the ColorSchemeProvider
+//      pattern) so no separate stylesheet has to be wired up.
+//   3. A small `<script>` that toggles the `data-visible` attribute on
+//      navigation lifecycle events. The event names come from the
+//      `@zudo-doc/zudo-doc-v2/transitions` shim — this component does
+//      not reach for the underlying Astro event names directly. When
+//      zfb later supplies its own router events, only the constants in
+//      `transitions/page-events.ts` change.
+//
+// The component is intentionally not hydrated. Hydrating Preact just to
+// attach two listeners would be wasteful given the original Astro file
+// shipped a tiny imperative script — this port keeps that profile.
+
+import {
+  AFTER_NAVIGATE_EVENT,
+  BEFORE_NAVIGATE_EVENT,
+} from "../transitions/page-events.js";
+
+/** Default `id` for the overlay element. Stable so test rigs can target it. */
+export const PAGE_LOADING_OVERLAY_ID = "page-loading-overlay";
+
+export interface PageLoadingOverlayProps {
+  /**
+   * Override the DOM `id` used by both the overlay element and the
+   * bootstrap script. Useful when multiple overlays could co-exist on
+   * the page (e.g. tests). Defaults to `PAGE_LOADING_OVERLAY_ID`.
+   */
+  id?: string;
+}
+
+/**
+ * Build the inline bootstrap script body. Exported so test rigs can
+ * inspect / snapshot it without rendering the component.
+ */
+export function buildPageLoadingOverlayBootstrap(overlayId: string): string {
+  // Values are inlined as JSON literals so the script is fully
+  // self-contained and matches the `define:vars` shape used elsewhere
+  // (see ColorSchemeProvider). Event names come from the shim's
+  // exported constants — no raw `astro:*` strings live in this file.
+  const id = JSON.stringify(overlayId);
+  const before = JSON.stringify(BEFORE_NAVIGATE_EVENT);
+  const after = JSON.stringify(AFTER_NAVIGATE_EVENT);
+  return `(function(){
+var id=${id};
+function show(){var el=document.getElementById(id);if(!el)return;el.setAttribute("data-visible","");el.setAttribute("aria-hidden","false");}
+function hide(){var el=document.getElementById(id);if(!el)return;el.removeAttribute("data-visible");el.setAttribute("aria-hidden","true");}
+document.addEventListener(${before},show);
+document.addEventListener(${after},hide);
+})();`;
+}
+
+const OVERLAY_CSS = `.page-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in oklch, var(--color-overlay) 60%, transparent);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 150ms ease-out;
+}
+
+.page-loading-overlay[data-visible] {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.page-loading-spinner {
+  width: 48px;
+  height: 48px;
+  border: 5px solid var(--color-fg, #fff);
+  border-bottom-color: transparent;
+  border-radius: 50%;
+  display: inline-block;
+  box-sizing: border-box;
+  animation: page-loading-spin 1s linear infinite;
+}
+
+@media (min-width: 1024px) {
+  .page-loading-spinner {
+    width: 64px;
+    height: 64px;
+    border-width: 6px;
+  }
+}
+
+@keyframes page-loading-spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .page-loading-spinner {
+    animation: none;
+    border-bottom-color: var(--color-fg, #fff);
+    opacity: 0.5;
+  }
+}`;
+
+/**
+ * Full-page loading overlay shown during view-transition navigations.
+ *
+ * Mount this once per layout (typically inside `DocLayoutWithDefaults`'s
+ * `bodyEnd` slot, alongside the existing body-end providers). It is
+ * server-rendered and self-wires its visibility — no hydration needed.
+ */
+export default function PageLoadingOverlay({
+  id = PAGE_LOADING_OVERLAY_ID,
+}: PageLoadingOverlayProps = {}) {
+  return (
+    <>
+      <style dangerouslySetInnerHTML={{ __html: OVERLAY_CSS }} />
+      <div
+        id={id}
+        class="page-loading-overlay"
+        aria-hidden="true"
+      >
+        <span class="page-loading-spinner" />
+      </div>
+      <script
+        dangerouslySetInnerHTML={{
+          __html: buildPageLoadingOverlayBootstrap(id),
+        }}
+      />
+    </>
+  );
+}

--- a/packages/zudo-doc-v2/src/sidebar-resizer/index.ts
+++ b/packages/zudo-doc-v2/src/sidebar-resizer/index.ts
@@ -1,0 +1,238 @@
+// Sidebar width resizer for the desktop documentation layout.
+//
+// Background
+// ----------
+// The Astro version shipped this as `src/scripts/sidebar-resizer.ts`,
+// invoked from the doc layout on initial load and on `astro:after-swap`.
+// In the zfb-based v2 stack there is no `astro:after-swap`; the layout
+// owner is responsible for calling `initSidebarResizer()` on first load
+// and again after each cross-page View Transition swap. The function
+// is idempotent — repeated calls on the same DOM are safe — so the
+// caller can hook it into whatever post-swap signal their router uses.
+//
+// What the resizer does
+// ---------------------
+// Finds `#desktop-sidebar` and grafts a 6px-wide drag handle onto its
+// right edge. The handle:
+//
+//   * is keyboard-accessible (tab into it, then Arrow keys / Home / End
+//     to step the width by `STEP` pixels, clamped to MIN_W…MAX_W),
+//   * supports pointer dragging with a fixed-position "ghost" line that
+//     tracks the cursor without forcing layout reflow on every move,
+//   * persists the chosen width to `localStorage` under
+//     `zudo-doc-sidebar-width`, and writes the live value to the
+//     `--zd-sidebar-w` CSS custom property on `:root` so the layout
+//     reflects it immediately.
+//
+// Why the explicit width range
+// ----------------------------
+// The CSS default is `clamp(14rem, 20vw, 22rem)` (224–352px at the
+// default 16px root size). The resizer intentionally allows a wider
+// range (192–448px) than that responsive default — the user opted into
+// a manual width by dragging or arrowing, so we let them go below or
+// above the responsive band.
+//
+// Why no auto-restore at boot
+// ---------------------------
+// The persisted value is read indirectly: the consuming layout is
+// expected to apply the saved `--zd-sidebar-w` before paint (e.g. via
+// an inline pre-hydration script). This module only mutates the value
+// in response to explicit user input. That keeps the module a pure
+// "wire up the handle" concern and avoids a flash-of-unstyled-width on
+// first paint that would happen if we tried to restore here.
+//
+// Re-entrancy
+// -----------
+// Subsequent calls find the existing `[data-sidebar-resizer]` handle
+// already attached and bail out early. This matches how the Astro
+// version was wired (initial call + `astro:after-swap` rebind).
+
+const SIDEBAR_ID = "desktop-sidebar";
+const HANDLE_MARKER = "data-sidebar-resizer";
+
+const MIN_W = 192;
+const MAX_W = 448;
+const STEP = 10;
+
+const LS_KEY = "zudo-doc-sidebar-width";
+const CSS_PROP = "--zd-sidebar-w";
+
+// These reuse the design-token accent color when it's present and fall
+// back to neutral grays so the handle is still visible on any palette.
+const ACCENT_BG = "var(--zd-accent, rgba(128,128,128,0.3))";
+const ACCENT_OUTLINE = "2px solid var(--zd-accent, rgba(128,128,128,0.5))";
+const ACCENT_GHOST = "var(--zd-accent, rgba(128,128,128,0.5))";
+
+/**
+ * Attach the sidebar drag handle to `#desktop-sidebar`. Idempotent —
+ * safe to call repeatedly (e.g. after each route swap). No-op if the
+ * sidebar element is missing or the handle is already in place.
+ *
+ * Designed to be called from the browser only. Guards against `document`
+ * being undefined so accidental SSR invocation does not throw.
+ */
+export function initSidebarResizer(): void {
+  if (typeof document === "undefined") return;
+
+  const sidebar = document.getElementById(SIDEBAR_ID);
+  if (!sidebar || sidebar.querySelector(`[${HANDLE_MARKER}]`)) return;
+
+  function readCurrentWidth(): number {
+    const raw = getComputedStyle(document.documentElement).getPropertyValue(
+      CSS_PROP,
+    );
+    return raw ? parseFloat(raw) || MIN_W : MIN_W;
+  }
+
+  let cachedWidth = readCurrentWidth();
+
+  const handle = document.createElement("div");
+  handle.setAttribute(HANDLE_MARKER, "");
+  handle.setAttribute("tabindex", "0");
+  handle.setAttribute("role", "separator");
+  handle.setAttribute("aria-orientation", "vertical");
+  handle.setAttribute("aria-label", "Resize sidebar");
+  handle.setAttribute("aria-valuemin", String(MIN_W));
+  handle.setAttribute("aria-valuemax", String(MAX_W));
+  handle.setAttribute("aria-valuenow", String(Math.round(cachedWidth)));
+  Object.assign(handle.style, {
+    position: "absolute",
+    top: "0",
+    right: "0",
+    width: "6px",
+    height: "100%",
+    cursor: "col-resize",
+    zIndex: "10",
+    transition: "background 0.15s",
+  });
+
+  let dragging = false;
+  let focused = false;
+
+  function applyWidth(w: number): void {
+    cachedWidth = Math.max(MIN_W, Math.min(MAX_W, w));
+    document.documentElement.style.setProperty(CSS_PROP, cachedWidth + "px");
+    // Storage can throw in privacy modes / disabled-storage browsers.
+    // The visual update has already happened, so silently swallow.
+    try {
+      localStorage.setItem(LS_KEY, String(Math.round(cachedWidth)));
+    } catch {
+      /* ignore */
+    }
+    handle.setAttribute("aria-valuenow", String(Math.round(cachedWidth)));
+  }
+
+  function updateHandleVisual(): void {
+    if (dragging || focused) {
+      handle.style.background = ACCENT_BG;
+    } else {
+      handle.style.background = "";
+    }
+    handle.style.outline = focused && !dragging ? ACCENT_OUTLINE : "";
+    handle.style.outlineOffset = focused && !dragging ? "1px" : "";
+  }
+
+  handle.addEventListener("focus", () => {
+    focused = true;
+    updateHandleVisual();
+  });
+  handle.addEventListener("blur", () => {
+    focused = false;
+    updateHandleVisual();
+  });
+
+  handle.addEventListener("keydown", (e: KeyboardEvent) => {
+    let w = cachedWidth;
+    switch (e.key) {
+      case "ArrowLeft":
+        w = Math.max(MIN_W, w - STEP);
+        break;
+      case "ArrowRight":
+        w = Math.min(MAX_W, w + STEP);
+        break;
+      case "Home":
+        w = MIN_W;
+        break;
+      case "End":
+        w = MAX_W;
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    applyWidth(w);
+  });
+
+  handle.addEventListener("mouseenter", () => {
+    if (!dragging && !focused) handle.style.background = ACCENT_BG;
+  });
+  handle.addEventListener("mouseleave", () => {
+    if (!dragging && !focused) handle.style.background = "";
+  });
+
+  handle.addEventListener("pointerdown", (e: PointerEvent) => {
+    e.preventDefault();
+    handle.setPointerCapture(e.pointerId);
+    dragging = true;
+    updateHandleVisual();
+    document.documentElement.style.cursor = "col-resize";
+    document.documentElement.style.userSelect = "none";
+
+    // Ghost line — cheap to move (no reflow), shows the target position
+    // while the actual sidebar width is only committed on pointerup.
+    const ghost = document.createElement("div");
+    Object.assign(ghost.style, {
+      position: "fixed",
+      top: "0",
+      width: "2px",
+      height: "100vh",
+      background: ACCENT_GHOST,
+      pointerEvents: "none",
+      zIndex: "9999",
+    });
+    const sidebarRect = sidebar.getBoundingClientRect();
+    const sidebarLeft = sidebarRect.left;
+    ghost.style.left = sidebarLeft + sidebarRect.width + "px";
+    document.body.appendChild(ghost);
+    let targetWidth = 0;
+
+    const onMove = (ev: PointerEvent) => {
+      targetWidth = Math.max(
+        MIN_W,
+        Math.min(MAX_W, ev.clientX - sidebarLeft),
+      );
+      ghost.style.left = sidebarLeft + targetWidth + "px";
+    };
+
+    const cleanup = () => {
+      dragging = false;
+      updateHandleVisual();
+      document.documentElement.style.cursor = "";
+      document.documentElement.style.userSelect = "";
+      ghost.remove();
+      handle.removeEventListener("pointermove", onMove);
+      handle.removeEventListener("pointerup", onUp);
+      handle.removeEventListener("pointercancel", onCancel);
+      handle.removeEventListener("lostpointercapture", onCancel);
+    };
+
+    const onUp = (ev: PointerEvent) => {
+      handle.releasePointerCapture(ev.pointerId);
+      cleanup();
+      if (targetWidth > 0) {
+        applyWidth(targetWidth);
+      }
+    };
+
+    const onCancel = () => {
+      cleanup();
+    };
+
+    handle.addEventListener("pointermove", onMove);
+    handle.addEventListener("pointerup", onUp);
+    handle.addEventListener("pointercancel", onCancel);
+    handle.addEventListener("lostpointercapture", onCancel);
+  });
+
+  sidebar.appendChild(handle);
+}

--- a/packages/zudo-doc-v2/src/sidebar/index.ts
+++ b/packages/zudo-doc-v2/src/sidebar/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Public entry for the framework-agnostic sidebar shell.
+ *
+ * Consumers import from `@zudo-doc/zudo-doc-v2/sidebar`:
+ *
+ *   import {
+ *     Sidebar,
+ *     type SidebarProps,
+ *     type SidebarNavNode,
+ *     type SidebarRootMenuItem,
+ *     type SidebarLocaleLink,
+ *     type SidebarTreeIslandProps,
+ *   } from "@zudo-doc/zudo-doc-v2/sidebar";
+ *
+ * The shell does NOT include the SidebarTree island itself — the host
+ * project's existing Preact island is plugged in via the
+ * `treeComponent` prop (or rendered as `children`).
+ */
+
+export { Sidebar } from "./sidebar";
+export type { SidebarProps } from "./sidebar";
+export type {
+  SidebarLocaleLink,
+  SidebarNavNode,
+  SidebarRootMenuItem,
+  SidebarTreeIslandProps,
+} from "./types";

--- a/packages/zudo-doc-v2/src/sidebar/sidebar.tsx
+++ b/packages/zudo-doc-v2/src/sidebar/sidebar.tsx
@@ -1,0 +1,99 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+// JSX port of src/components/sidebar.astro.
+//
+// The original Astro template was almost entirely data assembly —
+// build root-menu items from `settings.headerNav`, load the locale's
+// docs collection, build the nav tree for the active section, optionally
+// remap hrefs for versioned routes, and finally render the project's
+// `<SidebarTree client:load .../>` Preact island.
+//
+// All of that data-prep depends on host-only helpers (`@/config/i18n`,
+// `@/utils/sidebar`, `@/utils/locale-docs`, `@/utils/base`,
+// `@/config/settings`) that v2 must not import. This shell therefore
+// keeps the data-prep on the host side and only provides:
+//
+//   - typed props that match the SidebarTree island's prop shape, so
+//     the host's prep code can be typed against v2's interface;
+//   - a `treeComponent` prop the host supplies (their existing Preact
+//     island) — the shell instantiates it with the typed props and
+//     forwards everything;
+//   - a `children` fallback for callers that want to render the tree
+//     themselves (useful for tests, fixtures, and downstream projects
+//     that swap the tree out wholesale).
+//
+// In Astro, the host invokes this through a small `.astro` wrapper that
+// adds the `client:load` directive on the island. Everything else lives
+// in v2.
+
+import type { ComponentChildren, FunctionComponent, VNode } from "preact";
+
+import type { SidebarTreeIslandProps } from "./types";
+
+export interface SidebarProps extends SidebarTreeIslandProps {
+  /**
+   * The host's SidebarTree component. When present, the shell renders
+   * `<TreeComponent {...islandProps} />` with the typed props below.
+   * Mutually exclusive with `children`: prefer this form so v2 owns the
+   * prop forwarding contract.
+   */
+  treeComponent?: FunctionComponent<SidebarTreeIslandProps>;
+  /**
+   * Pre-rendered tree content — falls back to this when
+   * `treeComponent` is omitted. Useful for tests and for layouts that
+   * compose the tree separately (e.g. inside an Astro `.astro` wrapper
+   * that needs `client:load` on the actual island element).
+   */
+  children?: ComponentChildren;
+}
+
+/**
+ * Sidebar shell — typed wrapper around the SidebarTree island.
+ *
+ * Two usage shapes (matching the breadcrumb shell's pattern):
+ *
+ *   1. Pass `treeComponent` plus the data props (`nodes`,
+ *      `rootMenuItems`, `localeLinks`, …). The shell forwards them all
+ *      to the supplied component.
+ *
+ *   2. Pass `children` (e.g. a pre-instantiated `<SidebarTree
+ *      client:load … />` from an Astro wrapper). The shell renders
+ *      them as-is — the typed island props are then unused but kept on
+ *      the type signature so call-sites stay self-documenting.
+ *
+ * Returns `null` when neither path produces content; matches the
+ * implicit "render nothing" behaviour the Astro template would have if
+ * the host passed an empty tree island.
+ */
+export function Sidebar(props: SidebarProps): VNode | null {
+  const {
+    treeComponent: TreeComponent,
+    children,
+    nodes,
+    currentSlug,
+    rootMenuItems,
+    backToMenuLabel,
+    localeLinks,
+    themeDefaultMode,
+  } = props;
+
+  if (TreeComponent) {
+    return (
+      <TreeComponent
+        nodes={nodes}
+        currentSlug={currentSlug}
+        rootMenuItems={rootMenuItems}
+        backToMenuLabel={backToMenuLabel}
+        localeLinks={localeLinks}
+        themeDefaultMode={themeDefaultMode}
+      />
+    );
+  }
+
+  if (children !== undefined && children !== null) {
+    return <>{children}</>;
+  }
+
+  return null;
+}

--- a/packages/zudo-doc-v2/src/sidebar/types.ts
+++ b/packages/zudo-doc-v2/src/sidebar/types.ts
@@ -1,0 +1,73 @@
+/**
+ * Public types for the framework-agnostic sidebar shell.
+ *
+ * The original Astro `sidebar.astro` mixed three concerns:
+ *   1. Building `rootMenuItems` from `settings.headerNav` (with i18n
+ *      label resolution and version-aware hrefs).
+ *   2. Building the doc tree via `loadLocaleDocs` +
+ *      `buildSidebarForSection`, then optionally remapping hrefs to
+ *      versioned paths.
+ *   3. Rendering a `<SidebarTree client:load .../>` Preact island.
+ *
+ * Concerns (1) and (2) depend on host-only helpers that v2 must not
+ * reach into. The v2 shell exists to:
+ *   - publish the prop shape so the host's data prep code can be
+ *     typed against a v2-owned interface, and
+ *   - render whatever the host hands in (typically the project's
+ *     `<SidebarTree client:load .../>` island) inside a typed wrapper.
+ *
+ * The structural types here mirror `src/utils/docs.ts` (`NavNode`) and
+ * `src/types/locale.ts` (`LocaleLink`) so the host can keep using its
+ * existing data-prep pipeline without re-mapping fields.
+ */
+
+/**
+ * One node in the navigation tree the SidebarTree island renders.
+ * Matches `NavNode` in the host project's `src/utils/docs.ts`.
+ */
+export interface SidebarNavNode {
+  slug: string;
+  label: string;
+  description?: string;
+  position: number;
+  href?: string;
+  hasPage: boolean;
+  children: SidebarNavNode[];
+  sortOrder?: "asc" | "desc";
+  collapsed?: boolean;
+}
+
+/**
+ * Item in the root-level "Docusaurus-style" menu shown above the
+ * doc tree on mobile / inside the back-to-menu view.
+ */
+export interface SidebarRootMenuItem {
+  label: string;
+  href: string;
+  children?: SidebarRootMenuItem[];
+}
+
+/**
+ * Locale switcher link rendered inside the mobile sidebar footer.
+ * Matches `LocaleLink` in the host project's `src/types/locale.ts`.
+ */
+export interface SidebarLocaleLink {
+  code: string;
+  label: string;
+  href: string;
+  active: boolean;
+}
+
+/**
+ * Props the SidebarTree island consumes. The shell forwards these
+ * to whichever component the host plugs in via {@link SidebarProps.treeComponent}
+ * (or to nothing, when the host renders its own tree as `children`).
+ */
+export interface SidebarTreeIslandProps {
+  nodes: SidebarNavNode[];
+  currentSlug?: string;
+  rootMenuItems?: SidebarRootMenuItem[];
+  backToMenuLabel?: string;
+  localeLinks?: SidebarLocaleLink[];
+  themeDefaultMode?: "light" | "dark";
+}

--- a/packages/zudo-doc-v2/src/tab-item/__tests__/tab-item.test.tsx
+++ b/packages/zudo-doc-v2/src/tab-item/__tests__/tab-item.test.tsx
@@ -1,0 +1,42 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { describe, expect, it } from "vitest";
+import { render } from "preact-render-to-string";
+import { TabItem } from "../tab-item";
+
+describe("<TabItem />", () => {
+  it("renders a hidden tabpanel with label-derived data-tab-value when value is omitted", () => {
+    const html = render(
+      <TabItem label="Apple">
+        <p>fruit body</p>
+      </TabItem>,
+    );
+    expect(html).toContain('role="tabpanel"');
+    expect(html).toContain('data-tab-value="Apple"');
+    expect(html).toContain('data-tab-label="Apple"');
+    expect(html).toContain("hidden");
+    expect(html).not.toContain("data-tab-default");
+    expect(html).toContain("<p>fruit body</p>");
+  });
+
+  it("uses an explicit value over the label when both are provided", () => {
+    const html = render(<TabItem label="Apple" value="apple-id" />);
+    expect(html).toContain('data-tab-value="apple-id"');
+    expect(html).toContain('data-tab-label="Apple"');
+  });
+
+  it("encodes default={true} as a present data-tab-default attribute", () => {
+    const html = render(<TabItem label="Banana" default />);
+    // preact-render-to-string emits boolean-style bare attributes for
+    // empty strings (`data-tab-default `); the Astro template emitted
+    // `data-tab-default=""`. Both forms satisfy `[data-tab-default]`
+    // selectors and `getAttribute("data-tab-default")` reads as "".
+    expect(html).toMatch(/data-tab-default(=""|\s|>)/);
+  });
+
+  it("omits data-tab-default when default is false or not set", () => {
+    const html = render(<TabItem label="Cherry" default={false} />);
+    expect(html).not.toContain("data-tab-default");
+  });
+});

--- a/packages/zudo-doc-v2/src/tab-item/index.ts
+++ b/packages/zudo-doc-v2/src/tab-item/index.ts
@@ -1,0 +1,7 @@
+// E5 framework primitives — tab-item visual wrapper.
+//
+// Subpath: `@zudo-doc/zudo-doc-v2/tab-item`. JSX port of
+// `src/components/tab-item.astro` from the host project.
+
+export { TabItem, default } from "./tab-item";
+export type { TabItemProps } from "./tab-item";

--- a/packages/zudo-doc-v2/src/tab-item/tab-item.tsx
+++ b/packages/zudo-doc-v2/src/tab-item/tab-item.tsx
@@ -1,0 +1,58 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+// JSX port of src/components/tab-item.astro.
+//
+// Visual wrapper for one tab panel inside a Tabs group. Server-rendered,
+// no hydration. The companion Tabs island reads `data-tab-value` /
+// `data-tab-label` / `data-tab-default` to wire interactivity, so the
+// attribute shape here must mirror the Astro original byte-for-byte.
+
+import type { ComponentChildren } from "preact";
+
+export interface TabItemProps {
+  /** Human-readable label rendered by the parent Tabs trigger row. */
+  label: string;
+  /**
+   * Optional stable value for the tab. Falls back to `label` when
+   * omitted, matching the Astro original's `value ?? label`.
+   */
+  value?: string;
+  /**
+   * When true, this panel is the initially-active one. Encoded as the
+   * empty-string `data-tab-default` attribute so plain attribute
+   * selectors (`[data-tab-default]`) still match.
+   */
+  default?: boolean;
+  /** Panel body. */
+  children?: ComponentChildren;
+}
+
+/**
+ * One tab panel. Always rendered with `hidden` so the page never paints
+ * a flash of all-tabs-visible before the Tabs island activates the
+ * default tab.
+ */
+export function TabItem({
+  label,
+  value,
+  default: isDefault,
+  children,
+}: TabItemProps) {
+  return (
+    <div
+      class="tab-panel"
+      role="tabpanel"
+      data-tab-value={value ?? label}
+      data-tab-label={label}
+      // `data-tab-default={undefined}` omits the attribute entirely,
+      // matching the Astro template's conditional spread.
+      data-tab-default={isDefault ? "" : undefined}
+      hidden
+    >
+      {children}
+    </div>
+  );
+}
+
+export default TabItem;

--- a/packages/zudo-doc-v2/src/transitions/index.ts
+++ b/packages/zudo-doc-v2/src/transitions/index.ts
@@ -26,3 +26,10 @@ export {
   applyPersistName,
   clearPersistName,
 } from "./persist.js";
+
+export {
+  BEFORE_NAVIGATE_EVENT,
+  AFTER_NAVIGATE_EVENT,
+  onBeforeNavigate,
+  onAfterNavigate,
+} from "./page-events.js";

--- a/packages/zudo-doc-v2/src/transitions/page-events.ts
+++ b/packages/zudo-doc-v2/src/transitions/page-events.ts
@@ -1,0 +1,63 @@
+// Page navigation lifecycle events for the v2 transitions shim.
+//
+// Background
+// ----------
+// During the Astro → zfb migration, cross-page View Transitions still
+// rely on Astro's `<ClientRouter />` lifecycle events:
+//
+//   * `astro:before-preparation` — fires just before the new page DOM
+//     is fetched / prepared (i.e. immediately when navigation starts).
+//   * `astro:page-load` — fires after the new page has fully loaded
+//     (initial load + every soft navigation).
+//
+// Components inside zudo-doc-v2 should not reach for those event names
+// directly. The transitions module owns the cross-page lifecycle
+// vocabulary so that, when zfb later supplies its own router events,
+// only this file has to change. Consumers go through the helpers below
+// (or, when an inline `<script>` is required, through the constants
+// re-exported from `./index.ts`).
+//
+// All functions are SSR-safe: when `document` is unavailable they
+// return a no-op unsubscribe and never throw.
+
+/**
+ * Event name fired at the start of a page navigation, before the
+ * incoming DOM has been prepared. Equivalent to "page-loading-begin"
+ * in the v2 vocabulary; today resolves to Astro's
+ * `astro:before-preparation`.
+ */
+export const BEFORE_NAVIGATE_EVENT = "astro:before-preparation";
+
+/**
+ * Event name fired once the new page has fully loaded (initial paint
+ * and after every soft navigation). Equivalent to "page-loading-end"
+ * in the v2 vocabulary; today resolves to Astro's `astro:page-load`.
+ */
+export const AFTER_NAVIGATE_EVENT = "astro:page-load";
+
+/**
+ * Subscribe to "navigation start" — runs `handler` each time the user
+ * triggers a soft navigation, before the new DOM is swapped in.
+ *
+ * Returns an unsubscribe function. SSR-safe: if `document` is undefined
+ * (server / non-browser host) returns a no-op unsubscribe.
+ */
+export function onBeforeNavigate(handler: () => void): () => void {
+  if (typeof document === "undefined") return () => {};
+  document.addEventListener(BEFORE_NAVIGATE_EVENT, handler);
+  return () => document.removeEventListener(BEFORE_NAVIGATE_EVENT, handler);
+}
+
+/**
+ * Subscribe to "navigation end" — runs `handler` after each page load
+ * (including the initial paint). Mirrors Astro's `astro:page-load`,
+ * which fires once on first load and after every soft navigation.
+ *
+ * Returns an unsubscribe function. SSR-safe: returns a no-op when
+ * called outside a browser.
+ */
+export function onAfterNavigate(handler: () => void): () => void {
+  if (typeof document === "undefined") return () => {};
+  document.addEventListener(AFTER_NAVIGATE_EVENT, handler);
+  return () => document.removeEventListener(AFTER_NAVIGATE_EVENT, handler);
+}


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/476
- super-epic issue
    - https://github.com/zudolab/zudo-doc/issues/473
- super-epic PR base
    - base/astro-zfb-migration

---

## Summary

First half of the .astro → JSX component port for the super-epic Astro→zfb migration. Twelve Astro components and one vanilla script ported across six topics (run in parallel via `/x-wt-teams`), all merged into `base/astro-zfb-migration-components-a` and consolidated under `packages/zudo-doc-v2/` with stable subpath exports. The host site is unchanged — this PR only adds new framework primitives; consumer wiring lands in later epics.

## What's ported

| Subpath export | Source | Notes |
|---|---|---|
| `./header` | `src/components/header.astro` (581 lines) | Top-level Header primitive + nav-active helpers + nav-overflow inline-script string + 16 unit tests + astro:content type shim |
| `./footer` | `src/components/footer.astro` (204 lines) | Framework-agnostic JSX shell |
| `./sidebar` | `src/components/sidebar.astro` (89 lines) | Slot-based; existing SidebarTree Preact island plugs in via `treeComponent`/children prop |
| `./i18n-version` | `src/components/language-switcher.astro` (36) + `version-switcher.astro` (188) | Pure presentational; host pre-builds locale links / version URLs / availability set. Version-switcher init script hoisted as exported `VERSION_SWITCHER_INIT_SCRIPT` |
| `./page-loading` | `src/components/page-loading-overlay.astro` (77) | Routes through new `transitions/page-events.ts` constants instead of raw `astro:*` strings |
| `./tab-item` | `src/components/tab-item.astro` (19) | Small visual wrapper |
| `./body-foot-util` | `src/components/body-foot-util-area.astro` (93) + `edit-link.astro` | Includes `DocHistoryIsland` SSR-skip wrapper preserving `client:idle` hydration |
| `./sidebar-resizer` | `src/scripts/sidebar-resizer.ts` | Plain side-effect helper exporting `initSidebarResizer`; SSR-safe, idempotent, identical 192–448px clamp + keyboard + pointer behavior + localStorage persistence |

`color-scheme-provider` was already ported in an earlier wave (`packages/zudo-doc-v2/src/theme/color-scheme-provider.tsx`); verified faithful in this epic.

## Verification

- `pnpm exec vitest run` in `packages/zudo-doc-v2` — 131/131 passing (14 test files)
- `pnpm exec tsc --noEmit` in `packages/zudo-doc-v2` — clean for new code (only pre-existing errors in host `src/components/design-token-tweak/` remain unchanged)
- Per-topic self-review via `/light-review -gcoc` — clean
- Manager-side `/gcoc-review` — verdict was FAIL but the cited HIGH SSR/cleanup concerns were verified as false positives (the `document.*` references are inside template-literal inline-script strings emitted via `dangerouslySetInnerHTML`, not in JSX runtime code; AbortController + `astro:after-swap` re-init are preserved bit-for-bit from the original .astro behavior)

## Topics merged into this base branch

- `astro-zfb-migration-components-a/layout-shell-a` — header
- `astro-zfb-migration-components-a/layout-shell-b` — footer + sidebar
- `astro-zfb-migration-components-a/layout-shell-c` — language-switcher + version-switcher + color-scheme-provider verification
- `astro-zfb-migration-components-a/interactive-shell` — page-loading-overlay + tab-item
- `astro-zfb-migration-components-a/body-foot-util` — body-foot-util-area + edit-link + DocHistoryIsland
- `astro-zfb-migration-components-a/sidebar-resizer` — vanilla TS port

(All topic branches deleted post-merge.)

## Test plan

- [x] All v2 vitest tests pass (131/131)
- [x] v2 tsc clean for new code
- [x] No host code touched outside new `packages/zudo-doc-v2/src/` files (zero risk to existing site)
- [ ] Consumer wiring (host `doc-layout` rewires) lands in epic E5 / B
