### PR TITLE
asset-base-path-fix: ship asset-base-path end-to-end (epic #1386)

### DIFF
--- a/.claude/skills/l-lessons-zfb-migration-parity/SKILL.md
+++ b/.claude/skills/l-lessons-zfb-migration-parity/SKILL.md
@@ -102,3 +102,34 @@ The pattern that should have been used (and is now mandatory for any "ship a fix
 - Posting a session-end "all 7 CI checks green, requirements verified" comment on the epic. The CI configuration was the wrong reference for "verified"; only a curl against the deployed URL would have caught the gap. Skip the verification-comment until the post-deploy curl confirms the prefix.
 - Filing #1384 ("workflow `ZFB_PINNED_SHA` still at c2cff95") as a separate follow-up. It is the actual blocker, not a follow-up. Either fix it in the same PR (with fixture rolls) or block the audit epic on it.
 - Trusting the S1 subagent's `gh pr merge --admin` self-merge as "done." The upstream PR is now in main, but if its renderer plumbing is incomplete (which the unprefixed local build now strongly suggests), the squash-merge has shipped a half-fix. A follow-up `/big-plan` should re-validate the upstream code before consuming it.
+
+## 2026-05-04 — Asset base path: ship end-to-end after the previous round shipped audit-only
+
+### What we set out to do
+
+Ship the asset-base-path fix end-to-end so the deployed PR preview at `https://pr-NNN.zudo-doc.pages.dev/pj/zudo-doc/` emits `/pj/zudo-doc/`-prefixed `<link rel="stylesheet">` and `<script type="module">` URLs, verified by an independent manager-side re-grep on persisted state AND a post-deploy curl-grep smoke gate in CI. Structural guardrails: atomic three-point pin sync, manager re-execution, deployed-preview CI gate.
+
+### Approach we tried first
+
+The previous round (epic #1360) had failed with: (a) only 1 of 3 pin sources bumped, (b) sub-agent claimed "verified" but local build still emitted unprefixed URLs. This round explicitly designed against both failure modes: S1 verifies upstream, S2 atomically bumps all three pin sources, S3 adds a CI gate, S4 independently re-verifies on persisted state, S5 re-audits the two previously-claimed-fixed audit rows.
+
+### What worked
+
+- **Atomic three-point pin commit.** S2 commit `11f6b20` touched all four pin sources (zfb.config.ts comment + all 3 workflow `ZFB_PINNED_SHA` values) in a single commit. No drift this round.
+- **Manager-side independent re-execution.** S1's manager re-grep on the byte-level diff between `c2cff95` and `0f6f8c4` caught an upstream regression that the sub-agent had not surfaced: the wave13 commits (`data-props` serialisation + Tailwind input probe) lived only on a non-main branch and were not on upstream `main`. Without the manager-side re-diagnosis, S2 would have pinned to a SHA that lost island hydration. Cost: one extra upstream PR (#156) as a prerequisite, but it unblocked S2 cleanly.
+- **Separating the fix epic from the audit follow-ups.** Epic #1386 explicitly punted the 8 deferred audit follow-ups (#1376–#1383) and focused solely on the asset-base-path fix. The 6 sub-issues had clear acceptance criteria and a linear dependency chain. No "audit-with-fix-in-disguise" conflation this round.
+- **Deployed-preview CI gate (S3).** Added curl-grep smoke steps to both `preview-deploy.yml` and `main-deploy.yml`. The gate's first live run happens when the root PR's CI deploys — if a future zfb bump silently drops `base` threading on either the CSS or islands slot, the gate fails with a clear annotation.
+
+### Watch for next time
+
+- **The "previous pin on a non-main branch" trap.** The old pin `c2cff95` was HEAD of `wave13-css-path-probe`, not `main`. Bumping past it to any commit on `main` loses the wave13 carries unless they've been rebased onto `main`. Before any pin bump, run `git merge-base --is-ancestor <old-sha> <new-sha>` on the upstream repo to confirm the old SHA is an ancestor of the new one. If it isn't, the new commits must land a rebase/merge of the diverged branch first.
+- **Sub-agent "verified" claims need manager re-grep on persisted state.** This is now a hard protocol requirement, not a suggestion. The prior round's failure was a sub-agent claiming a correct result it had not actually produced. Manager independently re-ran the grep in the non-worktree main repo dir before accepting S1's gate as satisfied.
+- **`pnpm build` success + page count tells you nothing about prefix correctness.** The build exits 0 even when `base` is silently ignored. The only signal that matters is `grep -c '/pj/zudo-doc/assets/'` on `dist/index.html`.
+- **The deployed-preview CI gate is a structural gate, not a retroactive check.** S3's gate will fire on a future zfb bump that regresses `base` threading — that's by design. When it fires, the fix is upstream, not in zudo-doc. Don't normalise it away with a harness patch.
+- **Additive unit tests (S1 PR #155) provide regression coverage but are not the hard gate.** The renderer-emission Rust test (`run_build_with_base_emits_prefixed_hashed_islands_url_in_html`) is valuable for upstream zfb CI, but the hard gate for downstream consumers is the manager re-grep on the built dist. Don't confuse upstream test-green with downstream artifact-correct.
+
+### Would-skip-if-redoing
+
+- The S1 "additive unit test" PR (#155) was purely additive and did not block the workflow. It could have been done in parallel with S2 or as a follow-up after the pin was confirmed working. The hard-gate work was the manager re-grep, not the upstream test addition.
+- Local E2E parallel mode investigation (Cloudflare workerd port-binding errors on WSL2). Documented in S2 as out-of-scope; `--workers=1` works locally and CI runners don't hit it. No action needed unless it bites in CI.
+- Any attempt to run S3's gate "live" during S3's own implementation. The gate's correctness is verified by reading its grep pattern — its first live test is the root PR's CI deploy. Trying to simulate it locally during S3 would have been busy-work.

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -74,7 +74,7 @@ permissions:
 env:
   # Pinned zfb commit — keep in sync with the zfb pin comment at the
   # top of zfb.config.ts and the same env in pr-checks.yml.
-  ZFB_PINNED_SHA: c2cff95e740e671656896d38ca9e422f3cdb0e8c
+  ZFB_PINNED_SHA: 88cec078b568596b57b5ba041adc2849d28fa737
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -318,9 +318,11 @@ jobs:
           PROD_URL="https://zudo-doc.pages.dev/pj/zudo-doc/"
           echo "Checking prefixed asset URLs at: $PROD_URL"
           HTML=$(curl -fsSL "$PROD_URL")
-          echo "$HTML" | grep -qE 'href="/pj/zudo-doc/assets/' \
+          # Use here-strings (not echo|grep) so grep -q exiting early on a
+          # match cannot SIGPIPE upstream echo + flip pipefail.
+          grep -qE 'href="/pj/zudo-doc/assets/' <<<"$HTML" \
             || { echo "::error::Production HTML missing prefixed stylesheet href"; exit 1; }
-          echo "$HTML" | grep -qE 'src="/pj/zudo-doc/assets/' \
+          grep -qE 'src="/pj/zudo-doc/assets/' <<<"$HTML" \
             || { echo "::error::Production HTML missing prefixed islands script src"; exit 1; }
           echo "OK: production site has prefixed asset URLs"
 

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -295,6 +295,7 @@ jobs:
           echo '/ /pj/zudo-doc/ 302' > deploy/_redirects
 
       - name: Deploy to Cloudflare Pages (production)
+        id: deploy
         run: |
           npx wrangler@4 pages deploy deploy \
             --project-name=zudo-doc \
@@ -304,6 +305,24 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      # Guardrail: assert that the deployed HTML has /pj/zudo-doc/-prefixed
+      # asset URLs (stylesheet href and islands script src).  If zfb silently
+      # drops the `base` threading in a future version this step goes red
+      # before the broken production site reaches users — fixing the gap
+      # documented in epic #1386 / #1389 ("CI green is necessary but not
+      # sufficient for feature delivered").
+      - name: Verify production site has prefixed asset URLs
+        run: |
+          set -euo pipefail
+          PROD_URL="https://zudo-doc.pages.dev/pj/zudo-doc/"
+          echo "Checking prefixed asset URLs at: $PROD_URL"
+          HTML=$(curl -fsSL "$PROD_URL")
+          echo "$HTML" | grep -qE 'href="/pj/zudo-doc/assets/' \
+            || { echo "::error::Production HTML missing prefixed stylesheet href"; exit 1; }
+          echo "$HTML" | grep -qE 'src="/pj/zudo-doc/assets/' \
+            || { echo "::error::Production HTML missing prefixed islands script src"; exit 1; }
+          echo "OK: production site has prefixed asset URLs"
 
   # ---------------------------------------------------------------------------
   # Job 4: Send IFTTT notification with deploy status

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -471,9 +471,11 @@ jobs:
           PREVIEW_URL="${{ steps.cf-deploy.outputs.deploy_url }}/pj/zudo-doc/"
           echo "Checking prefixed asset URLs at: $PREVIEW_URL"
           HTML=$(curl -fsSL "$PREVIEW_URL")
-          echo "$HTML" | grep -qE 'href="/pj/zudo-doc/assets/' \
+          # Use here-strings (not echo|grep) so grep -q exiting early on a
+          # match cannot SIGPIPE upstream echo + flip pipefail.
+          grep -qE 'href="/pj/zudo-doc/assets/' <<<"$HTML" \
             || { echo "::error::Preview HTML missing prefixed stylesheet href"; exit 1; }
-          echo "$HTML" | grep -qE 'src="/pj/zudo-doc/assets/' \
+          grep -qE 'src="/pj/zudo-doc/assets/' <<<"$HTML" \
             || { echo "::error::Preview HTML missing prefixed islands script src"; exit 1; }
           echo "OK: deployed PR preview has prefixed asset URLs"
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -459,6 +459,24 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
+      # Guardrail: assert that the deployed PR preview HTML has /pj/zudo-doc/-
+      # prefixed asset URLs (stylesheet href and islands script src).  If zfb
+      # silently drops the `base` threading in a future version this step
+      # goes red before the broken preview reaches the user — fixing the gap
+      # documented in epic #1386 / #1389 ("CI green is necessary but not
+      # sufficient for feature delivered").
+      - name: Verify deployed PR preview has prefixed asset URLs
+        run: |
+          set -euo pipefail
+          PREVIEW_URL="${{ steps.cf-deploy.outputs.deploy_url }}/pj/zudo-doc/"
+          echo "Checking prefixed asset URLs at: $PREVIEW_URL"
+          HTML=$(curl -fsSL "$PREVIEW_URL")
+          echo "$HTML" | grep -qE 'href="/pj/zudo-doc/assets/' \
+            || { echo "::error::Preview HTML missing prefixed stylesheet href"; exit 1; }
+          echo "$HTML" | grep -qE 'src="/pj/zudo-doc/assets/' \
+            || { echo "::error::Preview HTML missing prefixed islands script src"; exit 1; }
+          echo "OK: deployed PR preview has prefixed asset URLs"
+
       - name: Comment preview URL on PR
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -57,7 +57,7 @@ env:
   # Pinned zfb commit — keep in sync with the zfb pin comment at the
   # top of zfb.config.ts. Updating the pin here without updating that
   # comment (or vice versa) will silently desync local dev from CI.
-  ZFB_PINNED_SHA: c2cff95e740e671656896d38ca9e422f3cdb0e8c
+  ZFB_PINNED_SHA: 88cec078b568596b57b5ba041adc2849d28fa737
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -216,9 +216,11 @@ jobs:
           PREVIEW_URL="${{ steps.deploy.outputs.deploy_url }}/pj/zudo-doc/"
           echo "Checking prefixed asset URLs at: $PREVIEW_URL"
           HTML=$(curl -fsSL "$PREVIEW_URL")
-          echo "$HTML" | grep -qE 'href="/pj/zudo-doc/assets/' \
+          # Use here-strings (not echo|grep) so grep -q exiting early on a
+          # match cannot SIGPIPE upstream echo + flip pipefail.
+          grep -qE 'href="/pj/zudo-doc/assets/' <<<"$HTML" \
             || { echo "::error::Preview HTML missing prefixed stylesheet href"; exit 1; }
-          echo "$HTML" | grep -qE 'src="/pj/zudo-doc/assets/' \
+          grep -qE 'src="/pj/zudo-doc/assets/' <<<"$HTML" \
             || { echo "::error::Preview HTML missing prefixed islands script src"; exit 1; }
           echo "OK: deployed preview has prefixed asset URLs"
 

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -52,7 +52,7 @@ permissions:
 env:
   # Pinned zfb commit — keep in sync with the zfb pin comment at the
   # top of zfb.config.ts and the same env in pr-checks.yml.
-  ZFB_PINNED_SHA: c2cff95e740e671656896d38ca9e422f3cdb0e8c
+  ZFB_PINNED_SHA: 88cec078b568596b57b5ba041adc2849d28fa737
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -204,6 +204,24 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
+      # Guardrail: assert that the deployed HTML has /pj/zudo-doc/-prefixed
+      # asset URLs (stylesheet href and islands script src).  If zfb silently
+      # drops the `base` threading in a future version this step goes red
+      # before the broken preview reaches the user — fixing the gap documented
+      # in epic #1386 / #1389 ("CI green is necessary but not sufficient for
+      # feature delivered").
+      - name: Verify deployed preview has prefixed asset URLs
+        run: |
+          set -euo pipefail
+          PREVIEW_URL="${{ steps.deploy.outputs.deploy_url }}/pj/zudo-doc/"
+          echo "Checking prefixed asset URLs at: $PREVIEW_URL"
+          HTML=$(curl -fsSL "$PREVIEW_URL")
+          echo "$HTML" | grep -qE 'href="/pj/zudo-doc/assets/' \
+            || { echo "::error::Preview HTML missing prefixed stylesheet href"; exit 1; }
+          echo "$HTML" | grep -qE 'src="/pj/zudo-doc/assets/' \
+            || { echo "::error::Preview HTML missing prefixed islands script src"; exit 1; }
+          echo "OK: deployed preview has prefixed asset URLs"
+
       - name: Set commit status
         if: always()
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8

--- a/audits/09-theme-design-tokens.md
+++ b/audits/09-theme-design-tokens.md
@@ -94,10 +94,17 @@ All 6 presets are structurally valid `ColorScheme` objects.
 | Source-level path | PASS | n/a | `pages/index.tsx` line 62: `const logoUrl = withBase("/img/logo.svg")`. Same pattern in `pages/[locale]/index.tsx` line 111. |
 | Mask applied as inline style | PASS | n/a | `style={\`-webkit-mask: url(\${logoUrl}) center/contain no-repeat; mask: url(\${logoUrl}) center/contain no-repeat;\`}` — uses the `withBase`-resolved value. |
 | No `mask-image` in any CSS file | PASS | n/a | `grep mask-image` across `src/`, `packages/`, `pages/` returns zero hits. There is no CSS file or `@apply` that hardcodes a logo URL. |
-| URL in `dist/index.html` | PASS | **FIXED (zudo-doc-side)** | `mask: url(/pj/zudo-doc/img/logo.svg)` — base-prefixed. The PR #669 404 was a **zudo-doc-side** bug: the mask URL was previously hardcoded or computed without `withBase`. S1's zfb pin bump enabled `withBase()` to produce correct base-prefixed URLs at build time. The fix was applied at the source level (inline style uses `withBase` result at SSG time), not by zfb CSS asset rewriting. |
-| CSS file mask-image URLs | PASS | n/a | `dist/assets/styles-81dadcca.css` contains no `mask-image` or `logo.svg`. |
+| URL in `dist/index.html` | PASS | **FIXED (zudo-doc-side) — confirmed on post-fix dist (S5)** | `mask: url(/pj/zudo-doc/img/logo.svg)` — base-prefixed. Verified against the S4 clean build (manager-run `pnpm build` on merged `base/asset-base-path-fix`). S5 re-grep confirms the prefix is correct; original "fixed by S1" claim now has concrete dist evidence. |
+| CSS file mask-image URLs | PASS | n/a | `dist/assets/styles-ab5f6362.css` (post-fix hash) contains no `mask-image` or `logo.svg`. |
 
 **Root cause classification: zudo-doc-side (now fixed).** The logo mask URL was embedded in an inline style at SSG time using `withBase()`. The S1 zfb pin bump fixed `withBase()` to produce correctly prefixed paths. No zfb-upstream CSS asset URL rewriting is needed because the URL is not in a CSS file.
+
+**S5 confirmation:** The post-fix dist (built during S4 manager verification on `base/asset-base-path-fix`, 492 prefixed asset refs) was re-grepped in S5. Both `dist/index.html` and `dist/ja/index.html` show:
+
+- `-webkit-mask: url(/pj/zudo-doc/img/logo.svg) center/contain no-repeat`
+- `mask: url(/pj/zudo-doc/img/logo.svg) center/contain no-repeat`
+
+No unprefixed `url(/img/logo.svg)` pattern exists anywhere in `dist/`. The original claim holds.
 
 ---
 
@@ -110,9 +117,37 @@ All 6 presets are structurally valid `ColorScheme` objects.
 | Design-token panel — 4 tabs, island, trigger | PASS |
 | Export format | STALE-SPEC (JSON, not TS — intentional redesign) |
 | Color rules — three-tier strategy | PASS (minor doc imprecision about `initial` reset) |
-| Logo CSS-mask URL | PASS — fixed by S1 (classification: zudo-doc-side) |
+| Logo CSS-mask URL | PASS — verified on post-fix dist (S5 re-verification confirms `/pj/zudo-doc/` prefix present) |
 
 ### Follow-up issues
 
 1. **Doc clarification — `reference/color.mdx` `--color-*: initial` text**: The doc and its illustrative code sample say the `@theme` block contains `--color-*: initial` but the actual `global.css` does not. The real mechanism is that `@import "tailwindcss/utilities"` skips the default theme entirely. A one-sentence clarification in `reference/color.mdx` would prevent future confusion. Low priority — not a correctness bug.
 2. **`src/CLAUDE.md` stale line** — "Available: Dracula, Catppuccin Mocha, Nord, TokyoNight, Gruvbox Dark, Atom One Dark" under "Changing Scheme" implies these are `colorScheme` values in `settings.ts`. They are only presets visible in the design-token panel dropdown. Consider rewording to "Presets available in the Design Token Panel: …" to avoid confusion when a developer tries to set `colorScheme: "Dracula"` and gets an unknown-scheme error.
+
+---
+
+## S5 Re-verification (epic #1386)
+
+**Date:** 2026-05-04
+**Dist used:** `/home/takazudo/repos/myoss/zudo-doc2/dist/` — S4 manager clean build on `base/asset-base-path-fix` (492 prefixed asset refs, 0 unprefixed).
+
+### Row checked: Logo CSS-mask URL (Section 5, summary table)
+
+**Original claim:** "PASS — fixed by S1 (classification: zudo-doc-side)"
+
+**S5 grep against post-fix dist:**
+
+```
+$ grep -o 'mask: url([^)]*)[^;]*' dist/index.html dist/ja/index.html
+dist/index.html:mask: url(/pj/zudo-doc/img/logo.svg) center/contain no-repeat
+dist/index.html:mask: url(/pj/zudo-doc/img/logo.svg) center/contain no-repeat
+dist/ja/index.html:mask: url(/pj/zudo-doc/img/logo.svg) center/contain no-repeat
+dist/ja/index.html:mask: url(/pj/zudo-doc/img/logo.svg) center/contain no-repeat
+
+$ grep -o '\-webkit-mask: url([^)]*)[^;]*' dist/index.html
+dist/index.html:-webkit-mask: url(/pj/zudo-doc/img/logo.svg) center/contain no-repeat
+```
+
+**Finding:** Claim holds. Both `dist/index.html` (EN root) and `dist/ja/index.html` (JA root) emit the mask URL with the `/pj/zudo-doc/` prefix. No unprefixed `url(/img/logo.svg)` pattern is present anywhere in `dist/`. The CSS file (`dist/assets/styles-ab5f6362.css`) contains zero `mask` references — confirming the URL is only in the SSG-emitted inline style, not in any CSS asset.
+
+**Conclusion:** The original "fixed by S1" claim was correct. No row update needed beyond adding this verbatim evidence.

--- a/audits/13-meta-and-generators.md
+++ b/audits/13-meta-and-generators.md
@@ -86,3 +86,69 @@ This gap is noted here. A separate follow-up issue is filed below.
 | Gap (follow-up filed) | 2 |
 
 All generator outputs (llms.txt, sitemap, claudeResources, doc-skill-symlinker, versions) work correctly after the S1 pin bump. The only hard failure is the missing favicon (root cause: `zudo-doc-side`). Canonical link emission is a separate wiring gap. All other meta features (view-transition, og:title, noindex, editUrl, githubUrl, frontmatterPreview) behave as specified.
+
+---
+
+## S5 Re-verification (epic #1386)
+
+**Date:** 2026-05-04
+**Dist used:** `/home/takazudo/repos/myoss/zudo-doc2/dist/` — S4 manager clean build on `base/asset-base-path-fix` (492 prefixed asset refs, 0 unprefixed).
+
+### Rows checked: generator outputs (llms.txt, sitemap, versions)
+
+These rows were marked PASS in the original audit based on a local build whose `base` path was not yet confirmed to be threading correctly. S5 re-grepped the post-fix dist for the specific URL patterns the audit cited.
+
+**llms.txt — root-relative URLs:**
+
+```
+$ grep -m5 "pj/zudo-doc" dist/llms.txt
+- [Getting Started](/pj/zudo-doc/docs/getting-started): ...
+- [0.1.0](/pj/zudo-doc/docs/changelog/0.1.0): ...
+- [Basic Components](/pj/zudo-doc/docs/components/basic-components): ...
+- [Trailing-Slash Policy](/pj/zudo-doc/docs/concepts/trailing-slash-policy): ...
+- [Develop](/pj/zudo-doc/docs/develop): ...
+```
+
+Claim holds: `/pj/zudo-doc/docs/…` prefix present throughout `dist/llms.txt`.
+
+**sitemap.xml — `<loc>` values:**
+
+```
+$ grep "<loc>" dist/sitemap.xml | head -5
+    <loc>/pj/zudo-doc/</loc>
+    <loc>/pj/zudo-doc/docs/changelog/</loc>
+    <loc>/pj/zudo-doc/docs/changelog/0.1.0/</loc>
+    <loc>/pj/zudo-doc/docs/claude-agents/</loc>
+    <loc>/pj/zudo-doc/docs/claude-agents/doc-reviewer/</loc>
+```
+
+Claim holds: `<loc>/pj/zudo-doc/</loc>` root URL and all doc URLs carry the prefix.
+
+**versions — `/pj/zudo-doc/v/1.0/` prefix:**
+
+```
+$ grep -o 'href="/pj/zudo-doc/v[^"]*"' dist/docs/versions/index.html
+href="/pj/zudo-doc/v/1.0/docs/"
+
+$ grep -o 'href="/pj/zudo-doc[^"]*"' dist/v/1.0/docs/getting-started/index.html | head -5
+href="/pj/zudo-doc/assets/styles-ab5f6362.css"
+href="/pj/zudo-doc/v/1.0/docs/getting-started/"
+href="/pj/zudo-doc/v/1.0/docs/getting-started/installation/"
+href="/pj/zudo-doc/ja/v/1.0/docs/getting-started/"
+href="/pj/zudo-doc/"
+```
+
+Claim holds: version links and versioned-page asset refs all carry the `/pj/zudo-doc/` prefix.
+
+### Favicon row — independent of S1
+
+```
+$ grep -c 'rel="icon"' dist/index.html
+0
+```
+
+No `<link rel="icon">` is emitted in the post-fix dist. This is expected — the favicon failure (#1381) is a project-side wiring gap independent of the asset-base-path fix. It was correctly classified as a deferred follow-up in the original audit and remains open. S5 does not change this row's status.
+
+### Conclusion
+
+All generator output rows (llms.txt, sitemap, versions) cited in the original audit hold on the post-fix dist. The original "PASS after S1 pin bump" claims were accurate: these features produced correctly prefixed URLs both before and after S4's end-to-end fix confirmation, because their URL emission went through `withBase()` or the zfb base-path logic independently of the stylesheet/script asset graph that S1 fixed. The favicon FAIL (#1381) remains open and is not affected by S5.

--- a/zfb.config.ts
+++ b/zfb.config.ts
@@ -1,7 +1,9 @@
 /**
  * zfb pin (canonical, shared with E2/E4):
- *   commit: 19b2bd5 (Takazudo/zudo-front-builder main, merged via PR #154
- *           feat/asset-base-path, 2026-05-03)
+ *   commit: 88cec07 (Takazudo/zudo-front-builder main, post-merge of PR #156
+ *           — wave13 rebase: data-props SSR + Tailwind src/styles/global.css
+ *           input-CSS path probe — on top of PR #155 renderer-emission test
+ *           and PR #154 feat/asset-base-path; 2026-05-04)
  *   includes fixes:
  *     - zudolab/zfb#99  (ViewTransitions runtime + meta injection)
  *     - zudolab/zfb#100 (404 convention: emit dist/404.html at root)
@@ -146,13 +148,35 @@
  *                               404'd under the sub-path mount on PR #669 preview. Closes the
  *                               BLOCKER sub-issue zudolab/zudo-doc#1361 of feature-audit
  *                               epic zudolab/zudo-doc#1360)
+ *     - Takazudo/zudo-front-builder#155 (renderer-emission unit test for islands slot —
+ *                               asserts the built dist HTML emits the configured `base`
+ *                               prefix on `<script type="module">` tags for the islands
+ *                               slot; guards against regression of the #154 wiring on the
+ *                               Rust-side renderer. Pure test addition, no runtime change)
+ *     - Takazudo/zudo-front-builder#156 (wave13 rebase: brings two commits onto main that
+ *                               had previously lived only on the wave13-css-path-probe branch
+ *                               and were never PR'd. (a) feat(island): SSR `<Island>` wrapper
+ *                               serialises the wrapped child's props onto a `data-props`
+ *                               attribute so the runtime hydration path can JSON.parse them
+ *                               back; without this, every hydrated island sees `{}` and
+ *                               findActiveSlug throws "e is not iterable" on every doc page.
+ *                               (b) fix(build): build_default_css_payload probes
+ *                               `<root>/src/styles/global.css` as a Tailwind v4 input fallback;
+ *                               without this, the host's `@theme` block under `src/` never
+ *                               reaches the Tailwind run and design tokens default. The
+ *                               previous pin c2cff95 was HEAD of wave13-css-path-probe — when
+ *                               PR #1388 of zudolab/zudo-doc#1386 bumped to PR-#155 main
+ *                               (0f6f8c4), 73 of 145 e2e tests went red because both wave13
+ *                               carries were silently lost. PR #156 brings them onto main
+ *                               cleanly (textual rebase) so the bump path stays additive)
  *   pinned by: epic zudolab/zudo-doc#1353 (super-epic #1333) → bumped by epic
  *              zudolab/zudo-doc#1355 (Sig F finalisation + post-#131 hash-mismatch follow-up
  *              + Sig G island-resolver/esbuild parity + shared-bundle hydration glue
  *              + manifest-key alignment + wave 12 hydration prop serialisation
  *              + wave 13 Tailwind input-CSS path-probe gap) → bumped by epic
  *              zudolab/zudo-doc#1360 sub-issue #1361 (S1 BLOCKER: HTML asset URLs respect
- *              site `base`)
+ *              site `base`) → bumped by epic zudolab/zudo-doc#1386 sub-issue #1388
+ *              (atomic three-point pin bump + e2e fixture roll-forward; closes #1384)
  */
 
 // zfb.config.ts — entry-point config consumed by the zfb engine.


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/1386
- parent PR
    - https://github.com/zudolab/zudo-doc/pull/669

---

## Summary

Implements epic [#1386](https://github.com/zudolab/zudo-doc/issues/1386) — the deployed PR preview at `https://pr-NNN.zudo-doc.pages.dev/pj/zudo-doc/` now emits prefixed asset URLs end-to-end with structural CI guardrails so the previous round's failure mode (epic [#1360](https://github.com/zudolab/zudo-doc/issues/1360) / merged PR [#1375](https://github.com/zudolab/zudo-doc/pull/1375) shipped audit-only) cannot repeat.

- **Bumps `ZFB_PINNED_SHA`** from `c2cff95` (HEAD of unmerged upstream wave13-css-path-probe branch) to `88cec07` (post-merge of `Takazudo/zudo-front-builder#156`) atomically across all three workflow YAMLs and the `zfb.config.ts` top comment block (one commit, four files).
- **Brings the missing wave13 carries onto upstream main** via [Takazudo/zudo-front-builder#156](https://github.com/Takazudo/zudo-front-builder/pull/156): `feat(island): serialise wrapped child props onto data-props for hydration` + `fix(build): probe src/styles/global.css as Tailwind input fallback`. These two commits had lived only on a non-PR'd branch; bumping past `19b2bd5` without the rebase would silently lose island data-props serialisation (73 of 145 e2e tests would fail with "e is not iterable" on every doc page) and the Tailwind input-CSS path probe (host's `@theme` block under `src/` would never reach Tailwind).
- **Adds `Takazudo/zudo-front-builder#155`** — purely additive renderer-emission unit test for the islands slot. PR [#154](https://github.com/Takazudo/zudo-front-builder/pull/154) already covered the CSS slot; #155 closes the symmetry so future regressions of the islands slot are caught at zfb build time.
- **Adds a deployed-preview asset-prefix smoke CI gate** in `preview-deploy.yml`, `pr-checks.yml`, and `main-deploy.yml`. Each curls the deployed HTML and asserts both `href="/pj/zudo-doc/assets/..."` and `src="/pj/zudo-doc/assets/..."` are present. Verified live on this PR's preview: the gate runs and passes.
- **Re-verifies and corrects audit S9 / S13** rows whose "fixed by S1" claim was based on broken local-build output last round. Both audits now have explicit `## S5 re-verification` sections with verbatim grep output against the post-fix `dist/`.
- **Appends a 2026-05-04 retro section** to `.claude/skills/l-lessons-zfb-migration-parity/SKILL.md` so the lessons survive future `/big-plan` invocations.

Closes [#1386](https://github.com/zudolab/zudo-doc/issues/1386), [#1387](https://github.com/zudolab/zudo-doc/issues/1387), [#1388](https://github.com/zudolab/zudo-doc/issues/1388), [#1389](https://github.com/zudolab/zudo-doc/issues/1389), [#1390](https://github.com/zudolab/zudo-doc/issues/1390), [#1391](https://github.com/zudolab/zudo-doc/issues/1391), [#1392](https://github.com/zudolab/zudo-doc/issues/1392), [#1384](https://github.com/zudolab/zudo-doc/issues/1384) (subsumed by S2).

## Topic PRs

Sub-tasks merged into `base/asset-base-path-fix` in dependency order; topic branches were merged locally (regular non-fast-forward) and deleted as they integrated, so this PR carries the full multi-merge-commit history rather than separate topic-PRs.

| Sub | Issue | Merge commit | Concern |
|---|---|---|---|
| S1 | [#1387](https://github.com/zudolab/zudo-doc/issues/1387) | _verification only — no host-repo commits; landed `Takazudo/zudo-front-builder#155` upstream_ | Verify upstream PR #154 threads `base` end-to-end + add islands-slot renderer-emission test |
| S2 | [#1388](https://github.com/zudolab/zudo-doc/issues/1388) | `c0b68b0` | Atomic three-point pin bump + roll e2e fixtures forward (closes [#1384](https://github.com/zudolab/zudo-doc/issues/1384)) |
| S3 | [#1389](https://github.com/zudolab/zudo-doc/issues/1389) | `728581d` (+ `c2c6b49` fix-up + `a640ea8` SIGPIPE fix) | Deployed-preview asset-prefix smoke CI gate |
| S4 | [#1390](https://github.com/zudolab/zudo-doc/issues/1390) | _manager-driven verification only — no commits_ | Independent end-to-end verification on persisted state |
| S5 | [#1391](https://github.com/zudolab/zudo-doc/issues/1391) | `03a1c18` | Re-verify audits S9 (logo CSS-mask) + S13 against post-fix preview |
| S6 | [#1392](https://github.com/zudolab/zudo-doc/issues/1392) | `4126376` | Append retro entry to lessons file |

## Independent verification (S4 deliverable)

The structural anti-trap to epic #1360's failure mode. Verification was reproduced by the manager (Opus, `/x-wt-teams` root session) on persisted base AND deployed preview, NOT delegated.

### Local clean build (post-S6 merge)

```
$ git rev-parse HEAD
4126376e24ff81256098c953b44794646cf43946  (pre-CI-fixup; same content for asset-prefix purposes as a640ea8)
$ rm -rf dist node_modules/.cache && pnpm build
✓ 247 pages built in 42.18s
$ grep -roE '(href|src)="/?assets/[^"]*"' dist/ | grep -v '/pj/zudo-doc/' | head
(no matches — zero unprefixed)
$ grep -roE '(href|src)="/pj/zudo-doc/assets/[^"]*"' dist/ | wc -l
492
$ grep -oE '(href|src)="[^"]*assets/[^"]*"' dist/index.html
href="/pj/zudo-doc/assets/styles-ab5f6362.css"
src="/pj/zudo-doc/assets/islands-ce0a5b92.js"
$ grep -oE '(href|src)="[^"]*assets/[^"]*"' dist/docs/getting-started/installation/index.html
href="/pj/zudo-doc/assets/styles-ab5f6362.css"
src="/pj/zudo-doc/assets/islands-ce0a5b92.js"
$ grep -oE '(href|src)="[^"]*assets/[^"]*"' dist/ja/docs/getting-started/installation/index.html
href="/pj/zudo-doc/assets/styles-ab5f6362.css"
src="/pj/zudo-doc/assets/islands-ce0a5b92.js"
$ grep -roE 'data-props=' dist/ --include='*.html' | wc -l
1335
```

### Deployed preview (https://pr-1393.zudo-doc.pages.dev/pj/zudo-doc/)

```
$ curl -fsSL https://pr-1393.zudo-doc.pages.dev/pj/zudo-doc/ | grep -oE '(href|src)="[^"]*assets/[^"]*"'
href="/pj/zudo-doc/assets/styles-dc890411.css"
src="/pj/zudo-doc/assets/islands-ce0a5b92.js"
$ curl -fsSL https://pr-1393.zudo-doc.pages.dev/pj/zudo-doc/docs/getting-started/installation/ | grep -oE '(href|src)="[^"]*assets/[^"]*"'
href="/pj/zudo-doc/assets/styles-dc890411.css"
src="/pj/zudo-doc/assets/islands-ce0a5b92.js"
$ curl -fsSL https://pr-1393.zudo-doc.pages.dev/pj/zudo-doc/ja/docs/getting-started/installation/ | grep -oE '(href|src)="[^"]*assets/[^"]*"'
href="/pj/zudo-doc/assets/styles-dc890411.css"
src="/pj/zudo-doc/assets/islands-ce0a5b92.js"
```

### Browser-side verification (one-shot Opus subagent per skill resource-coordination rule)

- Root + deep page render styled (header, sidebar, breadcrumb, TOC visible)
- SidebarToggle hydrates: `aria-expanded` toggles on click, drawer opens (mobile viewport)
- Theme toggle hydrates: `data-theme` flips light ↔ dark
- Multiple Preact islands (sidebar, theme toggle, search, AI assistant, design-token panel, history) all reach interactive state
- Zero 404s on `/pj/zudo-doc/assets/...` (the build-bundle slot — the asset-base-path-fix scope)

### CI gate verification

The new pr-checks.yml Preview Deploy smoke step ran live on this PR (commit `a640ea8`) and passed:

```
2026-05-04T00:22:35Z Checking prefixed asset URLs at: https://pr-1393.zudo-doc.pages.dev/pj/zudo-doc/
2026-05-04T00:22:35Z OK: deployed PR preview has prefixed asset URLs
```

## Out-of-scope findings (NOT introduced by this epic, NOT blocking)

Discovered during S4 deployed-preview browser verification, filed honestly as separate concerns per the skill's "raise unrelated findings" default behavior:

1. **`/pj/zudo-doc/img/logo.svg` returns 404** — `public/` directory contents not copied to `dist/` (the host's `public/img/logo.svg` exists in source but doesn't make it to deploy). The CSS-mask URL is correctly *prefixed* — the audit S9 "fixed by S1" claim about `withBase()` URL emission holds — but the asset itself is missing. Filed as new issue [#1394](https://github.com/zudolab/zudo-doc/issues/1394).
2. **`[zfb fallback render]` raw-text body on deep MDX content pages** — already tracked as [#1380](https://github.com/zudolab/zudo-doc/issues/1380) (deferred follow-up per epic #1386 body).

Per the epic body, these belong to the deferred-follow-up `/big-plan` after epic #1386 lands. They do NOT regress anything from before this epic.

## Test plan

- [x] Local clean build emits prefixed asset URLs in `dist/` on root + deep EN + deep JA pages
- [x] `data-props` SSR attribute populated on islands (1335 occurrences in HTML, was 0 at intermediate broken SHA)
- [x] `pnpm test:e2e:ci --workers=1` passes locally (145 / 0 / 3.4m)
- [x] CI E2E Tests pass on this PR (commit `a640ea8`)
- [x] Deployed PR preview emits prefixed asset URLs (curl-verified)
- [x] Hydration works on deployed preview (sidebar toggle, theme toggle interactive)
- [x] Browser console: zero `/pj/zudo-doc/assets/...` 404s
- [x] New pr-checks.yml smoke gate runs in CI and passes
- [x] All 7 CI checks green on `a640ea8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)