### PR TITLE
feat(landmarks): restore complementary+navigation ARIA landmarks on hide-sidebar routes

### DIFF
--- a/packages/zudo-doc-v2/src/doclayout/doc-layout.tsx
+++ b/packages/zudo-doc-v2/src/doclayout/doc-layout.tsx
@@ -222,7 +222,14 @@ export function DocLayout(props: DocLayoutProps): JSX.Element {
     bodyEndScripts,
   } = props;
 
-  const showSidebar = !hideSidebar && sidebar !== undefined;
+  // `hasSidebar` tracks whether sidebar content was supplied at all.
+  // `showSidebar` is true only when the sidebar should be visually rendered.
+  // Separating the two lets us emit the <aside> landmark even on hide_sidebar
+  // pages so the complementary ARIA role is preserved for screen readers —
+  // matching the Astro layout's SidebarToggle mobile aside that was always
+  // present in the DOM regardless of the hideSidebar flag.
+  const hasSidebar = sidebar !== undefined;
+  const showSidebar = !hideSidebar && hasSidebar;
   const showToc = !hideToc && toc !== undefined;
 
   // The desktop-sidebar gets a `view-transition-name` so the native
@@ -269,12 +276,19 @@ export function DocLayout(props: DocLayoutProps): JSX.Element {
       <body class="min-h-screen antialiased">
         {header}
 
-        {showSidebar && (
+        {hasSidebar && (
           <aside
             id={DESKTOP_SIDEBAR_ID}
             aria-label="Documentation sidebar"
-            class="hidden lg:block fixed top-[3.5rem] left-0 z-30 w-[var(--zd-sidebar-w)] h-[calc(100vh-3.5rem)] overflow-y-auto bg-bg border-r border-muted pb-vsp-xl"
-            style={sidebarStyle}
+            // When the sidebar is visible: standard fixed desktop panel.
+            // When hideSidebar=true: sr-only so the complementary ARIA
+            // landmark is still present (matches the Astro layout's mobile
+            // SidebarToggle aside that was always in the DOM).
+            class={showSidebar
+              ? "hidden lg:block fixed top-[3.5rem] left-0 z-30 w-[var(--zd-sidebar-w)] h-[calc(100vh-3.5rem)] overflow-y-auto bg-bg border-r border-muted pb-vsp-xl"
+              : "sr-only"
+            }
+            style={showSidebar ? sidebarStyle : undefined}
           >
             {sidebar}
           </aside>

--- a/pages/[locale]/index.tsx
+++ b/pages/[locale]/index.tsx
@@ -31,6 +31,7 @@ import { collectTags } from "@/utils/tags";
 import { toRouteSlug } from "@/utils/slug";
 import { DocLayoutWithDefaults } from "@zudo-doc/zudo-doc-v2/doclayout";
 import { DocsSitemap } from "@zudo-doc/zudo-doc-v2/nav-indexing";
+import { Header } from "@zudo-doc/zudo-doc-v2/header";
 import type { JSX } from "preact";
 import { bridgeEntries } from "../_data";
 import { FooterWithDefaults } from "../lib/_footer-with-defaults";
@@ -112,6 +113,10 @@ export default function LocaleIndexPage({ params }: PageArgs): JSX.Element {
       lang={locale}
       hideSidebar={true}
       hideToc={true}
+      // Use the full Header (logo + main nav) so the navigation ARIA landmark
+      // is present even when hideSidebar=true. Mirrors the Astro layout's
+      // header.astro which always rendered <nav aria-label="Main">.
+      headerOverride={<Header lang={locale} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
     >
       {/* Hero: logo left, title+desc+links right, block centered */}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -28,6 +28,7 @@ import { collectTags } from "@/utils/tags";
 import { toRouteSlug } from "@/utils/slug";
 import { DocLayoutWithDefaults } from "@zudo-doc/zudo-doc-v2/doclayout";
 import { DocsSitemap } from "@zudo-doc/zudo-doc-v2/nav-indexing";
+import { Header } from "@zudo-doc/zudo-doc-v2/header";
 import type { JSX } from "preact";
 import { FooterWithDefaults } from "./lib/_footer-with-defaults";
 
@@ -63,6 +64,10 @@ export default function IndexPage(): JSX.Element {
       lang={locale}
       hideSidebar={true}
       hideToc={true}
+      // Use the full Header (logo + main nav) so the navigation ARIA landmark
+      // is present even when hideSidebar=true. Mirrors the Astro layout's
+      // header.astro which always rendered <nav aria-label="Main">.
+      headerOverride={<Header lang={locale} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
     >
       {/* Hero: logo left, title+desc+links right, block centered */}


### PR DESCRIPTION
## Summary

- **DocLayout** (`packages/zudo-doc-v2/src/doclayout/doc-layout.tsx`): split the old single `showSidebar` flag into `hasSidebar` (content exists) and `showSidebar` (should render visually); render `<aside class="sr-only">` when `hasSidebar && !showSidebar` so the `complementary` ARIA landmark is always present for screen readers — matching Astro's mobile SidebarToggle `<aside>` which was always in the DOM regardless of `hideSidebar`.
- **Homepage pages** (`pages/index.tsx`, `pages/[locale]/index.tsx`): add `headerOverride={<Header lang={locale} />}` so the full site header (with `<nav aria-label="Main">`) is rendered on both homepages; the default header is a minimal element with no nav, causing the `navigation` landmark to be absent.

## Cause

Phase A findings Cause 5: 6 routes missing `complementary` and `navigation` ARIA landmarks after zfb migration (`/`, `/ja`, `/docs/guides/layout-demos/hide-sidebar`, `/docs/guides/layout-demos/hide-both`, and their `/ja` mirrors).

## Verification

- `pnpm build` passes (215 pages, no errors)
- `pnpm migration-check --rerun`: all 6 target routes now have `predicates: []` — the `landmark-removed` findings are gone

## Test plan

- [x] `pnpm build` succeeds
- [x] Migration check shows no landmark-removed predicates for all 6 affected routes
- [x] HTML for `/` contains `<nav aria-label="Main">` (navigation) and `<aside class="sr-only" aria-label="Documentation sidebar">` (complementary)
- [x] HTML for `/ja` same structure
- [x] HTML for hide-sidebar page contains `<aside class="sr-only">` (complementary)
- [x] Self-review via gcoc + 2× haiku code-reviewer: no high-priority bugs found

🤖 Generated with [Claude Code](https://claude.com/claude-code)