### PR TITLE
Phase B-5: Fix homepage and layout-demo sidebar landmark structure

### DIFF
--- a/packages/zudo-doc-v2/src/doclayout/doc-layout.tsx
+++ b/packages/zudo-doc-v2/src/doclayout/doc-layout.tsx
@@ -222,7 +222,14 @@ export function DocLayout(props: DocLayoutProps): JSX.Element {
     bodyEndScripts,
   } = props;
 
-  const showSidebar = !hideSidebar && sidebar !== undefined;
+  // `hasSidebar` tracks whether sidebar content was supplied at all.
+  // `showSidebar` is true only when the sidebar should be visually rendered.
+  // Separating the two lets us emit the <aside> landmark even on hide_sidebar
+  // pages so the complementary ARIA role is preserved for screen readers —
+  // matching the Astro layout's SidebarToggle mobile aside that was always
+  // present in the DOM regardless of the hideSidebar flag.
+  const hasSidebar = sidebar !== undefined;
+  const showSidebar = !hideSidebar && hasSidebar;
   const showToc = !hideToc && toc !== undefined;
 
   // The desktop-sidebar gets a `view-transition-name` so the native
@@ -269,12 +276,19 @@ export function DocLayout(props: DocLayoutProps): JSX.Element {
       <body class="min-h-screen antialiased">
         {header}
 
-        {showSidebar && (
+        {hasSidebar && (
           <aside
             id={DESKTOP_SIDEBAR_ID}
             aria-label="Documentation sidebar"
-            class="hidden lg:block fixed top-[3.5rem] left-0 z-30 w-[var(--zd-sidebar-w)] h-[calc(100vh-3.5rem)] overflow-y-auto bg-bg border-r border-muted pb-vsp-xl"
-            style={sidebarStyle}
+            // When the sidebar is visible: standard fixed desktop panel.
+            // When hideSidebar=true: sr-only so the complementary ARIA
+            // landmark is still present (matches the Astro layout's mobile
+            // SidebarToggle aside that was always in the DOM).
+            class={showSidebar
+              ? "hidden lg:block fixed top-[3.5rem] left-0 z-30 w-[var(--zd-sidebar-w)] h-[calc(100vh-3.5rem)] overflow-y-auto bg-bg border-r border-muted pb-vsp-xl"
+              : "sr-only"
+            }
+            style={showSidebar ? sidebarStyle : undefined}
           >
             {sidebar}
           </aside>

--- a/pages/[locale]/index.tsx
+++ b/pages/[locale]/index.tsx
@@ -31,6 +31,7 @@ import { collectTags } from "@/utils/tags";
 import { toRouteSlug } from "@/utils/slug";
 import { DocLayoutWithDefaults } from "@zudo-doc/zudo-doc-v2/doclayout";
 import { DocsSitemap } from "@zudo-doc/zudo-doc-v2/nav-indexing";
+import { Header } from "@zudo-doc/zudo-doc-v2/header";
 import type { JSX } from "preact";
 import { bridgeEntries } from "../_data";
 import { FooterWithDefaults } from "../lib/_footer-with-defaults";
@@ -112,6 +113,10 @@ export default function LocaleIndexPage({ params }: PageArgs): JSX.Element {
       lang={locale}
       hideSidebar={true}
       hideToc={true}
+      // Use the full Header (logo + main nav) so the navigation ARIA landmark
+      // is present even when hideSidebar=true. Mirrors the Astro layout's
+      // header.astro which always rendered <nav aria-label="Main">.
+      headerOverride={<Header lang={locale} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
     >
       {/* Hero: logo left, title+desc+links right, block centered */}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -28,6 +28,7 @@ import { collectTags } from "@/utils/tags";
 import { toRouteSlug } from "@/utils/slug";
 import { DocLayoutWithDefaults } from "@zudo-doc/zudo-doc-v2/doclayout";
 import { DocsSitemap } from "@zudo-doc/zudo-doc-v2/nav-indexing";
+import { Header } from "@zudo-doc/zudo-doc-v2/header";
 import type { JSX } from "preact";
 import { FooterWithDefaults } from "./lib/_footer-with-defaults";
 
@@ -63,6 +64,10 @@ export default function IndexPage(): JSX.Element {
       lang={locale}
       hideSidebar={true}
       hideToc={true}
+      // Use the full Header (logo + main nav) so the navigation ARIA landmark
+      // is present even when hideSidebar=true. Mirrors the Astro layout's
+      // header.astro which always rendered <nav aria-label="Main">.
+      headerOverride={<Header lang={locale} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
     >
       {/* Hero: logo left, title+desc+links right, block centered */}


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/675
- super-epic
    - https://github.com/zudolab/zudo-doc/issues/663

---

## Summary

Phase B-5 of the zfb migration parity epic (#663). Restores the missing complementary and navigation ARIA landmarks on the 6 routes flagged by Phase A's Cause 5: `/`, `/ja`, `/docs/guides/layout-demos/hide-sidebar`, `/docs/guides/layout-demos/hide-both`, and the JA mirrors of the layout-demo pages.

## What changed

**`packages/zudo-doc-v2/src/doclayout/doc-layout.tsx`** — Split the existing `showSidebar` gate into two flags:

- `hasSidebar`: sidebar content was supplied at all
- `showSidebar`: it should be visually rendered

When `hasSidebar` is true but `hideSidebar` is also true, the `<aside id="desktop-sidebar" aria-label="Documentation sidebar">` is now rendered with `class="sr-only"` so the complementary landmark stays in the accessibility tree (matching the Astro layout's mobile SidebarToggle aside which was always in the DOM).

**`pages/index.tsx`, `pages/[locale]/index.tsx`** — Pass `headerOverride={<Header lang={locale} />}` so the homepages emit the full site header with `<nav aria-label="Main">`. Without this they fell back to `DocLayoutWithDefaults`'s minimal header (just `<ThemeToggle />`), which had no `<nav>` and dropped the navigation landmark.

## Verification

`pnpm migration-check --rerun` reports 0 `complementary` or `navigation` predicates fired on all 6 routes (verified by child agent before merge).

## Topic PRs

- #681 — feat(landmarks): restore complementary+navigation ARIA landmarks on hide-sidebar routes (merged)

## Review

`/gcoc-review` ran on the merged base branch — no actionable findings. Confirmed `sr-only` is Tailwind v4's standard utility (already used elsewhere in the codebase for the same kind of landmark-preserving fix on the AI Assistant and Revision History h2 elements).