### PR TITLE
zfb migration parity Phase B-7 — host-side header + mobile-sidebar overrides

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -17,6 +17,7 @@ import { withBase } from "@/utils/base";
 import { DocLayoutWithDefaults } from "@zudo-doc/zudo-doc-v2/doclayout";
 import type { JSX } from "preact";
 import { FooterWithDefaults } from "./lib/_footer-with-defaults";
+import { HeaderWithDefaults } from "./lib/_header-with-defaults";
 
 export const frontmatter = { title: "404" };
 
@@ -30,6 +31,7 @@ export default function NotFoundPage(): JSX.Element {
       noindex={true}
       hideSidebar={true}
       hideToc={true}
+      headerOverride={<HeaderWithDefaults lang={locale} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
     >
       <div class="min-h-[60vh] flex flex-col items-center justify-center px-hsp-2xl py-vsp-xl">

--- a/pages/[locale]/docs/[...slug].tsx
+++ b/pages/[locale]/docs/[...slug].tsx
@@ -46,6 +46,7 @@ import { bridgeEntries } from "../../_data";
 import { FooterWithDefaults } from "../../lib/_footer-with-defaults";
 import { DocHistoryArea } from "../../lib/_doc-history-area";
 import { SidebarWithDefaults } from "../../lib/_sidebar-with-defaults";
+import { HeaderWithDefaults } from "../../lib/_header-with-defaults";
 
 export const frontmatter = { title: "Docs" };
 
@@ -230,6 +231,14 @@ export default function LocaleDocsPage({ params, props }: PageArgs): JSX.Element
       lang={locale}
       hideSidebar={entry?.data?.hide_sidebar}
       hideToc={entry?.data?.hide_toc}
+      headerOverride={
+        <HeaderWithDefaults
+          lang={locale}
+          currentSlug={slug}
+          navSection={getNavSectionForSlug(slug)}
+          currentPath={docsUrl(slug, locale)}
+        />
+      }
       breadcrumbOverride={
         breadcrumbs.length > 0 ? <Breadcrumb items={breadcrumbs} /> : undefined
       }

--- a/pages/[locale]/docs/tags/[tag].tsx
+++ b/pages/[locale]/docs/tags/[tag].tsx
@@ -28,6 +28,7 @@ import type { BreadcrumbItem } from "@zudo-doc/zudo-doc-v2/breadcrumb";
 import { DocCardGrid } from "@zudo-doc/zudo-doc-v2/nav-indexing";
 import type { JSX } from "preact";
 import { FooterWithDefaults } from "../../../lib/_footer-with-defaults";
+import { HeaderWithDefaults } from "../../../lib/_header-with-defaults";
 
 export const frontmatter = { title: "Tag" };
 
@@ -96,6 +97,7 @@ export default function LocaleDocTagPage({
       lang={locale}
       hideSidebar={true}
       hideToc={true}
+      headerOverride={<HeaderWithDefaults lang={locale} currentPath={withBase(`/${locale}/docs/tags/${tag}`)} />}
       breadcrumbOverride={<Breadcrumb items={breadcrumbItems} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
     >

--- a/pages/[locale]/docs/tags/index.tsx
+++ b/pages/[locale]/docs/tags/index.tsx
@@ -27,6 +27,7 @@ import { TagNav } from "@zudo-doc/zudo-doc-v2/nav-indexing";
 import type { TagItem, TagNavLabels } from "@zudo-doc/zudo-doc-v2/nav-indexing";
 import type { JSX } from "preact";
 import { FooterWithDefaults } from "../../../lib/_footer-with-defaults";
+import { HeaderWithDefaults } from "../../../lib/_header-with-defaults";
 
 export const frontmatter = { title: "All Tags" };
 
@@ -75,6 +76,7 @@ export default function LocaleTagsIndexPage({
       lang={locale}
       hideSidebar={true}
       hideToc={true}
+      headerOverride={<HeaderWithDefaults lang={locale} currentPath={withBase(`/${locale}/docs/tags`)} />}
       breadcrumbOverride={<Breadcrumb items={breadcrumbItems} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
     >

--- a/pages/[locale]/docs/versions.tsx
+++ b/pages/[locale]/docs/versions.tsx
@@ -18,6 +18,7 @@ import { VersionsPageContent } from "@zudo-doc/zudo-doc-v2/nav-indexing";
 import type { VersionPageEntry, VersionsPageLabels } from "@zudo-doc/zudo-doc-v2/nav-indexing";
 import type { JSX } from "preact";
 import { FooterWithDefaults } from "../../lib/_footer-with-defaults";
+import { HeaderWithDefaults } from "../../lib/_header-with-defaults";
 
 export const frontmatter = { title: "Versions" };
 
@@ -80,6 +81,7 @@ export default function LocaleVersionsPage({ params }: PageArgs): JSX.Element {
       lang={locale}
       hideSidebar={true}
       hideToc={true}
+      headerOverride={<HeaderWithDefaults lang={locale} currentPath={withBase(`/${locale}/docs/versions`)} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
     >
       <VersionsPageContent

--- a/pages/[locale]/index.tsx
+++ b/pages/[locale]/index.tsx
@@ -31,10 +31,10 @@ import { collectTags } from "@/utils/tags";
 import { toRouteSlug } from "@/utils/slug";
 import { DocLayoutWithDefaults } from "@zudo-doc/zudo-doc-v2/doclayout";
 import { DocsSitemap } from "@zudo-doc/zudo-doc-v2/nav-indexing";
-import { Header } from "@zudo-doc/zudo-doc-v2/header";
 import type { JSX } from "preact";
 import { bridgeEntries } from "../_data";
 import { FooterWithDefaults } from "../lib/_footer-with-defaults";
+import { HeaderWithDefaults } from "../lib/_header-with-defaults";
 
 export const frontmatter = { title: "Home" };
 
@@ -113,10 +113,7 @@ export default function LocaleIndexPage({ params }: PageArgs): JSX.Element {
       lang={locale}
       hideSidebar={true}
       hideToc={true}
-      // Use the full Header (logo + main nav) so the navigation ARIA landmark
-      // is present even when hideSidebar=true. Mirrors the Astro layout's
-      // header.astro which always rendered <nav aria-label="Main">.
-      headerOverride={<Header lang={locale} />}
+      headerOverride={<HeaderWithDefaults lang={locale} currentPath={withBase(`/${locale}/`)} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
     >
       {/* Hero: logo left, title+desc+links right, block centered */}

--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -47,6 +47,7 @@ import { mdxComponents } from "../_mdx-components";
 import { FooterWithDefaults } from "../lib/_footer-with-defaults";
 import { DocHistoryArea } from "../lib/_doc-history-area";
 import { SidebarWithDefaults } from "../lib/_sidebar-with-defaults";
+import { HeaderWithDefaults } from "../lib/_header-with-defaults";
 import type { JSX } from "preact";
 import { bridgeEntries } from "../_data";
 
@@ -206,6 +207,14 @@ export default function DocsPage({ props }: PageArgs): JSX.Element {
       lang={locale}
       hideSidebar={entry?.data?.hide_sidebar}
       hideToc={entry?.data?.hide_toc}
+      headerOverride={
+        <HeaderWithDefaults
+          lang={locale}
+          currentSlug={slug}
+          navSection={getNavSectionForSlug(slug)}
+          currentPath={docsUrl(slug, locale)}
+        />
+      }
       breadcrumbOverride={
         breadcrumbs.length > 0 ? <Breadcrumb items={breadcrumbs} /> : undefined
       }

--- a/pages/docs/tags/[tag].tsx
+++ b/pages/docs/tags/[tag].tsx
@@ -28,6 +28,7 @@ import { DocCardGrid } from "@zudo-doc/zudo-doc-v2/nav-indexing";
 import type { JSX } from "preact";
 import { bridgeEntries } from "../../_data";
 import { FooterWithDefaults } from "../../lib/_footer-with-defaults";
+import { HeaderWithDefaults } from "../../lib/_header-with-defaults";
 
 export const frontmatter = { title: "Tag" };
 
@@ -80,6 +81,7 @@ export default function DocTagPage({ params, props }: PageProps): JSX.Element {
       title={pageTitle}
       hideSidebar={true}
       hideToc={true}
+      headerOverride={<HeaderWithDefaults lang={locale} currentPath={withBase(`/docs/tags/${tag}`)} />}
       breadcrumbOverride={<Breadcrumb items={breadcrumbItems} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
     >

--- a/pages/docs/tags/index.tsx
+++ b/pages/docs/tags/index.tsx
@@ -27,6 +27,7 @@ import type { TagItem, TagNavLabels } from "@zudo-doc/zudo-doc-v2/nav-indexing";
 import type { JSX } from "preact";
 import { bridgeEntries } from "../../_data";
 import { FooterWithDefaults } from "../../lib/_footer-with-defaults";
+import { HeaderWithDefaults } from "../../lib/_header-with-defaults";
 
 export const frontmatter = { title: "All Tags" };
 
@@ -62,6 +63,7 @@ export default function DocsTagsIndexPage(): JSX.Element {
       title={pageTitle}
       hideSidebar={true}
       hideToc={true}
+      headerOverride={<HeaderWithDefaults lang={locale} currentPath={withBase("/docs/tags")} />}
       breadcrumbOverride={<Breadcrumb items={breadcrumbItems} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
     >

--- a/pages/docs/versions.tsx
+++ b/pages/docs/versions.tsx
@@ -18,6 +18,7 @@ import { VersionsPageContent } from "@zudo-doc/zudo-doc-v2/nav-indexing";
 import type { VersionPageEntry, VersionsPageLabels } from "@zudo-doc/zudo-doc-v2/nav-indexing";
 import type { JSX } from "preact";
 import { FooterWithDefaults } from "../lib/_footer-with-defaults";
+import { HeaderWithDefaults } from "../lib/_header-with-defaults";
 
 export const frontmatter = { title: "Versions" };
 
@@ -58,6 +59,7 @@ export default function VersionsPage(): JSX.Element {
       lang={locale}
       hideSidebar={true}
       hideToc={true}
+      headerOverride={<HeaderWithDefaults lang={locale} currentPath={withBase("/docs/versions")} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
     >
       <VersionsPageContent

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -28,9 +28,9 @@ import { collectTags } from "@/utils/tags";
 import { toRouteSlug } from "@/utils/slug";
 import { DocLayoutWithDefaults } from "@zudo-doc/zudo-doc-v2/doclayout";
 import { DocsSitemap } from "@zudo-doc/zudo-doc-v2/nav-indexing";
-import { Header } from "@zudo-doc/zudo-doc-v2/header";
 import type { JSX } from "preact";
 import { FooterWithDefaults } from "./lib/_footer-with-defaults";
+import { HeaderWithDefaults } from "./lib/_header-with-defaults";
 
 export const frontmatter = { title: "Home" };
 
@@ -64,10 +64,7 @@ export default function IndexPage(): JSX.Element {
       lang={locale}
       hideSidebar={true}
       hideToc={true}
-      // Use the full Header (logo + main nav) so the navigation ARIA landmark
-      // is present even when hideSidebar=true. Mirrors the Astro layout's
-      // header.astro which always rendered <nav aria-label="Main">.
-      headerOverride={<Header lang={locale} />}
+      headerOverride={<HeaderWithDefaults lang={locale} currentPath={withBase("/")} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
     >
       {/* Hero: logo left, title+desc+links right, block centered */}

--- a/pages/lib/_header-with-defaults.tsx
+++ b/pages/lib/_header-with-defaults.tsx
@@ -1,0 +1,249 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+// Locale-/version-aware Header wrapper for the zfb doc pages.
+//
+// Mirrors the data-prep that lived in src/components/header.astro
+// (deleted in commit a4d9956): build the header nav, compute active-path
+// state, wire the mobile SidebarToggle island (hamburger + slide-in panel)
+// with the full sidebar tree for doc routes, and feed everything into the
+// v2 <Header> shell.
+//
+// Why this wrapper exists: the v2 Header shell is intentionally
+// framework-agnostic — it accepts slot props (sidebarToggle, themeToggle,
+// etc.) but does not import host helpers (@/config/*, @/utils/*) so the
+// package can be published independently. The data prep stays on the host
+// side. Without this wrapper the zfb doc pages fall through to the
+// DocLayoutWithDefaults minimal default (a bare <header> with only
+// <ThemeToggle>) — the full logo + nav + mobile-sidebar markup is absent
+// from the SSG output, failing the migration-check parity test.
+//
+// Mobile sidebar strategy:
+//   - The v2 <Header> accepts a `sidebarToggle` slot that holds the
+//     complete mobile sidebar widget: hamburger button + backdrop overlay +
+//     slide-in <aside> panel (all rendered by <SidebarToggle>).
+//   - This wrapper builds the same nav-tree data that _sidebar-with-defaults
+//     produces, then wraps <SidebarToggle>(<SidebarTree ...>) in Island so
+//     the SSG output carries the full tree HTML (closed/hidden by CSS
+//     transform) AND a data-zfb-island="SidebarToggle" hydration marker.
+//   - The mobile sidebar slot is only wired when `navSection` is defined
+//     (i.e. the caller is rendering a doc route with an active sidebar
+//     section). Pages with hideSidebar=true or no docs section (404, index,
+//     tags, versions) omit the sidebarToggle prop; the Header renders without
+//     the hamburger in that case, which matches the Astro original.
+//   - ThemeToggle from the package (self-island-wrapped) is always passed to
+//     Header.themeToggle so the ThemeToggle island marker appears in the
+//     header on every page — matching the original header.astro behavior.
+
+import type { VNode, JSX } from "preact";
+import { Island } from "@takazudo/zfb";
+import { Header } from "@zudo-doc/zudo-doc-v2/header";
+import { ThemeToggle } from "@zudo-doc/zudo-doc-v2/theme";
+import SidebarToggle from "@/components/sidebar-toggle";
+import SidebarTree from "@/components/sidebar-tree";
+import { settings } from "@/config/settings";
+import { defaultLocale, locales, t, type Locale } from "@/config/i18n";
+import { buildLocaleLinks, navHref, versionedDocsUrl } from "@/utils/base";
+import {
+  isNavVisible,
+  loadCategoryMeta,
+  type CategoryMeta,
+  type NavNode,
+} from "@/utils/docs";
+import { buildSidebarForSection } from "@/utils/sidebar";
+import type { DocsEntry } from "@/types/docs-entry";
+import { loadDocs } from "../_data";
+
+// ---------------------------------------------------------------------------
+// Internal helpers — duplicated from _sidebar-with-defaults.tsx so that
+// module stays self-contained and this wrapper owns its own data-prep.
+// ---------------------------------------------------------------------------
+
+/**
+ * Rewrite versioned hrefs — same logic as _sidebar-with-defaults.tsx.
+ * The nav tree always emits hrefs via docsUrl(); when the active route lives
+ * under /v/{version}/... we need the same nodes pointing at the versioned URL.
+ */
+function remapVersionedHrefs(
+  nodes: NavNode[],
+  version: string,
+  nodeLang: Locale,
+): NavNode[] {
+  return nodes.map((node) => {
+    const children =
+      node.children.length > 0
+        ? remapVersionedHrefs(node.children, version, nodeLang)
+        : node.children;
+
+    if (!node.href || node.slug.startsWith("__link__")) {
+      return children !== node.children ? { ...node, children } : node;
+    }
+
+    const newHref = versionedDocsUrl(node.slug, version, nodeLang);
+    return { ...node, href: newHref, children };
+  });
+}
+
+/**
+ * Pick the right loadDocs() collection for the (locale, version) pair —
+ * same merge strategy as _sidebar-with-defaults.tsx.
+ */
+function loadNavSourceDocs(
+  lang: Locale,
+  currentVersion: string | undefined,
+): { docs: DocsEntry[]; categoryMeta: Map<string, CategoryMeta> } {
+  if (currentVersion) {
+    const collectionName = `docs-v-${currentVersion}`;
+    const versionConfig = settings.versions?.find((v) => v.slug === currentVersion);
+    const docs = loadDocs(collectionName).filter((d) => !d.data.draft);
+    const categoryMeta = loadCategoryMeta(versionConfig?.docsDir ?? settings.docsDir);
+    return { docs, categoryMeta };
+  }
+
+  if (lang === defaultLocale) {
+    const docs = loadDocs("docs").filter((d) => !d.data.draft);
+    const categoryMeta = loadCategoryMeta(settings.docsDir);
+    return { docs, categoryMeta };
+  }
+
+  // Non-default locale: locale-first merge with EN fallback.
+  const localeDocs = loadDocs(`docs-${lang}`).filter((d) => !d.data.draft);
+  const baseDocs = loadDocs("docs").filter((d) => !d.data.draft);
+  const localeSlugSet = new Set(localeDocs.map((d) => d.data.slug ?? d.id));
+  const fallbackDocs = baseDocs.filter(
+    (d) => !localeSlugSet.has(d.data.slug ?? d.id),
+  );
+  const allDocs = [...localeDocs, ...fallbackDocs];
+
+  const localeDir =
+    (settings.locales as Record<string, { dir?: string }>)[lang]?.dir ??
+    settings.docsDir;
+  const categoryMeta = new Map<string, CategoryMeta>([
+    ...loadCategoryMeta(settings.docsDir),
+    ...loadCategoryMeta(localeDir),
+  ]);
+
+  return { docs: allDocs, categoryMeta };
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export interface HeaderWithDefaultsProps {
+  /** Active locale; defaults to the configured defaultLocale. */
+  lang?: Locale;
+  /**
+   * Current page URL path (as the layout passes from Astro.url.pathname or
+   * the zfb equivalent). Used by the Header to compute the active nav item
+   * and by the mobile sidebar footer locale-switcher links.
+   */
+  currentPath?: string;
+  /** Active version slug, when rendering inside /v/{version}/... routes. */
+  currentVersion?: string;
+  /**
+   * Slug of the active doc page — forwarded to SidebarTree so it can
+   * highlight the current entry. Required when navSection is set.
+   */
+  currentSlug?: string;
+  /**
+   * Header-nav category matcher used to scope the sidebar tree (e.g.
+   * "guides"). When provided the mobile sidebar toggle is wired with the
+   * full sidebar tree for this section. When omitted (404, index, tags,
+   * versions pages) no mobile sidebar toggle is included in the header.
+   */
+  navSection?: string;
+}
+
+/**
+ * Default-bearing host wrapper around v2's <Header> shell.
+ *
+ * Handles:
+ *  1. Logo, main nav with active-path highlight — delegated to <Header>.
+ *  2. ThemeToggle island in the right items row — passed as themeToggle slot.
+ *  3. Mobile SidebarToggle island (hamburger + slide-in aside + tree) —
+ *     built from the same nav data as SidebarWithDefaults and passed as
+ *     the sidebarToggle slot when navSection is defined.
+ */
+export function HeaderWithDefaults(
+  props: HeaderWithDefaultsProps,
+): JSX.Element {
+  const {
+    lang = defaultLocale,
+    currentPath = "",
+    currentVersion,
+    currentSlug,
+    navSection,
+  } = props;
+
+  // Root-menu items for the mobile sidebar's "back to menu" list.
+  // Mirrors the data-prep in _sidebar-with-defaults.tsx.
+  const rootMenuItems = settings.headerNav.map((item) => ({
+    label: item.labelKey
+      ? t(item.labelKey as Parameters<typeof t>[0], lang)
+      : item.label,
+    href: navHref(item.path, lang, currentVersion),
+    children: item.children?.map((child) => ({
+      label: child.labelKey
+        ? t(child.labelKey as Parameters<typeof t>[0], lang)
+        : child.label,
+      href: navHref(child.path, lang, currentVersion),
+    })),
+  }));
+
+  // Build the mobile sidebar toggle only when we have an active docs section.
+  // Pages with hideSidebar=true or no sidebar section (404, index, tags,
+  // versions) pass no navSection and get no hamburger button / slide-in panel.
+  let sidebarToggle: VNode | undefined;
+
+  if (navSection !== undefined) {
+    const backToMenuLabel = t("nav.backToMenu", lang);
+    const { docs, categoryMeta } = loadNavSourceDocs(lang, currentVersion);
+    const navDocs = docs.filter(isNavVisible);
+    const rawNodes = buildSidebarForSection(navDocs, lang, navSection, categoryMeta);
+    const nodes = currentVersion
+      ? remapVersionedHrefs(rawNodes, currentVersion, lang)
+      : rawNodes;
+
+    // Locale-switcher links in the mobile sidebar footer — only when
+    // multiple locales are configured (mirrors _sidebar-with-defaults.tsx).
+    const localeLinks =
+      locales.length > 1 ? buildLocaleLinks(currentPath, lang) : undefined;
+
+    const themeDefaultMode = settings.colorMode
+      ? settings.colorMode.defaultMode
+      : undefined;
+
+    // Wrap SidebarToggle (hamburger button + slide-in aside + SidebarTree) in
+    // Island so the SSG output carries the full tree HTML AND the
+    // data-zfb-island="SidebarToggle" marker for client-side hydration.
+    // Island.captureComponentName reads SidebarToggle.name → "SidebarToggle".
+    sidebarToggle = Island({
+      when: "load",
+      children: (
+        <SidebarToggle>
+          <SidebarTree
+            nodes={nodes}
+            currentSlug={currentSlug}
+            rootMenuItems={rootMenuItems}
+            backToMenuLabel={backToMenuLabel}
+            localeLinks={localeLinks}
+            themeDefaultMode={themeDefaultMode}
+          />
+        </SidebarToggle>
+      ),
+    }) as unknown as VNode;
+  }
+
+  return (
+    <Header
+      lang={lang}
+      currentPath={currentPath}
+      currentVersion={currentVersion}
+      sidebarToggle={sidebarToggle}
+      // Pass the package's self-island-wrapped ThemeToggle so the
+      // data-zfb-island="ThemeToggle" marker appears in the header right
+      // items on every page — matching the original header.astro output.
+      themeToggle={<ThemeToggle />}
+    />
+  );
+}

--- a/pages/lib/_header-with-defaults.tsx
+++ b/pages/lib/_header-with-defaults.tsx
@@ -37,7 +37,14 @@
 import type { VNode, JSX } from "preact";
 import { Island } from "@takazudo/zfb";
 import { Header } from "@zudo-doc/zudo-doc-v2/header";
-import { ThemeToggle } from "@zudo-doc/zudo-doc-v2/theme";
+// Don't import ThemeToggle from "@zudo-doc/zudo-doc-v2/theme" — that barrel
+// also re-exports DesignTokenTweakPanel and ColorTweakExportModal, which
+// transitively pull `src/components/design-token-tweak/*` and the v2 panel
+// modules into the zfb esbuild graph. Those files import `react`, which
+// zfb does not alias to `preact/compat`, so the build fails. Use the host's
+// local ThemeToggle (already on `preact/hooks`) and wrap it in Island here
+// so the SSG output still emits the `data-zfb-island="ThemeToggle"` marker.
+import ThemeToggle from "@/components/theme-toggle";
 import SidebarToggle from "@/components/sidebar-toggle";
 import SidebarTree from "@/components/sidebar-tree";
 import { settings } from "@/config/settings";
@@ -234,16 +241,24 @@ export function HeaderWithDefaults(
     }) as unknown as VNode;
   }
 
+  // Wrap the host's local ThemeToggle in Island({when:"load"}) so the SSG
+  // output emits a data-zfb-island="ThemeToggle" marker the hydration
+  // runtime can find — matching the original header.astro output. The v2
+  // package's <ThemeToggle> already does this internally, but importing it
+  // forces the v2 theme barrel into the bundle (see import note at the top
+  // of this file).
+  const themeToggle = Island({
+    when: "load",
+    children: <ThemeToggle />,
+  }) as unknown as VNode;
+
   return (
     <Header
       lang={lang}
       currentPath={currentPath}
       currentVersion={currentVersion}
       sidebarToggle={sidebarToggle}
-      // Pass the package's self-island-wrapped ThemeToggle so the
-      // data-zfb-island="ThemeToggle" marker appears in the header right
-      // items on every page — matching the original header.astro output.
-      themeToggle={<ThemeToggle />}
+      themeToggle={themeToggle}
     />
   );
 }

--- a/pages/v/[version]/docs/[...slug].tsx
+++ b/pages/v/[version]/docs/[...slug].tsx
@@ -46,6 +46,7 @@ import type { JSX } from "preact";
 import { bridgeEntries } from "../../../_data";
 import { FooterWithDefaults } from "../../../lib/_footer-with-defaults";
 import { SidebarWithDefaults } from "../../../lib/_sidebar-with-defaults";
+import { HeaderWithDefaults } from "../../../lib/_header-with-defaults";
 
 export const frontmatter = { title: "Docs" };
 
@@ -210,6 +211,15 @@ export default function VersionedDocsPage({ props }: PageArgs): JSX.Element {
       lang={locale}
       hideSidebar={entry?.data?.hide_sidebar}
       hideToc={entry?.data?.hide_toc}
+      headerOverride={
+        <HeaderWithDefaults
+          lang={locale}
+          currentSlug={slug}
+          navSection={getNavSectionForSlug(slug)}
+          currentVersion={version.slug}
+          currentPath={versionedDocsUrl(slug, version.slug, locale)}
+        />
+      }
       breadcrumbOverride={
         breadcrumbs.length > 0 ? <Breadcrumb items={breadcrumbs} /> : undefined
       }

--- a/pages/v/[version]/ja/docs/[...slug].tsx
+++ b/pages/v/[version]/ja/docs/[...slug].tsx
@@ -45,6 +45,7 @@ import type { JSX } from "preact";
 import { bridgeEntries } from "../../../../_data";
 import { FooterWithDefaults } from "../../../../lib/_footer-with-defaults";
 import { SidebarWithDefaults } from "../../../../lib/_sidebar-with-defaults";
+import { HeaderWithDefaults } from "../../../../lib/_header-with-defaults";
 
 export const frontmatter = { title: "Docs" };
 
@@ -244,6 +245,15 @@ export default function VersionedJaDocsPage({ props }: PageArgs): JSX.Element {
       lang={locale}
       hideSidebar={entry?.data?.hide_sidebar}
       hideToc={entry?.data?.hide_toc}
+      headerOverride={
+        <HeaderWithDefaults
+          lang={locale}
+          currentSlug={slug}
+          navSection={getNavSectionForSlug(slug)}
+          currentVersion={version.slug}
+          currentPath={versionedDocsUrl(slug, version.slug, locale)}
+        />
+      }
       breadcrumbOverride={
         breadcrumbs.length > 0 ? <Breadcrumb items={breadcrumbs} /> : undefined
       }

--- a/src/components/sidebar-toggle.tsx
+++ b/src/components/sidebar-toggle.tsx
@@ -1,4 +1,10 @@
-import { useState, useEffect } from "react";
+// Use preact hook entrypoints directly — zfb's esbuild step doesn't alias
+// "react" to "preact/compat" the way Astro's `@astrojs/preact` integration
+// did, so importing values from "react" here would fail to resolve at
+// SSR/island bundle time. Same pattern as src/components/sidebar-tree.tsx
+// and packages/zudo-doc-v2/src/theme/theme-toggle.tsx. Type references via
+// the global React namespace still resolve via @types/react.
+import { useState, useEffect } from "preact/hooks";
 
 interface SidebarToggleProps {
   children: React.ReactNode;


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/685
- parent PR
    - https://github.com/zudolab/zudo-doc/pull/669

---

## Summary

Wires the host-side `headerOverride` and mobile-sidebar slot for `<DocLayoutWithDefaults>` so the SSG output matches the Astro baseline. Closes the two systematic clusters identified by Phase B-7 (#685): empty `<header>` on 100% of content-loss routes; missing mobile `<aside>` on 96%.

The package side was already correct — the v2 `DocLayoutWithDefaults` exposes a `headerOverride` slot and the v2 `Header` exposes a `sidebarToggle` slot. The host side just was not passing them. This PR adds the host wrapper and wires it in 13 places.

## What changed

- New `pages/lib/_header-with-defaults.tsx` — host data-prep wrapper for v2's `<Header>` shell:
    - Builds `rootMenuItems` from `settings.headerNav` (locale-aware via `t()` and `navHref()`).
    - Computes the sidebar tree for the active section using the same locale-first / version-aware merge strategy as `_sidebar-with-defaults.tsx`.
    - Wraps `<SidebarToggle><SidebarTree .../></SidebarToggle>` in `Island({ when: "load" })` so SSG output carries the full mobile slide-in panel HTML _and_ the `data-zfb-island="SidebarToggle"` hydration marker.
    - Passes the host's local `<ThemeToggle>` wrapped in `Island({ when: "load" })` for the `themeToggle` slot.
    - Mobile sidebar wiring is gated on `navSection` being defined — non-doc pages (404, index, tags, versions) get no hamburger / slide-in, matching the Astro baseline.
- 13 call-site updates passing `headerOverride={<HeaderWithDefaults .../>}`:
  `pages/404.tsx`, `pages/index.tsx`, `pages/docs/[...slug].tsx`, `pages/docs/tags/index.tsx`, `pages/docs/tags/[tag].tsx`, `pages/docs/versions.tsx`, `pages/[locale]/index.tsx`, `pages/[locale]/docs/[...slug].tsx`, `pages/[locale]/docs/tags/index.tsx`, `pages/[locale]/docs/tags/[tag].tsx`, `pages/[locale]/docs/versions.tsx`, `pages/v/[version]/docs/[...slug].tsx`, `pages/v/[version]/ja/docs/[...slug].tsx`.
- Build-fix follow-up commit `9b78e65`:
    - `src/components/sidebar-toggle.tsx`: switch `useState` / `useEffect` imports from `react` to `preact/hooks` (same pattern already used by `sidebar-tree.tsx` and `theme-toggle.tsx`). Required because the new wrapper imports `<SidebarToggle>` into the zfb pages graph; zfb's esbuild step does not alias `react` to `preact/compat` the way `@astrojs/preact` does.
    - `pages/lib/_header-with-defaults.tsx`: switch `<ThemeToggle>` from `@zudo-doc/zudo-doc-v2/theme` to the host's local `@/components/theme-toggle`. The v2 theme barrel transitively re-exports `DesignTokenTweakPanel` and `ColorTweakExportModal`, which pull `src/components/design-token-tweak/*` (and the v2 panel modules) into the zfb bundle — those files import `react` and break the build. Wrapping the host's local `<ThemeToggle>` in `Island({ when: "load" })` here preserves the SSG hydration marker without dragging in the broken transitive graph.

## Acceptance verification (`pnpm migration-check` rerun against `base/zfb-migration-parity`)

| Cluster (B-7 in scope)                   | Pre-B-7 (post-B-6) | Post-B-7 |
|------------------------------------------|--------------------|----------|
| Empty `<header>` cluster                 | 133 / 133 routes   | **0 / 0 — gone** |
| Missing mobile `<aside>` cluster         | 128 / 133 routes   | **0 / 0 — gone** |

Both systematic clusters identified in #685 are eliminated. SSG header on a sample doc route (`/docs/claude-agents/doc-reviewer`) is now 36,870 chars (vs Astro 49,401; vs pre-B-7 ~250) and contains the full nav, mobile-menu trigger, search trigger, ThemeToggle, plus the mobile slide-in `<aside>` with the SidebarToggle island marker.

`pnpm check` and `pnpm build` both pass on this branch (215 pages built; pre-existing TS errors in `scripts/migration-check/__tests__/` are unchanged and unrelated).

## Residual finding (next sibling epic)

Post-B-7 content-loss is **121 routes** (down from 133), all sharing one new systematic signature: missing `og:title`, `og:description`, `astro-view-transitions-enabled`, `astro-view-transitions-fallback` `<meta>` tags. This was hidden behind B-7's larger clusters before. Filed as **#687 — Phase B-8 (host-side meta-tag wiring)** for the next sibling-epic session. Per #665's gating rule, B-7 lands here because its specific clusters are gone; the new cluster is the next phase's input.

## Topic PRs

Single-topic merge — `merge: topic-b7-host-chrome` is the no-ff merge commit on this base. The topic branch was deleted after merge.