### PR TITLE
feat(create-zudo-doc): JSX layout/header templates with 22 injection anchors

### DIFF
--- a/packages/create-zudo-doc/src/astro-config-gen.ts
+++ b/packages/create-zudo-doc/src/astro-config-gen.ts
@@ -164,6 +164,16 @@ export function generateAstroConfig(choices: UserChoices): string {
   // Vite
   lines.push(`  vite: {`);
   lines.push(`    plugins: [tailwindcss()],`);
+  lines.push(`    resolve: {`);
+  lines.push(`      alias: {`);
+  lines.push(`        // Phase-A bridge: map \`@takazudo/zfb\` (unpublished) to the local`);
+  lines.push(`        // Island stub so .astro / .mdx imports typecheck and bundle`);
+  lines.push(`        // correctly until the real package ships.`);
+  lines.push(`        "@takazudo/zfb": fileURLToPath(`);
+  lines.push(`          new URL("./src/components/island.tsx", import.meta.url),`);
+  lines.push(`        ),`);
+  lines.push(`      },`);
+  lines.push(`    },`);
   lines.push(`  },`);
 
   // Markdown

--- a/packages/create-zudo-doc/src/compose.ts
+++ b/packages/create-zudo-doc/src/compose.ts
@@ -50,8 +50,20 @@ export type FeatureModule = (choices: UserChoices) => FeatureDefinition;
 // Anchor patterns
 // ---------------------------------------------------------------------------
 
-/** Regex that matches any line containing an @slot anchor comment. */
-const ANCHOR_LINE_RE = /^[ \t]*(?:\/\/|\/\*|<!--|#)\s*@slot:[^\n]*(?:\*\/|-->)?[ \t]*\r?\n?$/gm;
+/**
+ * Regex that matches any line containing an @slot anchor comment.
+ *
+ * Handles four comment forms:
+ *   1. `// @slot:…`          — JS/TS line comment
+ *   2. `/* @slot:… *\/`      — JS/TS block comment
+ *   3. `<!-- @slot:… -->`    — HTML/Astro comment
+ *   4. `# @slot:…`           — shell / CSS comment
+ *   5. `{/* <!-- @slot:… --> *\/}` — JSX comment expression embedding an
+ *                              HTML-style anchor so the Astro anchor string
+ *                              is still findable via content.indexOf().
+ */
+const ANCHOR_LINE_RE =
+  /^[ \t]*(?:(?:\/\/|\/\*|<!--|#)\s*@slot:[^\n]*(?:\*\/|-->)?|\{\/\*[^\n]*@slot:[^\n]*\*\/\})[ \t]*\r?\n?$/gm;
 
 // ---------------------------------------------------------------------------
 // Core functions
@@ -223,10 +235,20 @@ export function validateDependencies(
   }
 }
 
-/** Files that may contain injection anchors and need cleaning. */
+/**
+ * Files that may contain injection anchors and need cleaning.
+ *
+ * Both the legacy Astro files and the new JSX files are listed so that
+ * anchor cleanup runs on whichever version is present in the generated
+ * project.  Feature modules currently target the `.astro` files; once
+ * topic-feature-modules updates those injection targets to the `.tsx`
+ * equivalents, the `.astro` entries can be removed.
+ */
 export const ANCHOR_FILES = [
   "src/layouts/doc-layout.astro",
+  "src/layouts/doc-layout.tsx",
   "src/components/header.astro",
+  "src/components/header.tsx",
   "src/styles/global.css",
 ];
 

--- a/packages/create-zudo-doc/templates/base/src/components/header.astro
+++ b/packages/create-zudo-doc/templates/base/src/components/header.astro
@@ -4,6 +4,7 @@ import ThemeToggle from "@/components/theme-toggle";
 import { settings } from "@/config/settings";
 import { withBase, stripBase, navHref } from "@/utils/base";
 import { defaultLocale, t, type Locale } from "@/config/i18n";
+import { Island } from "@takazudo/zfb";
 // @slot:header:imports
 
 interface Props {
@@ -51,9 +52,11 @@ function isNavItemActive(item: (typeof settings.headerNav)[number]): boolean {
   class="sticky top-0 z-50 flex h-[3.5rem] items-center border-b border-muted bg-surface px-hsp-lg"
   data-header
 >
-  <SidebarToggle client:media="(max-width: 1023px)">
-    <slot name="sidebar" />
-  </SidebarToggle>
+  <Island when="media">
+    <SidebarToggle>
+      <slot name="sidebar" />
+    </SidebarToggle>
+  </Island>
 
   <a
     href={withBase(isNonDefaultLocale ? `/${lang}/` : "/")}
@@ -182,10 +185,9 @@ function isNavItemActive(item: (typeof settings.headerNav)[number]): boolean {
     <div class="hidden lg:flex items-center gap-x-hsp-md">
       {
         settings.colorMode && (
-          <ThemeToggle
-            defaultMode={settings.colorMode.defaultMode}
-            client:load
-          />
+          <Island when="load">
+            <ThemeToggle defaultMode={settings.colorMode.defaultMode} />
+          </Island>
         )
       }
       {

--- a/packages/create-zudo-doc/templates/base/src/components/header.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/header.tsx
@@ -1,0 +1,253 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+// header.tsx — JSX port of src/components/header.astro.
+//
+// Carries the 6 create-zudo-doc injection anchors verbatim so that the
+// composition engine (compose.ts) and the drift checker can locate them
+// in either this file or the parallel header.astro.
+//
+// Module-scope anchors (line-comment form used by compose.ts):
+//   // @slot:header:imports
+//   // @slot:header:props
+//   // @slot:header:props-destructure
+//
+// Body-region anchors are embedded as JSX comment expressions
+// ({/* <!-- @slot:... --> */}).  `content.indexOf("<!-- @slot:... -->")` still
+// matches the literal substring inside the {/* */}, so existing feature-module
+// injection strings require no changes.
+//
+// // @slot:header:imports
+// // @slot:header:props
+// // @slot:header:props-destructure
+
+import type { ComponentChildren, JSX } from "preact";
+import SidebarToggle from "@/components/sidebar-toggle";
+import ThemeToggle from "@/components/theme-toggle";
+import { settings } from "@/config/settings";
+import { withBase, stripBase, navHref } from "@/utils/base";
+import { defaultLocale, t, type Locale } from "@/config/i18n";
+import { Island } from "@takazudo/zfb";
+// @slot:header:imports
+
+export interface HeaderProps {
+  lang?: Locale;
+  currentPath?: string;
+  currentVersion?: string;
+  currentSlug?: string;
+  /** Sidebar contents projected into the mobile `<SidebarToggle>` island. */
+  sidebarSlot?: ComponentChildren;
+  // @slot:header:props
+}
+
+export function Header(props: HeaderProps): JSX.Element {
+  const {
+    lang,
+    currentPath = "",
+    currentVersion,
+    currentSlug,
+    sidebarSlot,
+    // @slot:header:props-destructure
+  } = props;
+  void currentSlug;
+
+  const isNonDefaultLocale = lang != null && lang !== defaultLocale;
+  const pathWithoutBase = stripBase(currentPath);
+  const pathForMatch = isNonDefaultLocale
+    ? pathWithoutBase.replace(new RegExp(`^/${lang}`), "")
+    : pathWithoutBase;
+
+  // Collect all matchable paths: parent paths + children paths
+  const allNavPaths = settings.headerNav.flatMap((item) => {
+    const paths = [item.path];
+    if (item.children) {
+      paths.push(...item.children.map((child) => child.path));
+    }
+    return paths;
+  });
+  const activeNavPath = allNavPaths
+    .filter((p) => pathForMatch.startsWith(p))
+    .sort((a, b) => b.length - a.length)[0];
+
+  function isNavItemActive(
+    item: (typeof settings.headerNav)[number],
+  ): boolean {
+    if (activeNavPath === item.path) return true;
+    if (item.children?.some((child) => activeNavPath === child.path))
+      return true;
+    return false;
+  }
+
+  return (
+    <header
+      class="sticky top-0 z-50 flex h-[3.5rem] items-center border-b border-muted bg-surface px-hsp-lg"
+      data-header
+    >
+      <Island when="media">
+        <SidebarToggle>{sidebarSlot}</SidebarToggle>
+      </Island>
+
+      <a
+        href={withBase(isNonDefaultLocale ? `/${lang}/` : "/")}
+        class="whitespace-nowrap text-subheading font-bold text-fg hover:underline focus:underline shrink-0"
+        data-header-logo
+      >
+        {settings.siteName}
+      </a>
+
+      <nav
+        aria-label="Main"
+        class="relative ml-hsp-xl hidden min-w-0 flex-1 items-center gap-x-hsp-2xs whitespace-nowrap lg:flex"
+        data-header-nav
+      >
+        {settings.headerNav.map((item) => {
+          const isActive = isNavItemActive(item);
+          const href = navHref(item.path, lang, currentVersion);
+          const label = item.labelKey ? t(item.labelKey, lang) : item.label;
+
+          if (item.children && item.children.length > 0) {
+            return (
+              <div
+                key={item.path}
+                class="group relative shrink-0"
+                data-nav-item
+                data-nav-item-dropdown
+              >
+                <a
+                  href={href}
+                  aria-current={isActive ? "page" : undefined}
+                  aria-haspopup="true"
+                  aria-expanded="false"
+                  class={[
+                    "flex items-center gap-x-hsp-xs px-hsp-md py-vsp-2xs text-small font-medium transition-colors",
+                    isActive
+                      ? "bg-fg text-bg"
+                      : "text-muted hover:underline focus:underline",
+                  ].join(" ")}
+                >
+                  {label}
+                  <svg
+                    class={[
+                      "h-[0.5rem] w-[0.5rem] shrink-0",
+                      isActive ? "text-bg" : "text-muted",
+                    ].join(" ")}
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    stroke-width="3"
+                    aria-hidden="true"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      d="M19 9l-7 7-7-7"
+                    />
+                  </svg>
+                </a>
+                <div class="absolute left-0 top-full z-50 hidden group-hover:block group-focus-within:block pt-vsp-3xs">
+                  <div class="min-w-[10rem] border border-muted rounded bg-surface shadow-lg py-vsp-3xs">
+                    {item.children.map((child) => {
+                      const childHref = navHref(
+                        child.path,
+                        lang,
+                        currentVersion,
+                      );
+                      const childLabel = child.labelKey
+                        ? t(child.labelKey, lang)
+                        : child.label;
+                      const childActive = activeNavPath === child.path;
+                      return (
+                        <a
+                          key={child.path}
+                          href={childHref}
+                          data-active={childActive ? "" : undefined}
+                          class={[
+                            "block px-hsp-md py-vsp-2xs text-small hover:bg-accent/10 hover:underline",
+                            childActive ? "font-bold text-accent" : "text-fg",
+                          ].join(" ")}
+                        >
+                          {childLabel}
+                        </a>
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+            );
+          }
+
+          return (
+            <a
+              key={item.path}
+              href={href}
+              aria-current={isActive ? "page" : undefined}
+              data-nav-item
+              class={[
+                "px-hsp-md py-vsp-2xs text-small font-medium transition-colors shrink-0",
+                isActive
+                  ? "bg-fg text-bg"
+                  : "text-muted hover:underline focus:underline",
+              ].join(" ")}
+            >
+              {label}
+            </a>
+          );
+        })}
+
+        <div class="relative shrink-0" data-nav-more style="display:none">
+          <button
+            type="button"
+            class="px-hsp-md py-vsp-2xs text-small font-medium text-muted hover:underline cursor-pointer"
+            data-nav-more-toggle
+            aria-expanded="false"
+          >
+            {"···"}
+          </button>
+          <ul
+            class="absolute right-0 top-full z-10 mt-vsp-3xs hidden min-w-[8rem] border border-muted rounded bg-surface shadow-lg whitespace-nowrap"
+            data-nav-more-menu
+          />
+        </div>
+      </nav>
+
+      <div
+        class="ml-auto flex shrink-0 items-center gap-x-hsp-md"
+        data-header-right
+      >
+        {/* <!-- @slot:header:actions-start --> */}
+        <div class="hidden lg:flex items-center gap-x-hsp-md">
+          {settings.colorMode && (
+            <Island when="load">
+              <ThemeToggle defaultMode={settings.colorMode.defaultMode} />
+            </Island>
+          )}
+          {settings.githubUrl && (
+            <a
+              href={settings.githubUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="flex items-center justify-center text-muted transition-colors hover:text-fg"
+              aria-label={t("header.github", lang)}
+              title={t("header.github", lang)}
+            >
+              <span class="sr-only">{t("header.github", lang)}</span>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M12 .5C5.649.5.5 5.649.5 12a11.5 11.5 0 0 0 7.86 10.915c.575.106.785-.25.785-.556 0-.274-.01-1-.016-1.962-3.198.695-3.873-1.541-3.873-1.541-.523-1.327-1.277-1.68-1.277-1.68-1.044-.714.079-.699.079-.699 1.154.082 1.761 1.186 1.761 1.186 1.026 1.758 2.692 1.25 3.348.956.104-.743.401-1.25.73-1.537-2.553-.29-5.238-1.276-5.238-5.682 0-1.255.448-2.282 1.182-3.086-.119-.29-.512-1.458.111-3.04 0 0 .964-.309 3.159 1.18A10.98 10.98 0 0 1 12 6.036c.977.005 1.963.132 2.883.387 2.193-1.49 3.155-1.18 3.155-1.18.625 1.582.232 2.75.114 3.04.736.804 1.18 1.831 1.18 3.086 0 4.417-2.689 5.389-5.25 5.673.412.355.779 1.056.779 2.129 0 1.538-.014 2.778-.014 3.156 0 .31.207.668.79.555A11.502 11.502 0 0 0 23.5 12C23.5 5.649 18.351.5 12 .5Z" />
+              </svg>
+            </a>
+          )}
+          {/* <!-- @slot:header:after-theme-toggle --> */}
+        </div>
+        {/* <!-- @slot:header:actions-end --> */}
+      </div>
+    </header>
+  );
+}
+
+export default Header;

--- a/packages/create-zudo-doc/templates/base/src/components/html-preview-wrapper.astro
+++ b/packages/create-zudo-doc/templates/base/src/components/html-preview-wrapper.astro
@@ -1,5 +1,6 @@
 ---
 import HtmlPreview from "./html-preview/html-preview";
+import { Island } from "@takazudo/zfb";
 import { settings } from "@/config/settings";
 
 interface Props {
@@ -23,16 +24,17 @@ const mergedCss =
 const mergedJs = [globalConfig?.js, js].filter(Boolean).join("\n") || undefined;
 ---
 
-<HtmlPreview
-  client:visible
-  html={html}
-  css={mergedCss}
-  head={mergedHead}
-  js={mergedJs}
-  title={title}
-  height={height}
-  defaultOpen={defaultOpen}
-  componentCss={css}
-  componentHead={head}
-  componentJs={js}
-/>
+<Island when="visible">
+  <HtmlPreview
+    html={html}
+    css={mergedCss}
+    head={mergedHead}
+    js={mergedJs}
+    title={title}
+    height={height}
+    defaultOpen={defaultOpen}
+    componentCss={css}
+    componentHead={head}
+    componentJs={js}
+  />
+</Island>

--- a/packages/create-zudo-doc/templates/base/src/components/island.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/island.tsx
@@ -1,0 +1,41 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+// Phase-A stub for the `Island` hydration-boundary primitive from
+// `@takazudo/zfb`. The real implementation lives in the zfb repo and
+// will replace this file once the package is published and integrated.
+//
+// For now, Island renders its children transparently (server-side).
+// Client-side hydration scheduling (`when` prop) is recorded on the
+// element via data-attributes so the zfb runtime can pick it up once
+// it is wired in. During Phase A the `when` value is preserved here
+// in a comment — no actual data-attribute is emitted by this stub.
+
+import type { ComponentChildren } from "preact";
+
+/** Hydration scheduling strategy — mirrors zfb's `IslandWhen` union. */
+export type IslandWhen = "load" | "idle" | "visible" | "media";
+
+export interface IslandProps {
+  /** When to hydrate on the client. Phase-A: ignored; recorded for review. */
+  when?: IslandWhen;
+  /**
+   * Server-side fallback shown before hydration (SSR-skip mode). Phase-A:
+   * not used; accepted for API shape compatibility.
+   */
+  ssrFallback?: ComponentChildren;
+  children?: ComponentChildren;
+}
+
+/**
+ * Phase-A `Island` stub. Renders `children` server-side. Client-side
+ * hydration wiring lands once the zfb runtime is fully integrated.
+ *
+ * This file is the local implementation target for the Vite alias
+ * `"@takazudo/zfb"` → `"./src/components/island.tsx"`. All imports
+ * of `{ Island } from "@takazudo/zfb"` in the project resolve here.
+ */
+export function Island({ children }: IslandProps) {
+  // eslint-disable-next-line react/jsx-no-useless-fragment
+  return <>{children}</>;
+}

--- a/packages/create-zudo-doc/templates/base/src/components/sidebar.astro
+++ b/packages/create-zudo-doc/templates/base/src/components/sidebar.astro
@@ -1,5 +1,6 @@
 ---
 import SidebarTree from "@/components/sidebar-tree";
+import { Island } from "@takazudo/zfb";
 import { buildSidebarForSection } from "@/utils/sidebar";
 import { defaultLocale, locales, t, type Locale } from "@/config/i18n";
 import { buildLocaleLinks, versionedDocsUrl, navHref } from "@/utils/base";
@@ -76,14 +77,15 @@ const localeLinks =
   locales.length > 1 ? buildLocaleLinks(Astro.url.pathname, lang) : undefined;
 ---
 
-<SidebarTree
-  nodes={nodes}
-  currentSlug={currentSlug}
-  rootMenuItems={rootMenuItems}
-  backToMenuLabel={backToMenuLabel}
-  localeLinks={localeLinks}
-  themeDefaultMode={settings.colorMode
-    ? settings.colorMode.defaultMode
-    : undefined}
-  client:load
-/>
+<Island when="load">
+  <SidebarTree
+    nodes={nodes}
+    currentSlug={currentSlug}
+    rootMenuItems={rootMenuItems}
+    backToMenuLabel={backToMenuLabel}
+    localeLinks={localeLinks}
+    themeDefaultMode={settings.colorMode
+      ? settings.colorMode.defaultMode
+      : undefined}
+  />
+</Island>

--- a/packages/create-zudo-doc/templates/base/src/components/site-tree-nav-demo.astro
+++ b/packages/create-zudo-doc/templates/base/src/components/site-tree-nav-demo.astro
@@ -5,6 +5,7 @@ import { stripBase } from "@/utils/base";
 import { detectLocaleFromPath, type Locale } from "@/config/i18n";
 import { getCategoryOrder } from "@/utils/nav-scope";
 import SiteTreeNav from "@/components/site-tree-nav.tsx";
+import { Island } from "@takazudo/zfb";
 
 const currentPath = Astro.url.pathname;
 const pathWithoutBase = stripBase(currentPath);
@@ -17,9 +18,10 @@ const tree = buildNavTree(navDocs, lang, categoryMeta);
 const groupedTree = groupSatelliteNodes(tree, categoryOrder);
 ---
 
-<SiteTreeNav
-  tree={groupedTree}
-  categoryOrder={categoryOrder}
-  categoryIgnore={["inbox"]}
-  client:visible
-/>
+<Island when="visible">
+  <SiteTreeNav
+    tree={groupedTree}
+    categoryOrder={categoryOrder}
+    categoryIgnore={["inbox"]}
+  />
+</Island>

--- a/packages/create-zudo-doc/templates/base/src/layouts/doc-layout.astro
+++ b/packages/create-zudo-doc/templates/base/src/layouts/doc-layout.astro
@@ -16,6 +16,7 @@ import { getNavSectionForSlug } from "@/utils/nav-scope";
 import { defaultLocale, t, type Locale } from "@/config/i18n";
 import { withBase, docsUrl } from "@/utils/base";
 import type { VersionConfig } from "@/config/settings-types";
+import { Island } from "@takazudo/zfb";
 // @slot:doc-layout:imports
 
 interface Props {
@@ -170,11 +171,9 @@ const contentTransition = {
             <!-- @slot:doc-layout:after-breadcrumb -->
             {
               !hideToc && (
-                <MobileToc
-                  headings={headings}
-                  title={t("toc.title", lang)}
-                  client:load
-                />
+                <Island when="load">
+                  <MobileToc headings={headings} title={t("toc.title", lang)} />
+                </Island>
               )
             }
             <article class="zd-content max-w-none">
@@ -184,7 +183,13 @@ const contentTransition = {
           </main>
 
           {/* Table of contents */}
-          {!hideToc && <Toc headings={headings} client:load />}
+          {
+            !hideToc && (
+              <Island when="load">
+                <Toc headings={headings} />
+              </Island>
+            )
+          }
         </div>
       </div>
       <!-- @slot:doc-layout:footer -->

--- a/packages/create-zudo-doc/templates/base/src/layouts/doc-layout.tsx
+++ b/packages/create-zudo-doc/templates/base/src/layouts/doc-layout.tsx
@@ -1,0 +1,233 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+// doc-layout.tsx — composable JSX documentation-page layout.
+//
+// Carries the 16 create-zudo-doc injection anchors verbatim so that the
+// composition engine (compose.ts) and the drift checker can locate them
+// in either this file or the parallel doc-layout.astro.
+//
+// Module-scope anchors (line-comment form used by compose.ts):
+//   // @slot:doc-layout:imports
+//   // @slot:doc-layout:frontmatter
+//
+// Body-region anchors are embedded as JSX comment expressions
+// ({/* <!-- @slot:... --> */}).  `content.indexOf("<!-- @slot:... -->")` still
+// matches the literal substring inside the {/* */}, so existing feature-module
+// injection strings require no changes.
+//
+// // @slot:doc-layout:imports
+// // @slot:doc-layout:frontmatter
+
+import type { ComponentChildren, JSX } from "preact";
+import "@/styles/global.css";
+import { Toc } from "@/components/toc";
+import { MobileToc } from "@/components/mobile-toc";
+import { Island } from "@takazudo/zfb";
+import { settings } from "@/config/settings";
+import { defaultLocale, t, type Locale } from "@/config/i18n";
+import type { Heading } from "@/types/heading";
+import { getNavSectionForSlug } from "@/utils/nav-scope";
+import { docsUrl } from "@/utils/base";
+import type { VersionConfig } from "@/config/settings-types";
+// @slot:doc-layout:imports
+
+export interface DocLayoutProps {
+  title: string;
+  description?: string;
+  lang?: Locale;
+  currentSlug?: string;
+  contentDir?: string;
+  entryId?: string;
+  headings?: Heading[];
+  unlisted?: boolean;
+  currentVersion?: string;
+  versionBanner?: VersionConfig["banner"];
+  hideSidebar?: boolean;
+  hideToc?: boolean;
+  docHistory?: boolean;
+  // @slot:doc-layout:frontmatter
+  // ---- slot content props -----------------------------------------------
+  /** Pre-rendered site header. */
+  header?: ComponentChildren;
+  /** Pre-rendered sidebar contents. */
+  sidebar?: ComponentChildren;
+  /** Breadcrumb slot rendered above the article. */
+  breadcrumb?: ComponentChildren;
+  /** Slot rendered between breadcrumb and article. */
+  afterBreadcrumb?: ComponentChildren;
+  /** Slot rendered after the desktop sidebar `<aside>`. */
+  afterSidebar?: ComponentChildren;
+  /** Slot rendered after main article content. */
+  afterContent?: ComponentChildren;
+  /** Footer slot. */
+  footer?: ComponentChildren;
+  /** Components rendered just before `</body>`. */
+  bodyEndComponents?: ComponentChildren;
+  /** Scripts rendered last before `</body>`. */
+  bodyEndScripts?: ComponentChildren;
+  /** Main article body content. */
+  children?: ComponentChildren;
+}
+
+// Sidebar scroll-position preservation across View Transitions.
+// Mirrors the inline <script> in doc-layout.astro.
+const SIDEBAR_SCROLL_SCRIPT = `(function(){var t=0;document.addEventListener("astro:before-swap",function(){var e=document.getElementById("desktop-sidebar");if(e)t=e.scrollTop});document.addEventListener("astro:after-swap",function(){var e=document.getElementById("desktop-sidebar");if(e)e.scrollTop=t})})();`;
+
+export function DocLayout(props: DocLayoutProps): JSX.Element {
+  const {
+    title,
+    description,
+    lang = defaultLocale,
+    currentSlug,
+    contentDir,
+    entryId,
+    headings = [],
+    unlisted = false,
+    currentVersion,
+    versionBanner,
+    hideSidebar = false,
+    hideToc = false,
+    docHistory,
+    header,
+    sidebar,
+    breadcrumb,
+    afterBreadcrumb,
+    afterSidebar,
+    afterContent,
+    footer,
+    bodyEndComponents,
+    bodyEndScripts,
+    children,
+  } = props;
+  // Silence unused-var warnings when no feature consumes these.
+  void contentDir;
+  void entryId;
+  void docHistory;
+  void versionBanner;
+  const latestUrl = currentSlug ? docsUrl(currentSlug, lang) : undefined;
+  void latestUrl;
+
+  const fullTitle =
+    title === settings.siteName ? title : `${title} | ${settings.siteName}`;
+  const navSection = currentSlug
+    ? getNavSectionForSlug(currentSlug)
+    : undefined;
+  const showSidebar = !hideSidebar && sidebar !== undefined;
+
+  const htmlAttrs: JSX.HTMLAttributes<HTMLHtmlElement> = { lang };
+  if (settings.colorMode) {
+    (htmlAttrs as Record<string, unknown>)["data-theme"] =
+      settings.colorMode.defaultMode;
+    htmlAttrs.style = `color-scheme: ${settings.colorMode.defaultMode}`;
+  }
+
+  return (
+    <html {...htmlAttrs}>
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>{fullTitle}</title>
+        {description !== undefined && (
+          <meta name="description" content={description} />
+        )}
+        {settings.noindex && (
+          <meta name="robots" content="noindex, nofollow" />
+        )}
+        {!settings.noindex && unlisted && (
+          <meta name="robots" content="noindex" />
+        )}
+        <meta property="og:title" content={fullTitle} />
+        {description !== undefined && (
+          <meta property="og:description" content={description} />
+        )}
+        {/* <!-- @slot:doc-layout:head-scripts --> */}
+        {settings.math && (
+          <link
+            rel="stylesheet"
+            href="https://cdn.jsdelivr.net/npm/katex@0.16.38/dist/katex.min.css"
+            integrity="sha384-/L6i+LN3dyoaK2jYG5ZLh5u13cjdsPDcFOSNJeFBFa/KgVXR5kOfTdiN3ft1uMAq"
+            crossOrigin="anonymous"
+          />
+        )}
+        {/* <!-- @slot:doc-layout:head-links --> */}
+      </head>
+      <body class="min-h-screen antialiased">
+        {/* <!-- @slot:doc-layout:header-call:start --> */}
+        {header}
+        {/* <!-- @slot:doc-layout:header-call:end --> */}
+
+        {showSidebar && (
+          <aside
+            id="desktop-sidebar"
+            aria-label="Documentation sidebar"
+            class="hidden lg:block fixed top-[3.5rem] left-0 z-30 w-[var(--zd-sidebar-w)] h-[calc(100vh-3.5rem)] overflow-y-auto bg-bg border-r border-muted pb-vsp-xl"
+            style={{
+              viewTransitionName: `sidebar-${lang}-${navSection ?? "default"}`,
+            }}
+          >
+            {sidebar}
+          </aside>
+        )}
+        {/* <!-- @slot:doc-layout:after-sidebar --> */}
+        {afterSidebar}
+
+        {/* <!-- @slot:doc-layout:content-wrapper:start --> */}
+        <div
+          class={
+            showSidebar ? "lg:ml-[var(--zd-sidebar-w)]" : undefined
+          }
+        >
+          {/* <!-- @slot:doc-layout:content-wrapper:end --> */}
+          <div class="flex min-h-[calc(100vh-3.5rem)] justify-center">
+            <div
+              class={[
+                "flex w-full gap-[clamp(1.5rem,3vw,4rem)]",
+                hideSidebar
+                  ? "max-w-[80rem]"
+                  : "max-w-[clamp(50rem,75vw,90rem)]",
+              ].join(" ")}
+            >
+              {/* Main content */}
+              <main class="flex-1 min-w-0 px-hsp-xl py-vsp-xl lg:px-hsp-2xl lg:py-vsp-2xl">
+                {/* <!-- @slot:doc-layout:breadcrumb:start --> */}
+                {breadcrumb}
+                {/* <!-- @slot:doc-layout:breadcrumb:end --> */}
+                {/* <!-- @slot:doc-layout:after-breadcrumb --> */}
+                {afterBreadcrumb}
+                {!hideToc && (
+                  <Island when="load">
+                    <MobileToc
+                      headings={headings}
+                      title={t("toc.title", lang)}
+                    />
+                  </Island>
+                )}
+                <article class="zd-content max-w-none">{children}</article>
+                {/* <!-- @slot:doc-layout:after-content --> */}
+                {afterContent}
+              </main>
+
+              {/* Table of contents */}
+              {!hideToc && (
+                <Island when="load">
+                  <Toc headings={headings} />
+                </Island>
+              )}
+            </div>
+          </div>
+          {/* <!-- @slot:doc-layout:footer --> */}
+          {footer}
+        </div>
+        {/* <!-- @slot:doc-layout:body-end-components --> */}
+        {bodyEndComponents}
+        <script
+          dangerouslySetInnerHTML={{ __html: SIDEBAR_SCROLL_SCRIPT }}
+        />
+        {/* <!-- @slot:doc-layout:body-end-scripts --> */}
+        {bodyEndScripts}
+      </body>
+    </html>
+  );
+}
+
+export default DocLayout;

--- a/packages/create-zudo-doc/templates/base/src/pages/index.astro
+++ b/packages/create-zudo-doc/templates/base/src/pages/index.astro
@@ -6,6 +6,7 @@ import { buildNavTree, groupSatelliteNodes, isNavVisible } from "@/utils/docs";
 import { loadLocaleDocs } from "@/utils/locale-docs";
 import { getCategoryOrder } from "@/utils/nav-scope";
 import SiteTreeNav from "@/components/site-tree-nav.tsx";
+import { Island } from "@takazudo/zfb";
 import { collectTags } from "@/utils/tags";
 import TagNav from "@/components/tag-nav.astro";
 import { toRouteSlug } from "@/utils/slug";
@@ -88,12 +89,13 @@ const tagCount = collectTags(
   </div>
 
   <!-- Sitemap grid -->
-  <SiteTreeNav
-    tree={groupedTree}
-    categoryOrder={categoryOrder}
-    categoryIgnore={["inbox"]}
-    client:idle
-  />
+  <Island when="idle">
+    <SiteTreeNav
+      tree={groupedTree}
+      categoryOrder={categoryOrder}
+      categoryIgnore={["inbox"]}
+    />
+  </Island>
 
   {
     settings.docTags && tagCount > 0 && (

--- a/packages/create-zudo-doc/templates/base/tsconfig.json
+++ b/packages/create-zudo-doc/templates/base/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["src/*"],
+      "@takazudo/zfb": ["src/components/island"]
     }
   },
   "exclude": ["dist", "e2e/fixtures", "packages", "worktrees", "vendor", "src/**/__tests__", "vitest.config.ts"]

--- a/packages/create-zudo-doc/templates/features/bodyFootUtil/files/src/components/body-foot-util-area.astro
+++ b/packages/create-zudo-doc/templates/features/bodyFootUtil/files/src/components/body-foot-util-area.astro
@@ -1,5 +1,6 @@
 ---
 import { DocHistory } from "@/components/doc-history";
+import { Island } from "@takazudo/zfb";
 import { settings } from "@/config/settings";
 import { defaultLocale, t, type Locale } from "@/config/i18n";
 import { withBase } from "@/utils/base";
@@ -81,12 +82,13 @@ const hasContent = docHistoryEnabled || sourceUrl;
         </div>
       )}
       {docHistoryEnabled && (
-        <DocHistory
-          slug={currentSlug}
-          locale={lang !== defaultLocale ? lang : undefined}
-          basePath={withBase("/")}
-          client:idle
-        />
+        <Island when="idle">
+          <DocHistory
+            slug={currentSlug}
+            locale={lang !== defaultLocale ? lang : undefined}
+            basePath={withBase("/")}
+          />
+        </Island>
       )}
     </section>
   )

--- a/packages/create-zudo-doc/templates/features/i18n/files/src/pages/[locale]/index.astro
+++ b/packages/create-zudo-doc/templates/features/i18n/files/src/pages/[locale]/index.astro
@@ -6,6 +6,7 @@ import { buildNavTree, groupSatelliteNodes, isNavVisible } from "@/utils/docs";
 import { loadLocaleDocs } from "@/utils/locale-docs";
 import { getCategoryOrder } from "@/utils/nav-scope";
 import SiteTreeNav from "@/components/site-tree-nav.tsx";
+import { Island } from "@takazudo/zfb";
 import { collectTags } from "@/utils/tags";
 import TagNav from "@/components/tag-nav.astro";
 import { toRouteSlug } from "@/utils/slug";
@@ -96,12 +97,13 @@ const tagCount = collectTags(
   </div>
 
   <!-- Sitemap grid -->
-  <SiteTreeNav
-    tree={groupedTree}
-    categoryOrder={categoryOrder}
-    categoryIgnore={["inbox"]}
-    client:idle
-  />
+  <Island when="idle">
+    <SiteTreeNav
+      tree={groupedTree}
+      categoryOrder={categoryOrder}
+      categoryIgnore={["inbox"]}
+    />
+  </Island>
 
   {
     settings.docTags && tagCount > 0 && (


### PR DESCRIPTION
## Summary

- Add `src/layouts/doc-layout.tsx` — JSX port of `doc-layout.astro` carrying all 16 `create-zudo-doc` injection anchors
- Add `src/components/header.tsx` — JSX port of `header.astro` carrying all 6 injection anchors
- Update `compose.ts` ANCHOR_LINE_RE to handle JSX comment expression anchors `{/* <!-- @slot:... --> */}`
- Update `compose.ts` ANCHOR_FILES to include the new `.tsx` files alongside the existing `.astro` files

### Anchor compatibility strategy

Body-region anchors in the `.tsx` files use the format `{/* <!-- @slot:doc-layout:... --> */}`.  The HTML-comment substring (`<!-- @slot:... -->`) is still findable via `content.indexOf()` so existing feature-module injection strings work without changes.  Module-scope anchors (`// @slot:header:imports`, etc.) remain as plain JS line comments, already handled by the regex.

The `.astro` files are kept alongside the new `.tsx` files.  Feature modules currently target `src/layouts/doc-layout.astro`; that is updated in the `topic-feature-modules` topic.  Once that merge lands the `.astro` entries in `ANCHOR_FILES` can be removed.

### Phase 1 (previous commit — `9d2f1ba`)

All `client:*` island directives in the existing Astro templates replaced with `<Island when="...">` wrappers; `island.tsx` stub added; Vite alias + tsconfig path mapping added for `@takazudo/zfb`.

## Test plan

- [ ] Verify all 16 `doc-layout` anchor substrings are findable in `doc-layout.tsx` via `content.indexOf()`
- [ ] Verify all 6 `header` anchor substrings are findable in `header.tsx` via `content.indexOf()`
- [ ] Verify updated `ANCHOR_LINE_RE` matches both `<!-- @slot:... -->` and `{/* <!-- @slot:... --> */}` line formats
- [ ] Confirm that `compose.ts` anchor cleanup removes JSX comment anchor lines from generated projects
- [ ] Run `pnpm test` in `packages/create-zudo-doc` to verify scaffold tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)