### PR TITLE
feat(routing): port entire docs route family to zfb pages/

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,0 +1,45 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+// Port of src/pages/404.astro → zfb page module.
+//
+// The 404 page is a static route with no dynamic params. zfb emits it as
+// dist/404.html so the host platform (Cloudflare Pages, Netlify, etc.) can
+// serve it for unmatched requests. No paths() export needed.
+//
+// The original Astro page rendered the full html/head/body inline without
+// DocLayout because the 404 page intentionally has no sidebar/TOC/header.
+// This port wraps via DocLayoutWithDefaults with hideSidebar/hideToc plus
+// a noindex meta so search engines do not index it.
+
+import { settings } from "@/config/settings";
+import { defaultLocale } from "@/config/i18n";
+import { withBase } from "@/utils/base";
+import { DocLayoutWithDefaults } from "@zudo-doc/zudo-doc-v2/doclayout";
+import type { JSX } from "preact";
+
+export const frontmatter = { title: "404" };
+
+export default function NotFoundPage(): JSX.Element {
+  const locale = defaultLocale;
+
+  return (
+    <DocLayoutWithDefaults
+      title={`Page Not Found | ${settings.siteName}`}
+      lang={locale}
+      noindex={true}
+      hideSidebar={true}
+      hideToc={true}
+    >
+      <div class="min-h-[60vh] flex flex-col items-center justify-center px-hsp-2xl py-vsp-xl">
+        <h1 class="text-display font-bold mb-vsp-md">404</h1>
+        <p class="text-subheading text-muted mb-vsp-xl">Page not found.</p>
+        <a
+          href={withBase("/")}
+          class="bg-accent px-hsp-lg py-vsp-xs font-medium text-bg hover:bg-accent-hover"
+        >
+          Back to Home
+        </a>
+      </div>
+    </DocLayoutWithDefaults>
+  );
+}

--- a/pages/[locale]/docs/[...slug].tsx
+++ b/pages/[locale]/docs/[...slug].tsx
@@ -1,0 +1,321 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+// Port of src/pages/[locale]/docs/[...slug].astro → zfb page module.
+//
+// Non-default-locale catch-all docs route. paths() emits one route per
+// (locale, slug) combination — one locale from settings.locales per each
+// doc in that locale's merged collection (locale-first + base fallback).
+//
+// paths() contract (zfb ADR-004 — synchronous):
+//   params: { locale: string; slug: string[] }
+//   props:  { entry, autoIndex, contentDir, isFallback, breadcrumbs, prev, next }
+//
+// i18n / locale routing:
+//   - Default locale (EN) is handled by pages/docs/[...slug].tsx
+//     (prefixDefaultLocale: false).
+//   - Non-default locales emit /{locale}/docs/{slug}.
+//   - Locale-first merge: locale docs take priority; base EN docs fill in
+//     pages not translated yet (shown with a fallback notice).
+
+import { getCollection } from "zfb/content";
+import type { CollectionEntry } from "zfb/content";
+import type { DocsEntry } from "@/types/docs-entry";
+import { settings } from "@/config/settings";
+import { t, getContentDir } from "@/config/i18n";
+import { docsUrl } from "@/utils/base";
+import {
+  buildNavTree,
+  buildBreadcrumbs,
+  flattenTree,
+  findNode,
+  loadCategoryMeta,
+  collectAutoIndexNodes,
+  isNavVisible,
+  type NavNode,
+  type BreadcrumbItem,
+} from "@/utils/docs";
+import { getNavSectionForSlug, getNavSubtree } from "@/utils/nav-scope";
+import { toRouteSlug } from "@/utils/slug";
+import { DocLayoutWithDefaults } from "@zudo-doc/zudo-doc-v2/doclayout";
+import { Breadcrumb } from "@zudo-doc/zudo-doc-v2/breadcrumb";
+import { htmlOverrides } from "@zudo-doc/zudo-doc-v2/content";
+import { NavCardGrid } from "@zudo-doc/zudo-doc-v2/nav-indexing";
+import type { JSX } from "preact";
+
+export const frontmatter = { title: "Docs" };
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface DocPageEntry extends DocsEntry {
+  Content: CollectionEntry<unknown>["Content"];
+  module_specifier: string;
+}
+
+interface AutoIndexNode extends NavNode {
+  children: NavNode[];
+}
+
+interface DocPageProps {
+  entry: DocPageEntry | null;
+  autoIndex?: AutoIndexNode;
+  /** Content directory for the active locale (or base EN for fallbacks). */
+  contentDir: string;
+  /** True when this page falls back to the base EN collection. */
+  isFallback: boolean;
+  breadcrumbs: BreadcrumbItem[];
+  prev: NavNode | null;
+  next: NavNode | null;
+}
+
+// ---------------------------------------------------------------------------
+// paths() — synchronous (ADR-004)
+// ---------------------------------------------------------------------------
+
+/**
+ * Emit one route per (non-default locale, slug) combination.
+ *
+ * Merge strategy:
+ *   1. Load locale docs (e.g. "docs-ja").
+ *   2. Load base EN docs ("docs").
+ *   3. Locale docs take priority; base EN fills in slugs not translated.
+ *   4. Track fallback slugs for the fallback-notice banner.
+ *   5. Build nav tree, compute breadcrumbs and prev/next for each entry.
+ *
+ * Fallback slug set drives `isFallback` which the component uses to show
+ * the "not yet translated" notice (matching the Astro original).
+ */
+export function paths(): Array<{
+  params: { locale: string; slug: string[] };
+  props: DocPageProps;
+}> {
+  const result: Array<{
+    params: { locale: string; slug: string[] };
+    props: DocPageProps;
+  }> = [];
+
+  for (const locale of Object.keys(settings.locales) as string[]) {
+    const localeConfig = (settings.locales as Record<string, { dir: string }>)[locale];
+    const contentDir = localeConfig?.dir ?? settings.docsDir;
+
+    // Load locale + base docs, filter drafts
+    const localeDocs = (getCollection(`docs-${locale}`) as unknown as DocPageEntry[]).filter(
+      (d) => !d.data.draft,
+    );
+    const baseDocs = (getCollection("docs") as unknown as DocPageEntry[]).filter(
+      (d) => !d.data.draft,
+    );
+
+    const localeSlugSet = new Set(localeDocs.map((d) => d.data.slug ?? toRouteSlug(d.id)));
+    const fallbackDocs = baseDocs.filter(
+      (d) => !localeSlugSet.has(d.data.slug ?? toRouteSlug(d.id)),
+    );
+    const fallbackSlugs = new Set(fallbackDocs.map((d) => d.data.slug ?? toRouteSlug(d.id)));
+    const allDocs = [...localeDocs, ...fallbackDocs];
+
+    // Merge category metadata: base first, locale overrides
+    const baseCategoryMeta = loadCategoryMeta(settings.docsDir);
+    const localeCategoryMeta = loadCategoryMeta(contentDir);
+    const categoryMeta = new Map([...baseCategoryMeta, ...localeCategoryMeta]);
+
+    const navDocs = allDocs.filter(isNavVisible);
+    const tree = buildNavTree(navDocs as unknown as DocsEntry[], locale, categoryMeta);
+    const fullTree = buildNavTree(allDocs as unknown as DocsEntry[], locale, categoryMeta);
+
+    // Regular doc pages
+    for (const entry of allDocs) {
+      const slug = entry.data.slug ?? toRouteSlug(entry.id);
+      const isFallback = fallbackSlugs.has(slug);
+      const entryContentDir = isFallback ? settings.docsDir : contentDir;
+
+      const navSection = getNavSectionForSlug(slug);
+      const subtree = getNavSubtree(tree, navSection);
+      const flat = flattenTree(subtree);
+      const idx = flat.findIndex((n) => n.slug === slug);
+
+      let prevNode = idx > 0 ? flat[idx - 1] ?? null : null;
+      let nextNode = idx >= 0 && idx < flat.length - 1 ? flat[idx + 1] ?? null : null;
+
+      if (entry.data.pagination_prev !== undefined) {
+        if (entry.data.pagination_prev === null) {
+          prevNode = null;
+        } else {
+          const found = findNode(tree, entry.data.pagination_prev);
+          prevNode = found ?? prevNode;
+        }
+      }
+      if (entry.data.pagination_next !== undefined) {
+        if (entry.data.pagination_next === null) {
+          nextNode = null;
+        } else {
+          const found = findNode(tree, entry.data.pagination_next);
+          nextNode = found ?? nextNode;
+        }
+      }
+
+      result.push({
+        params: { locale, slug: slug.split("/") },
+        props: {
+          entry,
+          contentDir: entryContentDir,
+          isFallback,
+          breadcrumbs: buildBreadcrumbs(fullTree, slug, locale),
+          prev: prevNode,
+          next: nextNode,
+        },
+      });
+    }
+
+    // Auto-generated index pages for categories without index.mdx
+    for (const node of collectAutoIndexNodes(tree)) {
+      result.push({
+        params: { locale, slug: node.slug.split("/") },
+        props: {
+          entry: null,
+          autoIndex: node as AutoIndexNode,
+          contentDir,
+          isFallback: false,
+          breadcrumbs: buildBreadcrumbs(fullTree, node.slug, locale),
+          prev: null,
+          next: null,
+        },
+      });
+    }
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Page component
+// ---------------------------------------------------------------------------
+
+interface PageArgs {
+  params: { locale: string; slug: string[] };
+  props: DocPageProps;
+}
+
+export default function LocaleDocsPage({ params, props }: PageArgs): JSX.Element {
+  const locale = params.locale;
+  const { entry, autoIndex, isFallback, breadcrumbs, prev, next } = props;
+
+  const slug = autoIndex
+    ? autoIndex.slug
+    : (entry!.data.slug ?? toRouteSlug(entry!.id));
+
+  const title = autoIndex ? autoIndex.label : entry!.data.title;
+  const description = autoIndex ? autoIndex.description : entry!.data.description;
+
+  const components = { ...htmlOverrides };
+
+  const autoIndexChildren = autoIndex
+    ? autoIndex.children
+        .filter((c: NavNode) => c.hasPage || c.children.length > 0)
+        .map((c: NavNode) => ({
+          ...c,
+          href: c.href ?? docsUrl(c.slug, locale),
+        }))
+    : [];
+
+  return (
+    <DocLayoutWithDefaults
+      title={title}
+      description={description}
+      lang={locale}
+      hideSidebar={entry?.data?.hide_sidebar}
+      hideToc={entry?.data?.hide_toc}
+      breadcrumbOverride={
+        breadcrumbs.length > 0 ? <Breadcrumb items={breadcrumbs} /> : undefined
+      }
+    >
+      {autoIndex ? (
+        <div>
+          <h1 class="text-heading font-bold mb-vsp-xs">{autoIndex.label}</h1>
+          {autoIndex.description && (
+            <p class="mt-0 mb-vsp-lg text-subheading text-muted">
+              {autoIndex.description}
+            </p>
+          )}
+          <NavCardGrid children={autoIndexChildren} />
+        </div>
+      ) : (
+        <div>
+          <h1 class="text-heading font-bold mb-vsp-xs">{entry!.data.title}</h1>
+
+          {/* Fallback notice for non-translated pages */}
+          {isFallback && !entry!.data.generated && (
+            <div
+              class="mb-vsp-md border border-info/30 bg-info/5 px-hsp-lg py-vsp-sm text-small text-muted rounded"
+              role="note"
+            >
+              {t("doc.fallbackNotice", locale)}
+            </div>
+          )}
+
+          {entry!.data.description && (
+            <p class="mt-0 mb-vsp-lg text-subheading text-muted">
+              {entry!.data.description}
+            </p>
+          )}
+
+          {entry && <entry.Content components={components} />}
+
+          {/* Prev / Next pagination */}
+          <nav class="mt-vsp-2xl grid grid-cols-2 gap-hsp-xl">
+            {prev ? (
+              <a
+                href={prev.href}
+                class="group border border-muted rounded-lg p-hsp-lg hover:border-accent"
+              >
+                <div class="flex items-center gap-hsp-xs text-caption text-muted mb-vsp-2xs">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="h-[1.125rem] w-[1.125rem]"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+                  </svg>
+                  <span class="no-underline">{t("nav.previous", locale)}</span>
+                </div>
+                <p class="text-small font-semibold underline group-hover:text-accent">
+                  {prev.label}
+                </p>
+              </a>
+            ) : (
+              <div />
+            )}
+            {next ? (
+              <a
+                href={next.href}
+                class="group border border-muted rounded-lg p-hsp-lg hover:border-accent text-right"
+              >
+                <div class="flex items-center justify-end gap-hsp-xs text-caption text-muted mb-vsp-2xs">
+                  <span class="no-underline">{t("nav.next", locale)}</span>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="h-[1.125rem] w-[1.125rem]"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+                  </svg>
+                </div>
+                <p class="text-small font-semibold underline group-hover:text-accent">
+                  {next.label}
+                </p>
+              </a>
+            ) : (
+              <div />
+            )}
+          </nav>
+        </div>
+      )}
+    </DocLayoutWithDefaults>
+  );
+}

--- a/pages/[locale]/docs/versions.tsx
+++ b/pages/[locale]/docs/versions.tsx
@@ -1,0 +1,90 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+// Port of src/pages/[locale]/docs/versions.astro → zfb page module.
+//
+// Non-default-locale versions page. paths() emits one route per locale in
+// settings.locales. Locale string is passed as a prop to drive label
+// translation in the component.
+//
+// paths() contract (zfb ADR-004 — synchronous):
+//   params: { locale: string }
+//   props:  { locale }
+
+import { settings } from "@/config/settings";
+import { t } from "@/config/i18n";
+import { withBase } from "@/utils/base";
+import { DocLayoutWithDefaults } from "@zudo-doc/zudo-doc-v2/doclayout";
+import { VersionsPageContent } from "@zudo-doc/zudo-doc-v2/nav-indexing";
+import type { VersionPageEntry, VersionsPageLabels } from "@zudo-doc/zudo-doc-v2/nav-indexing";
+import type { JSX } from "preact";
+
+export const frontmatter = { title: "Versions" };
+
+// ---------------------------------------------------------------------------
+// paths() — synchronous (ADR-004)
+// ---------------------------------------------------------------------------
+
+/** One route per non-default locale. */
+export function paths(): Array<{
+  params: { locale: string };
+  props: { locale: string };
+}> {
+  return Object.keys(settings.locales).map((locale) => ({
+    params: { locale },
+    props: { locale },
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Page component
+// ---------------------------------------------------------------------------
+
+interface PageArgs {
+  params: { locale: string };
+  props: { locale: string };
+}
+
+export default function LocaleVersionsPage({ params }: PageArgs): JSX.Element {
+  const locale = params.locale;
+  const pageTitle = t("version.page.title", locale);
+
+  const labels: VersionsPageLabels = {
+    pageTitle,
+    latestTitle: t("version.page.latest.title", locale),
+    latestDescription: t("version.page.latest.description", locale),
+    latestLink: t("version.page.latest.link", locale),
+    pastTitle: t("version.page.past.title", locale),
+    pastDescription: t("version.page.past.description", locale),
+    unmaintained: t("version.page.unmaintained", locale),
+    unreleased: t("version.page.unreleased", locale),
+    versionCol: t("version.switcher.label", locale),
+    statusCol: t("version.page.status", locale),
+    docsCol: t("version.page.docs", locale),
+  };
+
+  const latestHref = withBase(`/${locale}/docs/getting-started`);
+
+  const versions: VersionPageEntry[] = settings.versions
+    ? settings.versions.map((v) => ({
+        slug: v.slug,
+        label: v.label ?? v.slug,
+        docsHref: withBase(`/${locale}/v/${v.slug}/docs`),
+        banner: v.banner as "unmaintained" | "unreleased" | undefined,
+      }))
+    : [];
+
+  return (
+    <DocLayoutWithDefaults
+      title={pageTitle}
+      lang={locale}
+      hideSidebar={true}
+      hideToc={true}
+    >
+      <VersionsPageContent
+        latestHref={latestHref}
+        versions={versions}
+        labels={labels}
+      />
+    </DocLayoutWithDefaults>
+  );
+}

--- a/pages/[locale]/index.tsx
+++ b/pages/[locale]/index.tsx
@@ -1,0 +1,176 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+// Port of src/pages/[locale]/index.astro → zfb page module.
+//
+// Non-default-locale site index. paths() emits one route per locale defined
+// in settings.locales (never the default locale — that is handled by
+// pages/index.tsx since prefixDefaultLocale is false).
+//
+// paths() contract (zfb ADR-004 — synchronous):
+//   params: { locale: string }   — e.g. "ja"
+//   props:  { locale }           — resolved locale passed to component
+//
+// Data flow (inside component — sync per ADR-004):
+//   getCollection(`docs-${locale}`)  + base fallback merge
+//   → buildNavTree()   → groupSatelliteNodes()
+//   → collectTags()    → tag section
+
+import { getCollection } from "zfb/content";
+import type { DocsEntry } from "@/types/docs-entry";
+import { settings } from "@/config/settings";
+import { t } from "@/config/i18n";
+import { withBase } from "@/utils/base";
+import {
+  buildNavTree,
+  groupSatelliteNodes,
+  isNavVisible,
+  loadCategoryMeta,
+} from "@/utils/docs";
+import { getCategoryOrder } from "@/utils/nav-scope";
+import { collectTags } from "@/utils/tags";
+import { toRouteSlug } from "@/utils/slug";
+import { DocLayoutWithDefaults } from "@zudo-doc/zudo-doc-v2/doclayout";
+import { DocsSitemap } from "@zudo-doc/zudo-doc-v2/nav-indexing";
+import type { JSX } from "preact";
+
+export const frontmatter = { title: "Home" };
+
+// ---------------------------------------------------------------------------
+// paths() — synchronous (ADR-004)
+// ---------------------------------------------------------------------------
+
+/** Emit one route per non-default locale. */
+export function paths(): Array<{
+  params: { locale: string };
+  props: { locale: string };
+}> {
+  return Object.keys(settings.locales).map((locale) => ({
+    params: { locale },
+    props: { locale },
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Merge locale docs with base (EN) fallbacks.
+ * Mirrors the merge strategy in src/utils/locale-docs.ts.
+ */
+function mergeLocaleDocs(locale: string): DocsEntry[] {
+  const localeDocs = (getCollection(`docs-${locale}`) as unknown as DocsEntry[]).filter(
+    (d) => !d.data.draft,
+  );
+  const baseDocs = (getCollection("docs") as unknown as DocsEntry[]).filter(
+    (d) => !d.data.draft,
+  );
+  const localeSlugSet = new Set(localeDocs.map((d) => d.data.slug ?? toRouteSlug(d.id)));
+  return [
+    ...localeDocs,
+    ...baseDocs.filter((d) => !localeSlugSet.has(d.data.slug ?? toRouteSlug(d.id))),
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Page component
+// ---------------------------------------------------------------------------
+
+interface PageArgs {
+  params: { locale: string };
+  props: { locale: string };
+}
+
+export default function LocaleIndexPage({ params }: PageArgs): JSX.Element {
+  const locale = params.locale;
+
+  const allDocs = mergeLocaleDocs(locale);
+  const localeConfig = (settings.locales as Record<string, { dir: string }>)[locale];
+  const categoryMeta = localeConfig
+    ? loadCategoryMeta(localeConfig.dir)
+    : loadCategoryMeta(settings.docsDir);
+
+  const navDocs = allDocs.filter(isNavVisible);
+  const tree = buildNavTree(navDocs, locale, categoryMeta);
+  const categoryOrder = getCategoryOrder();
+  const groupedTree = groupSatelliteNodes(tree, categoryOrder);
+
+  const tagCount = collectTags(
+    navDocs,
+    (id, data) => data.slug ?? toRouteSlug(id),
+  ).size;
+
+  const ctaNav = settings.headerNav[0] ?? null;
+  const overview = ctaNav ? withBase(`/${locale}${ctaNav.path}`) : null;
+  const logoUrl = withBase("/img/logo.svg");
+
+  return (
+    <DocLayoutWithDefaults
+      title={settings.siteName}
+      lang={locale}
+      hideSidebar={true}
+      hideToc={true}
+    >
+      {/* Hero: logo left, title+desc+links right, block centered */}
+      <div class="flex justify-center mb-vsp-xl">
+        <div class="flex flex-col items-center text-center gap-hsp-md lg:flex-row lg:text-left lg:gap-hsp-xl">
+          <div
+            class="w-[80%] aspect-square lg:h-[10.5rem] lg:w-[10.5rem] bg-fg shrink-0"
+            style={`-webkit-mask: url(${logoUrl}) center/contain no-repeat; mask: url(${logoUrl}) center/contain no-repeat;`}
+            aria-hidden="true"
+          />
+          <div>
+            <h1 class="text-heading font-bold mb-vsp-2xs">{settings.siteName}</h1>
+            <p class="text-muted text-small mb-vsp-sm">{settings.siteDescription}</p>
+            <div class="flex items-center justify-center lg:justify-start gap-hsp-md text-small">
+              {overview && (
+                <>
+                  <a href={overview} class="text-fg underline hover:text-accent">
+                    {t("nav.overview", locale)}
+                  </a>
+                  <span class="text-muted">/</span>
+                </>
+              )}
+              {settings.githubUrl && (
+                <>
+                  <a
+                    href={settings.githubUrl as string}
+                    class="inline-flex items-center gap-[0.3em] text-fg underline hover:text-accent"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <svg viewBox="0 0 16 16" aria-hidden="true" class="w-[1em] h-[1em] shrink-0">
+                      <path
+                        fill="currentColor"
+                        d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"
+                      />
+                    </svg>
+                    GitHub
+                  </a>
+                  <span class="text-muted">/</span>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Sitemap grid */}
+      <DocsSitemap tree={groupedTree} />
+
+      {settings.docTags && tagCount > 0 && (
+        <section class="mt-vsp-xl">
+          <h2 class="text-subheading font-bold mb-vsp-md">
+            {t("doc.allTags", locale)}
+          </h2>
+          <a
+            href={withBase(`/${locale}/docs/tags`)}
+            class="text-accent underline hover:text-accent-hover"
+          >
+            {t("doc.allTags", locale)}
+          </a>
+        </section>
+      )}
+    </DocLayoutWithDefaults>
+  );
+}

--- a/pages/_data.ts
+++ b/pages/_data.ts
@@ -1,0 +1,136 @@
+// pages/_data.ts — zfb-compatible data helpers for doc page modules.
+//
+// Provides the bridge between zfb's CollectionEntry (from "zfb/content") and
+// the utility functions in @/utils/docs that expect DocsEntry (which carries
+// an `id` field mirroring Astro's collection entry id).
+//
+// Sync convention (ADR-004):
+//   getCollection() resolves from the pre-loaded ContentSnapshot without an
+//   async boundary. paths() exports call getDocs() without await. The Promise
+//   wrapper on the type is a v0 artefact — the synchronous snapshot path is
+//   the production contract.
+
+import { getCollection } from "zfb/content";
+import type { CollectionEntry } from "zfb/content";
+import type { DocsEntry } from "@/types/docs-entry";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Frontmatter shape shared by all docs collections (EN, locale, versioned).
+ * Matches the zod schema in zfb.config.ts field-for-field.
+ * `.passthrough()` equivalent: the index signature [key: string]: unknown
+ * keeps custom frontmatter keys available (e.g. for frontmatter-preview).
+ */
+export type ZfbDocsData = {
+  title: string;
+  description?: string;
+  category?: string;
+  sidebar_position?: number;
+  sidebar_label?: string;
+  tags?: string[];
+  search_exclude?: boolean;
+  pagination_next?: string | null;
+  pagination_prev?: string | null;
+  draft?: boolean;
+  unlisted?: boolean;
+  hide_sidebar?: boolean;
+  hide_toc?: boolean;
+  doc_history?: boolean;
+  standalone?: boolean;
+  slug?: string;
+  generated?: boolean;
+  [key: string]: unknown;
+};
+
+/**
+ * zfb collection entry augmented with the `id` and `collection` fields that
+ * @/utils/docs utility functions (buildNavTree, buildBreadcrumbs, …) expect
+ * from DocsEntry.
+ *
+ * `id` is bridged from `slug` — in Astro, `id` was the file-path identifier
+ * (e.g. "getting-started/intro"); in zfb, the same role is played by `slug`.
+ * Mapping them keeps the utility functions working without modification.
+ */
+export type ZfbDocsEntry = CollectionEntry<ZfbDocsData> & {
+  /** Bridged from `slug` for @/utils/docs compat. */
+  id: string;
+  /** Collection name, e.g. "docs", "docs-ja", "docs-v-1.0". */
+  collection: string;
+};
+
+// ---------------------------------------------------------------------------
+// Loaders
+// ---------------------------------------------------------------------------
+
+/**
+ * Load docs from a named collection synchronously (ADR-004 sync contract).
+ *
+ * `getCollection` resolves from the ContentSnapshot when called inside a
+ * paths() evaluation. The `as unknown as` cast converts the nominal Promise
+ * wrapper to a plain array — safe because the snapshot path is synchronous.
+ *
+ * The returned entries include:
+ *   - All CollectionEntry fields (slug, data, body, module_specifier, Content)
+ *   - `id` — same value as `slug`, for @/utils/docs compat
+ *   - `collection` — the collection name, for DocsEntry compat
+ */
+export function getDocs(collectionName: string): ZfbDocsEntry[] {
+  const entries = getCollection(collectionName) as unknown as CollectionEntry<ZfbDocsData>[];
+  return entries.map((e) => ({
+    ...e,
+    id: e.slug,
+    collection: collectionName,
+  }));
+}
+
+/**
+ * Cast ZfbDocsEntry[] to DocsEntry[] for passing to @/utils/docs utilities.
+ *
+ * The types are structurally compatible: ZfbDocsEntry has every required field
+ * of DocsEntry (id, collection, data, body). The optional `rendered` and
+ * `filePath` fields of DocsEntry are absent but not required.
+ */
+export function asDocsEntries(entries: ZfbDocsEntry[]): DocsEntry[] {
+  return entries as unknown as DocsEntry[];
+}
+
+/**
+ * Filter out draft entries.
+ * Drafts are always excluded in static-build paths() context.
+ */
+export function filterDrafts(entries: ZfbDocsEntry[]): ZfbDocsEntry[] {
+  return entries.filter((e) => !e.data.draft);
+}
+
+/**
+ * Merge locale docs with base (EN) fallbacks.
+ *
+ * Strategy (mirrors src/utils/locale-docs.ts):
+ *   1. Load locale docs (e.g. "docs-ja")
+ *   2. Load base docs ("docs")
+ *   3. Locale docs take priority; base docs fill in missing slugs.
+ *   4. Track which slugs came from base (fallbackSlugs).
+ *
+ * Returns { allDocs, fallbackSlugs }.
+ * categoryMeta is not merged here — callers use loadCategoryMeta() directly.
+ */
+export function mergeLocaleDocs(
+  locale: string,
+): { allDocs: ZfbDocsEntry[]; fallbackSlugs: Set<string> } {
+  const localeDocs = filterDrafts(getDocs(`docs-${locale}`));
+  const baseDocs = filterDrafts(getDocs("docs"));
+
+  const localeSlugSet = new Set(localeDocs.map((d) => d.data.slug ?? d.id));
+
+  const fallbackDocs = baseDocs.filter(
+    (d) => !localeSlugSet.has(d.data.slug ?? d.id),
+  );
+
+  return {
+    allDocs: [...localeDocs, ...fallbackDocs],
+    fallbackSlugs: new Set(fallbackDocs.map((d) => d.data.slug ?? d.id)),
+  };
+}

--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -1,0 +1,294 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+// Port of src/pages/docs/[...slug].astro → zfb page module.
+//
+// Default-locale (EN) catch-all docs route. paths() enumerates every page in
+// the "docs" collection plus auto-generated category index pages (for
+// categories without an index.mdx). Per-page props carry all pre-computed
+// data so the component is a pure renderer with no collection reads.
+//
+// paths() contract (zfb ADR-004 — synchronous):
+//   params: { slug: string[] }   — e.g. ["getting-started", "intro"]
+//   props:  { entry, autoIndex, breadcrumbs, prev, next }
+//
+// The catchall slug is an array per zfb spec — the component joins it when
+// deriving the string form (e.g. for Content lookups, breadcrumbs, etc.).
+//
+// Locale: defaultLocale (EN). Non-default locales are handled by
+// pages/[locale]/docs/[...slug].tsx.
+
+import { getCollection } from "zfb/content";
+import type { CollectionEntry } from "zfb/content";
+import type { DocsEntry } from "@/types/docs-entry";
+import { settings } from "@/config/settings";
+import { defaultLocale, t } from "@/config/i18n";
+import { docsUrl } from "@/utils/base";
+import {
+  buildNavTree,
+  buildBreadcrumbs,
+  flattenTree,
+  findNode,
+  loadCategoryMeta,
+  collectAutoIndexNodes,
+  isNavVisible,
+  type NavNode,
+  type BreadcrumbItem,
+} from "@/utils/docs";
+import { getNavSectionForSlug, getNavSubtree } from "@/utils/nav-scope";
+import { toRouteSlug } from "@/utils/slug";
+import { DocLayoutWithDefaults } from "@zudo-doc/zudo-doc-v2/doclayout";
+import { Breadcrumb } from "@zudo-doc/zudo-doc-v2/breadcrumb";
+import { htmlOverrides } from "@zudo-doc/zudo-doc-v2/content";
+import { NavCardGrid } from "@zudo-doc/zudo-doc-v2/nav-indexing";
+import type { JSX } from "preact";
+
+export const frontmatter = { title: "Docs" };
+
+// ---------------------------------------------------------------------------
+// Props contract
+// ---------------------------------------------------------------------------
+
+interface DocPageEntry extends DocsEntry {
+  /** zfb content renderer. */
+  Content: CollectionEntry<unknown>["Content"];
+  /** zfb module specifier (for Content bridge). */
+  module_specifier: string;
+}
+
+interface AutoIndexNode extends NavNode {
+  children: NavNode[];
+}
+
+interface DocPageProps {
+  /** The docs entry to render, or null for auto-index pages. */
+  entry: DocPageEntry | null;
+  /** Pre-built auto-index node (categories without index.mdx). */
+  autoIndex?: AutoIndexNode;
+  /** Breadcrumb trail, first item is home. */
+  breadcrumbs: BreadcrumbItem[];
+  /** Preceding page in the nav tree. */
+  prev: NavNode | null;
+  /** Following page in the nav tree. */
+  next: NavNode | null;
+}
+
+// ---------------------------------------------------------------------------
+// paths() — synchronous route enumeration (ADR-004)
+// ---------------------------------------------------------------------------
+
+/**
+ * Enumerate all doc routes for the default locale (EN).
+ *
+ * Synchronous per ADR-004: getCollection() resolves from the pre-loaded
+ * ContentSnapshot. All nav-tree and breadcrumb computation is done here
+ * so the component is a pure renderer.
+ */
+export function paths(): Array<{
+  params: { slug: string[] };
+  props: DocPageProps;
+}> {
+  const locale = defaultLocale;
+  const allDocs = getCollection("docs") as unknown as DocPageEntry[];
+  // In static builds, always exclude drafts.
+  const docs = allDocs.filter((doc) => !doc.data.draft);
+  const categoryMeta = loadCategoryMeta(settings.docsDir);
+
+  // Nav docs: exclude unlisted (for sidebar/prev-next) but keep for breadcrumbs
+  const navDocs = docs.filter(isNavVisible);
+  const tree = buildNavTree(navDocs as unknown as DocsEntry[], locale, categoryMeta);
+  // Full tree (including unlisted) for accurate breadcrumbs
+  const fullTree = buildNavTree(docs as unknown as DocsEntry[], locale, categoryMeta);
+
+  const result: Array<{ params: { slug: string[] }; props: DocPageProps }> = [];
+
+  // Regular doc pages
+  for (const entry of docs) {
+    const slug = entry.data.slug ?? toRouteSlug(entry.id);
+    const navSection = getNavSectionForSlug(slug);
+    const subtree = getNavSubtree(tree, navSection);
+    const flat = flattenTree(subtree);
+    const idx = flat.findIndex((n) => n.slug === slug);
+
+    let prevNode = idx > 0 ? flat[idx - 1] ?? null : null;
+    let nextNode = idx >= 0 && idx < flat.length - 1 ? flat[idx + 1] ?? null : null;
+
+    // Frontmatter pagination overrides
+    if (entry.data.pagination_prev !== undefined) {
+      if (entry.data.pagination_prev === null) {
+        prevNode = null;
+      } else {
+        const found = findNode(tree, entry.data.pagination_prev);
+        prevNode = found ?? prevNode;
+      }
+    }
+    if (entry.data.pagination_next !== undefined) {
+      if (entry.data.pagination_next === null) {
+        nextNode = null;
+      } else {
+        const found = findNode(tree, entry.data.pagination_next);
+        nextNode = found ?? nextNode;
+      }
+    }
+
+    result.push({
+      params: { slug: slug.split("/") },
+      props: {
+        entry,
+        breadcrumbs: buildBreadcrumbs(fullTree, slug, locale),
+        prev: prevNode,
+        next: nextNode,
+      },
+    });
+  }
+
+  // Auto-generated index pages for categories without index.mdx
+  for (const node of collectAutoIndexNodes(tree)) {
+    result.push({
+      params: { slug: node.slug.split("/") },
+      props: {
+        entry: null,
+        autoIndex: node as AutoIndexNode,
+        breadcrumbs: buildBreadcrumbs(fullTree, node.slug, locale),
+        prev: null,
+        next: null,
+      },
+    });
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Page component
+// ---------------------------------------------------------------------------
+
+interface PageArgs {
+  params: { slug: string[] };
+  props: DocPageProps;
+}
+
+export default function DocsPage({ props }: PageArgs): JSX.Element {
+  const { entry, autoIndex, breadcrumbs, prev, next } = props;
+  const locale = defaultLocale;
+
+  const slug = autoIndex
+    ? autoIndex.slug
+    : (entry!.data.slug ?? toRouteSlug(entry!.id));
+
+  const title = autoIndex ? autoIndex.label : entry!.data.title;
+  const description = autoIndex ? autoIndex.description : entry!.data.description;
+
+  const components = { ...htmlOverrides };
+
+  // Resolve child hrefs for auto-index pages
+  const autoIndexChildren = autoIndex
+    ? autoIndex.children
+        .filter((c: NavNode) => c.hasPage || c.children.length > 0)
+        .map((c: NavNode) => ({
+          ...c,
+          href: c.href ?? docsUrl(c.slug, locale),
+        }))
+    : [];
+
+  return (
+    <DocLayoutWithDefaults
+      title={title}
+      description={description}
+      lang={locale}
+      hideSidebar={entry?.data?.hide_sidebar}
+      hideToc={entry?.data?.hide_toc}
+      breadcrumbOverride={
+        breadcrumbs.length > 0 ? <Breadcrumb items={breadcrumbs} /> : undefined
+      }
+    >
+      {autoIndex ? (
+        /* Auto-index page: category without an index.mdx */
+        <div>
+          <h1 class="text-heading font-bold mb-vsp-xs">{autoIndex.label}</h1>
+          {autoIndex.description && (
+            <p class="mt-0 mb-vsp-lg text-subheading text-muted">
+              {autoIndex.description}
+            </p>
+          )}
+          <NavCardGrid children={autoIndexChildren} />
+        </div>
+      ) : (
+        /* Regular doc page */
+        <div>
+          <h1 class="text-heading font-bold mb-vsp-xs">{entry!.data.title}</h1>
+
+          {entry!.data.description && (
+            <p class="mt-0 mb-vsp-lg text-subheading text-muted">
+              {entry!.data.description}
+            </p>
+          )}
+
+          {/* MDX content rendered via zfb's Content bridge */}
+          {entry && <entry.Content components={components} />}
+
+          {/* Prev / Next pagination */}
+          <nav class="mt-vsp-2xl grid grid-cols-2 gap-hsp-xl">
+            {prev ? (
+              <a
+                href={prev.href}
+                class="group border border-muted rounded-lg p-hsp-lg hover:border-accent"
+              >
+                <div class="flex items-center gap-hsp-xs text-caption text-muted mb-vsp-2xs">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="h-[1.125rem] w-[1.125rem]"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      d="M15 19l-7-7 7-7"
+                    />
+                  </svg>
+                  <span class="no-underline">{t("nav.previous", locale)}</span>
+                </div>
+                <p class="text-small font-semibold underline group-hover:text-accent">
+                  {prev.label}
+                </p>
+              </a>
+            ) : (
+              <div />
+            )}
+            {next ? (
+              <a
+                href={next.href}
+                class="group border border-muted rounded-lg p-hsp-lg hover:border-accent text-right"
+              >
+                <div class="flex items-center justify-end gap-hsp-xs text-caption text-muted mb-vsp-2xs">
+                  <span class="no-underline">{t("nav.next", locale)}</span>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="h-[1.125rem] w-[1.125rem]"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      d="M9 5l7 7-7 7"
+                    />
+                  </svg>
+                </div>
+                <p class="text-small font-semibold underline group-hover:text-accent">
+                  {next.label}
+                </p>
+              </a>
+            ) : (
+              <div />
+            )}
+          </nav>
+        </div>
+      )}
+    </DocLayoutWithDefaults>
+  );
+}

--- a/pages/docs/versions.tsx
+++ b/pages/docs/versions.tsx
@@ -1,0 +1,68 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+// Port of src/pages/docs/versions.astro → zfb page module.
+//
+// Default-locale (EN) documentation versions page. Static route — no
+// paths() export needed. Lists the latest version and any past versions
+// configured in settings.versions.
+//
+// Data flow:
+//   settings.versions          → build version entry list
+//   t() for locale strings     → labels bag passed to VersionsPageContent
+
+import { settings } from "@/config/settings";
+import { defaultLocale, t } from "@/config/i18n";
+import { withBase } from "@/utils/base";
+import { DocLayoutWithDefaults } from "@zudo-doc/zudo-doc-v2/doclayout";
+import { VersionsPageContent } from "@zudo-doc/zudo-doc-v2/nav-indexing";
+import type { VersionPageEntry, VersionsPageLabels } from "@zudo-doc/zudo-doc-v2/nav-indexing";
+import type { JSX } from "preact";
+
+export const frontmatter = { title: "Versions" };
+
+export default function VersionsPage(): JSX.Element {
+  const locale = defaultLocale;
+  const pageTitle = t("version.page.title", locale);
+
+  const labels: VersionsPageLabels = {
+    pageTitle,
+    latestTitle: t("version.page.latest.title", locale),
+    latestDescription: t("version.page.latest.description", locale),
+    latestLink: t("version.page.latest.link", locale),
+    pastTitle: t("version.page.past.title", locale),
+    pastDescription: t("version.page.past.description", locale),
+    unmaintained: t("version.page.unmaintained", locale),
+    unreleased: t("version.page.unreleased", locale),
+    versionCol: t("version.switcher.label", locale),
+    statusCol: t("version.page.status", locale),
+    docsCol: t("version.page.docs", locale),
+  };
+
+  // Latest docs href — points to the default docs entry point
+  const latestHref = withBase("/docs/getting-started");
+
+  // Past version entries from settings
+  const versions: VersionPageEntry[] = settings.versions
+    ? settings.versions.map((v) => ({
+        slug: v.slug,
+        label: v.label ?? v.slug,
+        docsHref: withBase(`/v/${v.slug}/docs`),
+        banner: v.banner as "unmaintained" | "unreleased" | undefined,
+      }))
+    : [];
+
+  return (
+    <DocLayoutWithDefaults
+      title={pageTitle}
+      lang={locale}
+      hideSidebar={true}
+      hideToc={true}
+    >
+      <VersionsPageContent
+        latestHref={latestHref}
+        versions={versions}
+        labels={labels}
+      />
+    </DocLayoutWithDefaults>
+  );
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,122 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+// Port of src/pages/index.astro → zfb page module.
+//
+// Default-locale (EN) site index. Static route — no paths() export needed.
+// Collects the EN docs tree and renders the site-map grid plus optional
+// tag count.
+//
+// Data flow:
+//   getCollection("docs")   [sync, zfb ADR-004]
+//   → buildNavTree()        builds the nav tree for the sitemap grid
+//   → collectTags()         counts unique tags for the tag section header
+//   → DocLayoutWithDefaults renders the page with no sidebar/TOC
+
+import { getCollection } from "zfb/content";
+import type { DocsEntry } from "@/types/docs-entry";
+import { settings } from "@/config/settings";
+import { defaultLocale, t } from "@/config/i18n";
+import { withBase } from "@/utils/base";
+import {
+  buildNavTree,
+  groupSatelliteNodes,
+  isNavVisible,
+} from "@/utils/docs";
+import { loadCategoryMeta } from "@/utils/docs";
+import { getCategoryOrder } from "@/utils/nav-scope";
+import { collectTags } from "@/utils/tags";
+import { toRouteSlug } from "@/utils/slug";
+import { DocLayoutWithDefaults } from "@zudo-doc/zudo-doc-v2/doclayout";
+import { DocsSitemap } from "@zudo-doc/zudo-doc-v2/nav-indexing";
+import type { JSX } from "preact";
+
+export const frontmatter = { title: "Home" };
+
+export default function IndexPage(): JSX.Element {
+  const locale = defaultLocale;
+
+  const allDocs = getCollection("docs") as unknown as DocsEntry[];
+  const docs = allDocs.filter((doc) => !doc.data.draft);
+  const categoryMeta = loadCategoryMeta(settings.docsDir);
+  const navDocs = docs.filter(isNavVisible);
+  const tree = buildNavTree(navDocs, locale, categoryMeta);
+  const categoryOrder = getCategoryOrder();
+  const groupedTree = groupSatelliteNodes(tree, categoryOrder);
+
+  const tagDocs = docs.filter(isNavVisible);
+  const tagCount = collectTags(
+    tagDocs,
+    (id, data) => data.slug ?? toRouteSlug(id),
+  ).size;
+
+  const ctaNav = settings.headerNav[0] ?? null;
+  const overview = ctaNav ? withBase(ctaNav.path) : null;
+  const logoUrl = withBase("/img/logo.svg");
+
+  return (
+    <DocLayoutWithDefaults
+      title={settings.siteName}
+      lang={locale}
+      hideSidebar={true}
+      hideToc={true}
+    >
+      {/* Hero: logo left, title+desc+links right, block centered */}
+      <div class="flex justify-center mb-vsp-xl">
+        <div class="flex flex-col items-center text-center gap-hsp-md lg:flex-row lg:text-left lg:gap-hsp-xl">
+          <div
+            class="w-[80%] aspect-square lg:h-[10.5rem] lg:w-[10.5rem] bg-fg shrink-0"
+            style={`-webkit-mask: url(${logoUrl}) center/contain no-repeat; mask: url(${logoUrl}) center/contain no-repeat;`}
+            aria-hidden="true"
+          />
+          <div>
+            <h1 class="text-heading font-bold mb-vsp-2xs">{settings.siteName}</h1>
+            <p class="text-muted text-small mb-vsp-sm">{settings.siteDescription}</p>
+            <div class="flex items-center justify-center lg:justify-start gap-hsp-md text-small">
+              {overview && (
+                <>
+                  <a href={overview} class="text-fg underline hover:text-accent">
+                    {t("nav.overview", locale)}
+                  </a>
+                  <span class="text-muted">/</span>
+                </>
+              )}
+              {settings.githubUrl && (
+                <>
+                  <a
+                    href={settings.githubUrl as string}
+                    class="inline-flex items-center gap-[0.3em] text-fg underline hover:text-accent"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <svg viewBox="0 0 16 16" aria-hidden="true" class="w-[1em] h-[1em] shrink-0">
+                      <path
+                        fill="currentColor"
+                        d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"
+                      />
+                    </svg>
+                    GitHub
+                  </a>
+                  <span class="text-muted">/</span>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Sitemap grid */}
+      <DocsSitemap tree={groupedTree} />
+
+      {settings.docTags && tagCount > 0 && (
+        <section class="mt-vsp-xl">
+          <h2 class="text-subheading font-bold mb-vsp-md">
+            {t("doc.allTags", locale)}
+          </h2>
+          <a href={withBase("/docs/tags")} class="text-accent underline hover:text-accent-hover">
+            {t("doc.allTags", locale)}
+          </a>
+        </section>
+      )}
+    </DocLayoutWithDefaults>
+  );
+}

--- a/pages/v/[version]/docs/[...slug].tsx
+++ b/pages/v/[version]/docs/[...slug].tsx
@@ -1,0 +1,292 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+// Port of src/pages/v/[version]/docs/[...slug].astro → zfb page module.
+//
+// Versioned EN docs route. paths() enumerates one route per (version, slug)
+// combination using the `docs-v-${version.slug}` collection for each version
+// configured in settings.versions.
+//
+// paths() contract (zfb ADR-004 — synchronous):
+//   params: { version: string; slug: string[] }
+//   props:  { entry, autoIndex, version, breadcrumbs, prev, next }
+//
+// Each version renders with its own nav tree (from the version's docsDir
+// category metadata). Prev/next hrefs are pre-resolved to the versioned URL
+// form (e.g. /v/1.0/docs/…) so the component needs no URL computation.
+//
+// Version banner: if version.banner is set ("unmaintained" | "unreleased"),
+// the DocLayoutWithDefaults version-banner prop drives the banner display.
+
+import { getCollection } from "zfb/content";
+import type { CollectionEntry } from "zfb/content";
+import type { DocsEntry } from "@/types/docs-entry";
+import { settings } from "@/config/settings";
+import type { VersionConfig } from "@/config/settings";
+import { t } from "@/config/i18n";
+import { versionedDocsUrl } from "@/utils/base";
+import {
+  buildNavTree,
+  buildBreadcrumbs,
+  flattenTree,
+  findNode,
+  loadCategoryMeta,
+  collectAutoIndexNodes,
+  isNavVisible,
+  type NavNode,
+  type BreadcrumbItem,
+} from "@/utils/docs";
+import { getNavSectionForSlug, getNavSubtree } from "@/utils/nav-scope";
+import { toRouteSlug } from "@/utils/slug";
+import { DocLayoutWithDefaults } from "@zudo-doc/zudo-doc-v2/doclayout";
+import { Breadcrumb } from "@zudo-doc/zudo-doc-v2/breadcrumb";
+import { htmlOverrides } from "@zudo-doc/zudo-doc-v2/content";
+import { NavCardGrid } from "@zudo-doc/zudo-doc-v2/nav-indexing";
+import type { JSX } from "preact";
+
+export const frontmatter = { title: "Docs" };
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface DocPageEntry extends DocsEntry {
+  Content: CollectionEntry<unknown>["Content"];
+  module_specifier: string;
+}
+
+interface AutoIndexNode extends NavNode {
+  children: NavNode[];
+}
+
+interface DocPageProps {
+  entry: DocPageEntry | null;
+  autoIndex?: AutoIndexNode;
+  /** The version config for the active version. */
+  version: VersionConfig;
+  breadcrumbs: BreadcrumbItem[];
+  prev: NavNode | null;
+  next: NavNode | null;
+}
+
+// ---------------------------------------------------------------------------
+// paths() — synchronous (ADR-004)
+// ---------------------------------------------------------------------------
+
+/**
+ * Emit one route per (version, slug) combination.
+ *
+ * For each version in settings.versions, loads docs from
+ * `docs-v-${version.slug}` and enumerates all pages plus
+ * auto-generated category index pages.
+ *
+ * Prev/next hrefs are pre-resolved to the versioned form.
+ */
+export function paths(): Array<{
+  params: { version: string; slug: string[] };
+  props: DocPageProps;
+}> {
+  if (!settings.versions) return [];
+
+  const result: Array<{
+    params: { version: string; slug: string[] };
+    props: DocPageProps;
+  }> = [];
+
+  for (const version of settings.versions) {
+    const collectionName = `docs-v-${version.slug}`;
+    const allDocs = (getCollection(collectionName) as unknown as DocPageEntry[]).filter(
+      (doc) => !doc.data.draft,
+    );
+
+    const categoryMeta = loadCategoryMeta(version.docsDir);
+    const navDocs = allDocs.filter(isNavVisible);
+    // Versioned docs always use EN locale for nav tree
+    const tree = buildNavTree(navDocs as unknown as DocsEntry[], "en", categoryMeta);
+
+    // Regular doc pages
+    for (const entry of allDocs) {
+      const slug = entry.data.slug ?? toRouteSlug(entry.id);
+      const navSection = getNavSectionForSlug(slug);
+      const subtree = getNavSubtree(tree, navSection);
+      const flat = flattenTree(subtree);
+      const idx = flat.findIndex((n) => n.slug === slug);
+
+      let prevNode = idx > 0 ? flat[idx - 1] ?? null : null;
+      let nextNode = idx >= 0 && idx < flat.length - 1 ? flat[idx + 1] ?? null : null;
+
+      if (entry.data.pagination_prev !== undefined) {
+        if (entry.data.pagination_prev === null) {
+          prevNode = null;
+        } else {
+          const found = findNode(tree, entry.data.pagination_prev);
+          prevNode = found ?? prevNode;
+        }
+      }
+      if (entry.data.pagination_next !== undefined) {
+        if (entry.data.pagination_next === null) {
+          nextNode = null;
+        } else {
+          const found = findNode(tree, entry.data.pagination_next);
+          nextNode = found ?? nextNode;
+        }
+      }
+
+      result.push({
+        params: { version: version.slug, slug: slug.split("/") },
+        props: {
+          entry,
+          version,
+          breadcrumbs: buildBreadcrumbs(tree, slug, "en"),
+          // Pre-resolve prev/next hrefs to versioned URLs
+          prev: prevNode
+            ? { ...prevNode, href: versionedDocsUrl(prevNode.slug, version.slug) }
+            : null,
+          next: nextNode
+            ? { ...nextNode, href: versionedDocsUrl(nextNode.slug, version.slug) }
+            : null,
+        },
+      });
+    }
+
+    // Auto-generated index pages for categories without index.mdx
+    for (const node of collectAutoIndexNodes(tree)) {
+      result.push({
+        params: { version: version.slug, slug: node.slug.split("/") },
+        props: {
+          entry: null,
+          autoIndex: {
+            ...node,
+            children: node.children.map((c: NavNode) => ({
+              ...c,
+              href: c.href ?? versionedDocsUrl(c.slug, version.slug),
+            })) as NavNode[],
+          } as AutoIndexNode,
+          version,
+          breadcrumbs: buildBreadcrumbs(tree, node.slug, "en"),
+          prev: null,
+          next: null,
+        },
+      });
+    }
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Page component
+// ---------------------------------------------------------------------------
+
+interface PageArgs {
+  params: { version: string; slug: string[] };
+  props: DocPageProps;
+}
+
+export default function VersionedDocsPage({ props }: PageArgs): JSX.Element {
+  const { entry, autoIndex, version, breadcrumbs, prev, next } = props;
+  const locale = "en";
+
+  const slug = autoIndex
+    ? autoIndex.slug
+    : (entry!.data.slug ?? toRouteSlug(entry!.id));
+
+  const title = autoIndex ? autoIndex.label : entry!.data.title;
+  const description = autoIndex ? autoIndex.description : entry!.data.description;
+
+  const components = { ...htmlOverrides };
+
+  const autoIndexChildren = autoIndex
+    ? autoIndex.children.filter((c: NavNode) => c.hasPage || c.children.length > 0)
+    : [];
+
+  return (
+    <DocLayoutWithDefaults
+      title={title}
+      description={description}
+      lang={locale}
+      hideSidebar={entry?.data?.hide_sidebar}
+      hideToc={entry?.data?.hide_toc}
+      breadcrumbOverride={
+        breadcrumbs.length > 0 ? <Breadcrumb items={breadcrumbs} /> : undefined
+      }
+    >
+      {autoIndex ? (
+        <div>
+          <h1 class="text-heading font-bold mb-vsp-xs">{autoIndex.label}</h1>
+          {autoIndex.description && (
+            <p class="mt-0 mb-vsp-lg text-subheading text-muted">
+              {autoIndex.description}
+            </p>
+          )}
+          <NavCardGrid children={autoIndexChildren} />
+        </div>
+      ) : (
+        <div>
+          <h1 class="text-heading font-bold mb-vsp-xs">{entry!.data.title}</h1>
+
+          {entry!.data.description && (
+            <p class="mt-0 mb-vsp-lg text-subheading text-muted">
+              {entry!.data.description}
+            </p>
+          )}
+
+          {entry && <entry.Content components={components} />}
+
+          {/* Prev / Next pagination */}
+          <nav class="mt-vsp-2xl grid grid-cols-2 gap-hsp-xl">
+            {prev ? (
+              <a
+                href={prev.href}
+                class="group border border-muted rounded-lg p-hsp-lg hover:border-accent"
+              >
+                <div class="flex items-center gap-hsp-xs text-caption text-muted mb-vsp-2xs">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="h-[1.125rem] w-[1.125rem]"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+                  </svg>
+                  <span class="no-underline">{t("nav.previous", locale)}</span>
+                </div>
+                <p class="text-small font-semibold underline group-hover:text-accent">
+                  {prev.label}
+                </p>
+              </a>
+            ) : (
+              <div />
+            )}
+            {next ? (
+              <a
+                href={next.href}
+                class="group border border-muted rounded-lg p-hsp-lg hover:border-accent text-right"
+              >
+                <div class="flex items-center justify-end gap-hsp-xs text-caption text-muted mb-vsp-2xs">
+                  <span class="no-underline">{t("nav.next", locale)}</span>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="h-[1.125rem] w-[1.125rem]"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+                  </svg>
+                </div>
+                <p class="text-small font-semibold underline group-hover:text-accent">
+                  {next.label}
+                </p>
+              </a>
+            ) : (
+              <div />
+            )}
+          </nav>
+        </div>
+      )}
+    </DocLayoutWithDefaults>
+  );
+}

--- a/pages/v/[version]/ja/docs/[...slug].tsx
+++ b/pages/v/[version]/ja/docs/[...slug].tsx
@@ -1,0 +1,336 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+// Port of src/pages/v/[version]/ja/docs/[...slug].astro → zfb page module.
+//
+// Versioned JA docs route. paths() cross-products settings.versions with a
+// locale-first merge strategy: locale-specific collection (`docs-v-${version.slug}-ja`)
+// takes priority; the base EN collection (`docs-v-${version.slug}`) fills in
+// pages not translated yet (shown with a fallback notice).
+//
+// If version.locales?.ja is not configured, only the base EN collection is used.
+//
+// paths() contract (zfb ADR-004 — synchronous):
+//   params: { version: string; slug: string[] }
+//   props:  { entry, autoIndex, version, contentDir, isFallback, breadcrumbs, prev, next }
+//
+// Prev/next hrefs are pre-resolved to the versioned JA URL form
+// (e.g. /v/1.0/ja/docs/…) so the component needs no URL computation.
+
+import { getCollection } from "zfb/content";
+import type { CollectionEntry } from "zfb/content";
+import type { DocsEntry } from "@/types/docs-entry";
+import { settings } from "@/config/settings";
+import type { VersionConfig } from "@/config/settings";
+import { t } from "@/config/i18n";
+import { versionedDocsUrl } from "@/utils/base";
+import {
+  buildNavTree,
+  buildBreadcrumbs,
+  flattenTree,
+  findNode,
+  loadCategoryMeta,
+  collectAutoIndexNodes,
+  isNavVisible,
+  type NavNode,
+  type BreadcrumbItem,
+} from "@/utils/docs";
+import { getNavSectionForSlug, getNavSubtree } from "@/utils/nav-scope";
+import { toRouteSlug } from "@/utils/slug";
+import { DocLayoutWithDefaults } from "@zudo-doc/zudo-doc-v2/doclayout";
+import { Breadcrumb } from "@zudo-doc/zudo-doc-v2/breadcrumb";
+import { htmlOverrides } from "@zudo-doc/zudo-doc-v2/content";
+import { NavCardGrid } from "@zudo-doc/zudo-doc-v2/nav-indexing";
+import type { JSX } from "preact";
+
+export const frontmatter = { title: "Docs" };
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface DocPageEntry extends DocsEntry {
+  Content: CollectionEntry<unknown>["Content"];
+  module_specifier: string;
+}
+
+interface AutoIndexNode extends NavNode {
+  children: NavNode[];
+}
+
+interface DocPageProps {
+  entry: DocPageEntry | null;
+  autoIndex?: AutoIndexNode;
+  /** The version config for the active version. */
+  version: VersionConfig;
+  /** Content directory for this page (locale dir if translated, version docsDir if fallback). */
+  contentDir: string;
+  /** True when this page falls back to the base EN collection for this version. */
+  isFallback: boolean;
+  breadcrumbs: BreadcrumbItem[];
+  prev: NavNode | null;
+  next: NavNode | null;
+}
+
+// ---------------------------------------------------------------------------
+// paths() — synchronous (ADR-004)
+// ---------------------------------------------------------------------------
+
+/**
+ * Emit one route per (version, slug) combination for JA locale.
+ *
+ * Merge strategy per version:
+ *   1. Load locale docs (e.g. "docs-v-1.0-ja") if version.locales.ja is set.
+ *   2. Load base EN docs ("docs-v-1.0").
+ *   3. Locale docs take priority; base EN fills in slugs not translated.
+ *   4. Track fallback slugs for the fallback-notice banner.
+ *   5. Build nav tree with "ja" locale, compute breadcrumbs and prev/next.
+ *
+ * Prev/next hrefs are pre-resolved to the versioned JA URL form.
+ */
+export function paths(): Array<{
+  params: { version: string; slug: string[] };
+  props: DocPageProps;
+}> {
+  if (!settings.versions) return [];
+
+  const result: Array<{
+    params: { version: string; slug: string[] };
+    props: DocPageProps;
+  }> = [];
+
+  for (const version of settings.versions) {
+    const baseCollectionName = `docs-v-${version.slug}`;
+    const localeDir = (version.locales as Record<string, { dir: string }> | undefined)?.ja?.dir;
+    const localeCollectionName = localeDir ? `docs-v-${version.slug}-ja` : null;
+
+    const baseDocs = (getCollection(baseCollectionName) as unknown as DocPageEntry[]).filter(
+      (doc) => !doc.data.draft,
+    );
+    const localeDocs = localeCollectionName
+      ? (getCollection(localeCollectionName) as unknown as DocPageEntry[]).filter(
+          (doc) => !doc.data.draft,
+        )
+      : [];
+
+    // Build slug set from locale docs (locale takes priority)
+    const localeSlugSet = new Set(localeDocs.map((d) => d.data.slug ?? toRouteSlug(d.id)));
+
+    // Merge: locale docs first, then base docs for missing pages
+    const fallbackDocs = baseDocs.filter(
+      (d) => !localeSlugSet.has(d.data.slug ?? toRouteSlug(d.id)),
+    );
+    const fallbackSlugs = new Set(fallbackDocs.map((d) => d.data.slug ?? toRouteSlug(d.id)));
+    const allDocs = [...localeDocs, ...fallbackDocs];
+
+    // Merge category metadata: base first, locale overrides
+    const baseCategoryMeta = loadCategoryMeta(version.docsDir);
+    const localeCategoryMeta = localeDir ? loadCategoryMeta(localeDir) : new Map();
+    const categoryMeta = new Map([...baseCategoryMeta, ...localeCategoryMeta]);
+
+    const navDocs = allDocs.filter(isNavVisible);
+    const tree = buildNavTree(navDocs as unknown as DocsEntry[], "ja", categoryMeta);
+
+    // Regular doc pages
+    for (const entry of allDocs) {
+      const slug = entry.data.slug ?? toRouteSlug(entry.id);
+      const isFallback = fallbackSlugs.has(slug);
+      const entryContentDir = isFallback ? version.docsDir : (localeDir ?? version.docsDir);
+
+      const navSection = getNavSectionForSlug(slug);
+      const subtree = getNavSubtree(tree, navSection);
+      const flat = flattenTree(subtree);
+      const idx = flat.findIndex((n) => n.slug === slug);
+
+      let prevNode = idx > 0 ? flat[idx - 1] ?? null : null;
+      let nextNode = idx >= 0 && idx < flat.length - 1 ? flat[idx + 1] ?? null : null;
+
+      if (entry.data.pagination_prev !== undefined) {
+        if (entry.data.pagination_prev === null) {
+          prevNode = null;
+        } else {
+          const found = findNode(tree, entry.data.pagination_prev);
+          prevNode = found ?? prevNode;
+        }
+      }
+      if (entry.data.pagination_next !== undefined) {
+        if (entry.data.pagination_next === null) {
+          nextNode = null;
+        } else {
+          const found = findNode(tree, entry.data.pagination_next);
+          nextNode = found ?? nextNode;
+        }
+      }
+
+      result.push({
+        params: { version: version.slug, slug: slug.split("/") },
+        props: {
+          entry,
+          version,
+          contentDir: entryContentDir,
+          isFallback,
+          breadcrumbs: buildBreadcrumbs(tree, slug, "ja"),
+          // Pre-resolve prev/next hrefs to versioned JA URLs
+          prev: prevNode
+            ? { ...prevNode, href: versionedDocsUrl(prevNode.slug, version.slug, "ja") }
+            : null,
+          next: nextNode
+            ? { ...nextNode, href: versionedDocsUrl(nextNode.slug, version.slug, "ja") }
+            : null,
+        },
+      });
+    }
+
+    // Auto-generated index pages for categories without index.mdx
+    for (const node of collectAutoIndexNodes(tree)) {
+      result.push({
+        params: { version: version.slug, slug: node.slug.split("/") },
+        props: {
+          entry: null,
+          autoIndex: {
+            ...node,
+            children: node.children.map((c: NavNode) => ({
+              ...c,
+              href: c.href ?? versionedDocsUrl(c.slug, version.slug, "ja"),
+            })) as NavNode[],
+          } as AutoIndexNode,
+          version,
+          contentDir: localeDir ?? version.docsDir,
+          isFallback: false,
+          breadcrumbs: buildBreadcrumbs(tree, node.slug, "ja"),
+          prev: null,
+          next: null,
+        },
+      });
+    }
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Page component
+// ---------------------------------------------------------------------------
+
+interface PageArgs {
+  params: { version: string; slug: string[] };
+  props: DocPageProps;
+}
+
+export default function VersionedJaDocsPage({ props }: PageArgs): JSX.Element {
+  const { entry, autoIndex, version, isFallback, breadcrumbs, prev, next } = props;
+  const locale = "ja";
+
+  const slug = autoIndex
+    ? autoIndex.slug
+    : (entry!.data.slug ?? toRouteSlug(entry!.id));
+
+  const title = autoIndex ? autoIndex.label : entry!.data.title;
+  const description = autoIndex ? autoIndex.description : entry!.data.description;
+
+  const components = { ...htmlOverrides };
+
+  const autoIndexChildren = autoIndex
+    ? autoIndex.children.filter((c: NavNode) => c.hasPage || c.children.length > 0)
+    : [];
+
+  return (
+    <DocLayoutWithDefaults
+      title={title}
+      description={description}
+      lang={locale}
+      hideSidebar={entry?.data?.hide_sidebar}
+      hideToc={entry?.data?.hide_toc}
+      breadcrumbOverride={
+        breadcrumbs.length > 0 ? <Breadcrumb items={breadcrumbs} /> : undefined
+      }
+    >
+      {autoIndex ? (
+        <div>
+          <h1 class="text-heading font-bold mb-vsp-xs">{autoIndex.label}</h1>
+          {autoIndex.description && (
+            <p class="mt-0 mb-vsp-lg text-subheading text-muted">
+              {autoIndex.description}
+            </p>
+          )}
+          <NavCardGrid children={autoIndexChildren} />
+        </div>
+      ) : (
+        <div>
+          <h1 class="text-heading font-bold mb-vsp-xs">{entry!.data.title}</h1>
+
+          {/* Fallback notice for non-translated pages */}
+          {isFallback && !entry!.data.generated && (
+            <div
+              class="mb-vsp-md border border-info/30 bg-info/5 px-hsp-lg py-vsp-sm text-small text-muted rounded"
+              role="note"
+            >
+              {t("doc.fallbackNotice", locale)}
+            </div>
+          )}
+
+          {entry!.data.description && (
+            <p class="mt-0 mb-vsp-lg text-subheading text-muted">
+              {entry!.data.description}
+            </p>
+          )}
+
+          {entry && <entry.Content components={components} />}
+
+          {/* Prev / Next pagination */}
+          <nav class="mt-vsp-2xl grid grid-cols-2 gap-hsp-xl">
+            {prev ? (
+              <a
+                href={prev.href}
+                class="group border border-muted rounded-lg p-hsp-lg hover:border-accent"
+              >
+                <div class="flex items-center gap-hsp-xs text-caption text-muted mb-vsp-2xs">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="h-[1.125rem] w-[1.125rem]"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+                  </svg>
+                  <span class="no-underline">{t("nav.previous", locale)}</span>
+                </div>
+                <p class="text-small font-semibold underline group-hover:text-accent">
+                  {prev.label}
+                </p>
+              </a>
+            ) : (
+              <div />
+            )}
+            {next ? (
+              <a
+                href={next.href}
+                class="group border border-muted rounded-lg p-hsp-lg hover:border-accent text-right"
+              >
+                <div class="flex items-center justify-end gap-hsp-xs text-caption text-muted mb-vsp-2xs">
+                  <span class="no-underline">{t("nav.next", locale)}</span>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="h-[1.125rem] w-[1.125rem]"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+                  </svg>
+                </div>
+                <p class="text-small font-semibold underline group-hover:text-accent">
+                  {next.label}
+                </p>
+              </a>
+            ) : (
+              <div />
+            )}
+          </nav>
+        </div>
+      )}
+    </DocLayoutWithDefaults>
+  );
+}


### PR DESCRIPTION
## Summary

- Ports all docs routing logic from Astro `getStaticPaths()` to synchronous zfb `paths()` contract (ADR-004)
- Adds `pages/_data.ts` with bridge helpers: `getDocs`, `asDocsEntries`, `filterDrafts`, `mergeLocaleDocs`
- Covers 10 route modules: default-locale (EN), non-default locales, versioned EN, and versioned JA with locale-first merge + fallback tracking

## Route coverage

| File | Route | Notes |
|---|---|---|
| `pages/index.tsx` | `/` | Site index with DocsSitemap |
| `pages/404.tsx` | `404.html` | Static, noindex |
| `pages/docs/[...slug].tsx` | `/docs/…` | EN docs + auto-index |
| `pages/docs/versions.tsx` | `/docs/versions` | EN versions page |
| `pages/[locale]/index.tsx` | `/{locale}/` | Locale site index |
| `pages/[locale]/docs/[...slug].tsx` | `/{locale}/docs/…` | Locale docs with fallback merge |
| `pages/[locale]/docs/versions.tsx` | `/{locale}/docs/versions` | Locale versions page |
| `pages/v/[version]/docs/[...slug].tsx` | `/v/{version}/docs/…` | Versioned EN docs |
| `pages/v/[version]/ja/docs/[...slug].tsx` | `/v/{version}/ja/docs/…` | Versioned JA with locale merge |

## Test plan

- [ ] gcoc review: passed with no high-priority findings
- [ ] All `paths()` follow synchronous ADR-004 contract (no await)
- [ ] Locale-first merge strategy mirrors `src/utils/locale-docs.ts`
- [ ] Prev/next hrefs pre-resolved to versioned/locale URLs
- [ ] Auto-index pages generated for categories without index.mdx
- [ ] Fallback notice rendered for non-translated pages (`isFallback && !entry.data.generated`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)