### PR TITLE
port: body-foot-util-area + edit-link → zudo-doc-v2 JSX

### DIFF
--- a/packages/zudo-doc-v2/package.json
+++ b/packages/zudo-doc-v2/package.json
@@ -38,6 +38,10 @@
       "types": "./src/ssr-skip/index.ts",
       "default": "./src/ssr-skip/index.ts"
     },
+    "./body-foot-util": {
+      "types": "./src/body-foot-util/index.ts",
+      "default": "./src/body-foot-util/index.ts"
+    },
     "./transitions": {
       "types": "./src/transitions/index.ts",
       "default": "./src/transitions/index.ts"

--- a/packages/zudo-doc-v2/src/body-foot-util/body-foot-util-area.tsx
+++ b/packages/zudo-doc-v2/src/body-foot-util/body-foot-util-area.tsx
@@ -1,0 +1,106 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import type { VNode } from "preact";
+import { DocHistoryIsland, type DocHistoryIslandProps } from "./doc-history-island.js";
+
+/**
+ * Default label used when the consumer doesn't pass one. The legacy
+ * Astro template translated `doc.viewSource` via the project's i18n
+ * module; v2 stays framework-agnostic, so callers resolve their
+ * translation upstream and pass the result here. The English string
+ * is mirrored verbatim from the legacy translations table so the
+ * component degrades to the original wording when no override is
+ * supplied.
+ */
+export const DEFAULT_VIEW_SOURCE_LABEL = "View source on GitHub";
+
+export interface BodyFootUtilAreaProps {
+  /**
+   * Final, pre-computed GitHub source URL. The legacy template
+   * derived this from `settings.githubUrl + contentDir + entryId`; the
+   * v2 component delegates that computation to the consumer (no
+   * upstream dependency on the project settings module).
+   *
+   * When falsy, the view-source link is suppressed.
+   */
+  sourceUrl?: string | null;
+  /**
+   * Display text for the view-source link. Defaults to
+   * `"View source on GitHub"`; pass the i18n-resolved string from
+   * upstream to localise.
+   */
+  viewSourceLabel?: string;
+  /**
+   * When provided, mounts the `DocHistoryIsland` SSR-skip wrapper.
+   * The legacy Astro template owned three gating predicates
+   * (`utilSettings.docHistory`, `currentSlug`, and the per-page /
+   * `isCategoryIndex` resolution); v2 collapses all of those into a
+   * single nullable prop so the v2 package stays oblivious to the
+   * project's settings shape.
+   *
+   * Pass `null` / `undefined` to suppress the history trigger
+   * entirely.
+   */
+  docHistory?: DocHistoryIslandProps | null;
+}
+
+/**
+ * Footer utility area shown below an article body — composes the
+ * "View source on GitHub" link and the `DocHistoryIsland` SSR-skip
+ * wrapper. JSX port of `src/components/body-foot-util-area.astro`.
+ *
+ * Returns `null` when neither slot has anything to render, mirroring
+ * the `hasContent && (...)` guard in the original template so the
+ * surrounding `<section>` (with its top border + spacing) doesn't
+ * appear as an empty band.
+ */
+export function BodyFootUtilArea(props: BodyFootUtilAreaProps): VNode | null {
+  const { sourceUrl, viewSourceLabel = DEFAULT_VIEW_SOURCE_LABEL, docHistory } =
+    props;
+
+  const showSource = Boolean(sourceUrl);
+  const showHistory = Boolean(docHistory);
+  if (!showSource && !showHistory) return null;
+
+  return (
+    <section
+      class="mt-vsp-xl border-t border-muted pt-vsp-md"
+      aria-label="Document utilities"
+    >
+      {showSource && (
+        <div class="mb-vsp-md">
+          <a
+            href={sourceUrl as string}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center gap-hsp-2xs text-small text-muted hover:text-accent"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-[0.875rem] w-[0.875rem]"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              stroke-width="2"
+              aria-hidden="true"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M14 3h7m0 0v7m0-7L10 14"
+              />
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M5 5h5m-5 0a2 2 0 00-2 2v12a2 2 0 002 2h12a2 2 0 002-2v-5"
+              />
+            </svg>
+            <span>{viewSourceLabel}</span>
+          </a>
+        </div>
+      )}
+      {showHistory && docHistory && <DocHistoryIsland {...docHistory} />}
+    </section>
+  );
+}

--- a/packages/zudo-doc-v2/src/body-foot-util/doc-history-island.tsx
+++ b/packages/zudo-doc-v2/src/body-foot-util/doc-history-island.tsx
@@ -1,0 +1,62 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+// Framework wrapper around the doc-history Preact island — emits an
+// SSR-skip placeholder so the heavy revision-history component (with
+// its diff library, dialog.showModal(), keyboard handlers, View
+// Transitions hooks, and runtime fetch) is never evaluated during the
+// static build.
+//
+// The original Astro template wired the component as
+// `<DocHistory ... client:idle />`; the v2 equivalent is the SSR-skip
+// placeholder pattern formalised in `../ssr-skip/types.ts`. This
+// wrapper sits next to the body-foot-util-area component because the
+// island is only ever mounted from there — it is part of this topic
+// rather than a generic ssr-skip primitive.
+//
+// Default fallback: `null`. The real component renders an inline
+// "History" trigger button + a closed `<dialog>`; both have zero
+// layout footprint until the user opens the panel, so there is
+// nothing meaningful to mock up server-side.
+
+import type { VNode } from "preact";
+import {
+  renderSsrSkipPlaceholder,
+  type SsrSkipFallbackProps,
+} from "../ssr-skip/types.js";
+
+/**
+ * Props delivered to the real `DocHistory` Preact component on
+ * hydration. Mirrors the constructor signature in
+ * `src/components/doc-history.tsx` so the runtime can JSON-decode
+ * `data-zfb-island-props` and forward the values straight through.
+ */
+export interface DocHistoryIslandProps extends SsrSkipFallbackProps {
+  /** Page slug used to build the history JSON fetch path. */
+  slug: string;
+  /**
+   * Locale code, omitted for the default locale. Forwarded to the
+   * fetch path resolver inside the real component.
+   */
+  locale?: string;
+  /**
+   * Site base path. Defaults to `"/"` inside the real component when
+   * omitted; explicit when the site is served from a subpath.
+   */
+  basePath?: string;
+}
+
+/**
+ * SSR-skip wrapper for the doc-history dialog. Drop-in replacement for
+ * the legacy `<DocHistory ... client:idle />` Astro pattern.
+ *
+ * The marker emitted here is `"DocHistory"` — the hydration manifest
+ * shipped by the consumer must bind that name to the real component
+ * constructor.
+ */
+export function DocHistoryIsland(props: DocHistoryIslandProps): VNode {
+  const { when = "idle", ssrFallback = null, ...forwarded } = props;
+  return renderSsrSkipPlaceholder("DocHistory", when, ssrFallback, {
+    ...forwarded,
+  });
+}

--- a/packages/zudo-doc-v2/src/body-foot-util/edit-link.tsx
+++ b/packages/zudo-doc-v2/src/body-foot-util/edit-link.tsx
@@ -1,0 +1,74 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import type { VNode } from "preact";
+
+/**
+ * Default label used when the consumer doesn't pass one. The legacy
+ * Astro template translated `doc.editPage` via the project's i18n
+ * module; v2 stays framework-agnostic and lets the caller pass the
+ * already-translated label as `label` instead. The English string is
+ * mirrored verbatim from the legacy translations table.
+ */
+export const DEFAULT_EDIT_LINK_LABEL = "Edit this page";
+
+export interface EditLinkProps {
+  /**
+   * Final, pre-computed edit URL. The legacy Astro version derived
+   * this from `settings.editUrl + contentDir + entryId`; that
+   * computation belongs in the consumer (so this v2 component has no
+   * upward dependency on the project settings module).
+   *
+   * When `null` / `undefined` / empty string the link is suppressed
+   * entirely — the component returns `null` to mirror the
+   * `editUrl && (...)` guard in the original template.
+   */
+  editUrl?: string | null;
+  /**
+   * Display text for the link. The legacy template called
+   * `t("doc.editPage", locale)`; consumers should resolve their i18n
+   * lookup upstream and pass the result here. Defaults to
+   * `"Edit this page"` so the component degrades to the original
+   * English label when no translation is provided.
+   */
+  label?: string;
+}
+
+/**
+ * "Edit this page" link — JSX port of `src/components/edit-link.astro`.
+ *
+ * The legacy component owned three concerns: URL computation, i18n
+ * lookup, and presentation. v2 keeps only presentation; URL and label
+ * are pre-resolved by the caller. This matches the breadcrumb subpath
+ * pattern of "no settings/i18n imports inside the v2 package".
+ */
+export function EditLink(props: EditLinkProps): VNode | null {
+  const { editUrl, label = DEFAULT_EDIT_LINK_LABEL } = props;
+  if (!editUrl) return null;
+
+  return (
+    <a
+      href={editUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      class="inline-flex items-center gap-hsp-2xs text-small text-muted hover:text-accent"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        class="h-[0.875rem] w-[0.875rem]"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        stroke-width="2"
+        aria-hidden="true"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+        />
+      </svg>
+      <span>{label}</span>
+    </a>
+  );
+}

--- a/packages/zudo-doc-v2/src/body-foot-util/index.ts
+++ b/packages/zudo-doc-v2/src/body-foot-util/index.ts
@@ -1,0 +1,15 @@
+// Barrel for the body-foot-util topic — JSX port of
+// `src/components/body-foot-util-area.astro` and its sibling
+// `edit-link.astro`. The DocHistory SSR-skip wrapper lives next to the
+// area component because it is only ever mounted from there.
+export {
+  BodyFootUtilArea,
+  DEFAULT_VIEW_SOURCE_LABEL,
+} from "./body-foot-util-area.js";
+export type { BodyFootUtilAreaProps } from "./body-foot-util-area.js";
+
+export { EditLink, DEFAULT_EDIT_LINK_LABEL } from "./edit-link.js";
+export type { EditLinkProps } from "./edit-link.js";
+
+export { DocHistoryIsland } from "./doc-history-island.js";
+export type { DocHistoryIslandProps } from "./doc-history-island.js";


### PR DESCRIPTION
## Summary

- Ports `src/components/body-foot-util-area.astro` and its sibling `src/components/edit-link.astro` to JSX/TSX in `@zudo-doc/zudo-doc-v2` under the new `./body-foot-util` subpath.
- Wraps the existing `DocHistory` Preact island via the SSR-skip placeholder pattern (`renderSsrSkipPlaceholder`) so legacy `client:idle` semantics are preserved without re-implementing the diff/dialog/keyboard logic.
- v2 components stay framework-agnostic (no `@/config/settings`, no `@/config/i18n`, no `@/utils/*` imports) — caller pre-resolves URLs and labels, matching the breadcrumb subpath conventions.

## Topic — astro-zfb-migration-components-a / Task #5

Tracking issue: zudolab/zudo-doc#476.

## Files

- `packages/zudo-doc-v2/src/body-foot-util/body-foot-util-area.tsx` — `BodyFootUtilArea`. Returns `null` when neither view-source nor doc-history slots have anything (mirrors legacy `hasContent &&` guard).
- `packages/zudo-doc-v2/src/body-foot-util/edit-link.tsx` — `EditLink`.
- `packages/zudo-doc-v2/src/body-foot-util/doc-history-island.tsx` — `DocHistoryIsland`. Marker `"DocHistory"`, default hydration `idle`.
- `packages/zudo-doc-v2/src/body-foot-util/index.ts` — barrel.
- `packages/zudo-doc-v2/package.json` — adds `./body-foot-util` subpath export.

## Design notes

- All settings-driven predicates from the legacy Astro template (`utilSettings.docHistory`, `docHistoryPerPage`, `isCategoryIndex`) collapse into a single nullable `docHistory` prop on `BodyFootUtilArea`. Suppression is the consumer's call.
- Default English labels (`"View source on GitHub"`, `"Edit this page"`) match the strings in `src/config/i18n.ts` so the components degrade gracefully when no override is supplied.
- The DocHistory SSR-skip wrapper lives inside the topic subpath rather than alongside the framework-level wrappers in `src/ssr-skip/` — it is only ever mounted from this topic and the manager's brief permits "nested .tsx in the same subpath".

## Test plan

- [x] `pnpm check` passes (Astro sync + project-wide tsc --noEmit).
- [x] `pnpm exec vitest run` in `packages/zudo-doc-v2` — 95/95 tests pass.
- [x] `pnpm exec tsc --noEmit -p .` in `packages/zudo-doc-v2` — zero errors in the new files.
- [x] `/light-review -gcoc` (GitHub Copilot CLI, gpt-4.1) ran clean — no bugs, no security issues, no error-handling problems flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)