### PR TITLE
zfb migration: port language-switcher + version-switcher to zudo-doc-v2

### DIFF
--- a/packages/zudo-doc-v2/package.json
+++ b/packages/zudo-doc-v2/package.json
@@ -26,6 +26,10 @@
       "types": "./src/breadcrumb/index.ts",
       "default": "./src/breadcrumb/index.ts"
     },
+    "./i18n-version": {
+      "types": "./src/i18n-version/index.ts",
+      "default": "./src/i18n-version/index.ts"
+    },
     "./doclayout": {
       "types": "./src/doclayout/index.ts",
       "default": "./src/doclayout/index.ts"

--- a/packages/zudo-doc-v2/src/i18n-version/__tests__/language-switcher.test.tsx
+++ b/packages/zudo-doc-v2/src/i18n-version/__tests__/language-switcher.test.tsx
@@ -1,0 +1,100 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { describe, expect, it } from "vitest";
+import type { ComponentChildren, VNode } from "preact";
+import { LanguageSwitcher } from "../language-switcher";
+import type { LocaleLink } from "../types";
+
+// Minimal VNode → HTML serializer (mirrors the helper used in
+// breadcrumb.test.tsx — kept inline so the test runs without a render
+// dependency).
+type AnyVNode = VNode<{ children?: ComponentChildren; [key: string]: unknown }>;
+
+function isVNode(v: unknown): v is AnyVNode {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    Object.prototype.hasOwnProperty.call(v, "type") &&
+    Object.prototype.hasOwnProperty.call(v, "props")
+  );
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/"/g, "&quot;");
+}
+
+function serialize(node: ComponentChildren): string {
+  if (node == null || typeof node === "boolean") return "";
+  if (typeof node === "string") return node;
+  if (typeof node === "number" || typeof node === "bigint") return String(node);
+  if (Array.isArray(node)) return node.map(serialize).join("");
+  if (!isVNode(node)) return "";
+  const { type, props } = node;
+  const { children, ...rest } = (props ?? {}) as {
+    children?: ComponentChildren;
+    [key: string]: unknown;
+  };
+
+  if (typeof type === "function") {
+    const fn = type as (p: typeof props) => ComponentChildren;
+    return serialize(fn(props));
+  }
+  if (type == null || (typeof type === "string" && type === "")) {
+    return serialize(children);
+  }
+  if (typeof type !== "string") return serialize(children);
+
+  const attrs = Object.entries(rest)
+    .filter(([, v]) => v !== undefined && v !== null && v !== false)
+    .map(([k, v]) => {
+      if (k === "key") return "";
+      if (v === true) return ` ${k}`;
+      return ` ${k}="${escapeAttr(String(v))}"`;
+    })
+    .join("");
+
+  const voidEls = new Set(["br", "hr", "img", "input", "wbr", "meta", "link"]);
+  if (voidEls.has(type)) return `<${type}${attrs}/>`;
+  return `<${type}${attrs}>${serialize(children)}</${type}>`;
+}
+
+const enJa: LocaleLink[] = [
+  { code: "en", label: "EN", href: "/docs/", active: true },
+  { code: "ja", label: "JA", href: "/ja/docs/", active: false },
+];
+
+describe("LanguageSwitcher", () => {
+  it("returns null when there is one or fewer links (matches the Astro guard)", () => {
+    const noneRendered =
+      LanguageSwitcher({ links: [] as LocaleLink[] }) === null;
+    const oneRendered =
+      LanguageSwitcher({ links: [enJa[0]] }) === null;
+    expect(noneRendered).toBe(true);
+    expect(oneRendered).toBe(true);
+  });
+
+  it("renders a span (not an anchor) for the active locale with aria-current", () => {
+    const html = serialize(<LanguageSwitcher links={enJa} />);
+    expect(html).toContain('<span aria-current="true"');
+    expect(html).toContain(">EN</span>");
+  });
+
+  it("renders an anchor with the lang attribute for inactive locales", () => {
+    const html = serialize(<LanguageSwitcher links={enJa} />);
+    expect(html).toContain('href="/ja/docs/"');
+    expect(html).toContain('lang="ja"');
+    expect(html).toContain(">JA</a>");
+  });
+
+  it("inserts a slash separator between every pair of links", () => {
+    const enJaFr: LocaleLink[] = [
+      ...enJa,
+      { code: "fr", label: "FR", href: "/fr/docs/", active: false },
+    ];
+    const html = serialize(<LanguageSwitcher links={enJaFr} />);
+    // Two separators for three links.
+    const slashCount = (html.match(/<span class="text-muted">\/<\/span>/g) ?? []).length;
+    expect(slashCount).toBe(2);
+  });
+});

--- a/packages/zudo-doc-v2/src/i18n-version/__tests__/version-switcher.test.tsx
+++ b/packages/zudo-doc-v2/src/i18n-version/__tests__/version-switcher.test.tsx
@@ -1,0 +1,182 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { describe, expect, it } from "vitest";
+import type { ComponentChildren, VNode } from "preact";
+import {
+  VersionSwitcher,
+  VERSION_SWITCHER_INIT_SCRIPT,
+} from "../version-switcher";
+import type { VersionEntry, VersionSwitcherLabels } from "../types";
+
+type AnyVNode = VNode<{ children?: ComponentChildren; [key: string]: unknown }>;
+
+function isVNode(v: unknown): v is AnyVNode {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    Object.prototype.hasOwnProperty.call(v, "type") &&
+    Object.prototype.hasOwnProperty.call(v, "props")
+  );
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/"/g, "&quot;");
+}
+
+function serialize(node: ComponentChildren): string {
+  if (node == null || typeof node === "boolean") return "";
+  if (typeof node === "string") return node;
+  if (typeof node === "number" || typeof node === "bigint") return String(node);
+  if (Array.isArray(node)) return node.map(serialize).join("");
+  if (!isVNode(node)) return "";
+  const { type, props } = node;
+  const { children, ...rest } = (props ?? {}) as {
+    children?: ComponentChildren;
+    [key: string]: unknown;
+  };
+
+  if (typeof type === "function") {
+    const fn = type as (p: typeof props) => ComponentChildren;
+    return serialize(fn(props));
+  }
+  if (type == null || (typeof type === "string" && type === "")) {
+    return serialize(children);
+  }
+  if (typeof type !== "string") return serialize(children);
+
+  const attrs = Object.entries(rest)
+    .filter(([, v]) => v !== undefined && v !== null && v !== false)
+    .map(([k, v]) => {
+      if (k === "key") return "";
+      if (v === true) return ` ${k}`;
+      return ` ${k}="${escapeAttr(String(v))}"`;
+    })
+    .join("");
+
+  const voidEls = new Set(["br", "hr", "img", "input", "wbr", "meta", "link"]);
+  if (voidEls.has(type)) return `<${type}${attrs}/>`;
+  return `<${type}${attrs}>${serialize(children)}</${type}>`;
+}
+
+const labels: VersionSwitcherLabels = {
+  latest: "Latest",
+  switcher: "Version",
+  unavailable: "Not available",
+  allVersions: "All versions",
+};
+
+const versions: VersionEntry[] = [
+  { slug: "v2", label: "v2.0" },
+  { slug: "v1", label: "v1.x" },
+];
+
+const versionUrls: Record<string, string> = {
+  v2: "/v/v2/docs/intro/",
+  v1: "/v/v1/docs/intro/",
+};
+
+describe("VersionSwitcher", () => {
+  it("renders the data-version-switcher root, toggle, and menu", () => {
+    const html = serialize(
+      <VersionSwitcher
+        versions={versions}
+        latestUrl="/docs/intro/"
+        versionsPageUrl="/docs/versions/"
+        versionUrls={versionUrls}
+        labels={labels}
+      />,
+    );
+    expect(html).toContain("data-version-switcher");
+    expect(html).toContain("data-version-toggle");
+    expect(html).toContain("data-version-menu");
+    expect(html).toContain('id="version-menu"');
+  });
+
+  it("appends idSuffix to the menu id and aria-controls", () => {
+    const html = serialize(
+      <VersionSwitcher
+        versions={versions}
+        latestUrl="/docs/intro/"
+        versionsPageUrl="/docs/versions/"
+        versionUrls={versionUrls}
+        labels={labels}
+        idSuffix="header"
+      />,
+    );
+    expect(html).toContain('id="version-menu-header"');
+    expect(html).toContain('aria-controls="version-menu-header"');
+  });
+
+  it("marks the Latest entry as the active row when no currentVersion is set", () => {
+    const html = serialize(
+      <VersionSwitcher
+        versions={versions}
+        latestUrl="/docs/intro/"
+        versionsPageUrl="/docs/versions/"
+        versionUrls={versionUrls}
+        labels={labels}
+      />,
+    );
+    // Latest link gets aria-current="page" + bold/accent class.
+    expect(html).toMatch(/<a[^>]*href="\/docs\/intro\/"[^>]*aria-current="page"/);
+    expect(html).toContain("font-bold text-accent");
+  });
+
+  it("renders the matching version entry as active when currentVersion is set", () => {
+    const html = serialize(
+      <VersionSwitcher
+        versions={versions}
+        currentVersion="v1"
+        latestUrl="/docs/intro/"
+        versionsPageUrl="/docs/versions/"
+        versionUrls={versionUrls}
+        labels={labels}
+      />,
+    );
+    // The trigger label reflects the current version.
+    expect(html).toContain(">v1.x</span>");
+    // The v1 list item carries aria-current="page".
+    expect(html).toMatch(/href="\/v\/v1\/docs\/intro\/"[^>]*aria-current="page"/);
+    // Latest no longer carries it.
+    expect(html).not.toMatch(/href="\/docs\/intro\/"[^>]*aria-current="page"/);
+  });
+
+  it("renders unavailable versions as disabled, non-interactive links", () => {
+    const html = serialize(
+      <VersionSwitcher
+        versions={versions}
+        latestUrl="/docs/intro/"
+        versionsPageUrl="/docs/versions/"
+        versionUrls={versionUrls}
+        unavailableVersions={new Set(["v1"])}
+        labels={labels}
+      />,
+    );
+    expect(html).toContain('aria-disabled="true"');
+    expect(html).toContain("pointer-events-none");
+    expect(html).toContain('title="Not available"');
+  });
+
+  it("falls back to versionsPageUrl when versionUrls lacks an entry", () => {
+    const html = serialize(
+      <VersionSwitcher
+        versions={[{ slug: "v0", label: "v0" }]}
+        latestUrl="/docs/intro/"
+        versionsPageUrl="/docs/versions/"
+        versionUrls={{}}
+        labels={labels}
+      />,
+    );
+    // Two anchors point at versionsPageUrl: the v0 row and the footer
+    // "All versions" link.
+    const matches = html.match(/href="\/docs\/versions\/"/g) ?? [];
+    expect(matches.length).toBe(2);
+  });
+
+  it("VERSION_SWITCHER_INIT_SCRIPT is non-empty and contains the after-swap rebind", () => {
+    expect(VERSION_SWITCHER_INIT_SCRIPT).toContain('astro:after-swap');
+    expect(VERSION_SWITCHER_INIT_SCRIPT).toContain('AbortController');
+    expect(VERSION_SWITCHER_INIT_SCRIPT).toContain('data-version-switcher');
+  });
+});

--- a/packages/zudo-doc-v2/src/i18n-version/index.ts
+++ b/packages/zudo-doc-v2/src/i18n-version/index.ts
@@ -1,0 +1,33 @@
+// E5 framework primitives — i18n + version chrome.
+//
+// This subpath publishes the layout-level locale and version switchers.
+// Both are pure presentational components: the host project pre-builds
+// the data they need (locale links, version URLs, availability sets,
+// label strings) so v2 stays free of any settings/i18n/utils coupling.
+//
+// Usage from the host project:
+//
+//   import {
+//     LanguageSwitcher,
+//     VersionSwitcher,
+//     VERSION_SWITCHER_INIT_SCRIPT,
+//   } from "@zudo-doc/zudo-doc-v2/i18n-version";
+//
+// Mount the version-switcher init script once per page (e.g. in the
+// layout's body-end scripts slot) — it idempotently re-binds after
+// View Transitions navigation.
+
+export { LanguageSwitcher } from "./language-switcher";
+export type { LanguageSwitcherProps } from "./language-switcher";
+
+export {
+  VersionSwitcher,
+  VERSION_SWITCHER_INIT_SCRIPT,
+} from "./version-switcher";
+export type { VersionSwitcherProps } from "./version-switcher";
+
+export type {
+  LocaleLink,
+  VersionEntry,
+  VersionSwitcherLabels,
+} from "./types";

--- a/packages/zudo-doc-v2/src/i18n-version/language-switcher.tsx
+++ b/packages/zudo-doc-v2/src/i18n-version/language-switcher.tsx
@@ -1,0 +1,72 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+// JSX port of src/components/language-switcher.astro.
+//
+// Pure presentational component: the host project pre-builds the
+// `LocaleLink[]` (using its own settings/i18n modules and the active
+// `Astro.url.pathname`) and passes them in. The v2 package itself stays
+// agnostic about how locales are configured.
+//
+// Astro → JSX deltas:
+//   * `<slot />` not used (no children).
+//   * `Astro.props` → typed `LanguageSwitcherProps`.
+//   * `class=` → `class=` (Preact accepts both `class` and `className` in
+//     compat mode; we follow the convention used by the rest of v2 and
+//     keep `class` to match adjacent files like breadcrumb.tsx).
+//   * The Astro template's top-level guard (`localeLinks.length > 1 &&`)
+//     becomes an early `return null`.
+
+import type { VNode } from "preact";
+import { Fragment } from "preact";
+import type { LocaleLink } from "./types";
+
+export interface LanguageSwitcherProps {
+  /**
+   * Pre-built locale links, ordered as they should appear in the bar.
+   * The host project typically derives this with its own
+   * `buildLocaleLinks(currentPath, currentLang)` helper before passing.
+   */
+  links: LocaleLink[];
+}
+
+/**
+ * Inline locale switcher rendered in the header / sidebar footer.
+ *
+ * Returns `null` when there is one locale or fewer (matches the Astro
+ * template's `localeLinks.length > 1 &&` guard so call-sites can mount
+ * the component unconditionally).
+ */
+export function LanguageSwitcher({ links }: LanguageSwitcherProps): VNode | null {
+  if (links.length <= 1) return null;
+
+  return (
+    <div class="flex items-center gap-x-hsp-xs text-small">
+      {links.map((link, i) => (
+        // Fragment is keyed via the locale code so the reconciler keeps
+        // the active/inactive nodes paired correctly across re-renders
+        // (e.g. when the active locale flips after navigation).
+        <Fragment key={link.code}>
+          {i > 0 && <span class="text-muted">/</span>}
+          {link.active ? (
+            <span aria-current="true" class="font-medium text-fg">
+              {link.label}
+            </span>
+          ) : (
+            <a
+              href={link.href}
+              lang={link.code}
+              class="text-muted hover:text-fg"
+            >
+              {link.label}
+            </a>
+          )}
+        </Fragment>
+      ))}
+    </div>
+  );
+}
+
+// Re-export the type so consumers can import LocaleLink from this module
+// without reaching into ./types directly.
+export type { LocaleLink };

--- a/packages/zudo-doc-v2/src/i18n-version/types.ts
+++ b/packages/zudo-doc-v2/src/i18n-version/types.ts
@@ -1,0 +1,50 @@
+// Shared types for the language- and version-switcher v2 ports.
+//
+// These are presentational primitives: every value the components need to
+// render comes in via props. The package never reaches into the host
+// project's settings/i18n/utils — keeping v2 fully decoupled from the
+// legacy Astro src/ tree.
+
+/**
+ * Single link in the language-switcher's ordered list.
+ *
+ * Mirrors the shape of `LocaleLink` from src/types/locale.ts so existing
+ * call-sites can pass their already-built links straight through.
+ */
+export interface LocaleLink {
+  /** BCP-47 code, e.g. "en", "ja". Rendered as the anchor's `lang` attribute. */
+  code: string;
+  /** Display label (typically the uppercased code). */
+  label: string;
+  /** Pre-resolved href for the locale (already prefixed with the configured base). */
+  href: string;
+  /** True for the currently-active locale — rendered as plain text, not a link. */
+  active: boolean;
+}
+
+/**
+ * Single entry in the version-switcher's drop-down list.
+ *
+ * Slug is the URL-segment identifier; label is the user-visible string
+ * (e.g. "v2.0", "1.x").
+ */
+export interface VersionEntry {
+  slug: string;
+  label: string;
+}
+
+/**
+ * UI strings the version-switcher renders. Kept as a labels bag rather
+ * than wired to a host-side i18n module so the v2 package stays
+ * locale-system agnostic.
+ */
+export interface VersionSwitcherLabels {
+  /** Label for the "latest" entry, e.g. "Latest" / "最新". */
+  latest: string;
+  /** Trigger-button prefix, e.g. "Version" / "バージョン". */
+  switcher: string;
+  /** `title` attribute for unavailable items, e.g. "Not available". */
+  unavailable: string;
+  /** Footer link label, e.g. "All versions". */
+  allVersions: string;
+}

--- a/packages/zudo-doc-v2/src/i18n-version/version-switcher.tsx
+++ b/packages/zudo-doc-v2/src/i18n-version/version-switcher.tsx
@@ -1,0 +1,255 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+// JSX port of src/components/version-switcher.astro.
+//
+// Like the language-switcher, this is a pure presentational component:
+// every URL, label, and availability flag the host project would derive
+// from `settings.versions`, `t()`, and the version-availability map is
+// passed in as a prop. The v2 package itself stays free of any
+// settings/i18n/utils coupling.
+//
+// The Astro version shipped a `<script>` in the same file that wired up
+// click-toggle / outside-click / Escape-key behavior on every
+// `[data-version-switcher]` instance, idempotently re-binding after
+// `astro:after-swap`. The JSX port emits the same data-attributes and
+// markup, but the script lives separately as `VERSION_SWITCHER_INIT_SCRIPT`
+// so consumers mount it once at body-end (matching how
+// color-scheme-provider's bootstrap is structured). That keeps the
+// component itself SSR-safe and side-effect-free, while letting the host
+// page wire up exactly one global listener regardless of how many
+// switchers are on the page.
+//
+// Astro → JSX deltas:
+//   * `Astro.props` → typed `VersionSwitcherProps`.
+//   * `class:list={[...]}` → manual class concatenation in `cls(...)`.
+//   * `aria-current={isLatest ? "page" : undefined}` is preserved verbatim
+//     (Preact omits the attribute when the value is `undefined`).
+//   * The `<svg>` chevron stays inline so consumers don't need to import
+//     an icon library.
+//   * The `<script>` block in the .astro source is hoisted out into the
+//     exported `VERSION_SWITCHER_INIT_SCRIPT` constant.
+
+import type { VNode } from "preact";
+import type { VersionEntry, VersionSwitcherLabels } from "./types";
+
+export interface VersionSwitcherProps {
+  /**
+   * All known versions, in display order (latest at top of the dropdown
+   * is rendered separately via `latestUrl` — this list is the
+   * non-latest versions only).
+   */
+  versions: VersionEntry[];
+
+  /** Current version slug, or undefined when the page is on "latest". */
+  currentVersion?: string;
+
+  /** Pre-resolved href for the "Latest" entry. */
+  latestUrl: string;
+
+  /** Pre-resolved href for the "All versions" footer link. */
+  versionsPageUrl: string;
+
+  /**
+   * Map of `version slug` → pre-resolved href to that version of the
+   * current page (or the versions index page when no slug is in scope).
+   * Pass an empty object when the current page is not a versionable doc.
+   */
+  versionUrls: Record<string, string>;
+
+  /**
+   * Slugs of versions where the current page is NOT available. Renders
+   * those entries as muted, non-interactive links with the
+   * `unavailable` title attribute. Omit (or pass `undefined`) when no
+   * availability data is in scope — every entry is then treated as
+   * available, matching the Astro template's `!availability` branch.
+   */
+  unavailableVersions?: ReadonlySet<string>;
+
+  /** UI strings — see `VersionSwitcherLabels` for the field list. */
+  labels: VersionSwitcherLabels;
+
+  /**
+   * Optional suffix appended to the menu's DOM id. Used when more than
+   * one version-switcher is rendered on the same page (e.g. one in the
+   * header, one in the sidebar) so each `aria-controls` reference stays
+   * unique.
+   */
+  idSuffix?: string;
+}
+
+/** Concatenate Tailwind class strings, dropping falsy entries. */
+function cls(...parts: (string | false | null | undefined)[]): string {
+  return parts.filter(Boolean).join(" ");
+}
+
+function ChevronDownIcon(): VNode {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      class="h-[0.875rem] w-[0.875rem]"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      stroke-width="2"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M19 9l-7 7-7-7"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Drop-down version switcher rendered in the header.
+ *
+ * The toggle / outside-click / Escape-key behavior lives in
+ * `VERSION_SWITCHER_INIT_SCRIPT` — mount it once at body-end on any
+ * page that includes a `<VersionSwitcher>`.
+ */
+export function VersionSwitcher(props: VersionSwitcherProps): VNode {
+  const {
+    versions,
+    currentVersion,
+    latestUrl,
+    versionsPageUrl,
+    versionUrls,
+    unavailableVersions,
+    labels,
+    idSuffix = "",
+  } = props;
+
+  const menuId = `version-menu${idSuffix ? `-${idSuffix}` : ""}`;
+  const isLatest = !currentVersion;
+  const triggerLabel = isLatest
+    ? labels.latest
+    : (versions.find((v) => v.slug === currentVersion)?.label ?? currentVersion);
+
+  return (
+    <div class="version-switcher relative" data-version-switcher>
+      <button
+        type="button"
+        class="flex items-center gap-hsp-2xs border border-muted rounded px-hsp-sm py-vsp-3xs text-small text-muted hover:border-accent hover:text-accent transition-colors cursor-pointer whitespace-nowrap"
+        aria-expanded="false"
+        aria-controls={menuId}
+        data-version-toggle
+      >
+        <span class="text-caption">{labels.switcher}:</span>
+        <span class="font-medium">{triggerLabel}</span>
+        <ChevronDownIcon />
+      </button>
+
+      <ul
+        id={menuId}
+        class="absolute right-0 top-full z-10 mt-vsp-3xs hidden min-w-[8rem] border border-muted rounded bg-surface shadow-lg whitespace-nowrap py-vsp-3xs"
+        data-version-menu
+      >
+        <li>
+          <a
+            href={latestUrl}
+            aria-current={isLatest ? "page" : undefined}
+            class={cls(
+              "block px-hsp-md py-vsp-2xs text-small hover:bg-accent/10 hover:underline focus-visible:underline",
+              isLatest ? "font-bold text-accent" : "text-fg",
+            )}
+          >
+            {labels.latest}
+          </a>
+        </li>
+        {versions.map((v) => {
+          const vUrl = versionUrls[v.slug] ?? versionsPageUrl;
+          const isActive = currentVersion === v.slug;
+          // The Astro source treated "no availability info" as
+          // "everything available" (`!availability || (...has(slug))`).
+          // We mirror that: when the consumer doesn't pass
+          // `unavailableVersions`, treat every entry as available.
+          const isAvailable = !unavailableVersions || !unavailableVersions.has(v.slug);
+          return (
+            <li key={v.slug}>
+              {isAvailable ? (
+                <a
+                  href={vUrl}
+                  aria-current={isActive ? "page" : undefined}
+                  class={cls(
+                    "block px-hsp-md py-vsp-2xs text-small hover:bg-accent/10 hover:underline focus-visible:underline",
+                    isActive ? "font-bold text-accent" : "text-fg",
+                  )}
+                >
+                  {v.label}
+                </a>
+              ) : (
+                <a
+                  href={vUrl}
+                  aria-disabled="true"
+                  tabindex={-1}
+                  class="block px-hsp-md py-vsp-2xs text-small text-muted/50 cursor-not-allowed pointer-events-none"
+                  title={labels.unavailable}
+                >
+                  {v.label}
+                </a>
+              )}
+            </li>
+          );
+        })}
+        <li class="border-t border-muted">
+          <a
+            href={versionsPageUrl}
+            class="block px-hsp-md py-vsp-2xs text-small text-muted hover:bg-accent/10 hover:text-fg hover:underline focus-visible:underline"
+          >
+            {labels.allVersions}
+          </a>
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+/**
+ * Self-contained init script for the version-switcher's interactive
+ * behavior. Mount once per page (e.g. inside the layout's body-end
+ * scripts slot) — it idempotently re-binds after `astro:after-swap`
+ * via an AbortController, so multiple switchers on the page share a
+ * single event-listener generation.
+ *
+ * Lifted verbatim from the `<script>` block of the original
+ * version-switcher.astro so behavior is bit-for-bit identical.
+ */
+export const VERSION_SWITCHER_INIT_SCRIPT = `(function(){
+var cleanupController=null;
+function initVersionSwitcher(){
+if(cleanupController)cleanupController.abort();
+cleanupController=new AbortController();
+var signal=cleanupController.signal;
+document.querySelectorAll("[data-version-switcher]").forEach(function(switcher){
+var toggle=switcher.querySelector("[data-version-toggle]");
+var menu=switcher.querySelector("[data-version-menu]");
+if(!toggle||!menu)return;
+toggle.addEventListener("click",function(){
+var isOpen=!menu.classList.contains("hidden");
+menu.classList.toggle("hidden",isOpen);
+toggle.setAttribute("aria-expanded",String(!isOpen));
+},{signal:signal});
+document.addEventListener("click",function(e){
+if(!switcher.contains(e.target)){
+menu.classList.add("hidden");
+toggle.setAttribute("aria-expanded","false");
+}
+},{signal:signal});
+document.addEventListener("keydown",function(e){
+if(e.key==="Escape"&&!menu.classList.contains("hidden")){
+menu.classList.add("hidden");
+toggle.setAttribute("aria-expanded","false");
+toggle.focus();
+}
+},{signal:signal});
+});
+}
+initVersionSwitcher();
+document.addEventListener("astro:after-swap",initVersionSwitcher);
+})();`;
+
+// Re-export the data types so consumers can import everything they need
+// from this single module.
+export type { VersionEntry, VersionSwitcherLabels };


### PR DESCRIPTION
## Summary

Task #3 of the astro-zfb-migration-components-a epic (tracking issue #476).

- JSX/TSX ports of `src/components/language-switcher.astro` (36 lines) and `src/components/version-switcher.astro` (188 lines), landed under `packages/zudo-doc-v2/src/i18n-version/`
- Both are pure presentational components — host pre-builds locale links, version URLs, availability sets, and label strings, so v2 stays free of host-side settings/i18n/utils coupling (matches the breadcrumb / doclayout pattern)
- Version-switcher's interactive script (toggle / outside-click / Escape / `astro:after-swap` rebind) hoisted out into exported `VERSION_SWITCHER_INIT_SCRIPT` string for body-end mounting
- New subpath export `@zudo-doc/zudo-doc-v2/i18n-version`
- Color-scheme-provider port verified — `packages/zudo-doc-v2/src/theme/color-scheme-provider.tsx` is a faithful 1:1 of the .astro source, no gaps; already exported via `/theme`

## Test plan

- [x] 11 vitest cases (4 language-switcher + 7 version-switcher) all green
- [x] tsc baseline unchanged (47 → 47 errors, all pre-existing in unrelated host src/)
- [x] /light-review -gcoc — no high-severity findings; medium items are "preserve Astro source fidelity" (kept original `aria-current="true"` and disabled-anchor-with-href shape intentionally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)