### PR TITLE
[REFERENCE — DO NOT MERGE] Wave 3 #1458 mermaid light-dark() crash

### DIFF
--- a/packages/zudo-doc-v2/src/code-syntax/__tests__/mermaid-init.test.tsx
+++ b/packages/zudo-doc-v2/src/code-syntax/__tests__/mermaid-init.test.tsx
@@ -80,6 +80,22 @@ describe("MERMAID_INIT_SCRIPT", () => {
   it("skips already-rendered diagrams", () => {
     expect(MERMAID_INIT_SCRIPT).toContain("data-mermaid-rendered");
   });
+
+  it("resolves light-dark() tokens by reading data-theme from <html> (zudolab/zudo-doc#1458)", () => {
+    // khroma 2.1.0 does not support the CSS light-dark() function syntax.
+    // The script must parse light-dark(<light>, <dark>) manually and pick
+    // the appropriate arm using document.documentElement.getAttribute("data-theme").
+    expect(MERMAID_INIT_SCRIPT).toContain("light-dark");
+    expect(MERMAID_INIT_SCRIPT).toContain('getAttribute("data-theme")');
+  });
+
+  it("MutationObserver watches data-theme in addition to style (zudolab/zudo-doc#1458)", () => {
+    // Theme toggle sets data-theme on <html> (not only the style attribute).
+    // Watching data-theme ensures mermaid re-renders when the user toggles
+    // light ↔ dark so the resolved color picks up the new theme arm.
+    expect(MERMAID_INIT_SCRIPT).toContain('"data-theme"');
+    expect(MERMAID_INIT_SCRIPT).toContain('"style"');
+  });
 });
 
 describe("MERMAID_CDN_MODULE_URL", () => {

--- a/packages/zudo-doc-v2/src/code-syntax/mermaid-init-script.ts
+++ b/packages/zudo-doc-v2/src/code-syntax/mermaid-init-script.ts
@@ -98,9 +98,11 @@ export function buildMermaidInitScript(cdnUrl: string): string {
   /**
    * Resolve a CSS value to a hex color (#rrggbb).
    * CSS custom properties return raw values from getComputedStyle (e.g.
-   * "light-dark(#fff, #000)") which mermaid cannot parse. This uses a
-   * temporary element so the browser resolves any CSS function to a
-   * concrete rgb() value, then converts it to hex.
+   * "light-dark(#fff, #000)") which mermaid cannot parse. Handles:
+   *   1. light-dark() function — resolved by reading data-theme on <html>
+   *      (zudolab/zudo-doc#1458: khroma 2.1.0 does not support light-dark()).
+   *   2. Other CSS functions (e.g. oklch, hsl) — resolved via a temporary
+   *      element so the browser returns a concrete rgb() value.
    */
   function resolveColor(value) {
     if (!value) return value;
@@ -111,6 +113,15 @@ export function buildMermaidInitScript(cdnUrl: string): string {
     if (/^#[0-9a-fA-F]{8}$/.test(value)) return value.slice(0, 7);
     if (/^#[0-9a-fA-F]{4}$/.test(value)) {
       return "#" + value[1] + value[1] + value[2] + value[2] + value[3] + value[3];
+    }
+    // Resolve CSS light-dark(<light>, <dark>) by reading data-theme from <html>.
+    // khroma cannot parse the light-dark() syntax; resolve it here so mermaid
+    // always receives a plain hex/rgb value regardless of browser support for
+    // light-dark() inside el.style.color.
+    var ldMatch = value.match(/^light-dark\\(\\s*([^,]+?)\\s*,\\s*([^)]+?)\\s*\\)$/i);
+    if (ldMatch) {
+      var isDark = document.documentElement.getAttribute("data-theme") === "dark";
+      return resolveColor(isDark ? ldMatch[2].trim() : ldMatch[1].trim());
     }
     var el = document.createElement("div");
     el.style.display = "none";
@@ -231,14 +242,16 @@ export function buildMermaidInitScript(cdnUrl: string): string {
   // listener also covers the post-navigation re-render path.
   document.addEventListener(${JSON.stringify(AFTER_NAVIGATE_EVENT)}, function () { initMermaid(); });
 
-  // Re-render mermaid when color tweak panel changes CSS custom properties (debounced).
+  // Re-render mermaid when color tweak panel changes CSS custom properties, or when
+  // the theme toggle changes data-theme (light ↔ dark). Debounced so rapid successive
+  // changes (e.g. tweak-panel sliders) coalesce into a single re-render.
   var tweakTimer;
   new MutationObserver(function () {
     clearTimeout(tweakTimer);
     tweakTimer = setTimeout(reinitMermaid, 300);
   }).observe(document.documentElement, {
     attributes: true,
-    attributeFilter: ["style"],
+    attributeFilter: ["style", "data-theme"],
   });
 })();`;
 }


### PR DESCRIPTION
Reference branch from a parallel /x-wt-teams session that was discarded mid-flight. **Do not merge** — provided for cross-reference review against the canonical session.

- issue: https://github.com/zudolab/zudo-doc/issues/1458
- epic: https://github.com/zudolab/zudo-doc/issues/1443

Fixes: parses light-dark(\<light\>, \<dark\>) tokens in mermaid-init-script's resolveColor() and selects the active arm via document.documentElement.dataset.theme. Adds data-theme to MutationObserver attributeFilter so diagrams re-render on theme toggle. khroma 2.1.0 cannot parse the CSS light-dark() function — JS-side resolution is the recommended fix.