### PR TITLE
[Epic] Phase B-14 — harness normalization (Astro runtime + version-switcher + whitespace + asset paths) + zfb MDX named-import upstream fix

### DIFF
--- a/scripts/migration-check/__tests__/diff-artifacts.test.ts
+++ b/scripts/migration-check/__tests__/diff-artifacts.test.ts
@@ -19,6 +19,8 @@ import {
   diffText,
   diffBinary,
   walkArtifactsDir,
+  extractAstroCanonicalBasename,
+  buildAstroCanonicalMap,
 } from "../diff-artifacts.mjs";
 
 const FIXTURES = join(import.meta.dirname, "fixtures");
@@ -44,6 +46,9 @@ describe("getArtifactType", () => {
   it("returns 'binary' for image extensions", () => {
     expect(getArtifactType("icon.png")).toBe("binary");
     expect(getArtifactType("photo.jpg")).toBe("binary");
+    expect(getArtifactType("image-wide.webp")).toBe("binary");
+    expect(getArtifactType("logo.svg")).toBe("binary");
+    expect(getArtifactType("_astro/image-wide.D1YdccyX_1EtJL4.webp")).toBe("binary");
   });
 
   it("returns 'text' for known text artifact names", () => {
@@ -287,6 +292,87 @@ describe("walkArtifactsDir", () => {
   it("returns an empty array for a non-existent directory", async () => {
     const files = await walkArtifactsDir(join(FIXTURES, "nonexistent-dir"));
     expect(files).toEqual([]);
+  });
+});
+
+// ── extractAstroCanonicalBasename ─────────────────────────────────────────────
+
+describe("extractAstroCanonicalBasename", () => {
+  it("strips Astro content hash and returns canonical basename", () => {
+    expect(extractAstroCanonicalBasename("_astro/image-wide.D1YdccyX_1EtJL4.webp")).toBe(
+      "image-wide.webp",
+    );
+  });
+
+  it("handles hashes with underscores and hyphens (base64url charset)", () => {
+    expect(extractAstroCanonicalBasename("_astro/image-small.A1B2C3D4_efgh.webp")).toBe(
+      "image-small.webp",
+    );
+  });
+
+  it("handles different extensions (png, jpg)", () => {
+    expect(extractAstroCanonicalBasename("_astro/logo.ABCDEFGH12345678.png")).toBe("logo.png");
+    expect(extractAstroCanonicalBasename("_astro/photo.abcdefgh.jpg")).toBe("photo.jpg");
+  });
+
+  it("returns null for paths not under _astro/", () => {
+    expect(extractAstroCanonicalBasename("img/image-enlarge/image-wide.webp")).toBeNull();
+    expect(extractAstroCanonicalBasename("favicon.ico")).toBeNull();
+    expect(extractAstroCanonicalBasename("robots.txt")).toBeNull();
+  });
+
+  it("returns null when hash segment is shorter than 8 characters", () => {
+    // 7 chars is too short — likely not a content hash
+    expect(extractAstroCanonicalBasename("_astro/image.short.webp")).toBeNull();
+    expect(extractAstroCanonicalBasename("_astro/image.abc1234.webp")).toBeNull();
+  });
+
+  it("returns null when filename has no hash pattern (no dot-separated segments)", () => {
+    expect(extractAstroCanonicalBasename("_astro/image-wide.webp")).toBeNull();
+  });
+
+  it("returns null for nested _astro paths (subdirectory inside _astro/)", () => {
+    // Only top-level _astro/<name>.<HASH>.<ext> is supported
+    expect(extractAstroCanonicalBasename("_astro/sub/image.D1YdccyX.webp")).toBeNull();
+  });
+});
+
+// ── buildAstroCanonicalMap ────────────────────────────────────────────────────
+
+describe("buildAstroCanonicalMap", () => {
+  it("builds a map of canonical basename → actual path for _astro paths", () => {
+    const paths = [
+      "_astro/image-wide.D1YdccyX_1EtJL4.webp",
+      "_astro/image-small.ABCDEFGH12345678.webp",
+      "robots.txt",
+      "img/image-enlarge/image-opt-out.webp",
+    ];
+    const map = buildAstroCanonicalMap(paths);
+    expect(map.size).toBe(2);
+    expect(map.get("image-wide.webp")).toBe("_astro/image-wide.D1YdccyX_1EtJL4.webp");
+    expect(map.get("image-small.webp")).toBe("_astro/image-small.ABCDEFGH12345678.webp");
+  });
+
+  it("ignores non-_astro paths", () => {
+    const paths = ["robots.txt", "search-index.json", "favicon.ico"];
+    const map = buildAstroCanonicalMap(paths);
+    expect(map.size).toBe(0);
+  });
+
+  it("returns empty map for empty input", () => {
+    const map = buildAstroCanonicalMap([]);
+    expect(map.size).toBe(0);
+  });
+
+  it("last writer wins when two _astro paths canonicalize to the same basename", () => {
+    // Unlikely in practice, but the Map will hold the last one written
+    const paths = [
+      "_astro/image-wide.HASH00001234.webp",
+      "_astro/image-wide.HASH99998765.webp",
+    ];
+    const map = buildAstroCanonicalMap(paths);
+    expect(map.size).toBe(1);
+    expect(map.has("image-wide.webp")).toBe(true);
   });
 });
 

--- a/scripts/migration-check/__tests__/normalize-html.test.ts
+++ b/scripts/migration-check/__tests__/normalize-html.test.ts
@@ -190,6 +190,107 @@ describe("normalizeHtml – CF workerd error overlay stripping", () => {
   });
 });
 
+// ── Astro framework runtime stripping (B-14-1) ───────────────────────────────
+
+describe("normalizeHtml – Astro runtime noise stripping", () => {
+  it("strips the astro-island/astro-slot display:contents style block", () => {
+    const html =
+      '<head><style>astro-island,astro-slot,astro-static-slot{display:contents}</style></head><body><main><p>Content</p></main></body>';
+    const result = normalizeHtml(html);
+    expect(result).not.toContain("astro-island,astro-slot");
+    expect(result).not.toContain("display:contents");
+    expect(result).toContain("<p>Content</p>");
+  });
+
+  it("strips an inline script containing self.Astro", () => {
+    const html =
+      '<main><script>(()=>{var e=async t=>{await(await t())()};(self.Astro||(self.Astro={})).load=e;window.dispatchEvent(new Event("astro:load"));})();</script><p>Content</p></main>';
+    const result = normalizeHtml(html);
+    expect(result).not.toContain("self.Astro");
+    expect(result).toContain("<p>Content</p>");
+  });
+
+  it("strips an inline script containing astro:idle", () => {
+    const html =
+      '<main><script>(()=>{var l=(n,t)=>{window.addEventListener("astro:idle",()=>{})}})();</script><p>Content</p></main>';
+    const result = normalizeHtml(html);
+    expect(result).not.toContain("astro:idle");
+    expect(result).toContain("<p>Content</p>");
+  });
+
+  it("strips an inline script containing astro-island class registration", () => {
+    const html =
+      '<header><script>(()=>{class astro-island extends HTMLElement{}})()</script><nav>Nav</nav></header>';
+    const result = normalizeHtml(html);
+    expect(result).not.toContain("astro-island extends");
+    expect(result).toContain("<nav>Nav</nav>");
+  });
+
+  it("leaves unrelated inline scripts intact", () => {
+    const html = '<script>var x = 1; console.log(x);</script><p>Text</p>';
+    const result = normalizeHtml(html);
+    expect(result).toContain("var x = 1");
+    expect(result).toContain("<p>Text</p>");
+  });
+
+  it("leaves external scripts (with src) intact", () => {
+    const html = '<script src="/app.js"></script><p>Text</p>';
+    const result = normalizeHtml(html);
+    expect(result).toContain('src="/app.js"');
+    expect(result).toContain("<p>Text</p>");
+  });
+
+  it("leaves JSON-LD scripts (with type attribute) intact", () => {
+    const html =
+      '<script type="application/ld+json">{"@type":"WebPage"}</script><p>Text</p>';
+    const result = normalizeHtml(html);
+    expect(result).toContain("application/ld+json");
+    expect(result).toContain("@type");
+  });
+});
+
+// ── Non-breaking whitespace canonicalization (B-14-3) ────────────────────────
+
+describe("normalizeHtml – non-breaking whitespace canonicalization", () => {
+  it("converts &nbsp; entity to plain ASCII space", () => {
+    const html = "<p>#ai&nbsp;(3)</p>";
+    const result = normalizeHtml(html);
+    expect(result).not.toContain("&nbsp;");
+    expect(result).toContain("#ai");
+    expect(result).toContain("(3)");
+  });
+
+  it("converts multiple &nbsp; occurrences", () => {
+    const html = "<p>#ai&nbsp;(3)&nbsp;#cloudflare&nbsp;(2)</p>";
+    const result = normalizeHtml(html);
+    expect(result).not.toContain("&nbsp;");
+  });
+
+  it("is case-insensitive for &NBSP; / &Nbsp;", () => {
+    const html = "<p>foo&NBSP;bar</p>";
+    const result = normalizeHtml(html);
+    expect(result).not.toContain("&NBSP;");
+    expect(result).not.toContain("&nbsp;");
+  });
+
+  it("converts U+00A0 non-breaking space to plain ASCII space", () => {
+    // U+00A0 is the decoded form of &nbsp; — also canonicalize it
+    const html = "<p>tag (5)</p>";
+    const result = normalizeHtml(html);
+    expect(result).not.toContain(" ");
+    expect(result).toContain("tag");
+    expect(result).toContain("(5)");
+  });
+
+  it("preserves other content around &nbsp;", () => {
+    const html = "<span>#ai</span><span>&nbsp;(3)</span>";
+    const result = normalizeHtml(html);
+    expect(result).not.toContain("&nbsp;");
+    expect(result).toContain("#ai");
+    expect(result).toContain("(3)");
+  });
+});
+
 // ── Fixture pair tests ────────────────────────────────────────────────────────
 
 describe("normalizeHtml – fixture pairs", () => {

--- a/scripts/migration-check/__tests__/normalize-html.test.ts
+++ b/scripts/migration-check/__tests__/normalize-html.test.ts
@@ -289,6 +289,24 @@ describe("normalizeHtml – non-breaking whitespace canonicalization", () => {
     expect(result).toContain("#ai");
     expect(result).toContain("(3)");
   });
+
+  it("converts &#160; (decimal NCR for U+00A0) to plain ASCII space", () => {
+    const html = "<p>#ai&#160;(3)</p>";
+    const result = normalizeHtml(html);
+    expect(result).not.toContain("&#160;");
+    expect(result).toContain("#ai (3)");
+  });
+
+  it("converts &#xa0; (hex NCR for U+00A0) to plain ASCII space", () => {
+    const html = "<p>#ai&#xa0;(3)</p><p>#ja&#xA0;(2)</p><p>#en&#x00a0;(1)</p>";
+    const result = normalizeHtml(html);
+    expect(result).not.toContain("&#xa0;");
+    expect(result).not.toContain("&#xA0;");
+    expect(result).not.toContain("&#x00a0;");
+    expect(result).toContain("#ai (3)");
+    expect(result).toContain("#ja (2)");
+    expect(result).toContain("#en (1)");
+  });
 });
 
 // ── Fixture pair tests ────────────────────────────────────────────────────────

--- a/scripts/migration-check/__tests__/strip-version-switcher.test.ts
+++ b/scripts/migration-check/__tests__/strip-version-switcher.test.ts
@@ -1,0 +1,197 @@
+/**
+ * strip-version-switcher.test.ts
+ *
+ * Unit tests for hasVersionSwitcher(), stripVersionSwitcher(), and
+ * maybeStripVersionSwitcher() from lib/strip-version-switcher.mjs.
+ *
+ * Covers:
+ *   - Detection of A-side div.version-switcher marker
+ *   - Detection of B-side div[data-version-switcher] marker
+ *   - Non-detection on pages without a version-switcher
+ *   - Removal of the div element and all its children (button + dropdown ul)
+ *   - Symmetric stripping: A-side and B-side version-switcher markup both fall out
+ *   - Toggle: maybeStripVersionSwitcher is a no-op when enabled=false
+ *   - Edge cases: nested divs inside the switcher, switcher absent
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  hasVersionSwitcher,
+  stripVersionSwitcher,
+  maybeStripVersionSwitcher,
+} from "../lib/strip-version-switcher.mjs";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+// A-side (Astro) inline version-switcher — renders in <main> next to breadcrumb.
+const A_SIDE_VERSION_SWITCHER = `<div class="version-switcher"><button type="button">Version: Latest</button><ul class="hidden"><li><a href="/docs/">Latest</a></li><li><a href="/docs/1.0.0/">1.0.0</a></li><li><a href="/docs/all/">All versions</a></li></ul></div>`;
+
+// B-side (zfb) version-switcher marker using a data attribute.
+const B_SIDE_VERSION_SWITCHER = `<div data-version-switcher><button type="button">Version: Latest</button></div>`;
+
+// A-side switcher with additional classes alongside "version-switcher".
+const A_SIDE_VERSION_SWITCHER_EXTRA_CLASSES = `<div class="relative version-switcher ml-4"><button>Version: Latest</button></div>`;
+
+// ── hasVersionSwitcher ────────────────────────────────────────────────────────
+
+describe("hasVersionSwitcher", () => {
+  it("detects div with class version-switcher (A-side pattern)", () => {
+    expect(hasVersionSwitcher(A_SIDE_VERSION_SWITCHER)).toBe(true);
+  });
+
+  it("detects div with data-version-switcher attribute (B-side pattern)", () => {
+    expect(hasVersionSwitcher(B_SIDE_VERSION_SWITCHER)).toBe(true);
+  });
+
+  it("detects version-switcher even when surrounded by page markup", () => {
+    const html = `<body><main><div class="breadcrumb">Home</div>${A_SIDE_VERSION_SWITCHER}<article>Content</article></main></body>`;
+    expect(hasVersionSwitcher(html)).toBe(true);
+  });
+
+  it("detects version-switcher when class has additional class names", () => {
+    expect(hasVersionSwitcher(A_SIDE_VERSION_SWITCHER_EXTRA_CLASSES)).toBe(true);
+  });
+
+  it("returns false for a plain div without version-switcher markers", () => {
+    const html = `<body><div class="breadcrumb"><a href="/">Home</a></div><main>Content</main></body>`;
+    expect(hasVersionSwitcher(html)).toBe(false);
+  });
+
+  it("returns false when there are no divs at all", () => {
+    const html = `<html><body><main><p>Content</p></main></body></html>`;
+    expect(hasVersionSwitcher(html)).toBe(false);
+  });
+
+  it("returns false for a div with a class that partially matches (not a whole word)", () => {
+    const html = `<div class="version-switcher-wrapper"><button>Version</button></div>`;
+    expect(hasVersionSwitcher(html)).toBe(false);
+  });
+});
+
+// ── stripVersionSwitcher ──────────────────────────────────────────────────────
+
+describe("stripVersionSwitcher", () => {
+  it("removes the entire A-side div.version-switcher including its children", () => {
+    const html = `<body><main><div class="breadcrumb">Home</div>${A_SIDE_VERSION_SWITCHER}<article>Page content</article></main></body>`;
+    const result = stripVersionSwitcher(html);
+    expect(result).not.toContain("version-switcher");
+    expect(result).not.toContain("Version: Latest");
+    expect(result).not.toContain("All versions");
+    expect(result).toContain("<article>Page content</article>");
+    expect(result).toContain('<div class="breadcrumb">Home</div>');
+  });
+
+  it("removes the B-side data-version-switcher div", () => {
+    const html = `<body><main>${B_SIDE_VERSION_SWITCHER}<article>Page content</article></main></body>`;
+    const result = stripVersionSwitcher(html);
+    expect(result).not.toContain("data-version-switcher");
+    expect(result).not.toContain("Version: Latest");
+    expect(result).toContain("<article>Page content</article>");
+  });
+
+  it("leaves the rest of the document intact", () => {
+    const html = `<body><main>${A_SIDE_VERSION_SWITCHER}<h1>Title</h1><p>Body text</p></main></body>`;
+    const result = stripVersionSwitcher(html);
+    expect(result).toBe("<body><main><h1>Title</h1><p>Body text</p></main></body>");
+  });
+
+  it("is a no-op when there is no version-switcher", () => {
+    const html = `<body><main><p>Content</p></main></body>`;
+    expect(stripVersionSwitcher(html)).toBe(html);
+  });
+
+  it("handles nested divs inside the version-switcher without stripping them separately", () => {
+    // The switcher contains a nested dropdown div — depth tracking must handle this.
+    const html = `<body><div class="version-switcher"><div class="dropdown"><div class="item">1.0.0</div></div></div><main>Main</main></body>`;
+    const result = stripVersionSwitcher(html);
+    expect(result).not.toContain("version-switcher");
+    expect(result).not.toContain("dropdown");
+    expect(result).not.toContain("1.0.0");
+    expect(result).toContain("<main>Main</main>");
+  });
+
+  it("strips version-switcher div with additional classes alongside the marker", () => {
+    const html = `<body>${A_SIDE_VERSION_SWITCHER_EXTRA_CLASSES}<main>Main</main></body>`;
+    const result = stripVersionSwitcher(html);
+    expect(result).not.toContain("version-switcher");
+    expect(result).not.toContain("Version: Latest");
+    expect(result).toContain("<main>Main</main>");
+  });
+
+  it("leaves non-version-switcher divs untouched", () => {
+    const html = `<body><div class="breadcrumb"><a href="/">Home</a></div><main>Main</main></body>`;
+    expect(stripVersionSwitcher(html)).toBe(html);
+  });
+
+  it("strips both A-side and B-side shapes in the same document", () => {
+    const html = `<body>${A_SIDE_VERSION_SWITCHER}<main>Hello</main>${B_SIDE_VERSION_SWITCHER}</body>`;
+    const result = stripVersionSwitcher(html);
+    expect(result).not.toContain("version-switcher");
+    expect(result).not.toContain("data-version-switcher");
+    expect(result).not.toContain("Version: Latest");
+    expect(result).toContain("<main>Hello</main>");
+  });
+
+  it("strips multiple version-switcher divs when they appear more than once in a document", () => {
+    // Unlikely in practice but the walker is a loop — verify it removes all occurrences.
+    const html = `<body>${A_SIDE_VERSION_SWITCHER}<main>Middle</main>${A_SIDE_VERSION_SWITCHER}</body>`;
+    const result = stripVersionSwitcher(html);
+    expect(result).not.toContain("version-switcher");
+    expect(result).not.toContain("Version: Latest");
+    expect(result).toContain("<main>Middle</main>");
+  });
+});
+
+// ── maybeStripVersionSwitcher ─────────────────────────────────────────────────
+
+describe("maybeStripVersionSwitcher", () => {
+  const withSwitcherHtml = `<body><main>${A_SIDE_VERSION_SWITCHER}<article>Page content</article></main></body>`;
+  const withoutSwitcherHtml = `<body><main><article>Page content</article></main></body>`;
+
+  it("strips version-switcher when enabled=true and page has version-switcher", () => {
+    const result = maybeStripVersionSwitcher(withSwitcherHtml, true);
+    expect(result).not.toContain("version-switcher");
+    expect(result).not.toContain("Version: Latest");
+    expect(result).toContain("Page content");
+  });
+
+  it("is a no-op when enabled=false even if page has version-switcher", () => {
+    const result = maybeStripVersionSwitcher(withSwitcherHtml, false);
+    expect(result).toBe(withSwitcherHtml);
+  });
+
+  it("is a no-op when enabled=true but no version-switcher present", () => {
+    const result = maybeStripVersionSwitcher(withoutSwitcherHtml, true);
+    expect(result).toBe(withoutSwitcherHtml);
+  });
+
+  it("is a no-op when enabled=false and no version-switcher present", () => {
+    expect(maybeStripVersionSwitcher(withoutSwitcherHtml, false)).toBe(withoutSwitcherHtml);
+  });
+
+  it("symmetric stripping: same version-switcher text disappears from both A and B", () => {
+    // A-side has the inline div.version-switcher with dropdown text.
+    const sideA = `<body><main>${A_SIDE_VERSION_SWITCHER}<article>Doc content</article></main></body>`;
+    // B-side has a simpler data-version-switcher marker (header-only; inline is minimal).
+    const sideB = `<body><main>${B_SIDE_VERSION_SWITCHER}<article>Doc content</article></main></body>`;
+
+    const strippedA = maybeStripVersionSwitcher(sideA, true);
+    const strippedB = maybeStripVersionSwitcher(sideB, true);
+
+    // After stripping, neither side has version-switcher DOM.
+    expect(strippedA).not.toContain("version-switcher");
+    expect(strippedB).not.toContain("data-version-switcher");
+    // Main content is unchanged on both sides.
+    expect(strippedA).toContain("Doc content");
+    expect(strippedB).toContain("Doc content");
+  });
+
+  it("symmetric stripping: A-side without switcher and B-side without switcher both pass through unchanged", () => {
+    // Pages with no version-switcher at all — must be no-ops on both sides.
+    const sideA = `<body><main><article>Doc content</article></main></body>`;
+    const sideB = `<body><main><article>Doc content</article></main></body>`;
+
+    expect(maybeStripVersionSwitcher(sideA, true)).toBe(sideA);
+    expect(maybeStripVersionSwitcher(sideB, true)).toBe(sideB);
+  });
+});

--- a/scripts/migration-check/compare-routes.mjs
+++ b/scripts/migration-check/compare-routes.mjs
@@ -30,6 +30,7 @@ import { fileURLToPath } from "node:url";
 import { normalizeHtml } from "./lib/normalize-html.mjs";
 import { extractSignals } from "./lib/extract-signals.mjs";
 import { maybeStripHiddenSidebar } from "./lib/strip-hidden-sidebar.mjs";
+import { maybeStripVersionSwitcher } from "./lib/strip-version-switcher.mjs";
 import * as config from "./config.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -336,19 +337,28 @@ async function compareRoute({ route, baseA, baseB, sitePrefix }) {
   }
 
   // Normalize and extract signals.
-  // maybeStripHiddenSidebar runs after normalizeHtml so the aside's class
-  // attribute has been sorted/normalised before detection fires.
-  // Stripping is symmetric (both A and B) so the sidebar content falls out
-  // of the diff entirely — see lib/strip-hidden-sidebar.mjs for rationale.
+  // Strip passes run after normalizeHtml so class attributes are sorted/normalised
+  // before detection fires. Stripping is symmetric (both A and B) so the
+  // stripped content falls out of the diff entirely.
+  //   1. maybeStripHiddenSidebar — removes sr-only / mobile-drawer sidebar asides
+  //      (see lib/strip-hidden-sidebar.mjs for rationale).
+  //   2. maybeStripVersionSwitcher — removes the inline version-switcher div
+  //      (see lib/strip-version-switcher.mjs for rationale).
   let sigA, sigB;
   try {
-    const normA = maybeStripHiddenSidebar(
-      normalizeHtml(fetchA.text, { sitePrefix }),
-      config.stripHiddenSidebarDom,
+    const normA = maybeStripVersionSwitcher(
+      maybeStripHiddenSidebar(
+        normalizeHtml(fetchA.text, { sitePrefix }),
+        config.stripHiddenSidebarDom,
+      ),
+      config.stripVersionSwitcherDom,
     );
-    const normB = maybeStripHiddenSidebar(
-      normalizeHtml(fetchB.text, { sitePrefix }),
-      config.stripHiddenSidebarDom,
+    const normB = maybeStripVersionSwitcher(
+      maybeStripHiddenSidebar(
+        normalizeHtml(fetchB.text, { sitePrefix }),
+        config.stripHiddenSidebarDom,
+      ),
+      config.stripVersionSwitcherDom,
     );
     sigA = extractSignals(normA);
     sigB = extractSignals(normB);

--- a/scripts/migration-check/config.mjs
+++ b/scripts/migration-check/config.mjs
@@ -100,3 +100,22 @@ export const cosmeticByDefaultMarkers = [
   "sitemap-route-order",
   "build-hash-filename",
 ];
+
+// ── Known upstream fixes (pending binary rebuild) ─────────────────────────────
+//
+// These are routes that show harness diffs due to a known zfb upstream bug that
+// has been fixed but requires a `cargo build -p zfb` rebuild to take effect.
+// Once the fix is compiled and the binary is re-linked (`pnpm install`), the
+// listed routes should return to parity without any zudo-doc changes.
+//
+// B-14-5 — zfb MDX named-import stripped from rendered output (issue #914)
+//   Root cause: `import { X } from "pkg"` was parsed as a Paragraph because
+//   markdown-rs's MdxjsEsm construct requires `mdx_esm_parse` to be Some.
+//   Without it the `{ X }` binding became an MdxTextExpression evaluating to
+//   `undefined`, leaving a visible double-space skeleton in the page body.
+//   Fix: Takazudo/zudo-front-builder#94 — supply a permissive mdx_esm_parse.
+//   Affected routes (2): /docs/getting-started/setup-preset-generator (EN + JA)
+export const pendingBinaryRebuildRoutes = [
+  "/docs/getting-started/setup-preset-generator",
+  "/ja/docs/getting-started/setup-preset-generator",
+];

--- a/scripts/migration-check/config.mjs
+++ b/scripts/migration-check/config.mjs
@@ -81,6 +81,25 @@ export const sitePrefix = "/pj/zudo-doc/";
  */
 export const stripHiddenSidebarDom = true;
 
+// ── Version-switcher strip ────────────────────────────────────────────────────
+
+/**
+ * Strip the inline version-switcher <div> element from both A and B HTML
+ * before signal extraction.
+ *
+ * Background (phase B-14-2, issue #914):
+ *   A's Astro DocLayout renders <div class="version-switcher"> inline in <main>
+ *   next to the breadcrumb, containing "Version: Latest" button text and a
+ *   hidden dropdown with version links. zfb's host puts the version-switcher
+ *   only in the header. The inline dropdown is cosmetic chrome that is
+ *   functionally redundant with the header switcher, but its text (~45 chars)
+ *   was counted as content-loss on ~30 of 51 affected routes.
+ *
+ *   Default ON for B-14-2 rerun and beyond. Set to false to restore the old
+ *   behaviour where version-switcher text was included in the content comparison.
+ */
+export const stripVersionSwitcherDom = true;
+
 // ── Cosmetic-by-default markers ───────────────────────────────────────────────
 
 /**

--- a/scripts/migration-check/diff-artifacts.mjs
+++ b/scripts/migration-check/diff-artifacts.mjs
@@ -52,6 +52,8 @@ const BINARY_EXTENSIONS = new Set([
   ".jpeg",
   ".gif",
   ".bmp",
+  ".webp",
+  ".svg",
   ".woff",
   ".woff2",
   ".ttf",
@@ -213,6 +215,52 @@ export async function diffBinary(aPath, bPath) {
   };
 }
 
+// ── Astro asset path canonicalization ────────────────────────────────────────
+
+/**
+ * Astro's image pipeline emits content-hashed filenames under /_astro/:
+ *   _astro/<name>.<HASH>.<ext>   e.g. _astro/image-wide.D1YdccyX_1EtJL4.webp
+ *
+ * When a migration moves those images to a stable public path
+ * (e.g. /img/image-enlarge/image-wide.webp), the A and B artifact directories
+ * reference the same content at different relative paths.
+ *
+ * This function strips the hash to produce a canonical basename so the two
+ * sides can be matched.  It only activates for paths whose first segment is
+ * exactly `_astro` and whose filename contains an 8+-char base64url hash
+ * segment.
+ *
+ * @param {string} relPath Relative artifact path
+ * @returns {string | null} Canonical basename (e.g. "image-wide.webp") or null
+ */
+export function extractAstroCanonicalBasename(relPath) {
+  // Require path starts with `_astro/` with no subdirectory (flat filename only)
+  const match = relPath.match(/^_astro\/([^/]+?)\.([A-Za-z0-9_-]{8,})\.([A-Za-z0-9]+)$/);
+  if (!match) return null;
+  return `${match[1]}.${match[3]}`;
+}
+
+/**
+ * Build a Map from canonical basename → relative path for every _astro entry
+ * in the given path list that matches the Astro hash pattern.
+ *
+ * Used to cross-match A-side Astro-hashed paths against B-side public paths
+ * that carry the same image content under a different directory structure.
+ *
+ * @param {string[]} paths List of relative artifact paths
+ * @returns {Map<string, string>} canonical basename → actual relPath
+ */
+export function buildAstroCanonicalMap(paths) {
+  const map = new Map();
+  for (const p of paths) {
+    const canonical = extractAstroCanonicalBasename(p);
+    if (canonical !== null) {
+      map.set(canonical, p);
+    }
+  }
+  return map;
+}
+
 // ── Artifact directory walking ────────────────────────────────────────────────
 
 /**
@@ -277,11 +325,88 @@ export async function diffArtifacts(opts = {}) {
 
   const setA = new Set(pathsA);
   const setB = new Set(pathsB);
-  const allPaths = [...new Set([...pathsA, ...pathsB])].sort();
+
+  // ── Astro cross-matching ─────────────────────────────────────────────────────
+  // A-side images under _astro/<name>.HASH.<ext> may correspond to B-side images
+  // at a stable public path like img/image-enlarge/<name>.<ext>.
+  // Pair them by canonical basename (hash stripped) when exactly one B candidate
+  // shares that basename and neither path has an exact counterpart on the other side.
+
+  const astroCanonicalMapA = buildAstroCanonicalMap(pathsA);
+
+  // Build basename → B paths map (only consider B paths not already in A)
+  const basenameMapB = new Map();
+  for (const p of pathsB) {
+    if (setA.has(p)) continue; // exact match; handled by normal path comparison
+    const bn = p.split("/").at(-1);
+    if (!basenameMapB.has(bn)) basenameMapB.set(bn, []);
+    basenameMapB.get(bn).push(p);
+  }
+
+  // aRelPath → bRelPath for safely cross-matched pairs
+  const astroCrossMatch = new Map();
+  for (const [canonical, aRelPath] of astroCanonicalMapA) {
+    if (setB.has(aRelPath)) continue; // exact path exists in B; no canonicalization needed
+    const bCandidates = basenameMapB.get(canonical) ?? [];
+    if (bCandidates.length === 1) {
+      astroCrossMatch.set(aRelPath, bCandidates[0]);
+    }
+  }
+  const crossMatchedBPaths = new Set(astroCrossMatch.values());
+
+  if (astroCrossMatch.size > 0) {
+    console.log(`[S4] Astro cross-matched ${astroCrossMatch.size} path(s) by canonical basename`);
+  }
+
+  // ── Helper to compare two artifact files ────────────────────────────────────
+  async function compareFiles(type, aFilePath, bFilePath) {
+    if (type === "json") {
+      const [aContent, bContent] = await Promise.all([
+        readFile(aFilePath, "utf8"),
+        readFile(bFilePath, "utf8"),
+      ]);
+      return diffJson(aContent, bContent);
+    } else if (type === "text") {
+      const [aContent, bContent] = await Promise.all([
+        readFile(aFilePath, "utf8"),
+        readFile(bFilePath, "utf8"),
+      ]);
+      return diffText(aContent, bContent);
+    } else if (type === "binary") {
+      return diffBinary(aFilePath, bFilePath);
+    }
+    return null;
+  }
 
   const artifacts = [];
 
-  for (const relPath of allPaths) {
+  // ── Process Astro cross-matched pairs ───────────────────────────────────────
+  for (const [aRelPath, bRelPath] of astroCrossMatch) {
+    const canonical = extractAstroCanonicalBasename(aRelPath);
+    const type = getArtifactType(aRelPath);
+    const comparison = await compareFiles(
+      type,
+      join(artifactsADir, aRelPath),
+      join(artifactsBDir, bRelPath),
+    );
+    artifacts.push({
+      path: canonical,
+      pathA: aRelPath,
+      pathB: bRelPath,
+      presence: "present-in-both",
+      canonicalized: true,
+      type,
+      comparison,
+    });
+  }
+
+  // ── Process remaining paths (exact-path comparison) ──────────────────────────
+  const crossMatchedAPaths = new Set(astroCrossMatch.keys());
+  const remainingPaths = [...new Set([...pathsA, ...pathsB])]
+    .filter((p) => !crossMatchedAPaths.has(p) && !crossMatchedBPaths.has(p))
+    .sort();
+
+  for (const relPath of remainingPaths) {
     const inA = setA.has(relPath);
     const inB = setB.has(relPath);
 
@@ -290,28 +415,18 @@ export async function diffArtifacts(opts = {}) {
     let comparison = null;
 
     if (presence === "present-in-both") {
-      const aPath = join(artifactsADir, relPath);
-      const bPath = join(artifactsBDir, relPath);
-
-      if (type === "json") {
-        const [aContent, bContent] = await Promise.all([
-          readFile(aPath, "utf8"),
-          readFile(bPath, "utf8"),
-        ]);
-        comparison = diffJson(aContent, bContent);
-      } else if (type === "text") {
-        const [aContent, bContent] = await Promise.all([
-          readFile(aPath, "utf8"),
-          readFile(bPath, "utf8"),
-        ]);
-        comparison = diffText(aContent, bContent);
-      } else if (type === "binary") {
-        comparison = await diffBinary(aPath, bPath);
-      }
+      comparison = await compareFiles(
+        type,
+        join(artifactsADir, relPath),
+        join(artifactsBDir, relPath),
+      );
     }
 
     artifacts.push({ path: relPath, presence, type, comparison });
   }
+
+  // Re-sort so cross-matched and exact-path entries are interleaved by path
+  artifacts.sort((a, b) => a.path.localeCompare(b.path));
 
   const stats = {
     total: artifacts.length,

--- a/scripts/migration-check/lib/normalize-html.mjs
+++ b/scripts/migration-check/lib/normalize-html.mjs
@@ -276,6 +276,8 @@ export function normalizeHtml(html, options = {}) {
   //
   // Phase B-14-3, issue #914.
   result = result.replace(/&nbsp;/gi, " ");
+  result = result.replace(/&#160;/g, " "); // decimal numeric character reference for U+00A0
+  result = result.replace(/&#x0*a0;/gi, " "); // hex numeric character reference for U+00A0
   result = result.replace(/\u00a0/g, " "); // U+00A0 NON-BREAKING SPACE -> ASCII SPACE
 
   // ── 3. Process open tags (sort attrs, strip runtime data-*, normalize URLs) ─

--- a/scripts/migration-check/lib/normalize-html.mjs
+++ b/scripts/migration-check/lib/normalize-html.mjs
@@ -204,6 +204,48 @@ export function normalizeHtml(html, options = {}) {
     ""
   );
 
+  // ── 1b. Strip Astro framework runtime inline scripts and style block ──────
+  // Astro emits a display:contents inline <style> for astro-island/astro-slot
+  // elements, plus one or more inline IIFE <script> blocks that register the
+  // Astro runtime namespace (self.Astro, astro:idle, astro:load). These appear
+  // in every Astro page that contains an <astro-island> element (i.e. virtually
+  // every doc page with a Toc/MobileToc/SidebarTree island).
+  //
+  // zfb has no equivalent inline runtime — its islands hydrate via
+  // data-zfb-island markers handled by a single shared external script.
+  // Stripping these elements from both sides (only A has them; B output is a
+  // no-op) eliminates DOM-shape noise from domShapeHash and prevents the
+  // character-by-character typography walker from misinterpreting JS operators
+  // (< / >) as HTML tag boundaries. Conceptually identical to the #701
+  // asset-loss carve-out for Astro-emitted assets.
+  //
+  // Phase B-14-1, issue #914.
+
+  // The astro-island/astro-slot display:contents style block — emitted once per
+  // page whenever any <astro-island> element is present.
+  result = result.replace(
+    /<style[^>]*>\s*astro-island\s*,\s*astro-slot[^<]*<\/style>/gi,
+    ""
+  );
+
+  // Inline <script> bodies that register or invoke the Astro runtime namespace.
+  // Only matches attribute-less <script> tags (Astro runtime scripts never carry
+  // a src= attribute; JSON-LD uses type="application/ld+json" and is unaffected).
+  result = result.replace(
+    /<script>([\s\S]*?)<\/script>/g,
+    (match, body) => {
+      if (
+        body.includes("self.Astro") ||
+        body.includes("astro:idle") ||
+        body.includes("astro:load") ||
+        body.includes("astro-island")
+      ) {
+        return "";
+      }
+      return match;
+    }
+  );
+
   // ── 2. Collapse whitespace between tags, preserve pre/code/textarea ──────
   // Also canonicalize quote / apostrophe typography in text content so the
   // zfb MDX output (literal `&quot;` entity, U+0027 straight apostrophe)
@@ -219,6 +261,22 @@ export function normalizeHtml(html, options = {}) {
       return applyTypographyNormalizationToTextNodes(collapsed);
     })
     .join("");
+
+  // ── 2b. Canonicalize non-breaking whitespace ─────────────────────────────
+  // Tag-listing pages in Astro emit "#tag &nbsp;(N)" while zfb uses a plain
+  // space: "#tag (N)". After HTML entity decoding both are semantically
+  // equivalent, but the raw &nbsp; entity (6 chars) vs ASCII space (1 char)
+  // flips the textHash and can push B's visible-text length below the 95%
+  // content-loss threshold.
+  //
+  // Decode &nbsp; and U+00A0 to plain ASCII space so both sides converge
+  // before signal extraction. The existing whitespace-between-tags collapse
+  // (step 2 above) only handles inter-tag whitespace; text-content &nbsp; is
+  // unaffected by that pass and must be handled explicitly here.
+  //
+  // Phase B-14-3, issue #914.
+  result = result.replace(/&nbsp;/gi, " ");
+  result = result.replace(/\u00a0/g, " "); // U+00A0 NON-BREAKING SPACE -> ASCII SPACE
 
   // ── 3. Process open tags (sort attrs, strip runtime data-*, normalize URLs) ─
   // Tag regex: matches open tags handling quoted attribute values.

--- a/scripts/migration-check/lib/strip-version-switcher.mjs
+++ b/scripts/migration-check/lib/strip-version-switcher.mjs
@@ -1,0 +1,176 @@
+/**
+ * strip-version-switcher.mjs — strip version-switcher DOM before signal extraction.
+ *
+ * Context (phase B-14-2, issue #914):
+ *   A's Astro DocLayout renders <div class="version-switcher"> inline in <main>
+ *   next to the breadcrumb. The element contains a button ("Version: Latest")
+ *   and a hidden <ul> with version links (Latest, 1.0.0, All versions — ~45 chars).
+ *   zfb's host puts the version-switcher only in the header; the inline dropdown
+ *   is cosmetic chrome that is functionally redundant with the header switcher.
+ *
+ *   Coverage: ~30 of 51 content-loss routes have "Version: Latest" in A's main
+ *   extraction, making this the dominant false-positive signal.
+ *
+ *   Strategy: strip version-switcher <div> elements from both A (Astro) and B
+ *   (zfb) HTML before signal extraction. When both sides are stripped
+ *   symmetrically the switcher text ("Version: Latest", "1.0.0", "All versions")
+ *   falls out of the diff entirely. Two markup shapes are stripped:
+ *
+ *   1. **A-side (Astro) div.version-switcher** — `<div class="version-switcher" …>`.
+ *      Emitted inline in <main> by A's DocLayout next to the breadcrumb.
+ *
+ *   2. **B-side marker** — `<div data-version-switcher …>`. Emitted when zfb's
+ *      DocLayout renders its own switcher component; stripped so that any
+ *      incidental inline switcher on B falls out of the diff too.
+ *
+ *   The strip is gated by `enabled` in the run config and only fires when one
+ *   of the two markers is present, so pages without a version-switcher pass
+ *   through untouched.
+ *
+ *   Same pattern as strip-hidden-sidebar.mjs — see that module for the general
+ *   balanced-depth walk rationale.
+ */
+
+// ── Tag-level pattern matchers ────────────────────────────────────────────────
+
+/**
+ * @param {string} tag  A `<div …>` opening tag.
+ * @returns {boolean}   True when the tag's class attribute contains
+ *                      the word "version-switcher" (A-side Astro pattern).
+ */
+function isVersionSwitcherClassTag(tag) {
+  const classMatch = tag.match(/\bclass\s*=\s*"([^"]*)"/i);
+  if (!classMatch) return false;
+  // Split on whitespace and require exact token equality so that
+  // compound class names like "version-switcher-wrapper" are NOT matched.
+  return classMatch[1].split(/\s+/).some((token) => token === "version-switcher");
+}
+
+/**
+ * @param {string} tag  A `<div …>` opening tag.
+ * @returns {boolean}   True when the tag carries a `data-version-switcher`
+ *                      attribute (B-side zfb marker).
+ */
+function isVersionSwitcherDataTag(tag) {
+  return /\bdata-version-switcher\b/i.test(tag);
+}
+
+/**
+ * @param {string} tag  A `<div …>` opening tag.
+ * @returns {boolean}   True when the tag is one of the recognised
+ *                      version-switcher shapes (A-side class OR B-side data
+ *                      attribute).
+ */
+function isVersionSwitcherDivTag(tag) {
+  return isVersionSwitcherClassTag(tag) || isVersionSwitcherDataTag(tag);
+}
+
+// ── Detection ─────────────────────────────────────────────────────────────────
+
+/**
+ * Return true when the HTML contains at least one version-switcher marker —
+ * either a `<div class="… version-switcher …">` (A-side) or a
+ * `<div data-version-switcher …>` (B-side).
+ *
+ * Only `<div>` opening tags are scanned — both known markup shapes use a
+ * `<div>` as the container.
+ *
+ * @param {string} html  Normalized HTML string.
+ * @returns {boolean}
+ */
+export function hasVersionSwitcher(html) {
+  const openTagRe = /<div\b[^>]*>/gi;
+  let match;
+  while ((match = openTagRe.exec(html)) !== null) {
+    if (isVersionSwitcherDivTag(match[0])) return true;
+  }
+  return false;
+}
+
+// ── Stripping ─────────────────────────────────────────────────────────────────
+
+/**
+ * Remove every version-switcher div element from `html`.
+ *
+ * For each `<div …>` opening tag we recognise as a version-switcher (class or
+ * data-attribute shape), splice out the entire balanced element including its
+ * children. Other divs are left intact.
+ *
+ * Uses a balanced-depth walker to correctly handle nested `<div>` elements
+ * inside the switcher (the hidden `<ul>`, button, etc.). This is regex-based
+ * parsing of controlled Astro/zfb output — the existing harness pipeline is
+ * regex-based throughout and we follow that convention.
+ *
+ * @param {string} html  HTML string (normalized or raw).
+ * @returns {string}     HTML with version-switcher div elements removed.
+ */
+export function stripVersionSwitcher(html) {
+  let result = html;
+  let scanFrom = 0;
+
+  while (true) {
+    const openTagRe = /<div\b[^>]*>/gi;
+    openTagRe.lastIndex = scanFrom;
+    const match = openTagRe.exec(result);
+    if (!match) break;
+
+    if (!isVersionSwitcherDivTag(match[0])) {
+      // Not a version-switcher div — skip past this opening tag and keep scanning.
+      scanFrom = match.index + match[0].length;
+      continue;
+    }
+
+    const startIdx = match.index;
+    const afterOpen = startIdx + match[0].length;
+
+    // Walk from afterOpen to find the matching </div>.
+    // Track nesting depth (div-within-div is common inside the switcher dropdown).
+    let depth = 1;
+    const bodyRe = /<\/?div\b[^>]*>/gi;
+    bodyRe.lastIndex = afterOpen;
+
+    let inner;
+    while (depth > 0 && (inner = bodyRe.exec(result)) !== null) {
+      if (inner[0].startsWith("</")) {
+        depth--;
+      } else {
+        depth++;
+      }
+    }
+
+    if (depth !== 0) {
+      // Unbalanced div — leave unchanged to avoid data loss.
+      break;
+    }
+
+    // inner.index points to the start of the closing </div>.
+    const endIdx = inner.index + inner[0].length;
+    result = result.slice(0, startIdx) + result.slice(endIdx);
+
+    // Continue scanning from the splice point — the next div (if any)
+    // starts at or after this position in the rewritten string.
+    scanFrom = startIdx;
+  }
+
+  return result;
+}
+
+// ── Main export ───────────────────────────────────────────────────────────────
+
+/**
+ * Conditionally strip version-switcher div elements from an HTML string.
+ *
+ * When `enabled` is false (or the page does not have any version-switcher
+ * marker), the input is returned unchanged. This makes it safe to call
+ * unconditionally in the pipeline — pages without a version-switcher pass
+ * through untouched.
+ *
+ * @param {string}  html     Normalized HTML.
+ * @param {boolean} enabled  Master toggle (from config.stripVersionSwitcherDom).
+ * @returns {string}         HTML with version-switcher elements removed (or unchanged).
+ */
+export function maybeStripVersionSwitcher(html, enabled) {
+  if (!enabled) return html;
+  if (!hasVersionSwitcher(html)) return html;
+  return stripVersionSwitcher(html);
+}


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/914
    - https://github.com/zudolab/zudo-doc/issues/666 (Phase C parent)
    - https://github.com/zudolab/zudo-doc/issues/663 (Super-epic)

---

## Summary

Five sub-epics that target the dominant remaining residual in the zfb migration parity check. Four are pure harness-side fixes (no host-code change); one is a zfb upstream parser fix shipped as a separate PR with a docs-only marker on the zudo-doc side.

- B-14-1: strip Astro framework runtime (inline `<script>` IIFE, `astro-island/astro-slot{display:contents}` style block) from text extraction in `normalize-html.mjs`. Astro emits this on every page that contains an `<astro-island>` element; zfb has no equivalent. Same shape as the #701 asset-loss carve-out — framework noise should not count as content-loss.
- B-14-2: new `strip-version-switcher.mjs` module mirroring `strip-hidden-sidebar.mjs`. Strips `<div class="version-switcher">` (A-side Astro) and `<div data-version-switcher>` (B-side zfb) on both sides before signal extraction so the inline switcher's `Version: Latest` / `1.0.0` / `All versions` text drops out of the diff. Wired into `compare-routes.mjs` after the existing hidden-sidebar strip pass; gated by `stripVersionSwitcherDom` in `config.mjs` (default true).
- B-14-3: canonicalize `&nbsp;`, `&#160;`, `&#xa0;`, and the literal U+00A0 character to plain ASCII space in `normalize-html.mjs`. Tag-listing pages emit `#tag &nbsp;(N)` on A and `#tag (N)` on B; the byte difference flipped textHash and pushed B's visible-text length below the 95% content-loss threshold on 19 routes.
- B-14-4: canonicalize Astro's content-hashed `/_astro/<basename>.HASH.<ext>` asset URLs in `diff-artifacts.mjs`. After B-13-4 moved the image-enlarge demo assets to `public/img/image-enlarge/*.webp`, A's HTML kept referencing the Astro-optimized hashed path while B references the public path. Now both sides are bucketed by canonical basename so they reconcile as present-in-both. Also fixes `.webp` and `.svg` being missing from `BINARY_EXTENSIONS`.
- B-14-5: upstream zfb fix (PR https://github.com/Takazudo/zudo-front-builder/pull/94) — root cause is `markdown-rs`'s `MdxjsEsm` construct requiring `mdx_esm_parse` to be `Some` before it fires. zfb's `ParseOptions::mdx()` left it as `None`, so `import { Island } from "@takazudo/zfb"` fell through to Paragraph parsing and the `{ Island }` named binding became an `MdxTextExpression` evaluating to `undefined`, producing the visible `import  from "@takazudo/zfb"` skeleton in the rendered page. One-line fix in `mdx_jsx_emit.rs` plus four regression tests. zudo-doc side documents the 2 affected routes (`setup-preset-generator` EN + JA) in `pendingBinaryRebuildRoutes` until the upstream PR merges and the binary is rebuilt.

After Phase B-14 ships and the zfb binary is rebuilt, the post-rerun residual should fit Phase C's `5 < N ≤ 10` band, unblocking the per-page mop-up plan in #666.

## Changes

### Harness (this repo)

- `scripts/migration-check/lib/normalize-html.mjs` — added Astro runtime strip (B-14-1) and whitespace canonicalization (B-14-3) including the additional `&#160;` / `&#xa0;` numeric character references caught in gcoc review.
- `scripts/migration-check/lib/strip-version-switcher.mjs` — new module (B-14-2).
- `scripts/migration-check/compare-routes.mjs` — wired `maybeStripVersionSwitcher` after the existing hidden-sidebar strip.
- `scripts/migration-check/config.mjs` — added `stripVersionSwitcherDom` (B-14-2) and `pendingBinaryRebuildRoutes` (B-14-5).
- `scripts/migration-check/diff-artifacts.mjs` — added `extractAstroCanonicalBasename` and `buildAstroCanonicalMap` (B-14-4); added `.webp` and `.svg` to `BINARY_EXTENSIONS`.
- `scripts/migration-check/__tests__/normalize-html.test.ts` — 14 new tests for runtime strip + whitespace canonicalization.
- `scripts/migration-check/__tests__/strip-version-switcher.test.ts` — 22 new tests for the new module.
- `scripts/migration-check/__tests__/diff-artifacts.test.ts` — 4 new tests for the asset-path canonicalization.

### zfb upstream (separate repo)

- See https://github.com/Takazudo/zudo-front-builder/pull/94 — `crates/zfb-content/src/mdx_jsx_emit.rs` supplies a permissive `mdx_esm_parse` so all `import`/`export` lines are classified as `MdxjsEsm` nodes. 4 regression tests added; full 211-test zfb suite green.

## Test Plan

Local verification (manager already ran):

- `pnpm vitest run scripts/migration-check/__tests__/normalize-html.test.ts scripts/migration-check/__tests__/strip-version-switcher.test.ts scripts/migration-check/__tests__/diff-artifacts.test.ts` — 112 unit tests pass (43 + 22 + 47 across the three files after the gcoc-review follow-up commit).

Migration-check rerun (deferred to Phase C):

- After this epic merges into the super-epic base AND zfb upstream PR #94 ships AND the local zfb binary is rebuilt (`cargo build -p zfb` + `pnpm install`), rerun the migration-check harness on the same revision pair as the round-7 / round-8 inputs.
- Acceptance gate from #914:
    - B-14-1 + B-14-3 should drop ≥38 + 19 = ~57 content-loss routes.
    - B-14-2 should drop the ~30-route `Version: Latest` cluster.
    - B-14-4 should drop the 2 image-enlarge routes from non-carve-out asset-loss.
    - B-14-5 should drop the 2 setup-preset-generator routes once the binary is rebuilt.
- Phase C inline-acceptance gate: residual content-loss + non-carve-out asset-loss ≤ 10.

## CI

The Type Check / Build Site / E2E Tests checks fail on this PR with `sh: 1: zfb: not found`. This is a pre-existing CI infrastructure issue affecting the entire `base/zfb-migration-parity` super-epic — the same failure pattern is present on every prior epic-PR and on the super-epic base itself. Phase B-14 does not introduce any new CI breakage. Build Doc History and Template Drift Check both pass.