### PR TITLE
Epic: zfb pin 38ba297 + e2e migration gap finalisation

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -74,7 +74,7 @@ permissions:
 env:
   # Pinned zfb commit — keep in sync with the zfb pin comment at the
   # top of zfb.config.ts and the same env in pr-checks.yml.
-  ZFB_PINNED_SHA: d2762c9e67eb9b2df8668fd4101d09cd11dbdccf
+  ZFB_PINNED_SHA: 38ba297c2292b57168e93d9be888c8db8bc256d7
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -57,7 +57,7 @@ env:
   # Pinned zfb commit — keep in sync with the zfb pin comment at the
   # top of zfb.config.ts. Updating the pin here without updating that
   # comment (or vice versa) will silently desync local dev from CI.
-  ZFB_PINNED_SHA: d2762c9e67eb9b2df8668fd4101d09cd11dbdccf
+  ZFB_PINNED_SHA: 38ba297c2292b57168e93d9be888c8db8bc256d7
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -52,7 +52,7 @@ permissions:
 env:
   # Pinned zfb commit — keep in sync with the zfb pin comment at the
   # top of zfb.config.ts and the same env in pr-checks.yml.
-  ZFB_PINNED_SHA: d2762c9e67eb9b2df8668fd4101d09cd11dbdccf
+  ZFB_PINNED_SHA: 38ba297c2292b57168e93d9be888c8db8bc256d7
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/e2e/smoke-edit-link.spec.ts
+++ b/e2e/smoke-edit-link.spec.ts
@@ -1,28 +1,36 @@
 import { test, expect } from "@playwright/test";
 import { readDistFile } from "./smoke-dist-helper";
 
-test.describe("Edit link: renders correctly", () => {
+/**
+ * The Astro-era footer rendered an "Edit this page" link pointing at
+ * settings.editUrl (`<repo>/edit/main/<file>`). The zfb-era footer
+ * renders a "View source on GitHub" link pointing at settings.githubUrl
+ * via buildGitHubSourceUrl (`<repo>/blob/HEAD/<contentDir>/<file>`).
+ * Read-link semantics are clearer than the misleading edit semantics —
+ * these specs are retargeted to assert the new wording and URL shape.
+ */
+test.describe("View source link: renders correctly", () => {
   let html: string;
 
   test.beforeAll(() => {
     html = readDistFile("docs/guides/page-1/index.html");
   });
 
-  test("edit link href contains the configured editUrl base", () => {
+  test("view-source link href is the GitHub blob/HEAD URL for the page", () => {
     expect(html).toContain(
-      "https://github.com/example/repo/edit/main",
+      "https://github.com/example/repo/blob/HEAD/src/content/docs/guides/page-1.mdx",
     );
   });
 
-  test("edit link opens in a new tab", () => {
+  test("view-source link opens in a new tab", () => {
     expect(html).toContain('target="_blank"');
   });
 
-  test("edit link has noopener noreferrer rel attribute", () => {
+  test("view-source link has noopener noreferrer rel attribute", () => {
     expect(html).toContain('rel="noopener noreferrer"');
   });
 
-  test("edit link text contains Edit", () => {
-    expect(html).toContain("Edit this page");
+  test("view-source link text is 'View source on GitHub'", () => {
+    expect(html).toContain("View source on GitHub");
   });
 });

--- a/e2e/versioning-navigation.spec.ts
+++ b/e2e/versioning-navigation.spec.ts
@@ -90,7 +90,7 @@ test.describe("Versioned navigation: sidebar links", () => {
 test.describe("Versioned navigation: version switcher visibility", () => {
   test("version switcher is visible on versioned page", async ({ page }) => {
     await page.goto("/v/1.0/docs/getting-started", { waitUntil: "load" });
-    const switcher = page.locator("main [data-version-switcher]");
+    const switcher = page.locator("[data-version-switcher]");
     await expect(switcher).toBeVisible();
   });
 

--- a/e2e/versioning.spec.ts
+++ b/e2e/versioning.spec.ts
@@ -8,8 +8,9 @@ import { test, expect } from "@playwright/test";
  * - Version 1.0 docs at /v/1.0/docs/getting-started (title: "Getting Started (v1)")
  * - Version 1.0 configured with banner: "unmaintained"
  *
- * Note: The version switcher renders in both the header and the main content
- * area. Tests scope selectors to `main` to target the content version switcher.
+ * Note: The version switcher renders in the header right rail (zfb era).
+ * Selectors target the unique `[data-version-switcher]` directly — the
+ * page contains exactly one instance, mounted in the header.
  */
 
 test.describe("Versioning: latest version pages", () => {
@@ -33,7 +34,7 @@ test.describe("Versioning: latest version pages", () => {
 
   test("version switcher is visible on latest page", async ({ page }) => {
     await page.goto("/docs/getting-started", { waitUntil: "load" });
-    const switcher = page.locator("main [data-version-switcher]");
+    const switcher = page.locator("[data-version-switcher]");
     await expect(switcher).toBeVisible();
   });
 
@@ -41,7 +42,7 @@ test.describe("Versioning: latest version pages", () => {
     page,
   }) => {
     await page.goto("/docs/getting-started", { waitUntil: "load" });
-    const toggle = page.locator("main [data-version-toggle]");
+    const toggle = page.locator("[data-version-toggle]");
     const text = await toggle.textContent();
     expect(text).toContain("Latest");
   });
@@ -93,7 +94,7 @@ test.describe("Versioning: versioned pages", () => {
     page,
   }) => {
     await page.goto("/v/1.0/docs/getting-started", { waitUntil: "load" });
-    const toggle = page.locator("main [data-version-toggle]");
+    const toggle = page.locator("[data-version-toggle]");
     const text = await toggle.textContent();
     expect(text).toContain("1.0.0");
   });
@@ -103,8 +104,8 @@ test.describe("Versioning: version switcher interaction", () => {
   test("clicking toggle opens dropdown menu", async ({ page }) => {
     await page.goto("/docs/getting-started", { waitUntil: "load" });
 
-    const toggle = page.locator("main [data-version-toggle]");
-    const menu = page.locator("main [data-version-menu]");
+    const toggle = page.locator("[data-version-toggle]");
+    const menu = page.locator("[data-version-menu]");
 
     // Menu should be hidden initially
     await expect(menu).toHaveClass(/hidden/);
@@ -120,8 +121,8 @@ test.describe("Versioning: version switcher interaction", () => {
   test("clicking outside closes dropdown menu", async ({ page }) => {
     await page.goto("/docs/getting-started", { waitUntil: "load" });
 
-    const toggle = page.locator("main [data-version-toggle]");
-    const menu = page.locator("main [data-version-menu]");
+    const toggle = page.locator("[data-version-toggle]");
+    const menu = page.locator("[data-version-menu]");
 
     // Open menu
     await toggle.click();
@@ -136,8 +137,8 @@ test.describe("Versioning: version switcher interaction", () => {
   test("Escape key closes dropdown menu", async ({ page }) => {
     await page.goto("/docs/getting-started", { waitUntil: "load" });
 
-    const toggle = page.locator("main [data-version-toggle]");
-    const menu = page.locator("main [data-version-menu]");
+    const toggle = page.locator("[data-version-toggle]");
+    const menu = page.locator("[data-version-menu]");
 
     // Open menu
     await toggle.click();
@@ -152,10 +153,10 @@ test.describe("Versioning: version switcher interaction", () => {
   test("dropdown contains links to all versions", async ({ page }) => {
     await page.goto("/docs/getting-started", { waitUntil: "load" });
 
-    const toggle = page.locator("main [data-version-toggle]");
+    const toggle = page.locator("[data-version-toggle]");
     await toggle.click();
 
-    const menu = page.locator("main [data-version-menu]");
+    const menu = page.locator("[data-version-menu]");
     const links = menu.locator("a");
 
     // Should have 3 links: Latest + 1.0.0 + "All versions"
@@ -176,11 +177,11 @@ test.describe("Versioning: version switcher interaction", () => {
     await page.goto("/docs/getting-started", { waitUntil: "load" });
 
     // Open version switcher
-    const toggle = page.locator("main [data-version-toggle]");
+    const toggle = page.locator("[data-version-toggle]");
     await toggle.click();
 
     // Click version 1.0.0 link
-    const versionLink = page.locator("main [data-version-menu] a").nth(1);
+    const versionLink = page.locator("[data-version-menu] a").nth(1);
     await versionLink.click();
 
     // Should navigate to versioned page

--- a/packages/zudo-doc-v2/src/doclayout/doc-layout-with-defaults.tsx
+++ b/packages/zudo-doc-v2/src/doclayout/doc-layout-with-defaults.tsx
@@ -79,6 +79,10 @@ import {
 } from "../ssr-skip/index.js";
 import { TabsInit } from "../code-syntax/tabs-init.js";
 import { VERSION_SWITCHER_INIT_SCRIPT } from "../i18n-version/version-switcher.js";
+import {
+  VersionBanner,
+  type VersionBannerLabels,
+} from "../i18n-version/version-banner.js";
 
 // Sibling-topic barrels. Each is being authored by a peer agent in the
 // same parallel session; the imports below assume the canonical shape
@@ -140,6 +144,21 @@ export interface DocLayoutWithDefaultsProps
    * this prop — the components gracefully handle both cases.
    */
   headings?: readonly HeadingItem[];
+
+  /**
+   * Version-banner variant. When set, a `<VersionBanner>` is rendered in
+   * the `afterBreadcrumb` slot. `false` / `undefined` suppress it. This
+   * matches the legacy `version.banner` frontmatter shape.
+   *
+   * The host must also pass `versionBannerLatestUrl` and
+   * `versionBannerLabels` so the banner can render a localized notice
+   * with a link to the latest version of the current page.
+   */
+  versionBanner?: "unmaintained" | "unreleased" | false;
+  /** Pre-resolved href used by the version banner's "view latest" link. */
+  versionBannerLatestUrl?: string;
+  /** Localized labels used by the version banner. */
+  versionBannerLabels?: VersionBannerLabels;
 }
 
 /**
@@ -191,8 +210,32 @@ export function DocLayoutWithDefaults(
     afterContent,
     head,
     lang,
+    versionBanner,
+    versionBannerLatestUrl,
+    versionBannerLabels,
     ...rest
   } = props;
+
+  // When the host opts into a version banner, prepend it to the
+  // `afterBreadcrumb` slot so the banner sits between the breadcrumb and
+  // the article body — matching the legacy Astro placement (the
+  // `@slot:doc-layout:after-breadcrumb` anchor).
+  const composedAfterBreadcrumb =
+    versionBanner !== undefined &&
+    versionBanner !== false &&
+    versionBannerLatestUrl !== undefined &&
+    versionBannerLabels !== undefined ? (
+      <>
+        <VersionBanner
+          type={versionBanner}
+          latestUrl={versionBannerLatestUrl}
+          labels={versionBannerLabels}
+        />
+        {afterBreadcrumb}
+      </>
+    ) : (
+      afterBreadcrumb
+    );
 
   // Coerce undefined to empty array so Toc/MobileToc always receive an array.
   const tocHeadings: readonly HeadingItem[] = headings ?? [];
@@ -269,7 +312,7 @@ export function DocLayoutWithDefaults(
         toc={tocOverride ?? defaultToc}
         mobileToc={mobileTocOverride ?? defaultMobileToc}
         breadcrumb={breadcrumbOverride}
-        afterBreadcrumb={afterBreadcrumb}
+        afterBreadcrumb={composedAfterBreadcrumb}
         afterSidebar={afterSidebar}
         afterContent={afterContent}
         // Default: bare <Footer /> shell so the contentinfo ARIA landmark

--- a/packages/zudo-doc-v2/src/i18n-version/index.ts
+++ b/packages/zudo-doc-v2/src/i18n-version/index.ts
@@ -26,6 +26,9 @@ export {
 } from "./version-switcher";
 export type { VersionSwitcherProps } from "./version-switcher";
 
+export { VersionBanner } from "./version-banner";
+export type { VersionBannerProps, VersionBannerLabels } from "./version-banner";
+
 export type {
   LocaleLink,
   VersionEntry,

--- a/packages/zudo-doc-v2/src/i18n-version/version-banner.tsx
+++ b/packages/zudo-doc-v2/src/i18n-version/version-banner.tsx
@@ -1,0 +1,55 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+// Version banner shown above the article on versioned doc pages.
+//
+// Pure presentational primitive — every label and URL the host project
+// would derive from settings/i18n is passed in via props. The v2 package
+// itself stays free of any settings/i18n/utils coupling.
+//
+// Renders a `<div role="note">` so screen readers announce the
+// banner contents. The role also doubles as the e2e selector
+// (`[role='note']`) used by versioning specs.
+
+import type { VNode } from "preact";
+
+export interface VersionBannerLabels {
+  /** Banner body text (e.g. "You are viewing documentation for an older version."). */
+  message: string;
+  /** Link label to the latest version (e.g. "View the latest version"). */
+  latestLink: string;
+}
+
+export interface VersionBannerProps {
+  /** Variant — drives icon/colour selection downstream and is exposed via `data-variant`. */
+  type: "unmaintained" | "unreleased";
+  /** Pre-resolved href to the latest version of the current page. */
+  latestUrl: string;
+  /** UI strings — see `VersionBannerLabels`. */
+  labels: VersionBannerLabels;
+}
+
+/**
+ * Banner element rendered above the article body on versioned doc
+ * pages. Displays a localized notice and a link to the latest version
+ * of the current page.
+ *
+ * The host typically resolves `labels` via `t("version.banner.*", lang)`
+ * and `latestUrl` via the project's URL helpers.
+ */
+export function VersionBanner(props: VersionBannerProps): VNode {
+  const { type, latestUrl, labels } = props;
+  return (
+    <div
+      role="note"
+      data-version-banner
+      data-variant={type}
+      class="mb-vsp-md border border-warning/30 bg-warning/5 px-hsp-lg py-vsp-sm text-small text-muted rounded"
+    >
+      <span>{labels.message}</span>{" "}
+      <a href={latestUrl} class="underline text-accent hover:text-accent-hover">
+        {labels.latestLink}
+      </a>
+    </div>
+  );
+}

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -11,7 +11,6 @@
 // This port wraps via DocLayoutWithDefaults with hideSidebar/hideToc plus
 // a noindex meta so search engines do not index it.
 
-import { settings } from "@/config/settings";
 import { defaultLocale } from "@/config/i18n";
 import { withBase } from "@/utils/base";
 import { DocLayoutWithDefaults } from "@zudo-doc/zudo-doc-v2/doclayout";
@@ -19,16 +18,18 @@ import type { JSX } from "preact";
 import { FooterWithDefaults } from "./lib/_footer-with-defaults";
 import { HeaderWithDefaults } from "./lib/_header-with-defaults";
 import { HeadWithDefaults } from "./lib/_head-with-defaults";
+import { composeMetaTitle } from "./lib/_compose-meta-title";
 
 export const frontmatter = { title: "404" };
 
 export default function NotFoundPage(): JSX.Element {
   const locale = defaultLocale;
+  const title = "Page Not Found";
 
   return (
     <DocLayoutWithDefaults
-      title={`Page Not Found | ${settings.siteName}`}
-      head={<HeadWithDefaults title={`Page Not Found | ${settings.siteName}`} />}
+      title={composeMetaTitle(title)}
+      head={<HeadWithDefaults title={title} />}
       lang={locale}
       noindex={true}
       hideSidebar={true}

--- a/pages/[locale]/docs/[...slug].tsx
+++ b/pages/[locale]/docs/[...slug].tsx
@@ -50,6 +50,7 @@ import { DocMetainfoArea } from "../../lib/_doc-metainfo-area";
 import { SidebarWithDefaults } from "../../lib/_sidebar-with-defaults";
 import { HeaderWithDefaults } from "../../lib/_header-with-defaults";
 import { HeadWithDefaults } from "../../lib/_head-with-defaults";
+import { composeMetaTitle } from "../../lib/_compose-meta-title";
 
 export const frontmatter = { title: "Docs" };
 
@@ -235,7 +236,7 @@ export default function LocaleDocsPage({ params, props }: PageArgs): JSX.Element
 
   return (
     <DocLayoutWithDefaults
-      title={title}
+      title={composeMetaTitle(title)}
       description={description}
       head={<HeadWithDefaults title={title} description={description} />}
       lang={locale}

--- a/pages/[locale]/docs/[...slug].tsx
+++ b/pages/[locale]/docs/[...slug].tsx
@@ -39,6 +39,7 @@ import { toRouteSlug } from "@/utils/slug";
 import { DocLayoutWithDefaults } from "@zudo-doc/zudo-doc-v2/doclayout";
 import { Breadcrumb } from "@zudo-doc/zudo-doc-v2/breadcrumb";
 import { NavCardGrid } from "@zudo-doc/zudo-doc-v2/nav-indexing";
+import { FrontmatterPreview } from "@zudo-doc/zudo-doc-v2/metainfo";
 // Shared MDX components bag — see `pages/_mdx-components.ts`.
 import { createMdxComponents } from "../../_mdx-components";
 import type { JSX } from "preact";
@@ -50,6 +51,7 @@ import { DocMetainfoArea } from "../../lib/_doc-metainfo-area";
 import { SidebarWithDefaults } from "../../lib/_sidebar-with-defaults";
 import { HeaderWithDefaults } from "../../lib/_header-with-defaults";
 import { HeadWithDefaults } from "../../lib/_head-with-defaults";
+import { buildFrontmatterPreviewEntries } from "../../lib/_frontmatter-preview-data";
 
 export const frontmatter = { title: "Docs" };
 
@@ -297,6 +299,16 @@ export default function LocaleDocsPage({ params, props }: PageArgs): JSX.Element
               {entry!.data.description}
             </p>
           )}
+
+          {/* Frontmatter preview — non-system, custom keys only. Returns
+              null when the entries array is empty, so pages without
+              custom frontmatter emit nothing. */}
+          <FrontmatterPreview
+            entries={buildFrontmatterPreviewEntries(entry!.data)}
+            title={t("frontmatter.preview.title", locale)}
+            keyColLabel={t("frontmatter.preview.keyCol", locale)}
+            valueColLabel={t("frontmatter.preview.valueCol", locale)}
+          />
 
           {entry && <entry.Content components={components} />}
 

--- a/pages/[locale]/docs/tags/[tag].tsx
+++ b/pages/[locale]/docs/tags/[tag].tsx
@@ -30,6 +30,7 @@ import type { JSX } from "preact";
 import { FooterWithDefaults } from "../../../lib/_footer-with-defaults";
 import { HeaderWithDefaults } from "../../../lib/_header-with-defaults";
 import { HeadWithDefaults } from "../../../lib/_head-with-defaults";
+import { composeMetaTitle } from "../../../lib/_compose-meta-title";
 import { DocHistoryArea } from "../../../lib/_doc-history-area";
 
 export const frontmatter = { title: "Tag" };
@@ -95,7 +96,7 @@ export default function LocaleDocTagPage({
 
   return (
     <DocLayoutWithDefaults
-      title={pageTitle}
+      title={composeMetaTitle(pageTitle)}
       head={<HeadWithDefaults title={pageTitle} />}
       lang={locale}
       hideSidebar={true}

--- a/pages/[locale]/docs/tags/index.tsx
+++ b/pages/[locale]/docs/tags/index.tsx
@@ -29,6 +29,7 @@ import type { JSX } from "preact";
 import { FooterWithDefaults } from "../../../lib/_footer-with-defaults";
 import { HeaderWithDefaults } from "../../../lib/_header-with-defaults";
 import { HeadWithDefaults } from "../../../lib/_head-with-defaults";
+import { composeMetaTitle } from "../../../lib/_compose-meta-title";
 import { DocHistoryArea } from "../../../lib/_doc-history-area";
 
 export const frontmatter = { title: "All Tags" };
@@ -74,7 +75,7 @@ export default function LocaleTagsIndexPage({
 
   return (
     <DocLayoutWithDefaults
-      title={pageTitle}
+      title={composeMetaTitle(pageTitle)}
       head={<HeadWithDefaults title={pageTitle} />}
       lang={locale}
       hideSidebar={true}

--- a/pages/[locale]/docs/versions.tsx
+++ b/pages/[locale]/docs/versions.tsx
@@ -20,6 +20,7 @@ import type { JSX } from "preact";
 import { FooterWithDefaults } from "../../lib/_footer-with-defaults";
 import { HeaderWithDefaults } from "../../lib/_header-with-defaults";
 import { HeadWithDefaults } from "../../lib/_head-with-defaults";
+import { composeMetaTitle } from "../../lib/_compose-meta-title";
 
 export const frontmatter = { title: "Versions" };
 
@@ -78,7 +79,7 @@ export default function LocaleVersionsPage({ params }: PageArgs): JSX.Element {
 
   return (
     <DocLayoutWithDefaults
-      title={pageTitle}
+      title={composeMetaTitle(pageTitle)}
       head={<HeadWithDefaults title={pageTitle} />}
       lang={locale}
       hideSidebar={true}

--- a/pages/[locale]/index.tsx
+++ b/pages/[locale]/index.tsx
@@ -36,6 +36,7 @@ import { bridgeEntries } from "../_data";
 import { FooterWithDefaults } from "../lib/_footer-with-defaults";
 import { HeaderWithDefaults } from "../lib/_header-with-defaults";
 import { HeadWithDefaults } from "../lib/_head-with-defaults";
+import { composeMetaTitle } from "../lib/_compose-meta-title";
 
 export const frontmatter = { title: "Home" };
 
@@ -110,7 +111,7 @@ export default function LocaleIndexPage({ params }: PageArgs): JSX.Element {
 
   return (
     <DocLayoutWithDefaults
-      title={settings.siteName}
+      title={composeMetaTitle(settings.siteName)}
       head={<HeadWithDefaults title={settings.siteName} />}
       lang={locale}
       hideSidebar={true}

--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -39,6 +39,7 @@ import { toRouteSlug } from "@/utils/slug";
 import { DocLayoutWithDefaults } from "@zudo-doc/zudo-doc-v2/doclayout";
 import { Breadcrumb } from "@zudo-doc/zudo-doc-v2/breadcrumb";
 import { NavCardGrid } from "@zudo-doc/zudo-doc-v2/nav-indexing";
+import { FrontmatterPreview } from "@zudo-doc/zudo-doc-v2/metainfo";
 // Shared MDX-tag → Preact-component bag. Includes htmlOverrides
 // (native typography), HtmlPreviewWrapper (Island), and stub bindings
 // for every other custom tag the MDX corpus references — see
@@ -50,6 +51,7 @@ import { DocMetainfoArea } from "../lib/_doc-metainfo-area";
 import { SidebarWithDefaults } from "../lib/_sidebar-with-defaults";
 import { HeaderWithDefaults } from "../lib/_header-with-defaults";
 import { HeadWithDefaults } from "../lib/_head-with-defaults";
+import { buildFrontmatterPreviewEntries } from "../lib/_frontmatter-preview-data";
 import type { JSX } from "preact";
 import { bridgeEntries } from "../_data";
 import { extractHeadings } from "../lib/_extract-headings";
@@ -264,6 +266,16 @@ export default function DocsPage({ props }: PageArgs): JSX.Element {
               {entry!.data.description}
             </p>
           )}
+
+          {/* Frontmatter preview — non-system, custom keys only. Returns
+              null when the entries array is empty, so pages without
+              custom frontmatter emit nothing. */}
+          <FrontmatterPreview
+            entries={buildFrontmatterPreviewEntries(entry!.data)}
+            title={t("frontmatter.preview.title", locale)}
+            keyColLabel={t("frontmatter.preview.keyCol", locale)}
+            valueColLabel={t("frontmatter.preview.valueCol", locale)}
+          />
 
           {/* MDX content rendered via zfb's Content bridge */}
           {entry && <entry.Content components={components} />}

--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -50,6 +50,7 @@ import { DocMetainfoArea } from "../lib/_doc-metainfo-area";
 import { SidebarWithDefaults } from "../lib/_sidebar-with-defaults";
 import { HeaderWithDefaults } from "../lib/_header-with-defaults";
 import { HeadWithDefaults } from "../lib/_head-with-defaults";
+import { composeMetaTitle } from "../lib/_compose-meta-title";
 import type { JSX } from "preact";
 import { bridgeEntries } from "../_data";
 import { extractHeadings } from "../lib/_extract-headings";
@@ -210,7 +211,7 @@ export default function DocsPage({ props }: PageArgs): JSX.Element {
 
   return (
     <DocLayoutWithDefaults
-      title={title}
+      title={composeMetaTitle(title)}
       description={description}
       head={<HeadWithDefaults title={title} description={description} />}
       lang={locale}

--- a/pages/docs/tags/[tag].tsx
+++ b/pages/docs/tags/[tag].tsx
@@ -30,6 +30,7 @@ import { bridgeEntries } from "../../_data";
 import { FooterWithDefaults } from "../../lib/_footer-with-defaults";
 import { HeaderWithDefaults } from "../../lib/_header-with-defaults";
 import { HeadWithDefaults } from "../../lib/_head-with-defaults";
+import { composeMetaTitle } from "../../lib/_compose-meta-title";
 import { DocHistoryArea } from "../../lib/_doc-history-area";
 
 export const frontmatter = { title: "Tag" };
@@ -80,7 +81,7 @@ export default function DocTagPage({ params, props }: PageProps): JSX.Element {
 
   return (
     <DocLayoutWithDefaults
-      title={pageTitle}
+      title={composeMetaTitle(pageTitle)}
       head={<HeadWithDefaults title={pageTitle} />}
       hideSidebar={true}
       hideToc={true}

--- a/pages/docs/tags/index.tsx
+++ b/pages/docs/tags/index.tsx
@@ -29,6 +29,7 @@ import { bridgeEntries } from "../../_data";
 import { FooterWithDefaults } from "../../lib/_footer-with-defaults";
 import { HeaderWithDefaults } from "../../lib/_header-with-defaults";
 import { HeadWithDefaults } from "../../lib/_head-with-defaults";
+import { composeMetaTitle } from "../../lib/_compose-meta-title";
 import { DocHistoryArea } from "../../lib/_doc-history-area";
 
 export const frontmatter = { title: "All Tags" };
@@ -62,7 +63,7 @@ export default function DocsTagsIndexPage(): JSX.Element {
 
   return (
     <DocLayoutWithDefaults
-      title={pageTitle}
+      title={composeMetaTitle(pageTitle)}
       head={<HeadWithDefaults title={pageTitle} />}
       hideSidebar={true}
       hideToc={true}

--- a/pages/docs/versions.tsx
+++ b/pages/docs/versions.tsx
@@ -20,6 +20,7 @@ import type { JSX } from "preact";
 import { FooterWithDefaults } from "../lib/_footer-with-defaults";
 import { HeaderWithDefaults } from "../lib/_header-with-defaults";
 import { HeadWithDefaults } from "../lib/_head-with-defaults";
+import { composeMetaTitle } from "../lib/_compose-meta-title";
 
 export const frontmatter = { title: "Versions" };
 
@@ -56,7 +57,7 @@ export default function VersionsPage(): JSX.Element {
 
   return (
     <DocLayoutWithDefaults
-      title={pageTitle}
+      title={composeMetaTitle(pageTitle)}
       head={<HeadWithDefaults title={pageTitle} />}
       lang={locale}
       hideSidebar={true}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -32,6 +32,7 @@ import type { JSX } from "preact";
 import { FooterWithDefaults } from "./lib/_footer-with-defaults";
 import { HeaderWithDefaults } from "./lib/_header-with-defaults";
 import { HeadWithDefaults } from "./lib/_head-with-defaults";
+import { composeMetaTitle } from "./lib/_compose-meta-title";
 
 export const frontmatter = { title: "Home" };
 
@@ -61,7 +62,7 @@ export default function IndexPage(): JSX.Element {
 
   return (
     <DocLayoutWithDefaults
-      title={settings.siteName}
+      title={composeMetaTitle(settings.siteName)}
       head={<HeadWithDefaults title={settings.siteName} />}
       lang={locale}
       hideSidebar={true}

--- a/pages/lib/_compose-meta-title.ts
+++ b/pages/lib/_compose-meta-title.ts
@@ -1,0 +1,35 @@
+/**
+ * Compose the canonical "<title> | <siteName>" page-title shape used by
+ * both <title> (emitted by DocLayout) and og:title (emitted by
+ * HeadWithDefaults).
+ *
+ * Why this exists: the legacy Astro layout synthesised this suffix
+ * inline. The zfb DocLayout shell intentionally renders only what the
+ * host passes as `title`, so the host has to compose the suffix itself.
+ * Centralising the composition in one helper keeps every host call
+ * site in sync and matches the SEO/UX-recognised shape the original
+ * site shipped (also asserted by smoke-seo.spec.ts).
+ *
+ * Edge cases:
+ * - When `title` is identical to `settings.siteName` (e.g. the home
+ *   page already passes `settings.siteName` as the title), do NOT
+ *   duplicate — return just the bare site name. Mirrors the legacy
+ *   Astro behaviour.
+ * - When `siteName` is missing/empty (defensive — settings.ts always
+ *   has it in practice), fall back to the bare title.
+ *
+ * Out-of-scope call sites: this helper is currently NOT applied at
+ *   pages/v/[version]/docs/[...slug].tsx
+ *   pages/v/[version]/ja/docs/[...slug].tsx
+ * because those are owned by a sibling agent's versionBanner work.
+ * After that branch merges, those host pages should also route their
+ * title prop through composeMetaTitle for consistency.
+ */
+import { settings } from "@/config/settings";
+
+export function composeMetaTitle(title: string): string {
+  const siteName = settings.siteName;
+  if (!siteName) return title;
+  if (title === siteName) return siteName;
+  return `${title} | ${siteName}`;
+}

--- a/pages/lib/_compose-meta-title.ts
+++ b/pages/lib/_compose-meta-title.ts
@@ -18,12 +18,6 @@
  * - When `siteName` is missing/empty (defensive — settings.ts always
  *   has it in practice), fall back to the bare title.
  *
- * Out-of-scope call sites: this helper is currently NOT applied at
- *   pages/v/[version]/docs/[...slug].tsx
- *   pages/v/[version]/ja/docs/[...slug].tsx
- * because those are owned by a sibling agent's versionBanner work.
- * After that branch merges, those host pages should also route their
- * title prop through composeMetaTitle for consistency.
  */
 import { settings } from "@/config/settings";
 

--- a/pages/lib/_frontmatter-preview-data.ts
+++ b/pages/lib/_frontmatter-preview-data.ts
@@ -27,13 +27,21 @@ export function buildFrontmatterPreviewEntries(
 ): Array<[string, unknown]> {
   if (!data) return [];
 
-  const config = settings.frontmatterPreview;
-  if (config === false) return [];
+  // `frontmatterPreview` may be absent (undefined) in fixtures that
+  // don't opt into the feature. `false` means the host explicitly
+  // disabled the block. Both should produce an empty entries array.
+  const config = (settings as { frontmatterPreview?: unknown })
+    .frontmatterPreview;
+  if (config === false || config === undefined) return [];
 
+  const cfg = config as {
+    ignoreKeys?: string[];
+    extraIgnoreKeys?: string[];
+  };
   const ignoreSet = new Set<string>(
-    config.ignoreKeys ?? [
+    cfg.ignoreKeys ?? [
       ...DEFAULT_FRONTMATTER_IGNORE_KEYS,
-      ...(config.extraIgnoreKeys ?? []),
+      ...(cfg.extraIgnoreKeys ?? []),
     ],
   );
 

--- a/pages/lib/_frontmatter-preview-data.ts
+++ b/pages/lib/_frontmatter-preview-data.ts
@@ -1,0 +1,47 @@
+// Host-side filter helper that turns a doc entry's `data` (frontmatter)
+// into the `entries` array expected by `<FrontmatterPreview>`.
+//
+// The v2 component (packages/zudo-doc-v2/src/metainfo/frontmatter-preview.tsx)
+// is a pure renderer — the caller is responsible for:
+//
+//  1. Honouring `settings.frontmatterPreview === false` (block hidden everywhere).
+//  2. Removing schema-managed system keys (DEFAULT_FRONTMATTER_IGNORE_KEYS).
+//  3. Applying the host's `ignoreKeys` (replaces the default list) or
+//     `extraIgnoreKeys` (adds to the default).
+//  4. Skipping null/undefined values.
+//
+// Returning an empty array suppresses the block — the v2 component
+// short-circuits with `null` when `entries` is empty.
+//
+// Note: `frontmatterRenderers` integration is intentionally skipped for
+// now. The v2 component does not yet accept a renderer map; the simple
+// text path covers every case the e2e smoke spec checks for. Custom
+// renderer support can be added as a follow-up without changing this
+// helper's signature.
+
+import { settings } from "@/config/settings";
+import { DEFAULT_FRONTMATTER_IGNORE_KEYS } from "@/config/frontmatter-preview-defaults";
+
+export function buildFrontmatterPreviewEntries(
+  data: Record<string, unknown> | null | undefined,
+): Array<[string, unknown]> {
+  if (!data) return [];
+
+  const config = settings.frontmatterPreview;
+  if (config === false) return [];
+
+  const ignoreSet = new Set<string>(
+    config.ignoreKeys ?? [
+      ...DEFAULT_FRONTMATTER_IGNORE_KEYS,
+      ...(config.extraIgnoreKeys ?? []),
+    ],
+  );
+
+  const entries: Array<[string, unknown]> = [];
+  for (const [key, value] of Object.entries(data)) {
+    if (ignoreSet.has(key)) continue;
+    if (value === null || value === undefined) continue;
+    entries.push([key, value]);
+  }
+  return entries;
+}

--- a/pages/lib/_head-with-defaults.tsx
+++ b/pages/lib/_head-with-defaults.tsx
@@ -17,6 +17,7 @@
 
 import type { JSX } from "preact";
 import { OgTags } from "@zudo-doc/zudo-doc-v2/head";
+import { composeMetaTitle } from "./_compose-meta-title";
 
 export interface HeadWithDefaultsProps {
   /** Page title forwarded to og:title. Required. */
@@ -29,6 +30,11 @@ export interface HeadWithDefaultsProps {
  * Default-bearing host wrapper that injects og:title and og:description
  * into the v2 layout's `head` slot.
  *
+ * og:title is run through composeMetaTitle so it matches the
+ * "<title> | <siteName>" shape emitted by the host's <title> element
+ * (the legacy Astro layout produced both shapes; the zfb host has to
+ * compose them itself).
+ *
  * Pure SSR — no state, no client-only imports. Intended for use as:
  *   head={<HeadWithDefaults title={title} description={description} />}
  * on every DocLayoutWithDefaults call site in the host pages.
@@ -37,5 +43,5 @@ export function HeadWithDefaults({
   title,
   description,
 }: HeadWithDefaultsProps): JSX.Element {
-  return <OgTags title={title} description={description} />;
+  return <OgTags title={composeMetaTitle(title)} description={description} />;
 }

--- a/pages/v/[version]/docs/[...slug].tsx
+++ b/pages/v/[version]/docs/[...slug].tsx
@@ -53,6 +53,7 @@ import { HeadWithDefaults } from "../../../lib/_head-with-defaults";
 import { DocHistoryArea } from "../../../lib/_doc-history-area";
 import { DocMetainfoArea } from "../../../lib/_doc-metainfo-area";
 import { buildFrontmatterPreviewEntries } from "../../../lib/_frontmatter-preview-data";
+import { composeMetaTitle } from "../../../lib/_compose-meta-title";
 
 export const frontmatter = { title: "Docs" };
 
@@ -236,7 +237,7 @@ export default function VersionedDocsPage({ props }: PageArgs): JSX.Element {
 
   return (
     <DocLayoutWithDefaults
-      title={title}
+      title={composeMetaTitle(title)}
       description={description}
       head={<HeadWithDefaults title={title} description={description} />}
       lang={locale}

--- a/pages/v/[version]/docs/[...slug].tsx
+++ b/pages/v/[version]/docs/[...slug].tsx
@@ -23,7 +23,7 @@ import type { DocsEntry } from "@/types/docs-entry";
 import { settings } from "@/config/settings";
 import type { VersionConfig } from "@/config/settings";
 import { t } from "@/config/i18n";
-import { versionedDocsUrl } from "@/utils/base";
+import { docsUrl, versionedDocsUrl } from "@/utils/base";
 import {
   buildNavTree,
   buildBreadcrumbs,
@@ -40,6 +40,7 @@ import { toRouteSlug } from "@/utils/slug";
 import { DocLayoutWithDefaults } from "@zudo-doc/zudo-doc-v2/doclayout";
 import { Breadcrumb } from "@zudo-doc/zudo-doc-v2/breadcrumb";
 import { NavCardGrid } from "@zudo-doc/zudo-doc-v2/nav-indexing";
+import { FrontmatterPreview } from "@zudo-doc/zudo-doc-v2/metainfo";
 // Locale-aware MDX components factory — see `pages/_mdx-components.ts`.
 import { createMdxComponents } from "../../../_mdx-components";
 import type { JSX } from "preact";
@@ -51,6 +52,7 @@ import { HeaderWithDefaults } from "../../../lib/_header-with-defaults";
 import { HeadWithDefaults } from "../../../lib/_head-with-defaults";
 import { DocHistoryArea } from "../../../lib/_doc-history-area";
 import { DocMetainfoArea } from "../../../lib/_doc-metainfo-area";
+import { buildFrontmatterPreviewEntries } from "../../../lib/_frontmatter-preview-data";
 
 export const frontmatter = { title: "Docs" };
 
@@ -214,6 +216,24 @@ export default function VersionedDocsPage({ props }: PageArgs): JSX.Element {
     ? autoIndex.children.filter((c: NavNode) => c.hasPage || c.children.length > 0)
     : [];
 
+  // Version banner: drives the `<VersionBanner>` element inside
+  // DocLayoutWithDefaults when `version.banner` is "unmaintained" or
+  // "unreleased". The banner links out to the latest version of the
+  // current page (slug-preserving — strips the /v/{version}/ prefix).
+  const versionBannerType = version.banner ? version.banner : undefined;
+  const versionBannerLatestUrl = versionBannerType
+    ? docsUrl(slug, locale)
+    : undefined;
+  const versionBannerLabels = versionBannerType
+    ? {
+        message:
+          versionBannerType === "unmaintained"
+            ? t("version.banner.unmaintained", locale)
+            : t("version.banner.unreleased", locale),
+        latestLink: t("version.banner.latestLink", locale),
+      }
+    : undefined;
+
   return (
     <DocLayoutWithDefaults
       title={title}
@@ -223,6 +243,9 @@ export default function VersionedDocsPage({ props }: PageArgs): JSX.Element {
       hideSidebar={entry?.data?.hide_sidebar}
       hideToc={entry?.data?.hide_toc}
       headings={headings}
+      versionBanner={versionBannerType ?? false}
+      versionBannerLatestUrl={versionBannerLatestUrl}
+      versionBannerLabels={versionBannerLabels}
       headerOverride={
         <HeaderWithDefaults
           lang={locale}
@@ -270,6 +293,16 @@ export default function VersionedDocsPage({ props }: PageArgs): JSX.Element {
               {entry!.data.description}
             </p>
           )}
+
+          {/* Frontmatter preview — non-system, custom keys only. Returns
+              null when the entries array is empty, so pages without
+              custom frontmatter emit nothing. */}
+          <FrontmatterPreview
+            entries={buildFrontmatterPreviewEntries(entry!.data)}
+            title={t("frontmatter.preview.title", locale)}
+            keyColLabel={t("frontmatter.preview.keyCol", locale)}
+            valueColLabel={t("frontmatter.preview.valueCol", locale)}
+          />
 
           {entry && <entry.Content components={components} />}
 

--- a/pages/v/[version]/ja/docs/[...slug].tsx
+++ b/pages/v/[version]/ja/docs/[...slug].tsx
@@ -22,7 +22,7 @@ import type { DocsEntry } from "@/types/docs-entry";
 import { settings } from "@/config/settings";
 import type { VersionConfig } from "@/config/settings";
 import { t } from "@/config/i18n";
-import { versionedDocsUrl } from "@/utils/base";
+import { docsUrl, versionedDocsUrl } from "@/utils/base";
 import {
   buildNavTree,
   buildBreadcrumbs,
@@ -39,6 +39,7 @@ import { toRouteSlug } from "@/utils/slug";
 import { DocLayoutWithDefaults } from "@zudo-doc/zudo-doc-v2/doclayout";
 import { Breadcrumb } from "@zudo-doc/zudo-doc-v2/breadcrumb";
 import { NavCardGrid } from "@zudo-doc/zudo-doc-v2/nav-indexing";
+import { FrontmatterPreview } from "@zudo-doc/zudo-doc-v2/metainfo";
 // Locale-aware MDX components factory — see `pages/_mdx-components.ts`.
 import { createMdxComponents } from "../../../../_mdx-components";
 import type { JSX } from "preact";
@@ -50,6 +51,7 @@ import { HeaderWithDefaults } from "../../../../lib/_header-with-defaults";
 import { HeadWithDefaults } from "../../../../lib/_head-with-defaults";
 import { DocHistoryArea } from "../../../../lib/_doc-history-area";
 import { DocMetainfoArea } from "../../../../lib/_doc-metainfo-area";
+import { buildFrontmatterPreviewEntries } from "../../../../lib/_frontmatter-preview-data";
 
 export const frontmatter = { title: "Docs" };
 
@@ -248,6 +250,25 @@ export default function VersionedJaDocsPage({ props }: PageArgs): JSX.Element {
     ? autoIndex.children.filter((c: NavNode) => c.hasPage || c.children.length > 0)
     : [];
 
+  // Version banner: drives the `<VersionBanner>` element inside
+  // DocLayoutWithDefaults when `version.banner` is "unmaintained" or
+  // "unreleased". The banner links out to the latest version of the
+  // current page (slug-preserving — strips the /v/{version}/ prefix,
+  // keeps the /ja/ locale prefix).
+  const versionBannerType = version.banner ? version.banner : undefined;
+  const versionBannerLatestUrl = versionBannerType
+    ? docsUrl(slug, locale)
+    : undefined;
+  const versionBannerLabels = versionBannerType
+    ? {
+        message:
+          versionBannerType === "unmaintained"
+            ? t("version.banner.unmaintained", locale)
+            : t("version.banner.unreleased", locale),
+        latestLink: t("version.banner.latestLink", locale),
+      }
+    : undefined;
+
   return (
     <DocLayoutWithDefaults
       title={title}
@@ -257,6 +278,9 @@ export default function VersionedJaDocsPage({ props }: PageArgs): JSX.Element {
       hideSidebar={entry?.data?.hide_sidebar}
       hideToc={entry?.data?.hide_toc}
       headings={headings}
+      versionBanner={versionBannerType ?? false}
+      versionBannerLatestUrl={versionBannerLatestUrl}
+      versionBannerLabels={versionBannerLabels}
       headerOverride={
         <HeaderWithDefaults
           lang={locale}
@@ -314,6 +338,16 @@ export default function VersionedJaDocsPage({ props }: PageArgs): JSX.Element {
               {entry!.data.description}
             </p>
           )}
+
+          {/* Frontmatter preview — non-system, custom keys only. Returns
+              null when the entries array is empty, so pages without
+              custom frontmatter emit nothing. */}
+          <FrontmatterPreview
+            entries={buildFrontmatterPreviewEntries(entry!.data)}
+            title={t("frontmatter.preview.title", locale)}
+            keyColLabel={t("frontmatter.preview.keyCol", locale)}
+            valueColLabel={t("frontmatter.preview.valueCol", locale)}
+          />
 
           {entry && <entry.Content components={components} />}
 

--- a/pages/v/[version]/ja/docs/[...slug].tsx
+++ b/pages/v/[version]/ja/docs/[...slug].tsx
@@ -52,6 +52,7 @@ import { HeadWithDefaults } from "../../../../lib/_head-with-defaults";
 import { DocHistoryArea } from "../../../../lib/_doc-history-area";
 import { DocMetainfoArea } from "../../../../lib/_doc-metainfo-area";
 import { buildFrontmatterPreviewEntries } from "../../../../lib/_frontmatter-preview-data";
+import { composeMetaTitle } from "../../../../lib/_compose-meta-title";
 
 export const frontmatter = { title: "Docs" };
 
@@ -271,7 +272,7 @@ export default function VersionedJaDocsPage({ props }: PageArgs): JSX.Element {
 
   return (
     <DocLayoutWithDefaults
-      title={title}
+      title={composeMetaTitle(title)}
       description={description}
       head={<HeadWithDefaults title={title} description={description} />}
       lang={locale}

--- a/zfb.config.ts
+++ b/zfb.config.ts
@@ -1,6 +1,6 @@
 /**
  * zfb pin (canonical, shared with E2/E4):
- *   commit: d2762c9 (Takazudo/zudo-front-builder main, 2026-05-02)
+ *   commit: 38ba297 (Takazudo/zudo-front-builder main, 2026-05-02)
  *   includes fixes:
  *     - zudolab/zfb#99  (ViewTransitions runtime + meta injection)
  *     - zudolab/zfb#100 (404 convention: emit dist/404.html at root)
@@ -9,7 +9,12 @@
  *     - zudolab/zfb#103 (ResolveLinksPlugin: probe extensionless candidates)
  *     - zudolab/zfb#104 (rehype output parity: heading-links, code-title, mermaid, image-enlarge, strip-md-ext)
  *     - zudolab/zfb#113 (tailwindcss v4 binary fetch script + ZFB_TAILWIND_BIN env var)
- *   pinned by: epic zudolab/zudo-doc#1334 (super-epic #1333)
+ *     - zudolab/zfb#118 (mdast-phase MDX pipeline wiring)
+ *     - zudolab/zfb#121 (hast-phase MDX→JSX wiring)
+ *     - zudolab/zfb#122 (islands prod-bundle workspace-probe fix)
+ *     - zudolab/zfb#123 (doctest fence stabilization)
+ *     - zudolab/zfb#124 (watcher test stabilization)
+ *   pinned by: epic zudolab/zudo-doc#1353 (super-epic #1333)
  */
 
 // zfb.config.ts — entry-point config consumed by the zfb engine.


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/1353
- super-epic
    - https://github.com/zudolab/zudo-doc/issues/1333
- follow-up sibling epic
    - https://github.com/zudolab/zudo-doc/issues/1355

---

## Summary

- Bumps the upstream zfb pin from `d2762c9` to `38ba297`, consuming five new fixes (zfb#118 mdast-phase MDX, #121 hast-phase MDX, #122 islands workspace-probe, #123 doctest fence, #124 watcher test stabilization)
- Wires the host-side `versionBanner` prop on the versioned doc pages, adds a new `<VersionBanner>` component, and renders `<FrontmatterPreview>` on every regular doc page host (closes #1351)
- Restores the `${title} | ${siteName}` suffix on `<title>` and `og:title` via a new `composeMetaTitle` helper applied at all 13 host call sites
- Retargets e2e specs: drops the `main` ancestor from version-switcher selectors (now in the header right-rail) and rewords the edit-link spec to assert `"View source on GitHub"` + `blob/HEAD/...` URL (partially closes #1352)
- ⚠️ Full `pnpm test:e2e:ci` is NOT yet green — 35 remaining failures are NEW upstream zfb gaps not covered by the consumed fixes; all tracked in follow-up sibling epic #1355

## Changes

### Pin bump (4 canonical sites)

- `zfb.config.ts` header pin block — SHA + included-fixes list updated; `pinned by:` switched from epic #1334 to epic #1353
- `.github/workflows/{pr-checks,main-deploy,preview-deploy}.yml` — `ZFB_PINNED_SHA` env var bumped to the full 40-character SHA `38ba297c2292b57168e93d9be888c8db8bc256d7`

### Host wiring (closes #1351)

- New `packages/zudo-doc-v2/src/i18n-version/version-banner.tsx` — `<VersionBanner>` component (role="note" wrapper, localized message, link to latest version)
- `packages/zudo-doc-v2/src/doclayout/doc-layout-with-defaults.tsx` — adds `versionBanner` + `versionBannerLatestUrl` + `versionBannerLabels` props; renders `<VersionBanner>` after the breadcrumb when set
- `packages/zudo-doc-v2/src/i18n-version/index.ts` — exports the new component
- `pages/v/[version]/docs/[...slug].tsx` + `pages/v/[version]/ja/docs/[...slug].tsx` — pass `versionBanner={version.banner ?? false}` and the resolved latest URL through to the layout
- New `pages/lib/_frontmatter-preview-data.ts` — host helper that filters frontmatter entries via the project's ignore-list (covers all schema-defined system keys), honours `settings.frontmatterPreview` gating, and returns `[key, value]` tuples ready for the `<FrontmatterPreview>` component
- All 4 doc-page hosts (`pages/docs/[...slug].tsx`, `pages/[locale]/docs/[...slug].tsx`, both versioned variants) — render `<FrontmatterPreview entries={…} />` on the regular branch (NOT auto-index)

### Title suffix (Sig D)

- New `pages/lib/_compose-meta-title.ts` — `composeMetaTitle(title)` returns `"${title} | ${siteName}"`, with a guard against duplication when `title === siteName`
- `pages/lib/_head-with-defaults.tsx` — runs the og:title input through `composeMetaTitle`
- 13 host call sites — pass `title={composeMetaTitle(…)}` to `<DocLayoutWithDefaults>` (covers `pages/index.tsx`, `pages/404.tsx`, the regular and locale-prefixed `pages/docs/...` hierarchy, both versioned variants, the tags pages, and the versions pages)

### E2E spec retargets

- **Sig C(1)** — `e2e/versioning.spec.ts` + `e2e/versioning-navigation.spec.ts`: every `main [data-version-...]` selector retargeted to plain `[data-version-...]`. The header switcher (`idSuffix="header"`, id `version-menu-header`) is the unique match. Assertions unchanged.
- **Sig E** — `e2e/smoke-edit-link.spec.ts`: assertions retargeted to `"View source on GitHub"` text + `https://github.com/example/repo/blob/HEAD/...` URL pattern (per `src/utils/github.ts` line 18). `target="_blank"` and `rel="noopener noreferrer"` assertions kept.

## Test Plan

- [x] `pnpm install` — clean, lockfile not regenerated
- [x] `pnpm build` — 217 pages built, dist/index.html present
- [x] `pnpm check` — typecheck clean
- [x] Targeted specs:
    - `e2e/smoke-frontmatter-preview.spec.ts` — 3 / 3 passed (system-only block absent, custom rows visible, auto-index block absent)
    - `e2e/versioning.spec.ts -g "version banner"` — 3 / 3 passed
    - `e2e/smoke-seo.spec.ts` "page title contains expected text" — passed (suffix correct)
    - `e2e/smoke-edit-link.spec.ts` (Sig E) — passes per substring spot-check on built fixture HTML
    - `e2e/versioning.spec.ts` + `e2e/versioning-navigation.spec.ts` — 19 / 21 passed (2 expected failures matched the cross-topic boundary, both green after merge)
- [⚠️] `pnpm test:e2e:ci` — **110 passed / 35 failed**. The 35 failures are tracked in sibling epic #1355 (Sig F MDX custom-plugin pipeline gap, Sig G island hydration gap, Sig H outliers). Per the epic #1347 lesson — "if a category fails 50%+ with the same diff signature after this work lands, default suspicion is a NEW upstream zfb gap, not an E2E patch — escalate rather than mass-edit" — the in-scope work was completed and the remaining gaps escalated to a sibling epic rather than mass-edited away.

## Notes

- The package `@zudo-doc/zudo-doc-v2` exports source directly (no built `dist/` re-export); no rebuild step required after the source-side changes.
- `frontmatterRenderers` integration (custom per-key renderers) is documented as a follow-up — the v2 component does not yet accept a renderer map, and the simple text path is sufficient for the smoke spec scope.
- `pages/v/[version]/docs/[...slug].tsx` and `pages/v/[version]/ja/docs/[...slug].tsx` were originally split between two parallel agents during implementation; the final commit (`fix(host): apply composeMetaTitle to versioned doc pages`) closes the consistency gap on those two sites.