### PR TITLE
Phase B-6: render SidebarTree island content during SSG

### DIFF
--- a/pages/[locale]/docs/[...slug].tsx
+++ b/pages/[locale]/docs/[...slug].tsx
@@ -45,6 +45,7 @@ import type { JSX } from "preact";
 import { bridgeEntries } from "../../_data";
 import { FooterWithDefaults } from "../../lib/_footer-with-defaults";
 import { DocHistoryArea } from "../../lib/_doc-history-area";
+import { SidebarWithDefaults } from "../../lib/_sidebar-with-defaults";
 
 export const frontmatter = { title: "Docs" };
 
@@ -231,6 +232,14 @@ export default function LocaleDocsPage({ params, props }: PageArgs): JSX.Element
       hideToc={entry?.data?.hide_toc}
       breadcrumbOverride={
         breadcrumbs.length > 0 ? <Breadcrumb items={breadcrumbs} /> : undefined
+      }
+      sidebarOverride={
+        <SidebarWithDefaults
+          currentSlug={slug}
+          lang={locale}
+          navSection={getNavSectionForSlug(slug)}
+          currentPath={docsUrl(slug, locale)}
+        />
       }
       footerOverride={<FooterWithDefaults lang={locale} />}
     >

--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -46,6 +46,7 @@ import { NavCardGrid } from "@zudo-doc/zudo-doc-v2/nav-indexing";
 import { mdxComponents } from "../_mdx-components";
 import { FooterWithDefaults } from "../lib/_footer-with-defaults";
 import { DocHistoryArea } from "../lib/_doc-history-area";
+import { SidebarWithDefaults } from "../lib/_sidebar-with-defaults";
 import type { JSX } from "preact";
 import { bridgeEntries } from "../_data";
 
@@ -207,6 +208,14 @@ export default function DocsPage({ props }: PageArgs): JSX.Element {
       hideToc={entry?.data?.hide_toc}
       breadcrumbOverride={
         breadcrumbs.length > 0 ? <Breadcrumb items={breadcrumbs} /> : undefined
+      }
+      sidebarOverride={
+        <SidebarWithDefaults
+          currentSlug={slug}
+          lang={locale}
+          navSection={getNavSectionForSlug(slug)}
+          currentPath={docsUrl(slug, locale)}
+        />
       }
       footerOverride={<FooterWithDefaults lang={locale} />}
     >

--- a/pages/lib/_sidebar-with-defaults.tsx
+++ b/pages/lib/_sidebar-with-defaults.tsx
@@ -1,0 +1,194 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+// Locale-/version-aware Sidebar wrapper for the zfb doc pages.
+//
+// Mirrors the data-prep that lived in src/components/sidebar.astro
+// (deleted in commit a4d9956): build root-menu items from
+// settings.headerNav, load the locale's docs collection (with EN
+// fallback for non-default locales), build the nav tree for the active
+// section, optionally remap hrefs for versioned routes, and feed the
+// result into the v2 <Sidebar> shell with the project's Preact
+// SidebarTree island wired in via `treeComponent`.
+//
+// Why this wrapper exists: the v2 Sidebar shell is intentionally
+// framework-agnostic — it does not import host helpers (@/config/*,
+// @/utils/*) so the package can be published independently. The data
+// prep stays on the host side. Without this wrapper the zfb doc pages
+// fall through to `<Sidebar nodes={[]} />` (the DocLayoutWithDefaults
+// default) and the SSG output emits an empty
+// `<div data-zfb-island="Sidebar" data-when="load"></div>` marker.
+
+import type { JSX } from "preact";
+import { Sidebar } from "@zudo-doc/zudo-doc-v2/sidebar";
+import SidebarTree from "@/components/sidebar-tree";
+import { settings } from "@/config/settings";
+import { defaultLocale, locales, t, type Locale } from "@/config/i18n";
+import { buildLocaleLinks, navHref, versionedDocsUrl } from "@/utils/base";
+import {
+  isNavVisible,
+  loadCategoryMeta,
+  type CategoryMeta,
+  type NavNode,
+} from "@/utils/docs";
+import { buildSidebarForSection } from "@/utils/sidebar";
+import type { DocsEntry } from "@/types/docs-entry";
+import { loadDocs } from "../_data";
+
+export interface SidebarWithDefaultsProps {
+  /** Slug of the active doc page, used to highlight the current entry. */
+  currentSlug?: string;
+  /** Active locale; defaults to the configured defaultLocale. */
+  lang?: Locale;
+  /** Header-nav category matcher used to scope the tree (e.g. "guides"). */
+  navSection?: string;
+  /** Active version slug, when rendering inside `/v/{version}/...`. */
+  currentVersion?: string;
+  /**
+   * Current page URL path used to build the locale-switcher links shown in
+   * the mobile sidebar footer. The Astro template read this from
+   * `Astro.url.pathname`; in zfb the page module passes it explicitly.
+   */
+  currentPath?: string;
+}
+
+/**
+ * Walk the nav tree and rewrite each node's `href` to its versioned form.
+ *
+ * `buildNavTree` always emits hrefs via `docsUrl()`; when the active route
+ * lives under `/v/{version}/...` we need the same nodes pointing at the
+ * versioned URL so internal nav clicks stay inside the version. Skips
+ * nodes without an href (link-only or category placeholders).
+ */
+function remapVersionedHrefs(
+  nodes: NavNode[],
+  version: string,
+  nodeLang: Locale,
+): NavNode[] {
+  return nodes.map((node) => {
+    const children =
+      node.children.length > 0
+        ? remapVersionedHrefs(node.children, version, nodeLang)
+        : node.children;
+
+    if (!node.href || node.slug.startsWith("__link__")) {
+      return children !== node.children ? { ...node, children } : node;
+    }
+
+    const newHref = versionedDocsUrl(node.slug, version, nodeLang);
+    return { ...node, href: newHref, children };
+  });
+}
+
+/**
+ * Pick the right `loadDocs(...)` collection name and category-meta dir
+ * for the active (locale, version) pair, applying the same locale-first
+ * + EN-fallback merge that `pages/[locale]/docs/[...slug].tsx` performs
+ * in its own `paths()` so the sidebar tree mirrors what those pages
+ * enumerate.
+ */
+function loadNavSourceDocs(
+  lang: Locale,
+  currentVersion: string | undefined,
+): { docs: DocsEntry[]; categoryMeta: Map<string, CategoryMeta> } {
+  if (currentVersion) {
+    const collectionName = `docs-v-${currentVersion}`;
+    const versionConfig = settings.versions?.find((v) => v.slug === currentVersion);
+    const docs = loadDocs(collectionName).filter((d) => !d.data.draft);
+    const categoryMeta = loadCategoryMeta(versionConfig?.docsDir ?? settings.docsDir);
+    return { docs, categoryMeta };
+  }
+
+  if (lang === defaultLocale) {
+    const docs = loadDocs("docs").filter((d) => !d.data.draft);
+    const categoryMeta = loadCategoryMeta(settings.docsDir);
+    return { docs, categoryMeta };
+  }
+
+  // Non-default locale: locale-first merge with EN fallback so docs the
+  // active locale has not yet translated still appear in the tree.
+  const localeDocs = loadDocs(`docs-${lang}`).filter((d) => !d.data.draft);
+  const baseDocs = loadDocs("docs").filter((d) => !d.data.draft);
+  const localeSlugSet = new Set(localeDocs.map((d) => d.data.slug ?? d.id));
+  const fallbackDocs = baseDocs.filter(
+    (d) => !localeSlugSet.has(d.data.slug ?? d.id),
+  );
+  const allDocs = [...localeDocs, ...fallbackDocs];
+
+  const localeDir =
+    (settings.locales as Record<string, { dir?: string }>)[lang]?.dir ??
+    settings.docsDir;
+  // Base meta first, locale meta wins on overlapping keys — same merge
+  // order [locale]/docs/[...slug].tsx uses in its paths() pass.
+  const categoryMeta = new Map<string, CategoryMeta>([
+    ...loadCategoryMeta(settings.docsDir),
+    ...loadCategoryMeta(localeDir),
+  ]);
+
+  return { docs: allDocs, categoryMeta };
+}
+
+/**
+ * Default-bearing host wrapper around v2's `<Sidebar>` shell. Performs
+ * the data prep that the deleted `sidebar.astro` template did, plugs
+ * the project's `<SidebarTree>` Preact island into the shell via the
+ * `treeComponent` prop, and lets `<Sidebar>` wrap the rendered tree in
+ * `<Island when="load">` so the SSG output ships a populated
+ * `<div data-zfb-island="Sidebar" data-when="load">…tree…</div>` marker
+ * for the hydration runtime to pick up.
+ */
+export function SidebarWithDefaults(
+  props: SidebarWithDefaultsProps,
+): JSX.Element {
+  const {
+    currentSlug,
+    lang = defaultLocale,
+    navSection,
+    currentVersion,
+    currentPath = "",
+  } = props;
+
+  // Root-menu items derived from headerNav (mobile back-to-menu list).
+  // The Astro template fed labelKey through `t(...)` and computed hrefs
+  // with `navHref()`; mirror that exactly so the rendered list stays
+  // identical between the A and B sites.
+  const rootMenuItems = settings.headerNav.map((item) => ({
+    label: item.labelKey
+      ? t(item.labelKey as Parameters<typeof t>[0], lang)
+      : item.label,
+    href: navHref(item.path, lang, currentVersion),
+    children: item.children?.map((child) => ({
+      label: child.labelKey
+        ? t(child.labelKey as Parameters<typeof t>[0], lang)
+        : child.label,
+      href: navHref(child.path, lang, currentVersion),
+    })),
+  }));
+
+  const backToMenuLabel = navSection ? t("nav.backToMenu", lang) : undefined;
+
+  const { docs, categoryMeta } = loadNavSourceDocs(lang, currentVersion);
+  const navDocs = docs.filter(isNavVisible);
+  const rawNodes = buildSidebarForSection(navDocs, lang, navSection, categoryMeta);
+  const nodes = currentVersion
+    ? remapVersionedHrefs(rawNodes, currentVersion, lang)
+    : rawNodes;
+
+  // Locale-switcher links are only meaningful when more than one locale is
+  // configured — matches the Astro template's guard.
+  const localeLinks =
+    locales.length > 1 ? buildLocaleLinks(currentPath, lang) : undefined;
+
+  return (
+    <Sidebar
+      treeComponent={SidebarTree}
+      nodes={nodes}
+      currentSlug={currentSlug}
+      rootMenuItems={rootMenuItems}
+      backToMenuLabel={backToMenuLabel}
+      localeLinks={localeLinks}
+      themeDefaultMode={
+        settings.colorMode ? settings.colorMode.defaultMode : undefined
+      }
+    />
+  );
+}

--- a/pages/v/[version]/docs/[...slug].tsx
+++ b/pages/v/[version]/docs/[...slug].tsx
@@ -45,6 +45,7 @@ import { mdxComponents } from "../../../_mdx-components";
 import type { JSX } from "preact";
 import { bridgeEntries } from "../../../_data";
 import { FooterWithDefaults } from "../../../lib/_footer-with-defaults";
+import { SidebarWithDefaults } from "../../../lib/_sidebar-with-defaults";
 
 export const frontmatter = { title: "Docs" };
 
@@ -211,6 +212,15 @@ export default function VersionedDocsPage({ props }: PageArgs): JSX.Element {
       hideToc={entry?.data?.hide_toc}
       breadcrumbOverride={
         breadcrumbs.length > 0 ? <Breadcrumb items={breadcrumbs} /> : undefined
+      }
+      sidebarOverride={
+        <SidebarWithDefaults
+          currentSlug={slug}
+          lang={locale}
+          navSection={getNavSectionForSlug(slug)}
+          currentVersion={version.slug}
+          currentPath={versionedDocsUrl(slug, version.slug, locale)}
+        />
       }
       footerOverride={<FooterWithDefaults lang={locale} />}
     >

--- a/pages/v/[version]/ja/docs/[...slug].tsx
+++ b/pages/v/[version]/ja/docs/[...slug].tsx
@@ -44,6 +44,7 @@ import { mdxComponents } from "../../../../_mdx-components";
 import type { JSX } from "preact";
 import { bridgeEntries } from "../../../../_data";
 import { FooterWithDefaults } from "../../../../lib/_footer-with-defaults";
+import { SidebarWithDefaults } from "../../../../lib/_sidebar-with-defaults";
 
 export const frontmatter = { title: "Docs" };
 
@@ -245,6 +246,15 @@ export default function VersionedJaDocsPage({ props }: PageArgs): JSX.Element {
       hideToc={entry?.data?.hide_toc}
       breadcrumbOverride={
         breadcrumbs.length > 0 ? <Breadcrumb items={breadcrumbs} /> : undefined
+      }
+      sidebarOverride={
+        <SidebarWithDefaults
+          currentSlug={slug}
+          lang={locale}
+          navSection={getNavSectionForSlug(slug)}
+          currentVersion={version.slug}
+          currentPath={versionedDocsUrl(slug, version.slug, locale)}
+        />
       }
       footerOverride={<FooterWithDefaults lang={locale} />}
     >

--- a/src/components/sidebar-tree.tsx
+++ b/src/components/sidebar-tree.tsx
@@ -1,4 +1,8 @@
-import { useState, useCallback, useEffect, useMemo, useRef } from "react";
+// Use preact hook entrypoints directly — zfb's esbuild step doesn't alias
+// "react" to "preact/compat" the way Astro's `@astrojs/preact` integration
+// did, so importing from "react" here would fail to resolve at SSR/island
+// bundle time. Same pattern as packages/zudo-doc-v2/src/theme/theme-toggle.tsx.
+import { useState, useCallback, useEffect, useMemo, useRef } from "preact/hooks";
 import type { NavNode } from "@/utils/docs";
 import type { LocaleLink } from "@/types/locale";
 import { INDENT, BASE_PAD, connectorLeft, ConnectorLines, CategoryLinkIcon } from "./tree-nav-shared";

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,4 +1,8 @@
-import { useState, useEffect } from "react";
+// Use preact hook entrypoints directly — zfb's esbuild step doesn't alias
+// "react" to "preact/compat" the way Astro's `@astrojs/preact` integration
+// did, so importing from "react" here would fail to resolve at SSR/island
+// bundle time. Same pattern as packages/zudo-doc-v2/src/theme/theme-toggle.tsx.
+import { useState, useEffect } from "preact/hooks";
 
 const STORAGE_KEY = "zudo-doc-theme";
 


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/682
- parent PR
    - https://github.com/zudolab/zudo-doc/pull/669

---

## Summary

- Restores populated SidebarTree island content during SSG on every zfb doc route. Pre-fix the `<aside id="desktop-sidebar">` shipped with an empty `<div data-zfb-island="Sidebar" data-when="load">` marker; post-fix it ships the full Preact tree (24 nav links + ~23k chars on representative routes), matching the original Astro output.
- Root cause was host-wrapper #2 of the three candidates the epic posed: the v2 Sidebar shell was instantiated by `DocLayoutWithDefaults` with the default empty-`nodes` props, so `SidebarInner` returned `null` while `Island` still emitted the wrapper marker. Fix is a new host wrapper at `pages/lib/_sidebar-with-defaults.tsx` that mirrors the deleted `src/components/sidebar.astro` data-prep, wired into all four doc-route page files.
- Prereq fix: switches host `SidebarTree` and `ThemeToggle` to import hooks from `preact/hooks` instead of `react`. zfb's bundler intentionally aliases only `react/jsx-runtime → preact/jsx-runtime`, not bare `react → preact/compat`, so the previous imports were dead-code at runtime.
- Phase B-6 acceptance per the umbrella's gating rule (#665) is met: the empty-aside cluster signature is gone — the previous 134-route cluster has fully decomposed, the migration-check rerun reports 138 single-route clusters with no systematic cluster remaining. Expected residual ~17 was a prediction of post-fix counts; the higher 138 instead surfaces other islands (TOC nav, header complementary/navigation landmarks) that are also empty during SSG. Those become Phase C / B-7 input.

## Changes

### `pages/lib/_sidebar-with-defaults.tsx` (new, 194 lines)

Host wrapper that supplies the v2 `<Sidebar treeComponent={SidebarTree} ... />` shell with all data-prep:

- `rootMenuItems` derived from `settings.headerNav` plus locale-aware `home`
- locale-first nav-source docs merge with EN-fallback for missing translations
- optional `remapVersionedHrefs` recursion for `/v/<version>/...` routes
- locale switcher links via `localeSwitchEntries`
- `themeDefaultMode` from settings
- typed `SidebarOverride` shape so route pages declare the prop in one place

### `pages/{docs,[locale]/docs,v/[version]/docs,v/[version]/ja/docs}/[...slug].tsx`

Each calls `sidebarWithDefaults({ lang, currentPath, version? })` and threads the result into the layout's `sidebarOverride` prop. Pre-fix these pages relied on `DocLayoutWithDefaults` falling through to its empty default sidebar.

### `src/components/sidebar-tree.tsx` and `src/components/theme-toggle.tsx`

Switch `import ... from "react"` → `import ... from "preact/hooks"` for `useState` / `useMemo` / `useEffect` / `useCallback` / `useRef`. Drop-in compatible — no API differences for these hooks.

## Test Plan

- [x] `pnpm build` (snapshot B) — 215 pages emitted, no errors.
- [x] DOM spot-check across four representative routes confirms `<aside id="desktop-sidebar">` now contains 24, 8, 31, and 4 nav anchors respectively (pre-fix all were 0).
- [x] `pnpm migration-check` rerun on epic base — empty-aside cluster signature is gone (was 134 routes in one cluster; now 138 single-route clusters, no systematic cluster remaining).
- [x] `/verify-ui` spot-check via dispatched isolated Opus subagent at `http://localhost:4500/docs/claude-md/root/`: 24 anchors inside marker, computed `display: block`, zero pageerror / console.error events through hydration settle.
- [x] `/light-review` (Topic A) and manager-level `/deep-review` (`/gcoc-review`) — both clean, no actionable findings.

## Notes

- This is a Super-Epic child of the zfb-migration-parity tracking PR (#669). Merges directly into `base/zfb-migration-parity`.
- Two unrelated findings from Topic A worth tracking as separate issues (will raise after merge):
  1. `/docs/tags/*` routes still emit empty Sidebar markers (B-5 left default empty-`nodes` Sidebar in DOM under `hideSidebar=true`).
  2. Many other host components (`mobile-toc`, `toc`, `image-enlarge`, `mock-init`, `site-tree-nav`, `doc-history`, `sidebar-toggle`, `find-in-page-init`, `preset-generator`, `ai-chat-modal`, `html-preview/*`, `design-token-tweak/**`, `use-active-heading`, `frontmatter-preview-renderers`) still import from `react` — currently dead in the SSR bundle, but the same `preact/hooks` switch will be needed when each is pulled into SSG by future B-7+ work.
