### PR TITLE
feat(zfb): wire doc-history+search-index+llms-txt via devMiddleware hooks (T5)

### DIFF
--- a/packages/zudo-doc-v2/src/integrations/llms-txt/dev-middleware.ts
+++ b/packages/zudo-doc-v2/src/integrations/llms-txt/dev-middleware.ts
@@ -1,0 +1,168 @@
+// Dev-time middleware: serve `/llms.txt`, `/llms-full.txt`, and the
+// per-locale `/<code>/llms.txt` / `/<code>/llms-full.txt` variants from
+// the on-the-fly `generateLlmsTxt` / `generateLlmsFullTxt` generators.
+//
+// The body is rebuilt per request so content edits surface without
+// restarting the dev server, mirroring the `searchIndex` middleware's
+// "live" behaviour. Production output (`emitLlmsTxt`) walks the same
+// loader so dev and build stay byte-for-byte aligned.
+//
+// The signature is the standard Connect/Vite middleware shape (`req`,
+// `res`, `next`) so the handler plugs into Vite, Connect, Express,
+// Node `http`, or a future zfb-native dev server with no glue. The
+// factory was lifted out of the host-repo `scripts/dev-sidecar.mjs`
+// when the sidecar process was retired in favour of zfb's
+// `devMiddleware` plugin lifecycle hook (epic zudolab/zudo-doc#1334).
+//
+// The factory is shaped exactly like `createDocHistoryDevMiddleware`
+// and `createSearchIndexDevMiddleware`: one input options struct, an
+// optional logger, returns a Connect-style handler. That symmetry is
+// what lets the host's three plugin modules share a single Connect→
+// zfb-handler adapter.
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+import { generateLlmsFullTxt, generateLlmsTxt } from "./generate.ts";
+import { loadDocEntries } from "./load.ts";
+import type {
+  LlmsTxtLocaleConfig,
+  LlmsTxtSiteMeta,
+} from "./types.ts";
+
+/** Connect-style middleware signature — works as a Vite plugin middleware. */
+export type LlmsTxtNextFn = (err?: unknown) => void;
+
+export type LlmsTxtMiddleware = (
+  req: IncomingMessage,
+  res: ServerResponse,
+  next: LlmsTxtNextFn,
+) => void;
+
+/** Minimal logger surface used by the middleware on generation failure. */
+export interface LlmsTxtMiddlewareLogger {
+  warn(msg: string): void;
+}
+
+/**
+ * Build-time + dev-time options. Mirrors {@link LlmsTxtEmitOptions}
+ * minus the `outDir` field (the dev middleware never writes to disk)
+ * so callers can hand a single options object to both `emitLlmsTxt`
+ * (build) and `createLlmsTxtDevMiddleware` (dev).
+ */
+export interface LlmsTxtDevMiddlewareOptions extends LlmsTxtSiteMeta {
+  /** URL base used when materialising per-page links. */
+  base: string;
+  /** Optional absolute site URL; see `LlmsTxtLoadOptions.siteUrl`. */
+  siteUrl?: string;
+  /** Default-locale content directory. */
+  defaultLocaleDir: string;
+  /** Additional locales (e.g. `[{ code: "ja", dir: "src/content/docs-ja" }]`). */
+  locales?: LlmsTxtLocaleConfig[];
+}
+
+/** Public route suffixes the middleware recognises. */
+const LLMS_KIND_PATTERN = /^(?:\/(.+?))?\/(llms|llms-full)\.txt$/;
+
+/**
+ * Build a dev-server middleware that responds to GET requests for
+ * `/llms.txt`, `/llms-full.txt`, `/<code>/llms.txt`, and
+ * `/<code>/llms-full.txt`. Unknown locale prefixes fall through (the
+ * chain returns 404), avoiding collisions with future routes that
+ * might share the `/<thing>/llms.txt` shape.
+ *
+ * Every request rebuilds the entries from disk — the same pattern the
+ * sibling `searchIndex` middleware uses — so authoring loops surface
+ * content edits without a dev-server restart.
+ */
+export function createLlmsTxtDevMiddleware(
+  options: LlmsTxtDevMiddlewareOptions,
+  logger?: LlmsTxtMiddlewareLogger,
+): LlmsTxtMiddleware {
+  const meta: LlmsTxtSiteMeta = {
+    siteName: options.siteName,
+    siteDescription: options.siteDescription,
+  };
+  // Build the set of recognised locale codes once so the matcher can
+  // validate the prefix against `options.locales` without a repeat
+  // lookup on every request.
+  const localeCodes = new Set((options.locales ?? []).map((l) => l.code));
+  const localeDirByCode = new Map(
+    (options.locales ?? []).map((l) => [l.code, l.dir] as const),
+  );
+  const base = options.base ?? "";
+  const siteUrl = options.siteUrl || undefined;
+
+  return (req, res, next) => {
+    const url = req.url ?? "";
+    const match = matchLlmsRoute(url, localeCodes);
+    if (!match) {
+      next();
+      return;
+    }
+
+    // Reject non-GET to mirror static-file semantics.
+    if (req.method && req.method !== "GET" && req.method !== "HEAD") {
+      res.statusCode = 405;
+      res.setHeader("Content-Type", "text/plain; charset=utf-8");
+      res.end("Method Not Allowed");
+      return;
+    }
+
+    try {
+      const contentDir =
+        match.locale === null
+          ? options.defaultLocaleDir
+          : localeDirByCode.get(match.locale);
+      if (contentDir === undefined) {
+        // Defensive: locale code was in `localeCodes` but we couldn't
+        // find its dir. Should be impossible given the maps were built
+        // from the same source.
+        res.statusCode = 404;
+        res.setHeader("Content-Type", "text/plain; charset=utf-8");
+        res.end("Not Found");
+        return;
+      }
+      const entries = loadDocEntries({
+        contentDir,
+        locale: match.locale,
+        base,
+        siteUrl,
+      });
+      const body =
+        match.kind === "llms"
+          ? generateLlmsTxt(entries, meta)
+          : generateLlmsFullTxt(entries, meta);
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "text/plain; charset=utf-8");
+      res.end(body);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger?.warn(`llms-txt generation failed: ${msg}`);
+      res.statusCode = 500;
+      res.setHeader("Content-Type", "text/plain; charset=utf-8");
+      res.end("Internal Server Error");
+    }
+  };
+}
+
+/**
+ * Match `/llms.txt`, `/llms-full.txt`, `/<locale>/llms.txt`, or
+ * `/<locale>/llms-full.txt`. Returns `{ kind, locale }` or null.
+ *
+ * Strips the query string before matching so a `?cache-bust=…`
+ * suffix doesn't break the route. The locale segment is validated
+ * against the supplied set so unknown prefixes fall through.
+ */
+function matchLlmsRoute(
+  url: string,
+  localeCodes: Set<string>,
+): { kind: "llms" | "llms-full"; locale: string | null } | null {
+  const pathname = url.split("?")[0];
+  const m = pathname.match(LLMS_KIND_PATTERN);
+  if (!m) return null;
+  const prefix = m[1];
+  const kind = m[2] as "llms" | "llms-full";
+  if (prefix === undefined) return { kind, locale: null };
+  if (localeCodes.has(prefix)) return { kind, locale: prefix };
+  return null;
+}

--- a/packages/zudo-doc-v2/src/integrations/llms-txt/index.ts
+++ b/packages/zudo-doc-v2/src/integrations/llms-txt/index.ts
@@ -25,6 +25,13 @@
  * the strings directly without touching the filesystem twice.
  */
 
+export { createLlmsTxtDevMiddleware } from "./dev-middleware.ts";
+export type {
+  LlmsTxtDevMiddlewareOptions,
+  LlmsTxtMiddleware,
+  LlmsTxtMiddlewareLogger,
+  LlmsTxtNextFn,
+} from "./dev-middleware.ts";
 export { emitLlmsTxt } from "./emit.ts";
 export {
   generateLlmsFullTxt,

--- a/packages/zudo-doc-v2/src/integrations/search-index/build-emitter.ts
+++ b/packages/zudo-doc-v2/src/integrations/search-index/build-emitter.ts
@@ -6,8 +6,8 @@
 
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { collectSearchEntries } from "./collect";
-import type { SearchIndexConfig, SearchIndexEntry } from "./types";
+import { collectSearchEntries } from "./collect.ts";
+import type { SearchIndexConfig, SearchIndexEntry } from "./types.ts";
 
 export interface SearchIndexBuildResult {
   /** Absolute path of the JSON file that was written. */

--- a/packages/zudo-doc-v2/src/integrations/search-index/collect.ts
+++ b/packages/zudo-doc-v2/src/integrations/search-index/collect.ts
@@ -11,12 +11,12 @@ import {
   parseMarkdownFile,
   slugToUrl,
   stripMarkdown,
-} from "./content-files";
+} from "./content-files.ts";
 import {
   MAX_BODY_LENGTH,
   type SearchIndexConfig,
   type SearchIndexEntry,
-} from "./types";
+} from "./types.ts";
 
 function truncateBody(text: string): string {
   return text.length > MAX_BODY_LENGTH

--- a/packages/zudo-doc-v2/src/integrations/search-index/dev-middleware.ts
+++ b/packages/zudo-doc-v2/src/integrations/search-index/dev-middleware.ts
@@ -8,11 +8,11 @@
 // future zfb-native dev server with no glue.
 
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { collectSearchEntries } from "./collect";
+import { collectSearchEntries } from "./collect.ts";
 import {
   SEARCH_INDEX_ROUTE,
   type SearchIndexConfig,
-} from "./types";
+} from "./types.ts";
 
 export type SearchIndexNextFn = (err?: unknown) => void;
 

--- a/packages/zudo-doc-v2/src/integrations/search-index/index.ts
+++ b/packages/zudo-doc-v2/src/integrations/search-index/index.ts
@@ -12,23 +12,23 @@
 // in `./types`, the worker continues to serve server-side search
 // unchanged. Nothing in this integration touches the Worker bundle.
 
-export { emitSearchIndex } from "./build-emitter";
+export { emitSearchIndex } from "./build-emitter.ts";
 export type {
   SearchIndexBuildOptions,
   SearchIndexBuildResult,
-} from "./build-emitter";
-export { collectSearchEntries } from "./collect";
-export { createSearchIndexDevMiddleware } from "./dev-middleware";
+} from "./build-emitter.ts";
+export { collectSearchEntries } from "./collect.ts";
+export { createSearchIndexDevMiddleware } from "./dev-middleware.ts";
 export type {
   SearchIndexMiddleware,
   SearchIndexNextFn,
-} from "./dev-middleware";
+} from "./dev-middleware.ts";
 export {
   MAX_BODY_LENGTH,
   SEARCH_INDEX_ROUTE,
-} from "./types";
+} from "./types.ts";
 export type {
   SearchIndexConfig,
   SearchIndexEntry,
   SearchIndexLocaleConfig,
-} from "./types";
+} from "./types.ts";

--- a/plugins/zfb-plugins/claude-resources.mjs
+++ b/plugins/zfb-plugins/claude-resources.mjs
@@ -1,0 +1,15 @@
+// zfb plugin module — claude-resources.
+//
+// Stub created so the plugin name resolves at config-load time (zfb's
+// config-loader resolves every `plugins[i].name` to an absolute module
+// specifier; an unresolvable name aborts dev / build before the plugin
+// host even spawns). The actual `preBuild` hook that runs the
+// claude-resources copier is owned by sibling epic task T3 — that task
+// edits this file to add the matching exported function. T5 only
+// touches `devMiddleware` (the doc-history / search-index / llms-txt
+// trio); claude-resources has no dev middleware, so this module is a
+// no-op for now.
+
+export default {
+  name: "claude-resources",
+};

--- a/plugins/zfb-plugins/connect-adapter.mjs
+++ b/plugins/zfb-plugins/connect-adapter.mjs
@@ -1,0 +1,144 @@
+// Adapter from Connect-style middleware (`(req, res, next) => void`) to
+// the request-response shape zfb's `devMiddleware` lifecycle hook
+// expects (`(req: ZfbDevMiddlewareRequest) => Promise<ZfbDevMiddlewareResponse | undefined>`).
+//
+// zfb's plugin host runs in a separate Node subprocess and only sees a
+// JSON envelope of the request — `{ method, url, headers, body? }` —
+// not real Node IPC. The adapter mocks just enough of `IncomingMessage`
+// and `ServerResponse` for the v2 integration middlewares (which were
+// written against Node's `http` types) to think they are talking to a
+// regular HTTP server, then captures the response status / headers /
+// body and returns them in the shape the host expects.
+//
+// The adapter is shared by every plugin module under this directory so
+// any future Connect-style middleware can be wired into zfb's
+// devMiddleware hook without rewriting it. Lives at the host repo —
+// the v2 integration package keeps its Connect-style API surface so
+// non-zfb embedders (Astro, plain Vite, a unit test) continue to work.
+
+import { Buffer } from "node:buffer";
+
+/**
+ * Convert a Connect-style middleware to a zfb devMiddleware handler.
+ * The returned async function takes a `ZfbDevMiddlewareRequest` and
+ * returns either `undefined` (passthrough — zfb falls through to its
+ * built-in routes) or a `ZfbDevMiddlewareResponse` envelope.
+ *
+ * Behaviour:
+ *
+ *   - `next()` from the middleware → resolves with `undefined`
+ *     (passthrough).
+ *   - `res.end(body)` → resolves with `{ status, headers, body }`.
+ *     `status` defaults to 200 if the middleware didn't set one,
+ *     mirroring Node's `ServerResponse` default.
+ *   - `next(err)` or a thrown error → rejects so the host surfaces a
+ *     500 with the error message the same way it does for any other
+ *     plugin throw.
+ *   - Binary bodies (Buffer / Uint8Array) → encoded as base64 and
+ *     flagged `bodyEncoding: "base64"` so the JSON envelope round-trip
+ *     stays loss-less.
+ */
+export function connectToZfbHandler(middleware) {
+  return (zfbReq) => {
+    return new Promise((resolveResponse, rejectResponse) => {
+      // Build a minimal `IncomingMessage` shim. Only the fields the v2
+      // integration middlewares actually read are populated — `method`,
+      // `url`, and `headers`. Body parsing is not used by any of the
+      // three middlewares (they're all GET routes), so we leave the
+      // stream surface unimplemented.
+      const req = {
+        method: zfbReq.method,
+        url: zfbReq.url,
+        headers: zfbReq.headers ?? {},
+      };
+
+      // Build a `ServerResponse` shim that captures status, headers,
+      // and body. We expose the API surface the v2 middlewares touch
+      // today (`statusCode`, `setHeader`, `getHeader`, `end`) — extend
+      // here if a future middleware needs more.
+      let statusCode = 200;
+      const headers = {};
+      let settled = false;
+
+      const finish = (body) => {
+        if (settled) return;
+        settled = true;
+        // Lower-case header names so the host's response shape matches
+        // axum's expectation (`Record<string, string>` of arbitrary
+        // case). Last-wins on collision; with `setHeader` callers this
+        // shouldn't happen.
+        const normalisedHeaders = {};
+        for (const [k, v] of Object.entries(headers)) {
+          normalisedHeaders[k.toLowerCase()] = String(v);
+        }
+
+        if (Buffer.isBuffer(body) || body instanceof Uint8Array) {
+          resolveResponse({
+            status: statusCode,
+            headers: normalisedHeaders,
+            body: Buffer.from(body).toString("base64"),
+            bodyEncoding: "base64",
+          });
+          return;
+        }
+        resolveResponse({
+          status: statusCode,
+          headers: normalisedHeaders,
+          body: body == null ? "" : String(body),
+          bodyEncoding: "utf8",
+        });
+      };
+
+      const res = {
+        get statusCode() {
+          return statusCode;
+        },
+        set statusCode(v) {
+          statusCode = v;
+        },
+        setHeader(name, value) {
+          headers[name] = value;
+        },
+        getHeader(name) {
+          // Header lookup is case-insensitive in Node's real
+          // ServerResponse — mirror that so middlewares that probe an
+          // existing header before overwriting it (`if
+          // (!res.getHeader("Content-Type"))`) keep working.
+          const lower = name.toLowerCase();
+          for (const [k, v] of Object.entries(headers)) {
+            if (k.toLowerCase() === lower) return v;
+          }
+          return undefined;
+        },
+        get headersSent() {
+          return settled;
+        },
+        end(body) {
+          finish(body);
+        },
+      };
+
+      const next = (err) => {
+        if (settled) return;
+        if (err) {
+          settled = true;
+          rejectResponse(err instanceof Error ? err : new Error(String(err)));
+          return;
+        }
+        // Connect's `next()` with no error means "I did not handle
+        // this request". Resolve with `undefined` so zfb's host
+        // surfaces a passthrough.
+        settled = true;
+        resolveResponse(undefined);
+      };
+
+      try {
+        middleware(req, res, next);
+      } catch (err) {
+        if (settled) return;
+        settled = true;
+        rejectResponse(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+  };
+}

--- a/plugins/zfb-plugins/doc-history.mjs
+++ b/plugins/zfb-plugins/doc-history.mjs
@@ -1,0 +1,36 @@
+// zfb plugin module — doc-history.
+//
+// Wires `@zudo-doc/zudo-doc-v2/integrations/doc-history`'s Connect-style
+// dev middleware into zfb's `devMiddleware` lifecycle hook (Sub 3 /
+// issue zudolab/zfb#101). The middleware reverse-proxies
+// `/doc-history/*` requests to the standalone
+// `@zudo-doc/doc-history-server` running on port 4322.
+//
+// Sibling plugin modules (search-index.mjs, llms-txt.mjs) follow the
+// same shape: import the v2 integration's Connect-style factory, adapt
+// it to zfb's request-response handler shape, register it on the
+// matching path prefix.
+//
+// Pre / post-build lifecycle hooks for this plugin are owned by sibling
+// epic tasks (T3 adds `preBuild` for the doc-history-meta JSON write,
+// T4 adds `postBuild` for the inline history generation). Those tasks
+// edit this file to add the matching exported functions; T5 only owns
+// `devMiddleware`.
+
+import { createDocHistoryDevMiddleware } from "@zudo-doc/zudo-doc-v2/integrations/doc-history";
+
+import { connectToZfbHandler } from "./connect-adapter.mjs";
+
+export default {
+  name: "doc-history",
+  devMiddleware(ctx) {
+    const middleware = createDocHistoryDevMiddleware(ctx.options, ctx.logger);
+    // The Connect middleware itself filters on the `/doc-history/`
+    // substring; we still register on `/doc-history` so zfb only
+    // dispatches matching requests through the JSON-envelope round-
+    // trip. zfb's `register(path, handler)` is exact-prefix: the
+    // single registration covers `/doc-history` and `/doc-history/foo`
+    // alike.
+    ctx.register("/doc-history", connectToZfbHandler(middleware));
+  },
+};

--- a/plugins/zfb-plugins/llms-txt.mjs
+++ b/plugins/zfb-plugins/llms-txt.mjs
@@ -1,0 +1,37 @@
+// zfb plugin module — llms-txt.
+//
+// Wires `@zudo-doc/zudo-doc-v2/integrations/llms-txt`'s Connect-style
+// dev middleware into zfb's `devMiddleware` lifecycle hook (Sub 3 /
+// issue zudolab/zfb#101). The middleware serves `/llms.txt`,
+// `/llms-full.txt`, and the per-locale `/<code>/llms.txt` /
+// `/<code>/llms-full.txt` variants from the on-the-fly `generateLlmsTxt`
+// generator so dev output stays in lockstep with the production
+// `emitLlmsTxt` byte-for-byte.
+//
+// `postBuild` (the build-time `emitLlmsTxt` call) is owned by sibling
+// epic task T4 — that task edits this file to add the matching
+// exported function; T5 only owns `devMiddleware`.
+
+import { createLlmsTxtDevMiddleware } from "@zudo-doc/zudo-doc-v2/integrations/llms-txt";
+
+import { connectToZfbHandler } from "./connect-adapter.mjs";
+
+export default {
+  name: "llms-txt",
+  devMiddleware(ctx) {
+    const middleware = createLlmsTxtDevMiddleware(ctx.options, ctx.logger);
+    const handler = connectToZfbHandler(middleware);
+
+    // zfb's `register(path, handler)` is exact-prefix, so register
+    // every route the v2 middleware recognises. The middleware itself
+    // does the real matching — these registrations just tell zfb which
+    // paths to round-trip through this plugin (so the dev server
+    // doesn't 404 before the middleware runs).
+    ctx.register("/llms.txt", handler);
+    ctx.register("/llms-full.txt", handler);
+    for (const locale of ctx.options.locales ?? []) {
+      ctx.register(`/${locale.code}/llms.txt`, handler);
+      ctx.register(`/${locale.code}/llms-full.txt`, handler);
+    }
+  },
+};

--- a/plugins/zfb-plugins/search-index.mjs
+++ b/plugins/zfb-plugins/search-index.mjs
@@ -1,0 +1,28 @@
+// zfb plugin module — search-index.
+//
+// Wires `@zudo-doc/zudo-doc-v2/integrations/search-index`'s Connect-
+// style dev middleware into zfb's `devMiddleware` lifecycle hook (Sub
+// 3 / issue zudolab/zfb#101). The middleware rebuilds the in-memory
+// search index from disk on every request so authoring edits surface
+// without a dev-server restart.
+//
+// `postBuild` (the build-time `emitSearchIndex` call) is owned by
+// sibling epic task T4 — that task edits this file to add the matching
+// exported function; T5 only owns `devMiddleware`.
+
+import { createSearchIndexDevMiddleware } from "@zudo-doc/zudo-doc-v2/integrations/search-index";
+
+import { connectToZfbHandler } from "./connect-adapter.mjs";
+
+export default {
+  name: "search-index",
+  devMiddleware(ctx) {
+    const middleware = createSearchIndexDevMiddleware(ctx.options);
+    // `register` is exact-prefix; the v2 middleware itself accepts any
+    // URL ending in `/search-index.json` (so a `base`-prefixed dev
+    // server still works), but a `/search-index.json` registration is
+    // sufficient because the dev server canonicalises the request URL
+    // before dispatch.
+    ctx.register("/search-index.json", connectToZfbHandler(middleware));
+  },
+};

--- a/zfb.config.ts
+++ b/zfb.config.ts
@@ -149,19 +149,25 @@ if (settings.versions) {
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
-// Plugins — declarative breadcrumbs for the v0 plugin runtime.
+// Plugins — wired through zfb's lifecycle hooks (Sub 3 / zfb#101).
 // ---------------------------------------------------------------------------
 //
-// zfb v0 accepts `plugins: PluginConfig[]` as `{ name, options }` metadata
-// only — no lifecycle hooks fire today. The host wires the actual work via
-// npm-script lifecycle hooks (`scripts/zfb-prebuild.mjs` for claude-resources,
-// `scripts/zfb-postbuild.mjs` for doc-history / search-index / llms-txt) and
-// a dev sidecar (S3) for the dev-mode middlewares.
+// Each entry is a `{ name, options }` descriptor where `name` is a path-
+// relative specifier that zfb's config loader resolves against the project
+// root and the plugin host imports via dynamic `import()`. The plugin
+// modules under `./plugins/zfb-plugins/` export a [`ZfbPlugin`] default with
+// the matching lifecycle hooks (`preBuild`, `postBuild`, `devMiddleware`).
 //
-// The entries below are forward-compat breadcrumbs: once zfb adopts plugin
-// lifecycle hooks the script glue can be retired and these descriptors will
-// pick up the matching `runClaudeResourcesPreStep` / `runDocHistoryPostBuild`
-// / `emitSearchIndex` / `emitLlmsTxt` runners automatically.
+// Today's hook coverage:
+//
+//   - **devMiddleware** — `doc-history`, `search-index`, `llms-txt` mount
+//     their Connect-style dev middlewares on the zfb dev server, replacing
+//     the standalone `scripts/dev-sidecar.mjs` (port 4323) the v0 era ran.
+//     Sibling epic task T6 retires the sidecar script + its npm entry
+//     point in a follow-up commit.
+//   - **preBuild** / **postBuild** — owned by sibling tasks T3 and T4. The
+//     interim npm-script glue (`scripts/zfb-prebuild.mjs`,
+//     `scripts/zfb-postbuild.mjs`) keeps running until those tasks land.
 //
 // Sitemap is NOT in this list — it is served as a `pages/sitemap.xml.tsx`
 // zfb route (per ADR-005's "non-HTML page" pattern) introduced in epic E8.
@@ -178,7 +184,7 @@ const integrationPlugins = [
   ...(settings.claudeResources
     ? [
         {
-          name: "claude-resources",
+          name: "./plugins/zfb-plugins/claude-resources.mjs",
           options: {
             claudeDir: settings.claudeResources.claudeDir,
             projectRoot: settings.claudeResources.projectRoot,
@@ -190,7 +196,7 @@ const integrationPlugins = [
   ...(settings.docHistory
     ? [
         {
-          name: "doc-history",
+          name: "./plugins/zfb-plugins/doc-history.mjs",
           options: {
             docsDir: settings.docsDir,
             locales: localeRecord,
@@ -199,7 +205,7 @@ const integrationPlugins = [
       ]
     : []),
   {
-    name: "search-index",
+    name: "./plugins/zfb-plugins/search-index.mjs",
     options: {
       docsDir: settings.docsDir,
       locales: localeRecord,
@@ -209,7 +215,7 @@ const integrationPlugins = [
   ...(settings.llmsTxt
     ? [
         {
-          name: "llms-txt",
+          name: "./plugins/zfb-plugins/llms-txt.mjs",
           options: {
             siteName: settings.siteName,
             siteDescription: settings.siteDescription,

--- a/zfb.config.ts
+++ b/zfb.config.ts
@@ -1,3 +1,16 @@
+/**
+ * zfb pin (canonical, shared with E2/E4):
+ *   commit: 4b16b32 (Takazudo/zudo-front-builder main, 2026-05-01)
+ *   includes fixes:
+ *     - zudolab/zfb#99  (ViewTransitions runtime + meta injection)
+ *     - zudolab/zfb#100 (404 convention: emit dist/404.html at root)
+ *     - zudolab/zfb#101 (plugin lifecycle hooks: preBuild, postBuild, devMiddleware)
+ *     - zudolab/zfb#102 (CJK-aware emphasis/strong tokenisation in MDX pipeline)
+ *     - zudolab/zfb#103 (ResolveLinksPlugin: probe extensionless candidates)
+ *     - zudolab/zfb#104 (rehype output parity: heading-links, code-title, mermaid, image-enlarge, strip-md-ext)
+ *   pinned by: epic zudolab/zudo-doc#1334 (super-epic #1333)
+ */
+
 // zfb.config.ts — entry-point config consumed by the zfb engine.
 //
 // This file replaces the Astro-flavoured `src/content.config.ts` while the


### PR DESCRIPTION
## Summary

Implements **Task 5** of the `zfb-migration-finalisation-lifecycle` epic: mounting three dev-time middlewares directly on the zfb dev server via its new `devMiddleware` plugin lifecycle hook.

- Creates `plugins/zfb-plugins/connect-adapter.mjs` — shared adapter from Connect-style `(req, res, next)` middleware to zfb's `(ZfbDevMiddlewareRequest) => ZfbDevMiddlewareResponse` handler shape; handles binary (base64) and text bodies
- Creates `plugins/zfb-plugins/doc-history.mjs` — registers `/doc-history` prefix via `createDocHistoryDevMiddleware`
- Creates `plugins/zfb-plugins/search-index.mjs` — registers `/search-index.json` via `createSearchIndexDevMiddleware`
- Creates `plugins/zfb-plugins/llms-txt.mjs` — registers `/llms.txt`, `/llms-full.txt`, and per-locale `/<code>/llms.txt` + `/<code>/llms-full.txt` via new `createLlmsTxtDevMiddleware`
- Creates `plugins/zfb-plugins/claude-resources.mjs` — stub module so the name resolves; T3 adds `preBuild`
- Updates `zfb.config.ts` — all plugin `name` fields updated from bare specifiers to `./plugins/zfb-plugins/*.mjs` paths; comment block rewritten to explain plugin module pattern
- Adds `packages/zudo-doc-v2/src/integrations/llms-txt/dev-middleware.ts` — new Connect-style factory with per-request locale rebuilding
- Fixes `.ts` extensions on relative imports across search-index integration (Node 24 ESM requirement)

## Architecture note

`PluginConfig` in zfb is data-only (`{ name, options? }`) — functions are dropped in the JSON round-trip to Rust. Plugin logic lives in separate module files resolved by `config-loader.mjs`, not inline callbacks.

## Key decisions

- **Connect-style API preserved** in v2 integration packages — non-zfb embedders (Astro, plain Vite, unit tests) continue to work unchanged. The adapter only lives at the host repo level.
- **`plugins/zfb-plugins/` subdirectory** to separate devMiddleware plugins (T5) from the postBuild plugins T4 placed at `plugins/` root; T6's consolidation pass will unify.
- **Per-request llms-txt rebuild** in dev middleware — avoids stale content during `pnpm dev` without needing a file watcher.

## Test plan

- [x] `pnpm check` — passes (no type errors)
- [x] `pnpm format:check` — passes
- [x] `pnpm test:unit` — 793/796 pass (3 pre-existing failures in setup-doc-skill symlink test, unrelated)
- [x] Functional: `curl http://localhost:4321/doc-history/slug`, `/search-index.json`, `/llms.txt`, `/llms-full.txt`, `/ja/llms.txt`, `/ja/llms-full.txt` — all 200 OK in dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)