### PR TITLE
chore(b-12-5): harness — strip hidden-sidebar DOM on tag-listing routes

### DIFF
--- a/scripts/migration-check/__tests__/strip-hidden-sidebar.test.ts
+++ b/scripts/migration-check/__tests__/strip-hidden-sidebar.test.ts
@@ -1,0 +1,139 @@
+/**
+ * strip-hidden-sidebar.test.ts
+ *
+ * Unit tests for hasHiddenSidebar(), stripDesktopSidebarAside(), and
+ * maybeStripHiddenSidebar() from lib/strip-hidden-sidebar.mjs.
+ *
+ * Covers:
+ *   - Detection of hidden sidebar markers (class="sr-only" on aside#desktop-sidebar)
+ *   - Non-detection on normal (visible) sidebar pages
+ *   - Removal of the aside element and all its children
+ *   - Symmetric stripping: content in the stripped block is gone from both sides
+ *   - Toggle: maybeStripHiddenSidebar is a no-op when enabled=false
+ *   - Edge cases: nested asides, sidebar absent entirely
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  hasHiddenSidebar,
+  stripDesktopSidebarAside,
+  maybeStripHiddenSidebar,
+} from "../lib/strip-hidden-sidebar.mjs";
+
+// ── hasHiddenSidebar ──────────────────────────────────────────────────────────
+
+describe("hasHiddenSidebar", () => {
+  it("detects aside#desktop-sidebar with class sr-only (B-side pattern)", () => {
+    const html = `<aside id="desktop-sidebar" aria-label="Documentation sidebar" class="sr-only"><nav>links</nav></aside>`;
+    expect(hasHiddenSidebar(html)).toBe(true);
+  });
+
+  it("detects aside#desktop-sidebar with class sr-only as first class", () => {
+    const html = `<aside class="sr-only" id="desktop-sidebar" aria-label="Documentation sidebar"><nav>links</nav></aside>`;
+    expect(hasHiddenSidebar(html)).toBe(true);
+  });
+
+  it("returns false when aside has visible sidebar classes (not hidden)", () => {
+    // On regular doc pages the aside has the full CSS layout class, not sr-only
+    const html = `<aside id="desktop-sidebar" class="hidden lg:block fixed top-[3.5rem] left-0 z-30"><nav>links</nav></aside>`;
+    expect(hasHiddenSidebar(html)).toBe(false);
+  });
+
+  it("returns false when there is no aside#desktop-sidebar at all", () => {
+    const html = `<html><body><main>content</main></body></html>`;
+    expect(hasHiddenSidebar(html)).toBe(false);
+  });
+
+  it("returns false for an aside with sr-only but a different id", () => {
+    const html = `<aside id="mobile-sidebar" class="sr-only"><nav>links</nav></aside>`;
+    expect(hasHiddenSidebar(html)).toBe(false);
+  });
+});
+
+// ── stripDesktopSidebarAside ──────────────────────────────────────────────────
+
+describe("stripDesktopSidebarAside", () => {
+  it("removes the entire aside element including children", () => {
+    const html = `<body><header>H</header><aside id="desktop-sidebar" class="sr-only"><nav><a href="/docs/intro">Intro</a></nav></aside><main>Content</main></body>`;
+    const result = stripDesktopSidebarAside(html);
+    expect(result).not.toContain("desktop-sidebar");
+    expect(result).not.toContain("/docs/intro");
+    expect(result).toContain("<main>Content</main>");
+    expect(result).toContain("<header>H</header>");
+  });
+
+  it("leaves the rest of the document intact", () => {
+    const html = `<body><aside id="desktop-sidebar" class="sr-only"><nav>NAV</nav></aside><main><h1>Title</h1><p>Body text</p></main></body>`;
+    const result = stripDesktopSidebarAside(html);
+    expect(result).toBe("<body><main><h1>Title</h1><p>Body text</p></main></body>");
+  });
+
+  it("is a no-op when there is no aside#desktop-sidebar", () => {
+    const html = `<body><main>Content</main></body>`;
+    expect(stripDesktopSidebarAside(html)).toBe(html);
+  });
+
+  it("handles aside with attributes in any order", () => {
+    const html = `<html><body><aside aria-label="Sidebar" class="sr-only" id="desktop-sidebar" style="color:red"><p>Sidebar content</p></aside><main>Main</main></body></html>`;
+    const result = stripDesktopSidebarAside(html);
+    expect(result).not.toContain("Sidebar content");
+    expect(result).toContain("<main>Main</main>");
+  });
+
+  it("strips the aside even when it is large (many nav links)", () => {
+    const navLinks = Array.from({ length: 50 }, (_, i) =>
+      `<a href="/docs/page-${i}">Page ${i}</a>`
+    ).join("");
+    const html = `<body><aside id="desktop-sidebar" class="sr-only"><nav>${navLinks}</nav></aside><main>Main content</main></body>`;
+    const result = stripDesktopSidebarAside(html);
+    expect(result).not.toContain("Page 0");
+    expect(result).not.toContain("Page 49");
+    expect(result).toContain("Main content");
+  });
+});
+
+// ── maybeStripHiddenSidebar ───────────────────────────────────────────────────
+
+describe("maybeStripHiddenSidebar", () => {
+  const hiddenSidebarHtml = `<body><aside id="desktop-sidebar" class="sr-only"><nav><a href="/docs/x">X</a></nav></aside><main>Page content</main></body>`;
+  const visibleSidebarHtml = `<body><aside id="desktop-sidebar" class="hidden lg:block fixed"><nav><a href="/docs/x">X</a></nav></aside><main>Page content</main></body>`;
+
+  it("strips hidden sidebar when enabled=true and page has hidden sidebar", () => {
+    const result = maybeStripHiddenSidebar(hiddenSidebarHtml, true);
+    expect(result).not.toContain("desktop-sidebar");
+    expect(result).not.toContain("/docs/x");
+    expect(result).toContain("Page content");
+  });
+
+  it("is a no-op when enabled=false even if page has hidden sidebar", () => {
+    const result = maybeStripHiddenSidebar(hiddenSidebarHtml, false);
+    expect(result).toBe(hiddenSidebarHtml);
+  });
+
+  it("is a no-op when enabled=true but sidebar is visible (not sr-only)", () => {
+    const result = maybeStripHiddenSidebar(visibleSidebarHtml, true);
+    expect(result).toBe(visibleSidebarHtml);
+  });
+
+  it("is a no-op when enabled=true but no sidebar present at all", () => {
+    const html = `<body><main>No sidebar here</main></body>`;
+    expect(maybeStripHiddenSidebar(html, true)).toBe(html);
+  });
+
+  it("symmetric stripping: same content disappears from both sides", () => {
+    // Simulate A-side: aside present with sr-only (e.g. Astro CSS-hidden sidebar)
+    const sideA = `<body><aside id="desktop-sidebar" class="sr-only"><nav><a href="/docs/guide">Guide</a></nav></aside><main>Tag page content</main></body>`;
+    // Simulate B-side: same aside but with empty sidebar island
+    const sideB = `<body><aside id="desktop-sidebar" class="sr-only"><div data-zfb-island="Sidebar"></div></aside><main>Tag page content</main></body>`;
+
+    const strippedA = maybeStripHiddenSidebar(sideA, true);
+    const strippedB = maybeStripHiddenSidebar(sideB, true);
+
+    // After stripping, both sides have no sidebar DOM
+    expect(strippedA).not.toContain("desktop-sidebar");
+    expect(strippedB).not.toContain("desktop-sidebar");
+    // Main content is unchanged on both sides
+    expect(strippedA).toContain("Tag page content");
+    expect(strippedB).toContain("Tag page content");
+  });
+});

--- a/scripts/migration-check/compare-routes.mjs
+++ b/scripts/migration-check/compare-routes.mjs
@@ -29,6 +29,7 @@ import { fileURLToPath } from "node:url";
 
 import { normalizeHtml } from "./lib/normalize-html.mjs";
 import { extractSignals } from "./lib/extract-signals.mjs";
+import { maybeStripHiddenSidebar } from "./lib/strip-hidden-sidebar.mjs";
 import * as config from "./config.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -334,11 +335,23 @@ async function compareRoute({ route, baseA, baseB, sitePrefix }) {
     };
   }
 
-  // Normalize and extract signals
+  // Normalize and extract signals.
+  // maybeStripHiddenSidebar runs after normalizeHtml so the aside's class
+  // attribute has been sorted/normalised before detection fires.
+  // Stripping is symmetric (both A and B) so the sidebar content falls out
+  // of the diff entirely — see lib/strip-hidden-sidebar.mjs for rationale.
   let sigA, sigB;
   try {
-    sigA = extractSignals(normalizeHtml(fetchA.text, { sitePrefix }));
-    sigB = extractSignals(normalizeHtml(fetchB.text, { sitePrefix }));
+    const normA = maybeStripHiddenSidebar(
+      normalizeHtml(fetchA.text, { sitePrefix }),
+      config.stripHiddenSidebarDom,
+    );
+    const normB = maybeStripHiddenSidebar(
+      normalizeHtml(fetchB.text, { sitePrefix }),
+      config.stripHiddenSidebarDom,
+    );
+    sigA = extractSignals(normA);
+    sigB = extractSignals(normB);
   } catch (err) {
     return {
       route,

--- a/scripts/migration-check/config.mjs
+++ b/scripts/migration-check/config.mjs
@@ -63,6 +63,24 @@ export const lockDir = "/tmp/l-zfb-migration-check-locks/";
  */
 export const sitePrefix = "/pj/zudo-doc/";
 
+// ── Hidden-sidebar strip ──────────────────────────────────────────────────────
+
+/**
+ * Strip the hidden desktop-sidebar <aside> element from both A and B HTML
+ * before signal extraction.
+ *
+ * Background (phase B-12, issue #907, option (b)):
+ *   Tag-listing routes (/docs/tags/<tag> and JA mirrors) use hideSidebar=true.
+ *   Site A (old Astro layout) rendered the full nav tree in the DOM and hid it
+ *   via CSS; site B (zfb DocLayout) intentionally omits the tree. Stripping
+ *   symmetrically from both sides removes the sidebar from the diff so that the
+ *   18 affected routes are no longer classified as content-loss.
+ *
+ *   Default ON for round-7 rerun and beyond. Set to false to restore the old
+ *   behaviour where sidebar DOM was included in the content-loss calculation.
+ */
+export const stripHiddenSidebarDom = true;
+
 // ── Cosmetic-by-default markers ───────────────────────────────────────────────
 
 /**

--- a/scripts/migration-check/lib/strip-hidden-sidebar.mjs
+++ b/scripts/migration-check/lib/strip-hidden-sidebar.mjs
@@ -1,0 +1,132 @@
+/**
+ * strip-hidden-sidebar.mjs — strip hidden-sidebar DOM before signal extraction.
+ *
+ * Context (phase B-12, issue #907, option (b)):
+ *   Tag-listing routes (/docs/tags/<tag> and JA mirrors) set hideSidebar=true
+ *   in their layout. The old Astro layout (site A) rendered the full sidebar
+ *   nav tree in the DOM and hid it via CSS — contributing navigation link text
+ *   to visibleText. The zfb DocLayout (site B) intentionally omits that tree
+ *   when hideSidebar=true, emitting only an empty sr-only <aside> marker.
+ *
+ *   This DOM reduction is not a regression — it is a deliberate improvement:
+ *   less DOM noise on pages where the sidebar is never shown. The harness must
+ *   not count the hidden sidebar HTML against site B in the content-loss check.
+ *
+ *   Strategy: strip the <aside id="desktop-sidebar"> element from both A and B
+ *   HTML before signal extraction. When both sides are stripped symmetrically
+ *   the sidebar content falls out of the diff entirely, so the route is
+ *   classified by its actual visible content rather than by DOM that was always
+ *   hidden from the user.
+ *
+ *   The strip is ONLY applied when the route has a hidden sidebar — detected by
+ *   the presence of <aside ... class="sr-only"> on the rendered page, which is
+ *   the exact marker the DocLayout emits when hideSidebar=true. On regular doc
+ *   pages the aside has a visible CSS class, so stripping is skipped.
+ */
+
+// ── Detection ─────────────────────────────────────────────────────────────────
+
+/**
+ * Return true when the HTML contains a hidden-sidebar marker.
+ *
+ * Two conditions are checked (either is sufficient):
+ *   1. The aside has class="sr-only" — this is what zfb DocLayout emits for
+ *      hideSidebar=true (site B). It's also what site A emits for the mobile
+ *      sidebar-toggle aside when the sidebar is hidden.
+ *   2. The aside has a class that starts with "sr-only" — covers the case
+ *      where Tailwind produces "sr-only ..." with trailing classes.
+ *
+ * @param {string} html  Normalized HTML string.
+ * @returns {boolean}
+ */
+export function hasHiddenSidebar(html) {
+  // Match <aside id="desktop-sidebar" ...> with sr-only in the class value.
+  // The aside may have other attributes (aria-label, style, etc.) in any order.
+  // We check for "sr-only" anywhere in the class attribute of the aside.
+  return /<aside\b[^>]*\bid="desktop-sidebar"[^>]*class="[^"]*\bsr-only\b[^"]*"[^>]*>/i.test(html)
+    || /<aside\b[^>]*class="[^"]*\bsr-only\b[^"]*"[^>]*\bid="desktop-sidebar"[^>]*>/i.test(html);
+}
+
+// ── Stripping ─────────────────────────────────────────────────────────────────
+
+/**
+ * Remove the <aside id="desktop-sidebar">…</aside> element from HTML.
+ *
+ * Uses a balanced-depth tracker rather than a simple regex so that nested
+ * aside elements (if any) are handled correctly. This is regex-based parsing
+ * of controlled Astro/zfb output — the sidebar aside has no nested asides in
+ * practice, but being defensive here avoids silent data corruption.
+ *
+ * The function does NOT use a full DOM parser — the existing harness pipeline
+ * is regex-based (see normalize-html.mjs, extract-signals.mjs) and we follow
+ * that convention.
+ *
+ * @param {string} html  HTML string (normalized or raw).
+ * @returns {string}     HTML with the desktop-sidebar aside removed.
+ */
+export function stripDesktopSidebarAside(html) {
+  // Find the opening <aside id="desktop-sidebar" ...> tag.
+  // The aside may have attributes in any order.
+  const openTagRe = /<aside\b(?=[^>]*\bid="desktop-sidebar")[^>]*>/gi;
+
+  let result = html;
+  let match;
+
+  while ((match = openTagRe.exec(result)) !== null) {
+    const startIdx = match.index;
+    const afterOpen = startIdx + match[0].length;
+
+    // Walk from afterOpen to find the matching </aside>.
+    // Track nesting depth (aside-within-aside is rare but possible).
+    let depth = 1;
+    let pos = afterOpen;
+
+    const bodyRe = /<\/?aside\b[^>]*>/gi;
+    bodyRe.lastIndex = pos;
+
+    let inner;
+    while (depth > 0 && (inner = bodyRe.exec(result)) !== null) {
+      if (inner[0].startsWith("</")) {
+        depth--;
+      } else {
+        depth++;
+      }
+    }
+
+    if (depth !== 0) {
+      // Unbalanced aside — leave unchanged to avoid data loss.
+      break;
+    }
+
+    // inner.index points to the start of the closing </aside>.
+    // inner[0].length is the length of </aside>.
+    const endIdx = inner.index + inner[0].length;
+
+    // Splice out [startIdx, endIdx).
+    result = result.slice(0, startIdx) + result.slice(endIdx);
+
+    // Reset the outer regex since the string has changed.
+    openTagRe.lastIndex = startIdx;
+  }
+
+  return result;
+}
+
+// ── Main export ───────────────────────────────────────────────────────────────
+
+/**
+ * Conditionally strip the hidden desktop-sidebar aside from an HTML string.
+ *
+ * When `enabled` is false (or the page does not have a hidden sidebar), the
+ * input is returned unchanged. This makes it safe to call unconditionally in
+ * the pipeline — if the page shows its sidebar normally, nothing is removed.
+ *
+ * @param {string}  html     Normalized HTML.
+ * @param {boolean} enabled  Master toggle (from config.stripHiddenSidebarDom).
+ * @returns {string}         HTML with the hidden sidebar removed (or unchanged).
+ */
+export function maybeStripHiddenSidebar(html, enabled) {
+  if (!enabled) return html;
+  if (!hasHiddenSidebar(html)) return html;
+  return stripDesktopSidebarAside(html);
+}


### PR DESCRIPTION
## Summary

- Adds `lib/strip-hidden-sidebar.mjs` which strips `<aside id="desktop-sidebar">` from HTML when the aside carries `class="sr-only"` — the marker emitted by the zfb DocLayout for `hideSidebar=true`
- Adds `config.stripHiddenSidebarDom` toggle (default `true`) for round-7 rerun
- Wires `maybeStripHiddenSidebar` into `compare-routes.mjs` symmetrically (both A and B sides) after `normalizeHtml` and before `extractSignals`
- 15 unit tests covering detection, stripping, the config toggle, and symmetric-stripping

## Background / Decision

18 tag-listing routes (`/docs/tags/<tag>` + JA mirrors) were flagged as `content-loss`. The old Astro layout (site A) rendered the full sidebar nav tree in the DOM and hid it via CSS. The zfb DocLayout (site B) with `hideSidebar=true` intentionally omits the tree.

Decision: **option (b)** from issue #907 — accept B's less-DOM behaviour. This is not a regression; it is a deliberate improvement (less DOM noise on pages where the sidebar is never shown). The harness must not count the hidden sidebar HTML against B.

Stripping symmetrically from both sides means the sidebar falls out of the diff entirely, and the route is classified by its actual visible content.

## Test plan

- [x] 15 unit tests green (`pnpm vitest run scripts/migration-check/__tests__/strip-hidden-sidebar.test.ts`)
- [x] Full harness test suite: 288 passing, 1 pre-existing EADDRINUSE failure in serve-snapshots unrelated to this change
- [x] gcoc review: "No bugs or logic errors found. The implementation is correct and safe."

## Related

Closes the harness side of [issue #907](https://github.com/zudolab/zudo-doc/issues/907) B-12-5.
Manager verifies the 18 tag-listing routes drop out of content-loss on round-7 rerun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)