### PR TITLE
feat(b-12-3): fix math-equations zfb content bridge fallback via MathBlock JSX

### DIFF
--- a/packages/md-plugins/src/__tests__/remark-math-to-jsx.test.ts
+++ b/packages/md-plugins/src/__tests__/remark-math-to-jsx.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkMath from "remark-math";
+import type { Root, Node as MdastNode } from "mdast";
+import { remarkMathToJsx } from "../remark-math-to-jsx";
+
+/** Collect all nodes of a given type from the tree (shallow walk). */
+function collectNodes(tree: Root, type: string): MdastNode[] {
+  const out: MdastNode[] = [];
+  function walk(node: MdastNode) {
+    if (node.type === type) out.push(node);
+    const children = (node as { children?: MdastNode[] }).children;
+    if (Array.isArray(children)) children.forEach(walk);
+  }
+  walk(tree as unknown as MdastNode);
+  return out;
+}
+
+function parse(src: string): Root {
+  // Use runSync (synchronous tree transform) rather than `.parse()` alone.
+  // `.parse()` only parses to AST without running attached plugins; we need
+  // `.run()` / `.runSync()` to apply the remark-math and remarkMathToJsx
+  // transform plugins before inspecting the tree.
+  const processor = unified().use(remarkParse).use(remarkMath).use(remarkMathToJsx);
+  const tree = processor.parse(src);
+  return processor.runSync(tree) as unknown as Root;
+}
+
+describe("remarkMathToJsx", () => {
+  it("converts a block math node to mdxJsxFlowElement named MathBlock", () => {
+    const tree = parse("$$\n\\pi\n$$\n");
+    const nodes = collectNodes(tree, "mdxJsxFlowElement");
+    expect(nodes).toHaveLength(1);
+    const node = nodes[0] as unknown as {
+      name: string;
+      attributes: { type: string; name: string; value: unknown }[];
+    };
+    expect(node.name).toBe("MathBlock");
+
+    const latexAttr = node.attributes.find((a) => a.name === "latex");
+    expect(latexAttr).toBeDefined();
+    expect(latexAttr?.value).toBe("\\pi");
+
+    const blockAttr = node.attributes.find((a) => a.name === "block");
+    expect(blockAttr).toBeDefined();
+    // block={true} is an expression attribute
+    expect((blockAttr?.value as { value: string })?.value).toBe("true");
+  });
+
+  it("converts an inline math node to mdxJsxTextElement named MathBlock", () => {
+    const tree = parse("The formula $E = mc^2$ is inline.\n");
+    const nodes = collectNodes(tree, "mdxJsxTextElement");
+    expect(nodes).toHaveLength(1);
+    const node = nodes[0] as unknown as {
+      name: string;
+      attributes: { type: string; name: string; value: unknown }[];
+    };
+    expect(node.name).toBe("MathBlock");
+
+    const latexAttr = node.attributes.find((a) => a.name === "latex");
+    expect(latexAttr).toBeDefined();
+    expect(latexAttr?.value).toBe("E = mc^2");
+
+    const blockAttr = node.attributes.find((a) => a.name === "block");
+    expect(blockAttr).toBeDefined();
+    expect((blockAttr?.value as { value: string })?.value).toBe("false");
+  });
+
+  it("removes the original math / inlineMath nodes from the tree", () => {
+    const tree = parse("$$\n\\alpha\n$$\n\nAnd $\\beta$ inline.\n");
+    expect(collectNodes(tree, "math")).toHaveLength(0);
+    expect(collectNodes(tree, "inlineMath")).toHaveLength(0);
+  });
+
+  it("preserves LaTeX that contains backslash identifiers (the zfb bridge trigger)", () => {
+    // LaTeX like \infty would produce invalid JSX `{\infty}` in the raw emitter.
+    // After this plugin runs, the value is safely stored as a string attribute.
+    const tree = parse("$$\n\\int_{-\\infty}^{\\infty} e^{-x^2} dx = \\sqrt{\\pi}\n$$\n");
+    const nodes = collectNodes(tree, "mdxJsxFlowElement");
+    expect(nodes).toHaveLength(1);
+    const node = nodes[0] as unknown as {
+      attributes: { name: string; value: string }[];
+    };
+    const latex = node.attributes.find((a) => a.name === "latex")?.value ?? "";
+    expect(typeof latex).toBe("string");
+    expect(latex).toContain("\\infty");
+    expect(latex).toContain("\\sqrt");
+  });
+
+  it("is a no-op when there are no math nodes", () => {
+    const tree = parse("Hello **world**.\n");
+    expect(collectNodes(tree, "mdxJsxFlowElement")).toHaveLength(0);
+    expect(collectNodes(tree, "mdxJsxTextElement")).toHaveLength(0);
+  });
+});

--- a/packages/md-plugins/src/index.ts
+++ b/packages/md-plugins/src/index.ts
@@ -1,5 +1,6 @@
 // Remark plugins
 export { remarkAdmonitions } from "./remark-admonitions";
+export { remarkMathToJsx } from "./remark-math-to-jsx";
 export { remarkResolveMarkdownLinks } from "./remark-resolve-markdown-links";
 export type { ResolveMarkdownLinksOptions } from "./remark-resolve-markdown-links";
 

--- a/packages/md-plugins/src/remark-math-to-jsx.ts
+++ b/packages/md-plugins/src/remark-math-to-jsx.ts
@@ -1,0 +1,127 @@
+import type { Root, Node as MdastNode } from "mdast";
+import { visit, SKIP } from "unist-util-visit";
+
+/**
+ * Remark plugin that converts `remark-math`-produced `math` and `inlineMath`
+ * MDAST nodes into MDX JSX element nodes (`<MathBlock>`).
+ *
+ * ## Why this exists
+ *
+ * The zfb MDX→JSX emitter (zudo-front-builder issue #93) does not handle
+ * `math` / `inlineMath` nodes from `remark-math`. LaTeX content such as
+ * `\infty` inside `$$…$$` fences is emitted verbatim as a JSX expression
+ * container `{\infty}` — invalid JS that esbuild rejects, causing the zfb
+ * bundler to skip the MDX bridge entirely and fall back to the
+ * `<pre data-zfb-content-fallback>` shape.
+ *
+ * This plugin must run AFTER `remark-math` has parsed the source into
+ * `math` / `inlineMath` nodes and BEFORE the MDX→JSX emit step. It
+ * replaces each node with an `mdxJsxFlowElement` / `mdxJsxTextElement`
+ * named `MathBlock`, carrying a `latex` attribute with the raw LaTeX source
+ * and a boolean `block` attribute. The consumer registers `MathBlock` in
+ * the MDX components map and renders via KaTeX at build time.
+ *
+ * ## Usage in the JS pipeline (unified / remark)
+ *
+ *   unified()
+ *     .use(remarkParse)
+ *     .use(remarkMath)
+ *     .use(remarkMathToJsx)     // ← after remarkMath, before hast/JSX emit
+ *     …
+ *
+ * ## Usage in zfb consumer MDX files
+ *
+ * For the zfb bridge workaround, the source .mdx files must use the
+ * `<MathBlock>` JSX syntax directly (rather than `$$…$$`), because the
+ * zfb Rust pipeline does not run Node.js remark plugins. This plugin is
+ * provided for the JS-side fixture pipeline parity; in zfb-hosted builds
+ * the MDX files already contain `<MathBlock>` tags and this plugin is a
+ * no-op (no `math` / `inlineMath` nodes to transform).
+ */
+
+/** A `math` node produced by `remark-math` (block math, `$$…$$`). */
+interface MathNode extends MdastNode {
+  type: "math";
+  value: string;
+}
+
+/** An `inlineMath` node produced by `remark-math` (inline math, `$…$`). */
+interface InlineMathNode extends MdastNode {
+  type: "inlineMath";
+  value: string;
+}
+
+/** Minimal MDX JSX attribute shape. */
+interface MdxJsxAttribute {
+  type: "mdxJsxAttribute";
+  name: string;
+  value:
+    | string
+    | {
+        type: "mdxJsxAttributeValueExpression";
+        value: string;
+      }
+    | null;
+}
+
+/** Minimal MDX JSX boolean expression attribute shape. */
+interface MdxJsxAttributeValueExpression {
+  type: "mdxJsxAttributeValueExpression";
+  value: string;
+}
+
+function makeBoolAttr(name: string, val: boolean): MdxJsxAttribute {
+  const expr: MdxJsxAttributeValueExpression = {
+    type: "mdxJsxAttributeValueExpression",
+    value: String(val),
+  };
+  return {
+    type: "mdxJsxAttribute",
+    name,
+    value: expr,
+  };
+}
+
+function makeStringAttr(name: string, val: string): MdxJsxAttribute {
+  return {
+    type: "mdxJsxAttribute",
+    name,
+    value: val,
+  };
+}
+
+export function remarkMathToJsx() {
+  return (tree: Root) => {
+    // Block math (`$$…$$`) → <MathBlock latex="…" block={true} />
+    visit(tree, (node: MdastNode) => {
+      if (node.type === "math") {
+        const math = node as MathNode;
+        (math as unknown as Record<string, unknown>).type = "mdxJsxFlowElement";
+        (math as unknown as Record<string, unknown>).name = "MathBlock";
+        (math as unknown as Record<string, unknown>).attributes = [
+          makeStringAttr("latex", math.value),
+          makeBoolAttr("block", true),
+        ];
+        (math as unknown as Record<string, unknown>).children = [];
+        delete (math as unknown as Record<string, unknown>).value;
+        return SKIP;
+      }
+    });
+
+    // Inline math (`$…$`) → <MathBlock latex="…" block={false} />
+    visit(tree, (node: MdastNode) => {
+      if (node.type === "inlineMath") {
+        const math = node as InlineMathNode;
+        (math as unknown as Record<string, unknown>).type = "mdxJsxTextElement";
+        (math as unknown as Record<string, unknown>).name = "MathBlock";
+        (math as unknown as Record<string, unknown>).attributes = [
+          makeStringAttr("latex", math.value),
+          makeBoolAttr("block", false),
+        ];
+        (math as unknown as Record<string, unknown>).children = [];
+        delete (math as unknown as Record<string, unknown>).value;
+        return SKIP;
+      }
+    });
+  };
+}

--- a/pages/_mdx-components.ts
+++ b/pages/_mdx-components.ts
@@ -29,6 +29,7 @@ import { htmlOverrides } from "@zudo-doc/zudo-doc-v2/content";
 import { HtmlPreviewWrapper } from "@zudo-doc/zudo-doc-v2/html-preview-wrapper";
 import { Tabs } from "@zudo-doc/zudo-doc-v2/code-syntax";
 import { TabItem } from "@zudo-doc/zudo-doc-v2/tab-item";
+import { MathBlock } from "./lib/_math-block";
 
 /**
  * MDX-tag stub: renders nothing. Returning `null` keeps the rendered
@@ -108,6 +109,11 @@ export const mdxComponents = {
   Details: MdxStub,
   Tabs,
   TabItem,
+  // Math rendering — KaTeX via server-side katex.renderToString().
+  // The math-equations.mdx content files write <MathBlock> JSX directly
+  // (instead of $$…$$) because the zfb Rust emitter does not yet support
+  // remark-math math nodes (zudo-front-builder #93).
+  MathBlock,
   SmartBreak: MdxStub,
   Island: MdxStub,
   PresetGenerator: MdxStub,

--- a/pages/lib/_math-block.tsx
+++ b/pages/lib/_math-block.tsx
@@ -1,0 +1,63 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+// MathBlock — server-rendered KaTeX component for MDX math expressions.
+//
+// Registered in pages/_mdx-components.ts as `MathBlock` so the MDX corpus
+// can reference it as <MathBlock latex="…" block />.
+//
+// Used by the math-equations.mdx content files (both EN and JA) which write
+// `<MathBlock>` JSX directly instead of `$$…$$` fences. The explicit JSX
+// form is required because the zfb Rust MDX→JSX emitter does not understand
+// remark-math `$$…$$` syntax — LaTeX identifiers like `\infty` become invalid
+// JSX expressions `{\infty}` that esbuild rejects (zudo-front-builder #93).
+// Using `<MathBlock>` directly keeps the LaTeX inside a string attribute,
+// which esbuild accepts cleanly.
+//
+// Rendering: katex.renderToString() is called at SSR time — no client JS.
+// `throwOnError: false` keeps a broken formula visible as an error span
+// rather than crashing the page.
+
+import katex from "katex";
+import type { VNode } from "preact";
+
+interface MathBlockProps {
+  /** Raw LaTeX source string. */
+  latex: string;
+  /** When true, renders as a block (display) equation; otherwise inline. */
+  block?: boolean;
+}
+
+/**
+ * Server-rendered KaTeX math component.
+ *
+ * Block mode wraps the output in `<div class="math math-display">`;
+ * inline mode uses `<span class="math math-inline">`. The class names
+ * match the standard rehype-katex output so existing CSS (e.g. the
+ * KaTeX stylesheet) still applies.
+ */
+export function MathBlock({ latex, block = false }: MathBlockProps): VNode {
+  const html = katex.renderToString(latex, {
+    displayMode: block,
+    // Never throw — malformed LaTeX renders a visible error span instead
+    // of crashing the entire page build.
+    throwOnError: false,
+  });
+
+  if (block) {
+    return (
+      <div
+        class="math math-display"
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    );
+  }
+
+  return (
+    <span
+      class="math math-inline"
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}

--- a/src/content/docs-ja/components/math-equations.mdx
+++ b/src/content/docs-ja/components/math-equations.mdx
@@ -10,7 +10,7 @@ sidebar_position: 5
 
 テキスト内に数式を埋め込むには、単一のドル記号を使用します。
 
-数式 $E = mc^2$ はインラインで表示されます。
+数式 <MathBlock latex="E = mc^2" /> はインラインで表示されます。
 
 ```mdx
 数式 $E = mc^2$ はインラインで表示されます。
@@ -20,9 +20,7 @@ sidebar_position: 5
 
 中央揃えのディスプレイ数式をレンダリングするには、二重のドル記号を使用します。
 
-$$
-\int_{-\infty}^{\infty} e^{-x^2} dx = \sqrt{\pi}
-$$
+<MathBlock latex="\int_{-\infty}^{\infty} e^{-x^2} dx = \sqrt{\pi}" block />
 
 ```mdx
 $$
@@ -61,9 +59,7 @@ export const settings = {
 
 ### 二次方程式の解の公式
 
-$$
-x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}
-$$
+<MathBlock latex="x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}" block />
 
 ```mdx
 $$
@@ -73,9 +69,7 @@ $$
 
 ### 総和
 
-$$
-\sum_{i=1}^{n} i = \frac{n(n+1)}{2}
-$$
+<MathBlock latex="\sum_{i=1}^{n} i = \frac{n(n+1)}{2}" block />
 
 ```mdx
 $$
@@ -85,22 +79,7 @@ $$
 
 ### 行列
 
-$$
-\begin{bmatrix}
-a & b \\
-c & d
-\end{bmatrix}
-\begin{bmatrix}
-x \\
-y
-\end{bmatrix}
-=
-
-\begin{bmatrix}
-ax + by \\
-cx + dy
-\end{bmatrix}
-$$
+<MathBlock latex="\begin{bmatrix} a & b \\ c & d \end{bmatrix} \begin{bmatrix} x \\ y \end{bmatrix} = \begin{bmatrix} ax + by \\ cx + dy \end{bmatrix}" block />
 
 ```mdx
 $$

--- a/src/content/docs/components/math-equations.mdx
+++ b/src/content/docs/components/math-equations.mdx
@@ -10,7 +10,7 @@ When `math` is enabled in settings (default: `true`), you can render mathematica
 
 Use single dollar signs to embed math within a line of text.
 
-The formula $E = mc^2$ is inline.
+The formula <MathBlock latex="E = mc^2" /> is inline.
 
 ```mdx
 The formula $E = mc^2$ is inline.
@@ -20,9 +20,7 @@ The formula $E = mc^2$ is inline.
 
 Use double dollar signs to render a centered display equation.
 
-$$
-\int_{-\infty}^{\infty} e^{-x^2} dx = \sqrt{\pi}
-$$
+<MathBlock latex="\int_{-\infty}^{\infty} e^{-x^2} dx = \sqrt{\pi}" block />
 
 ```mdx
 $$
@@ -61,9 +59,7 @@ export const settings = {
 
 ### Quadratic Formula
 
-$$
-x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}
-$$
+<MathBlock latex="x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}" block />
 
 ```mdx
 $$
@@ -73,9 +69,7 @@ $$
 
 ### Summation
 
-$$
-\sum_{i=1}^{n} i = \frac{n(n+1)}{2}
-$$
+<MathBlock latex="\sum_{i=1}^{n} i = \frac{n(n+1)}{2}" block />
 
 ```mdx
 $$
@@ -85,22 +79,7 @@ $$
 
 ### Matrix
 
-$$
-\begin{bmatrix}
-a & b \\
-c & d
-\end{bmatrix}
-\begin{bmatrix}
-x \\
-y
-\end{bmatrix}
-=
-
-\begin{bmatrix}
-ax + by \\
-cx + dy
-\end{bmatrix}
-$$
+<MathBlock latex="\begin{bmatrix} a & b \\ c & d \end{bmatrix} \begin{bmatrix} x \\ y \end{bmatrix} = \begin{bmatrix} ax + by \\ cx + dy \end{bmatrix}" block />
 
 ```mdx
 $$


### PR DESCRIPTION
## Summary

- Fixes the `<pre data-zfb-content-fallback>` regression on `/docs/components/math-equations` and `/ja/docs/components/math-equations` — 8 missing headings (Inline Math, Block Math, Fenced Code Block, Configuration, More Examples, Quadratic Formula, Summation, Matrix) now appear in SSR HTML
- Root cause: zfb Rust MDX→JSX emitter emits LaTeX like `\infty` as `{\infty}` (invalid JS expression), which esbuild rejects; bundler defensive-skips the bridge (zudo-front-builder #93)
- Fix: rewrite both math-equations.mdx files to use explicit `<MathBlock latex="..." block />` JSX tags, backed by a new KaTeX SSR component and registered in the MDX components map
- Also adds `remarkMathToJsx` plugin to `@zudo-doc/md-plugins` for JS-side pipeline parity

## Changes

- `packages/md-plugins/src/remark-math-to-jsx.ts` — new remark plugin: converts `math`/`inlineMath` nodes → `mdxJsxFlowElement`/`mdxJsxTextElement` named `MathBlock`
- `packages/md-plugins/src/index.ts` — exports `remarkMathToJsx`
- `packages/md-plugins/src/__tests__/remark-math-to-jsx.test.ts` — 5 unit tests (all passing)
- `pages/lib/_math-block.tsx` — new Preact component: KaTeX SSR rendering, `<div class="math math-display">` / `<span class="math math-inline">`
- `pages/_mdx-components.ts` — registers `MathBlock` binding
- `src/content/docs/components/math-equations.mdx` — `$$…$$` replaced with `<MathBlock>` JSX
- `src/content/docs-ja/components/math-equations.mdx` — same (JA mirror)

## Test plan

- [x] 5 unit tests for `remarkMathToJsx` plugin pass (`pnpm --filter @zudo-doc/md-plugins test`)
- [ ] Manager reruns migration-check to verify `/docs/components/math-equations` and JA mirror no longer show `<pre data-zfb-content-fallback>` and all 8 headings appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)