### PR TITLE
[Astro→zfb][Epic #477] Component port B: nav + content + code + 40 islands wrap + 11 typography reuse

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -77,6 +77,16 @@ export default defineConfig({
   },
   vite: {
     plugins: [tailwindcss()],
+    resolve: {
+      alias: {
+        // Phase-A bridge: map `@takazudo/zfb` (unpublished) to the local
+        // Island stub so `.astro` / `.mdx` imports typecheck and bundle
+        // correctly until the real package ships.
+        "@takazudo/zfb": fileURLToPath(
+          new URL("./src/components/island.tsx", import.meta.url),
+        ),
+      },
+    },
   },
   markdown: {
     shikiConfig,

--- a/packages/zudo-doc-v2/package.json
+++ b/packages/zudo-doc-v2/package.json
@@ -101,6 +101,10 @@
     "./integrations/claude-resources": {
       "types": "./src/integrations/claude-resources/index.ts",
       "default": "./src/integrations/claude-resources/index.ts"
+    },
+    "./content": {
+      "types": "./src/content/index.ts",
+      "default": "./src/content/index.ts"
     }
   },
   "files": [

--- a/packages/zudo-doc-v2/package.json
+++ b/packages/zudo-doc-v2/package.json
@@ -50,6 +50,10 @@
       "types": "./src/tab-item/index.ts",
       "default": "./src/tab-item/index.ts"
     },
+    "./code-syntax": {
+      "types": "./src/code-syntax/index.ts",
+      "default": "./src/code-syntax/index.ts"
+    },
     "./body-foot-util": {
       "types": "./src/body-foot-util/index.ts",
       "default": "./src/body-foot-util/index.ts"

--- a/packages/zudo-doc-v2/package.json
+++ b/packages/zudo-doc-v2/package.json
@@ -101,6 +101,10 @@
     "./integrations/claude-resources": {
       "types": "./src/integrations/claude-resources/index.ts",
       "default": "./src/integrations/claude-resources/index.ts"
+    },
+    "./nav-indexing": {
+      "types": "./src/nav-indexing/index.ts",
+      "default": "./src/nav-indexing/index.ts"
     }
   },
   "files": [

--- a/packages/zudo-doc-v2/package.json
+++ b/packages/zudo-doc-v2/package.json
@@ -70,21 +70,9 @@
       "types": "./src/ssr-skip/index.ts",
       "default": "./src/ssr-skip/index.ts"
     },
-    "./body-foot-util": {
-      "types": "./src/body-foot-util/index.ts",
-      "default": "./src/body-foot-util/index.ts"
-    },
     "./transitions": {
       "types": "./src/transitions/index.ts",
       "default": "./src/transitions/index.ts"
-    },
-    "./page-loading": {
-      "types": "./src/page-loading/index.ts",
-      "default": "./src/page-loading/index.ts"
-    },
-    "./tab-item": {
-      "types": "./src/tab-item/index.ts",
-      "default": "./src/tab-item/index.ts"
     },
     "./integrations/doc-history": {
       "types": "./src/integrations/doc-history/index.ts",
@@ -101,6 +89,18 @@
     "./integrations/claude-resources": {
       "types": "./src/integrations/claude-resources/index.ts",
       "default": "./src/integrations/claude-resources/index.ts"
+    },
+    "./metainfo": {
+      "types": "./src/metainfo/index.ts",
+      "default": "./src/metainfo/index.ts"
+    },
+    "./html-preview-wrapper": {
+      "types": "./src/html-preview-wrapper/index.ts",
+      "default": "./src/html-preview-wrapper/index.ts"
+    },
+    "./details": {
+      "types": "./src/details/index.ts",
+      "default": "./src/details/index.ts"
     }
   },
   "files": [

--- a/packages/zudo-doc-v2/src/code-syntax/__tests__/code-block-enhancer.test.tsx
+++ b/packages/zudo-doc-v2/src/code-syntax/__tests__/code-block-enhancer.test.tsx
@@ -1,0 +1,61 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { describe, expect, it } from "vitest";
+import { render } from "preact-render-to-string";
+import { CodeBlockEnhancer } from "../code-block-enhancer";
+import { CODE_BLOCK_ENHANCER_SCRIPT } from "../code-block-enhancer-script";
+
+describe("<CodeBlockEnhancer />", () => {
+  it("renders the screen-reader announce region", () => {
+    const html = render(<CodeBlockEnhancer />);
+    expect(html).toContain('class="code-block-sr-announce"');
+    expect(html).toContain('aria-live="polite"');
+  });
+
+  it("renders a <script> tag with the init script", () => {
+    const html = render(<CodeBlockEnhancer />);
+    expect(html).toContain("<script");
+    // The script content should be present (not escaped as HTML entities).
+    expect(html).toContain("enhanceCodeBlocks");
+    expect(html).toContain("code-block-wrapper");
+  });
+
+  it("script contains copy and wrap button creation logic", () => {
+    const html = render(<CodeBlockEnhancer />);
+    expect(html).toContain("createCopyButton");
+    expect(html).toContain("createWrapButton");
+    expect(html).toContain("code-btn-copy");
+    expect(html).toContain("code-btn-wrap");
+  });
+
+  it("script hooks into astro:page-load for view transitions", () => {
+    const html = render(<CodeBlockEnhancer />);
+    expect(html).toContain("astro:page-load");
+  });
+
+  it("script cleans up before page swap", () => {
+    const html = render(<CodeBlockEnhancer />);
+    expect(html).toContain("astro:before-swap");
+  });
+});
+
+describe("CODE_BLOCK_ENHANCER_SCRIPT", () => {
+  it("is a non-empty string", () => {
+    expect(typeof CODE_BLOCK_ENHANCER_SCRIPT).toBe("string");
+    expect(CODE_BLOCK_ENHANCER_SCRIPT.length).toBeGreaterThan(0);
+  });
+
+  it("wraps the logic in an IIFE", () => {
+    expect(CODE_BLOCK_ENHANCER_SCRIPT).toMatch(/^\(function\s*\(\)/);
+    expect(CODE_BLOCK_ENHANCER_SCRIPT.trimEnd()).toMatch(/\)\(\);$/);
+  });
+
+  it("targets pre.astro-code elements", () => {
+    expect(CODE_BLOCK_ENHANCER_SCRIPT).toContain("pre.astro-code");
+  });
+
+  it("uses ResizeObserver for overflow detection", () => {
+    expect(CODE_BLOCK_ENHANCER_SCRIPT).toContain("ResizeObserver");
+  });
+});

--- a/packages/zudo-doc-v2/src/code-syntax/__tests__/mermaid-init.test.tsx
+++ b/packages/zudo-doc-v2/src/code-syntax/__tests__/mermaid-init.test.tsx
@@ -1,0 +1,68 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { describe, expect, it } from "vitest";
+import { render } from "preact-render-to-string";
+import { MermaidInit } from "../mermaid-init";
+import { MERMAID_INIT_SCRIPT } from "../mermaid-init-script";
+
+describe("<MermaidInit />", () => {
+  it("renders a <script> tag", () => {
+    const html = render(<MermaidInit />);
+    expect(html).toContain("<script");
+  });
+
+  it("script contains mermaid init logic", () => {
+    const html = render(<MermaidInit />);
+    expect(html).toContain("initMermaid");
+    expect(html).toContain("data-mermaid");
+  });
+
+  it("script hooks into astro:page-load for view transitions", () => {
+    const html = render(<MermaidInit />);
+    expect(html).toContain("astro:page-load");
+  });
+
+  it("script observes color scheme changes via MutationObserver", () => {
+    const html = render(<MermaidInit />);
+    expect(html).toContain("MutationObserver");
+    expect(html).toContain("reinitMermaid");
+  });
+
+  it("renders no extra HTML beyond the script tag", () => {
+    const html = render(<MermaidInit />);
+    // Should just be a script tag, no divs etc.
+    expect(html.trimStart()).toMatch(/^<script/);
+  });
+});
+
+describe("MERMAID_INIT_SCRIPT", () => {
+  it("is a non-empty string", () => {
+    expect(typeof MERMAID_INIT_SCRIPT).toBe("string");
+    expect(MERMAID_INIT_SCRIPT.length).toBeGreaterThan(0);
+  });
+
+  it("wraps the logic in an IIFE", () => {
+    expect(MERMAID_INIT_SCRIPT).toMatch(/^\(function\s*\(\)/);
+    expect(MERMAID_INIT_SCRIPT.trimEnd()).toMatch(/\)\(\);$/);
+  });
+
+  it("lazily imports mermaid via dynamic import", () => {
+    expect(MERMAID_INIT_SCRIPT).toContain('import("mermaid")');
+  });
+
+  it("resolves CSS custom properties for theme variables", () => {
+    expect(MERMAID_INIT_SCRIPT).toContain("resolveColor");
+    expect(MERMAID_INIT_SCRIPT).toContain("--zd-mermaid-node-bg");
+    expect(MERMAID_INIT_SCRIPT).toContain("--zd-bg");
+  });
+
+  it("detects dark mode from background luminance", () => {
+    expect(MERMAID_INIT_SCRIPT).toContain("luminance");
+    expect(MERMAID_INIT_SCRIPT).toContain("darkMode");
+  });
+
+  it("skips already-rendered diagrams", () => {
+    expect(MERMAID_INIT_SCRIPT).toContain("data-mermaid-rendered");
+  });
+});

--- a/packages/zudo-doc-v2/src/code-syntax/__tests__/tabs.test.tsx
+++ b/packages/zudo-doc-v2/src/code-syntax/__tests__/tabs.test.tsx
@@ -1,0 +1,167 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { describe, expect, it } from "vitest";
+import { render } from "preact-render-to-string";
+import { Tabs } from "../tabs";
+import { TabsInit } from "../tabs-init";
+import { TABS_INIT_SCRIPT } from "../tabs-init-script";
+import { TabItem } from "../../tab-item/tab-item";
+
+describe("<Tabs />", () => {
+  it("renders the [data-tabs] container", () => {
+    const html = render(
+      <Tabs>
+        <TabItem label="npm">npm content</TabItem>
+      </Tabs>,
+    );
+    expect(html).toContain("data-tabs");
+    expect(html).toContain("tabs-container");
+  });
+
+  it("renders a tabs-nav role=tablist", () => {
+    const html = render(
+      <Tabs>
+        <TabItem label="One">one</TabItem>
+      </Tabs>,
+    );
+    expect(html).toContain('role="tablist"');
+    expect(html).toContain("tabs-nav");
+  });
+
+  it("renders one nav button per TabItem with the correct label", () => {
+    const html = render(
+      <Tabs>
+        <TabItem label="npm">npm content</TabItem>
+        <TabItem label="pnpm">pnpm content</TabItem>
+        <TabItem label="yarn">yarn content</TabItem>
+      </Tabs>,
+    );
+    expect(html).toContain(">npm<");
+    expect(html).toContain(">pnpm<");
+    expect(html).toContain(">yarn<");
+  });
+
+  it("sets data-tab-btn from label when value is omitted", () => {
+    const html = render(
+      <Tabs>
+        <TabItem label="Alpha">alpha</TabItem>
+      </Tabs>,
+    );
+    expect(html).toContain('data-tab-btn="Alpha"');
+  });
+
+  it("sets data-tab-btn from value when provided", () => {
+    const html = render(
+      <Tabs>
+        <TabItem label="Alpha" value="alpha-id">alpha</TabItem>
+      </Tabs>,
+    );
+    expect(html).toContain('data-tab-btn="alpha-id"');
+  });
+
+  it("renders nav buttons with aria-selected=false initially (TabsInit activates)", () => {
+    const html = render(
+      <Tabs>
+        <TabItem label="One">one</TabItem>
+        <TabItem label="Two">two</TabItem>
+      </Tabs>,
+    );
+    // All buttons should have aria-selected=false; TabsInit sets the active one.
+    const matches = html.match(/aria-selected="[^"]+"/g) ?? [];
+    expect(matches.length).toBe(2);
+    expect(matches.every((m) => m === 'aria-selected="false"')).toBe(true);
+  });
+
+  it("renders the tabs-content area with TabItem panels", () => {
+    const html = render(
+      <Tabs>
+        <TabItem label="A">content A</TabItem>
+      </Tabs>,
+    );
+    expect(html).toContain("tabs-content");
+    expect(html).toContain("content A");
+    // The panel should be hidden (TabItem renders with hidden).
+    expect(html).toContain("hidden");
+  });
+
+  it("forwards the groupId as data-group-id", () => {
+    const html = render(
+      <Tabs groupId="install-manager">
+        <TabItem label="npm">npm</TabItem>
+      </Tabs>,
+    );
+    expect(html).toContain('data-group-id="install-manager"');
+  });
+
+  it("omits data-group-id when groupId is not provided", () => {
+    const html = render(
+      <Tabs>
+        <TabItem label="npm">npm</TabItem>
+      </Tabs>,
+    );
+    expect(html).not.toContain("data-group-id");
+  });
+
+  it("renders non-TabItem children in the content area without adding nav buttons", () => {
+    const html = render(
+      <Tabs>
+        <TabItem label="A">a</TabItem>
+        <p>extra content</p>
+      </Tabs>,
+    );
+    // Only one nav button (for the TabItem).
+    const navBtns = html.match(/data-tab-btn=/g) ?? [];
+    expect(navBtns).toHaveLength(1);
+    // The extra content still appears.
+    expect(html).toContain("<p>extra content</p>");
+  });
+});
+
+describe("<TabsInit />", () => {
+  it("renders a <script> tag", () => {
+    const html = render(<TabsInit />);
+    expect(html).toContain("<script");
+  });
+
+  it("script contains activateTab and showPanel logic", () => {
+    const html = render(<TabsInit />);
+    expect(html).toContain("activateTab");
+    expect(html).toContain("showPanel");
+  });
+
+  it("script hooks into astro:page-load", () => {
+    const html = render(<TabsInit />);
+    expect(html).toContain("astro:page-load");
+  });
+
+  it("script handles localStorage group sync", () => {
+    const html = render(<TabsInit />);
+    expect(html).toContain("localStorage");
+    expect(html).toContain("syncGroup");
+  });
+});
+
+describe("TABS_INIT_SCRIPT", () => {
+  it("is a non-empty string", () => {
+    expect(typeof TABS_INIT_SCRIPT).toBe("string");
+    expect(TABS_INIT_SCRIPT.length).toBeGreaterThan(0);
+  });
+
+  it("wraps the logic in an IIFE", () => {
+    expect(TABS_INIT_SCRIPT).toMatch(/^\(function\s*\(\)/);
+    expect(TABS_INIT_SCRIPT.trimEnd()).toMatch(/\)\(\);$/);
+  });
+
+  it("reads data-tab-default to find the default panel", () => {
+    expect(TABS_INIT_SCRIPT).toContain("data-tab-default");
+  });
+
+  it("targets [data-tab-btn] buttons (pre-rendered by Tabs component)", () => {
+    expect(TABS_INIT_SCRIPT).toContain("data-tab-btn");
+  });
+
+  it("uses a tabs-init marker to avoid double-initialization", () => {
+    expect(TABS_INIT_SCRIPT).toContain("tabsInit");
+  });
+});

--- a/packages/zudo-doc-v2/src/code-syntax/code-block-enhancer-script.ts
+++ b/packages/zudo-doc-v2/src/code-syntax/code-block-enhancer-script.ts
@@ -1,0 +1,151 @@
+// Browser init script for the code block enhancer.
+//
+// Converted from the TypeScript <script> block in
+// `src/components/code-block-enhancer.astro` — TypeScript syntax stripped
+// so the string can be emitted via `dangerouslySetInnerHTML` and parsed
+// by the browser directly.
+//
+// Wrapped in an IIFE to avoid polluting the global scope.
+// Kept in a separate module (rather than inlined in the TSX file) so
+// future edits can be reviewed in isolation — same pattern as
+// `src/header/nav-overflow-script.ts`.
+
+export const CODE_BLOCK_ENHANCER_SCRIPT = `(function () {
+  // Single shared ResizeObserver for all code blocks on the page.
+  var wrapButtons = new Map();
+  var resizeObserver = new ResizeObserver(function (entries) {
+    for (var i = 0; i < entries.length; i++) {
+      var btn = wrapButtons.get(entries[i].target);
+      if (btn) updateWrapVisibility(entries[i].target, btn);
+    }
+  });
+
+  function enhanceCodeBlocks() {
+    var pres = document.querySelectorAll("pre.astro-code");
+
+    for (var pi = 0; pi < pres.length; pi++) {
+      var pre = pres[pi];
+      if (pre.dataset.enhanced) continue;
+      pre.dataset.enhanced = "true";
+
+      var codeEl = pre.querySelector("code");
+      if (!codeEl) continue;
+      var rawCode = codeEl.textContent || "";
+
+      // Wrap <pre> in a container so buttons stay fixed during horizontal scroll.
+      var wrapper = document.createElement("div");
+      wrapper.className = "code-block-wrapper";
+      var parent = pre.parentNode;
+      if (!parent) continue;
+      parent.insertBefore(wrapper, pre);
+      wrapper.appendChild(pre);
+
+      // Button group (appended to wrapper, not pre).
+      var group = document.createElement("div");
+      group.className = "code-buttons";
+
+      // Word wrap toggle (only shown when content overflows).
+      var wrapBtn = createWrapButton(pre);
+      group.appendChild(wrapBtn);
+
+      // Copy button.
+      var copyBtn = createCopyButton(rawCode);
+      group.appendChild(copyBtn);
+
+      wrapper.appendChild(group);
+
+      // Track and observe for overflow changes.
+      wrapButtons.set(pre, wrapBtn);
+      updateWrapVisibility(pre, wrapBtn);
+      resizeObserver.observe(pre);
+    }
+  }
+
+  function createCopyButton(code) {
+    var btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "code-btn code-btn-copy";
+    btn.setAttribute("aria-label", "Copy code");
+    btn.innerHTML =
+      '<svg class="code-icon code-icon-copy" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+        '<rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>' +
+        '<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>' +
+      '</svg>' +
+      '<svg class="code-icon code-icon-check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+        '<polyline points="20 6 9 17 4 12"/>' +
+      '</svg>';
+
+    var copyTimeout;
+    var announce = document.querySelector(".code-block-sr-announce");
+
+    btn.addEventListener("click", async function () {
+      var success = true;
+      try {
+        await navigator.clipboard.writeText(code);
+      } catch (_) {
+        // Fallback for older browsers.
+        var textarea = document.createElement("textarea");
+        textarea.value = code;
+        textarea.style.cssText = "position:fixed;opacity:0;pointer-events:none";
+        document.body.appendChild(textarea);
+        textarea.select();
+        success = document.execCommand("copy");
+        document.body.removeChild(textarea);
+      }
+      if (success) {
+        btn.classList.add("copied");
+        if (announce) announce.textContent = "Copied!";
+        clearTimeout(copyTimeout);
+        copyTimeout = setTimeout(function () {
+          btn.classList.remove("copied");
+          if (announce) announce.textContent = "";
+        }, 1500);
+      }
+    });
+
+    return btn;
+  }
+
+  function createWrapButton(pre) {
+    var btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "code-btn code-btn-wrap";
+    btn.setAttribute("aria-label", "Toggle word wrap");
+    btn.setAttribute("aria-pressed", "false");
+    btn.innerHTML =
+      '<svg class="code-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+        '<polyline points="17 10 21 6 17 2" />' +
+        '<path d="M3 6h18" />' +
+        '<path d="M21 18H7" />' +
+        '<polyline points="11 22 7 18 11 14" />' +
+      '</svg>';
+
+    btn.addEventListener("click", function () {
+      var isWrapped = pre.classList.toggle("word-wrap");
+      btn.classList.toggle("active", isWrapped);
+      btn.setAttribute("aria-pressed", String(isWrapped));
+    });
+
+    return btn;
+  }
+
+  function updateWrapVisibility(pre, btn) {
+    // Keep visible when active (user needs to toggle back).
+    var isActive = btn.classList.contains("active");
+    btn.style.display = isActive || pre.scrollWidth > pre.clientWidth ? "" : "none";
+  }
+
+  // Clean up stale references before page swap (Astro view transitions).
+  document.addEventListener("astro:before-swap", function () {
+    wrapButtons.forEach(function (_btn, el) {
+      resizeObserver.unobserve(el);
+    });
+    wrapButtons.clear();
+  });
+
+  // Run on initial load.
+  enhanceCodeBlocks();
+
+  // Support Astro view transitions.
+  document.addEventListener("astro:page-load", enhanceCodeBlocks);
+})();`;

--- a/packages/zudo-doc-v2/src/code-syntax/code-block-enhancer.tsx
+++ b/packages/zudo-doc-v2/src/code-syntax/code-block-enhancer.tsx
@@ -1,0 +1,40 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+// JSX port of src/components/code-block-enhancer.astro.
+//
+// The original .astro component rendered:
+//   1. A `<div class="code-block-sr-announce">` live-region for screen-reader
+//      announcements after copying.
+//   2. A <script> tag that self-initializes the copy/wrap button enhancer.
+//
+// This JSX version renders the same markup via `dangerouslySetInnerHTML` so
+// the host can drop it into any SSR layout without Astro. The init function
+// is also exported separately for callers that manage their own script injection.
+
+import type { JSX } from "preact";
+import { CODE_BLOCK_ENHANCER_SCRIPT } from "./code-block-enhancer-script.js";
+
+/**
+ * Drop-in JSX replacement for `src/components/code-block-enhancer.astro`.
+ *
+ * Include **once** in the layout. Renders the screen-reader announce region
+ * and emits the code-block enhancer init script via `dangerouslySetInnerHTML`.
+ *
+ * The script:
+ * - Wraps each `<pre.astro-code>` in a `.code-block-wrapper` container.
+ * - Adds a copy-to-clipboard button and a word-wrap toggle button.
+ * - Observes resize events to hide the wrap button when content fits.
+ * - Handles `astro:before-swap` cleanup and `astro:page-load` re-init for
+ *   Astro view transitions.
+ */
+export function CodeBlockEnhancer(): JSX.Element {
+  return (
+    <>
+      <div class="code-block-sr-announce" aria-live="polite" />
+      <script dangerouslySetInnerHTML={{ __html: CODE_BLOCK_ENHANCER_SCRIPT }} />
+    </>
+  );
+}
+
+export default CodeBlockEnhancer;

--- a/packages/zudo-doc-v2/src/code-syntax/index.ts
+++ b/packages/zudo-doc-v2/src/code-syntax/index.ts
@@ -1,0 +1,29 @@
+// Public surface for `@zudo-doc/zudo-doc-v2/code-syntax`.
+//
+// Three JSX ports of the code/syntax Astro components:
+//
+//   CodeBlockEnhancer — wraps <pre.astro-code> blocks with copy + word-wrap
+//                       buttons. Include once in the layout.
+//
+//   MermaidInit       — lazily renders [data-mermaid] diagrams and re-renders
+//                       on color scheme changes. Include once in the layout.
+//
+//   Tabs / TabsInit   — server-rendered tab containers. <Tabs> renders the
+//                       nav buttons from its <TabItem> children; <TabsInit>
+//                       activates the correct panel and wires click handlers.
+//                       Include <TabsInit> once in the layout.
+//
+// Script constants are also exported so consumers can emit the scripts via
+// their own mechanisms (e.g. a framework-native <script> integration).
+
+export { CodeBlockEnhancer, default as CodeBlockEnhancerDefault } from "./code-block-enhancer.js";
+export { CODE_BLOCK_ENHANCER_SCRIPT } from "./code-block-enhancer-script.js";
+
+export { MermaidInit, default as MermaidInitDefault } from "./mermaid-init.js";
+export { MERMAID_INIT_SCRIPT } from "./mermaid-init-script.js";
+
+export { Tabs, default as TabsDefault } from "./tabs.js";
+export type { TabsProps } from "./tabs.js";
+
+export { TabsInit, default as TabsInitDefault } from "./tabs-init.js";
+export { TABS_INIT_SCRIPT } from "./tabs-init-script.js";

--- a/packages/zudo-doc-v2/src/code-syntax/mermaid-init-script.ts
+++ b/packages/zudo-doc-v2/src/code-syntax/mermaid-init-script.ts
@@ -1,0 +1,114 @@
+// Browser init script for mermaid diagram rendering.
+//
+// Converted from the TypeScript <script> block in
+// `src/components/mermaid-init.astro` — TypeScript syntax stripped
+// so the string can be emitted via `dangerouslySetInnerHTML` and parsed
+// by the browser directly.
+//
+// Wrapped in an IIFE to avoid polluting the global scope.
+// Kept in a separate module so future edits can be reviewed in isolation.
+
+export const MERMAID_INIT_SCRIPT = `(function () {
+  /**
+   * Resolve a CSS value to a hex color (#rrggbb).
+   * CSS custom properties return raw values from getComputedStyle (e.g.
+   * "light-dark(#fff, #000)") which mermaid cannot parse. This uses a
+   * temporary element so the browser resolves any CSS function to a
+   * concrete rgb() value, then converts it to hex.
+   */
+  function resolveColor(value) {
+    if (!value) return value;
+    if (/^#[0-9a-fA-F]{3}$/.test(value)) {
+      return "#" + value[1] + value[1] + value[2] + value[2] + value[3] + value[3];
+    }
+    if (/^#[0-9a-fA-F]{6}$/.test(value)) return value;
+    if (/^#[0-9a-fA-F]{8}$/.test(value)) return value.slice(0, 7);
+    if (/^#[0-9a-fA-F]{4}$/.test(value)) {
+      return "#" + value[1] + value[1] + value[2] + value[2] + value[3] + value[3];
+    }
+    var el = document.createElement("div");
+    el.style.display = "none";
+    el.style.color = value;
+    document.body.appendChild(el);
+    var resolved;
+    try {
+      resolved = getComputedStyle(el).color;
+    } finally {
+      el.remove();
+    }
+    var m = resolved.match(/(\d+)/g);
+    if (m && m.length >= 3) {
+      return "#" + m.slice(0, 3).map(function (n) { return Number(n).toString(16).padStart(2, "0"); }).join("");
+    }
+    return value;
+  }
+
+  async function initMermaid() {
+    var els = document.querySelectorAll("[data-mermaid]:not([data-mermaid-rendered])");
+    if (els.length === 0) return;
+
+    try {
+      var mod = await import("mermaid");
+      var mermaid = mod.default;
+      var s = getComputedStyle(document.documentElement);
+      var v = function (name) { return resolveColor(s.getPropertyValue(name).trim()); };
+      var bg = v("--zd-bg");
+      var hex = bg.replace("#", "");
+      var r = parseInt(hex.substring(0, 2), 16) / 255;
+      var g = parseInt(hex.substring(2, 4), 16) / 255;
+      var b = parseInt(hex.substring(4, 6), 16) / 255;
+      var luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: "base",
+        themeVariables: {
+          darkMode: Number.isNaN(luminance) ? true : luminance < 0.5,
+          background: "transparent",
+          primaryColor: v("--zd-mermaid-node-bg"),
+          primaryTextColor: v("--zd-mermaid-text"),
+          primaryBorderColor: v("--zd-mermaid-line"),
+          lineColor: v("--zd-mermaid-line"),
+          secondaryColor: v("--zd-mermaid-note-bg"),
+          tertiaryColor: v("--zd-mermaid-note-bg"),
+          edgeLabelBackground: v("--zd-mermaid-label-bg"),
+          labelTextColor: v("--zd-mermaid-text"),
+          transitionColor: v("--zd-mermaid-line"),
+          transitionLabelColor: v("--zd-mermaid-text"),
+          stateLabelColor: v("--zd-mermaid-text"),
+          noteBkgColor: v("--zd-mermaid-note-bg"),
+          noteTextColor: v("--zd-mermaid-text"),
+          noteBorderColor: v("--zd-mermaid-line"),
+          fontFamily: "inherit",
+        },
+      });
+      await mermaid.run({ nodes: Array.from(els) });
+      els.forEach(function (el) { el.setAttribute("data-mermaid-rendered", ""); });
+    } catch (e) {
+      console.error("[mermaid-init] Failed to render mermaid diagrams:", e);
+    }
+  }
+
+  /** Re-render all mermaid diagrams (clear rendered state so initMermaid picks them up). */
+  function reinitMermaid() {
+    document.querySelectorAll("[data-mermaid-rendered]").forEach(function (el) {
+      el.removeAttribute("data-mermaid-rendered");
+      // Remove rendered SVG so mermaid regenerates from source text.
+      var svg = el.querySelector("svg");
+      if (svg) svg.remove();
+    });
+    initMermaid();
+  }
+
+  // astro:page-load fires on initial load and after View Transition navigations.
+  document.addEventListener("astro:page-load", function () { initMermaid(); });
+
+  // Re-render mermaid when color tweak panel changes CSS custom properties (debounced).
+  var tweakTimer;
+  new MutationObserver(function () {
+    clearTimeout(tweakTimer);
+    tweakTimer = setTimeout(reinitMermaid, 300);
+  }).observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["style"],
+  });
+})();`;

--- a/packages/zudo-doc-v2/src/code-syntax/mermaid-init.tsx
+++ b/packages/zudo-doc-v2/src/code-syntax/mermaid-init.tsx
@@ -1,0 +1,36 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+// JSX port of src/components/mermaid-init.astro.
+//
+// The original .astro component rendered a single <script> tag that:
+//   1. Lazily imports mermaid on first `astro:page-load` event.
+//   2. Reads CSS custom properties to build mermaid theme variables.
+//   3. Renders `[data-mermaid]` elements and marks them with
+//      `[data-mermaid-rendered]` to avoid double-rendering.
+//   4. Watches `documentElement[style]` mutations (from the color-tweak panel)
+//      and re-renders diagrams when the palette changes.
+//
+// This JSX version emits the identical script via `dangerouslySetInnerHTML`.
+// Include once in the layout, before any mermaid diagram content.
+
+import type { JSX } from "preact";
+import { MERMAID_INIT_SCRIPT } from "./mermaid-init-script.js";
+
+/**
+ * Drop-in JSX replacement for `src/components/mermaid-init.astro`.
+ *
+ * Include **once** in the layout. Emits the mermaid init script via
+ * `dangerouslySetInnerHTML`. The script lazily imports mermaid only when
+ * `[data-mermaid]` elements are found on the page, so pages without any
+ * mermaid diagrams pay zero runtime cost.
+ *
+ * The script hooks into `astro:page-load` for View Transitions support
+ * and into a `MutationObserver` on `:root[style]` to re-render when the
+ * user changes the color scheme via the color-tweak panel.
+ */
+export function MermaidInit(): JSX.Element {
+  return <script dangerouslySetInnerHTML={{ __html: MERMAID_INIT_SCRIPT }} />;
+}
+
+export default MermaidInit;

--- a/packages/zudo-doc-v2/src/code-syntax/tabs-init-script.ts
+++ b/packages/zudo-doc-v2/src/code-syntax/tabs-init-script.ts
@@ -1,0 +1,116 @@
+// Browser init script for tabs interactivity.
+//
+// Simplified counterpart of `src/components/tabs-init.astro`.
+//
+// The original script created `<button>` elements for each panel entirely
+// at runtime. The JSX `<Tabs>` component now server-renders the buttons,
+// so this script only needs to:
+//   1. Determine which tab should be active (localStorage or data-tab-default
+//      or first panel).
+//   2. Apply active styles to the correct button and show the matching panel.
+//   3. Wire click handlers to every `[data-tab-btn]` button.
+//   4. Handle group-sync via localStorage when a `data-group-id` is present.
+//
+// Wrapped in an IIFE to avoid polluting the global scope.
+// Run on initial load and re-run on `astro:page-load` for view transitions.
+
+export const TABS_INIT_SCRIPT = `(function () {
+  var BASE_BTN = "px-hsp-lg py-vsp-xs text-small font-medium border-b-[5px] -mb-px transition-colors";
+  var ACTIVE_BTN = BASE_BTN + " text-accent border-accent";
+  var INACTIVE_BTN = BASE_BTN + " text-muted border-transparent hover:text-fg";
+
+  function activateTab(container, value) {
+    // Update button styles.
+    var buttons = container.querySelectorAll("[data-tab-btn]");
+    for (var i = 0; i < buttons.length; i++) {
+      var btn = buttons[i];
+      var isActive = btn.dataset.tabBtn === value;
+      btn.className = isActive ? ACTIVE_BTN : INACTIVE_BTN;
+      btn.setAttribute("aria-selected", String(isActive));
+    }
+    // Update panel visibility.
+    showPanel(container, value);
+  }
+
+  function showPanel(container, value) {
+    var panels = container.querySelectorAll(".tab-panel");
+    for (var i = 0; i < panels.length; i++) {
+      var panel = panels[i];
+      panel.hidden = panel.dataset.tabValue !== value;
+    }
+  }
+
+  function syncGroup(groupId, value, source) {
+    var others = document.querySelectorAll("[data-tabs][data-group-id=\\"" + CSS.escape(groupId) + "\\"]");
+    for (var i = 0; i < others.length; i++) {
+      var container = others[i];
+      if (container === source) continue;
+      var hasPanel = container.querySelector(".tab-panel[data-tab-value=\\"" + CSS.escape(value) + "\\"]");
+      if (hasPanel) activateTab(container, value);
+    }
+  }
+
+  function initTabs() {
+    var containers = document.querySelectorAll("[data-tabs]");
+
+    for (var ci = 0; ci < containers.length; ci++) {
+      var container = containers[ci];
+      if (container.dataset.tabsInit) continue;
+      container.dataset.tabsInit = "true";
+
+      var panels = container.querySelectorAll(".tab-panel");
+      if (panels.length === 0) continue;
+
+      var groupId = container.dataset.groupId;
+
+      // Determine which tab should be active.
+      var activeValue = null;
+
+      if (groupId) {
+        var stored = localStorage.getItem("tabs-group-" + groupId);
+        if (stored) {
+          // Only use stored value if a matching panel exists.
+          for (var pi = 0; pi < panels.length; pi++) {
+            if (panels[pi].dataset.tabValue === stored) {
+              activeValue = stored;
+              break;
+            }
+          }
+        }
+      }
+
+      if (!activeValue) {
+        var defaultPanel = container.querySelector(".tab-panel[data-tab-default]");
+        activeValue = defaultPanel
+          ? defaultPanel.dataset.tabValue
+          : panels[0].dataset.tabValue;
+      }
+
+      // Activate the correct tab (set button styles + show panel).
+      activateTab(container, activeValue);
+
+      // Wire click handlers on the server-rendered buttons.
+      (function (cont, gid) {
+        var buttons = cont.querySelectorAll("[data-tab-btn]");
+        for (var bi = 0; bi < buttons.length; bi++) {
+          (function (btn) {
+            btn.addEventListener("click", function () {
+              var val = btn.dataset.tabBtn;
+              activateTab(cont, val);
+              if (gid) {
+                localStorage.setItem("tabs-group-" + gid, val);
+                syncGroup(gid, val, cont);
+              }
+            });
+          })(buttons[bi]);
+        }
+      })(container, groupId);
+    }
+  }
+
+  // Run on initial load.
+  initTabs();
+
+  // Support Astro view transitions.
+  document.addEventListener("astro:page-load", initTabs);
+})();`;

--- a/packages/zudo-doc-v2/src/code-syntax/tabs-init.tsx
+++ b/packages/zudo-doc-v2/src/code-syntax/tabs-init.tsx
@@ -1,0 +1,36 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+// JSX port of src/components/tabs-init.astro.
+//
+// The original .astro component rendered a <script> tag that created nav
+// buttons from the `[data-tab-value]` / `[data-tab-label]` attributes on
+// `.tab-panel` elements. Because the JSX `<Tabs>` component now server-renders
+// those buttons, this script is simplified: it only activates the correct tab
+// and wires click handlers.
+//
+// Include once in the layout — NOT inside each <Tabs> component.
+
+import type { JSX } from "preact";
+import { TABS_INIT_SCRIPT } from "./tabs-init-script.js";
+
+/**
+ * Drop-in JSX replacement for `src/components/tabs-init.astro`.
+ *
+ * Include **once** in the layout (e.g. in the `<body>` foot). Emits the
+ * tabs interactivity script via `dangerouslySetInnerHTML`.
+ *
+ * The script:
+ * - Activates the correct panel on first paint (localStorage → default → first).
+ * - Wires click handlers to the pre-rendered `[data-tab-btn]` buttons from
+ *   the `<Tabs>` component.
+ * - Syncs tab state across containers that share a `data-group-id`.
+ * - Re-runs on `astro:page-load` to support Astro view transitions.
+ *
+ * Requires `<Tabs>` to have server-rendered the tab buttons in the DOM.
+ */
+export function TabsInit(): JSX.Element {
+  return <script dangerouslySetInnerHTML={{ __html: TABS_INIT_SCRIPT }} />;
+}
+
+export default TabsInit;

--- a/packages/zudo-doc-v2/src/code-syntax/tabs.tsx
+++ b/packages/zudo-doc-v2/src/code-syntax/tabs.tsx
@@ -1,0 +1,111 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+// JSX port of src/components/tabs.astro.
+//
+// The original .astro component rendered:
+//   1. A container `<div data-tabs data-group-id={groupId}>`.
+//   2. An empty `<div class="tabs-nav">` — the tab buttons were created
+//      imperatively by the companion `tabs-init.astro` script at runtime.
+//   3. A `<div class="tabs-content"><slot/></div>` holding the `<TabItem>`
+//      panels.
+//
+// This JSX port takes a different (more SSR-friendly) approach:
+//   - It uses Preact's `toChildArray` to discover `<TabItem>` children
+//     server-side and renders the nav buttons statically in the HTML.
+//   - The companion `<TabsInit>` component (see tabs-init.tsx) still needs
+//     to be included in the layout; its script activates the correct tab
+//     and wires click handlers — but it no longer has to create buttons.
+//
+// Children that are NOT `<TabItem>` elements are rendered into the content
+// area unchanged, so mixed content (e.g. a heading above a tab set) works.
+
+import { toChildArray } from "preact";
+import type { ComponentChildren, JSX, VNode } from "preact";
+import { TabItem } from "../tab-item/tab-item.js";
+import type { TabItemProps } from "../tab-item/tab-item.js";
+
+const BASE_BTN_CLASS =
+  "px-hsp-lg py-vsp-xs text-small font-medium border-b-[5px] -mb-px transition-colors";
+/** Initially every button is inactive; the TabsInit script activates the correct one. */
+const INACTIVE_BTN_CLASS = `${BASE_BTN_CLASS} text-muted border-transparent hover:text-fg`;
+
+export interface TabsProps {
+  /**
+   * When set, clicking a tab in this group persists the chosen value to
+   * `localStorage` under `tabs-group-{groupId}` and syncs all other
+   * containers that share the same `groupId`.
+   */
+  groupId?: string;
+  /** `<TabItem>` children (and any other content). */
+  children?: ComponentChildren;
+}
+
+/**
+ * Server-rendered tab container — JSX port of `src/components/tabs.astro`.
+ *
+ * Iterates `children` via `toChildArray` to discover `<TabItem>` elements
+ * and renders their labels as `<button>` elements in the tab nav bar.
+ * All panels remain `hidden` on first paint; `<TabsInit>` (the companion
+ * script component) activates the default/stored tab after hydration.
+ *
+ * Place `<TabsInit>` once in the layout — NOT inside each `<Tabs>`.
+ *
+ * @example
+ * ```tsx
+ * <Tabs>
+ *   <TabItem label="npm"><code>npm install …</code></TabItem>
+ *   <TabItem label="pnpm" default><code>pnpm add …</code></TabItem>
+ * </Tabs>
+ * ```
+ */
+export function Tabs({ groupId, children }: TabsProps): JSX.Element {
+  // Flatten children and locate TabItem VNodes so we can build nav buttons.
+  //
+  // TypeScript note: `toChildArray` returns `(string | number | VNode<{}>)[]`.
+  // We cannot use a type predicate of the form `child is VNode<TabItemProps>`
+  // because TypeScript treats VNode generics invariantly — `VNode<TabItemProps>`
+  // is not assignable to `VNode<{}>`. The two-step approach below narrows to
+  // the opaque `VNode` type first, then casts the props to `TabItemProps`.
+  const childArray = toChildArray(children);
+
+  // Step 1 — keep only VNodes whose `type` is the TabItem function.
+  const tabItemNodes = childArray.filter(
+    (child): child is VNode =>
+      typeof child === "object" &&
+      child !== null &&
+      (child as VNode).type === TabItem,
+  );
+
+  // Step 2 — cast props to the known shape so the JSX below is type-safe.
+  const tabItems = tabItemNodes.map((n) => ({
+    ...n,
+    props: n.props as TabItemProps,
+  }));
+
+  return (
+    <div
+      class="tabs-container my-vsp-md"
+      data-tabs
+      data-group-id={groupId}
+    >
+      <div class="tabs-nav flex border-b border-muted" role="tablist">
+        {tabItems.map((item) => (
+          <button
+            key={item.props.value ?? item.props.label}
+            type="button"
+            role="tab"
+            class={INACTIVE_BTN_CLASS}
+            data-tab-btn={item.props.value ?? item.props.label}
+            aria-selected="false"
+          >
+            {item.props.label}
+          </button>
+        ))}
+      </div>
+      <div class="tabs-content">{children}</div>
+    </div>
+  );
+}
+
+export default Tabs;

--- a/packages/zudo-doc-v2/src/content/__tests__/content.test.tsx
+++ b/packages/zudo-doc-v2/src/content/__tests__/content.test.tsx
@@ -1,0 +1,319 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { describe, expect, it } from "vitest";
+import type { ComponentChildren, VNode } from "preact";
+import { HeadingH2 } from "../heading-h2.js";
+import { HeadingH3 } from "../heading-h3.js";
+import { HeadingH4 } from "../heading-h4.js";
+import { ContentParagraph } from "../content-paragraph.js";
+import { ContentLink } from "../content-link.js";
+import { ContentStrong } from "../content-strong.js";
+import { ContentBlockquote } from "../content-blockquote.js";
+import { ContentUl } from "../content-ul.js";
+import { ContentOl } from "../content-ol.js";
+import { ContentTable } from "../content-table.js";
+import { ContentCode } from "../content-code.js";
+import { htmlOverrides, defaultComponents } from "../component-map.js";
+
+// ---------------------------------------------------------------------------
+// Minimal VNode serializer (copied from breadcrumb tests to avoid pulling in
+// preact-render-to-string at test time).
+// ---------------------------------------------------------------------------
+type AnyVNode = VNode<{ children?: ComponentChildren; [key: string]: unknown }>;
+
+function isVNode(v: unknown): v is AnyVNode {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    Object.prototype.hasOwnProperty.call(v, "type") &&
+    Object.prototype.hasOwnProperty.call(v, "props")
+  );
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/"/g, "&quot;");
+}
+
+function serialize(node: ComponentChildren): string {
+  if (node == null || typeof node === "boolean") return "";
+  if (typeof node === "string") return node;
+  if (typeof node === "number" || typeof node === "bigint") return String(node);
+  if (Array.isArray(node)) return node.map(serialize).join("");
+  if (!isVNode(node)) return "";
+  const { type, props } = node;
+  const { children, ...rest } = (props ?? {}) as {
+    children?: ComponentChildren;
+    [key: string]: unknown;
+  };
+
+  if (typeof type === "function") {
+    const fn = type as (p: typeof props) => ComponentChildren;
+    return serialize(fn(props));
+  }
+  if (type == null || (typeof type === "string" && type === "")) {
+    // Fragment
+    return serialize(children);
+  }
+  if (typeof type !== "string") return serialize(children);
+
+  const voidEls = new Set(["br", "hr", "img", "input", "wbr", "meta", "link"]);
+
+  const attrs = Object.entries(rest)
+    .filter(([, v]) => v !== undefined && v !== null && v !== false)
+    .map(([k, v]) => {
+      if (k === "key") return "";
+      if (v === true) return ` ${k}`;
+      if (k === "style" && typeof v === "object") {
+        // Serialize style object to inline string for attr comparison
+        const styleStr = Object.entries(v as Record<string, string>)
+          .map(([p, val]) => `${p.replace(/([A-Z])/g, "-$1").toLowerCase()}:${val}`)
+          .join(";");
+        return ` ${k}="${escapeAttr(styleStr)}"`;
+      }
+      return ` ${k}="${escapeAttr(String(v))}"`;
+    })
+    .join("");
+
+  if (voidEls.has(type)) return `<${type}${attrs}/>`;
+  return `<${type}${attrs}>${serialize(children)}</${type}>`;
+}
+
+// ---------------------------------------------------------------------------
+// Heading components
+// ---------------------------------------------------------------------------
+describe("HeadingH2", () => {
+  it("renders an h2 with the expected Tailwind classes", () => {
+    const html = serialize(<HeadingH2 id="section-1">Hello</HeadingH2>);
+    expect(html).toContain("<h2");
+    expect(html).toContain('id="section-1"');
+    expect(html).toContain("text-subheading");
+    expect(html).toContain("font-bold");
+    expect(html).toContain("Hello");
+  });
+
+  it("appends extra className to the default classes", () => {
+    const html = serialize(
+      <HeadingH2 className="extra-class">Text</HeadingH2>,
+    );
+    expect(html).toContain("extra-class");
+    expect(html).toContain("text-subheading");
+  });
+});
+
+describe("HeadingH3", () => {
+  it("renders an h3 with correct classes", () => {
+    const html = serialize(<HeadingH3>Hello</HeadingH3>);
+    expect(html).toContain("<h3");
+    expect(html).toContain("text-body");
+    expect(html).toContain("font-bold");
+  });
+});
+
+describe("HeadingH4", () => {
+  it("renders an h4 with correct classes", () => {
+    const html = serialize(<HeadingH4>Hello</HeadingH4>);
+    expect(html).toContain("<h4");
+    expect(html).toContain("text-body");
+    expect(html).toContain("font-semibold");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Simple passthrough / styled components
+// ---------------------------------------------------------------------------
+describe("ContentParagraph", () => {
+  it("renders a <p> element passing children through", () => {
+    const html = serialize(<ContentParagraph>paragraph text</ContentParagraph>);
+    expect(html).toContain("<p");
+    expect(html).toContain("paragraph text");
+  });
+});
+
+describe("ContentStrong", () => {
+  it("renders a <strong> with font-bold class", () => {
+    const html = serialize(<ContentStrong>bold text</ContentStrong>);
+    expect(html).toContain("<strong");
+    expect(html).toContain("font-bold");
+    expect(html).toContain("bold text");
+  });
+});
+
+describe("ContentBlockquote", () => {
+  it("renders a <blockquote> with border and italic classes", () => {
+    const html = serialize(<ContentBlockquote>quote</ContentBlockquote>);
+    expect(html).toContain("<blockquote");
+    expect(html).toContain("border-l-[3px]");
+    expect(html).toContain("italic");
+  });
+});
+
+describe("ContentUl", () => {
+  it("renders a <ul> with inline style for 2em indent and disc list-style", () => {
+    const html = serialize(
+      <ContentUl>
+        <li>item</li>
+      </ContentUl>,
+    );
+    expect(html).toContain("<ul");
+    expect(html).toContain("padding-left");
+    expect(html).toContain("2em");
+  });
+});
+
+describe("ContentOl", () => {
+  it("renders an <ol> with decimal list-style", () => {
+    const html = serialize(
+      <ContentOl>
+        <li>item</li>
+      </ContentOl>,
+    );
+    expect(html).toContain("<ol");
+    expect(html).toContain("decimal");
+  });
+});
+
+describe("ContentTable", () => {
+  it("wraps the table in an overflow-x-auto div", () => {
+    const html = serialize(
+      <ContentTable>
+        <tbody />
+      </ContentTable>,
+    );
+    expect(html).toContain("overflow-x-auto");
+    expect(html).toContain("<table");
+    expect(html).toContain("w-full");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ContentLink — SmartBreak integration
+// ---------------------------------------------------------------------------
+describe("ContentLink", () => {
+  it("renders a plain anchor with text-accent class", () => {
+    const html = serialize(
+      <ContentLink href="https://example.com">Example</ContentLink>,
+    );
+    expect(html).toContain("<a");
+    expect(html).toContain('href="https://example.com"');
+    expect(html).toContain("text-accent");
+    expect(html).toContain("Example");
+  });
+
+  it("injects <wbr> for path-like link text (string child)", () => {
+    const html = serialize(
+      <ContentLink href="/docs">src/utils/foo.ts</ContentLink>,
+    );
+    expect(html).toContain("<wbr");
+  });
+
+  it("does not inject <wbr> for prose link text", () => {
+    const html = serialize(
+      <ContentLink href="/docs">Getting Started</ContentLink>,
+    );
+    expect(html).not.toContain("<wbr");
+  });
+
+  it("bypasses styling for block-class links", () => {
+    const html = serialize(
+      <ContentLink href="/docs" className="block">
+        Block link
+      </ContentLink>,
+    );
+    expect(html).not.toContain("text-accent");
+  });
+
+  it("bypasses styling for hash-link anchors", () => {
+    const html = serialize(
+      <ContentLink href="#section" className="hash-link">
+        #section
+      </ContentLink>,
+    );
+    expect(html).not.toContain("text-accent");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ContentCode — Shiki block detection
+// ---------------------------------------------------------------------------
+describe("ContentCode", () => {
+  it("renders plain inline code as a <code> element", () => {
+    const html = serialize(<ContentCode>foo</ContentCode>);
+    expect(html).toContain("<code");
+    expect(html).toContain("foo");
+  });
+
+  it("passes through Shiki block code (language-* class) untouched", () => {
+    const html = serialize(
+      <ContentCode className="language-ts">const x = 1</ContentCode>,
+    );
+    expect(html).toContain("language-ts");
+    // should not inject wbr into highlighted blocks
+    expect(html).not.toContain("<wbr");
+  });
+
+  it("injects <wbr> for inline path-like code strings", () => {
+    const html = serialize(
+      <ContentCode>src/utils/smart-break.ts</ContentCode>,
+    );
+    expect(html).toContain("<wbr");
+  });
+
+  it("does not inject <wbr> for non-path inline code", () => {
+    const html = serialize(<ContentCode>const x</ContentCode>);
+    expect(html).not.toContain("<wbr");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// component-map
+// ---------------------------------------------------------------------------
+describe("htmlOverrides / defaultComponents", () => {
+  it("maps h2 to HeadingH2", () => {
+    expect(htmlOverrides.h2).toBe(HeadingH2);
+  });
+
+  it("maps h3 to HeadingH3", () => {
+    expect(htmlOverrides.h3).toBe(HeadingH3);
+  });
+
+  it("maps h4 to HeadingH4", () => {
+    expect(htmlOverrides.h4).toBe(HeadingH4);
+  });
+
+  it("maps p to ContentParagraph", () => {
+    expect(htmlOverrides.p).toBe(ContentParagraph);
+  });
+
+  it("maps a to ContentLink", () => {
+    expect(htmlOverrides.a).toBe(ContentLink);
+  });
+
+  it("maps strong to ContentStrong", () => {
+    expect(htmlOverrides.strong).toBe(ContentStrong);
+  });
+
+  it("maps blockquote to ContentBlockquote", () => {
+    expect(htmlOverrides.blockquote).toBe(ContentBlockquote);
+  });
+
+  it("maps ul to ContentUl", () => {
+    expect(htmlOverrides.ul).toBe(ContentUl);
+  });
+
+  it("maps ol to ContentOl", () => {
+    expect(htmlOverrides.ol).toBe(ContentOl);
+  });
+
+  it("maps table to ContentTable", () => {
+    expect(htmlOverrides.table).toBe(ContentTable);
+  });
+
+  it("maps code to ContentCode", () => {
+    expect(htmlOverrides.code).toBe(ContentCode);
+  });
+
+  it("defaultComponents is an alias for htmlOverrides", () => {
+    expect(defaultComponents).toBe(htmlOverrides);
+  });
+});

--- a/packages/zudo-doc-v2/src/content/component-map.ts
+++ b/packages/zudo-doc-v2/src/content/component-map.ts
@@ -1,0 +1,37 @@
+import { HeadingH2 } from "./heading-h2.js";
+import { HeadingH3 } from "./heading-h3.js";
+import { HeadingH4 } from "./heading-h4.js";
+import { ContentParagraph } from "./content-paragraph.js";
+import { ContentLink } from "./content-link.js";
+import { ContentStrong } from "./content-strong.js";
+import { ContentBlockquote } from "./content-blockquote.js";
+import { ContentUl } from "./content-ul.js";
+import { ContentOl } from "./content-ol.js";
+import { ContentTable } from "./content-table.js";
+import { ContentCode } from "./content-code.js";
+
+/**
+ * MDX component overrides map for the HTML elements used in doc content.
+ *
+ * Pass this to `<Content components={defaultComponents} />` (or spread it
+ * into a larger components object that also includes admonition overrides,
+ * custom shortcodes, etc.) at the Astro page layer.
+ */
+export const htmlOverrides = {
+  h2: HeadingH2,
+  h3: HeadingH3,
+  h4: HeadingH4,
+  p: ContentParagraph,
+  a: ContentLink,
+  strong: ContentStrong,
+  blockquote: ContentBlockquote,
+  ul: ContentUl,
+  ol: ContentOl,
+  table: ContentTable,
+  code: ContentCode,
+};
+
+/**
+ * Alias for `htmlOverrides`. Prefer this name in new consumer code.
+ */
+export const defaultComponents = htmlOverrides;

--- a/packages/zudo-doc-v2/src/content/content-blockquote.tsx
+++ b/packages/zudo-doc-v2/src/content/content-blockquote.tsx
@@ -1,0 +1,21 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import type { ComponentChildren } from "preact";
+
+type Props = {
+  children?: ComponentChildren;
+  className?: string;
+  [key: string]: any;
+};
+
+export function ContentBlockquote({ children, className, ...rest }: Props) {
+  return (
+    <blockquote
+      className={`border-l-[3px] border-muted pl-hsp-lg text-muted italic${className ? ` ${className}` : ""}`}
+      {...rest}
+    >
+      {children}
+    </blockquote>
+  );
+}

--- a/packages/zudo-doc-v2/src/content/content-code.tsx
+++ b/packages/zudo-doc-v2/src/content/content-code.tsx
@@ -1,0 +1,127 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import type { ComponentChildren } from "preact";
+import { SmartBreak as SmartBreakImpl } from "../toc/smart-break.js";
+
+// Preact VNode vs ComponentChildren type mismatch under compat mode; cast so the
+// content override type-checks. Runtime is fine since @astrojs/preact compat is on.
+const SmartBreak = SmartBreakImpl as unknown as (props: {
+  children?: unknown;
+}) => any;
+
+type Props = {
+  children?: ComponentChildren;
+  className?: string;
+  [key: string]: any;
+};
+
+/**
+ * Override for inline `<code>` in MDX. Wraps text-only inline code with
+ * <SmartBreak> so that path/URL-like strings (e.g. `src/foo/bar.ts`) can
+ * break at delimiters on narrow viewports.
+ *
+ * Block code inside a fenced block is processed by Shiki, which emits a
+ * <code> element with class "language-*" containing a tree of <span>
+ * nodes (not a plain string). We detect those and render untouched so
+ * syntax highlighting is never disturbed.
+ *
+ * Astro 6 passes pure-text MDX children wrapped in a `StaticHtml` Preact
+ * component whose text lives in `props.value`, not as a string child.
+ * `extractText` unwraps that so the heuristic works regardless of MDX's
+ * internal wrapping.
+ */
+export function ContentCode({ children, className, ...rest }: Props) {
+  const isShikiBlock =
+    typeof className === "string" && /(^|\s)language-/.test(className);
+
+  const textFromChildren = isShikiBlock ? null : extractText(children);
+
+  if (textFromChildren === null) {
+    return (
+      <code className={className} {...rest}>
+        {children}
+      </code>
+    );
+  }
+
+  return (
+    <code className={className} {...rest}>
+      <SmartBreak>{textFromChildren}</SmartBreak>
+    </code>
+  );
+}
+
+/**
+ * Walk a React/Preact children value and return a concatenated plain
+ * string when the entire subtree is text-only. Returns null if any
+ * non-text node (other than the StaticHtml wrapper Astro uses for pure
+ * text MDX content) is found — that signals inline markup inside the
+ * code span and means we must not inject <wbr>.
+ */
+function extractText(children: unknown): string | null {
+  if (typeof children === "string") return children;
+  if (typeof children === "number") return String(children);
+  // Only accept a single VNode whose `props.value` is text (the Astro
+  // StaticHtml wrapper used for pure-text MDX children). Deliberately do
+  // NOT recurse into arbitrary VNode trees — that would match Shiki's
+  // <span>-based block code output and inject <wbr> into syntax-highlighted
+  // tokens, breaking block code rendering.
+  if (children && typeof children === "object" && !Array.isArray(children)) {
+    const v = children as { props?: { value?: unknown } };
+    if (v.props && v.props.value != null) {
+      if (
+        typeof v.props.value === "string" ||
+        v.props.value instanceof String ||
+        (typeof v.props.value === "object" &&
+          typeof (v.props.value as object).toString === "function")
+      ) {
+        const s = String(v.props.value);
+        if (!s || s.startsWith("[object")) return null;
+        // Shiki block-code output also arrives as a StaticHtml wrapper, but
+        // its value is escaped HTML (e.g. "&lt;span class=...&gt;"). Inline
+        // code's value is the plain text of the backtick span (no HTML
+        // markup). If the value looks like HTML, refuse to unwrap — the
+        // block path below falls through to a plain <code> passthrough.
+        if (looksLikeHtmlMarkup(s)) return null;
+        return decodeEntities(s);
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Detect whether a string is the HTML-escaped rendering of a Shiki block
+ * (with nested <span> tokens) rather than the plain text of an inline
+ * `<code>` span. The presence of an escaped HTML-tag opener (`&lt;span`,
+ * `&lt;code`, etc.) is a reliable signal; plain URL/path inline code
+ * never contains those escaped sequences.
+ */
+function looksLikeHtmlMarkup(s: string): boolean {
+  return (
+    /&lt;(span|code|pre|div|br|i|b|em|strong)\b/i.test(s) ||
+    /<(span|code|pre)\s/i.test(s)
+  );
+}
+
+/**
+ * Minimal HTML entity decoder for the set MDX produces for inline text
+ * (`&amp;`, `&lt;`, `&gt;`, `&quot;`, `&#39;`, numeric). Keeps the
+ * result visually identical to the authored source so downstream
+ * SmartBreak operates on the original characters.
+ */
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#x27;/gi, "'")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, n) =>
+      String.fromCodePoint(parseInt(n, 16))
+    )
+    .replace(/&amp;/g, "&");
+}

--- a/packages/zudo-doc-v2/src/content/content-link.tsx
+++ b/packages/zudo-doc-v2/src/content/content-link.tsx
@@ -1,0 +1,90 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import type { ComponentChildren } from "preact";
+import { SmartBreak as SmartBreakBase } from "../toc/smart-break.js";
+
+// SmartBreak is defined with Preact's VNode return type, but content
+// components type children as ComponentChildren. Cast to a Preact-compatible
+// signature; at runtime Preact compat unifies the two.
+const SmartBreak = SmartBreakBase as unknown as (props: {
+  children?: ComponentChildren;
+}) => any;
+
+type Props = {
+  href?: string;
+  className?: string;
+  children?: ComponentChildren;
+  [key: string]: any;
+};
+
+export function ContentLink({ href, className, children, ...rest }: Props) {
+  // Block links and hash-links (heading anchors) should render without content link styling
+  const classes = className ? className.split(" ") : [];
+  if (classes.includes("block") || classes.includes("hash-link")) {
+    return (
+      <a href={href} className={className} {...rest}>
+        {children}
+      </a>
+    );
+  }
+
+  // Astro 6 wraps pure-text MDX children in a `StaticHtml` Preact component
+  // whose text lives in `props.value`, not as a direct string child. Unwrap
+  // when possible so path-like text gets smart-break treatment.
+  const textFromChildren = extractText(children);
+  const content =
+    textFromChildren !== null ? (
+      <SmartBreak>{textFromChildren}</SmartBreak>
+    ) : (
+      children
+    );
+
+  return (
+    <a
+      href={href}
+      className={`text-accent underline hover:text-accent-hover${className ? ` ${className}` : ""}`}
+      {...rest}
+    >
+      {content}
+    </a>
+  );
+}
+
+function extractText(children: unknown): string | null {
+  if (typeof children === "string") return children;
+  if (typeof children === "number") return String(children);
+  // Only accept a single StaticHtml-like VNode (Astro's wrapper for pure-text
+  // MDX children). Arrays or VNodes with inline markup indicate mixed content
+  // that must not be flattened through SmartBreak.
+  if (children && typeof children === "object" && !Array.isArray(children)) {
+    const v = children as { props?: { value?: unknown } };
+    if (v.props && v.props.value != null) {
+      if (
+        typeof v.props.value === "string" ||
+        v.props.value instanceof String ||
+        (typeof v.props.value === "object" &&
+          typeof (v.props.value as object).toString === "function")
+      ) {
+        const s = String(v.props.value);
+        if (s && !s.startsWith("[object")) return decodeEntities(s);
+      }
+    }
+  }
+  return null;
+}
+
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#x27;/gi, "'")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, n) =>
+      String.fromCodePoint(parseInt(n, 16))
+    )
+    .replace(/&amp;/g, "&");
+}

--- a/packages/zudo-doc-v2/src/content/content-ol.tsx
+++ b/packages/zudo-doc-v2/src/content/content-ol.tsx
@@ -1,0 +1,24 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import type { ComponentChildren } from "preact";
+
+type Props = {
+  children?: ComponentChildren;
+  className?: string;
+  [key: string]: any;
+};
+
+// 2em indent: enough room for 2-digit markers like "66." (#244)
+// Inline style — Tailwind v4 does not generate arbitrary values from these TSX files
+export function ContentOl({ children, className, ...rest }: Props) {
+  return (
+    <ol
+      {...rest}
+      className={className || undefined}
+      style={{ paddingLeft: "2em", listStyleType: "decimal" }}
+    >
+      {children}
+    </ol>
+  );
+}

--- a/packages/zudo-doc-v2/src/content/content-paragraph.tsx
+++ b/packages/zudo-doc-v2/src/content/content-paragraph.tsx
@@ -1,0 +1,15 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import type { ComponentChildren } from "preact";
+
+type Props = {
+  children?: ComponentChildren;
+  [key: string]: any;
+};
+
+// Passthrough: no custom styles needed for <p> (inherits from .zd-content base).
+// Override claimed to enable future Tailwind utilities without CSS cascade conflicts.
+export function ContentParagraph({ children, ...rest }: Props) {
+  return <p {...rest}>{children}</p>;
+}

--- a/packages/zudo-doc-v2/src/content/content-strong.tsx
+++ b/packages/zudo-doc-v2/src/content/content-strong.tsx
@@ -1,0 +1,21 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import type { ComponentChildren } from "preact";
+
+type Props = {
+  children?: ComponentChildren;
+  className?: string;
+  [key: string]: any;
+};
+
+export function ContentStrong({ children, className, ...rest }: Props) {
+  return (
+    <strong
+      className={`font-bold text-fg${className ? ` ${className}` : ""}`}
+      {...rest}
+    >
+      {children}
+    </strong>
+  );
+}

--- a/packages/zudo-doc-v2/src/content/content-table.tsx
+++ b/packages/zudo-doc-v2/src/content/content-table.tsx
@@ -1,0 +1,23 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import type { ComponentChildren } from "preact";
+
+type Props = {
+  children?: ComponentChildren;
+  className?: string;
+  [key: string]: any;
+};
+
+export function ContentTable({ children, className, ...rest }: Props) {
+  return (
+    <div className="overflow-x-auto">
+      <table
+        className={`w-full border-collapse text-small${className ? ` ${className}` : ""}`}
+        {...rest}
+      >
+        {children}
+      </table>
+    </div>
+  );
+}

--- a/packages/zudo-doc-v2/src/content/content-ul.tsx
+++ b/packages/zudo-doc-v2/src/content/content-ul.tsx
@@ -1,0 +1,23 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import type { ComponentChildren } from "preact";
+
+type Props = {
+  children?: ComponentChildren;
+  className?: string;
+  [key: string]: any;
+};
+
+// 2em indent via inline style — Tailwind v4 does not generate arbitrary values from these TSX files (#244)
+export function ContentUl({ children, className, ...rest }: Props) {
+  return (
+    <ul
+      {...rest}
+      className={className || undefined}
+      style={{ paddingLeft: "2em", listStyleType: "disc" }}
+    >
+      {children}
+    </ul>
+  );
+}

--- a/packages/zudo-doc-v2/src/content/heading-h2.tsx
+++ b/packages/zudo-doc-v2/src/content/heading-h2.tsx
@@ -1,0 +1,29 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import type { ComponentChildren, JSX } from "preact";
+
+type Props = {
+  id?: string;
+  className?: string;
+  children?: ComponentChildren;
+  [key: string]: any;
+};
+
+export function HeadingH2({ id, children, className, ...rest }: Props) {
+  return (
+    <h2
+      id={id}
+      className={`text-subheading font-bold leading-tight pt-vsp-sm border-t-[3px] border-transparent${className ? ` ${className}` : ""}`}
+      style={
+        {
+          borderImage:
+            "linear-gradient(to right, var(--color-fg), transparent) 1",
+        } as JSX.CSSProperties
+      }
+      {...rest}
+    >
+      {children}
+    </h2>
+  );
+}

--- a/packages/zudo-doc-v2/src/content/heading-h3.tsx
+++ b/packages/zudo-doc-v2/src/content/heading-h3.tsx
@@ -1,0 +1,29 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import type { ComponentChildren, JSX } from "preact";
+
+type Props = {
+  id?: string;
+  className?: string;
+  children?: ComponentChildren;
+  [key: string]: any;
+};
+
+export function HeadingH3({ id, children, className, ...rest }: Props) {
+  return (
+    <h3
+      id={id}
+      className={`text-body font-bold leading-snug pt-vsp-xs border-t-[2px] border-transparent${className ? ` ${className}` : ""}`}
+      style={
+        {
+          borderImage:
+            "linear-gradient(to right, var(--color-muted), transparent) 1",
+        } as JSX.CSSProperties
+      }
+      {...rest}
+    >
+      {children}
+    </h3>
+  );
+}

--- a/packages/zudo-doc-v2/src/content/heading-h4.tsx
+++ b/packages/zudo-doc-v2/src/content/heading-h4.tsx
@@ -1,0 +1,29 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import type { ComponentChildren, JSX } from "preact";
+
+type Props = {
+  id?: string;
+  className?: string;
+  children?: ComponentChildren;
+  [key: string]: any;
+};
+
+export function HeadingH4({ id, children, className, ...rest }: Props) {
+  return (
+    <h4
+      id={id}
+      className={`text-body font-semibold leading-snug pt-vsp-xs border-t border-transparent${className ? ` ${className}` : ""}`}
+      style={
+        {
+          borderImage:
+            "linear-gradient(to right, var(--color-muted), transparent) 1",
+        } as JSX.CSSProperties
+      }
+      {...rest}
+    >
+      {children}
+    </h4>
+  );
+}

--- a/packages/zudo-doc-v2/src/content/index.ts
+++ b/packages/zudo-doc-v2/src/content/index.ts
@@ -1,0 +1,33 @@
+/**
+ * Public entry for `@zudo-doc/zudo-doc-v2/content`.
+ *
+ * Exports the 11 MDX typography override components and the pre-assembled
+ * component map. Consumers compose the map at the Astro page layer:
+ *
+ *   import { defaultComponents } from "@zudo-doc/zudo-doc-v2/content";
+ *
+ *   const components = {
+ *     ...defaultComponents,
+ *     Note,
+ *     Tip,
+ *     // ... admonitions, shortcodes, etc.
+ *   };
+ *
+ *   <Content components={components} />
+ */
+
+// Components
+export { HeadingH2 } from "./heading-h2.js";
+export { HeadingH3 } from "./heading-h3.js";
+export { HeadingH4 } from "./heading-h4.js";
+export { ContentParagraph } from "./content-paragraph.js";
+export { ContentLink } from "./content-link.js";
+export { ContentStrong } from "./content-strong.js";
+export { ContentBlockquote } from "./content-blockquote.js";
+export { ContentUl } from "./content-ul.js";
+export { ContentOl } from "./content-ol.js";
+export { ContentTable } from "./content-table.js";
+export { ContentCode } from "./content-code.js";
+
+// Component map
+export { htmlOverrides, defaultComponents } from "./component-map.js";

--- a/packages/zudo-doc-v2/src/details/__tests__/details.test.tsx
+++ b/packages/zudo-doc-v2/src/details/__tests__/details.test.tsx
@@ -1,0 +1,95 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { describe, expect, it } from "vitest";
+import type { ComponentChildren, VNode } from "preact";
+import { Details } from "../details";
+
+// ---------------------------------------------------------------------------
+// Minimal VNode serialiser (copied from breadcrumb tests).
+// ---------------------------------------------------------------------------
+type AnyVNode = VNode<{ children?: ComponentChildren; [key: string]: unknown }>;
+
+function isVNode(v: unknown): v is AnyVNode {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    Object.prototype.hasOwnProperty.call(v, "type") &&
+    Object.prototype.hasOwnProperty.call(v, "props")
+  );
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/"/g, "&quot;");
+}
+
+function serialize(node: ComponentChildren): string {
+  if (node == null || typeof node === "boolean") return "";
+  if (typeof node === "string") return node;
+  if (typeof node === "number" || typeof node === "bigint") return String(node);
+  if (Array.isArray(node)) return node.map(serialize).join("");
+  if (!isVNode(node)) return "";
+  const { type, props } = node;
+  const { children, ...rest } = (props ?? {}) as {
+    children?: ComponentChildren;
+    [key: string]: unknown;
+  };
+  if (typeof type === "function") {
+    const fn = type as (p: typeof props) => ComponentChildren;
+    return serialize(fn(props));
+  }
+  if (type == null || (typeof type === "string" && type === "")) {
+    return serialize(children);
+  }
+  if (typeof type !== "string") return serialize(children);
+  const attrs = Object.entries(rest)
+    .filter(([, v]) => v !== undefined && v !== null && v !== false)
+    .map(([k, v]) => {
+      if (k === "key") return "";
+      if (v === true) return ` ${k}`;
+      return ` ${k}="${escapeAttr(String(v))}"`;
+    })
+    .join("");
+  const voidEls = new Set(["br", "hr", "img", "input", "wbr", "meta", "link"]);
+  if (voidEls.has(type)) return `<${type}${attrs}/>`;
+  return `<${type}${attrs}>${serialize(children)}</${type}>`;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Details", () => {
+  it("renders a <details> element", () => {
+    const html = serialize(<Details />);
+    expect(html).toMatch(/<details[^>]*>/);
+    expect(html).toContain("</details>");
+  });
+
+  it("renders a <summary> with the default title", () => {
+    const html = serialize(<Details />);
+    expect(html).toContain("<summary");
+    expect(html).toContain("Details");
+  });
+
+  it("renders a custom title in <summary>", () => {
+    const html = serialize(<Details title="Show more" />);
+    expect(html).toContain("Show more");
+  });
+
+  it("renders children inside the content div", () => {
+    const html = serialize(<Details title="Info">Hello world</Details>);
+    expect(html).toContain("Hello world");
+  });
+
+  it("applies the zd-content class to the inner div", () => {
+    const html = serialize(<Details />);
+    expect(html).toContain("zd-content");
+  });
+
+  it("applies border and rounded classes to <details>", () => {
+    const html = serialize(<Details />);
+    expect(html).toContain("border");
+    expect(html).toContain("rounded-lg");
+  });
+});

--- a/packages/zudo-doc-v2/src/details/details.tsx
+++ b/packages/zudo-doc-v2/src/details/details.tsx
@@ -1,0 +1,34 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import type { ComponentChildren, VNode } from "preact";
+
+export interface DetailsProps {
+  /**
+   * Summary / toggle label shown in the `<summary>` element.
+   * Defaults to `"Details"` — the same fallback used by the legacy
+   * `src/components/details.astro`.
+   */
+  title?: string;
+  /** Slot content rendered inside the collapsed body. */
+  children?: ComponentChildren;
+}
+
+/**
+ * Collapsible `<details>` / `<summary>` block — JSX port of
+ * `src/components/details.astro`.
+ *
+ * Keeps layout and token classes identical to the original template.
+ * The legacy component used Astro's `<slot />`; v2 accepts standard
+ * Preact `children`.
+ */
+export function Details({ title = "Details", children }: DetailsProps): VNode {
+  return (
+    <details class="my-vsp-md border border-muted rounded-lg overflow-hidden">
+      <summary class="cursor-pointer px-hsp-lg py-vsp-sm bg-surface font-medium text-fg select-none hover:text-accent">
+        {title}
+      </summary>
+      <div class="px-hsp-lg py-vsp-sm zd-content">{children}</div>
+    </details>
+  );
+}

--- a/packages/zudo-doc-v2/src/details/index.ts
+++ b/packages/zudo-doc-v2/src/details/index.ts
@@ -1,0 +1,4 @@
+// Barrel for the details topic — JSX port of
+// `src/components/details.astro`.
+export { Details } from "./details.js";
+export type { DetailsProps } from "./details.js";

--- a/packages/zudo-doc-v2/src/html-preview-wrapper/dedent.ts
+++ b/packages/zudo-doc-v2/src/html-preview-wrapper/dedent.ts
@@ -1,0 +1,27 @@
+/**
+ * Strip common leading whitespace from all lines of a template literal string.
+ * Similar to Python's textwrap.dedent().
+ *
+ * Copied from src/utils/dedent.ts so the v2 package has no upward dependency
+ * on the host project's source.
+ */
+export function dedent(text: string): string {
+  const lines = text.split("\n");
+
+  // Find minimum indentation (ignoring empty/whitespace-only lines)
+  let minIndent = Infinity;
+  for (const line of lines) {
+    if (line.trim().length === 0) continue;
+    const indent = line.match(/^(\s*)/)?.[1].length ?? 0;
+    if (indent < minIndent) minIndent = indent;
+  }
+
+  if (minIndent === 0 || minIndent === Infinity) {
+    return text.trim();
+  }
+
+  return lines
+    .map((line) => (line.trim().length === 0 ? "" : line.slice(minIndent)))
+    .join("\n")
+    .trim();
+}

--- a/packages/zudo-doc-v2/src/html-preview-wrapper/highlighted-code.tsx
+++ b/packages/zudo-doc-v2/src/html-preview-wrapper/highlighted-code.tsx
@@ -1,0 +1,91 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { useEffect, useState } from "preact/hooks";
+import type { VNode } from "preact";
+
+/**
+ * Lazily-loaded Shiki highlighter singleton. The dynamic import is
+ * intentional: Shiki is a large library that should not inflate the
+ * initial JS bundle. The promise is cached so subsequent calls reuse
+ * the same highlighter instance.
+ *
+ * Ported from src/components/html-preview/highlighted-code.tsx with
+ * React → Preact hook imports.
+ */
+let highlighterPromise: Promise<import("shiki").HighlighterCore> | null = null;
+
+function getHighlighter(): Promise<import("shiki").HighlighterCore> {
+  if (!highlighterPromise) {
+    highlighterPromise = import("shiki")
+      .then(({ createHighlighter }) =>
+        createHighlighter({
+          themes: ["catppuccin-latte", "vitesse-dark"],
+          langs: ["html", "css", "javascript"],
+        }),
+      )
+      .catch((err) => {
+        // Clear cached rejection so next call retries
+        highlighterPromise = null;
+        throw err;
+      });
+  }
+  return highlighterPromise;
+}
+
+export interface HighlightedCodeProps {
+  code: string;
+  language: string;
+}
+
+/**
+ * Syntax-highlighted code block backed by Shiki. Falls back to a
+ * plain `<pre><code>` block while Shiki is loading or if it fails.
+ *
+ * JSX port of src/components/html-preview/highlighted-code.tsx.
+ */
+export function HighlightedCode({
+  code,
+  language,
+}: HighlightedCodeProps): VNode {
+  const [html, setHtml] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getHighlighter()
+      .then((highlighter) => {
+        if (cancelled) return;
+        const lang = highlighter.getLoadedLanguages().includes(language)
+          ? language
+          : "text";
+        const result = highlighter.codeToHtml(code, {
+          lang,
+          themes: { light: "catppuccin-latte", dark: "vitesse-dark" },
+          defaultColor: false,
+        });
+        setHtml(result);
+      })
+      .catch(() => {
+        // Shiki failed to load — keep showing the plain-text fallback
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [code, language]);
+
+  if (!html) {
+    return (
+      <pre class="m-0 p-hsp-md bg-code-bg text-caption leading-relaxed overflow-x-auto">
+        <code class="font-mono whitespace-pre">{code}</code>
+      </pre>
+    );
+  }
+
+  return (
+    <div
+      class="zd-html-preview-code"
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}

--- a/packages/zudo-doc-v2/src/html-preview-wrapper/html-preview-wrapper.tsx
+++ b/packages/zudo-doc-v2/src/html-preview-wrapper/html-preview-wrapper.tsx
@@ -1,0 +1,91 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import type { VNode } from "preact";
+import { HtmlPreview } from "./html-preview.js";
+
+/**
+ * Global HTML preview configuration. Mirrors the `settings.htmlPreview`
+ * shape from the host project so callers can pass the resolved config
+ * object directly.
+ */
+export interface HtmlPreviewGlobalConfig {
+  /** CSS appended to every preview iframe (e.g. global component library styles). */
+  css?: string;
+  /** HTML injected into the `<head>` of every preview iframe. */
+  head?: string;
+  /** JavaScript appended to every preview iframe's `<body>`. */
+  js?: string;
+}
+
+export interface HtmlPreviewWrapperProps {
+  /**
+   * Site-wide HTML preview configuration (resolved from
+   * `settings.htmlPreview` by the caller). When provided, its
+   * `head`, `css`, and `js` are prepended to the per-usage values so
+   * that global styles/scripts apply to every preview.
+   *
+   * The legacy `html-preview-wrapper.astro` read this directly from
+   * `settings`; v2 accepts it as a prop so the component has no
+   * upward dependency on the project settings module.
+   */
+  globalConfig?: HtmlPreviewGlobalConfig | null;
+
+  /** HTML body content to display in the iframe. */
+  html: string;
+  /** Per-usage CSS injected after the global CSS. */
+  css?: string;
+  /** Per-usage `<head>` content injected after the global head. */
+  head?: string;
+  /** Per-usage JavaScript injected after the global JS. */
+  js?: string;
+
+  /** Optional title displayed in the preview title bar. */
+  title?: string;
+  /** Fixed iframe height in pixels. Auto-sizes when omitted. */
+  height?: number;
+  /** When true, the code section is expanded by default. */
+  defaultOpen?: boolean;
+}
+
+/**
+ * HTML preview wrapper — JSX port of
+ * `src/components/html-preview-wrapper.astro`.
+ *
+ * The legacy Astro wrapper merged `settings.htmlPreview` (global config)
+ * with per-usage props and forwarded everything to `<HtmlPreview
+ * client:visible />`. v2 collapses the merge into this component and
+ * renders `HtmlPreview` directly.
+ *
+ * This component requires client-side JS (iframe lifecycle). Mount it
+ * with `client:visible` in Astro, or wrap it in an SSR-skip placeholder
+ * for non-Astro consumers.
+ */
+export function HtmlPreviewWrapper(
+  props: HtmlPreviewWrapperProps,
+): VNode {
+  const { globalConfig, html, css, head, js, title, height, defaultOpen } =
+    props;
+
+  const mergedHead =
+    [globalConfig?.head, head].filter(Boolean).join("\n") || undefined;
+  const mergedCss =
+    [globalConfig?.css, css].filter(Boolean).join("\n") || undefined;
+  const mergedJs =
+    [globalConfig?.js, js].filter(Boolean).join("\n") || undefined;
+
+  return (
+    <HtmlPreview
+      html={html}
+      css={mergedCss}
+      head={mergedHead}
+      js={mergedJs}
+      title={title}
+      height={height}
+      defaultOpen={defaultOpen}
+      componentCss={css}
+      componentHead={head}
+      componentJs={js}
+    />
+  );
+}

--- a/packages/zudo-doc-v2/src/html-preview-wrapper/html-preview.tsx
+++ b/packages/zudo-doc-v2/src/html-preview-wrapper/html-preview.tsx
@@ -1,0 +1,120 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { useMemo } from "preact/hooks";
+import type { VNode } from "preact";
+import { PreviewBase } from "./preview-base.js";
+import { dedent } from "./dedent.js";
+import { preflightCss } from "./preflight.js";
+
+export interface HtmlPreviewProps {
+  html: string;
+  css?: string;
+  head?: string;
+  js?: string;
+  title?: string;
+  height?: number;
+  defaultOpen?: boolean;
+  /** Per-component css for code block display (before global merge) */
+  componentCss?: string;
+  /** Per-component head for code block display (before global merge) */
+  componentHead?: string;
+  /** Per-component js for code block display (before global merge) */
+  componentJs?: string;
+}
+
+function containsScript(head?: string, js?: string): boolean {
+  if (js) return true;
+  if (head && /<script/i.test(head)) return true;
+  return false;
+}
+
+function buildSrcdoc(
+  html: string,
+  css?: string,
+  head?: string,
+  js?: string,
+): string {
+  return `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>${preflightCss}</style>
+${head ?? ""}
+${css ? `<style>${css}</style>` : ""}
+</head>
+<body>${html}
+${js ? `<script>${js}</script>` : ""}
+</body>
+</html>`;
+}
+
+/**
+ * HTML preview widget — renders an isolated iframe with viewport
+ * controls and a collapsible code section.
+ *
+ * JSX port of src/components/html-preview/html-preview.tsx with
+ * React → Preact hook imports.
+ *
+ * Requires client-side JS (iframe load events, height sync, code
+ * toggle). Mount as an island via `<HtmlPreview client:visible />` in
+ * Astro, or wire up the SSR-skip placeholder pattern for non-Astro
+ * consumers.
+ */
+export function HtmlPreview({
+  html,
+  css,
+  head,
+  js,
+  title,
+  height,
+  defaultOpen,
+  componentCss,
+  componentHead,
+  componentJs,
+}: HtmlPreviewProps): VNode {
+  const srcdoc = useMemo(
+    () => buildSrcdoc(html, css, head, js),
+    [html, css, head, js],
+  );
+  const hasScripts = containsScript(head, js);
+  const syncDelay = hasScripts ? 300 : 0;
+  // allow-same-origin is needed alongside allow-scripts so that syncHeight
+  // can access iframe.contentDocument for auto-height measurement
+  const sandboxValue = hasScripts ? "allow-scripts allow-same-origin" : "";
+
+  const codeBlocks = useMemo(
+    () => [
+      { language: "html", title: "HTML", code: dedent(html) },
+      ...(componentCss
+        ? [{ language: "css", title: "CSS", code: dedent(componentCss) }]
+        : []),
+      ...(componentHead
+        ? [{ language: "html", title: "Head", code: dedent(componentHead) }]
+        : []),
+      ...(componentJs
+        ? [
+            {
+              language: "javascript",
+              title: "JS",
+              code: dedent(componentJs),
+            },
+          ]
+        : []),
+    ],
+    [html, componentCss, componentHead, componentJs],
+  );
+
+  return (
+    <PreviewBase
+      title={title}
+      height={height}
+      srcdoc={srcdoc}
+      defaultOpen={defaultOpen}
+      sandbox={sandboxValue}
+      syncDelay={syncDelay}
+      codeBlocks={codeBlocks}
+    />
+  );
+}

--- a/packages/zudo-doc-v2/src/html-preview-wrapper/index.ts
+++ b/packages/zudo-doc-v2/src/html-preview-wrapper/index.ts
@@ -1,0 +1,19 @@
+// Barrel for the html-preview-wrapper topic — JSX port of
+// `src/components/html-preview-wrapper.astro` and the full
+// `src/components/html-preview/` stack.
+export {
+  HtmlPreviewWrapper,
+} from "./html-preview-wrapper.js";
+export type {
+  HtmlPreviewWrapperProps,
+  HtmlPreviewGlobalConfig,
+} from "./html-preview-wrapper.js";
+
+export { HtmlPreview } from "./html-preview.js";
+export type { HtmlPreviewProps } from "./html-preview.js";
+
+export { PreviewBase } from "./preview-base.js";
+export type { PreviewBaseProps, CodeBlockData } from "./preview-base.js";
+
+export { HighlightedCode } from "./highlighted-code.js";
+export type { HighlightedCodeProps } from "./highlighted-code.js";

--- a/packages/zudo-doc-v2/src/html-preview-wrapper/preflight.ts
+++ b/packages/zudo-doc-v2/src/html-preview-wrapper/preflight.ts
@@ -1,0 +1,115 @@
+/**
+ * Tailwind CSS v4 preflight (modern-normalize/reset).
+ * Source: https://unpkg.com/tailwindcss@4/preflight.css
+ *
+ * The --theme() references are replaced with standard fallback values
+ * so the reset works standalone inside an iframe.
+ *
+ * Copied verbatim from src/components/html-preview/preflight.ts so the
+ * v2 package has no upward dependency on the host project's source.
+ */
+export const preflightCss = `
+*,
+::after,
+::before,
+::backdrop,
+::file-selector-button {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  border: 0 solid;
+}
+
+html,
+:host {
+  line-height: 1.5;
+  -webkit-text-size-adjust: 100%;
+  tab-size: 4;
+  font-family: ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  -webkit-tap-highlight-color: transparent;
+}
+
+hr {
+  height: 0;
+  color: inherit;
+  border-top-width: 1px;
+}
+
+abbr:where([title]) {
+  -webkit-text-decoration: underline dotted;
+  text-decoration: underline dotted;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+a {
+  color: inherit;
+  -webkit-text-decoration: inherit;
+  text-decoration: inherit;
+}
+
+b, strong {
+  font-weight: bolder;
+}
+
+code, kbd, samp, pre {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 1em;
+}
+
+small {
+  font-size: 80%;
+}
+
+sub, sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub { bottom: -0.25em; }
+sup { top: -0.5em; }
+
+table {
+  text-indent: 0;
+  border-color: inherit;
+  border-collapse: collapse;
+}
+
+ol, ul, menu {
+  list-style: none;
+}
+
+img, svg, video, canvas, audio, iframe, embed, object {
+  display: block;
+  vertical-align: middle;
+}
+
+img, video {
+  max-width: 100%;
+  height: auto;
+}
+
+button, input, select, optgroup, textarea, ::file-selector-button {
+  font: inherit;
+  font-feature-settings: inherit;
+  font-variation-settings: inherit;
+  letter-spacing: inherit;
+  color: inherit;
+  border-radius: 0;
+  background-color: transparent;
+  opacity: 1;
+}
+
+textarea {
+  resize: vertical;
+}
+
+[hidden]:where(:not([hidden='until-found'])) {
+  display: none !important;
+}
+`;

--- a/packages/zudo-doc-v2/src/html-preview-wrapper/preview-base.tsx
+++ b/packages/zudo-doc-v2/src/html-preview-wrapper/preview-base.tsx
@@ -1,0 +1,172 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { useCallback, useEffect, useRef, useState } from "preact/hooks";
+import type { VNode } from "preact";
+import { HighlightedCode } from "./highlighted-code.js";
+
+export interface CodeBlockData {
+  language: string;
+  title: string;
+  code: string;
+}
+
+export interface PreviewBaseProps {
+  title?: string;
+  height?: number;
+  srcdoc: string;
+  sandbox?: string;
+  syncDelay: number;
+  codeBlocks: CodeBlockData[];
+  defaultOpen?: boolean;
+}
+
+type Viewport = { label: string; width: string };
+
+const VIEWPORTS: Viewport[] = [
+  { label: "Mobile", width: "320px" },
+  { label: "Tablet", width: "768px" },
+  { label: "Full", width: "100%" },
+];
+
+/**
+ * Interactive preview base: iframe viewport switcher + collapsible code
+ * section.
+ *
+ * JSX port of src/components/html-preview/preview-base.tsx with
+ * React → Preact hook imports and `className` → `class` attribute.
+ */
+export function PreviewBase({
+  title,
+  height,
+  srcdoc,
+  sandbox,
+  syncDelay,
+  codeBlocks,
+  defaultOpen,
+}: PreviewBaseProps): VNode {
+  const [activeViewport, setActiveViewport] = useState(2); // default: Full
+  const [codeOpen, setCodeOpen] = useState(defaultOpen ?? false);
+  const [iframeHeight, setIframeHeight] = useState(height ?? 200);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  const syncHeight = useCallback(() => {
+    const iframe = iframeRef.current;
+    if (!iframe || height != null) return;
+    try {
+      const doc = iframe.contentDocument;
+      if (doc?.body) {
+        const h = doc.body.scrollHeight;
+        if (h > 0) setIframeHeight(Math.max(h + 16, 200));
+      }
+    } catch {
+      // cross-origin or not yet loaded — ignore
+    }
+  }, [height]);
+
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe) return;
+    let timeoutId: ReturnType<typeof setTimeout>;
+    const onLoad = () => {
+      if (syncDelay > 0) {
+        timeoutId = setTimeout(syncHeight, syncDelay);
+      } else {
+        syncHeight();
+      }
+    };
+    iframe.addEventListener("load", onLoad);
+    return () => {
+      iframe.removeEventListener("load", onLoad);
+      clearTimeout(timeoutId);
+    };
+  }, [syncHeight, srcdoc, syncDelay]);
+
+  // Re-measure height when viewport changes (content reflows)
+  useEffect(() => {
+    if (height != null) return;
+    const id = setTimeout(syncHeight, 150);
+    return () => clearTimeout(id);
+  }, [activeViewport, syncHeight, height]);
+
+  const containerWidth = VIEWPORTS[activeViewport].width;
+
+  return (
+    <div class="border border-muted rounded-lg overflow-hidden my-vsp-md">
+      {/* Title bar with viewport buttons */}
+      <div class="flex items-center justify-between px-hsp-md py-hsp-sm bg-surface border-b border-muted gap-hsp-sm flex-wrap">
+        {title && (
+          <span class="text-caption font-semibold text-fg">{title}</span>
+        )}
+        <div class="flex gap-hsp-2xs" role="group" aria-label="Viewport size">
+          {VIEWPORTS.map((vp, i) => (
+            <button
+              key={vp.label}
+              type="button"
+              class={`px-hsp-sm py-hsp-2xs text-caption border rounded-full cursor-pointer transition-[background,color,border-color] duration-150 leading-snug ${
+                i === activeViewport
+                  ? "bg-accent text-bg border-accent hover:bg-accent-hover hover:border-accent-hover"
+                  : "bg-transparent text-muted border-muted hover:bg-[color-mix(in_srgb,var(--color-surface)_80%,var(--color-fg)_20%)]"
+              }`}
+              aria-pressed={i === activeViewport}
+              onClick={() => setActiveViewport(i)}
+            >
+              {vp.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Preview area */}
+      <div class="bg-surface p-hsp-lg">
+        <div
+          class="resize-x overflow-auto max-w-full mx-auto"
+          style={{ width: containerWidth }}
+        >
+          {/* Intentional: white canvas regardless of site theme — matches standard browser context */}
+          <iframe
+            ref={iframeRef}
+            class="block w-full border-none bg-[#fff] rounded shadow-[0_1px_3px_color-mix(in_srgb,var(--color-fg)_8%,transparent)]"
+            srcDoc={srcdoc}
+            sandbox={sandbox}
+            style={{ height: iframeHeight }}
+            title={title ?? "Preview"}
+          />
+        </div>
+      </div>
+
+      {/* Code section */}
+      <div class="border-t border-muted">
+        <button
+          type="button"
+          class="flex items-center w-full px-hsp-md py-hsp-sm text-caption font-medium text-muted bg-surface border-none cursor-pointer gap-hsp-xs hover:bg-[color-mix(in_srgb,var(--color-surface)_80%,var(--color-fg)_20%)]"
+          onClick={() => setCodeOpen((v) => !v)}
+          aria-expanded={codeOpen}
+        >
+          <span
+            class={`text-caption transition-transform duration-200 ${codeOpen ? "rotate-90" : ""}`}
+            aria-hidden="true"
+          >
+            &#9654;
+          </span>
+          {codeOpen ? "Hide code" : "Show code"}
+        </button>
+        {codeOpen && (
+          <div>
+            {codeBlocks.map((block, idx) => (
+              <div
+                key={block.title}
+                class={`overflow-x-auto ${idx > 0 ? "border-t border-muted" : ""}`}
+              >
+                <span class="block px-hsp-md py-hsp-xs text-caption font-semibold text-muted bg-surface border-b border-muted uppercase tracking-wider">
+                  {block.title}
+                </span>
+                <HighlightedCode code={block.code} language={block.language} />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/zudo-doc-v2/src/metainfo/__tests__/doc-metainfo.test.tsx
+++ b/packages/zudo-doc-v2/src/metainfo/__tests__/doc-metainfo.test.tsx
@@ -1,0 +1,124 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { describe, expect, it } from "vitest";
+import type { ComponentChildren, VNode } from "preact";
+import { DocMetainfo } from "../doc-metainfo";
+
+// ---------------------------------------------------------------------------
+// Minimal VNode serialiser (shared pattern across v2 tests).
+// ---------------------------------------------------------------------------
+type AnyVNode = VNode<{ children?: ComponentChildren; [key: string]: unknown }>;
+
+function isVNode(v: unknown): v is AnyVNode {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    Object.prototype.hasOwnProperty.call(v, "type") &&
+    Object.prototype.hasOwnProperty.call(v, "props")
+  );
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/"/g, "&quot;");
+}
+
+function serialize(node: ComponentChildren): string {
+  if (node == null || typeof node === "boolean") return "";
+  if (typeof node === "string") return node;
+  if (typeof node === "number" || typeof node === "bigint") return String(node);
+  if (Array.isArray(node)) return node.map(serialize).join("");
+  if (!isVNode(node)) return "";
+  const { type, props } = node;
+  const { children, ...rest } = (props ?? {}) as {
+    children?: ComponentChildren;
+    [key: string]: unknown;
+  };
+  if (typeof type === "function") {
+    const fn = type as (p: typeof props) => ComponentChildren;
+    return serialize(fn(props));
+  }
+  if (type == null || (typeof type === "string" && type === "")) {
+    return serialize(children);
+  }
+  if (typeof type !== "string") return serialize(children);
+  const attrs = Object.entries(rest)
+    .filter(([, v]) => v !== undefined && v !== null && v !== false)
+    .map(([k, v]) => {
+      if (k === "key") return "";
+      if (v === true) return ` ${k}`;
+      return ` ${k}="${escapeAttr(String(v))}"`;
+    })
+    .join("");
+  const voidEls = new Set(["br", "hr", "img", "input", "wbr", "meta", "link"]);
+  if (voidEls.has(type)) return `<${type}${attrs}/>`;
+  return `<${type}${attrs}>${serialize(children)}</${type}>`;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DocMetainfo", () => {
+  it("returns null when no data is provided", () => {
+    expect(serialize(<DocMetainfo />)).toBe("");
+  });
+
+  it("returns null when only empty strings are passed", () => {
+    expect(
+      serialize(<DocMetainfo createdAt="" updatedAt="" author="" />),
+    ).toBe("");
+  });
+
+  it("renders createdAt when provided", () => {
+    const html = serialize(<DocMetainfo createdAt="Jan 1, 2024" />);
+    expect(html).toContain("Jan 1, 2024");
+  });
+
+  it("renders the default 'Created' label", () => {
+    const html = serialize(<DocMetainfo createdAt="Jan 1, 2024" />);
+    expect(html).toContain("Created");
+  });
+
+  it("renders a custom createdLabel", () => {
+    const html = serialize(
+      <DocMetainfo createdAt="Jan 1, 2024" createdLabel="作成" />,
+    );
+    expect(html).toContain("作成");
+  });
+
+  it("renders updatedAt when different from createdAt", () => {
+    const html = serialize(
+      <DocMetainfo createdAt="Jan 1, 2024" updatedAt="Feb 1, 2024" />,
+    );
+    expect(html).toContain("Feb 1, 2024");
+  });
+
+  it("suppresses updatedAt when equal to createdAt", () => {
+    const html = serialize(
+      <DocMetainfo createdAt="Jan 1, 2024" updatedAt="Jan 1, 2024" />,
+    );
+    // Should only contain the date once (as createdAt)
+    const matches = html.split("Jan 1, 2024").length - 1;
+    expect(matches).toBe(1);
+  });
+
+  it("renders author when provided", () => {
+    const html = serialize(<DocMetainfo author="Alice" />);
+    expect(html).toContain("Alice");
+  });
+
+  it("renders the clock SVG path for createdAt", () => {
+    const html = serialize(<DocMetainfo createdAt="Jan 1, 2024" />);
+    // Clock icon path
+    expect(html).toContain("M12 6v6l4 2");
+  });
+
+  it("renders the refresh SVG path for updatedAt", () => {
+    const html = serialize(
+      <DocMetainfo createdAt="Jan 1, 2024" updatedAt="Feb 1, 2024" />,
+    );
+    // Refresh icon path
+    expect(html).toContain("M4 4v5h.582");
+  });
+});

--- a/packages/zudo-doc-v2/src/metainfo/__tests__/doc-tags.test.tsx
+++ b/packages/zudo-doc-v2/src/metainfo/__tests__/doc-tags.test.tsx
@@ -1,0 +1,141 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { describe, expect, it } from "vitest";
+import type { ComponentChildren, VNode } from "preact";
+import { DocTags } from "../doc-tags";
+
+// ---------------------------------------------------------------------------
+// Minimal VNode serialiser.
+// ---------------------------------------------------------------------------
+type AnyVNode = VNode<{ children?: ComponentChildren; [key: string]: unknown }>;
+
+function isVNode(v: unknown): v is AnyVNode {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    Object.prototype.hasOwnProperty.call(v, "type") &&
+    Object.prototype.hasOwnProperty.call(v, "props")
+  );
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/"/g, "&quot;");
+}
+
+function serialize(node: ComponentChildren): string {
+  if (node == null || typeof node === "boolean") return "";
+  if (typeof node === "string") return node;
+  if (typeof node === "number" || typeof node === "bigint") return String(node);
+  if (Array.isArray(node)) return node.map(serialize).join("");
+  if (!isVNode(node)) return "";
+  const { type, props } = node;
+  const { children, ...rest } = (props ?? {}) as {
+    children?: ComponentChildren;
+    [key: string]: unknown;
+  };
+  if (typeof type === "function") {
+    const fn = type as (p: typeof props) => ComponentChildren;
+    return serialize(fn(props));
+  }
+  if (type == null || (typeof type === "string" && type === "")) {
+    return serialize(children);
+  }
+  if (typeof type !== "string") return serialize(children);
+  const attrs = Object.entries(rest)
+    .filter(([, v]) => v !== undefined && v !== null && v !== false)
+    .map(([k, v]) => {
+      if (k === "key") return "";
+      if (v === true) return ` ${k}`;
+      return ` ${k}="${escapeAttr(String(v))}"`;
+    })
+    .join("");
+  const voidEls = new Set(["br", "hr", "img", "input", "wbr", "meta", "link"]);
+  if (voidEls.has(type)) return `<${type}${attrs}/>`;
+  return `<${type}${attrs}>${serialize(children)}</${type}>`;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const sampleTags = [
+  { tag: "typescript", href: "/docs/tags/typescript" },
+  { tag: "astro", href: "/docs/tags/astro" },
+];
+
+describe("DocTags", () => {
+  it("returns null when tags is empty", () => {
+    expect(serialize(<DocTags placement="after-title" tags={[]} />)).toBe("");
+  });
+
+  it("returns null when tags is omitted", () => {
+    expect(serialize(<DocTags placement="after-title" />)).toBe("");
+  });
+
+  it("renders tag anchors for each tag", () => {
+    const html = serialize(
+      <DocTags placement="after-title" tags={sampleTags} />,
+    );
+    expect(html).toContain('href="/docs/tags/typescript"');
+    expect(html).toContain('href="/docs/tags/astro"');
+  });
+
+  it("renders tag text with # prefix", () => {
+    const html = serialize(
+      <DocTags placement="after-title" tags={sampleTags} />,
+    );
+    expect(html).toContain("#typescript");
+    expect(html).toContain("#astro");
+  });
+
+  it("includes aria-label using the default taggedWithLabel", () => {
+    const html = serialize(
+      <DocTags placement="after-title" tags={[sampleTags[0]]} />,
+    );
+    expect(html).toContain('aria-label="Tagged with: typescript"');
+  });
+
+  it("uses custom taggedWithLabel in aria-label", () => {
+    const html = serialize(
+      <DocTags
+        placement="after-title"
+        tags={[sampleTags[0]]}
+        taggedWithLabel="タグ付き"
+      />,
+    );
+    expect(html).toContain('aria-label="タグ付き: typescript"');
+  });
+
+  it("renders the default 'Tags' label", () => {
+    const html = serialize(
+      <DocTags placement="after-title" tags={sampleTags} />,
+    );
+    expect(html).toContain("Tags:");
+  });
+
+  it("renders a custom tagsLabel", () => {
+    const html = serialize(
+      <DocTags
+        placement="after-title"
+        tags={sampleTags}
+        tagsLabel="タグ"
+      />,
+    );
+    expect(html).toContain("タグ:");
+  });
+
+  it("applies mt-0 mb-vsp-md for after-title placement", () => {
+    const html = serialize(
+      <DocTags placement="after-title" tags={sampleTags} />,
+    );
+    expect(html).toContain("mt-0 mb-vsp-md");
+  });
+
+  it("applies mt-vsp-xl mb-0 for before-footer placement", () => {
+    const html = serialize(
+      <DocTags placement="before-footer" tags={sampleTags} />,
+    );
+    expect(html).toContain("mt-vsp-xl mb-0");
+  });
+});

--- a/packages/zudo-doc-v2/src/metainfo/__tests__/frontmatter-preview.test.tsx
+++ b/packages/zudo-doc-v2/src/metainfo/__tests__/frontmatter-preview.test.tsx
@@ -1,0 +1,168 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { describe, expect, it } from "vitest";
+import type { ComponentChildren, VNode } from "preact";
+import { FrontmatterPreview } from "../frontmatter-preview";
+
+// ---------------------------------------------------------------------------
+// Minimal VNode serialiser.
+// ---------------------------------------------------------------------------
+type AnyVNode = VNode<{ children?: ComponentChildren; [key: string]: unknown }>;
+
+function isVNode(v: unknown): v is AnyVNode {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    Object.prototype.hasOwnProperty.call(v, "type") &&
+    Object.prototype.hasOwnProperty.call(v, "props")
+  );
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/"/g, "&quot;");
+}
+
+function serialize(node: ComponentChildren): string {
+  if (node == null || typeof node === "boolean") return "";
+  if (typeof node === "string") return node;
+  if (typeof node === "number" || typeof node === "bigint") return String(node);
+  if (Array.isArray(node)) return node.map(serialize).join("");
+  if (!isVNode(node)) return "";
+  const { type, props } = node;
+  const { children, ...rest } = (props ?? {}) as {
+    children?: ComponentChildren;
+    [key: string]: unknown;
+  };
+  if (typeof type === "function") {
+    const fn = type as (p: typeof props) => ComponentChildren;
+    return serialize(fn(props));
+  }
+  if (type == null || (typeof type === "string" && type === "")) {
+    return serialize(children);
+  }
+  if (typeof type !== "string") return serialize(children);
+  const attrs = Object.entries(rest)
+    .filter(([, v]) => v !== undefined && v !== null && v !== false)
+    .map(([k, v]) => {
+      if (k === "key") return "";
+      if (v === true) return ` ${k}`;
+      return ` ${k}="${escapeAttr(String(v))}"`;
+    })
+    .join("");
+  const voidEls = new Set(["br", "hr", "img", "input", "wbr", "meta", "link"]);
+  if (voidEls.has(type)) return `<${type}${attrs}/>`;
+  return `<${type}${attrs}>${serialize(children)}</${type}>`;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("FrontmatterPreview", () => {
+  it("returns null when entries is empty", () => {
+    expect(serialize(<FrontmatterPreview entries={[]} />)).toBe("");
+  });
+
+  it("returns null when entries is omitted", () => {
+    expect(serialize(<FrontmatterPreview />)).toBe("");
+  });
+
+  it("renders data-testid='frontmatter-preview'", () => {
+    const html = serialize(
+      <FrontmatterPreview entries={[["title", "Hello"]]} />,
+    );
+    expect(html).toContain('data-testid="frontmatter-preview"');
+  });
+
+  it("renders the default 'Frontmatter' title", () => {
+    const html = serialize(
+      <FrontmatterPreview entries={[["title", "Hello"]]} />,
+    );
+    expect(html).toContain("Frontmatter");
+  });
+
+  it("renders a custom title", () => {
+    const html = serialize(
+      <FrontmatterPreview entries={[["title", "Hello"]]} title="メタデータ" />,
+    );
+    expect(html).toContain("メタデータ");
+  });
+
+  it("renders the default column labels", () => {
+    const html = serialize(
+      <FrontmatterPreview entries={[["title", "Hello"]]} />,
+    );
+    expect(html).toContain("Key");
+    expect(html).toContain("Value");
+  });
+
+  it("renders a custom keyColLabel", () => {
+    const html = serialize(
+      <FrontmatterPreview
+        entries={[["title", "Hello"]]}
+        keyColLabel="キー"
+      />,
+    );
+    expect(html).toContain("キー");
+  });
+
+  it("renders string values as plain text", () => {
+    const html = serialize(
+      <FrontmatterPreview entries={[["title", "My Page"]]} />,
+    );
+    expect(html).toContain("My Page");
+    expect(html).not.toContain("<code");
+  });
+
+  it("renders number values as plain text", () => {
+    const html = serialize(
+      <FrontmatterPreview entries={[["sidebar_position", 1]]} />,
+    );
+    expect(html).toContain("1");
+    expect(html).not.toContain("<code");
+  });
+
+  it("renders boolean values as plain text", () => {
+    const html = serialize(
+      <FrontmatterPreview entries={[["draft", true]]} />,
+    );
+    expect(html).toContain("true");
+    expect(html).not.toContain("<code");
+  });
+
+  it("renders string-array values as comma-joined text", () => {
+    const html = serialize(
+      <FrontmatterPreview entries={[["tags", ["a", "b", "c"]]]} />,
+    );
+    expect(html).toContain("a, b, c");
+  });
+
+  it("renders complex values in a <code> block", () => {
+    const html = serialize(
+      <FrontmatterPreview entries={[["meta", { key: "val" }]]} />,
+    );
+    expect(html).toContain("<code");
+    expect(html).toContain('{"key":"val"}');
+  });
+
+  it("renders each key in the key column", () => {
+    const html = serialize(
+      <FrontmatterPreview
+        entries={[
+          ["title", "Hello"],
+          ["description", "World"],
+        ]}
+      />,
+    );
+    expect(html).toContain("title");
+    expect(html).toContain("description");
+  });
+
+  it("renders a <table> element", () => {
+    const html = serialize(
+      <FrontmatterPreview entries={[["title", "Hello"]]} />,
+    );
+    expect(html).toMatch(/<table[^>]*>/);
+  });
+});

--- a/packages/zudo-doc-v2/src/metainfo/doc-metainfo.tsx
+++ b/packages/zudo-doc-v2/src/metainfo/doc-metainfo.tsx
@@ -1,0 +1,152 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import type { VNode } from "preact";
+
+export interface DocMetainfoProps {
+  /**
+   * Pre-formatted creation date string (e.g. `"Jan 1, 2024"`).
+   * The legacy `doc-metainfo.astro` called `formatDate(gitInfo.createdAt,
+   * locale)` inline; v2 delegates that computation to the caller.
+   * Omit (or pass `null`) to suppress the "created" row.
+   */
+  createdAt?: string | null;
+  /**
+   * Pre-formatted last-updated date string. Suppressed when equal to
+   * `createdAt` (matching the original template's guard
+   * `updatedAt !== createdAt`), or when null / omitted.
+   */
+  updatedAt?: string | null;
+  /**
+   * Git author name (or any attribution string). Omit to suppress.
+   */
+  author?: string | null;
+  /**
+   * Label for the "created" entry. Defaults to `"Created"`. Pass the
+   * i18n-resolved string (`t("doc.created", locale)`) from upstream.
+   */
+  createdLabel?: string;
+  /**
+   * Label for the "updated" entry. Defaults to `"Updated"`.
+   */
+  updatedLabel?: string;
+}
+
+export const DEFAULT_CREATED_LABEL = "Created";
+export const DEFAULT_UPDATED_LABEL = "Updated";
+
+function ClockIcon(): VNode {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      class="h-icon-xs w-icon-xs"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      stroke-width="2"
+      aria-hidden="true"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M12 6v6l4 2m6-2a9 9 0 11-18 0 9 9 0 0118 0z"
+      />
+    </svg>
+  );
+}
+
+function RefreshIcon(): VNode {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      class="h-icon-xs w-icon-xs"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      stroke-width="2"
+      aria-hidden="true"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+      />
+    </svg>
+  );
+}
+
+function UserIcon(): VNode {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      class="h-icon-xs w-icon-xs"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      stroke-width="2"
+      aria-hidden="true"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Document meta-information strip (created date, updated date, author)
+ * — JSX port of `src/components/doc-metainfo.astro`.
+ *
+ * The legacy component owned three responsibilities: reading
+ * `settings.docMetainfo`, calling `getGitInfo(filePath)`, and
+ * presentation. v2 keeps only presentation; the caller resolves git
+ * info and date formatting upstream.
+ *
+ * Returns `null` when no displayable field is provided, mirroring the
+ * original `hasInfo && (...)` guard.
+ */
+export function DocMetainfo(props: DocMetainfoProps): VNode | null {
+  const {
+    createdAt,
+    updatedAt,
+    author,
+    createdLabel = DEFAULT_CREATED_LABEL,
+    updatedLabel = DEFAULT_UPDATED_LABEL,
+  } = props;
+
+  const hasInfo =
+    Boolean(createdAt) ||
+    (Boolean(updatedAt) && updatedAt !== createdAt) ||
+    Boolean(author);
+
+  if (!hasInfo) return null;
+
+  return (
+    <div class="flex flex-wrap items-center gap-x-hsp-md gap-y-vsp-2xs text-caption text-fg mb-vsp-md border-t border-fg pt-vsp-xs">
+      {createdAt && (
+        <span class="inline-flex items-center gap-hsp-2xs">
+          <ClockIcon />
+          <span>
+            {createdLabel} {createdAt}
+          </span>
+        </span>
+      )}
+      {updatedAt && updatedAt !== createdAt && (
+        <span class="inline-flex items-center gap-hsp-2xs">
+          <RefreshIcon />
+          <span>
+            {updatedLabel} {updatedAt}
+          </span>
+        </span>
+      )}
+      {author && (
+        <span class="inline-flex items-center gap-hsp-2xs">
+          <UserIcon />
+          <span>{author}</span>
+        </span>
+      )}
+    </div>
+  );
+}

--- a/packages/zudo-doc-v2/src/metainfo/doc-tags.tsx
+++ b/packages/zudo-doc-v2/src/metainfo/doc-tags.tsx
@@ -1,0 +1,107 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import type { VNode } from "preact";
+
+/**
+ * A single resolved tag with its navigation href. The legacy
+ * `doc-tags.astro` called `resolvePageTags(tags)` and used `TagNav`
+ * which computed `tagHref()` internally. v2 delegates both to the
+ * caller so the component has no upward dependency on project routing
+ * utilities.
+ */
+export interface ResolvedTag {
+  /** Raw tag string (e.g. `"typescript"`). */
+  tag: string;
+  /** Pre-computed href for the tag page. */
+  href: string;
+}
+
+/**
+ * Controls vertical spacing: matches the `placement` prop on the
+ * legacy `doc-tags.astro` component.
+ *
+ * - `"after-title"` — tight top margin, bottom margin to separate from
+ *   the body (`mt-0 mb-vsp-md`).
+ * - `"before-footer"` — extra top space, no bottom margin
+ *   (`mt-vsp-xl mb-0`).
+ */
+export type TagPlacement = "after-title" | "before-footer";
+
+export interface DocTagsProps {
+  /**
+   * Resolved tags with pre-computed hrefs. Pass an empty array (or
+   * omit) to suppress rendering — mirrors the legacy
+   * `resolvedTags.length > 0` guard.
+   */
+  tags?: ResolvedTag[];
+  /**
+   * Placement context — controls the outer container spacing class.
+   */
+  placement: TagPlacement;
+  /**
+   * Label shown before the tag list (e.g. `"Tags:"`). Pass the
+   * i18n-resolved `t("doc.tags", locale)` string from upstream.
+   * Defaults to `"Tags"`.
+   */
+  tagsLabel?: string;
+  /**
+   * Used in each tag's `aria-label` (`"Tagged with: <tag>"`). Defaults
+   * to `"Tagged with"`.
+   */
+  taggedWithLabel?: string;
+}
+
+export const DEFAULT_TAGS_LABEL = "Tags";
+export const DEFAULT_TAGGED_WITH_LABEL = "Tagged with";
+
+/**
+ * Page-level tag chips — JSX port of `src/components/doc-tags.astro`
+ * (page-variant rendering from `src/components/tag-nav.astro`).
+ *
+ * Returns `null` when the `tags` array is empty, matching the original
+ * `resolvedTags.length > 0` guard.
+ *
+ * The pointed-chip shape is reproduced verbatim from the page-variant
+ * branch of `tag-nav.astro` using the same `clip-path` values.
+ */
+export function DocTags(props: DocTagsProps): VNode | null {
+  const {
+    tags = [],
+    placement,
+    tagsLabel = DEFAULT_TAGS_LABEL,
+    taggedWithLabel = DEFAULT_TAGGED_WITH_LABEL,
+  } = props;
+
+  if (tags.length === 0) return null;
+
+  const spacingClass =
+    placement === "after-title" ? "mt-0 mb-vsp-md" : "mt-vsp-xl mb-0";
+
+  return (
+    <div class={spacingClass}>
+      <div class="flex flex-wrap items-center gap-x-hsp-xs gap-y-vsp-xs">
+        <span class="text-caption text-muted">{tagsLabel}:</span>
+        {tags.map(({ tag, href }) => (
+          <a
+            key={tag}
+            href={href}
+            aria-label={`${taggedWithLabel}: ${tag}`}
+            class="group relative inline-flex no-underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+          >
+            <span
+              class="absolute inset-0 bg-muted group-hover:bg-fg"
+              style="clip-path: polygon(0 0, calc(100% - 12px) 0, 100% 50%, calc(100% - 12px) 100%, 0 100%)"
+            />
+            <span
+              class="relative inline-flex items-center text-caption text-fg bg-bg pl-hsp-sm pr-hsp-lg py-vsp-2xs group-hover:text-bg group-hover:bg-fg"
+              style="clip-path: polygon(1px 1px, calc(100% - 13px) 1px, calc(100% - 1px) 50%, calc(100% - 13px) calc(100% - 1px), 1px calc(100% - 1px))"
+            >
+              #{tag}
+            </span>
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/zudo-doc-v2/src/metainfo/frontmatter-preview.tsx
+++ b/packages/zudo-doc-v2/src/metainfo/frontmatter-preview.tsx
@@ -1,0 +1,118 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import type { VNode } from "preact";
+
+export interface FrontmatterPreviewProps {
+  /**
+   * Pre-filtered `[key, value]` pairs to display. The legacy component
+   * owned the filtering logic (ignore-keys, null/undefined removal,
+   * `settings.frontmatterPreview` gating, `frontmatterRenderers`
+   * dispatch). v2 delegates all of that to the caller and accepts only
+   * the final entries to render.
+   *
+   * Pass an empty array (or omit) to suppress rendering.
+   */
+  entries?: Array<[string, unknown]>;
+  /**
+   * Section heading above the table. Defaults to `"Frontmatter"`.
+   * Pass the i18n-resolved `t("frontmatter.preview.title", locale)`
+   * string from upstream.
+   */
+  title?: string;
+  /**
+   * Column header for the key column. Defaults to `"Key"`.
+   */
+  keyColLabel?: string;
+  /**
+   * Column header for the value column. Defaults to `"Value"`.
+   */
+  valueColLabel?: string;
+}
+
+export const DEFAULT_FRONTMATTER_PREVIEW_TITLE = "Frontmatter";
+export const DEFAULT_KEY_COL_LABEL = "Key";
+export const DEFAULT_VALUE_COL_LABEL = "Value";
+
+/**
+ * Render a scalar/array value as a plain string suitable for display.
+ *
+ * - Strings, numbers, booleans → string representation
+ * - String arrays → comma-joined
+ * - Anything else → JSON.stringify (displayed in a `<code>` block)
+ *
+ * The legacy `frontmatter-preview.astro` additionally ran
+ * `smartBreakToHtml` on strings and delegated to per-key
+ * `frontmatterRenderers`. v2 keeps only the simple text path so the
+ * component has no upward dependency on project utilities.
+ */
+function renderValue(v: unknown): { text?: string; code?: string } {
+  if (typeof v === "string") return { text: v };
+  if (typeof v === "number") return { text: String(v) };
+  if (typeof v === "boolean") return { text: v ? "true" : "false" };
+  if (Array.isArray(v) && v.every((item) => typeof item === "string")) {
+    return { text: (v as string[]).join(", ") };
+  }
+  return { code: JSON.stringify(v) };
+}
+
+/**
+ * Frontmatter data table — JSX port of
+ * `src/components/frontmatter-preview.astro`.
+ *
+ * Returns `null` when `entries` is empty, mirroring the original
+ * `entries.length > 0` guard.
+ */
+export function FrontmatterPreview(
+  props: FrontmatterPreviewProps,
+): VNode | null {
+  const {
+    entries = [],
+    title = DEFAULT_FRONTMATTER_PREVIEW_TITLE,
+    keyColLabel = DEFAULT_KEY_COL_LABEL,
+    valueColLabel = DEFAULT_VALUE_COL_LABEL,
+  } = props;
+
+  if (entries.length === 0) return null;
+
+  return (
+    <div data-testid="frontmatter-preview" class="my-vsp-lg">
+      <p class="text-caption text-muted mb-vsp-2xs">{title}</p>
+      <div class="overflow-x-auto">
+        <table class="w-full border-collapse text-caption">
+          <thead>
+            <tr>
+              <th class="text-left font-semibold px-hsp-md py-vsp-2xs border-b-2 border-muted text-fg">
+                {keyColLabel}
+              </th>
+              <th class="text-left font-semibold px-hsp-md py-vsp-2xs border-b-2 border-muted text-fg">
+                {valueColLabel}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map(([key, value]) => {
+              const rendered = renderValue(value);
+              return (
+                <tr key={key} class="border-b border-muted">
+                  <td class="px-hsp-md py-vsp-2xs text-muted font-mono align-top">
+                    {key}
+                  </td>
+                  <td class="px-hsp-md py-vsp-2xs text-fg break-words align-top">
+                    {rendered.code !== undefined ? (
+                      <code class="bg-code-bg text-code-fg px-hsp-xs py-0 rounded text-micro font-mono">
+                        {rendered.code}
+                      </code>
+                    ) : (
+                      rendered.text
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/packages/zudo-doc-v2/src/metainfo/index.ts
+++ b/packages/zudo-doc-v2/src/metainfo/index.ts
@@ -1,0 +1,26 @@
+// Barrel for the metainfo topic — JSX ports of:
+//   src/components/doc-metainfo.astro
+//   src/components/doc-tags.astro
+//   src/components/frontmatter-preview.astro
+
+export {
+  DocMetainfo,
+  DEFAULT_CREATED_LABEL,
+  DEFAULT_UPDATED_LABEL,
+} from "./doc-metainfo.js";
+export type { DocMetainfoProps } from "./doc-metainfo.js";
+
+export {
+  DocTags,
+  DEFAULT_TAGS_LABEL,
+  DEFAULT_TAGGED_WITH_LABEL,
+} from "./doc-tags.js";
+export type { DocTagsProps, ResolvedTag, TagPlacement } from "./doc-tags.js";
+
+export {
+  FrontmatterPreview,
+  DEFAULT_FRONTMATTER_PREVIEW_TITLE,
+  DEFAULT_KEY_COL_LABEL,
+  DEFAULT_VALUE_COL_LABEL,
+} from "./frontmatter-preview.js";
+export type { FrontmatterPreviewProps } from "./frontmatter-preview.js";

--- a/packages/zudo-doc-v2/src/nav-indexing/__tests__/category-nav.test.tsx
+++ b/packages/zudo-doc-v2/src/nav-indexing/__tests__/category-nav.test.tsx
@@ -1,0 +1,81 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { describe, it, expect } from "vitest";
+import { CategoryNav } from "../category-nav";
+import { serialize } from "./helpers";
+import type { NavNode } from "../types";
+
+function makeNode(
+  label: string,
+  href: string,
+  opts: Partial<NavNode> = {},
+): NavNode {
+  return {
+    label,
+    href,
+    hasPage: true,
+    children: [],
+    ...opts,
+  };
+}
+
+describe("CategoryNav", () => {
+  it("returns null when children is empty", () => {
+    expect(CategoryNav({ children: [] })).toBeNull();
+  });
+
+  it("returns null when no children have hasPage === true", () => {
+    const node: NavNode = { label: "X", hasPage: false, children: [] };
+    expect(CategoryNav({ children: [node] })).toBeNull();
+  });
+
+  it("renders a nav with one card link", () => {
+    const child = makeNode("Getting Started", "/docs/getting-started/");
+    const html = serialize(CategoryNav({ children: [child] }));
+    expect(html).toContain("<nav");
+    expect(html).toContain('href="/docs/getting-started/"');
+    expect(html).toContain("Getting Started");
+  });
+
+  it("renders descriptions when present", () => {
+    const child = makeNode("Guide", "/docs/guide/", {
+      description: "A helpful guide",
+    });
+    const html = serialize(CategoryNav({ children: [child] }));
+    expect(html).toContain("A helpful guide");
+  });
+
+  it("does not render description span when description is absent", () => {
+    const child = makeNode("Guide", "/docs/guide/");
+    const html = serialize(CategoryNav({ children: [child] }));
+    // description span should not be in output
+    expect(html).not.toContain("text-muted");
+  });
+
+  it("filters out nodes with hasPage === false", () => {
+    const withPage = makeNode("Page", "/docs/page/");
+    const noPage: NavNode = { label: "Category", hasPage: false, children: [] };
+    const html = serialize(CategoryNav({ children: [withPage, noPage] }));
+    expect(html).toContain("Page");
+    expect(html).not.toContain("Category");
+  });
+
+  it("renders multiple card links", () => {
+    const children = [
+      makeNode("Alpha", "/docs/alpha/"),
+      makeNode("Beta", "/docs/beta/"),
+    ];
+    const html = serialize(CategoryNav({ children }));
+    expect(html).toContain("Alpha");
+    expect(html).toContain("Beta");
+    expect(html).toContain('href="/docs/alpha/"');
+    expect(html).toContain('href="/docs/beta/"');
+  });
+
+  it("appends extra class to nav element", () => {
+    const child = makeNode("X", "/docs/x/");
+    const html = serialize(CategoryNav({ children: [child], class: "mt-8" }));
+    expect(html).toContain("mt-8");
+  });
+});

--- a/packages/zudo-doc-v2/src/nav-indexing/__tests__/category-tree-nav.test.tsx
+++ b/packages/zudo-doc-v2/src/nav-indexing/__tests__/category-tree-nav.test.tsx
@@ -1,0 +1,79 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { describe, it, expect } from "vitest";
+import { CategoryTreeNav } from "../category-tree-nav";
+import { serialize } from "./helpers";
+import type { NavNode } from "../types";
+
+function leaf(label: string, href: string): NavNode {
+  return { label, href, hasPage: true, children: [] };
+}
+
+function category(
+  label: string,
+  children: NavNode[],
+  href?: string,
+): NavNode {
+  return { label, href, hasPage: !!href, children };
+}
+
+describe("CategoryTreeNav", () => {
+  it("returns null when children is empty", () => {
+    expect(CategoryTreeNav({ children: [] })).toBeNull();
+  });
+
+  it("returns null when all nodes have hasPage false and no children", () => {
+    const node: NavNode = { label: "X", hasPage: false, children: [] };
+    expect(CategoryTreeNav({ children: [node] })).toBeNull();
+  });
+
+  it("renders a nav with a list for leaf nodes", () => {
+    const child = leaf("Introduction", "/docs/intro/");
+    const html = serialize(CategoryTreeNav({ children: [child] }));
+    expect(html).toContain("<nav");
+    expect(html).toContain("<ul");
+    expect(html).toContain('href="/docs/intro/"');
+    expect(html).toContain("Introduction");
+  });
+
+  it("renders plain text for nodes without href", () => {
+    const node = category("Reference", [leaf("API", "/docs/api/")]);
+    const html = serialize(CategoryTreeNav({ children: [node] }));
+    // Category label should be plain text (span), not a link
+    expect(html).toContain("<span");
+    expect(html).toContain("Reference");
+  });
+
+  it("renders nested children", () => {
+    const node = category("Guide", [leaf("Setup", "/docs/setup/")]);
+    const html = serialize(CategoryTreeNav({ children: [node] }));
+    expect(html).toContain("Guide");
+    expect(html).toContain("Setup");
+    expect(html).toContain('href="/docs/setup/"');
+  });
+
+  it("includes description after colon when present", () => {
+    const child = leaf("API", "/docs/api/");
+    (child as NavNode).description = "Reference material";
+    const html = serialize(CategoryTreeNav({ children: [child] }));
+    expect(html).toContain(": Reference material");
+  });
+
+  it("does not render children beyond maxDepth", () => {
+    const deep = category("Grandchild", [leaf("Leaf", "/docs/leaf/")]);
+    const mid = category("Child", [deep]);
+    const root = category("Root", [mid]);
+    const html = serialize(CategoryTreeNav({ children: [root], maxDepth: 1 }));
+    // Should render Root and Child but not Grandchild
+    expect(html).toContain("Root");
+    expect(html).toContain("Child");
+    expect(html).not.toContain("Grandchild");
+  });
+
+  it("renders linked category when it has an href", () => {
+    const node = category("Guide", [leaf("Setup", "/docs/setup/")], "/docs/guide/");
+    const html = serialize(CategoryTreeNav({ children: [node] }));
+    expect(html).toContain('href="/docs/guide/"');
+  });
+});

--- a/packages/zudo-doc-v2/src/nav-indexing/__tests__/doc-card-grid.test.tsx
+++ b/packages/zudo-doc-v2/src/nav-indexing/__tests__/doc-card-grid.test.tsx
@@ -1,0 +1,69 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { describe, it, expect } from "vitest";
+import { DocCardGrid } from "../doc-card-grid";
+import { serialize } from "./helpers";
+import type { DocCardItem } from "../doc-card-grid";
+
+describe("DocCardGrid", () => {
+  it("returns null when items is empty", () => {
+    expect(DocCardGrid({ items: [] })).toBeNull();
+  });
+
+  it("renders a nav element with default aria-label", () => {
+    const items: DocCardItem[] = [{ href: "/docs/a/", title: "Alpha" }];
+    const html = serialize(DocCardGrid({ items }));
+    expect(html).toContain('<nav aria-label="Child pages"');
+  });
+
+  it("uses a custom ariaLabel when provided", () => {
+    const items: DocCardItem[] = [{ href: "/docs/a/", title: "A" }];
+    const html = serialize(DocCardGrid({ items, ariaLabel: "Related docs" }));
+    expect(html).toContain('aria-label="Related docs"');
+  });
+
+  it("renders one link per item", () => {
+    const items: DocCardItem[] = [
+      { href: "/docs/a/", title: "Alpha" },
+      { href: "/docs/b/", title: "Beta" },
+    ];
+    const html = serialize(DocCardGrid({ items }));
+    expect(html).toContain('href="/docs/a/"');
+    expect(html).toContain('href="/docs/b/"');
+    expect(html).toContain("Alpha");
+    expect(html).toContain("Beta");
+  });
+
+  it("renders descriptions when present", () => {
+    const items: DocCardItem[] = [
+      {
+        href: "/docs/a/",
+        title: "Alpha",
+        description: "The first letter",
+      },
+    ];
+    const html = serialize(DocCardGrid({ items }));
+    expect(html).toContain("The first letter");
+  });
+
+  it("does not render description span when absent", () => {
+    const items: DocCardItem[] = [{ href: "/docs/a/", title: "Alpha" }];
+    const html = serialize(DocCardGrid({ items }));
+    // description span uses text-muted class
+    expect(html).not.toContain("text-small text-muted");
+  });
+
+  it("appends extra CSS class to nav element", () => {
+    const items: DocCardItem[] = [{ href: "/a/", title: "A" }];
+    const html = serialize(DocCardGrid({ items, class: "mb-8" }));
+    expect(html).toContain("mb-8");
+  });
+
+  it("renders the arrow SVG with text-accent class", () => {
+    const items: DocCardItem[] = [{ href: "/a/", title: "A" }];
+    const html = serialize(DocCardGrid({ items }));
+    expect(html).toContain("text-accent");
+    expect(html).toContain("<svg");
+  });
+});

--- a/packages/zudo-doc-v2/src/nav-indexing/__tests__/docs-sitemap.test.tsx
+++ b/packages/zudo-doc-v2/src/nav-indexing/__tests__/docs-sitemap.test.tsx
@@ -1,0 +1,91 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { describe, it, expect } from "vitest";
+import { DocsSitemap } from "../docs-sitemap";
+import { serialize } from "./helpers";
+import type { NavNode } from "../types";
+
+function leaf(label: string, href: string, desc?: string): NavNode {
+  return { label, href, hasPage: true, children: [], description: desc };
+}
+
+function category(label: string, children: NavNode[], href?: string): NavNode {
+  return { label, href, hasPage: !!href, children };
+}
+
+describe("DocsSitemap", () => {
+  it("returns null for empty tree", () => {
+    expect(DocsSitemap({ tree: [] })).toBeNull();
+  });
+
+  it("renders a details/summary for each top-level node", () => {
+    const tree = [
+      category("Guide", [leaf("Intro", "/docs/guide/intro/")]),
+      category("Reference", [leaf("API", "/docs/ref/api/")]),
+    ];
+    const html = serialize(DocsSitemap({ tree }));
+    expect(html).toContain("<details");
+    expect(html).toContain("<summary");
+    // Two top-level sections
+    const detailsCount = (html.match(/<details/g) || []).length;
+    expect(detailsCount).toBe(2);
+  });
+
+  it("renders flat leaf links inside each section", () => {
+    const tree = [
+      category("Guide", [
+        leaf("Setup", "/docs/guide/setup/"),
+        leaf("Config", "/docs/guide/config/"),
+      ]),
+    ];
+    const html = serialize(DocsSitemap({ tree }));
+    expect(html).toContain('href="/docs/guide/setup/"');
+    expect(html).toContain('href="/docs/guide/config/"');
+    expect(html).toContain("Setup");
+    expect(html).toContain("Config");
+  });
+
+  it("flattens nested leaves depth-first", () => {
+    const tree = [
+      category("Guide", [
+        category("Advanced", [
+          leaf("Deep", "/docs/guide/advanced/deep/"),
+        ]),
+        leaf("Simple", "/docs/guide/simple/"),
+      ]),
+    ];
+    const html = serialize(DocsSitemap({ tree }));
+    expect(html).toContain("Deep");
+    expect(html).toContain("Simple");
+  });
+
+  it("renders category heading as a link when href is set", () => {
+    const tree = [
+      category("Guide", [leaf("X", "/docs/guide/x/")], "/docs/guide/"),
+    ];
+    const html = serialize(DocsSitemap({ tree }));
+    expect(html).toContain('href="/docs/guide/"');
+  });
+
+  it("renders category heading as plain text when href is absent", () => {
+    const tree = [category("Reference", [leaf("API", "/docs/ref/api/")])];
+    const html = serialize(DocsSitemap({ tree }));
+    expect(html).toContain("<span>Reference</span>");
+    expect(html).not.toContain('"Reference"');
+  });
+
+  it("shows leaf description when present", () => {
+    const tree = [
+      category("G", [leaf("X", "/x/", "A helpful page")]),
+    ];
+    const html = serialize(DocsSitemap({ tree }));
+    expect(html).toContain("A helpful page");
+  });
+
+  it("renders with open attribute on details", () => {
+    const tree = [category("G", [leaf("X", "/x/")])];
+    const html = serialize(DocsSitemap({ tree }));
+    expect(html).toContain(" open");
+  });
+});

--- a/packages/zudo-doc-v2/src/nav-indexing/__tests__/helpers.ts
+++ b/packages/zudo-doc-v2/src/nav-indexing/__tests__/helpers.ts
@@ -1,0 +1,64 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+/**
+ * Shared VNode serializer for nav-indexing tests.
+ *
+ * Walks the Preact VNode tree and emits HTML markup for assertions.
+ * Function components are invoked with their props (sufficient for our
+ * pure, hook-less components). Adapted from the breadcrumb/__tests__
+ * pattern to avoid pulling in preact-render-to-string.
+ */
+
+import type { ComponentChildren, VNode } from "preact";
+
+type AnyVNode = VNode<{ children?: ComponentChildren; [key: string]: unknown }>;
+
+function isVNode(v: unknown): v is AnyVNode {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    Object.prototype.hasOwnProperty.call(v, "type") &&
+    Object.prototype.hasOwnProperty.call(v, "props")
+  );
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/"/g, "&quot;");
+}
+
+export function serialize(node: ComponentChildren): string {
+  if (node == null || typeof node === "boolean") return "";
+  if (typeof node === "string") return node;
+  if (typeof node === "number" || typeof node === "bigint") return String(node);
+  if (Array.isArray(node)) return node.map(serialize).join("");
+  if (!isVNode(node)) return "";
+  const { type, props } = node;
+  const { children, ...rest } = (props ?? {}) as {
+    children?: ComponentChildren;
+    [key: string]: unknown;
+  };
+
+  if (typeof type === "function") {
+    const fn = type as (p: typeof props) => ComponentChildren;
+    return serialize(fn(props));
+  }
+  if (type == null || (typeof type === "string" && type === "")) {
+    // Fragment
+    return serialize(children);
+  }
+  if (typeof type !== "string") return serialize(children);
+
+  const attrs = Object.entries(rest)
+    .filter(([, v]) => v !== undefined && v !== null && v !== false)
+    .map(([k, v]) => {
+      if (k === "key") return "";
+      if (v === true) return ` ${k}`;
+      return ` ${k}="${escapeAttr(String(v))}"`;
+    })
+    .join("");
+
+  const voidEls = new Set(["br", "hr", "img", "input", "wbr", "meta", "link"]);
+  if (voidEls.has(type)) return `<${type}${attrs}/>`;
+  return `<${type}${attrs}>${serialize(children)}</${type}>`;
+}

--- a/packages/zudo-doc-v2/src/nav-indexing/__tests__/nav-card-grid.test.tsx
+++ b/packages/zudo-doc-v2/src/nav-indexing/__tests__/nav-card-grid.test.tsx
@@ -1,0 +1,78 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { describe, it, expect } from "vitest";
+import { NavCardGrid } from "../nav-card-grid";
+import { serialize } from "./helpers";
+import type { NavNode } from "../types";
+
+function node(
+  label: string,
+  href: string,
+  opts: Partial<NavNode> = {},
+): NavNode {
+  return { label, href, hasPage: true, children: [], ...opts };
+}
+
+describe("NavCardGrid", () => {
+  it("returns null when children is empty", () => {
+    expect(NavCardGrid({ children: [] })).toBeNull();
+  });
+
+  it("returns null when no children have href", () => {
+    const noHref: NavNode = { label: "X", hasPage: true, children: [] };
+    expect(NavCardGrid({ children: [noHref] })).toBeNull();
+  });
+
+  it("renders nav with aria-label='Child pages'", () => {
+    const child = node("Intro", "/docs/intro/");
+    const html = serialize(NavCardGrid({ children: [child] }));
+    expect(html).toContain('aria-label="Child pages"');
+  });
+
+  it("renders a card for each node with href", () => {
+    const children = [
+      node("Alpha", "/docs/alpha/"),
+      node("Beta", "/docs/beta/"),
+    ];
+    const html = serialize(NavCardGrid({ children }));
+    expect(html).toContain('href="/docs/alpha/"');
+    expect(html).toContain("Alpha");
+    expect(html).toContain('href="/docs/beta/"');
+    expect(html).toContain("Beta");
+  });
+
+  it("renders description with group-hover:underline", () => {
+    const child = node("Guide", "/docs/guide/", {
+      description: "Learn the basics",
+    });
+    const html = serialize(NavCardGrid({ children: [child] }));
+    expect(html).toContain("Learn the basics");
+    expect(html).toContain("group-hover:underline");
+  });
+
+  it("skips nodes without href even if they have children", () => {
+    const noHref: NavNode = {
+      label: "Category",
+      hasPage: false,
+      children: [],
+    };
+    const withHref = node("Page", "/docs/page/");
+    const html = serialize(NavCardGrid({ children: [noHref, withHref] }));
+    expect(html).not.toContain("Category");
+    expect(html).toContain("Page");
+  });
+
+  it("appends extra CSS class to nav element", () => {
+    const child = node("X", "/x/");
+    const html = serialize(NavCardGrid({ children: [child], class: "mt-4" }));
+    expect(html).toContain("mt-4");
+  });
+
+  it("renders arrow SVG with text-accent class", () => {
+    const child = node("X", "/x/");
+    const html = serialize(NavCardGrid({ children: [child] }));
+    expect(html).toContain("text-accent");
+    expect(html).toContain("<svg");
+  });
+});

--- a/packages/zudo-doc-v2/src/nav-indexing/__tests__/tag-nav.test.tsx
+++ b/packages/zudo-doc-v2/src/nav-indexing/__tests__/tag-nav.test.tsx
@@ -1,0 +1,88 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { describe, it, expect } from "vitest";
+import { TagNav } from "../tag-nav";
+import { serialize } from "./helpers";
+import type { TagItem, TagLink, TagNavLabels } from "../types";
+
+const labels: TagNavLabels = {
+  tags: "Tags",
+  taggedWith: "Pages tagged with",
+};
+
+describe('TagNav variant="all"', () => {
+  it("returns null when tags is empty", () => {
+    expect(TagNav({ variant: "all", tags: [], labels })).toBeNull();
+  });
+
+  it("renders a chip for each tag", () => {
+    const tags: TagItem[] = [
+      { tag: "react", count: 5, href: "/docs/tags/react" },
+      { tag: "typescript", count: 3, href: "/docs/tags/typescript" },
+    ];
+    const html = serialize(TagNav({ variant: "all", tags, labels }));
+    expect(html).toContain("#react");
+    expect(html).toContain("(5)");
+    expect(html).toContain("#typescript");
+    expect(html).toContain("(3)");
+    expect(html).toContain('href="/docs/tags/react"');
+  });
+
+  it("sets aria-label from labels.taggedWith", () => {
+    const tags: TagItem[] = [{ tag: "css", count: 2, href: "/docs/tags/css" }];
+    const html = serialize(TagNav({ variant: "all", tags, labels }));
+    expect(html).toContain('aria-label="Pages tagged with: css"');
+  });
+
+  it("uses 16px clip-path for outer arrow", () => {
+    const tags: TagItem[] = [
+      { tag: "js", count: 1, href: "/docs/tags/js" },
+    ];
+    const html = serialize(TagNav({ variant: "all", tags, labels }));
+    expect(html).toContain("calc(100% - 16px)");
+  });
+
+  it("renders a ul wrapper", () => {
+    const tags: TagItem[] = [{ tag: "a", count: 1, href: "/a" }];
+    const html = serialize(TagNav({ variant: "all", tags, labels }));
+    expect(html).toContain("<ul");
+    expect(html).toContain("<li");
+  });
+});
+
+describe('TagNav variant="page"', () => {
+  it("returns null when tagLinks is empty", () => {
+    expect(TagNav({ variant: "page", tagLinks: [], labels })).toBeNull();
+  });
+
+  it("renders chips for each tag link", () => {
+    const tagLinks: TagLink[] = [
+      { tag: "guide", href: "/docs/tags/guide" },
+      { tag: "intro", href: "/docs/tags/intro" },
+    ];
+    const html = serialize(TagNav({ variant: "page", tagLinks, labels }));
+    expect(html).toContain("#guide");
+    expect(html).toContain("#intro");
+    expect(html).toContain('href="/docs/tags/guide"');
+  });
+
+  it("renders the tags prefix label", () => {
+    const tagLinks: TagLink[] = [{ tag: "x", href: "/docs/tags/x" }];
+    const html = serialize(TagNav({ variant: "page", tagLinks, labels }));
+    expect(html).toContain("Tags:");
+  });
+
+  it("uses 12px clip-path for outer arrow (smaller chip)", () => {
+    const tagLinks: TagLink[] = [{ tag: "x", href: "/x" }];
+    const html = serialize(TagNav({ variant: "page", tagLinks, labels }));
+    expect(html).toContain("calc(100% - 12px)");
+  });
+
+  it("does not render count badge", () => {
+    const tagLinks: TagLink[] = [{ tag: "x", href: "/x" }];
+    const html = serialize(TagNav({ variant: "page", tagLinks, labels }));
+    // No count in parentheses — the "all" variant shows "(N)" but page variant does not
+    expect(html).not.toContain("opacity-60");
+  });
+});

--- a/packages/zudo-doc-v2/src/nav-indexing/__tests__/versions-page-content.test.tsx
+++ b/packages/zudo-doc-v2/src/nav-indexing/__tests__/versions-page-content.test.tsx
@@ -1,0 +1,121 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { describe, it, expect } from "vitest";
+import { VersionsPageContent } from "../versions-page-content";
+import { serialize } from "./helpers";
+import type { VersionPageEntry, VersionsPageLabels } from "../types";
+
+const labels: VersionsPageLabels = {
+  pageTitle: "Documentation Versions",
+  latestTitle: "Latest Version (Current)",
+  latestDescription: "The latest and greatest.",
+  latestLink: "View latest docs",
+  pastTitle: "Past Versions",
+  pastDescription: "Older versions for reference.",
+  unmaintained: "Unmaintained",
+  unreleased: "Unreleased",
+  versionCol: "Version",
+  statusCol: "Status",
+  docsCol: "Docs",
+};
+
+describe("VersionsPageContent", () => {
+  it("renders the page title as h1", () => {
+    const html = serialize(
+      VersionsPageContent({ latestHref: "/docs/", versions: [], labels }),
+    );
+    expect(html).toContain("<h1");
+    expect(html).toContain("Documentation Versions");
+  });
+
+  it("renders the latest version section with a link", () => {
+    const html = serialize(
+      VersionsPageContent({
+        latestHref: "/docs/getting-started/",
+        versions: [],
+        labels,
+      }),
+    );
+    expect(html).toContain('href="/docs/getting-started/"');
+    expect(html).toContain("View latest docs");
+    expect(html).toContain("Latest Version (Current)");
+  });
+
+  it("does not render past versions section when versions is empty", () => {
+    const html = serialize(
+      VersionsPageContent({ latestHref: "/docs/", versions: [], labels }),
+    );
+    expect(html).not.toContain("Past Versions");
+    expect(html).not.toContain("<table");
+  });
+
+  it("renders past versions table when versions is non-empty", () => {
+    const versions: VersionPageEntry[] = [
+      { slug: "1.0", label: "1.0.0", docsHref: "/1.0/docs/intro/" },
+    ];
+    const html = serialize(
+      VersionsPageContent({ latestHref: "/docs/", versions, labels }),
+    );
+    expect(html).toContain("Past Versions");
+    expect(html).toContain("<table");
+    expect(html).toContain("1.0.0");
+    expect(html).toContain('href="/1.0/docs/intro/"');
+  });
+
+  it("renders unmaintained badge for unmaintained versions", () => {
+    const versions: VersionPageEntry[] = [
+      {
+        slug: "1.0",
+        label: "1.0.0",
+        docsHref: "/1.0/docs/",
+        banner: "unmaintained",
+      },
+    ];
+    const html = serialize(
+      VersionsPageContent({ latestHref: "/docs/", versions, labels }),
+    );
+    expect(html).toContain("Unmaintained");
+    expect(html).toContain("bg-warning/10");
+  });
+
+  it("renders unreleased badge for unreleased versions", () => {
+    const versions: VersionPageEntry[] = [
+      {
+        slug: "3.0",
+        label: "3.0.0",
+        docsHref: "/3.0/docs/",
+        banner: "unreleased",
+      },
+    ];
+    const html = serialize(
+      VersionsPageContent({ latestHref: "/docs/", versions, labels }),
+    );
+    expect(html).toContain("Unreleased");
+    expect(html).toContain("bg-info/10");
+  });
+
+  it("renders no badge when version has no banner", () => {
+    const versions: VersionPageEntry[] = [
+      { slug: "2.0", label: "2.0.0", docsHref: "/2.0/docs/" },
+    ];
+    const html = serialize(
+      VersionsPageContent({ latestHref: "/docs/", versions, labels }),
+    );
+    expect(html).not.toContain("Unmaintained");
+    expect(html).not.toContain("Unreleased");
+  });
+
+  it("renders correct column headers", () => {
+    const versions: VersionPageEntry[] = [
+      { slug: "1.0", label: "1.0.0", docsHref: "/1.0/docs/" },
+    ];
+    const html = serialize(
+      VersionsPageContent({ latestHref: "/docs/", versions, labels }),
+    );
+    expect(html).toContain("<th");
+    expect(html).toContain("Version");
+    expect(html).toContain("Status");
+    expect(html).toContain("Docs");
+  });
+});

--- a/packages/zudo-doc-v2/src/nav-indexing/category-nav.tsx
+++ b/packages/zudo-doc-v2/src/nav-indexing/category-nav.tsx
@@ -1,0 +1,92 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+// JSX port of src/components/category-nav.astro.
+//
+// The original Astro template built the nav tree, found a category node by
+// slug, and rendered the immediate children as a two-column card grid. This
+// v2 port accepts the already-resolved children directly so the host keeps
+// full control of data preparation.
+//
+// Behaviour parity notes:
+//   - The component returns null when `children` is empty — matching the
+//     Astro `children.length > 0 &&` guard.
+//   - Only nodes with `hasPage === true` are rendered (host should pre-
+//     filter, but the component also guards locally for safety).
+//   - The arrow SVG is identical to the one in the original template.
+
+import type { JSX } from "preact";
+
+import type { NavNode } from "./types";
+
+export interface CategoryNavProps {
+  /**
+   * Direct children of the target category node. The consumer pre-filters to
+   * the desired category and passes the immediate children. Only nodes with
+   * `hasPage === true` will be rendered.
+   */
+  children: NavNode[];
+  /** Optional extra CSS classes appended to the `<nav>` element. */
+  class?: string;
+}
+
+function ArrowIcon(): JSX.Element {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+      viewBox="0 0 103.395 107.049"
+      aria-hidden="true"
+      class="w-[16px] shrink-0"
+    >
+      <path d="M5.746 5.74 0 11.49l20.987 20.96C34.126 45.572 41.963 53.45 41.948 53.523c-.012.062-9.456 9.544-20.986 21.07L0 95.55l5.714 5.715c3.142 3.143 5.748 5.715 5.79 5.715s2.63-2.563 5.75-5.696l17.939-18.001c21.867-21.94 29.443-29.599 29.443-29.768 0-.114-.665-.804-5.084-5.275C51.872 40.47 11.71.125 11.565.036 11.525.01 8.906 2.578 5.746 5.74m38.345-.066c-3.132 3.13-5.696 5.71-5.696 5.732-.001.022 2.16 2.185 4.8 4.807 2.641 2.623 8.382 8.338 12.758 12.702 15.38 15.337 23.763 23.641 24.314 24.086.19.153.346.336.346.405 0 .07-1.738 1.847-3.887 3.976a17515 17515 0 0 0-20.35 20.264 19555 19555 0 0 1-17.223 17.158c-.416.409-.757.77-.757.8 0 .083 11.415 11.485 11.457 11.445.235-.22 53.542-53.528 53.542-53.543C103.395 53.472 49.891.02 49.837 0c-.028-.01-2.613 2.543-5.746 5.674" />
+    </svg>
+  );
+}
+
+/**
+ * CategoryNav — JSX port of `src/components/category-nav.astro`.
+ *
+ * Renders direct children of a category as a two-column grid of card links.
+ * Each card shows the node's label (with an arrow icon) and an optional
+ * description line.
+ *
+ * Returns `null` when no `hasPage` children are found.
+ */
+export function CategoryNav(props: CategoryNavProps): JSX.Element | null {
+  const { children, class: className } = props;
+  const items = children.filter((c) => c.hasPage);
+
+  if (items.length === 0) return null;
+
+  const navClass = [
+    "mt-vsp-lg mb-vsp-md grid grid-cols-1 gap-x-hsp-lg gap-y-vsp-md sm:grid-cols-2",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <nav class={navClass}>
+      {items.map((child, i) => (
+        <a
+          key={`cat-nav-${i}`}
+          href={child.href}
+          class="group block rounded border border-muted bg-surface px-hsp-lg py-vsp-md hover:border-accent"
+        >
+          <span class="flex items-start gap-hsp-xs font-medium text-accent underline group-hover:underline">
+            <span class="flex h-[1lh] items-center">
+              <ArrowIcon />
+            </span>
+            {child.label}
+          </span>
+          {child.description && (
+            <span class="mt-vsp-2xs block text-small text-muted">
+              {child.description}
+            </span>
+          )}
+        </a>
+      ))}
+    </nav>
+  );
+}

--- a/packages/zudo-doc-v2/src/nav-indexing/category-tree-nav.tsx
+++ b/packages/zudo-doc-v2/src/nav-indexing/category-tree-nav.tsx
@@ -1,0 +1,112 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+// JSX port of src/components/category-tree-nav.astro.
+//
+// The original Astro template built the full nav tree with groupSatelliteNodes,
+// found the target category node, and rendered its children as a hierarchical
+// disc-bulleted list up to three levels deep.
+//
+// This v2 port accepts the already-resolved children directly. The tree
+// rendering is recursive so it naturally supports any depth, not just three
+// levels. The host passes the immediate children of the desired category.
+//
+// Behaviour parity notes:
+//   - Items without `hasPage` and without `children` are hidden (matching the
+//     Astro `.filter((c) => c.hasPage || c.children.length > 0)` guard).
+//   - Nodes with `href` are rendered as links; nodes without are plain text.
+//   - Description is rendered after the label when present.
+//   - Returns null when no renderable children exist.
+
+import type { JSX } from "preact";
+
+import type { NavNode } from "./types";
+
+export interface CategoryTreeNavProps {
+  /**
+   * Direct children of the target category node. Nodes are filtered to
+   * those with `hasPage` or with child nodes before rendering.
+   */
+  children: NavNode[];
+  /** Maximum depth to recurse. Defaults to unlimited (full tree). */
+  maxDepth?: number;
+}
+
+interface NodeItemProps {
+  node: NavNode;
+  depth: number;
+  maxDepth: number;
+  index: number;
+}
+
+function NodeItem({ node, depth, maxDepth, index }: NodeItemProps): JSX.Element {
+  const visibleChildren = node.children.filter(
+    (c) => c.hasPage || c.children.length > 0,
+  );
+  const hasChildren = visibleChildren.length > 0 && depth < maxDepth;
+
+  return (
+    <li key={`tree-item-${depth}-${index}`} class="m-0 p-0">
+      {node.href ? (
+        <a
+          href={node.href}
+          class="inline-block py-vsp-3xs text-accent hover:underline"
+        >
+          {node.label}
+        </a>
+      ) : (
+        <span class="inline-block py-vsp-3xs text-fg font-medium">
+          {node.label}
+        </span>
+      )}
+      {node.description && (
+        <span class="ml-hsp-sm text-small text-muted">: {node.description}</span>
+      )}
+      {hasChildren && (
+        <ul class="list-disc m-0 p-0 pl-hsp-xl">
+          {visibleChildren.map((child, ci) => (
+            <NodeItem
+              key={`tree-child-${depth + 1}-${ci}`}
+              node={child}
+              depth={depth + 1}
+              maxDepth={maxDepth}
+              index={ci}
+            />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}
+
+/**
+ * CategoryTreeNav — JSX port of `src/components/category-tree-nav.astro`.
+ *
+ * Renders the children of a category as a recursive disc-bulleted list. Links
+ * are rendered for nodes that have a page; plain text for structural nodes.
+ * Descriptions are appended after a colon when present.
+ *
+ * Returns `null` when no renderable children exist.
+ */
+export function CategoryTreeNav(props: CategoryTreeNavProps): JSX.Element | null {
+  const { children, maxDepth = Infinity } = props;
+  const items = children.filter((c) => c.hasPage || c.children.length > 0);
+
+  if (items.length === 0) return null;
+
+  return (
+    <nav aria-label="Category navigation" class="mt-vsp-lg mb-vsp-md">
+      <ul class="list-disc m-0 p-0 pl-hsp-xl">
+        {items.map((child, i) => (
+          <NodeItem
+            key={`tree-top-${i}`}
+            node={child}
+            depth={0}
+            maxDepth={maxDepth}
+            index={i}
+          />
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/packages/zudo-doc-v2/src/nav-indexing/doc-card-grid.tsx
+++ b/packages/zudo-doc-v2/src/nav-indexing/doc-card-grid.tsx
@@ -1,0 +1,100 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+// JSX port of src/components/doc-card-grid.astro.
+//
+// The original Astro template accepted a flat list of pre-built items
+// (href + title + optional description) and rendered them in a two-column
+// card grid. Unlike category-nav / nav-card-grid, this component takes
+// fully resolved item objects rather than NavNode tree nodes.
+//
+// Behaviour parity notes:
+//   - Returns null when `items` is empty (matching the Astro `items.length > 0 &&` guard).
+//   - `ariaLabel` defaults to "Child pages" (same as the Astro template).
+//   - `class` prop is appended to the nav element via class:list equivalent.
+//   - The arrow SVG uses `text-accent` colouring — identical to nav-card-grid.
+
+import type { JSX } from "preact";
+
+/** A single resolved doc card item. */
+export interface DocCardItem {
+  /** Pre-resolved href (base-prefixed, locale-aware). */
+  href: string;
+  /** Display title for the card. */
+  title: string;
+  /** Optional description shown below the title. */
+  description?: string;
+}
+
+export interface DocCardGridProps {
+  /** Flat list of fully resolved card items. */
+  items: DocCardItem[];
+  /** Accessible label for the `<nav>` element. Defaults to "Child pages". */
+  ariaLabel?: string;
+  /** Optional extra CSS classes appended to the `<nav>` element. */
+  class?: string;
+}
+
+function ArrowIcon(): JSX.Element {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+      viewBox="0 0 103.395 107.049"
+      aria-hidden="true"
+      class="w-[16px] shrink-0 text-accent"
+    >
+      <path d="M5.746 5.74 0 11.49l20.987 20.96C34.126 45.572 41.963 53.45 41.948 53.523c-.012.062-9.456 9.544-20.986 21.07L0 95.55l5.714 5.715c3.142 3.143 5.748 5.715 5.79 5.715s2.63-2.563 5.75-5.696l17.939-18.001c21.867-21.94 29.443-29.599 29.443-29.768 0-.114-.665-.804-5.084-5.275C51.872 40.47 11.71.125 11.565.036 11.525.01 8.906 2.578 5.746 5.74m38.345-.066c-3.132 3.13-5.696 5.71-5.696 5.732-.001.022 2.16 2.185 4.8 4.807 2.641 2.623 8.382 8.338 12.758 12.702 15.38 15.337 23.763 23.641 24.314 24.086.19.153.346.336.346.405 0 .07-1.738 1.847-3.887 3.976a17515 17515 0 0 0-20.35 20.264 19555 19555 0 0 1-17.223 17.158c-.416.409-.757.77-.757.8 0 .083 11.415 11.485 11.457 11.445.235-.22 53.542-53.528 53.542-53.543C103.395 53.472 49.891.02 49.837 0c-.028-.01-2.613 2.543-5.746 5.674" />
+    </svg>
+  );
+}
+
+/**
+ * DocCardGrid — JSX port of `src/components/doc-card-grid.astro`.
+ *
+ * Renders a flat list of `{ href, title, description? }` items as a two-column
+ * card grid. Each card shows an arrow icon, the doc title, and an optional
+ * description.
+ *
+ * This is the simplest of the card-grid family: it takes fully resolved items
+ * rather than NavNode tree nodes, making it easy to use for hand-crafted link
+ * lists or computed result sets.
+ *
+ * Returns `null` when `items` is empty.
+ */
+export function DocCardGrid(props: DocCardGridProps): JSX.Element | null {
+  const { items, ariaLabel = "Child pages", class: className } = props;
+
+  if (items.length === 0) return null;
+
+  const navClass = [
+    "grid grid-cols-1 gap-x-hsp-lg gap-y-vsp-md sm:grid-cols-2",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <nav aria-label={ariaLabel} class={navClass}>
+      {items.map((item, i) => (
+        <a
+          key={`doc-card-${i}`}
+          href={item.href}
+          class="group block rounded border border-muted bg-surface px-hsp-lg py-vsp-md hover:border-accent"
+        >
+          <span class="flex items-center gap-hsp-xs">
+            <ArrowIcon />
+            <span class="font-medium text-accent group-hover:underline">
+              {item.title}
+            </span>
+          </span>
+          {item.description && (
+            <span class="mt-vsp-2xs block text-small text-muted">
+              {item.description}
+            </span>
+          )}
+        </a>
+      ))}
+    </nav>
+  );
+}

--- a/packages/zudo-doc-v2/src/nav-indexing/docs-sitemap.tsx
+++ b/packages/zudo-doc-v2/src/nav-indexing/docs-sitemap.tsx
@@ -1,0 +1,116 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+// JSX port of src/components/docs-sitemap.astro.
+//
+// The original Astro template loaded the docs collection, built the nav tree,
+// and rendered a collapsible `<details>/<summary>` section for each top-level
+// category. Within each section it flattened the children (depth-first,
+// hasPage only) and listed them as links.
+//
+// This v2 port accepts the already-built tree directly. The host calls
+// buildNavTree (or buildSidebarTree from @zudo-doc/zudo-doc-v2/sidebar-tree)
+// before rendering this component.
+//
+// Behaviour parity notes:
+//   - Each top-level node becomes one `<details>` block (open by default).
+//   - Only leaf nodes with `hasPage === true` appear in the flat list.
+//   - Nodes without children (leaf-only categories) render an empty details
+//     body — matching the original's behaviour of rendering the details
+//     wrapper regardless.
+//   - Returns null when the tree is empty.
+
+import type { JSX } from "preact";
+
+import type { NavNode } from "./types";
+
+export interface DocsSitemapProps {
+  /**
+   * Pre-built navigation tree. Each top-level entry maps to one collapsible
+   * section in the sitemap.
+   */
+  tree: NavNode[];
+}
+
+/** Flatten a node tree depth-first, collecting only nodes with pages. */
+function flattenTree(nodes: NavNode[]): NavNode[] {
+  const result: NavNode[] = [];
+  function collect(n: NavNode[]): void {
+    for (const node of n) {
+      if (node.hasPage) result.push(node);
+      collect(node.children);
+    }
+  }
+  collect(nodes);
+  return result;
+}
+
+interface SitemapSectionProps {
+  node: NavNode;
+  index: number;
+}
+
+function SitemapSection({ node, index }: SitemapSectionProps): JSX.Element {
+  const leaves = flattenTree(node.children);
+
+  return (
+    <details key={`section-${index}`} class="group border border-muted overflow-hidden" open>
+      <summary class="flex items-center gap-x-hsp-md px-hsp-xl py-vsp-md text-subheading font-bold cursor-pointer select-none bg-surface list-none [&::-webkit-details-marker]:hidden">
+        <span class="inline-block text-caption text-muted transition-transform duration-200 group-open:rotate-90">
+          &#9654;
+        </span>
+        {node.href ? (
+          <a href={node.href} class="hover:underline focus:underline">
+            {node.label}
+          </a>
+        ) : (
+          <span>{node.label}</span>
+        )}
+      </summary>
+      {leaves.length > 0 && (
+        <div class="px-hsp-xl py-vsp-md">
+          <ul class="space-y-vsp-2xs pl-[1.25rem] list-none">
+            {leaves.map((leaf, li) => (
+              <li key={`leaf-${index}-${li}`}>
+                <a
+                  href={leaf.href}
+                  class="text-accent hover:underline focus:underline"
+                >
+                  {leaf.label}
+                </a>
+                {leaf.description && (
+                  <span class="ml-hsp-sm text-small text-muted">
+                    {leaf.description}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </details>
+  );
+}
+
+/**
+ * DocsSitemap — JSX port of `src/components/docs-sitemap.astro`.
+ *
+ * Renders the full documentation tree as a series of collapsible
+ * `<details>` sections. Each top-level node becomes one section; its
+ * descendants with `hasPage === true` are listed flat within that section.
+ *
+ * Returns `null` when `tree` is empty.
+ */
+export function DocsSitemap(props: DocsSitemapProps): JSX.Element | null {
+  const { tree } = props;
+
+  if (tree.length === 0) return null;
+
+  return (
+    <div class="flex flex-col gap-y-vsp-lg">
+      {tree.map((node, i) => (
+        <SitemapSection key={`sitemap-${i}`} node={node} index={i} />
+      ))}
+    </div>
+  );
+}

--- a/packages/zudo-doc-v2/src/nav-indexing/index.ts
+++ b/packages/zudo-doc-v2/src/nav-indexing/index.ts
@@ -1,0 +1,57 @@
+/**
+ * Public entry for the nav-indexing v2 primitives.
+ *
+ * Consumers import from `@zudo-doc/zudo-doc-v2/nav-indexing`:
+ *
+ *   import {
+ *     CategoryNav,
+ *     CategoryTreeNav,
+ *     SiteTreeNavDemo,
+ *     TagNav,
+ *     DocsSitemap,
+ *     NavCardGrid,
+ *     DocCardGrid,
+ *     VersionsPageContent,
+ *   } from "@zudo-doc/zudo-doc-v2/nav-indexing";
+ *
+ * All components are purely presentational — the host project assembles the
+ * collection data (navtrees, tag lists, version entries) before rendering.
+ * No `getCollection()` calls, no `@/` host-project imports, no Astro APIs.
+ */
+
+export { CategoryNav } from "./category-nav";
+export type { CategoryNavProps } from "./category-nav";
+
+export { CategoryTreeNav } from "./category-tree-nav";
+export type { CategoryTreeNavProps } from "./category-tree-nav";
+
+export { SiteTreeNavDemo } from "./site-tree-nav-demo";
+export type { SiteTreeNavDemoProps } from "./site-tree-nav-demo";
+
+export { TagNav } from "./tag-nav";
+export type {
+  TagNavProps,
+  TagNavAllProps,
+  TagNavPageProps,
+} from "./tag-nav";
+
+export { DocsSitemap } from "./docs-sitemap";
+export type { DocsSitemapProps } from "./docs-sitemap";
+
+export { NavCardGrid } from "./nav-card-grid";
+export type { NavCardGridProps } from "./nav-card-grid";
+
+export { DocCardGrid } from "./doc-card-grid";
+export type { DocCardGridProps, DocCardItem } from "./doc-card-grid";
+
+export { VersionsPageContent } from "./versions-page-content";
+export type { VersionsPageContentProps } from "./versions-page-content";
+
+export type {
+  NavNode,
+  TagItem,
+  TagLink,
+  TagNavLabels,
+  VersionPageEntry,
+  VersionsPageLabels,
+} from "./types";

--- a/packages/zudo-doc-v2/src/nav-indexing/nav-card-grid.tsx
+++ b/packages/zudo-doc-v2/src/nav-indexing/nav-card-grid.tsx
@@ -1,0 +1,104 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+// JSX port of src/components/nav-card-grid.astro.
+//
+// The original Astro template received a NavNode[] (direct children) plus a
+// locale, and rendered a two-column grid of link cards. It used
+// `docsUrl(child.slug, locale)` as a fallback href when the node had none.
+//
+// Because v2 is decoupled from the host's URL helpers, this port requires the
+// caller to resolve hrefs before passing the nodes. Nodes without `href` (after
+// the caller's mapping) are skipped — the consumer should ensure every node
+// that should render has a resolved `href`.
+//
+// Visual differences from CategoryNav:
+//   - The arrow SVG uses `text-accent` colouring and appears to the left of the
+//     label (gap-hsp-sm, items-center) rather than the CategoryNav flex-start
+//     layout.
+//   - Description has `group-hover:underline decoration-muted` on the span.
+//
+// Behaviour parity notes:
+//   - Nodes without `hasPage` and without children are filtered out.
+//   - Returns null when no renderable items remain.
+
+import type { JSX } from "preact";
+
+import type { NavNode } from "./types";
+
+export interface NavCardGridProps {
+  /**
+   * Direct children of the target category node. The consumer should
+   * pre-resolve `href` for each node (e.g. via `docsUrl(slug, locale)`).
+   * Nodes without `href` are skipped.
+   */
+  children: NavNode[];
+  /** Optional extra CSS classes appended to the `<nav>` element. */
+  class?: string;
+}
+
+function ArrowIcon(): JSX.Element {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+      viewBox="0 0 103.395 107.049"
+      aria-hidden="true"
+      class="w-[16px] shrink-0 text-accent"
+    >
+      <path d="M5.746 5.74 0 11.49l20.987 20.96C34.126 45.572 41.963 53.45 41.948 53.523c-.012.062-9.456 9.544-20.986 21.07L0 95.55l5.714 5.715c3.142 3.143 5.748 5.715 5.79 5.715s2.63-2.563 5.75-5.696l17.939-18.001c21.867-21.94 29.443-29.599 29.443-29.768 0-.114-.665-.804-5.084-5.275C51.872 40.47 11.71.125 11.565.036 11.525.01 8.906 2.578 5.746 5.74m38.345-.066c-3.132 3.13-5.696 5.71-5.696 5.732-.001.022 2.16 2.185 4.8 4.807 2.641 2.623 8.382 8.338 12.758 12.702 15.38 15.337 23.763 23.641 24.314 24.086.19.153.346.336.346.405 0 .07-1.738 1.847-3.887 3.976a17515 17515 0 0 0-20.35 20.264 19555 19555 0 0 1-17.223 17.158c-.416.409-.757.77-.757.8 0 .083 11.415 11.485 11.457 11.445.235-.22 53.542-53.528 53.542-53.543C103.395 53.472 49.891.02 49.837 0c-.028-.01-2.613 2.543-5.746 5.674" />
+    </svg>
+  );
+}
+
+/**
+ * NavCardGrid — JSX port of `src/components/nav-card-grid.astro`.
+ *
+ * Renders direct children of a category as a two-column grid of card links.
+ * Unlike `CategoryNav`, the arrow icon uses `text-accent` and sits inline with
+ * the label via `items-center`. Description lines have a hover-underline effect.
+ *
+ * The caller must pre-resolve `href` for each node. Nodes with neither
+ * `hasPage` nor children are excluded; nodes without an `href` are skipped.
+ *
+ * Returns `null` when no renderable items remain.
+ */
+export function NavCardGrid(props: NavCardGridProps): JSX.Element | null {
+  const { children, class: className } = props;
+  const items = children.filter(
+    (c) => (c.hasPage || c.children.length > 0) && c.href,
+  );
+
+  if (items.length === 0) return null;
+
+  const navClass = [
+    "grid grid-cols-1 gap-x-hsp-lg gap-y-vsp-md sm:grid-cols-2",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <nav aria-label="Child pages" class={navClass}>
+      {items.map((child, i) => (
+        <a
+          key={`nav-card-${i}`}
+          href={child.href}
+          class="group block rounded border border-muted bg-surface px-hsp-lg py-vsp-md hover:border-accent"
+        >
+          <span class="flex items-center gap-hsp-sm">
+            <ArrowIcon />
+            <span class="font-medium text-accent group-hover:underline">
+              {child.label}
+            </span>
+          </span>
+          {child.description && (
+            <span class="mt-vsp-2xs block text-small text-muted group-hover:underline decoration-muted">
+              {child.description}
+            </span>
+          )}
+        </a>
+      ))}
+    </nav>
+  );
+}

--- a/packages/zudo-doc-v2/src/nav-indexing/site-tree-nav-demo.tsx
+++ b/packages/zudo-doc-v2/src/nav-indexing/site-tree-nav-demo.tsx
@@ -1,0 +1,160 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+// JSX port of src/components/site-tree-nav-demo.astro.
+//
+// The original Astro template loaded the full doc collection, built the nav
+// tree with groupSatelliteNodes, and rendered the interactive SiteTreeNav
+// Preact island (client:visible). Because v2 is decoupled from host helpers
+// and collection queries, this port:
+//
+//   1. Accepts the already-processed tree as a prop.
+//   2. Renders a static server-side tree view using <details>/<summary> for
+//      native collapse — no JS required, works in any rendering environment.
+//
+// The host project builds the tree upstream (buildNavTree + groupSatelliteNodes
+// from @/utils/docs, or buildSidebarTree from @zudo-doc/zudo-doc-v2/sidebar-tree)
+// and passes it in. The categoryOrder / categoryIgnore props mirror the
+// filtering that site-tree-nav.tsx applies at runtime.
+
+import type { JSX } from "preact";
+
+import type { NavNode } from "./types";
+
+export interface SiteTreeNavDemoProps {
+  /**
+   * Pre-built top-level tree nodes. The host calls buildNavTree (or
+   * buildSidebarTree) + groupSatelliteNodes before rendering this component.
+   */
+  tree: NavNode[];
+  /**
+   * Category slugs to pin at the front of the list, in order.
+   * Unmatched slugs are appended after the ordered ones.
+   */
+  categoryOrder?: string[];
+  /**
+   * Category slugs to exclude from the rendered tree entirely.
+   */
+  categoryIgnore?: string[];
+  /** aria-label for the wrapping <nav>. Defaults to "Site index". */
+  ariaLabel?: string;
+}
+
+/** Flatten a node list depth-first, collecting only nodes with pages. */
+function flattenTree(nodes: NavNode[]): NavNode[] {
+  const result: NavNode[] = [];
+  function collect(n: NavNode[]): void {
+    for (const node of n) {
+      if (node.hasPage) result.push(node);
+      collect(node.children);
+    }
+  }
+  collect(nodes);
+  return result;
+}
+
+/** Re-order a flat list by a declared slug order (matches SiteTreeNav logic). */
+function reorder(nodes: NavNode[], order: string[]): NavNode[] {
+  if (!order.length) return nodes;
+  const remaining = [...nodes];
+  const result: NavNode[] = [];
+  for (const slug of order) {
+    const idx = remaining.findIndex(
+      (n) => n.href?.includes(`/${slug}/`) || n.href?.includes(`/${slug}`),
+    );
+    if (idx !== -1) {
+      result.push(remaining.splice(idx, 1)[0]!);
+    }
+  }
+  return [...result, ...remaining];
+}
+
+interface SectionProps {
+  node: NavNode;
+}
+
+function Section({ node }: SectionProps): JSX.Element {
+  const leaves = flattenTree(node.children);
+  return (
+    <details class="group border border-muted overflow-hidden" open>
+      <summary class="flex items-center gap-x-hsp-md px-hsp-xl py-vsp-md text-subheading font-bold cursor-pointer select-none bg-surface list-none [&::-webkit-details-marker]:hidden">
+        <span class="inline-block text-caption text-muted transition-transform duration-200 group-open:rotate-90">
+          &#9654;
+        </span>
+        {node.href ? (
+          <a href={node.href} class="hover:underline focus:underline">
+            {node.label}
+          </a>
+        ) : (
+          <span>{node.label}</span>
+        )}
+      </summary>
+      {leaves.length > 0 && (
+        <div class="px-hsp-xl py-vsp-md">
+          <ul class="space-y-vsp-2xs pl-[1.25rem] list-none">
+            {leaves.map((leaf, i) => (
+              <li key={`leaf-${i}`}>
+                <a
+                  href={leaf.href}
+                  class="text-accent hover:underline focus:underline"
+                >
+                  {leaf.label}
+                </a>
+                {leaf.description && (
+                  <span class="ml-hsp-sm text-small text-muted">
+                    {leaf.description}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </details>
+  );
+}
+
+/**
+ * SiteTreeNavDemo — JSX port of `src/components/site-tree-nav-demo.astro`.
+ *
+ * Renders the full site tree as a static collapsible section-by-section view.
+ * Each top-level category becomes a `<details>` block; leaves within each
+ * section are listed as links.
+ *
+ * The host assembles the tree (e.g. via `buildSidebarTree` from
+ * `@zudo-doc/zudo-doc-v2/sidebar-tree`) and passes it as `tree`.
+ *
+ * Returns `null` when the tree is empty after filtering.
+ */
+export function SiteTreeNavDemo(props: SiteTreeNavDemoProps): JSX.Element | null {
+  const {
+    tree,
+    categoryOrder = [],
+    categoryIgnore = [],
+    ariaLabel = "Site index",
+  } = props;
+
+  const ignoreSet = new Set(categoryIgnore);
+
+  // Filter out ignored slugs, then re-order
+  let visible = tree.filter((node) => {
+    const slug =
+      node.href?.replace(/^\/(?:[\w-]+\/)?docs\//, "").replace(/\/$/, "") ??
+      node.label.toLowerCase().replace(/\s+/g, "-");
+    return !ignoreSet.has(slug);
+  });
+
+  visible = reorder(visible, categoryOrder);
+
+  if (visible.length === 0) return null;
+
+  return (
+    <nav aria-label={ariaLabel}>
+      <div class="flex flex-col gap-y-vsp-lg">
+        {visible.map((node, i) => (
+          <Section key={`section-${i}`} node={node} />
+        ))}
+      </div>
+    </nav>
+  );
+}

--- a/packages/zudo-doc-v2/src/nav-indexing/tag-nav.tsx
+++ b/packages/zudo-doc-v2/src/nav-indexing/tag-nav.tsx
@@ -1,0 +1,157 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+// JSX port of src/components/tag-nav.astro.
+//
+// The original Astro template had two rendering branches controlled by the
+// `variant` prop:
+//
+//   "all"  — collects all tags from the collection, sorts them, and renders
+//            a full tag cloud (pointed-chip style) with counts.
+//   "page" — renders a small inline chip row for the tags on the current page.
+//
+// Because v2 must not call getCollection() or import the host's collectTags /
+// settings helpers, both variants now accept pre-resolved data as props.
+// The host builds the tag list upstream and passes it in.
+//
+// Visual parity notes:
+//   - The "all" variant uses 16px/12px clip-path widths for the arrow shape.
+//   - The "page" variant uses 12px/8px clip-path widths (smaller chip).
+//   - Both use the same two-layer border-faking technique from the original.
+//   - Returns null when the relevant data is empty.
+
+import type { JSX } from "preact";
+
+import type { TagItem, TagLink, TagNavLabels } from "./types";
+
+// ─── "all" variant ──────────────────────────────────────────────────────────
+
+export interface TagNavAllProps {
+  variant: "all";
+  /** Pre-sorted tag list with counts and pre-resolved hrefs. */
+  tags: TagItem[];
+  /** i18n strings for aria-labels. */
+  labels: TagNavLabels;
+}
+
+// ─── "page" variant ─────────────────────────────────────────────────────────
+
+export interface TagNavPageProps {
+  variant: "page";
+  /** Tags for the current page with pre-resolved hrefs. */
+  tagLinks: TagLink[];
+  /** i18n strings for aria-labels. */
+  labels: TagNavLabels;
+}
+
+export type TagNavProps = TagNavAllProps | TagNavPageProps;
+
+// ─── Shared chip shapes ──────────────────────────────────────────────────────
+
+/**
+ * Large pointed chip — used in the "all" tag cloud.
+ *
+ * Outer: 16px arrow inset; inner: 17px (outer + 1px border rim).
+ */
+function AllTagChip({
+  tag,
+  count,
+  href,
+  labels,
+}: TagItem & { labels: TagNavLabels }): JSX.Element {
+  return (
+    <li class="inline-flex whitespace-nowrap">
+      <a
+        href={href}
+        aria-label={`${labels.taggedWith}: ${tag}`}
+        class="group relative inline-flex no-underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+      >
+        <span
+          class="absolute inset-0 bg-muted group-hover:bg-fg"
+          style="clip-path: polygon(0 0, calc(100% - 16px) 0, 100% 50%, calc(100% - 16px) 100%, 0 100%)"
+        />
+        <span
+          class="relative inline-flex items-center text-small text-fg bg-bg pl-hsp-sm pr-hsp-xl py-vsp-2xs group-hover:text-bg group-hover:bg-fg"
+          style="clip-path: polygon(1px 1px, calc(100% - 17px) 1px, calc(100% - 1px) 50%, calc(100% - 17px) calc(100% - 1px), 1px calc(100% - 1px))"
+        >
+          <span>#{tag}</span>
+          <span class="text-caption opacity-60">&nbsp;({count})</span>
+        </span>
+      </a>
+    </li>
+  );
+}
+
+/**
+ * Small pointed chip — used in the per-page tag row.
+ *
+ * Outer: 12px arrow inset; inner: 13px (outer + 1px border rim).
+ */
+function PageTagChip({
+  tag,
+  href,
+  labels,
+}: TagLink & { labels: TagNavLabels }): JSX.Element {
+  return (
+    <a
+      href={href}
+      aria-label={`${labels.taggedWith}: ${tag}`}
+      class="group relative inline-flex no-underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+    >
+      <span
+        class="absolute inset-0 bg-muted group-hover:bg-fg"
+        style="clip-path: polygon(0 0, calc(100% - 12px) 0, 100% 50%, calc(100% - 12px) 100%, 0 100%)"
+      />
+      <span
+        class="relative inline-flex items-center text-caption text-fg bg-bg pl-hsp-sm pr-hsp-lg py-vsp-2xs group-hover:text-bg group-hover:bg-fg"
+        style="clip-path: polygon(1px 1px, calc(100% - 13px) 1px, calc(100% - 1px) 50%, calc(100% - 13px) calc(100% - 1px), 1px calc(100% - 1px))"
+      >
+        #{tag}
+      </span>
+    </a>
+  );
+}
+
+// ─── Public component ────────────────────────────────────────────────────────
+
+/**
+ * TagNav — JSX port of `src/components/tag-nav.astro`.
+ *
+ * Two variants:
+ *
+ *   - `variant="all"` — full tag cloud with count badges, sorted alphabetically
+ *     by the caller. The host resolves `TagItem[]` (tag + count + href) before
+ *     passing them in.
+ *
+ *   - `variant="page"` — small per-page chip strip. The host maps the
+ *     frontmatter `tags: string[]` to `TagLink[]` (tag + href) before passing.
+ *
+ * Returns `null` when the relevant data is empty.
+ */
+export function TagNav(props: TagNavProps): JSX.Element | null {
+  if (props.variant === "all") {
+    const { tags, labels } = props;
+    if (tags.length === 0) return null;
+
+    return (
+      <ul class="flex flex-wrap gap-x-hsp-xs gap-y-vsp-xs">
+        {tags.map((item) => (
+          <AllTagChip key={`tag-${item.tag}`} {...item} labels={labels} />
+        ))}
+      </ul>
+    );
+  }
+
+  // variant === "page"
+  const { tagLinks, labels } = props;
+  if (tagLinks.length === 0) return null;
+
+  return (
+    <div class="flex flex-wrap items-center gap-x-hsp-xs gap-y-vsp-xs">
+      <span class="text-caption text-muted">{labels.tags}:</span>
+      {tagLinks.map((tl) => (
+        <PageTagChip key={`ptag-${tl.tag}`} {...tl} labels={labels} />
+      ))}
+    </div>
+  );
+}

--- a/packages/zudo-doc-v2/src/nav-indexing/types.ts
+++ b/packages/zudo-doc-v2/src/nav-indexing/types.ts
@@ -1,0 +1,99 @@
+/**
+ * Shared types for the nav-indexing v2 primitives.
+ *
+ * All types are presentational: every value the components need to render
+ * arrives via props. No host-project imports, no Astro collection queries.
+ */
+
+/**
+ * Minimal tree node used by tree-based nav components (CategoryNav,
+ * CategoryTreeNav, NavCardGrid, DocsSitemap, SiteTreeNavDemo).
+ *
+ * Structurally compatible with the host project's `NavNode` from
+ * `src/utils/docs.ts` and with `SidebarNode` from `sidebar-tree/`, so
+ * callers can pass either through with minor adapter mapping if needed.
+ */
+export interface NavNode {
+  label: string;
+  description?: string;
+  /** Pre-resolved href. Undefined for category-only nodes without an index page. */
+  href?: string;
+  /** True when an MDX page backs this node. */
+  hasPage: boolean;
+  children: NavNode[];
+}
+
+/**
+ * A single tag entry with pre-resolved href — for `TagNav` "all" variant.
+ */
+export interface TagItem {
+  tag: string;
+  count: number;
+  /** Pre-resolved href including locale prefix and base path. */
+  href: string;
+}
+
+/**
+ * A tag with its pre-resolved href — for `TagNav` "page" variant.
+ */
+export interface TagLink {
+  tag: string;
+  /** Pre-resolved href. */
+  href: string;
+}
+
+/**
+ * i18n label bag for `TagNav`. Keeps v2 decoupled from the host's `t()`
+ * function — the consumer resolves strings for the active locale and passes
+ * them in.
+ */
+export interface TagNavLabels {
+  /** e.g. "Tags" / "タグ" — prefix label shown before the chips. */
+  tags: string;
+  /** e.g. "Pages tagged with" — used for aria-label on each chip link. */
+  taggedWith: string;
+}
+
+/**
+ * A single past version entry for `VersionsPageContent`.
+ *
+ * Extends `VersionEntry` from `@zudo-doc/zudo-doc-v2/i18n-version/types`
+ * with the pre-resolved doc href and optional status banner.
+ */
+export interface VersionPageEntry {
+  slug: string;
+  label: string;
+  /** Pre-resolved href to the version's default doc page. */
+  docsHref: string;
+  /** Optional status badge rendered in the Status column. */
+  banner?: "unmaintained" | "unreleased";
+}
+
+/**
+ * i18n label bag for `VersionsPageContent`. The consumer resolves all
+ * strings for the active locale and passes them in.
+ */
+export interface VersionsPageLabels {
+  /** Page `<h1>` text, e.g. "Documentation Versions". */
+  pageTitle: string;
+  /** Latest version section heading, e.g. "Latest Version (Current)". */
+  latestTitle: string;
+  /** Description below the latest heading. */
+  latestDescription: string;
+  /** Link label for the latest docs link. */
+  latestLink: string;
+  /** Past versions section heading, e.g. "Past Versions". */
+  pastTitle: string;
+  /** Description below past versions heading. */
+  pastDescription: string;
+  /** "Unmaintained" badge label. */
+  unmaintained: string;
+  /** "Unreleased" badge label. */
+  unreleased: string;
+  /** Table column: version label heading. */
+  versionCol: string;
+  /** Table column: status heading. */
+  statusCol: string;
+  /** Table column: docs link heading (also used as the link text). */
+  docsCol: string;
+}

--- a/packages/zudo-doc-v2/src/nav-indexing/versions-page-content.tsx
+++ b/packages/zudo-doc-v2/src/nav-indexing/versions-page-content.tsx
@@ -1,0 +1,141 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+// JSX port of src/components/versions-page-content.astro.
+//
+// The original Astro template read settings.versions, resolved href helpers
+// from @/utils/base, called the host's t() i18n function, and rendered a
+// two-section versions page (latest + past versions table).
+//
+// This v2 port accepts all strings and data as props so it stays decoupled
+// from the host's settings, URL builders, and i18n system. The consumer
+// resolves translation strings for the active locale and passes them via
+// the `labels` bag.
+//
+// Behaviour parity notes:
+//   - "Latest version" section is always rendered (latestHref is required).
+//   - "Past versions" section only renders when `versions` is non-empty.
+//   - `unmaintained` renders an amber warning badge; `unreleased` renders
+//     a blue info badge — identical CSS to the original template.
+//   - Returns the page content (not null) regardless of whether past
+//     versions exist (matching the Astro template's unconditional h1).
+
+import type { JSX } from "preact";
+
+import type { VersionPageEntry, VersionsPageLabels } from "./types";
+
+export interface VersionsPageContentProps {
+  /** Pre-resolved href to the latest version's default docs page. */
+  latestHref: string;
+  /** Past version entries. Empty array hides the past-versions section. */
+  versions: VersionPageEntry[];
+  /** Localized label strings. */
+  labels: VersionsPageLabels;
+}
+
+/**
+ * VersionsPageContent — JSX port of `src/components/versions-page-content.astro`.
+ *
+ * Renders the full documentation versions page:
+ *   - An `<h1>` heading (from `labels.pageTitle`).
+ *   - A "Latest version" section with a link to the current docs.
+ *   - A "Past versions" table (only when `versions` is non-empty) showing
+ *     each version's label, status badge, and a docs link.
+ *
+ * All strings and hrefs are pre-resolved by the consumer so this component
+ * stays locale- and settings-agnostic.
+ */
+export function VersionsPageContent(
+  props: VersionsPageContentProps,
+): JSX.Element {
+  const { latestHref, versions, labels } = props;
+
+  return (
+    <>
+      <h1 class="text-heading font-bold mb-vsp-lg">{labels.pageTitle}</h1>
+
+      {/* Latest version section */}
+      <section class="mb-vsp-xl">
+        <h2 class="text-subheading font-bold mb-vsp-xs">{labels.latestTitle}</h2>
+        <p class="text-small text-muted mb-vsp-sm">{labels.latestDescription}</p>
+        <a
+          href={latestHref}
+          class="inline-flex items-center gap-hsp-xs text-small text-accent underline hover:text-accent-hover"
+        >
+          {labels.latestLink}
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-[0.875rem] w-[0.875rem]"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M9 5l7 7-7 7"
+            />
+          </svg>
+        </a>
+      </section>
+
+      {/* Past versions section */}
+      {versions.length > 0 && (
+        <section>
+          <h2 class="text-subheading font-bold mb-vsp-xs">{labels.pastTitle}</h2>
+          <p class="text-small text-muted mb-vsp-md">{labels.pastDescription}</p>
+          <div class="border border-muted rounded overflow-hidden">
+            <table class="w-full text-small">
+              <thead>
+                <tr class="border-b border-muted bg-surface">
+                  <th class="px-hsp-lg py-vsp-sm text-left font-medium text-muted">
+                    {labels.versionCol}
+                  </th>
+                  <th class="px-hsp-lg py-vsp-sm text-left font-medium text-muted">
+                    {labels.statusCol}
+                  </th>
+                  <th class="px-hsp-lg py-vsp-sm text-left font-medium text-muted">
+                    {labels.docsCol}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {versions.map((v) => (
+                  <tr
+                    key={`version-${v.slug}`}
+                    class="border-b border-muted last:border-b-0"
+                  >
+                    <td class="px-hsp-lg py-vsp-sm font-medium text-fg">
+                      {v.label}
+                    </td>
+                    <td class="px-hsp-lg py-vsp-sm">
+                      {v.banner === "unmaintained" && (
+                        <span class="inline-block rounded px-hsp-xs py-vsp-3xs text-caption bg-warning/10 text-warning">
+                          {labels.unmaintained}
+                        </span>
+                      )}
+                      {v.banner === "unreleased" && (
+                        <span class="inline-block rounded px-hsp-xs py-vsp-3xs text-caption bg-info/10 text-info">
+                          {labels.unreleased}
+                        </span>
+                      )}
+                    </td>
+                    <td class="px-hsp-lg py-vsp-sm">
+                      <a
+                        href={v.docsHref}
+                        class="text-accent underline hover:text-accent-hover"
+                      >
+                        {labels.docsCol}
+                      </a>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+    </>
+  );
+}

--- a/packages/zudo-doc-v2/vitest.config.ts
+++ b/packages/zudo-doc-v2/vitest.config.ts
@@ -1,6 +1,11 @@
 import { defineConfig } from "vitest/config";
 import { resolve } from "node:path";
 
+// The package directory — vitest resolves `include` globs relative to `root`,
+// which defaults to process.cwd() (the workspace root) rather than the config
+// file's directory. Setting it explicitly ensures tests in this package's
+// `src/**/__tests__/` are found, not the root-level `src/**/__tests__/`.
+const pkgRoot = __dirname;
 const repoRoot = resolve(__dirname, "../..");
 
 /**
@@ -32,6 +37,7 @@ export default defineConfig({
     },
   },
   test: {
+    root: pkgRoot,
     include: ["src/**/__tests__/**/*.test.{ts,tsx}"],
   },
 });

--- a/src/components/body-foot-util-area.astro
+++ b/src/components/body-foot-util-area.astro
@@ -1,5 +1,5 @@
 ---
-import { DocHistory } from "@/components/doc-history";
+import { DocHistoryIsland } from "@/components/ssr-islands";
 import { settings } from "@/config/settings";
 import { defaultLocale, t, type Locale } from "@/config/i18n";
 import { withBase } from "@/utils/base";
@@ -81,11 +81,10 @@ const hasContent = docHistoryEnabled || sourceUrl;
         </div>
       )}
       {docHistoryEnabled && (
-        <DocHistory
+        <DocHistoryIsland
           slug={currentSlug}
           locale={lang !== defaultLocale ? lang : undefined}
           basePath={withBase("/")}
-          client:idle
         />
       )}
     </section>

--- a/src/components/header.astro
+++ b/src/components/header.astro
@@ -1,6 +1,7 @@
 ---
 import SidebarToggle from "@/components/sidebar-toggle";
 import ThemeToggle from "@/components/theme-toggle";
+import { Island } from "@takazudo/zfb";
 import LanguageSwitcher from "@/components/language-switcher.astro";
 import VersionSwitcher from "@/components/version-switcher.astro";
 import Search from "@/components/search.astro";
@@ -61,9 +62,11 @@ function isNavItemActive(item: (typeof settings.headerNav)[number]): boolean {
   class="sticky top-0 z-50 flex h-[3.5rem] items-center border-b border-muted bg-surface px-hsp-lg"
   data-header
 >
-  <SidebarToggle client:media="(max-width: 1023px)">
-    <slot name="sidebar" />
-  </SidebarToggle>
+  <Island when="media">
+    <SidebarToggle>
+      <slot name="sidebar" />
+    </SidebarToggle>
+  </Island>
 
   <a
     href={withBase(isNonDefaultLocale ? `/${lang}/` : "/")}
@@ -295,10 +298,9 @@ function isNavItemActive(item: (typeof settings.headerNav)[number]): boolean {
           if (!settings.colorMode) return null;
           return (
             <div class="hidden lg:flex items-center">
-              <ThemeToggle
-                defaultMode={settings.colorMode.defaultMode}
-                client:load
-              />
+              <Island when="load">
+                <ThemeToggle defaultMode={settings.colorMode.defaultMode} />
+              </Island>
             </div>
           );
         }

--- a/src/components/html-preview-wrapper.astro
+++ b/src/components/html-preview-wrapper.astro
@@ -1,5 +1,6 @@
 ---
 import HtmlPreview from "./html-preview/html-preview";
+import { Island } from "@takazudo/zfb";
 import { settings } from "@/config/settings";
 
 interface Props {
@@ -23,16 +24,17 @@ const mergedCss =
 const mergedJs = [globalConfig?.js, js].filter(Boolean).join("\n") || undefined;
 ---
 
-<HtmlPreview
-  client:visible
-  html={html}
-  css={mergedCss}
-  head={mergedHead}
-  js={mergedJs}
-  title={title}
-  height={height}
-  defaultOpen={defaultOpen}
-  componentCss={css}
-  componentHead={head}
-  componentJs={js}
-/>
+<Island when="visible">
+  <HtmlPreview
+    html={html}
+    css={mergedCss}
+    head={mergedHead}
+    js={mergedJs}
+    title={title}
+    height={height}
+    defaultOpen={defaultOpen}
+    componentCss={css}
+    componentHead={head}
+    componentJs={js}
+  />
+</Island>

--- a/src/components/island.tsx
+++ b/src/components/island.tsx
@@ -1,0 +1,41 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+// Phase-A stub for the `Island` hydration-boundary primitive from
+// `@takazudo/zfb`. The real implementation lives in the zfb repo and
+// will replace this file once the package is published and integrated.
+//
+// For now, Island renders its children transparently (server-side).
+// Client-side hydration scheduling (`when` prop) is recorded on the
+// element via data-attributes so the zfb runtime can pick it up once
+// it is wired in. During Phase A the `when` value is preserved here
+// in a comment — no actual data-attribute is emitted by this stub.
+
+import type { ComponentChildren } from "preact";
+
+/** Hydration scheduling strategy — mirrors zfb's `IslandWhen` union. */
+export type IslandWhen = "load" | "idle" | "visible" | "media";
+
+export interface IslandProps {
+  /** When to hydrate on the client. Phase-A: ignored; recorded for review. */
+  when?: IslandWhen;
+  /**
+   * Server-side fallback shown before hydration (SSR-skip mode). Phase-A:
+   * not used; accepted for API shape compatibility.
+   */
+  ssrFallback?: ComponentChildren;
+  children?: ComponentChildren;
+}
+
+/**
+ * Phase-A `Island` stub. Renders `children` server-side. Client-side
+ * hydration wiring lands once the zfb runtime is fully integrated.
+ *
+ * This file is the local implementation target for the Vite alias
+ * `"@takazudo/zfb"` → `"./src/components/island.tsx"`. All imports
+ * of `{ Island } from "@takazudo/zfb"` in the project resolve here.
+ */
+export function Island({ children }: IslandProps) {
+  // eslint-disable-next-line react/jsx-no-useless-fragment
+  return <>{children}</>;
+}

--- a/src/components/sidebar.astro
+++ b/src/components/sidebar.astro
@@ -1,5 +1,6 @@
 ---
 import SidebarTree from "@/components/sidebar-tree";
+import { Island } from "@takazudo/zfb";
 import { buildSidebarForSection } from "@/utils/sidebar";
 import { defaultLocale, locales, t, type Locale } from "@/config/i18n";
 import { buildLocaleLinks, versionedDocsUrl, navHref } from "@/utils/base";
@@ -76,14 +77,15 @@ const localeLinks =
   locales.length > 1 ? buildLocaleLinks(Astro.url.pathname, lang) : undefined;
 ---
 
-<SidebarTree
-  nodes={nodes}
-  currentSlug={currentSlug}
-  rootMenuItems={rootMenuItems}
-  backToMenuLabel={backToMenuLabel}
-  localeLinks={localeLinks}
-  themeDefaultMode={settings.colorMode
-    ? settings.colorMode.defaultMode
-    : undefined}
-  client:load
-/>
+<Island when="load">
+  <SidebarTree
+    nodes={nodes}
+    currentSlug={currentSlug}
+    rootMenuItems={rootMenuItems}
+    backToMenuLabel={backToMenuLabel}
+    localeLinks={localeLinks}
+    themeDefaultMode={settings.colorMode
+      ? settings.colorMode.defaultMode
+      : undefined}
+  />
+</Island>

--- a/src/components/site-tree-nav-demo.astro
+++ b/src/components/site-tree-nav-demo.astro
@@ -5,6 +5,7 @@ import { stripBase } from "@/utils/base";
 import { detectLocaleFromPath, type Locale } from "@/config/i18n";
 import { getCategoryOrder } from "@/utils/nav-scope";
 import SiteTreeNav from "@/components/site-tree-nav.tsx";
+import { Island } from "@takazudo/zfb";
 
 const currentPath = Astro.url.pathname;
 const pathWithoutBase = stripBase(currentPath);
@@ -17,9 +18,10 @@ const tree = buildNavTree(navDocs, lang, categoryMeta);
 const groupedTree = groupSatelliteNodes(tree, categoryOrder);
 ---
 
-<SiteTreeNav
-  tree={groupedTree}
-  categoryOrder={categoryOrder}
-  categoryIgnore={["inbox"]}
-  client:visible
-/>
+<Island when="visible">
+  <SiteTreeNav
+    tree={groupedTree}
+    categoryOrder={categoryOrder}
+    categoryIgnore={["inbox"]}
+  />
+</Island>

--- a/src/components/ssr-islands.tsx
+++ b/src/components/ssr-islands.tsx
@@ -1,0 +1,136 @@
+// Phase-A local SSR-skip island stubs — local counterparts of the framework
+// wrappers in packages/zudo-doc-v2/src/ssr-skip/. Kept in src/ to avoid
+// cross-package import complexity during Phase A scaffolding.
+//
+// Each wrapper emits a placeholder `<div>` with zfb marker attributes so
+// the zfb hydration runtime can find and replace it on the client. The
+// marker contract (`data-zfb-island-skip-ssr`, `data-when`,
+// `data-zfb-island-props`) is identical to the package versions.
+//
+// Usage: import from "@/components/ssr-islands" in .astro files that need
+// these wrappers instead of `client:only="preact"` directives.
+
+import { h } from "preact";
+import type { ComponentChildren, VNode } from "preact";
+
+type IslandWhen = "load" | "idle" | "visible" | "media";
+
+interface SsrSkipBaseProps {
+  when?: IslandWhen;
+  ssrFallback?: ComponentChildren;
+}
+
+/** Internal helper: emit the placeholder `<div>` with zfb marker attrs. */
+function ssrSkipPlaceholder(
+  name: string,
+  when: IslandWhen,
+  fallback: ComponentChildren,
+  props: Record<string, unknown>,
+): VNode {
+  const attrs: Record<string, unknown> = {
+    "data-zfb-island-skip-ssr": name,
+    "data-when": when,
+  };
+  const serialisable = Object.fromEntries(
+    Object.entries(props).filter(([, v]) => v !== undefined),
+  );
+  if (Object.keys(serialisable).length > 0) {
+    try {
+      attrs["data-zfb-island-props"] = JSON.stringify(serialisable);
+    } catch {
+      // drop non-serialisable props rather than crash SSR
+    }
+  }
+  return h("div", attrs, fallback ?? null);
+}
+
+// ─── AiChatModal ─────────────────────────────────────────────────────────────
+
+export interface AiChatModalIslandProps extends SsrSkipBaseProps {
+  /** Base path forwarded to the real component on hydration. */
+  basePath: string;
+}
+
+/**
+ * SSR-skip wrapper for the AI chat modal.
+ * Drop-in replacement for `<AiChatModal basePath={...} client:load />`.
+ */
+export function AiChatModalIsland({
+  when = "load",
+  ssrFallback = null,
+  basePath,
+}: AiChatModalIslandProps): VNode {
+  return ssrSkipPlaceholder("AiChatModal", when, ssrFallback, { basePath });
+}
+
+// ─── ImageEnlarge ────────────────────────────────────────────────────────────
+
+export type ImageEnlargeIslandProps = SsrSkipBaseProps;
+
+/**
+ * SSR-skip wrapper for the image-enlarge dialog.
+ * Drop-in replacement for `<ImageEnlarge client:idle />`.
+ */
+export function ImageEnlargeIsland(
+  props: ImageEnlargeIslandProps = {},
+): VNode {
+  const { when = "idle", ssrFallback = null } = props;
+  return ssrSkipPlaceholder("ImageEnlarge", when, ssrFallback, {});
+}
+
+// ─── DesignTokenTweakPanel ───────────────────────────────────────────────────
+
+export type DesignTokenTweakPanelIslandProps = SsrSkipBaseProps;
+
+/**
+ * SSR-skip wrapper for the design-token tweak panel.
+ * Drop-in replacement for `<DesignTokenTweakPanel client:only="preact" />`.
+ */
+export function DesignTokenTweakPanelIsland(
+  props: DesignTokenTweakPanelIslandProps = {},
+): VNode {
+  const { when = "load", ssrFallback = null } = props;
+  return ssrSkipPlaceholder("DesignTokenTweakPanel", when, ssrFallback, {});
+}
+
+// ─── MockInit ────────────────────────────────────────────────────────────────
+
+export type MockInitIslandProps = SsrSkipBaseProps;
+
+/**
+ * SSR-skip wrapper for the dev-only MSW mock initialiser.
+ * Drop-in replacement for `<MockInit client:only="preact" />`.
+ */
+export function MockInitIsland(props: MockInitIslandProps = {}): VNode {
+  const { when = "idle", ssrFallback = null } = props;
+  return ssrSkipPlaceholder("MockInit", when, ssrFallback, {});
+}
+
+// ─── DocHistory ──────────────────────────────────────────────────────────────
+
+export interface DocHistoryIslandProps extends SsrSkipBaseProps {
+  /** Page slug for the history JSON fetch path. */
+  slug: string;
+  /** Locale code (omit for default locale). */
+  locale?: string;
+  /** Site base path. */
+  basePath?: string;
+}
+
+/**
+ * SSR-skip wrapper for the doc-history dialog.
+ * Drop-in replacement for `<DocHistory slug={...} client:idle />`.
+ */
+export function DocHistoryIsland({
+  when = "idle",
+  ssrFallback = null,
+  slug,
+  locale,
+  basePath,
+}: DocHistoryIslandProps): VNode {
+  return ssrSkipPlaceholder("DocHistory", when, ssrFallback, {
+    slug,
+    locale,
+    basePath,
+  });
+}

--- a/src/content/docs-ja/getting-started/setup-preset-generator.mdx
+++ b/src/content/docs-ja/getting-started/setup-preset-generator.mdx
@@ -5,10 +5,11 @@ sidebar_position: 2.5
 ---
 
 import PresetGenerator from '@/components/preset-generator';
+import { Island } from "@takazudo/zfb";
 
 このインタラクティブツールを使って、zudo-docプロジェクトのオプションを設定し、セットアッププリセットを生成できます。出力はプログラマティックAPI用のJSON、またはターミナル用のCLIコマンドとしてコピーできます。
 
-<PresetGenerator client:load />
+<Island when="load"><PresetGenerator /></Island>
 
 ## ヘッダー右側アイテム
 

--- a/src/content/docs/getting-started/setup-preset-generator.mdx
+++ b/src/content/docs/getting-started/setup-preset-generator.mdx
@@ -5,10 +5,11 @@ sidebar_position: 2.5
 ---
 
 import PresetGenerator from '@/components/preset-generator';
+import { Island } from "@takazudo/zfb";
 
 Use this interactive tool to configure your zudo-doc project options and generate a setup preset. You can copy the output as JSON for the programmatic API, or as a CLI command for terminal usage.
 
-<PresetGenerator client:load />
+<Island when="load"><PresetGenerator /></Island>
 
 ## Header right items
 

--- a/src/layouts/doc-layout.astro
+++ b/src/layouts/doc-layout.astro
@@ -21,12 +21,15 @@ import VersionSwitcher from "@/components/version-switcher.astro";
 import VersionBanner from "@/components/version-banner.astro";
 import { getVersionAvailability } from "@/utils/version-availability";
 import Footer from "@/components/footer.astro";
-import DesignTokenTweakPanel from "@/components/design-token-tweak";
-import AiChatModal from "@/components/ai-chat-modal";
-import MockInit from "@/components/mock-init";
 import DesktopSidebarToggle from "@/components/desktop-sidebar-toggle";
 import FindInPageInit from "@/components/find-in-page-init";
-import ImageEnlarge from "@/components/image-enlarge";
+import { Island } from "@takazudo/zfb";
+import {
+  AiChatModalIsland,
+  DesignTokenTweakPanelIsland,
+  ImageEnlargeIsland,
+  MockInitIsland,
+} from "@/components/ssr-islands";
 import { SEMANTIC_DEFAULTS, SEMANTIC_CSS_NAMES } from "@/config/color-scheme-utils";
 
 // Either the new `designTokenPanel` flag or the deprecated `colorTweakPanel`
@@ -207,10 +210,9 @@ const contentTransition = {
       </aside>
     )}
     {!hideSidebar && settings.sidebarToggle && (
-      <DesktopSidebarToggle
-        client:load
-        transition:persist="desktop-sidebar-toggle"
-      />
+      <Island when="load" transition:persist="desktop-sidebar-toggle">
+        <DesktopSidebarToggle />
+      </Island>
     )}
 
     {/* Content margin wrapper - pushes content right of fixed sidebar */}
@@ -233,7 +235,7 @@ const contentTransition = {
             {versionBanner && latestUrl && (
               <VersionBanner type={versionBanner} latestUrl={latestUrl} lang={lang} />
             )}
-            {!hideToc && <MobileToc headings={headings} title={t("toc.title", lang)} client:load />}
+            {!hideToc && <Island when="load"><MobileToc headings={headings} title={t("toc.title", lang)} /></Island>}
             <article class="zd-content max-w-none">
               <slot />
             </article>
@@ -247,19 +249,19 @@ const contentTransition = {
           </main>
 
           {/* Table of contents */}
-          {!hideToc && <Toc headings={headings} client:load />}
+          {!hideToc && <Island when="load"><Toc headings={headings} /></Island>}
         </div>
       </div>
       <Footer lang={lang} />
     </div>
-    {settings.aiAssistant && <AiChatModal basePath={withBase("/")} client:load />}
-    {designTokenPanelEnabled && <DesignTokenTweakPanel client:only="preact" />}
+    {settings.aiAssistant && <AiChatModalIsland basePath={withBase("/")} />}
+    {designTokenPanelEnabled && <DesignTokenTweakPanelIsland />}
     <CodeBlockEnhancer />
     <TabsInit />
     {settings.mermaid && <MermaidInit />}
-    {import.meta.env.DEV && import.meta.env.PUBLIC_ENABLE_MOCKS === "true" && settings.aiAssistant && <MockInit client:only="preact" />}
-    <FindInPageInit client:load />
-    {settings.imageEnlarge && <ImageEnlarge client:idle />}
+    {import.meta.env.DEV && import.meta.env.PUBLIC_ENABLE_MOCKS === "true" && settings.aiAssistant && <MockInitIsland />}
+    <Island when="load"><FindInPageInit /></Island>
+    {settings.imageEnlarge && <ImageEnlargeIsland />}
     <PageLoadingOverlay />
     <script>
       let _sidebarScrollTop = 0;

--- a/src/pages/[locale]/index.astro
+++ b/src/pages/[locale]/index.astro
@@ -6,6 +6,7 @@ import { buildNavTree, groupSatelliteNodes, isNavVisible } from "@/utils/docs";
 import { loadLocaleDocs } from "@/utils/locale-docs";
 import { getCategoryOrder } from "@/utils/nav-scope";
 import SiteTreeNav from "@/components/site-tree-nav.tsx";
+import { Island } from "@takazudo/zfb";
 import { collectTags } from "@/utils/tags";
 import TagNav from "@/components/tag-nav.astro";
 import { toRouteSlug } from "@/utils/slug";
@@ -96,12 +97,13 @@ const tagCount = collectTags(
   </div>
 
   <!-- Sitemap grid -->
-  <SiteTreeNav
-    tree={groupedTree}
-    categoryOrder={categoryOrder}
-    categoryIgnore={["inbox"]}
-    client:idle
-  />
+  <Island when="idle">
+    <SiteTreeNav
+      tree={groupedTree}
+      categoryOrder={categoryOrder}
+      categoryIgnore={["inbox"]}
+    />
+  </Island>
 
   {
     settings.docTags && tagCount > 0 && (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,6 +6,7 @@ import { buildNavTree, groupSatelliteNodes, isNavVisible } from "@/utils/docs";
 import { loadLocaleDocs } from "@/utils/locale-docs";
 import { getCategoryOrder } from "@/utils/nav-scope";
 import SiteTreeNav from "@/components/site-tree-nav.tsx";
+import { Island } from "@takazudo/zfb";
 import { collectTags } from "@/utils/tags";
 import TagNav from "@/components/tag-nav.astro";
 import { toRouteSlug } from "@/utils/slug";
@@ -88,12 +89,13 @@ const tagCount = collectTags(
   </div>
 
   <!-- Sitemap grid -->
-  <SiteTreeNav
-    tree={groupedTree}
-    categoryOrder={categoryOrder}
-    categoryIgnore={["inbox"]}
-    client:idle
-  />
+  <Island when="idle">
+    <SiteTreeNav
+      tree={groupedTree}
+      categoryOrder={categoryOrder}
+      categoryIgnore={["inbox"]}
+    />
+  </Island>
 
   {
     settings.docTags && tagCount > 0 && (

--- a/zfb-shim.d.ts
+++ b/zfb-shim.d.ts
@@ -1,4 +1,4 @@
-// Local type shim for `zfb/config`.
+// Local type shims for `zfb/config` and `@takazudo/zfb`.
 //
 // During the Astro→zfb migration, the `zfb` npm package is not yet
 // published (Phase A engine has landed in the zfb repo's main branch but
@@ -6,11 +6,46 @@
 // build tool internally aliases `zfb/config` to its own stub at parse
 // time, so the runtime import works once the build runs through zfb.
 //
-// This `.d.ts` exists purely so that `zfb.config.ts` (and any future
-// helper that imports from `zfb/config`) typechecks under `pnpm check`
-// today, without dragging in `zfb` as a runtime dependency. The real
-// public types live in `packages/zfb/src/config.ts` of the zfb repo and
-// mirror this shape one-for-one — keep the two in sync.
+// These `.d.ts` declarations exist purely so that:
+//   - `zfb.config.ts` (and any future helper importing from `zfb/config`)
+//     typechecks under `pnpm check` today.
+//   - `.astro` and `.mdx` files that import `{ Island } from "@takazudo/zfb"`
+//     (Phase A migration scaffold, islands-wrap topic) typecheck correctly.
+//
+// The real public types live in the zfb repo and mirror these shapes
+// one-for-one — keep the two in sync.
+//
+// Runtime resolution: a Vite alias in `astro.config.ts` maps
+// `"@takazudo/zfb"` → `"./src/components/island.tsx"` so the build
+// resolves to the local Phase-A stub.
+
+// ─── @takazudo/zfb ───────────────────────────────────────────────────────────
+// Minimal ambient declaration for the `Island` hydration-boundary primitive.
+// The concrete implementation is the local stub in
+// `src/components/island.tsx`; this declaration lets TypeScript typecheck
+// imports of `{ Island } from "@takazudo/zfb"` without requiring the real
+// (unpublished) package in `node_modules`.
+
+declare module "@takazudo/zfb" {
+  /** Hydration scheduling strategy. */
+  export type IslandWhen = "load" | "idle" | "visible" | "media";
+
+  export interface IslandProps {
+    /** When to hydrate on the client. */
+    when?: IslandWhen;
+    /** Fallback rendered server-side (SSR-skip mode). */
+    ssrFallback?: unknown;
+    children?: unknown;
+  }
+
+  /**
+   * Island hydration-boundary wrapper. Replaces Astro `client:*` directives.
+   * Usage: `<Island when="load"><MyComponent /></Island>`
+   */
+  export function Island(props: IslandProps): unknown;
+}
+
+// ─── zfb/config ──────────────────────────────────────────────────────────────
 
 declare module "zfb/config" {
   /** JSX framework runtime. */


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/477
- super-epic
    - https://github.com/zudolab/zudo-doc/issues/473

---

## Summary

Second half of the `.astro` → JSX component port. Lands the framework-side JSX equivalents of 22 legacy `.astro` components into `packages/zudo-doc-v2/`, replaces all 16 `client:*` directives in consumer `.astro`/layout files with `<Island when="...">` or framework SSR-skip wrappers, and ports the 11 content typography components into `packages/zudo-doc-v2/src/content/`. Five sub-tasks merged via no-ff topic branches.

Hard-gated dependency from the issue spec: Phase A E1 + E2 npm publish (the `@takazudo/zfb` package). During this epic the `Island` runtime is a **deliberately no-op Phase-A stub** (`src/components/island.tsx`) wired via Vite alias; the real hydration runtime lands when Phase A E1+E2 ship and the alias swap happens — no further code changes needed in this branch.

## Topics

- **typography-port** (`packages/zudo-doc-v2/src/content/`) — 11 typography components (heading-h2/h3/h4, content-paragraph/link/strong/blockquote/ul/ol/table/code) ported unchanged with Preact-native types (`ComponentChildren`, `JSX.CSSProperties`). New `./content` export. 162 unit tests added. DocLayout wiring deferred to a follow-up to avoid sibling-topic conflicts.
- **nav-indexing** (`packages/zudo-doc-v2/src/nav-indexing/`) — 8 nav/indexing components (category-nav, category-tree-nav, site-tree-nav-demo, tag-nav, docs-sitemap, nav-card-grid, doc-card-grid, versions-page-content). New `./nav-indexing` export. 58 unit tests.
- **code-syntax** (`packages/zudo-doc-v2/src/code-syntax/`) — `code-block-enhancer`, `mermaid-init`, `tabs` (with `<TabItem>` composition via `toChildArray`). New `./code-syntax` export. 39 unit tests. Mermaid + code-block scripts use the script-as-string + `dangerouslySetInnerHTML` pattern (SSR-safe).
- **content-specific** (`packages/zudo-doc-v2/src/{details,metainfo,html-preview-wrapper}/`) — 5 components (details, doc-metainfo, doc-tags, frontmatter-preview, html-preview-wrapper stack). New `./details`, `./metainfo`, `./html-preview-wrapper` exports. (`edit-link` skipped — already ported in `body-foot-util` by sibling epic.)
- **islands-wrap** (consumer `.astro` files) — 16 `client:*` directives replaced with `<Island when="load|idle|visible|media">` or framework SSR-skip wrappers. Adds `src/components/island.tsx` (Phase-A passthrough stub aliased as `@takazudo/zfb`) and `src/components/ssr-islands.tsx` (local SSR-skip wrappers re-implementing `AiChatModalIsland`, `ImageEnlargeIsland`, `DesignTokenTweakPanelIsland`, `MockInitIsland`, `DocHistoryIsland`). Final `grep -R "client:" src/` returns only doc-prose / comment hits — no live directives.

## Acceptance criteria from epic #477

- ✅ `grep -R "client:" src/` zero live directives (22 remaining hits are documentation prose and one self-referential comment block in `ssr-islands.tsx`).
- ⚠️  Typography byte-for-byte parity — cannot run that diff in this session (no browser tooling); deferred to super-PR review with a one-shot Opus subagent UI check after the super-epic base is reviewed.

## Quality

- `pnpm check` clean (typecheck + astro sync).
- `pnpm exec vitest run --config packages/zudo-doc-v2/vitest.config.ts` — 299/299 passing across 29 test files.
- `/gcoc-review` (gpt-4.1) on the merged diff — no in-branch fixes required. One unrelated finding raised as #491 (React imports leaking in `packages/zudo-doc-v2/src/theme/`, introduced by sibling epic aea48b6).

## Notes for super-PR review

- The `Island` Phase-A stub renders children server-side and ignores the `when` prop. This means all rewrapped islands are non-hydrating in the current build until `@takazudo/zfb` is wired. Coordinated with Phase A.
- `<SidebarToggle client:media="(max-width: 1023px)">` became `<Island when="media"><SidebarToggle/></Island>` — the explicit query string is dropped because the Phase-A Island API only carries the `when` keyword. Once the real Island runtime lands, the query carrier may need to be added back via `<Island when="media" mediaQuery="...">` or similar — flagged for Phase A integration follow-up.
- Consumer-side imports for typography (`src/components/content/`) and content-specific components remain pointed at the original `.astro`/local paths to avoid sibling-topic conflicts. Clean swap to `@zudo-doc/zudo-doc-v2/{content,metainfo,details,html-preview-wrapper}` is a follow-up.

## Topics merged

- typography-port → 692c797
- nav-indexing → 460c777
- code-syntax → b72c99e
- content-specific → 30ca7f8
- islands-wrap → e7cf21f (also #490 — auto-resolved when base was pushed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)