### PR TITLE
fix(migration-check): extend strip-toc-heading to cover Toc-island suffix (C-3 residual)

### DIFF
--- a/scripts/migration-check/__tests__/strip-toc-heading.test.ts
+++ b/scripts/migration-check/__tests__/strip-toc-heading.test.ts
@@ -41,6 +41,11 @@ const H3_JA = `<h3>目次</h3>`;
 const wrap = (mainContent: string, extraOutsideMain = "") =>
   `<body>${extraOutsideMain}<main>${mainContent}</main></body>`;
 
+// C-3 residual pattern: heading appears in the Toc island AFTER </main>,
+// not inside <main>. zfb's desktop Toc island emits the heading; Astro's does not.
+const wrapWithSuffix = (mainContent: string, suffix: string) =>
+  `<body><main>${mainContent}</main>${suffix}</body>`;
+
 // ── hasTocHeading ─────────────────────────────────────────────────────────────
 
 describe("hasTocHeading", () => {
@@ -97,6 +102,26 @@ describe("hasTocHeading", () => {
 
   it("detects JA heading even when wrapped in a span with a class", () => {
     expect(hasTocHeading(wrap(H2_JA_SPAN))).toBe(true);
+  });
+
+  // C-3 residual: heading in the Toc island AFTER </main>.
+  // zfb's desktop Toc island renders <h2>On this page</h2> / <h2>目次</h2>
+  // outside <main>; Astro's Toc does not emit this heading at all.
+  it("detects EN heading in suffix after </main> — C-3 residual Toc-island pattern", () => {
+    const suffix = `<div data-zfb-island="Toc"><nav>${H2_EN}<ul><li>§1</li></ul></nav></div>`;
+    expect(hasTocHeading(wrapWithSuffix("<p>Body</p>", suffix))).toBe(true);
+  });
+
+  it("detects JA heading in suffix after </main> — C-3 residual Toc-island pattern", () => {
+    const suffix = `<div data-zfb-island="Toc"><nav>${H2_JA}<ul><li>§1</li></ul></nav></div>`;
+    expect(hasTocHeading(wrapWithSuffix("<p>本文</p>", suffix))).toBe(true);
+  });
+
+  it("returns false when matching h2 is only before <main> (prefix is excluded)", () => {
+    // Heading before <main> must not trigger hasTocHeading to avoid false positives
+    // on site headers. (The before-main prefix is not a stripped region.)
+    const html = `<body>${H2_EN}<main><p>Content</p></main></body>`;
+    expect(hasTocHeading(html)).toBe(false);
   });
 });
 
@@ -205,6 +230,54 @@ describe("stripTocHeading", () => {
     expect(stripTocHeading(sideA)).toBe(sideA);
     expect(stripTocHeading(sideB)).toBe(sideB);
   });
+
+  // C-3 residual: heading in the Toc island AFTER </main>.
+  it("strips EN TOC h2 in suffix after </main> — C-3 residual Toc-island pattern", () => {
+    const suffix = `<div data-zfb-island="Toc"><nav>${H2_EN}<ul><li>§1</li></ul></nav></div>`;
+    const html = wrapWithSuffix("<article>Doc</article>", suffix);
+    const result = stripTocHeading(html);
+    expect(result).not.toContain("On this page");
+    expect(result).toContain("<article>Doc</article>");
+    expect(result).toContain("<ul><li>§1</li></ul>");
+  });
+
+  it("strips JA TOC h2 in suffix after </main> — C-3 residual Toc-island pattern", () => {
+    const suffix = `<div data-zfb-island="Toc"><nav>${H2_JA}<ul><li>§1</li></ul></nav></div>`;
+    const html = wrapWithSuffix("<article>本文</article>", suffix);
+    const result = stripTocHeading(html);
+    expect(result).not.toContain("目次");
+    expect(result).toContain("<article>本文</article>");
+    expect(result).toContain("<ul><li>§1</li></ul>");
+  });
+
+  it("does NOT strip h2 before <main> even when text matches (prefix is excluded)", () => {
+    // Site-header headings before <main> must be left intact.
+    const html = `<body>${H2_EN}<main><article>Content</article></main></body>`;
+    const result = stripTocHeading(html);
+    expect(result).toContain("On this page");
+    expect(result).toContain("<article>Content</article>");
+  });
+
+  it("C-3 symmetric: A-side (no Toc h2) and B-side (Toc island suffix) converge after strip", () => {
+    // A (Astro) — Toc island emits no h2 heading.
+    const sideA = wrapWithSuffix(
+      "<article>Doc</article>",
+      `<div data-zfb-island="Toc"><nav><ul><li>§1</li></ul></nav></div>`,
+    );
+    // B (zfb) — Toc island emits <h2>On this page</h2> outside <main>.
+    const sideB = wrapWithSuffix(
+      "<article>Doc</article>",
+      `<div data-zfb-island="Toc"><nav>${H2_EN}<ul><li>§1</li></ul></nav></div>`,
+    );
+
+    const strippedA = stripTocHeading(sideA);
+    const strippedB = stripTocHeading(sideB);
+
+    expect(strippedA).not.toContain("On this page");
+    expect(strippedB).not.toContain("On this page");
+    expect(strippedA).toContain("Doc");
+    expect(strippedB).toContain("Doc");
+  });
 });
 
 // ── maybeStripTocHeading ──────────────────────────────────────────────────────
@@ -259,5 +332,41 @@ describe("maybeStripTocHeading", () => {
     expect(strippedB).not.toContain("目次");
     expect(strippedA).toContain("コンテンツ");
     expect(strippedB).toContain("コンテンツ");
+  });
+
+  // C-3 residual: heading in suffix after </main> (Toc island outside main).
+  it("C-3: strips Toc-island suffix heading when enabled=true", () => {
+    const suffix = `<div data-zfb-island="Toc"><nav>${H2_EN}<ul><li>§1</li></ul></nav></div>`;
+    const html = wrapWithSuffix("<article>Content</article>", suffix);
+    const result = maybeStripTocHeading(html, true);
+    expect(result).not.toContain("On this page");
+    expect(result).toContain("Content");
+  });
+
+  it("C-3: is a no-op for suffix heading when enabled=false", () => {
+    const suffix = `<div data-zfb-island="Toc"><nav>${H2_JA}<ul><li>§1</li></ul></nav></div>`;
+    const html = wrapWithSuffix("<article>本文</article>", suffix);
+    expect(maybeStripTocHeading(html, false)).toBe(html);
+  });
+
+  it("C-3 symmetric: A-side passes through, B-side suffix heading stripped", () => {
+    // A (Astro) — Toc island has no h2.
+    const sideA = wrapWithSuffix(
+      "<article>Doc</article>",
+      `<div data-zfb-island="Toc"><nav><ul><li>§1</li></ul></nav></div>`,
+    );
+    // B (zfb) — Toc island suffix emits <h2>目次</h2> outside main.
+    const sideB = wrapWithSuffix(
+      "<article>Doc</article>",
+      `<div data-zfb-island="Toc"><nav>${H2_JA}<ul><li>§1</li></ul></nav></div>`,
+    );
+
+    const strippedA = maybeStripTocHeading(sideA, true);
+    const strippedB = maybeStripTocHeading(sideB, true);
+
+    expect(strippedA).not.toContain("目次");
+    expect(strippedB).not.toContain("目次");
+    expect(strippedA).toContain("Doc");
+    expect(strippedB).toContain("Doc");
   });
 });

--- a/scripts/migration-check/lib/strip-toc-heading.mjs
+++ b/scripts/migration-check/lib/strip-toc-heading.mjs
@@ -1,5 +1,5 @@
 /**
- * strip-toc-heading.mjs — strip in-content TOC heading before signal extraction.
+ * strip-toc-heading.mjs — strip TOC heading before signal extraction.
  *
  * Context (phase B-15-2, issue #917):
  *   zfb's DocLayout emits an in-content <h2>On this page</h2> (EN) /
@@ -13,11 +13,24 @@
  *   falls out of the diff entirely — routes that were clean except for this
  *   heading are reclassified as identical.
  *
- *   Only h2 elements inside <main> are stripped. h2s outside main, h2s with
- *   different text (including partial matches like "On this page only"), and
- *   h3s with the same text are left untouched. Text matching is exact after
- *   trimming and stripping inner tags — a <span> or similar wrapper around
- *   the text content is handled transparently.
+ *   Two placement variants are normalized (see hasTocHeading / stripTocHeading):
+ *
+ *   1. Inside <main> (B-15 pattern): the dominant case where zfb DocLayout
+ *      emits the heading adjacent to the MobileToc island inside the main
+ *      content area. h2s outside main and h2s with non-matching text are
+ *      left intact. Text matching is exact after trimming and stripping inner
+ *      tags — a <span> wrapper around the text content is handled transparently.
+ *
+ *   2. After </main> in the suffix (C-3 residual, phase C): zfb's desktop Toc
+ *      island itself emits <h2>On this page</h2> / <h2>目次</h2> in the
+ *      sidebar column outside <main>. Astro's Toc component does not emit
+ *      this heading at all, so the diff is framework-asymmetric. 4 routes
+ *      (/ja/docs/claude-skills, /ja/docs/components/mermaid-diagrams,
+ *      /v/1.0/docs/getting-started/installation,
+ *      /v/1.0/ja/docs/getting-started/installation) hit this pattern.
+ *
+ *   h2s before <main> (e.g. in the site header) are never stripped to avoid
+ *   false positives.
  *
  *   The strip is gated by `enabled` in the run config so pages without a
  *   TOC heading pass through untouched.
@@ -171,12 +184,19 @@ function stripTocH2sFrom(fragment) {
 // ── Detection ─────────────────────────────────────────────────────────────────
 
 /**
- * Return true when the HTML contains at least one in-content TOC h2 heading
- * inside <main> — either "On this page" (EN) or "目次" (JA).
+ * Return true when the HTML contains at least one TOC h2 heading — either
+ * "On this page" (EN) or "目次" (JA) — in any of the stripped regions:
  *
- * Only h2 elements inside the first <main> element are checked. h2s outside
- * main are ignored. Text matching is exact after stripping inner tags and
- * trimming — a <span> wrapper around the text does not prevent detection.
+ *   1. Inside <main>: the dominant B-15 pattern where zfb DocLayout emitted
+ *      the heading adjacent to the MobileToc island inside the main content
+ *      area.
+ *   2. After </main> (suffix): the C-3 residual pattern where zfb's Toc island
+ *      itself emits <h2>On this page</h2> / <h2>目次</h2> in the desktop
+ *      sidebar column, which sits outside <main>. Astro's Toc component does
+ *      not emit this heading at all, so the diff is framework-asymmetric.
+ *
+ * h2s before <main> (e.g. in the site header) are intentionally excluded to
+ * avoid false positives.
  *
  * @param {string} html  Normalized HTML string.
  * @returns {boolean}
@@ -184,26 +204,36 @@ function stripTocH2sFrom(fragment) {
 export function hasTocHeading(html) {
   const bounds = findMainInnerBounds(html);
   if (!bounds) return false;
-  return fragmentHasTocH2(html.slice(bounds.innerStart, bounds.innerEnd));
+  // Check inside <main> (B-15 pattern).
+  if (fragmentHasTocH2(html.slice(bounds.innerStart, bounds.innerEnd))) return true;
+  // Also check the suffix after </main> (C-3 residual: Toc island outside main).
+  return fragmentHasTocH2(html.slice(bounds.innerEnd));
 }
 
 // ── Stripping ─────────────────────────────────────────────────────────────────
 
 /**
- * Remove in-content TOC h2 headings from the <main> element of `html`.
+ * Remove TOC h2 headings from `html`, covering two distinct placement patterns:
  *
- * Strips every `<h2>On this page</h2>` (EN) and `<h2>目次</h2>` (JA)
- * element found inside <main>. Text matching is exact after stripping inner
- * tags and trimming — a <span> or other inline wrapper around the text
- * content is handled transparently. h2 elements outside <main> and h2s with
- * non-matching text are left intact.
+ *   1. Inside <main> (B-15 pattern) — zfb DocLayout emitted the heading
+ *      adjacent to the MobileToc island inside the main content area.
+ *   2. After </main> in the suffix (C-3 residual pattern) — zfb's desktop Toc
+ *      island emits `<h2>On this page</h2>` / `<h2>目次</h2>` as a sidebar
+ *      heading outside <main>. Astro's Toc component does not emit this
+ *      heading at all (text matching falls outside the sidebar nav entirely),
+ *      so the diff is framework-asymmetric and must be normalized.
+ *
+ * Text matching is exact after stripping inner tags and trimming — a <span>
+ * or other inline wrapper around the text content is handled transparently.
+ * h2 elements before <main> (site header area) are left intact to avoid
+ * false positives.
  *
  * Uses the same regex-based parsing approach as the rest of the harness
  * (see strip-version-switcher.mjs for the general rationale). This is safe
  * for the controlled Astro/zfb HTML output that the harness processes.
  *
  * @param {string} html  HTML string (normalized or raw).
- * @returns {string}     HTML with in-content TOC h2 elements removed.
+ * @returns {string}     HTML with TOC h2 elements removed from both regions.
  */
 export function stripTocHeading(html) {
   const bounds = findMainInnerBounds(html);
@@ -212,9 +242,11 @@ export function stripTocHeading(html) {
   const { innerStart, innerEnd } = bounds;
   const prefix = html.slice(0, innerStart);
   const mainContent = html.slice(innerStart, innerEnd);
+  // suffix starts from the </main> tag itself; strip covers the Toc island
+  // sidebar that zfb renders immediately after </main>.
   const suffix = html.slice(innerEnd);
 
-  return prefix + stripTocH2sFrom(mainContent) + suffix;
+  return prefix + stripTocH2sFrom(mainContent) + stripTocH2sFrom(suffix);
 }
 
 // ── Main export ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Extends `hasTocHeading` and `stripTocHeading` in `scripts/migration-check/lib/strip-toc-heading.mjs` to also normalize TOC h2 headings found in the document suffix (after `</main>`), covering the C-3 residual pattern
- Adds 10 new test cases for the C-3 suffix pattern (45 total, all pass)
- Updates module-level JSDoc to document both placement patterns (B-15 inside-main and C-3 suffix)

## Root Cause

Phase B-15 cleared the dominant cluster where zfb emitted `<h2>On this page</h2>` / `<h2>目次</h2>` **inside** `<main>`. Four residual routes hit a different code path: zfb's desktop Toc island emits that heading **outside** `<main>` in the sidebar column after `</main>`. Astro's Toc component never emits this heading at all, so the diff is framework-asymmetric and cannot resolve itself.

Affected routes:
- `/ja/docs/claude-skills`
- `/ja/docs/components/mermaid-diagrams`
- `/v/1.0/docs/getting-started/installation`
- `/v/1.0/ja/docs/getting-started/installation`

The existing strip rule only scanned inside `<main>`, so `hasTocHeading` returned false for these routes and `maybeStripTocHeading` short-circuited without stripping.

## Fix

Extended the two public functions:

**`hasTocHeading`** — now checks both inside `<main>` (B-15) and the suffix after `</main>` (C-3). h2s before `<main>` (site header) are still excluded to prevent false positives.

**`stripTocHeading`** — now applies `stripTocH2sFrom` to both `mainContent` and the `suffix`. The exact-match requirement (`TOC_HEADING_TEXTS = ["On this page", "目次"]`) ensures other suffix h2s (e.g. `AI Assistant`) are left intact.

## Test Plan

- [x] 10 new test cases added covering: suffix detection (EN + JA), suffix stripping (EN + JA), prefix exclusion, symmetric A/B convergence for `stripTocHeading` and `maybeStripTocHeading`
- [x] All 45 tests pass (`pnpm exec vitest run scripts/migration-check/__tests__/strip-toc-heading.test.ts`)
- [x] gcoc light review: no bugs or logic errors found

🤖 Generated with [Claude Code](https://claude.com/claude-code)