### PR TITLE
feat(zfb): wire doc-history+search-index+llms-txt via postBuild hooks

### DIFF
--- a/packages/zudo-doc-v2/package.json
+++ b/packages/zudo-doc-v2/package.json
@@ -127,6 +127,7 @@
     "preact": "*"
   },
   "dependencies": {
+    "@zudo-doc/doc-history-server": "workspace:*",
     "gray-matter": "^4.0.3"
   },
   "devDependencies": {

--- a/packages/zudo-doc-v2/src/integrations/search-index/build-emitter.ts
+++ b/packages/zudo-doc-v2/src/integrations/search-index/build-emitter.ts
@@ -6,8 +6,8 @@
 
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { collectSearchEntries } from "./collect";
-import type { SearchIndexConfig, SearchIndexEntry } from "./types";
+import { collectSearchEntries } from "./collect.ts";
+import type { SearchIndexConfig, SearchIndexEntry } from "./types.ts";
 
 export interface SearchIndexBuildResult {
   /** Absolute path of the JSON file that was written. */

--- a/packages/zudo-doc-v2/src/integrations/search-index/collect.ts
+++ b/packages/zudo-doc-v2/src/integrations/search-index/collect.ts
@@ -11,12 +11,12 @@ import {
   parseMarkdownFile,
   slugToUrl,
   stripMarkdown,
-} from "./content-files";
+} from "./content-files.ts";
 import {
   MAX_BODY_LENGTH,
   type SearchIndexConfig,
   type SearchIndexEntry,
-} from "./types";
+} from "./types.ts";
 
 function truncateBody(text: string): string {
   return text.length > MAX_BODY_LENGTH

--- a/packages/zudo-doc-v2/src/integrations/search-index/dev-middleware.ts
+++ b/packages/zudo-doc-v2/src/integrations/search-index/dev-middleware.ts
@@ -8,11 +8,11 @@
 // future zfb-native dev server with no glue.
 
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { collectSearchEntries } from "./collect";
+import { collectSearchEntries } from "./collect.ts";
 import {
   SEARCH_INDEX_ROUTE,
   type SearchIndexConfig,
-} from "./types";
+} from "./types.ts";
 
 export type SearchIndexNextFn = (err?: unknown) => void;
 

--- a/packages/zudo-doc-v2/src/integrations/search-index/index.ts
+++ b/packages/zudo-doc-v2/src/integrations/search-index/index.ts
@@ -12,23 +12,27 @@
 // in `./types`, the worker continues to serve server-side search
 // unchanged. Nothing in this integration touches the Worker bundle.
 
-export { emitSearchIndex } from "./build-emitter";
+// Note: relative imports keep the explicit `.ts` extension so the
+// runtime ESM loader (Node's native TS support, used by zfb's plugin
+// host) can resolve them without a TS-aware loader. Matches the
+// sibling `llms-txt/index.ts` convention.
+export { emitSearchIndex } from "./build-emitter.ts";
 export type {
   SearchIndexBuildOptions,
   SearchIndexBuildResult,
-} from "./build-emitter";
-export { collectSearchEntries } from "./collect";
-export { createSearchIndexDevMiddleware } from "./dev-middleware";
+} from "./build-emitter.ts";
+export { collectSearchEntries } from "./collect.ts";
+export { createSearchIndexDevMiddleware } from "./dev-middleware.ts";
 export type {
   SearchIndexMiddleware,
   SearchIndexNextFn,
-} from "./dev-middleware";
+} from "./dev-middleware.ts";
 export {
   MAX_BODY_LENGTH,
   SEARCH_INDEX_ROUTE,
-} from "./types";
+} from "./types.ts";
 export type {
   SearchIndexConfig,
   SearchIndexEntry,
   SearchIndexLocaleConfig,
-} from "./types";
+} from "./types.ts";

--- a/plugins/doc-history-plugin.mjs
+++ b/plugins/doc-history-plugin.mjs
@@ -1,0 +1,29 @@
+// zfb plugin module: doc-history.
+//
+// Wires `runDocHistoryPostBuild` (from `@zudo-doc/zudo-doc-v2/integrations/doc-history`)
+// into zfb's `postBuild` lifecycle hook. Replaces the npm `postbuild`-script
+// glue in `scripts/zfb-postbuild.mjs` for this step (the script remains in
+// place during the merge window — T6 retires it).
+//
+// `options` carries `{ docsDir, locales }` as supplied by the matching
+// entry in `zfb.config.ts`'s `integrationPlugins` array. The runner
+// internally honours `SKIP_DOC_HISTORY=1` (returns early with an info
+// log on `ctx.logger`).
+//
+// Inline functions are not supported by zfb's plugin runtime — see
+// `@takazudo/zfb/plugins` source comment ("Inline functions are NOT
+// supported"). Plugins must be authored as standalone modules and
+// referenced from `zfb.config.ts` by `name`.
+
+import { runDocHistoryPostBuild } from "@zudo-doc/zudo-doc-v2/integrations/doc-history";
+
+export default {
+  name: "doc-history",
+  async postBuild(ctx) {
+    const { docsDir, locales } = ctx.options;
+    await runDocHistoryPostBuild(
+      { docsDir, locales },
+      { outDir: ctx.outDir, logger: ctx.logger },
+    );
+  },
+};

--- a/plugins/llms-txt-plugin.mjs
+++ b/plugins/llms-txt-plugin.mjs
@@ -1,0 +1,40 @@
+// zfb plugin module: llms-txt.
+//
+// Wires `emitLlmsTxt` (from `@zudo-doc/zudo-doc-v2/integrations/llms-txt`)
+// into zfb's `postBuild` lifecycle hook. Replaces the npm `postbuild`-script
+// glue in `scripts/zfb-postbuild.mjs` for this step.
+//
+// `options` carries `{ siteName, siteDescription, base, siteUrl,
+// defaultLocaleDir, locales }` from the matching entry in
+// `zfb.config.ts`. `siteUrl` is normalised to `undefined` when falsy
+// because the runner switches between absolute and root-relative URLs
+// based on its presence (matches legacy Astro behaviour).
+//
+// Inline functions are not supported by zfb's plugin runtime; see the
+// sibling `doc-history-plugin.mjs` for the rationale.
+
+import { emitLlmsTxt } from "@zudo-doc/zudo-doc-v2/integrations/llms-txt";
+
+export default {
+  name: "llms-txt",
+  postBuild(ctx) {
+    const {
+      siteName,
+      siteDescription,
+      base,
+      siteUrl,
+      defaultLocaleDir,
+      locales,
+    } = ctx.options;
+    emitLlmsTxt({
+      outDir: ctx.outDir,
+      siteName,
+      siteDescription,
+      base,
+      siteUrl: siteUrl || undefined,
+      defaultLocaleDir,
+      locales,
+      logger: ctx.logger,
+    });
+  },
+};

--- a/plugins/search-index-plugin.mjs
+++ b/plugins/search-index-plugin.mjs
@@ -1,0 +1,28 @@
+// zfb plugin module: search-index.
+//
+// Wires `emitSearchIndex` (from `@zudo-doc/zudo-doc-v2/integrations/search-index`)
+// into zfb's `postBuild` lifecycle hook. Replaces the npm `postbuild`-script
+// glue in `scripts/zfb-postbuild.mjs` for this step.
+//
+// `options` carries `{ docsDir, locales, base }` from the matching entry
+// in `zfb.config.ts`. There is no settings gate — `emitSearchIndex` is
+// always emitted, matching the legacy Astro behaviour.
+//
+// Inline functions are not supported by zfb's plugin runtime; see the
+// sibling `doc-history-plugin.mjs` for the rationale.
+
+import { emitSearchIndex } from "@zudo-doc/zudo-doc-v2/integrations/search-index";
+
+export default {
+  name: "search-index",
+  postBuild(ctx) {
+    const { docsDir, locales, base } = ctx.options;
+    emitSearchIndex({
+      outDir: ctx.outDir,
+      docsDir,
+      locales,
+      base,
+      logger: ctx.logger,
+    });
+  },
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,6 +310,9 @@ importers:
 
   packages/zudo-doc-v2:
     dependencies:
+      '@zudo-doc/doc-history-server':
+        specifier: workspace:*
+        version: link:../doc-history-server
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3

--- a/zfb.config.ts
+++ b/zfb.config.ts
@@ -149,19 +149,32 @@ if (settings.versions) {
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
-// Plugins — declarative breadcrumbs for the v0 plugin runtime.
+// Plugins — wired through zfb's plugin lifecycle (issue #101 / 4b16b32).
 // ---------------------------------------------------------------------------
 //
-// zfb v0 accepts `plugins: PluginConfig[]` as `{ name, options }` metadata
-// only — no lifecycle hooks fire today. The host wires the actual work via
-// npm-script lifecycle hooks (`scripts/zfb-prebuild.mjs` for claude-resources,
-// `scripts/zfb-postbuild.mjs` for doc-history / search-index / llms-txt) and
-// a dev sidecar (S3) for the dev-mode middlewares.
+// zfb's plugin runtime loads each entry's `name` as a module specifier
+// (npm bare or `./`-relative path) and dispatches lifecycle hooks
+// (`preBuild`, `postBuild`, `devMiddleware`) on the module's default
+// export. Inline function hooks on this config are NOT supported — the
+// config goes through a JSON round-trip to the Rust side and any
+// function value would be silently dropped (see `@takazudo/zfb/plugins`
+// source comment for the rationale). Each entry below therefore
+// references a small wrapper module under `./plugins/` whose default
+// export is a `ZfbPlugin`.
 //
-// The entries below are forward-compat breadcrumbs: once zfb adopts plugin
-// lifecycle hooks the script glue can be retired and these descriptors will
-// pick up the matching `runClaudeResourcesPreStep` / `runDocHistoryPostBuild`
-// / `emitSearchIndex` / `emitLlmsTxt` runners automatically.
+// postBuild wiring (this commit) — doc-history / search-index / llms-txt
+// emit their dist-time artifacts via the wrapper modules' `postBuild`
+// hook. The legacy `scripts/zfb-postbuild.mjs` npm-script glue stays in
+// place during the merge window so the two paths co-run idempotently;
+// the script is retired in a sibling topic once all three lifecycle
+// epics land.
+//
+// preBuild wiring (sibling topic) — claude-resources and doc-history-meta
+// add `preBuild` hooks to their respective wrapper modules.
+//
+// devMiddleware wiring (sibling topic) — doc-history / search-index /
+// llms-txt all gain `devMiddleware` registrations on the same wrapper
+// modules so the dev sidecar can be retired.
 //
 // Sitemap is NOT in this list — it is served as a `pages/sitemap.xml.tsx`
 // zfb route (per ADR-005's "non-HTML page" pattern) introduced in epic E8.
@@ -190,7 +203,7 @@ const integrationPlugins = [
   ...(settings.docHistory
     ? [
         {
-          name: "doc-history",
+          name: "./plugins/doc-history-plugin.mjs",
           options: {
             docsDir: settings.docsDir,
             locales: localeRecord,
@@ -199,7 +212,7 @@ const integrationPlugins = [
       ]
     : []),
   {
-    name: "search-index",
+    name: "./plugins/search-index-plugin.mjs",
     options: {
       docsDir: settings.docsDir,
       locales: localeRecord,
@@ -209,7 +222,7 @@ const integrationPlugins = [
   ...(settings.llmsTxt
     ? [
         {
-          name: "llms-txt",
+          name: "./plugins/llms-txt-plugin.mjs",
           options: {
             siteName: settings.siteName,
             siteDescription: settings.siteDescription,

--- a/zfb.config.ts
+++ b/zfb.config.ts
@@ -1,3 +1,16 @@
+/**
+ * zfb pin (canonical, shared with E2/E4):
+ *   commit: 4b16b32 (Takazudo/zudo-front-builder main, 2026-05-01)
+ *   includes fixes:
+ *     - zudolab/zfb#99  (ViewTransitions runtime + meta injection)
+ *     - zudolab/zfb#100 (404 convention: emit dist/404.html at root)
+ *     - zudolab/zfb#101 (plugin lifecycle hooks: preBuild, postBuild, devMiddleware)
+ *     - zudolab/zfb#102 (CJK-aware emphasis/strong tokenisation in MDX pipeline)
+ *     - zudolab/zfb#103 (ResolveLinksPlugin: probe extensionless candidates)
+ *     - zudolab/zfb#104 (rehype output parity: heading-links, code-title, mermaid, image-enlarge, strip-md-ext)
+ *   pinned by: epic zudolab/zudo-doc#1334 (super-epic #1333)
+ */
+
 // zfb.config.ts — entry-point config consumed by the zfb engine.
 //
 // This file replaces the Astro-flavoured `src/content.config.ts` while the


### PR DESCRIPTION
## Summary

- Create three standalone wrapper plugin modules under `plugins/` (`doc-history-plugin.mjs`, `search-index-plugin.mjs`, `llms-txt-plugin.mjs`), each exporting a `ZfbPlugin` with a `postBuild` hook that calls the matching runner from `@zudo-doc/zudo-doc-v2`.
- Update `zfb.config.ts` plugin entries to reference the wrapper modules by relative path (`./plugins/...`) instead of bare specifier breadcrumbs. Update the comment block to document the rationale (inline functions unsupported via JSON round-trip in zfb's config loader).
- Fix Node 24 TS native-loader compatibility: add explicit `.ts` extensions to relative imports in `packages/zudo-doc-v2/src/integrations/search-index/` (four files).
- Add `@zudo-doc/doc-history-server: workspace:*` to `packages/zudo-doc-v2` dependencies so `createRequire` inside the doc-history integration can resolve the server binary via pnpm symlinks.

The legacy `scripts/zfb-postbuild.mjs` npm-script glue stays in place during the merge window; the two paths run idempotently. The script is retired in T6.

## Verification

Normal build: `dist/doc-history/` (~20 files), `dist/search-index.json`, `dist/llms.txt`, `dist/llms-full.txt`, `dist/ja/llms.txt`, `dist/ja/llms-full.txt` — all present.

With `SKIP_DOC_HISTORY=1`: doc-history absent, search-index and llms-txt outputs still emitted.

## Test plan

- [ ] Run `pnpm exec zfb build` — verify all three artifact groups appear in `dist/`
- [ ] Run `SKIP_DOC_HISTORY=1 pnpm exec zfb build` — verify `dist/doc-history/` is absent, `dist/search-index.json` and `dist/llms.txt` still present
- [ ] Inspect `dist/search-index.json` — should be ~111 KB with doc entries for both locales
- [ ] Inspect `dist/llms.txt` and `dist/ja/llms.txt` — should list all doc pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)