### PR TITLE
feat(b14-5): fix zfb MDX named-import rendering — upstream fix + harness config

### DIFF
--- a/scripts/migration-check/config.mjs
+++ b/scripts/migration-check/config.mjs
@@ -100,3 +100,22 @@ export const cosmeticByDefaultMarkers = [
   "sitemap-route-order",
   "build-hash-filename",
 ];
+
+// ── Known upstream fixes (pending binary rebuild) ─────────────────────────────
+//
+// These are routes that show harness diffs due to a known zfb upstream bug that
+// has been fixed but requires a `cargo build -p zfb` rebuild to take effect.
+// Once the fix is compiled and the binary is re-linked (`pnpm install`), the
+// listed routes should return to parity without any zudo-doc changes.
+//
+// B-14-5 — zfb MDX named-import stripped from rendered output (issue #914)
+//   Root cause: `import { X } from "pkg"` was parsed as a Paragraph because
+//   markdown-rs's MdxjsEsm construct requires `mdx_esm_parse` to be Some.
+//   Without it the `{ X }` binding became an MdxTextExpression evaluating to
+//   `undefined`, leaving a visible double-space skeleton in the page body.
+//   Fix: Takazudo/zudo-front-builder#94 — supply a permissive mdx_esm_parse.
+//   Affected routes (2): /docs/getting-started/setup-preset-generator (EN + JA)
+export const pendingBinaryRebuildRoutes = [
+  "/docs/getting-started/setup-preset-generator",
+  "/ja/docs/getting-started/setup-preset-generator",
+];


### PR DESCRIPTION
## Summary

- Identifies and fixes a zfb upstream parser bug: `import { X } from "pkg"` was rendered as a visible paragraph in the page body instead of being stripped
- Opens upstream PR Takazudo/zudo-front-builder#94 with the fix
- Documents the 2 affected routes in `scripts/migration-check/config.mjs` as `pendingBinaryRebuildRoutes`

## Root Cause

`markdown-rs`'s `MdxjsEsm` construct has a guard: it only activates when `mdx_esm_parse` is `Some`. `ParseOptions::mdx()` left this as `None`, so import statements with named bindings (`{ X }`) fell through to Paragraph parsing. The `{ X }` became an `MdxTextExpression` evaluating to `undefined` at runtime, leaving a double-space skeleton `import  from "pkg"` in the rendered body.

## Fix (upstream, Path A)

Takazudo/zudo-front-builder#94 — supplies a permissive `mdx_esm_parse` that always returns `Ok`. SWC handles ESM validation in the bundler step; all we need here is for import/export lines to be classified as `MdxjsEsm` nodes so the emitter silently drops them.

Four regression tests added:
- `esm_default_import_is_stripped`
- `esm_named_import_is_stripped` (the failing case)
- `esm_two_consecutive_imports_are_stripped` (exact setup-preset-generator pattern)
- `esm_export_statement_is_stripped`

## zudo-doc2 Change

Added `pendingBinaryRebuildRoutes` export to `scripts/migration-check/config.mjs` with context comment. Once the zfb PR merges and the binary is rebuilt (`cargo build -p zfb` + `pnpm install`), these 2 routes will reach parity without any further zudo-doc changes.

Affected routes (2):
- `/docs/getting-started/setup-preset-generator`
- `/ja/docs/getting-started/setup-preset-generator`

Closes #914