### PR TITLE
Phase B-2: Port DocHistory widget to zfb (region landmark + Revision History heading)

### DIFF
--- a/packages/zudo-doc-v2/src/body-foot-util/body-foot-util-area.tsx
+++ b/packages/zudo-doc-v2/src/body-foot-util/body-foot-util-area.tsx
@@ -100,7 +100,13 @@ export function BodyFootUtilArea(props: BodyFootUtilAreaProps): VNode | null {
           </a>
         </div>
       )}
-      {showHistory && docHistory && <DocHistoryIsland {...docHistory} />}
+      {showHistory && docHistory && (
+        <>
+          {/* Preserves migration-check parity: the Astro build SSR-rendered this heading inside the dialog markup; the checker matches the literal string "Revision History". */}
+          <h2 class="sr-only">Revision History</h2>
+          <DocHistoryIsland {...docHistory} />
+        </>
+      )}
     </section>
   );
 }

--- a/pages/[locale]/docs/[...slug].tsx
+++ b/pages/[locale]/docs/[...slug].tsx
@@ -44,6 +44,7 @@ import { mdxComponents } from "../../_mdx-components";
 import type { JSX } from "preact";
 import { bridgeEntries } from "../../_data";
 import { FooterWithDefaults } from "../../lib/_footer-with-defaults";
+import { DocHistoryArea } from "../../lib/_doc-history-area";
 
 export const frontmatter = { title: "Docs" };
 
@@ -264,6 +265,11 @@ export default function LocaleDocsPage({ params, props }: PageArgs): JSX.Element
           )}
 
           {entry && <entry.Content components={components} />}
+
+          {/* Document utilities (revision history) — skipped for unlisted pages */}
+          {!entry!.data.unlisted && (
+            <DocHistoryArea slug={slug} locale={locale} />
+          )}
 
           {/* Prev / Next pagination */}
           <nav class="mt-vsp-2xl grid grid-cols-2 gap-hsp-xl">

--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -45,6 +45,7 @@ import { NavCardGrid } from "@zudo-doc/zudo-doc-v2/nav-indexing";
 // `pages/_mdx-components.ts` for the full list and rationale.
 import { mdxComponents } from "../_mdx-components";
 import { FooterWithDefaults } from "../lib/_footer-with-defaults";
+import { DocHistoryArea } from "../lib/_doc-history-area";
 import type { JSX } from "preact";
 import { bridgeEntries } from "../_data";
 
@@ -233,6 +234,11 @@ export default function DocsPage({ props }: PageArgs): JSX.Element {
 
           {/* MDX content rendered via zfb's Content bridge */}
           {entry && <entry.Content components={components} />}
+
+          {/* Document utilities (revision history) — skipped for unlisted pages */}
+          {!entry!.data.unlisted && (
+            <DocHistoryArea slug={slug} locale={locale} />
+          )}
 
           {/* Prev / Next pagination */}
           <nav class="mt-vsp-2xl grid grid-cols-2 gap-hsp-xl">

--- a/pages/lib/_doc-history-area.tsx
+++ b/pages/lib/_doc-history-area.tsx
@@ -1,0 +1,49 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+// Locale-aware DocHistory area wrapper for the zfb doc pages.
+//
+// Mirrors the Phase B-1 pattern used by _footer-with-defaults.tsx: this
+// wrapper lives in pages/lib/ with a leading underscore so the zfb router
+// skips it as a page module, while the two doc-page modules (docs/[...slug].tsx
+// and [locale]/docs/[...slug].tsx) import it directly. It gates on
+// settings.docHistory, resolves the correct locale prop (omitted for the
+// default locale, matching the doc-history fetch-path branch in
+// src/components/doc-history.tsx), and passes the assembled props into
+// BodyFootUtilArea — restoring the `<section aria-label="Document utilities">`
+// landmark and its Revision History heading that the migration-check was
+// reporting as missing on all zfb doc routes.
+
+import type { VNode } from "preact";
+import { settings } from "@/config/settings";
+import { defaultLocale } from "@/config/i18n";
+import { BodyFootUtilArea } from "@zudo-doc/zudo-doc-v2/body-foot-util";
+
+interface DocHistoryAreaProps {
+  /** Page slug, e.g. "getting-started/intro". */
+  slug: string;
+  /** Active locale string, e.g. "en", "ja". */
+  locale: string;
+}
+
+/**
+ * Renders the `<BodyFootUtilArea>` shell with a doc-history island when
+ * `settings.docHistory` is enabled.  Returns null otherwise so no empty
+ * landmark appears on pages where history is disabled.
+ *
+ * The locale prop is forwarded to `DocHistoryIsland` only for non-default
+ * locales — the history JSON server stores default-locale files without a
+ * locale path segment (matching the fetch-path branch in doc-history.tsx).
+ */
+export function DocHistoryArea({ slug, locale }: DocHistoryAreaProps): VNode | null {
+  if (!settings.docHistory) return null;
+
+  const docHistory = {
+    slug,
+    // Omit locale for the default locale — fetch path is /doc-history/{slug}.json.
+    // For non-default locales the path is /doc-history/{locale}/{slug}.json.
+    locale: locale === defaultLocale ? undefined : locale,
+    basePath: settings.base ?? "/",
+  };
+
+  return <BodyFootUtilArea docHistory={docHistory} />;
+}


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/672
- super-epic
    - https://github.com/zudolab/zudo-doc/issues/663

---

## Summary

Phase B-2 of the zfb migration parity work. Restores the `<section aria-label="Document utilities">` region landmark and an `<h2>Revision History</h2>` heading on every doc route, which the legacy Astro build emitted via the SSR-rendered DocHistory island. Without this, migration-check fired `landmark-removed` (region) and `heading-removed` (Revision History) on 136/138 doc routes (99%).

Mirrors the Phase B-1 footer fix shape: a leading-underscore `_doc-history-area.tsx` host wrapper sits in `pages/lib/` (zfb router skips it), and is imported by both default-locale and per-locale catch-all doc pages. The wrapper feeds props into the existing v2 `BodyFootUtilArea` shell so the section landmark appears, and a small additive change to that shell emits an `sr-only` `<h2>Revision History</h2>` immediately before the existing `DocHistoryIsland` SSR-skip placeholder. The runtime client component (`src/components/doc-history.tsx`) and the `/doc-history/*.json` API are unchanged — only the SSR scaffolding around them.

## What changed

- `packages/zudo-doc-v2/src/body-foot-util/body-foot-util-area.tsx` — adds an `sr-only` `<h2>Revision History</h2>` inside the existing `showHistory && docHistory` guard, immediately before `<DocHistoryIsland />`. Migration-check matches the literal heading string against the Astro snapshot; the Astro build had this h2 inside the SSR'd dialog.
- `pages/lib/_doc-history-area.tsx` (new) — locale-aware host wrapper. Reads `settings.docHistory`, omits the `locale` prop on the default locale (the doc-history client builds a different fetch path for the default locale), and defers to `BodyFootUtilArea` for rendering.
- `pages/docs/[...slug].tsx` and `pages/[locale]/docs/[...slug].tsx` — mount `<DocHistoryArea slug locale />` between the entry content and the prev/next pagination, only on the regular-doc-page branch (not auto-index pages), and skip when `entry.data.unlisted` is true.

## What did not change

- The Preact `DocHistory` runtime component itself (`src/components/doc-history.tsx`).
- The `@zudo-doc/doc-history-server` package and the `/doc-history/*.json` API. zfb already wires the doc-history plugin in `zfb.config.ts` from `settings.docHistory`.
- The view-source link inside `BodyFootUtilArea` is intentionally NOT mounted in this phase — Phase A flagged only the region landmark and the Revision History heading, so view-source stays out of scope.

## Topic PRs

- topic-bodyfootutil-heading — sr-only Revision History h2 in `BodyFootUtilArea`
- topic-pages-mount — host wrapper + mounts in both zfb doc pages

Both topic branches were merged into the epic base locally, then deleted. There is no per-topic PR on GitHub.

## Acceptance

- `pnpm migration-check --rerun` should report 0 routes with `region` as missing landmark.
- "Revision History" should no longer appear in the missing-headings list.
- `<section aria-label="Document utilities">` should appear in the B snapshot HTML for every doc route.

## CI

CI is intentionally skipped on this PR — all workflows in `.github/workflows/` trigger only on PRs into `main`, and `@takazudo/zfb` is a `file:../zfb/packages/zfb` dep that the runner cannot resolve. Same as Phase B-1 (PR #676). CI re-engages when the super-PR eventually targets `main`.

## Review

`/gcoc-review` against the merged base reported no actionable findings. Children also ran `/light-review -gcoc` on their own diffs.