### PR TITLE
Wave 1 of zfb-pin-bump-embed-v8: planning + e2e flake patch

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -74,7 +74,7 @@ permissions:
 env:
   # Pinned zfb commit — keep in sync with the zfb pin comment at the
   # top of zfb.config.ts and the same env in pr-checks.yml.
-  ZFB_PINNED_SHA: 88cec078b568596b57b5ba041adc2849d28fa737
+  ZFB_PINNED_SHA: bdbfbfb80d57f86de2485100af380b4b8c82c8f7
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -83,7 +83,7 @@ jobs:
   build-zfb:
     name: Build zfb Binary
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
 
     steps:
       - name: Checkout pinned zfb

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -57,7 +57,7 @@ env:
   # Pinned zfb commit — keep in sync with the zfb pin comment at the
   # top of zfb.config.ts. Updating the pin here without updating that
   # comment (or vice versa) will silently desync local dev from CI.
-  ZFB_PINNED_SHA: 88cec078b568596b57b5ba041adc2849d28fa737
+  ZFB_PINNED_SHA: bdbfbfb80d57f86de2485100af380b4b8c82c8f7
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -87,7 +87,7 @@ jobs:
   build-zfb:
     name: Build zfb Binary
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
 
     steps:
       - name: Checkout pinned zfb

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -52,7 +52,7 @@ permissions:
 env:
   # Pinned zfb commit — keep in sync with the zfb pin comment at the
   # top of zfb.config.ts and the same env in pr-checks.yml.
-  ZFB_PINNED_SHA: 88cec078b568596b57b5ba041adc2849d28fa737
+  ZFB_PINNED_SHA: bdbfbfb80d57f86de2485100af380b4b8c82c8f7
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -61,7 +61,7 @@ jobs:
   build-zfb:
     name: Build zfb Binary
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
 
     steps:
       - name: Checkout pinned zfb

--- a/__planning/zfb-pin-bump/cache-strategy.md
+++ b/__planning/zfb-pin-bump/cache-strategy.md
@@ -1,0 +1,100 @@
+# Cache Strategy Decision — embed-v8 first-build cost
+
+**Epic:** zfb-pin-bump-embed-v8 (#1407)
+**Wave:** W1C
+**Date:** 2026-05-04
+
+---
+
+## 1. ZFB_PINNED_SHA occurrence count
+
+Manager pre-counted 15; actual count is **16** across the 3 workflow files.
+
+| File | Count | Lines |
+|---|---|---|
+| `.github/workflows/main-deploy.yml` | 5 | 77 (env decl), 93 (`ref:`), 101 (`key:`), 147 (`git -C checkout`), 213 (`git -C checkout`) |
+| `.github/workflows/preview-deploy.yml` | 4 | 55 (env decl), 71 (`ref:`), 79 (`key:`), 126 (`git -C checkout`) |
+| `.github/workflows/pr-checks.yml` | 7 | 60 (env decl), 97 (`ref:`), 105 (`key:`), 156 (`git -C checkout`), 215 (`git -C checkout`), 296 (`git -C checkout`), 353 (`git -C checkout`) |
+| **Total** | **16** | |
+
+The off-by-one vs. manager's pre-count of 15: `pr-checks.yml` has 7 occurrences (4 `git -C checkout` lines across `typecheck`, `build-site`, `build-history`, and `e2e` jobs), not 6. All references follow the same pattern: one `env:` declaration per file, one `ref:` in the `build-zfb` checkout step, one `key:` in the `Swatinem/rust-cache` step, and one `git -C ../zfb checkout "$ZFB_PINNED_SHA"` per install-bearing job.
+
+---
+
+## 2. Upstream health.yml cache config vs. ours
+
+**Upstream (`$HOME/repos/myoss/zfb/.github/workflows/health.yml`):**
+
+```yaml
+- uses: Swatinem/rust-cache@v2
+  with:
+    prefix-key: "v1-zfb"
+```
+
+No `shared-key` or `cache-directories` overrides. The `prefix-key: "v1-zfb"` comment in upstream explains the intent: _"Prefix so future workspace-member additions don't share a stale cache."_ The upstream also explicitly notes in an inline comment that the `timeout-minutes: 45` budget accounts for V8 first compile costing 15-30 min.
+
+**Ours (all 3 workflow files, `build-zfb` job):**
+
+```yaml
+- uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+  with:
+    workspaces: zfb-src
+    key: zfb-${{ env.ZFB_PINNED_SHA }}
+```
+
+We pin the action to a commit hash (good for supply-chain safety). We set `workspaces: zfb-src` (because we check out zfb into `zfb-src/`, not the repo root). We use `key: zfb-${{ env.ZFB_PINNED_SHA }}` as an extra suffix on top of Swatinem's auto-generated key.
+
+**Differences:**
+
+- Upstream uses `prefix-key: "v1-zfb"` for cache namespace isolation; we use `key:` (Swatinem's `key` is an _additional_ suffix appended to the auto-generated key — not a replacement for `prefix-key`).
+- Upstream has no `workspaces` override (builds in repo root); we need `workspaces: zfb-src` because our checkout path is non-standard.
+- Neither upstream nor ours sets `cache-directories` explicitly — both rely on Swatinem's defaults (`~/.cargo/registry`, `~/.cargo/git`, `target/`).
+
+---
+
+## 3. Decision: (A) No change
+
+**Rationale:** Our current `Swatinem/rust-cache@v2.9.1` config with `workspaces: zfb-src` and `key: zfb-${{ env.ZFB_PINNED_SHA }}` is already well-suited for the embed-v8 pin bump. The SHA-keyed cache suffix (`key: zfb-${{ env.ZFB_PINNED_SHA }}`) is actually _stricter_ than upstream's `prefix-key: "v1-zfb"` approach: when the SHA changes (the whole point of W3), Swatinem will automatically produce a cache miss on all three workflows, pay the 15-30 min first-build cost exactly once per SHA, and then cache the full deno_core / V8 compiled artifacts on subsequent runs. Adding a `prefix-key` bump (option B) would be redundant — the SHA suffix already provides per-pin cache isolation, so there is no stale `target/` risk. Adding explicit `cache-directories` (option C) is equally unnecessary because Swatinem's defaults already cover `~/.cargo/registry`, `~/.cargo/git`, and `target/`; deno_core and V8 build products land in `target/` under the workspace root, which Swatinem discovers automatically via the `workspaces: zfb-src` setting. The only actionable note for W3: the `timeout-minutes: 20` cap on all three `build-zfb` jobs may be tight for the first cold build post-SHA-bump given the ADR-007 estimate of 15-30 min. W3 should consider raising it to 45 min (matching upstream's budget) for the first post-embed-v8 run, then reverting or keeping it at 45 to stay conservative.
+
+---
+
+## 4. Diff hunks for W3
+
+Decision is **(A) No change** to cache config. No workflow YAML edits are required.
+
+**Optional (non-blocking) recommendation for W3:** raise `timeout-minutes` on `build-zfb` jobs from 20 to 45 to guard against the cold-compile window. This is not a cache-strategy change and is left to W3's discretion.
+
+If W3 wants to apply the timeout guard:
+
+```diff
+--- a/.github/workflows/main-deploy.yml
++++ b/.github/workflows/main-deploy.yml
+@@ -84,7 +84,7 @@ jobs:
+   build-zfb:
+     name: Build zfb Binary
+     runs-on: ubuntu-latest
+-    timeout-minutes: 20
++    timeout-minutes: 45
+```
+
+```diff
+--- a/.github/workflows/preview-deploy.yml
++++ b/.github/workflows/preview-deploy.yml
+@@ -61,7 +61,7 @@ jobs:
+   build-zfb:
+     name: Build zfb Binary
+     runs-on: ubuntu-latest
+-    timeout-minutes: 20
++    timeout-minutes: 45
+```
+
+```diff
+--- a/.github/workflows/pr-checks.yml
++++ b/.github/workflows/pr-checks.yml
+@@ -88,6 +88,6 @@ jobs:
+   build-zfb:
+     name: Build zfb Binary
+     runs-on: ubuntu-latest
+-    timeout-minutes: 20
++    timeout-minutes: 45
+```

--- a/__planning/zfb-pin-bump/final-report.md
+++ b/__planning/zfb-pin-bump/final-report.md
@@ -1,0 +1,89 @@
+# Wave 4 — Final verification report
+
+- **Date**: 2026-05-05
+- **Epic**: zudolab/zudo-doc#1407
+- **Root PR**: zudolab/zudo-doc#1416 (`base/zfb-pin-bump-embed-v8` → `base/zfb-migration-parity`)
+- **Final SHA**: `bdbfbfb80d57f86de2485100af380b4b8c82c8f7` (shifted twice from spec target during execution)
+
+## SHA evolution
+
+| Step | SHA | Reason |
+|---|---|---|
+| Plan target | `e550167` | Original upstream main HEAD when /big-plan ran |
+| W2 spec target | `0549132` | After W1B's autonomous fix (PR #170: cold-start rebuild + PageCache disk fallback) |
+| W3 final | `bdbfbfb` | After W3's discovery + autonomous fix of `node:async_hooks` stub gap (`AsyncLocalStorage` import in `@takazudo/zfb-adapter-cloudflare`) |
+
+W1B and W3 both exercised the autonomous upstream fix authority granted by the user for this epic.
+
+## CI verification (PR #1416)
+
+All 7 checks GREEN:
+
+| Check | Result |
+|---|---|
+| Type Check | pass |
+| Build Site | pass |
+| Build zfb Binary | pass (deno_core cold compile cached) |
+| Build Doc History | pass |
+| Template Drift | pass |
+| **E2E Tests** | **pass** — W1D `domcontentloaded` swap + smoke fixture build green |
+| **Preview Deploy** | **pass** — comment-posting transient 502 from earlier run did not recur |
+
+Final CI run: 2026-05-05 02:49 (durations consistent with cached deno_core artifacts).
+
+## Manager-side independent re-grep on persisted state
+
+```
+$ pnpm install   # 24.9s
+$ pnpm build     # 247 pages in 179.89s
+$ grep -c '/pj/zudo-doc/assets/' dist/index.html       # 1
+$ grep -c '/pj/zudo-doc/img/' dist/index.html          # 1
+$ grep -c 'type="module"' dist/index.html              # 2
+```
+
+Sample URLs in `dist/index.html`:
+
+- `/pj/zudo-doc/assets/islands-ce0a5b92.js`
+- `/pj/zudo-doc/assets/styles-303abaff.css`
+- `/pj/zudo-doc/img/logo.svg`
+
+Prefixed-asset regression guard (epic #1386) holds with the new pin.
+
+## Deployed-preview curl smoke
+
+Preview URL: `https://pr-1416.zudo-doc.pages.dev`
+
+```
+$ curl -sf "https://pr-1416.zudo-doc.pages.dev/pj/zudo-doc/" -o /tmp/preview.html
+$ wc -l /tmp/preview.html                              # 1040
+$ grep -c '/pj/zudo-doc/' /tmp/preview.html            # 2 (in style+script tags + many docs links)
+```
+
+Sample refs:
+
+- `href="/pj/zudo-doc/assets/styles-ea3fb6dc.css"`
+- `href="/pj/zudo-doc/docs/changelog/"` (and many sibling doc paths)
+
+Cloudflare Pages serves the prefixed deployment correctly.
+
+## Wave 1–4 commit summary
+
+```
+6a7e77c Merge W1A: upstream survey
+86d8e4f Merge W1B: upstream smoke + PR #170 fix
+bef5623 Merge W1C: cache strategy decision
+bfd5b4c Merge W1D: e2e smoke-search domcontentloaded fix
+e92482e Merge W2: pin-bump implementation spec
+a4df3c9 Merge W3: atomic pin bump 88cec07 → bdbfbfb (embed-v8 + async_hooks + consumer page fixes)
+```
+
+## Hand-off to Wave 5 (#1415)
+
+W5 should:
+
+1. Append `l-lessons-zfb-migration-parity` retro entry capturing:
+   - Two consecutive autonomous upstream fixes were needed (cold-start rebuild + async_hooks stub) — the embed-v8 architecture has more deferred edges than ADR-007 enumerated
+   - Consumer-side audit (W1A) missed the router-props signature change from upstream PR #157; future audits should grep for the page-handler call shape, not just keywords
+   - SHA target shifted twice during execution; the wave plan's "manager-confirm gate" (W2) successfully caught the first shift but the second only surfaced via build verification
+2. Delete `__planning/zfb-pin-bump/` (or move its contents into the lessons file)
+3. Close any remaining open Wave issues (#1414, #1413 will be closed automatically; #1415 closes itself)

--- a/__planning/zfb-pin-bump/spec.md
+++ b/__planning/zfb-pin-bump/spec.md
@@ -1,0 +1,435 @@
+# W2 Spec: zfb Pin Bump — embed-v8 + cold-start-rebuild
+
+**Date:** 2026-05-04
+**Wave:** W2 — Manager-confirm gate + implementation spec
+**Branch:** `zfb-pin-bump-embed-v8/w2-spec`
+**Depends on:** W1A (#1408), W1B (#1409), W1C (#1410)
+
+---
+
+## 1. Hard Gate — W1B Status
+
+**CLEAR. Proceed.**
+
+W1B found two bugs in `e550167` (cold-start rebuild + PageCache disk fallback) and autonomously merged PR #170 to upstream. The new upstream HEAD is `0549132`. W1B reported all three smokes PASS at `0549132`. No HOLD is warranted.
+
+---
+
+## 2. Final New SHA
+
+```
+0549132255827d1581c3933f7a422b0a577025ce
+```
+
+Short form: `0549132`
+
+Re-fetched from upstream on 2026-05-04:
+
+```bash
+cd $HOME/repos/myoss/zfb
+git fetch origin
+git rev-parse origin/main
+# → 0549132255827d1581c3933f7a422b0a577025ce
+```
+
+**Note:** W1A and W1B initially targeted `e550167` (merge of PR #168). W1B exercised upstream fix authority and merged PR #170 (`fix/dev-cold-start-rebuild`) on top. The new pin is `0549132` — the merge commit of PR #170, **not** `e550167`. The issue brief has been updated accordingly.
+
+---
+
+## 3. Linear-Ancestry Confirmation
+
+```bash
+cd $HOME/repos/myoss/zfb
+git merge-base --is-ancestor 88cec07 origin/main && echo "linear-ancestry-confirmed"
+# → linear-ancestry-confirmed
+
+git log 88cec07..origin/main --oneline | wc -l
+# → 35
+```
+
+**Result:** `88cec07` IS a linear ancestor of `0549132`. 35 commits in range. Ancestry confirmed.
+
+Merged PRs in range (chronological order):
+- PR #157 — `fix/basic-blog-end-to-end` (1 commit: `26f5141`)
+- PR #168 — `base/embed-v8` (sub-161 through sub-167, 33 commits including post-merge fixups)
+- PR #170 — `fix/dev-cold-start-rebuild` (2 commits: `11d6d64` + merge `0549132`)
+
+---
+
+## 4. Consumer-Side Audit
+
+**Re-grep result (2026-05-04):**
+
+```
+src/content/docs-ja/concepts/routing-conventions.mdx:17: miniflare (prose)
+src/content/docs-ja/concepts/routing-conventions.mdx:193: miniflare (prose)
+src/content/docs/concepts/routing-conventions.mdx:17: miniflare (prose)
+src/content/docs/concepts/routing-conventions.mdx:201: miniflare (prose)
+```
+
+**Assessment:** Only doc content prose. No `SpawnMiniflare`, `Backend::`, or `workerd` references in build/runtime code. No code changes required for the pin bump.
+
+**Post-merge follow-up (W4):** Update EN+JA routing-conventions.mdx to say "embedded V8 / deno_core" instead of "miniflare." See section 9b below.
+
+---
+
+## 5. ZFB_PINNED_SHA Occurrence Count: 16
+
+W1C confirmed 16 occurrences (not 15 as originally estimated by manager). The extra occurrence is in `pr-checks.yml`'s `e2e` job.
+
+| File | Count | Occurrence types |
+|------|-------|-----------------|
+| `.github/workflows/main-deploy.yml` | 5 | env decl (L77), `ref:` (L93), `key:` (L101), `git -C checkout` build-site (L147), `git -C checkout` build-history (L213) |
+| `.github/workflows/preview-deploy.yml` | 4 | env decl (L55), `ref:` (L71), `key:` (L79), `git -C checkout` build-and-deploy (L126) |
+| `.github/workflows/pr-checks.yml` | 7 | env decl (L60), `ref:` (L97), `key:` (L105), `git -C checkout` typecheck (L156), `git -C checkout` build-site (L215), `git -C checkout` build-history (L296), `git -C checkout` e2e (L353) |
+| **Total** | **16** | |
+
+---
+
+## 6. Per-File Diff Hunks
+
+**Old SHA:** `88cec078b568596b57b5ba041adc2849d28fa737`
+**New SHA:** `0549132255827d1581c3933f7a422b0a577025ce`
+
+### 6a. `.github/workflows/main-deploy.yml`
+
+**Occurrence 1 — L77: env declaration**
+```diff
+@@ -74,7 +74,7 @@ env:
+   # Pinned zfb commit — keep in sync with the zfb pin comment at the
+   # top of zfb.config.ts and the same env in pr-checks.yml.
+-  ZFB_PINNED_SHA: 88cec078b568596b57b5ba041adc2849d28fa737
++  ZFB_PINNED_SHA: 0549132255827d1581c3933f7a422b0a577025ce
+```
+
+**Occurrence 2 — L93: `ref:` in build-zfb checkout step**
+```diff
+@@ -90,7 +90,7 @@ jobs:
+       - name: Checkout pinned zfb
+         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+         with:
+           repository: Takazudo/zudo-front-builder
+-          ref: ${{ env.ZFB_PINNED_SHA }}
++          ref: ${{ env.ZFB_PINNED_SHA }}
+```
+*(This occurrence uses the env var `${{ env.ZFB_PINNED_SHA }}` — it does NOT hardcode the SHA. No change required here; it auto-picks up the new env value. The count still includes it because it IS a reference to ZFB_PINNED_SHA.)*
+
+**Occurrence 3 — L101: `key:` in Swatinem/rust-cache step**
+```diff
+@@ -99,7 +99,7 @@ jobs:
+       - name: Cache cargo build
+         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+         with:
+           workspaces: zfb-src
+-          key: zfb-${{ env.ZFB_PINNED_SHA }}
++          key: zfb-${{ env.ZFB_PINNED_SHA }}
+```
+*(Same pattern — uses env var, auto-picks up new value.)*
+
+**Occurrence 4 — L147: `git -C ../zfb checkout` in build-site job**
+```diff
+@@ -144,7 +144,7 @@ jobs:
+       - name: Clone zfb sibling repo
+         run: |
+           git clone https://github.com/Takazudo/zudo-front-builder.git ../zfb
+-          git -C ../zfb checkout "$ZFB_PINNED_SHA"
++          git -C ../zfb checkout "$ZFB_PINNED_SHA"
+```
+*(Uses env var — auto-picks up new value.)*
+
+**Occurrence 5 — L213: `git -C ../zfb checkout` in build-history job**
+```diff
+@@ -210,7 +210,7 @@ jobs:
+       - name: Clone zfb sibling repo
+         run: |
+           git clone https://github.com/Takazudo/zudo-front-builder.git ../zfb
+-          git -C ../zfb checkout "$ZFB_PINNED_SHA"
++          git -C ../zfb checkout "$ZFB_PINNED_SHA"
+```
+*(Uses env var — auto-picks up new value.)*
+
+**Summary for main-deploy.yml:** Only ONE actual text change — the `env:` declaration at L77. All other occurrences use `${{ env.ZFB_PINNED_SHA }}` or `"$ZFB_PINNED_SHA"` and auto-propagate.
+
+**Effective diff for main-deploy.yml:**
+```diff
+--- a/.github/workflows/main-deploy.yml
++++ b/.github/workflows/main-deploy.yml
+@@ -74,7 +74,7 @@ env:
+   # Pinned zfb commit — keep in sync with the zfb pin comment at the
+   # top of zfb.config.ts and the same env in pr-checks.yml.
+-  ZFB_PINNED_SHA: 88cec078b568596b57b5ba041adc2849d28fa737
++  ZFB_PINNED_SHA: 0549132255827d1581c3933f7a422b0a577025ce
+```
+
+### 6b. `.github/workflows/preview-deploy.yml`
+
+**Occurrence 1 — L55: env declaration**
+
+**Effective diff for preview-deploy.yml:**
+```diff
+--- a/.github/workflows/preview-deploy.yml
++++ b/.github/workflows/preview-deploy.yml
+@@ -52,7 +52,7 @@ env:
+   # Pinned zfb commit — keep in sync with the zfb pin comment at the
+   # top of zfb.config.ts and the same env in pr-checks.yml.
+-  ZFB_PINNED_SHA: 88cec078b568596b57b5ba041adc2849d28fa737
++  ZFB_PINNED_SHA: 0549132255827d1581c3933f7a422b0a577025ce
+```
+
+*(Occurrences 2–4 at L71 `ref:`, L79 `key:`, L126 `git -C checkout` all use the env var and auto-propagate.)*
+
+### 6c. `.github/workflows/pr-checks.yml`
+
+**Occurrence 1 — L60: env declaration**
+
+**Effective diff for pr-checks.yml:**
+```diff
+--- a/.github/workflows/pr-checks.yml
++++ b/.github/workflows/pr-checks.yml
+@@ -57,7 +57,7 @@ env:
+   # Pinned zfb commit — keep in sync with the zfb pin comment at the
+   # top of zfb.config.ts. Updating the pin here without updating that
+   # comment (or vice versa) will silently desync local dev from CI.
+-  ZFB_PINNED_SHA: 88cec078b568596b57b5ba041adc2849d28fa737
++  ZFB_PINNED_SHA: 0549132255827d1581c3933f7a422b0a577025ce
+```
+
+*(Occurrences 2–7 at L97 `ref:`, L105 `key:`, L156/L215/L296/L353 `git -C checkout` all use the env var and auto-propagate.)*
+
+---
+
+## 7. `zfb.config.ts` Comment Block Update
+
+The existing pin comment block occupies lines 1–180 of `zfb.config.ts`. W3 must replace lines 3–6 (the `commit:` line and its continuation) and append new `includes fixes:` entries, and update the `pinned by:` chain at lines 172–179.
+
+**Effective diff for zfb.config.ts:**
+```diff
+--- a/zfb.config.ts
++++ b/zfb.config.ts
+@@ -1,8 +1,12 @@
+ /**
+  * zfb pin (canonical, shared with E2/E4):
+- *   commit: 88cec07 (Takazudo/zudo-front-builder main, post-merge of PR #156
+- *           — wave13 rebase: data-props SSR + Tailwind src/styles/global.css
+- *           input-CSS path probe — on top of PR #155 renderer-emission test
+- *           and PR #154 feat/asset-base-path; 2026-05-04)
++ *   commit: 0549132 (Takazudo/zudo-front-builder main, post-merge of PR #170
++ *           — fix/dev-cold-start-rebuild: cold-start rebuild empty dirty set +
++ *           PageCache disk fallback; on top of PR #168 embed-v8 (replace
++ *           miniflare subprocess with embedded deno_core via deno_core crate)
++ *           and PR #157 basic-blog end-to-end fix; 2026-05-04)
+  *   includes fixes:
+```
+
+And after the existing last `includes fixes:` bullet (currently the `#156` wave13 rebase entry at ~L171), append:
+
+```
+ *     - Takazudo/zudo-front-builder PR #157 (fix examples/basic-blog build
+ *                               end-to-end — 6 bugs fixed; no consumer API
+ *                               change)
+ *     - Takazudo/zudo-front-builder PR #168 / sub-161 (ADR-007: author
+ *                               embedded deno_core ADR, superseding ADR-005
+ *                               miniflare subprocess)
+ *     - Takazudo/zudo-front-builder PR #168 / sub-162 (implement
+ *                               EmbeddedV8RenderHost: deno_core + node:*
+ *                               runtime stubs + deno_fetch/web/url/console
+ *                               Web API extensions)
+ *     - Takazudo/zudo-front-builder PR #168 / sub-163 (CI: wire
+ *                               Swatinem/rust-cache@v2; document 15-30 min
+ *                               V8 first-build cost in CONTRIBUTING.md)
+ *     - Takazudo/zudo-front-builder PR #168 / sub-164 (renderer: add
+ *                               Backend::EmbeddedV8 + Backend::Stub,
+ *                               WorkerDispatch enum; swap dispatch path)
+ *     - Takazudo/zudo-front-builder PR #168 / sub-165 (test: ContentSnapshot
+ *                               e2e verification tests)
+ *     - Takazudo/zudo-front-builder PR #168 / sub-166 (cli: flip default
+ *                               Backend from SpawnMiniflare → EmbeddedV8
+ *                               in build/dev pipelines)
+ *     - Takazudo/zudo-front-builder PR #168 / sub-167 (cleanup: delete
+ *                               miniflare-bootstrap.mjs, strip
+ *                               SpawnMiniflare backend, scrub all miniflare
+ *                               references from code/docs/config)
+ *     - Takazudo/zudo-front-builder PR #170 (fix(dev): cold-start rebuild
+ *                               empty dirty set (DependencyGraph seeded with
+ *                               all page IDs on startup; empty dirty escalates
+ *                               to PageSelection::All) + PageCache disk
+ *                               fallback (serve_page() reads from dist/ on
+ *                               cache miss instead of returning 500))
+```
+
+And update the `pinned by:` chain (currently lines 172–179) to append:
+
+```diff
+-  *   pinned by: epic zudolab/zudo-doc#1353 (super-epic #1333) → bumped by epic
+-  *              zudolab/zudo-doc#1355 (Sig F finalisation + post-#131 hash-mismatch follow-up
+-  *              + Sig G island-resolver/esbuild parity + shared-bundle hydration glue
+-  *              + manifest-key alignment + wave 12 hydration prop serialisation
+-  *              + wave 13 Tailwind input-CSS path-probe gap) → bumped by epic
+-  *              zudolab/zudo-doc#1360 sub-issue #1361 (S1 BLOCKER: HTML asset URLs respect
+-  *              site `base`) → bumped by epic zudolab/zudo-doc#1386 sub-issue #1388
+-  *              (atomic three-point pin bump + e2e fixture roll-forward; closes #1384)
++  *   pinned by: epic zudolab/zudo-doc#1353 (super-epic #1333) → bumped by epic
++  *              zudolab/zudo-doc#1355 (Sig F finalisation + post-#131 hash-mismatch follow-up
++  *              + Sig G island-resolver/esbuild parity + shared-bundle hydration glue
++  *              + manifest-key alignment + wave 12 hydration prop serialisation
++  *              + wave 13 Tailwind input-CSS path-probe gap) → bumped by epic
++  *              zudolab/zudo-doc#1360 sub-issue #1361 (S1 BLOCKER: HTML asset URLs respect
++  *              site `base`) → bumped by epic zudolab/zudo-doc#1386 sub-issue #1388
++  *              (atomic three-point pin bump + e2e fixture roll-forward; closes #1384)
++  *              → bumped by epic zudolab/zudo-doc#1407 (zfb-pin-bump-embed-v8: pick up
++  *              PR #168 embedded deno_core + PR #170 cold-start-rebuild fix)
+```
+
+---
+
+## 8. `publicDir` Workaround Status
+
+**zfb#158: OPEN** (confirmed 2026-05-04 via `gh issue view 158 --json state`).
+
+`plugins/copy-public-plugin.mjs` and its `zfb.config.ts` entry at L406 area must be **retained** in this pin bump. No change required for this item.
+
+---
+
+## 9. Atomic Commit Message for W3
+
+```
+chore(zfb): bump pin 88cec07 → 0549132 (embed-v8 + cold-start fix)
+
+Brings in upstream PR #168 (replaces miniflare subprocess with embedded
+deno_core via deno_core crate) and PR #170 (cold-start dev rebuild +
+PageCache disk fallback fix). Also includes PR #157 (basic-blog 6-bug fix).
+
+Linear ancestry confirmed: 88cec07 IS an ancestor of 0549132.
+Consumer-side audit: no Backend::SpawnMiniflare or workerd references in
+zudo-doc build/runtime code (4 miniflare mentions in routing-conventions.mdx
+are doc prose only — scheduled for W4 prose update).
+Upstream PR #168 smokes verified by W1B. PR #170 merged upstream by W1B.
+
+Workarounds retained: publicDir copy-public-plugin (zfb#158 OPEN),
+--color-*:initial CSS reset (zfb#159 OPEN).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+```
+
+---
+
+## 10. Pre-Flight Checks for W3
+
+Run all of these before committing the pin bump:
+
+```bash
+# 1. Confirm the new SHA is fetched locally in the zfb clone
+cd $HOME/repos/myoss/zfb
+git fetch origin
+git log 0549132 -1 --oneline
+# → should print: 0549132 Merge pull request #170 from Takazudo/fix/dev-cold-start-rebuild
+
+# 2. Belt-and-braces ancestry check
+git merge-base --is-ancestor 88cec07 0549132 && echo "ancestry-ok"
+# → ancestry-ok
+
+# 3. Confirm issue states before bumping
+gh issue view 158 --json state   # → {"state":"OPEN"}
+gh issue view 159 --json state   # → {"state":"OPEN"}
+
+# 4. Confirm occurrence count in workflows (should be 16)
+grep -rn 'ZFB_PINNED_SHA' \
+  .github/workflows/main-deploy.yml \
+  .github/workflows/preview-deploy.yml \
+  .github/workflows/pr-checks.yml | wc -l
+# → 16
+
+# 5. Dry-run: confirm all 3 env: declaration lines contain the OLD sha
+grep -n '88cec07' \
+  .github/workflows/main-deploy.yml \
+  .github/workflows/preview-deploy.yml \
+  .github/workflows/pr-checks.yml
+# → 3 hits (one per file, the env: declaration)
+
+# 6. Consumer re-audit (should only show doc prose)
+grep -rn 'SpawnMiniflare\|miniflare\|workerd\|Backend::' \
+  zfb.config.ts plugins/ packages/ pages/ src/ 2>/dev/null
+# → only routing-conventions.mdx hits (4 lines of doc prose)
+```
+
+---
+
+## 11. W4 Follow-Ups
+
+### 11a. Post-merge prose update — routing-conventions.mdx (EN + JA)
+
+**Files:**
+- `src/content/docs/concepts/routing-conventions.mdx` — L17 and L201
+- `src/content/docs-ja/concepts/routing-conventions.mdx` — L17 and L193
+
+**What to change:** Replace "miniflare" (runtime engine reference) with "embedded V8 (deno_core)" or equivalent accurate description, since the build-time engine is now the embedded V8 isolate, not miniflare. This is a prose-only doc update, not a code change.
+
+**EN prose (L17 current):**
+> zfb's `paths()` runs inside **miniflare** at build time and is **synchronous** by contract.
+
+**Suggested replacement:**
+> zfb's `paths()` runs inside an **embedded V8 isolate (deno_core)** at build time and is **synchronous** by contract.
+
+### 11b. smoke-search flake retry fallback
+
+W1B committed `ae653b4` (change `waitUntil: "load"` → `waitUntil: "domcontentloaded"` in `e2e/smoke-search.spec.ts`). This was already committed to the base by W1B. If flakiness persists post-merge, consider adding `test.describe.configure({ retries: 1 })` at the top of `e2e/smoke-search.spec.ts` as an additional guard.
+
+---
+
+## 12. Optional — `timeout-minutes` Bump (W1C Recommendation)
+
+W1C recommends (non-blocking) bumping `build-zfb` `timeout-minutes` from 20 to 45 to guard against cold V8 compile cost (ADR-007 estimates 15-30 min). W3 may apply this at its discretion.
+
+**Diff hunks if W3 applies the timeout guard:**
+
+```diff
+--- a/.github/workflows/main-deploy.yml
++++ b/.github/workflows/main-deploy.yml
+@@ -83,7 +83,7 @@ jobs:
+   build-zfb:
+     name: Build zfb Binary
+     runs-on: ubuntu-latest
+-    timeout-minutes: 20
++    timeout-minutes: 45
+```
+
+```diff
+--- a/.github/workflows/preview-deploy.yml
++++ b/.github/workflows/preview-deploy.yml
+@@ -61,7 +61,7 @@ jobs:
+   build-zfb:
+     name: Build zfb Binary
+     runs-on: ubuntu-latest
+-    timeout-minutes: 20
++    timeout-minutes: 45
+```
+
+```diff
+--- a/.github/workflows/pr-checks.yml
++++ b/.github/workflows/pr-checks.yml
+@@ -87,7 +87,7 @@ jobs:
+   build-zfb:
+     name: Build zfb Binary
+     runs-on: ubuntu-latest
+-    timeout-minutes: 20
++    timeout-minutes: 45
+```
+
+**Recommendation:** Apply. The 20 min cap was set before the embed-v8 epic landed deno_core. Cold V8 compile on a fresh GitHub Actions runner will likely hit 15-30 min. The Rust cache (`Swatinem/rust-cache` with `key: zfb-${{ env.ZFB_PINNED_SHA }}`) guarantees a cache miss on first run at the new SHA, so W3's first CI run post-bump will pay the full cost. Setting timeout to 45 matches upstream `health.yml` convention and eliminates the risk of a false-failure timeout on the initial cold build.
+
+---
+
+## 13. Manager-Confirm Decision Record
+
+| Item | W1 Finding | W2 Re-verify | Decision |
+|------|-----------|-------------|---------|
+| Upstream HEAD SHA | W1B: `0549132` (after merging PR #170) | Re-fetched: `0549132` confirmed | Pin to `0549132` |
+| zfb#158 (publicDir copy) | W1A: OPEN | Re-checked: OPEN | Retain workaround |
+| zfb#159 (default-theme leak) | W1A: OPEN | Re-checked: OPEN | Retain workaround |
+| Consumer code changes | W1A: None required | Re-grep: confirmed none | No consumer changes |
+| ZFB_PINNED_SHA count | W1C: 16 (not 15) | Verified: 16 across 3 files | All 16 covered in spec |
+| Cache config change | W1C: Decision A (no change) | Accepted | No cache config changes |
+| `timeout-minutes` bump | W1C: Optional 20→45 | Included as optional diff | W3 decides |
+| Linear ancestry | W1 (implied) | Confirmed: `88cec07` IS ancestor of `0549132` | Proceed |
+| Miniflare doc prose | W1A: Deferred post-W2 | Confirmed: 4 doc lines only | W4 follow-up |
+| smoke-search flake | W1B: Fixed with domcontentloaded | Commit `ae653b4` in base | If persists: retries: 1 |

--- a/__planning/zfb-pin-bump/survey.md
+++ b/__planning/zfb-pin-bump/survey.md
@@ -1,0 +1,192 @@
+# W1A Survey: zfb Pin Bump — Embed V8 (`88cec07..e550167`)
+
+**Date:** 2026-05-04
+**Branch:** `zfb-pin-bump-embed-v8/w1a-survey`
+**Target upstream SHA:** `e550167` (merge of PR #168 — `[Embed V8] Replace miniflare subprocess with embedded deno_core`)
+
+---
+
+## 1. Diff Summary (`88cec07..e550167`)
+
+Two independent PRs land in this range:
+
+### PR #157 — `fix/basic-blog-end-to-end` (1 non-merge commit)
+
+- `26f5141` `fix: make examples/basic-blog build end-to-end (6 bugs fixed)`
+  Minor bug fixes to the example project; no consumer-facing API change.
+
+### PR #168 — `base/embed-v8` (sub-issues #161–#167, 22 non-merge commits)
+
+The embed-v8 epic replaces the miniflare subprocess with an in-process V8 isolate via `deno_core`. Merged in seven sub-wave merges:
+
+| Sub-merge | Sub-issue | Summary |
+|-----------|-----------|---------|
+| sub-161 | #161 | Author ADR-007; cross-ref ADR-001/003/004/005 |
+| sub-162 | #162 | Implement `EmbeddedV8RenderHost` (`deno_core` + `node:*` stubs + Web polyfills) |
+| sub-163 | #163 | Wire `Swatinem/rust-cache` CI cache; document V8 first-build cost |
+| sub-164 | #164 | Add `Backend::EmbeddedV8` + `Backend::Stub`; swap renderer dispatch path |
+| sub-165 | #165 | Add `ContentSnapshot` e2e verification tests |
+| sub-166 | #166 | Flip default `Backend` from `SpawnMiniflare` → `EmbeddedV8` in build/dev |
+| sub-167 | #167 | Delete `miniflare-bootstrap.mjs`; strip `SpawnMiniflare` backend; scrub all miniflare references from code/docs/config |
+
+Post-merge fixups: Drop impl on V8 adapter shutdown, percent-encode fix in `synthesise_specifier`, Prettier pass on V8 host JS files, lockfile regeneration, and two test corrections.
+
+---
+
+## 2. ADR-007 Summary
+
+**File:** `$HOME/repos/myoss/zfb/docs/architecture/adr-007-embedded-v8.md`
+**Status:** Accepted (2026-05-04) — supersedes ADR-005.
+
+### Tauri motivation
+
+zfb targets a Tauri-bundled desktop distribution (`.app` / `.exe` / `.AppImage`). miniflare is a Node package; Node was the only remaining runtime requirement on end-user machines for `zfb build`. Removing that dependency is a hard prerequisite for the Tauri path.
+
+### Workerd-shape contract preservation
+
+ADR-005's runtime-parity argument ("use workerd at build time") rests on a premise that no longer holds: the stable deployment contract is the **bundle shape** (`export default { fetch }`), not the build-time engine. Whatever engine rendered the bundle at build time is irrelevant to what workerd does at request time. The production path (Cloudflare Workers) is **unchanged** by this ADR.
+
+### `node:*` runtime stub strategy
+
+`deno_core` does not natively resolve `node:*` specifiers. The chosen approach is a single `op_node_compat` extension that intercepts every `node:*` specifier in the module loader and returns a stub module whose exports throw at call time. This satisfies top-level `import "node:fs"` module-graph resolution without pulling in the full `deno_node` compat layer (~150k lines). v1 coverage: `node:fs`, `node:fs/promises`, `node:path`, `node:url`, `node:buffer`. Any uncovered `node:*` specifier uses the same stub template.
+
+### `compatibilityDate` migration
+
+miniflare-bootstrap.mjs pinned `compatibilityDate: "2025-01-01"`. `deno_core` has no equivalent concept. Replacement: pin exact crate versions for `deno_core`, `deno_fetch`, `deno_web`, `deno_url`, `deno_console` in `Cargo.toml`. Version pins serve the same intentionality as `compatibilityDate` bumps, with the added benefit of being visible in `Cargo.toml` diffs.
+
+### Source-map fidelity
+
+`deno_core` surfaces JS exceptions in the same `<file>:<line>:<col>` format that `crates/zfb-render/src/sourcemap.rs` was designed around. The decoder (`decode_position`) is format-agnostic and confirmed to require no structural change. Minor frame-parser adaption (if any) is in scope of sub-162.
+
+### Cloudflare production path unchanged
+
+`packages/zfb-adapter-cloudflare`, `packages/zfb-runtime` (Hono router), and the bundler shape are all untouched. workerd executes the `export default { fetch }` bundle on request exactly as before.
+
+---
+
+## 3. `publicDir` Workaround Cross-Check (zfb#158)
+
+**Location in consumer:** `zfb.config.ts:406` and `plugins/copy-public-plugin.mjs`
+
+**Comment text:** "Workaround for upstream zfb gap (zudolab/zudo-doc#1394; upstream issue: https://github.com/Takazudo/zudo-front-builder/issues/158) — zfb build does not copy publicDir to outDir; remove once upstream ships and pin is bumped."
+
+**Verification command:**
+
+```
+cd $HOME/repos/myoss/zfb && gh issue view 158 --json state,closedAt
+```
+
+**Result:** `{"closedAt":null,"state":"OPEN"}`
+
+**Conclusion:** zfb#158 is still OPEN. The `copy-public-plugin.mjs` workaround and its `zfb.config.ts` entry must be retained in this pin bump. No W2 spec change needed for this item.
+
+---
+
+## 4. Consumer-Side Audit
+
+**Grep command:**
+
+```bash
+grep -rn 'SpawnMiniflare|miniflare|workerd|Backend::|mini_flare' \
+  zfb.config.ts plugins/ packages/ pages/ src/
+```
+
+**Findings:**
+
+```
+src/content/docs-ja/concepts/routing-conventions.mdx:17:
+  zfbの`paths()`はビルド時に**miniflare**内で実行され、...
+
+src/content/docs-ja/concepts/routing-conventions.mdx:193:
+  | **ランタイム** | Node.js | miniflare |
+
+src/content/docs/concepts/routing-conventions.mdx:17:
+  zfb's `paths()` runs inside **miniflare** at build time and is **synchronous** by contract.
+
+src/content/docs/concepts/routing-conventions.mdx:201:
+  | **Runtime** | Node.js | miniflare |
+```
+
+**Assessment:** The two `miniflare` occurrences are in **doc content prose** (`src/content/docs/` and `src/content/docs-ja/`), not in any build-system, plugin, or runtime code. They describe historical context in the routing-conventions doc page. No code changes are required for the pin bump; however, once this ADR ships, those doc pages should be updated in a follow-on wave (post-W2) to say "embedded V8 / deno_core" instead of "miniflare." No `Backend::`, `SpawnMiniflare`, or `workerd` references appear anywhere in the consumer codebase.
+
+**The doc-history `node:child_process.spawn`** (in `packages/doc-history-server/`) is confirmed unrelated — it is a server-side Node.js tool, not part of the zfb SSG render path.
+
+**Verdict: No code changes required for the pin bump.**
+
+---
+
+## 5. Drafted New `zfb.config.ts` Long-Pin Comment Block
+
+Replace the existing block (lines 1–180) with the following after bumping to `e550167`:
+
+```
+/**
+ * zfb pin (canonical, shared with E2/E4):
+ *   commit: e550167 (Takazudo/zudo-front-builder main, post-merge of PR #168
+ *           — [Embed V8] Replace miniflare subprocess with embedded deno_core
+ *           build-time JS host; on top of PR #157 basic-blog end-to-end fix;
+ *           2026-05-04)
+ *   includes fixes:
+ *     [... all entries from 88cec07 pin block verbatim ...]
+ *     - Takazudo/zudo-front-builder PR #157 (fix examples/basic-blog build
+ *                               end-to-end — 6 bugs fixed; no consumer API
+ *                               change)
+ *     - Takazudo/zudo-front-builder PR #168 / sub-161 (ADR-007: author
+ *                               embedded deno_core ADR, superseding ADR-005
+ *                               miniflare subprocess)
+ *     - Takazudo/zudo-front-builder PR #168 / sub-162 (implement
+ *                               EmbeddedV8RenderHost: deno_core + node:*
+ *                               runtime stubs + deno_fetch/web/url/console
+ *                               Web API extensions)
+ *     - Takazudo/zudo-front-builder PR #168 / sub-163 (CI: wire
+ *                               Swatinem/rust-cache@v2; document 15-30 min
+ *                               V8 first-build cost in CONTRIBUTING.md)
+ *     - Takazudo/zudo-front-builder PR #168 / sub-164 (renderer: add
+ *                               Backend::EmbeddedV8 + Backend::Stub,
+ *                               WorkerDispatch enum; swap dispatch path)
+ *     - Takazudo/zudo-front-builder PR #168 / sub-165 (test: ContentSnapshot
+ *                               e2e verification tests)
+ *     - Takazudo/zudo-front-builder PR #168 / sub-166 (cli: flip default
+ *                               Backend from SpawnMiniflare → EmbeddedV8
+ *                               in build/dev pipelines)
+ *     - Takazudo/zudo-front-builder PR #168 / sub-167 (cleanup: delete
+ *                               miniflare-bootstrap.mjs, strip
+ *                               SpawnMiniflare backend, scrub all miniflare
+ *                               references from code/docs/config)
+ *   pinned by: epic zudolab/zudo-doc#1353 (super-epic #1333) → ... (previous
+ *              chain verbatim) → bumped by epic zudolab/zudo-doc#1407
+ *              (zfb-pin-bump-embed-v8: pick up PR #168 embedded deno_core)
+ */
+```
+
+Note: the full existing entry list (lines 8–179 of the current block) must be preserved verbatim before appending the new entries.
+
+---
+
+## 6. Other "Remove Once Upstream Ships" Comments
+
+Two additional workaround sites found:
+
+### A. `src/styles/global.css` — default-theme reset (zfb#159)
+
+- **Location:** `src/styles/global.css:83` — `--color-*: initial;` wildcard reset in `@theme`
+- **Comment summary:** zfb prepends `@import "tailwindcss"` (full bundle) unless the user CSS contains a literal `@import "tailwindcss"` line at column 0. The split-import pattern used here (`@import "tailwindcss/preflight"` + `@import "tailwindcss/utilities"`) does not match upstream's `user_has_import` check (`crates/zfb-css/src/engine.rs:234`), so the full default color palette leaks. The `--color-*: initial` wildcard removes the leak.
+- **Upstream issue:** `Takazudo/zudo-front-builder#159` — still OPEN (confirmed via `gh issue view 159 --json state,closedAt` → `{"closedAt":null,"state":"OPEN","title":"..."}`)
+- **Also referenced:** `src/CLAUDE.md:99`
+- **Action when fixed:** Remove `--color-*: initial;` line and the surrounding comment block. See Sub-5 of zfb-migration-parity epic for the removal task.
+
+### B. `zfb.config.ts:406` / `plugins/copy-public-plugin.mjs` — publicDir copy (zfb#158)
+
+Covered in section 3 above. State: OPEN. Workaround stays.
+
+---
+
+## Summary
+
+| Item | Status |
+|------|--------|
+| zfb#158 (publicDir copy) | OPEN — workaround retained |
+| zfb#159 (default-theme leak) | OPEN — workaround retained |
+| Consumer code changes for embed-v8 | None required |
+| Doc prose updates (routing-conventions.mdx) | Deferred post-W2 |
+| New pin comment block | Drafted (section 5) |

--- a/__planning/zfb-pin-bump/survey.md
+++ b/__planning/zfb-pin-bump/survey.md
@@ -117,7 +117,7 @@ src/content/docs/concepts/routing-conventions.mdx:201:
 
 ## 5. Drafted New `zfb.config.ts` Long-Pin Comment Block
 
-Replace the existing block (lines 1–180) with the following after bumping to `e550167`:
+Replace the existing block (lines 1–180) with the following after bumping to `e550167`. Keep every existing bullet in the `includes fixes:` list intact and append the new entries below them:
 
 ```
 /**
@@ -127,7 +127,7 @@ Replace the existing block (lines 1–180) with the following after bumping to `
  *           build-time JS host; on top of PR #157 basic-blog end-to-end fix;
  *           2026-05-04)
  *   includes fixes:
- *     [... all entries from 88cec07 pin block verbatim ...]
+ *     [carry all existing bullet entries from the 88cec07 block verbatim]
  *     - Takazudo/zudo-front-builder PR #157 (fix examples/basic-blog build
  *                               end-to-end — 6 bugs fixed; no consumer API
  *                               change)

--- a/__planning/zfb-pin-bump/zfb-side-smoke.md
+++ b/__planning/zfb-pin-bump/zfb-side-smoke.md
@@ -1,0 +1,114 @@
+# zfb-side smoke results — Wave 1B
+
+**Date**: 2026-05-04  
+**Epic**: zfb-pin-bump-embed-v8 (#1407)  
+**zfb commit tested**: `0549132` (Merge PR #170 — fix/dev-cold-start-rebuild)  
+**zfb binary**: `target/release/zfb` built 2026-05-05 00:09
+
+---
+
+## Smoke 1 — `zfb build` (basic-blog)
+
+**Status: PASS**
+
+`zfb build` in `examples/basic-blog/` with the current release binary produces 14 HTML pages:
+
+```
+dist/index.html
+dist/blog/page/1/index.html
+dist/blog/page/2/index.html
+dist/blog/hello-zfb/index.html
+dist/blog/why-rust-cli/index.html
+dist/blog/ssr-and-islands/index.html
+dist/blog/deploying-static-sites/index.html
+dist/blog/dev-loop-feel/index.html
+dist/tags/intro/index.html
+dist/tags/framework/index.html
+dist/tags/ssr/index.html
+dist/tags/deploy/index.html
+dist/tags/perf/index.html
+dist/tags/tooling/index.html
+```
+
+All pages include correct `<script type="module">` island hydration and `<link rel="stylesheet">` asset references. No build errors.
+
+---
+
+## Smoke 2 — `zfb dev` hot-reload
+
+**Status: PASS (mechanism verified)**
+
+Two architectural bugs were found and fixed in PR #170 (merged to `Takazudo/zudo-front-builder`):
+
+### Bug A — Cold-start rebuild: empty dirty set
+
+**Root cause**: `DependencyGraph` is seeded with page nodes but has no reverse dep edges on startup. When a content file changed, `graph.dirty_pages(&path)` returned an empty set, so the orchestrator planned zero pages.
+
+**Fix in `crates/zfb/src/commands/dev.rs`**: After startup, all page IDs are inserted into the graph as seed nodes:
+
+```rust
+for page_id in session.page_ids() {
+    g.upsert(PageDeps::new(page_id, vec![]));
+}
+```
+
+**Fix in `crates/zfb-build/src/orchestrator.rs`**: Empty dirty sets now escalate to `PageSelection::All`:
+
+```rust
+let effective = if dirty.is_empty() {
+    PageSelection::All
+} else {
+    dirty
+};
+```
+
+### Bug B — PageCache miss returns 500
+
+**Root cause**: `serve_page()` in `zfb-server` only checked the in-memory `PageCache`. On cold start the cache was empty, returning 500 instead of reading from `dist/`.
+
+**Fix in `crates/zfb-server/src/routes.rs`**: Added `dist_root: PathBuf` to `AppState` and a `read_from_dist()` disk fallback in `serve_page()`. Cache miss now falls back to reading the pre-built file from `dist/`.
+
+### Verification
+
+Debug prints confirmed the full path:
+
+1. `inotify` watcher fires for file changes (confirmed via `/proc/PID/fdinfo`)
+2. Orchestrator receives the event and calls `tick()`
+3. `tick()` rebuilds the affected pages (`pages_rendered=1`)
+4. `DevAssetPipeline.last_bytes` cache skips atomic write when bytes are identical (correct behavior — not a bug)
+5. Disk fallback serves the correct HTML via HTTP 200
+
+A `touch`-only change does not update the dist mtime — this is intentional: the `last_bytes` cache in `crates/zfb-build/src/pipeline/dev.rs` skips `atomic_write` when rendered bytes are identical. An actual content change (e.g., adding text) causes differing bytes and triggers the write.
+
+---
+
+## Smoke 3 — Islands hydration output
+
+**Status: PASS**
+
+`dist/assets/` contains:
+
+- `islands.js` (entry)
+- `islands-93961d8a.js` (fingerprinted build)
+- `styles-21be108d.css`
+
+Every HTML page includes `<script type="module" src="/assets/islands-93961d8a.js">`. Island hydration targets are present as `data-zfb-island="ThemeToggle"` markers.
+
+---
+
+## W1D — smoke-search flake patch
+
+**Status: PASS (committed)**
+
+Commit `ae653b4`: `test(e2e): use domcontentloaded for smoke-search to avoid load-event flake`
+
+All 8 `page.goto(DOCS_PAGE, { waitUntil: "load" })` calls in `e2e/smoke-search.spec.ts` changed to `waitUntil: "domcontentloaded"`. Root cause of flakiness: the `load` event waits for all subresources including lazy-loaded scripts/workers; `domcontentloaded` fires once the HTML is parsed, before network-dependent resources settle. The smoke-search assertions only inspect DOM elements, not network state, so `domcontentloaded` is the correct signal.
+
+---
+
+## PR #170 — Merge record
+
+- **Branch**: `Takazudo/zudo-front-builder` → `fix/dev-cold-start-rebuild`
+- **Status**: Merged 2026-05-04
+- **CI**: All 3 checks passed (Build docs site, health, Deploy PR preview)
+- **Commits**: 1 commit (`fix(dev): cold-start rebuild + server page-cache miss`)

--- a/e2e/smoke-search.spec.ts
+++ b/e2e/smoke-search.spec.ts
@@ -12,7 +12,7 @@ const DOCS_PAGE = "/docs/getting-started";
 
 test.describe("Search dialog", () => {
   test("Ctrl+K opens the search dialog", async ({ page }) => {
-    await page.goto(DOCS_PAGE, { waitUntil: "load" });
+    await page.goto(DOCS_PAGE, { waitUntil: "domcontentloaded" });
 
     const dialog = page.locator("[data-search-dialog]");
     await expect(dialog).not.toBeVisible();
@@ -23,7 +23,7 @@ test.describe("Search dialog", () => {
   });
 
   test("search input is focused when dialog opens", async ({ page }) => {
-    await page.goto(DOCS_PAGE, { waitUntil: "load" });
+    await page.goto(DOCS_PAGE, { waitUntil: "domcontentloaded" });
 
     await page.keyboard.press("Control+k");
 
@@ -32,7 +32,7 @@ test.describe("Search dialog", () => {
   });
 
   test("typing a query shows results", async ({ page }) => {
-    await page.goto(DOCS_PAGE, { waitUntil: "load" });
+    await page.goto(DOCS_PAGE, { waitUntil: "domcontentloaded" });
 
     await page.keyboard.press("Control+k");
     const input = page.locator("[data-search-input]");
@@ -50,7 +50,7 @@ test.describe("Search dialog", () => {
   });
 
   test("clicking a result navigates to that page", async ({ page }) => {
-    await page.goto(DOCS_PAGE, { waitUntil: "load" });
+    await page.goto(DOCS_PAGE, { waitUntil: "domcontentloaded" });
 
     await page.keyboard.press("Control+k");
     const input = page.locator("[data-search-input]");
@@ -76,7 +76,7 @@ test.describe("Search dialog", () => {
   });
 
   test("Escape closes the dialog", async ({ page }) => {
-    await page.goto(DOCS_PAGE, { waitUntil: "load" });
+    await page.goto(DOCS_PAGE, { waitUntil: "domcontentloaded" });
 
     await page.keyboard.press("Control+k");
     const dialog = page.locator("[data-search-dialog]");
@@ -88,7 +88,7 @@ test.describe("Search dialog", () => {
   });
 
   test("clicking backdrop closes the dialog", async ({ page }) => {
-    await page.goto(DOCS_PAGE, { waitUntil: "load" });
+    await page.goto(DOCS_PAGE, { waitUntil: "domcontentloaded" });
 
     await page.keyboard.press("Control+k");
     const dialog = page.locator("[data-search-dialog]");
@@ -102,7 +102,7 @@ test.describe("Search dialog", () => {
   });
 
   test("nonsense query shows 'No results found.'", async ({ page }) => {
-    await page.goto(DOCS_PAGE, { waitUntil: "load" });
+    await page.goto(DOCS_PAGE, { waitUntil: "domcontentloaded" });
 
     await page.keyboard.press("Control+k");
     const input = page.locator("[data-search-input]");
@@ -116,7 +116,7 @@ test.describe("Search dialog", () => {
   });
 
   test("matched keywords are highlighted with mark elements", async ({ page }) => {
-    await page.goto(DOCS_PAGE, { waitUntil: "load" });
+    await page.goto(DOCS_PAGE, { waitUntil: "domcontentloaded" });
 
     await page.keyboard.press("Control+k");
     const input = page.locator("[data-search-input]");

--- a/pages/[locale]/docs/[...slug].tsx
+++ b/pages/[locale]/docs/[...slug].tsx
@@ -210,12 +210,18 @@ export function paths(): Array<{
 
 interface PageArgs {
   params: { locale: string; slug: string[] };
-  props: DocPageProps;
+  entry: DocPageProps["entry"];
+  autoIndex?: DocPageProps["autoIndex"];
+  contentDir: DocPageProps["contentDir"];
+  isFallback: DocPageProps["isFallback"];
+  breadcrumbs: DocPageProps["breadcrumbs"];
+  prev: DocPageProps["prev"];
+  next: DocPageProps["next"];
+  headings: DocPageProps["headings"];
 }
 
-export default function LocaleDocsPage({ params, props }: PageArgs): JSX.Element {
+export default function LocaleDocsPage({ params, entry, autoIndex, contentDir, isFallback, breadcrumbs, prev, next, headings }: PageArgs): JSX.Element {
   const locale = params.locale;
-  const { entry, autoIndex, contentDir, isFallback, breadcrumbs, prev, next, headings } = props;
 
   const slug = autoIndex
     ? autoIndex.slug

--- a/pages/[locale]/docs/tags/[tag].tsx
+++ b/pages/[locale]/docs/tags/[tag].tsx
@@ -63,15 +63,14 @@ export function paths(): Array<{
 
 interface PageProps {
   params: { locale: string; tag: string };
-  props: { tagInfo: TagInfo };
+  tagInfo: TagInfo;
 }
 
 export default function LocaleDocTagPage({
   params,
-  props,
+  tagInfo,
 }: PageProps): JSX.Element {
   const { locale, tag } = params;
-  const { tagInfo } = props;
 
   const countText =
     tagInfo.count === 1

--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -184,11 +184,15 @@ export function paths(): Array<{
 
 interface PageArgs {
   params: { slug: string[] };
-  props: DocPageProps;
+  entry: DocPageProps["entry"];
+  autoIndex?: DocPageProps["autoIndex"];
+  breadcrumbs: DocPageProps["breadcrumbs"];
+  prev: DocPageProps["prev"];
+  next: DocPageProps["next"];
+  headings: DocPageProps["headings"];
 }
 
-export default function DocsPage({ props }: PageArgs): JSX.Element {
-  const { entry, autoIndex, breadcrumbs, prev, next, headings } = props;
+export default function DocsPage({ entry, autoIndex, breadcrumbs, prev, next, headings }: PageArgs): JSX.Element {
   const locale = defaultLocale;
 
   const slug = autoIndex

--- a/pages/docs/tags/[tag].tsx
+++ b/pages/docs/tags/[tag].tsx
@@ -54,12 +54,11 @@ export function paths(): Array<{
 
 interface PageProps {
   params: { tag: string };
-  props: { tagInfo: TagInfo };
+  tagInfo: TagInfo;
 }
 
-export default function DocTagPage({ params, props }: PageProps): JSX.Element {
+export default function DocTagPage({ params, tagInfo }: PageProps): JSX.Element {
   const { tag } = params;
-  const { tagInfo } = props;
   const locale = defaultLocale;
 
   const countText =

--- a/pages/v/[version]/docs/[...slug].tsx
+++ b/pages/v/[version]/docs/[...slug].tsx
@@ -196,11 +196,16 @@ export function paths(): Array<{
 
 interface PageArgs {
   params: { version: string; slug: string[] };
-  props: DocPageProps;
+  entry: DocPageProps["entry"];
+  autoIndex?: DocPageProps["autoIndex"];
+  version: DocPageProps["version"];
+  breadcrumbs: DocPageProps["breadcrumbs"];
+  prev: DocPageProps["prev"];
+  next: DocPageProps["next"];
+  headings: DocPageProps["headings"];
 }
 
-export default function VersionedDocsPage({ props }: PageArgs): JSX.Element {
-  const { entry, autoIndex, version, breadcrumbs, prev, next, headings } = props;
+export default function VersionedDocsPage({ entry, autoIndex, version, breadcrumbs, prev, next, headings }: PageArgs): JSX.Element {
   const locale = "en";
 
   const slug = autoIndex

--- a/pages/v/[version]/ja/docs/[...slug].tsx
+++ b/pages/v/[version]/ja/docs/[...slug].tsx
@@ -230,11 +230,18 @@ export function paths(): Array<{
 
 interface PageArgs {
   params: { version: string; slug: string[] };
-  props: DocPageProps;
+  entry: DocPageProps["entry"];
+  autoIndex?: DocPageProps["autoIndex"];
+  version: DocPageProps["version"];
+  contentDir: DocPageProps["contentDir"];
+  isFallback: DocPageProps["isFallback"];
+  breadcrumbs: DocPageProps["breadcrumbs"];
+  prev: DocPageProps["prev"];
+  next: DocPageProps["next"];
+  headings: DocPageProps["headings"];
 }
 
-export default function VersionedJaDocsPage({ props }: PageArgs): JSX.Element {
-  const { entry, autoIndex, version, isFallback, breadcrumbs, prev, next, headings } = props;
+export default function VersionedJaDocsPage({ entry, autoIndex, version, isFallback, breadcrumbs, prev, next, headings }: PageArgs): JSX.Element {
   const locale = "ja";
 
   const slug = autoIndex

--- a/pages/v/[version]/ja/docs/[...slug].tsx
+++ b/pages/v/[version]/ja/docs/[...slug].tsx
@@ -233,7 +233,6 @@ interface PageArgs {
   entry: DocPageProps["entry"];
   autoIndex?: DocPageProps["autoIndex"];
   version: DocPageProps["version"];
-  contentDir: DocPageProps["contentDir"];
   isFallback: DocPageProps["isFallback"];
   breadcrumbs: DocPageProps["breadcrumbs"];
   prev: DocPageProps["prev"];

--- a/zfb.config.ts
+++ b/zfb.config.ts
@@ -1,9 +1,11 @@
 /**
  * zfb pin (canonical, shared with E2/E4):
- *   commit: 88cec07 (Takazudo/zudo-front-builder main, post-merge of PR #156
- *           — wave13 rebase: data-props SSR + Tailwind src/styles/global.css
- *           input-CSS path probe — on top of PR #155 renderer-emission test
- *           and PR #154 feat/asset-base-path; 2026-05-04)
+ *   commit: bdbfbfb (Takazudo/zudo-front-builder main, post-#170 hotfix:
+ *           add node:async_hooks stub to embedded V8 v1 node:* list so
+ *           consumer bundles that import @takazudo/zfb-adapter-cloudflare
+ *           (AsyncLocalStorage) evaluate during SSG paths() step; on top of
+ *           PR #170 fix/dev-cold-start-rebuild + PR #168 embed-v8 + PR #157
+ *           basic-blog end-to-end fix; 2026-05-04)
  *   includes fixes:
  *     - zudolab/zfb#99  (ViewTransitions runtime + meta injection)
  *     - zudolab/zfb#100 (404 convention: emit dist/404.html at root)
@@ -169,6 +171,45 @@
  *                               (0f6f8c4), 73 of 145 e2e tests went red because both wave13
  *                               carries were silently lost. PR #156 brings them onto main
  *                               cleanly (textual rebase) so the bump path stays additive)
+ *     - Takazudo/zudo-front-builder PR #157 (fix examples/basic-blog build
+ *                               end-to-end — 6 bugs fixed; no consumer API
+ *                               change)
+ *     - Takazudo/zudo-front-builder PR #168 / sub-161 (ADR-007: author
+ *                               embedded deno_core ADR, superseding ADR-005
+ *                               miniflare subprocess)
+ *     - Takazudo/zudo-front-builder PR #168 / sub-162 (implement
+ *                               EmbeddedV8RenderHost: deno_core + node:*
+ *                               runtime stubs + deno_fetch/web/url/console
+ *                               Web API extensions)
+ *     - Takazudo/zudo-front-builder PR #168 / sub-163 (CI: wire
+ *                               Swatinem/rust-cache@v2; document 15-30 min
+ *                               V8 first-build cost in CONTRIBUTING.md)
+ *     - Takazudo/zudo-front-builder PR #168 / sub-164 (renderer: add
+ *                               Backend::EmbeddedV8 + Backend::Stub,
+ *                               WorkerDispatch enum; swap dispatch path)
+ *     - Takazudo/zudo-front-builder PR #168 / sub-165 (test: ContentSnapshot
+ *                               e2e verification tests)
+ *     - Takazudo/zudo-front-builder PR #168 / sub-166 (cli: flip default
+ *                               Backend from SpawnMiniflare → EmbeddedV8
+ *                               in build/dev pipelines)
+ *     - Takazudo/zudo-front-builder PR #168 / sub-167 (cleanup: delete
+ *                               miniflare-bootstrap.mjs, strip
+ *                               SpawnMiniflare backend, scrub all miniflare
+ *                               references from code/docs/config)
+ *     - Takazudo/zudo-front-builder PR #170 (fix(dev): cold-start rebuild
+ *                               empty dirty set (DependencyGraph seeded with
+ *                               all page IDs on startup; empty dirty escalates
+ *                               to PageSelection::All) + PageCache disk
+ *                               fallback (serve_page() reads from dist/ on
+ *                               cache miss instead of returning 500))
+ *     - Takazudo/zudo-front-builder bdbfbfb (fix(embedded-v8): add
+ *                               node:async_hooks stub to v1 node:* list;
+ *                               consumer bundles that import
+ *                               @takazudo/zfb-adapter-cloudflare do a
+ *                               top-level import of AsyncLocalStorage from
+ *                               node:async_hooks — without this stub the
+ *                               embedded V8 host fails at bundle-load time
+ *                               with "no in-memory source for node:async_hooks")
  *   pinned by: epic zudolab/zudo-doc#1353 (super-epic #1333) → bumped by epic
  *              zudolab/zudo-doc#1355 (Sig F finalisation + post-#131 hash-mismatch follow-up
  *              + Sig G island-resolver/esbuild parity + shared-bundle hydration glue
@@ -177,6 +218,9 @@
  *              zudolab/zudo-doc#1360 sub-issue #1361 (S1 BLOCKER: HTML asset URLs respect
  *              site `base`) → bumped by epic zudolab/zudo-doc#1386 sub-issue #1388
  *              (atomic three-point pin bump + e2e fixture roll-forward; closes #1384)
+ *              → bumped by epic zudolab/zudo-doc#1407 (zfb-pin-bump-embed-v8: pick up
+ *              PR #168 embedded deno_core + PR #170 cold-start-rebuild fix; hotfix
+ *              bdbfbfb adds node:async_hooks stub surfaced during W3 build verification)
  */
 
 // zfb.config.ts — entry-point config consumed by the zfb engine.


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/1407
- parent PR
    - https://github.com/zudolab/zudo-doc/pull/669

---

## Summary

Wave 1 of the zfb-pin-bump-embed-v8 epic (#1407). Lays the planning groundwork for the upcoming `88cec07` → `e550167+` pin bump and patches the smoke-search E2E flake. **No pin bump yet** — that lands in Wave 3 (#1414).

Notable side effect: W1B exercised the autonomous upstream fix authority and merged upstream `Takazudo/zudo-front-builder` PR #170 (cold-start dev-server rebuild + PageCache disk fallback). The upstream main HEAD is now `0549132`. Wave 2's spec must pin to this newer SHA, not `e550167`.

## Changes

- **Planning docs** (under `__planning/zfb-pin-bump/`)
  - `survey.md` (W1A, #1408): Upstream diff summary (`88cec07..e550167`), ADR-007 condensation, consumer-side audit (no `Backend::` / `miniflare` / `workerd` references in build/runtime code), drafted long-pin comment block, `zfb#158` and `zfb#159` confirmed still OPEN.
  - `zfb-side-smoke.md` (W1B, #1409): Smokes 1/2/3 results — all pass after fixing 2 bugs in upstream PR #170. New upstream HEAD recorded: `0549132`.
  - `cache-strategy.md` (W1C, #1410): Decision A — no cache config change. Confirmed 16 `ZFB_PINNED_SHA` occurrences (vs pre-counted 15) across 3 workflow files. Optional non-blocking note: `timeout-minutes: 20` in pr-checks may be tight for the cold V8 compile; W3 may bump to 45 (matches upstream).
- **E2E patch** (W1D, #1411)
  - `e2e/smoke-search.spec.ts`: 8 `page.goto(DOCS_PAGE, { waitUntil: 'load' })` → `'domcontentloaded'`. The original spec estimated 5 occurrences; actual was 8. Local fixture run: 8/8 pass.

## Test Plan

- Combined diff: 4 files, +414 −8.
- Reviewer (`/gcoc-review`): no high or actionable medium findings.
- E2E on this PR: 144/145 pass. The originally-targeted test (`smoke-search.spec.ts:52` "clicking a result navigates") no longer fails — the W1D fix is doing its job. The flake pattern has shifted to a sibling test (`:34` "typing a query shows results"). Per #1411's design, the documented retry fallback (`test.describe.configure({ retries: 1 })`) is W4's scope (#1413).
- Preview Deploy on this PR: deploy succeeded (`https://pr-1416.zudo-doc.pages.dev`); only the comment-posting step hit a transient GitHub API 502.

## Wave roadmap

- [x] **Wave 1** (this PR): W1A survey, W1B smoke (with upstream PR #170 fix), W1C cache, W1D e2e flake patch
- [ ] **Wave 2** (#1412): Manager-confirm gate + implementation spec — pin target updated to `0549132`
- [ ] **Wave 3** (#1414): Atomic pin bump — single commit, all 16 `ZFB_PINNED_SHA` occurrences + `zfb.config.ts` comment block
- [ ] **Wave 4** (#1413): Manager-verify on persisted state + watch CI; apply `retries: 1` retry fallback to `e2e/smoke-search.spec.ts` if needed
- [ ] **Wave 5** (#1415): Retro-notes append + `__planning/` cleanup

## Generated with Claude Code

🤖 [Claude Code](https://claude.com/claude-code)