### PR TITLE
Phase B-4: Wire real Tabs/TabItem in MDX components for ARIA parity

### DIFF
--- a/packages/zudo-doc-v2/src/doclayout/doc-layout-with-defaults.tsx
+++ b/packages/zudo-doc-v2/src/doclayout/doc-layout-with-defaults.tsx
@@ -75,6 +75,7 @@ import {
   DesignTokenTweakPanelIsland,
   ImageEnlargeIsland,
 } from "../ssr-skip/index.js";
+import { TabsInit } from "../code-syntax/tabs-init.js";
 
 // Sibling-topic barrels. Each is being authored by a peer agent in the
 // same parallel session; the imports below assume the canonical shape
@@ -251,7 +252,15 @@ export function DocLayoutWithDefaults(
             </>
           )
         }
-        bodyEndScripts={bodyEndScripts}
+        bodyEndScripts={
+          bodyEndScripts ?? (
+            // Default body-end script: activates the correct tab panel and
+            // wires click handlers for <Tabs> components. Emitted once per
+            // page; callers that need a different body-end script set should
+            // pass `bodyEndScripts` explicitly to override this default.
+            <TabsInit />
+          )
+        }
         main={children}
       />
     </>

--- a/pages/_mdx-components.ts
+++ b/pages/_mdx-components.ts
@@ -17,11 +17,9 @@
 //
 // ## Strategy
 //
-// Until each named tag has its proper Preact binding ported to `@zudo-doc/zudo-doc-v2`,
-// this module ships **stub bindings** that render nothing. That keeps the
-// build green and the typography/Island acceptance tests intact while the
-// proper bindings ship in sibling topics. As real components land, they
-// replace their stub here and propagate to every page automatically.
+// This module ships stub bindings for tags not yet ported to `@zudo-doc/zudo-doc-v2`
+// (render nothing), and real Preact bindings for tags whose ports are complete.
+// As real components land, they replace their stub here and propagate to every page automatically.
 //
 // `htmlOverrides` (basic typography — h2/h3/h4/p/a/ul/ol/blockquote/strong/table)
 // and `HtmlPreview: HtmlPreviewWrapper` (Island wrapper) stay in their
@@ -29,6 +27,8 @@
 
 import { htmlOverrides } from "@zudo-doc/zudo-doc-v2/content";
 import { HtmlPreviewWrapper } from "@zudo-doc/zudo-doc-v2/html-preview-wrapper";
+import { Tabs } from "@zudo-doc/zudo-doc-v2/code-syntax";
+import { TabItem } from "@zudo-doc/zudo-doc-v2/tab-item";
 
 /**
  * MDX-tag stub: renders nothing. Returning `null` keeps the rendered
@@ -106,8 +106,8 @@ export const mdxComponents = {
   SiteTreeNav: MdxStub,
   SiteTreeNavDemo: MdxStub,
   Details: MdxStub,
-  Tabs: MdxStub,
-  TabItem: MdxStub,
+  Tabs,
+  TabItem,
   SmartBreak: MdxStub,
   Island: MdxStub,
   PresetGenerator: MdxStub,


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/674
- super-epic
    - https://github.com/zudolab/zudo-doc/issues/663

---

## Summary

Restores ARIA-landmark parity for the zfb Tabs component (Phase B-4 of
the zfb migration). Before this change, zfb's SSR output for
`/docs/components/tabs` and `/ja/docs/components/tabs` contained zero
`role="tablist"` / `role="tab"` / `role="tabpanel"` landmarks because
`pages/_mdx-components.ts` wired `Tabs` and `TabItem` to a stub that
returns `null`. The real Preact components in
`@zudo-doc/zudo-doc-v2/code-syntax` (`Tabs`) and
`@zudo-doc/zudo-doc-v2/tab-item` (`TabItem`) already SSR-render the
correct ARIA attributes — they just weren't plugged in.

## Changes

- `pages/_mdx-components.ts` — replace `Tabs: MdxStub` / `TabItem: MdxStub`
  with imports of the real `Tabs` and `TabItem` Preact components.
- `packages/zudo-doc-v2/src/doclayout/doc-layout-with-defaults.tsx` —
  give `bodyEndScripts` a default value of `<TabsInit />` so the
  tab-activation script lands once on every doc page (mirrors the
  existing `bodyEndComponents ?? (...)` override pattern).

## Verification

- `pnpm check` — clean
- `pnpm build` — 215 pages, no errors
- `dist/docs/components/tabs/index.html` and
  `dist/ja/docs/components/tabs/index.html` now contain
  `role="tablist"`, `role="tab"`, and `role="tabpanel"`
- `vitest` — 23 existing component tests still pass
- `/gcoc-review` (Copilot CLI, gpt-4.1) — no findings

## Topic PRs

- `wire-tabs` (single topic, fast-forward merged into epic base; topic branch deleted)