### PR TITLE
Phase B-8: host-side og:title / og:description wiring

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -18,6 +18,7 @@ import { DocLayoutWithDefaults } from "@zudo-doc/zudo-doc-v2/doclayout";
 import type { JSX } from "preact";
 import { FooterWithDefaults } from "./lib/_footer-with-defaults";
 import { HeaderWithDefaults } from "./lib/_header-with-defaults";
+import { HeadWithDefaults } from "./lib/_head-with-defaults";
 
 export const frontmatter = { title: "404" };
 
@@ -27,6 +28,7 @@ export default function NotFoundPage(): JSX.Element {
   return (
     <DocLayoutWithDefaults
       title={`Page Not Found | ${settings.siteName}`}
+      head={<HeadWithDefaults title={`Page Not Found | ${settings.siteName}`} />}
       lang={locale}
       noindex={true}
       hideSidebar={true}

--- a/pages/[locale]/docs/[...slug].tsx
+++ b/pages/[locale]/docs/[...slug].tsx
@@ -47,6 +47,7 @@ import { FooterWithDefaults } from "../../lib/_footer-with-defaults";
 import { DocHistoryArea } from "../../lib/_doc-history-area";
 import { SidebarWithDefaults } from "../../lib/_sidebar-with-defaults";
 import { HeaderWithDefaults } from "../../lib/_header-with-defaults";
+import { HeadWithDefaults } from "../../lib/_head-with-defaults";
 
 export const frontmatter = { title: "Docs" };
 
@@ -228,6 +229,7 @@ export default function LocaleDocsPage({ params, props }: PageArgs): JSX.Element
     <DocLayoutWithDefaults
       title={title}
       description={description}
+      head={<HeadWithDefaults title={title} description={description} />}
       lang={locale}
       hideSidebar={entry?.data?.hide_sidebar}
       hideToc={entry?.data?.hide_toc}

--- a/pages/[locale]/docs/tags/[tag].tsx
+++ b/pages/[locale]/docs/tags/[tag].tsx
@@ -29,6 +29,7 @@ import { DocCardGrid } from "@zudo-doc/zudo-doc-v2/nav-indexing";
 import type { JSX } from "preact";
 import { FooterWithDefaults } from "../../../lib/_footer-with-defaults";
 import { HeaderWithDefaults } from "../../../lib/_header-with-defaults";
+import { HeadWithDefaults } from "../../../lib/_head-with-defaults";
 
 export const frontmatter = { title: "Tag" };
 
@@ -94,6 +95,7 @@ export default function LocaleDocTagPage({
   return (
     <DocLayoutWithDefaults
       title={pageTitle}
+      head={<HeadWithDefaults title={pageTitle} />}
       lang={locale}
       hideSidebar={true}
       hideToc={true}

--- a/pages/[locale]/docs/tags/index.tsx
+++ b/pages/[locale]/docs/tags/index.tsx
@@ -28,6 +28,7 @@ import type { TagItem, TagNavLabels } from "@zudo-doc/zudo-doc-v2/nav-indexing";
 import type { JSX } from "preact";
 import { FooterWithDefaults } from "../../../lib/_footer-with-defaults";
 import { HeaderWithDefaults } from "../../../lib/_header-with-defaults";
+import { HeadWithDefaults } from "../../../lib/_head-with-defaults";
 
 export const frontmatter = { title: "All Tags" };
 
@@ -73,6 +74,7 @@ export default function LocaleTagsIndexPage({
   return (
     <DocLayoutWithDefaults
       title={pageTitle}
+      head={<HeadWithDefaults title={pageTitle} />}
       lang={locale}
       hideSidebar={true}
       hideToc={true}

--- a/pages/[locale]/docs/versions.tsx
+++ b/pages/[locale]/docs/versions.tsx
@@ -19,6 +19,7 @@ import type { VersionPageEntry, VersionsPageLabels } from "@zudo-doc/zudo-doc-v2
 import type { JSX } from "preact";
 import { FooterWithDefaults } from "../../lib/_footer-with-defaults";
 import { HeaderWithDefaults } from "../../lib/_header-with-defaults";
+import { HeadWithDefaults } from "../../lib/_head-with-defaults";
 
 export const frontmatter = { title: "Versions" };
 
@@ -78,6 +79,7 @@ export default function LocaleVersionsPage({ params }: PageArgs): JSX.Element {
   return (
     <DocLayoutWithDefaults
       title={pageTitle}
+      head={<HeadWithDefaults title={pageTitle} />}
       lang={locale}
       hideSidebar={true}
       hideToc={true}

--- a/pages/[locale]/index.tsx
+++ b/pages/[locale]/index.tsx
@@ -35,6 +35,7 @@ import type { JSX } from "preact";
 import { bridgeEntries } from "../_data";
 import { FooterWithDefaults } from "../lib/_footer-with-defaults";
 import { HeaderWithDefaults } from "../lib/_header-with-defaults";
+import { HeadWithDefaults } from "../lib/_head-with-defaults";
 
 export const frontmatter = { title: "Home" };
 
@@ -110,6 +111,7 @@ export default function LocaleIndexPage({ params }: PageArgs): JSX.Element {
   return (
     <DocLayoutWithDefaults
       title={settings.siteName}
+      head={<HeadWithDefaults title={settings.siteName} />}
       lang={locale}
       hideSidebar={true}
       hideToc={true}

--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -48,6 +48,7 @@ import { FooterWithDefaults } from "../lib/_footer-with-defaults";
 import { DocHistoryArea } from "../lib/_doc-history-area";
 import { SidebarWithDefaults } from "../lib/_sidebar-with-defaults";
 import { HeaderWithDefaults } from "../lib/_header-with-defaults";
+import { HeadWithDefaults } from "../lib/_head-with-defaults";
 import type { JSX } from "preact";
 import { bridgeEntries } from "../_data";
 
@@ -204,6 +205,7 @@ export default function DocsPage({ props }: PageArgs): JSX.Element {
     <DocLayoutWithDefaults
       title={title}
       description={description}
+      head={<HeadWithDefaults title={title} description={description} />}
       lang={locale}
       hideSidebar={entry?.data?.hide_sidebar}
       hideToc={entry?.data?.hide_toc}

--- a/pages/docs/tags/[tag].tsx
+++ b/pages/docs/tags/[tag].tsx
@@ -29,6 +29,7 @@ import type { JSX } from "preact";
 import { bridgeEntries } from "../../_data";
 import { FooterWithDefaults } from "../../lib/_footer-with-defaults";
 import { HeaderWithDefaults } from "../../lib/_header-with-defaults";
+import { HeadWithDefaults } from "../../lib/_head-with-defaults";
 
 export const frontmatter = { title: "Tag" };
 
@@ -79,6 +80,7 @@ export default function DocTagPage({ params, props }: PageProps): JSX.Element {
   return (
     <DocLayoutWithDefaults
       title={pageTitle}
+      head={<HeadWithDefaults title={pageTitle} />}
       hideSidebar={true}
       hideToc={true}
       headerOverride={<HeaderWithDefaults lang={locale} currentPath={withBase(`/docs/tags/${tag}`)} />}

--- a/pages/docs/tags/index.tsx
+++ b/pages/docs/tags/index.tsx
@@ -28,6 +28,7 @@ import type { JSX } from "preact";
 import { bridgeEntries } from "../../_data";
 import { FooterWithDefaults } from "../../lib/_footer-with-defaults";
 import { HeaderWithDefaults } from "../../lib/_header-with-defaults";
+import { HeadWithDefaults } from "../../lib/_head-with-defaults";
 
 export const frontmatter = { title: "All Tags" };
 
@@ -61,6 +62,7 @@ export default function DocsTagsIndexPage(): JSX.Element {
   return (
     <DocLayoutWithDefaults
       title={pageTitle}
+      head={<HeadWithDefaults title={pageTitle} />}
       hideSidebar={true}
       hideToc={true}
       headerOverride={<HeaderWithDefaults lang={locale} currentPath={withBase("/docs/tags")} />}

--- a/pages/docs/versions.tsx
+++ b/pages/docs/versions.tsx
@@ -19,6 +19,7 @@ import type { VersionPageEntry, VersionsPageLabels } from "@zudo-doc/zudo-doc-v2
 import type { JSX } from "preact";
 import { FooterWithDefaults } from "../lib/_footer-with-defaults";
 import { HeaderWithDefaults } from "../lib/_header-with-defaults";
+import { HeadWithDefaults } from "../lib/_head-with-defaults";
 
 export const frontmatter = { title: "Versions" };
 
@@ -56,6 +57,7 @@ export default function VersionsPage(): JSX.Element {
   return (
     <DocLayoutWithDefaults
       title={pageTitle}
+      head={<HeadWithDefaults title={pageTitle} />}
       lang={locale}
       hideSidebar={true}
       hideToc={true}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -31,6 +31,7 @@ import { DocsSitemap } from "@zudo-doc/zudo-doc-v2/nav-indexing";
 import type { JSX } from "preact";
 import { FooterWithDefaults } from "./lib/_footer-with-defaults";
 import { HeaderWithDefaults } from "./lib/_header-with-defaults";
+import { HeadWithDefaults } from "./lib/_head-with-defaults";
 
 export const frontmatter = { title: "Home" };
 
@@ -61,6 +62,7 @@ export default function IndexPage(): JSX.Element {
   return (
     <DocLayoutWithDefaults
       title={settings.siteName}
+      head={<HeadWithDefaults title={settings.siteName} />}
       lang={locale}
       hideSidebar={true}
       hideToc={true}

--- a/pages/lib/_head-with-defaults.tsx
+++ b/pages/lib/_head-with-defaults.tsx
@@ -1,0 +1,41 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+// og:title / og:description head injection wrapper for the zfb doc pages.
+//
+// Why this wrapper exists: Astro's baseline doc-layout.astro synthesizes
+// og:title and og:description from frontmatter title/description and emits
+// them automatically on every page. The v2 <DocLayout> shell exposes a
+// `head` slot (ComponentChildren injected after the baseline charset /
+// viewport / title / description meta) but intentionally does NOT
+// synthesize og:* tags — that is the host's responsibility. Without this
+// wrapper all 121 content-loss routes built by the zfb host pages are
+// missing og:title and og:description, failing the migration-check parity
+// test. This wrapper plugs the gap by forwarding the per-page title and
+// description through <OgTags> so every zfb host page emits the same
+// og:title (always) and og:description (when set) that the Astro original
+// produced.
+
+import type { JSX } from "preact";
+import { OgTags } from "@zudo-doc/zudo-doc-v2/head";
+
+export interface HeadWithDefaultsProps {
+  /** Page title forwarded to og:title. Required. */
+  title: string;
+  /** Optional page description forwarded to og:description. */
+  description?: string;
+}
+
+/**
+ * Default-bearing host wrapper that injects og:title and og:description
+ * into the v2 layout's `head` slot.
+ *
+ * Pure SSR — no state, no client-only imports. Intended for use as:
+ *   head={<HeadWithDefaults title={title} description={description} />}
+ * on every DocLayoutWithDefaults call site in the host pages.
+ */
+export function HeadWithDefaults({
+  title,
+  description,
+}: HeadWithDefaultsProps): JSX.Element {
+  return <OgTags title={title} description={description} />;
+}

--- a/pages/v/[version]/docs/[...slug].tsx
+++ b/pages/v/[version]/docs/[...slug].tsx
@@ -47,6 +47,7 @@ import { bridgeEntries } from "../../../_data";
 import { FooterWithDefaults } from "../../../lib/_footer-with-defaults";
 import { SidebarWithDefaults } from "../../../lib/_sidebar-with-defaults";
 import { HeaderWithDefaults } from "../../../lib/_header-with-defaults";
+import { HeadWithDefaults } from "../../../lib/_head-with-defaults";
 
 export const frontmatter = { title: "Docs" };
 
@@ -208,6 +209,7 @@ export default function VersionedDocsPage({ props }: PageArgs): JSX.Element {
     <DocLayoutWithDefaults
       title={title}
       description={description}
+      head={<HeadWithDefaults title={title} description={description} />}
       lang={locale}
       hideSidebar={entry?.data?.hide_sidebar}
       hideToc={entry?.data?.hide_toc}

--- a/pages/v/[version]/ja/docs/[...slug].tsx
+++ b/pages/v/[version]/ja/docs/[...slug].tsx
@@ -46,6 +46,7 @@ import { bridgeEntries } from "../../../../_data";
 import { FooterWithDefaults } from "../../../../lib/_footer-with-defaults";
 import { SidebarWithDefaults } from "../../../../lib/_sidebar-with-defaults";
 import { HeaderWithDefaults } from "../../../../lib/_header-with-defaults";
+import { HeadWithDefaults } from "../../../../lib/_head-with-defaults";
 
 export const frontmatter = { title: "Docs" };
 
@@ -242,6 +243,7 @@ export default function VersionedJaDocsPage({ props }: PageArgs): JSX.Element {
     <DocLayoutWithDefaults
       title={title}
       description={description}
+      head={<HeadWithDefaults title={title} description={description} />}
       lang={locale}
       hideSidebar={entry?.data?.hide_sidebar}
       hideToc={entry?.data?.hide_toc}


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/687
- super-epic
    - https://github.com/zudolab/zudo-doc/issues/663

---

## Summary

- Wires host-side `og:title` and `og:description` meta tags into all 13 `<DocLayoutWithDefaults>` call sites under `pages/`. Pre-fix, 121 / 121 post-B-7 content-loss routes were missing both tags.
- Adds a small host wrapper `pages/lib/_head-with-defaults.tsx` that composes the existing v2 `OgTags` primitive with frontmatter `title` / `description`, slotted into `DocLayout.head`.
- `astro-view-transitions-*` markers are intentionally absent — zfb has no Astro `ClientRouter` analogue (the v2 transitions package is a client-only `startViewTransition` shim with no head emission). Out of scope for this epic.

## Changes

New file
- `pages/lib/_head-with-defaults.tsx` — `HeadWithDefaults({ title, description })` returns `<OgTags title={title} description={description} />`. Pure SSR, mirrors the convention of `_header-with-defaults.tsx` / `_footer-with-defaults.tsx` / `_sidebar-with-defaults.tsx`.

Wired at all 13 host page entry points
- `pages/404.tsx`
- `pages/index.tsx`
- `pages/docs/[...slug].tsx`
- `pages/docs/tags/[tag].tsx`
- `pages/docs/tags/index.tsx`
- `pages/docs/versions.tsx`
- `pages/[locale]/docs/[...slug].tsx`
- `pages/[locale]/docs/tags/[tag].tsx`
- `pages/[locale]/docs/tags/index.tsx`
- `pages/[locale]/docs/versions.tsx`
- `pages/[locale]/index.tsx`
- `pages/v/[version]/docs/[...slug].tsx`
- `pages/v/[version]/ja/docs/[...slug].tsx`

Each call site receives one extra prop on `<DocLayoutWithDefaults>`:

```
head={<HeadWithDefaults title={title} description={description} />}
```

`title` / `description` already exist as locals at every site (they were already passed as direct props to `DocLayoutWithDefaults`), so threading them through adds no new data plumbing.

## Test Plan

- `pnpm check` passes (no new type errors; pre-existing unrelated failures in `scripts/migration-check/__tests__/` left untouched).
- After merge into the super-epic base, `pnpm migration-check --rerun --raise-issues` should retire the 121-route og:* cluster signature. Remaining residual on those routes is just the `astro-view-transitions-*` markers, which are an intentional-absence (zfb has no `ClientRouter`) and should be reclassified into Phase C residual rather than counted as a regression.
- Visual sanity check (optional, post-merge): inspect a built page's `<head>` and confirm `<meta property="og:title">` and `<meta property="og:description">` appear after the baseline `<meta name="description">`, before any further meta tags.