### PR TITLE
feat(b-12-4): wire DocHistoryArea on tag-index page modules

### DIFF
--- a/pages/[locale]/docs/tags/index.tsx
+++ b/pages/[locale]/docs/tags/index.tsx
@@ -29,6 +29,7 @@ import type { JSX } from "preact";
 import { FooterWithDefaults } from "../../../lib/_footer-with-defaults";
 import { HeaderWithDefaults } from "../../../lib/_header-with-defaults";
 import { HeadWithDefaults } from "../../../lib/_head-with-defaults";
+import { DocHistoryArea } from "../../../lib/_doc-history-area";
 
 export const frontmatter = { title: "All Tags" };
 
@@ -88,6 +89,7 @@ export default function LocaleTagsIndexPage({
       ) : (
         <TagNav variant="all" tags={tags} labels={labels} />
       )}
+      <DocHistoryArea slug="tags" locale={locale} />
     </DocLayoutWithDefaults>
   );
 }

--- a/pages/docs/tags/index.tsx
+++ b/pages/docs/tags/index.tsx
@@ -29,6 +29,7 @@ import { bridgeEntries } from "../../_data";
 import { FooterWithDefaults } from "../../lib/_footer-with-defaults";
 import { HeaderWithDefaults } from "../../lib/_header-with-defaults";
 import { HeadWithDefaults } from "../../lib/_head-with-defaults";
+import { DocHistoryArea } from "../../lib/_doc-history-area";
 
 export const frontmatter = { title: "All Tags" };
 
@@ -75,6 +76,7 @@ export default function DocsTagsIndexPage(): JSX.Element {
       ) : (
         <TagNav variant="all" tags={tags} labels={labels} />
       )}
+      <DocHistoryArea slug="tags" locale={locale} />
     </DocLayoutWithDefaults>
   );
 }


### PR DESCRIPTION
## Summary

- Add `DocHistoryArea` import and render to `pages/docs/tags/index.tsx` (default locale)
- Add `DocHistoryArea` import and render to `pages/[locale]/docs/tags/index.tsx` (non-default locales)
- Passes `slug="tags"` with no `entrySlug`/`contentDir` — no underlying MDX file exists for tag-index routes; `_doc-history-area.tsx` already handles missing-meta gracefully via `meta?.author` guards

## Pattern

Mirrors B-11-3 fix already applied to `[tag].tsx` siblings. The tag-INDEX pages were missed in that pass.

## Acceptance

`/docs/tags` and `/ja/docs/tags` regain the `region:Document utilities` landmark + `h2:Revision History` heading (verified by migration-check on rerun).

## Test plan

- [ ] Manager runs migration-check to confirm `/docs/tags` and `/ja/docs/tags` now pass the DocHistory landmark check

🤖 Generated with [Claude Code](https://claude.com/claude-code)