### PR TITLE
[Epic] PR 669 parity fixes

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -378,7 +378,16 @@ jobs:
             cp -r doc-history-out/. deploy/pj/zudo-doc/doc-history/
           fi
           # (c) Root-level _redirects: bare-domain hits land on the based site.
-          echo '/ /pj/zudo-doc/ 302' > deploy/_redirects
+          # Changelog slug changed from /docs/changelog/010/ (old prod URL, no dots)
+          # to /docs/changelog/0.1.0/ (file-routed). Both slash variants and the
+          # JA locale are covered to preserve all external bookmarks from the Astro era.
+          printf '%s\n' \
+            '/ /pj/zudo-doc/ 302' \
+            '/pj/zudo-doc/docs/changelog/010 /pj/zudo-doc/docs/changelog/0.1.0/ 301' \
+            '/pj/zudo-doc/docs/changelog/010/ /pj/zudo-doc/docs/changelog/0.1.0/ 301' \
+            '/pj/zudo-doc/ja/docs/changelog/010 /pj/zudo-doc/ja/docs/changelog/0.1.0/ 301' \
+            '/pj/zudo-doc/ja/docs/changelog/010/ /pj/zudo-doc/ja/docs/changelog/0.1.0/ 301' \
+            > deploy/_redirects
 
       - name: Deploy to Cloudflare Pages (production)
         id: deploy

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -30,7 +30,8 @@
 #   (a) dist/index.html and per-route dist/**/index.html           (HTML pages)
 #   (b) dist/404.html at root                                      (zfb #100)
 #   (c) dist/_redirects                                            (overwritten
-#       at deploy time below to /  /pj/zudo-doc/ 302 — see step body)
+#       at deploy time below to /  /pj/zudo-doc/ 302 and
+#       /favicon.ico /pj/zudo-doc/favicon.svg 301 — see step body)
 #   (d) dist/sitemap.xml                                           (page route
 #       pages/sitemap.xml.tsx, ADR-005)
 #   (e) dist/search-index.json                                     (search-index
@@ -349,7 +350,7 @@ jobs:
 
       - name: Prepare deploy directory
         # Layout produced (audited in epic #1337 task 5):
-        #   deploy/_redirects                       — root-level redirect
+        #   deploy/_redirects                       — root-level redirects (/ + /favicon.ico)
         #   deploy/pj/zudo-doc/index.html           — (a) home + per-route HTML
         #   deploy/pj/zudo-doc/404.html             — (b) zfb #100 convention
         #   deploy/pj/zudo-doc/sitemap.xml          — (d) page route
@@ -378,7 +379,9 @@ jobs:
             cp -r doc-history-out/. deploy/pj/zudo-doc/doc-history/
           fi
           # (c) Root-level _redirects: bare-domain hits land on the based site.
-          echo '/ /pj/zudo-doc/ 302' > deploy/_redirects
+          # /favicon.ico: browsers request this automatically as a fallback;
+          # redirect to the real SVG favicon under the base path (#1533).
+          printf '/ /pj/zudo-doc/ 302\n/favicon.ico /pj/zudo-doc/favicon.svg 301\n' > deploy/_redirects
 
       - name: Deploy to Cloudflare Pages (production)
         id: deploy

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -527,7 +527,9 @@ jobs:
             cp -r doc-history-out/. deploy/pj/zudo-doc/doc-history/
           fi
           # (c) Root-level _redirects: bare-domain hits land on the based site.
-          echo '/ /pj/zudo-doc/ 302' > deploy/_redirects
+          # /favicon.ico: browsers request this automatically as a fallback;
+          # redirect to the real SVG favicon under the base path (#1533).
+          printf '/ /pj/zudo-doc/ 302\n/favicon.ico /pj/zudo-doc/favicon.svg 301\n' > deploy/_redirects
 
       - name: Deploy preview to Cloudflare Pages
         id: cf-deploy

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -527,7 +527,16 @@ jobs:
             cp -r doc-history-out/. deploy/pj/zudo-doc/doc-history/
           fi
           # (c) Root-level _redirects: bare-domain hits land on the based site.
-          echo '/ /pj/zudo-doc/ 302' > deploy/_redirects
+          # Changelog slug changed from /docs/changelog/010/ (old prod URL, no dots)
+          # to /docs/changelog/0.1.0/ (file-routed). Both slash variants and the
+          # JA locale are covered to preserve all external bookmarks from the Astro era.
+          printf '%s\n' \
+            '/ /pj/zudo-doc/ 302' \
+            '/pj/zudo-doc/docs/changelog/010 /pj/zudo-doc/docs/changelog/0.1.0/ 301' \
+            '/pj/zudo-doc/docs/changelog/010/ /pj/zudo-doc/docs/changelog/0.1.0/ 301' \
+            '/pj/zudo-doc/ja/docs/changelog/010 /pj/zudo-doc/ja/docs/changelog/0.1.0/ 301' \
+            '/pj/zudo-doc/ja/docs/changelog/010/ /pj/zudo-doc/ja/docs/changelog/0.1.0/ 301' \
+            > deploy/_redirects
 
       - name: Deploy preview to Cloudflare Pages
         id: cf-deploy

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -352,7 +352,16 @@ jobs:
             cp -r doc-history-out/. deploy/pj/zudo-doc/doc-history/
           fi
           # (c) Root-level _redirects: bare-domain hits land on the based site.
-          echo '/ /pj/zudo-doc/ 302' > deploy/_redirects
+          # Changelog slug changed from /docs/changelog/010/ (old prod URL, no dots)
+          # to /docs/changelog/0.1.0/ (file-routed). Both slash variants and the
+          # JA locale are covered to preserve all external bookmarks from the Astro era.
+          printf '%s\n' \
+            '/ /pj/zudo-doc/ 302' \
+            '/pj/zudo-doc/docs/changelog/010 /pj/zudo-doc/docs/changelog/0.1.0/ 301' \
+            '/pj/zudo-doc/docs/changelog/010/ /pj/zudo-doc/docs/changelog/0.1.0/ 301' \
+            '/pj/zudo-doc/ja/docs/changelog/010 /pj/zudo-doc/ja/docs/changelog/0.1.0/ 301' \
+            '/pj/zudo-doc/ja/docs/changelog/010/ /pj/zudo-doc/ja/docs/changelog/0.1.0/ 301' \
+            > deploy/_redirects
 
       - name: Deploy to Cloudflare Pages
         id: deploy

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -352,7 +352,9 @@ jobs:
             cp -r doc-history-out/. deploy/pj/zudo-doc/doc-history/
           fi
           # (c) Root-level _redirects: bare-domain hits land on the based site.
-          echo '/ /pj/zudo-doc/ 302' > deploy/_redirects
+          # /favicon.ico: browsers request this automatically as a fallback;
+          # redirect to the real SVG favicon under the base path (#1533).
+          printf '/ /pj/zudo-doc/ 302\n/favicon.ico /pj/zudo-doc/favicon.svg 301\n' > deploy/_redirects
 
       - name: Deploy to Cloudflare Pages
         id: deploy

--- a/packages/zudo-doc-v2/src/breadcrumb/breadcrumb.tsx
+++ b/packages/zudo-doc-v2/src/breadcrumb/breadcrumb.tsx
@@ -1,7 +1,7 @@
 /** @jsxRuntime automatic */
 /** @jsxImportSource preact */
 
-import type { VNode } from "preact";
+import type { ComponentChildren, VNode } from "preact";
 import { findPath } from "./find-path";
 import type { BreadcrumbItem, SidebarNode } from "./types";
 
@@ -130,6 +130,21 @@ export interface BreadcrumbProps {
   currentId?: string;
   /** Href for the leading home rung. Defaults to "/". */
   homeHref?: string;
+  /**
+   * Optional slot rendered at the right end of the breadcrumb row.
+   * When provided, the breadcrumb nav and this slot are wrapped in a
+   * flex row that matches the original Astro doc-layout's combined
+   * breadcrumb + version-switcher row:
+   *
+   *   class="mb-vsp-sm flex flex-col items-start gap-vsp-xs
+   *          sm:flex-row sm:items-center sm:justify-between [&_nav]:mb-0"
+   *
+   * The `[&_nav]:mb-0` rule strips the nav's own `mb-vsp-md` so the
+   * wrapper margin controls spacing instead. Use this to place the
+   * VersionSwitcher pill inline at the right of the breadcrumb row,
+   * matching the reference site's layout on category index pages.
+   */
+  rightSlot?: ComponentChildren;
 }
 
 /**
@@ -152,7 +167,7 @@ export function Breadcrumb(props: BreadcrumbProps): VNode | null {
 
   if (items.length === 0) return null;
 
-  return (
+  const nav = (
     <nav class="mb-vsp-md text-small" aria-label="Breadcrumb">
       <ol class="flex flex-wrap items-center gap-x-hsp-xs">
         {items.map((item, i) => (
@@ -175,5 +190,19 @@ export function Breadcrumb(props: BreadcrumbProps): VNode | null {
         ))}
       </ol>
     </nav>
+  );
+
+  if (props.rightSlot === undefined) return nav;
+
+  // When a rightSlot is provided, wrap both elements in a flex row that
+  // matches the original Astro doc-layout's breadcrumb + version-switcher
+  // row. The `[&_nav]:mb-0` rule cancels the nav's own bottom margin so
+  // the wrapper margin controls spacing instead (matching the Astro
+  // reference which used `mb-vsp-sm` on the outer div).
+  return (
+    <div class="mb-vsp-sm flex flex-col items-start gap-vsp-xs sm:flex-row sm:items-center sm:justify-between [&_nav]:mb-0">
+      {nav}
+      {props.rightSlot}
+    </div>
   );
 }

--- a/pages/[locale]/docs/[...slug].tsx
+++ b/pages/[locale]/docs/[...slug].tsx
@@ -275,9 +275,13 @@ export default function LocaleDocsPage({ params, entry, autoIndex, contentDir, i
         />
       }
       breadcrumbOverride={
-        breadcrumbs.length > 0 ? <Breadcrumb items={breadcrumbs} /> : undefined
+        breadcrumbs.length > 0 ? (
+          <Breadcrumb
+            items={breadcrumbs}
+            rightSlot={buildInlineVersionSwitcher(slug, locale)}
+          />
+        ) : undefined
       }
-      afterBreadcrumb={buildInlineVersionSwitcher(slug, locale)}
       sidebarOverride={
         <SidebarWithDefaults
           currentSlug={slug}

--- a/pages/[locale]/docs/[...slug].tsx
+++ b/pages/[locale]/docs/[...slug].tsx
@@ -374,17 +374,11 @@ export default function LocaleDocsPage({ params, entry, autoIndex, contentDir, i
 
           {entry && <entry.Content components={components} />}
 
-          {/* Document utilities (revision history + view-source link) — skipped for unlisted pages */}
-          {!entry!.data.unlisted && (
-            <DocHistoryArea
-              slug={slug}
-              locale={locale}
-              entrySlug={entry!.slug}
-              contentDir={contentDir}
-            />
-          )}
-
-          {/* Prev / Next pagination */}
+          {/* Prev / Next pagination — placed before the document utilities
+              section to match the Astro reference order: content → pager →
+              view-source / history. In the Astro layout, BodyFootUtilArea was
+              rendered by the doc-layout wrapper after the <slot /> content,
+              so the pager (inside the slot) came first. Fixes #1535. */}
           <nav class="mt-vsp-2xl grid grid-cols-2 gap-hsp-xl">
             {prev ? (
               <a
@@ -437,6 +431,16 @@ export default function LocaleDocsPage({ params, entry, autoIndex, contentDir, i
               <div />
             )}
           </nav>
+
+          {/* Document utilities (revision history + view-source link) — skipped for unlisted pages */}
+          {!entry!.data.unlisted && (
+            <DocHistoryArea
+              slug={slug}
+              locale={locale}
+              entrySlug={entry!.slug}
+              contentDir={contentDir}
+            />
+          )}
         </>
       )}
     </DocLayoutWithDefaults>

--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -249,9 +249,13 @@ export default function DocsPage({ entry, autoIndex, breadcrumbs, prev, next, he
         />
       }
       breadcrumbOverride={
-        breadcrumbs.length > 0 ? <Breadcrumb items={breadcrumbs} /> : undefined
+        breadcrumbs.length > 0 ? (
+          <Breadcrumb
+            items={breadcrumbs}
+            rightSlot={buildInlineVersionSwitcher(slug, locale)}
+          />
+        ) : undefined
       }
-      afterBreadcrumb={buildInlineVersionSwitcher(slug, locale)}
       sidebarOverride={
         <SidebarWithDefaults
           currentSlug={slug}

--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -347,17 +347,11 @@ export default function DocsPage({ entry, autoIndex, breadcrumbs, prev, next, he
           {/* MDX content rendered via zfb's Content bridge */}
           {entry && <entry.Content components={components} />}
 
-          {/* Document utilities (revision history + view-source link) — skipped for unlisted pages */}
-          {!entry!.data.unlisted && (
-            <DocHistoryArea
-              slug={slug}
-              locale={locale}
-              entrySlug={entry!.slug}
-              contentDir={settings.docsDir}
-            />
-          )}
-
-          {/* Prev / Next pagination */}
+          {/* Prev / Next pagination — placed before the document utilities
+              section to match the Astro reference order: content → pager →
+              view-source / history. In the Astro layout, BodyFootUtilArea was
+              rendered by the doc-layout wrapper after the <slot /> content,
+              so the pager (inside the slot) came first. Fixes #1535. */}
           <nav class="mt-vsp-2xl grid grid-cols-2 gap-hsp-xl">
             {prev ? (
               <a
@@ -418,6 +412,16 @@ export default function DocsPage({ entry, autoIndex, breadcrumbs, prev, next, he
               <div />
             )}
           </nav>
+
+          {/* Document utilities (revision history + view-source link) — skipped for unlisted pages */}
+          {!entry!.data.unlisted && (
+            <DocHistoryArea
+              slug={slug}
+              locale={locale}
+              entrySlug={entry!.slug}
+              contentDir={settings.docsDir}
+            />
+          )}
         </>
       )}
     </DocLayoutWithDefaults>

--- a/pages/lib/_inline-version-switcher.tsx
+++ b/pages/lib/_inline-version-switcher.tsx
@@ -1,18 +1,23 @@
 /** @jsxRuntime automatic */
 /** @jsxImportSource preact */
-// Inline VersionSwitcher for the afterBreadcrumb slot on doc pages.
+// Inline VersionSwitcher for the breadcrumb rightSlot on doc pages.
 //
-// The reference site (takazudomodular.com) renders a
-// <div class="version-switcher relative" data-version-switcher> block
-// inside <main> immediately after the breadcrumb on every doc page
-// (Wave 2 parity sweep, zudolab/zudo-doc#1478). The header already
-// shows a VersionSwitcher via _header-with-defaults.tsx; this helper
-// provides the same component for the `afterBreadcrumb` slot so the
-// DOM position matches the reference.
+// The reference site (takazudomodular.com) renders the version-switcher
+// pill inline at the right of the breadcrumb row on every doc page:
+//
+//   <div class="mb-vsp-sm flex ... sm:justify-between [&_nav]:mb-0">
+//     <breadcrumb nav>
+//     <VersionSwitcher ... />
+//   </div>
+//
+// (Wave 2 parity sweep, zudolab/zudo-doc#1478; placement fix #1534.)
+// The header already shows a VersionSwitcher via _header-with-defaults.tsx;
+// this helper provides the pill for the breadcrumb's `rightSlot` prop so
+// both the DOM position AND the flex-row layout match the reference.
 //
 // Gate: only returns a non-null element when settings.versions is a
 // non-empty array. When versioning is disabled the caller gets undefined
-// and DocLayoutWithDefaults renders nothing in the slot.
+// and <Breadcrumb> renders without a rightSlot (no wrapper div emitted).
 
 import type { JSX } from "preact";
 import {
@@ -24,11 +29,12 @@ import { defaultLocale, t, type Locale } from "@/config/i18n";
 import { docsUrl, versionedDocsUrl, withBase } from "@/utils/base";
 
 /**
- * Build an inline VersionSwitcher element for the `afterBreadcrumb` slot.
+ * Build an inline VersionSwitcher element for the `<Breadcrumb rightSlot>` prop.
  *
  * Returns `undefined` when versioning is not configured (callers can pass
- * the return value directly as `afterBreadcrumb` — DocLayoutWithDefaults
- * renders nothing for `undefined`).
+ * the return value directly as `rightSlot` — `<Breadcrumb>` renders the
+ * plain nav (no flex wrapper, no version pill) when `rightSlot` is
+ * `undefined`).
  *
  * @param slug       - Slug of the current doc page (used to build per-version URLs).
  * @param locale     - Active locale string.

--- a/pages/v/[version]/docs/[...slug].tsx
+++ b/pages/v/[version]/docs/[...slug].tsx
@@ -365,12 +365,9 @@ export default function VersionedDocsPage({ entry, autoIndex, version, breadcrum
 
           {entry && <entry.Content components={components} />}
 
-          {/* Document utilities (revision history) — gated on entry, matching regular slug page pattern */}
-          {entry && (
-            <DocHistoryArea slug={slug} locale={locale} />
-          )}
-
-          {/* Prev / Next pagination */}
+          {/* Prev / Next pagination — placed before the document utilities
+              section to match the Astro reference order: content → pager →
+              view-source / history. Fixes #1535. */}
           <nav class="mt-vsp-2xl grid grid-cols-2 gap-hsp-xl">
             {prev ? (
               <a
@@ -423,6 +420,11 @@ export default function VersionedDocsPage({ entry, autoIndex, version, breadcrum
               <div />
             )}
           </nav>
+
+          {/* Document utilities (revision history) — gated on entry, matching regular slug page pattern */}
+          {entry && (
+            <DocHistoryArea slug={slug} locale={locale} />
+          )}
         </>
       )}
     </DocLayoutWithDefaults>

--- a/pages/v/[version]/docs/[...slug].tsx
+++ b/pages/v/[version]/docs/[...slug].tsx
@@ -277,9 +277,13 @@ export default function VersionedDocsPage({ entry, autoIndex, version, breadcrum
         />
       }
       breadcrumbOverride={
-        breadcrumbs.length > 0 ? <Breadcrumb items={breadcrumbs} /> : undefined
+        breadcrumbs.length > 0 ? (
+          <Breadcrumb
+            items={breadcrumbs}
+            rightSlot={buildInlineVersionSwitcher(slug, locale, version.slug)}
+          />
+        ) : undefined
       }
-      afterBreadcrumb={buildInlineVersionSwitcher(slug, locale, version.slug)}
       sidebarOverride={
         <SidebarWithDefaults
           currentSlug={slug}

--- a/pages/v/[version]/ja/docs/[...slug].tsx
+++ b/pages/v/[version]/ja/docs/[...slug].tsx
@@ -404,12 +404,9 @@ export default function VersionedJaDocsPage({ entry, autoIndex, version, isFallb
 
           {entry && <entry.Content components={components} />}
 
-          {/* Document utilities (revision history) — gated on entry, matching regular slug page pattern */}
-          {entry && (
-            <DocHistoryArea slug={slug} locale={locale} />
-          )}
-
-          {/* Prev / Next pagination */}
+          {/* Prev / Next pagination — placed before the document utilities
+              section to match the Astro reference order: content → pager →
+              view-source / history. Fixes #1535. */}
           <nav class="mt-vsp-2xl grid grid-cols-2 gap-hsp-xl">
             {prev ? (
               <a
@@ -462,6 +459,11 @@ export default function VersionedJaDocsPage({ entry, autoIndex, version, isFallb
               <div />
             )}
           </nav>
+
+          {/* Document utilities (revision history) — gated on entry, matching regular slug page pattern */}
+          {entry && (
+            <DocHistoryArea slug={slug} locale={locale} />
+          )}
         </>
       )}
     </DocLayoutWithDefaults>

--- a/pages/v/[version]/ja/docs/[...slug].tsx
+++ b/pages/v/[version]/ja/docs/[...slug].tsx
@@ -313,9 +313,13 @@ export default function VersionedJaDocsPage({ entry, autoIndex, version, isFallb
         />
       }
       breadcrumbOverride={
-        breadcrumbs.length > 0 ? <Breadcrumb items={breadcrumbs} /> : undefined
+        breadcrumbs.length > 0 ? (
+          <Breadcrumb
+            items={breadcrumbs}
+            rightSlot={buildInlineVersionSwitcher(slug, locale, version.slug)}
+          />
+        ) : undefined
       }
-      afterBreadcrumb={buildInlineVersionSwitcher(slug, locale, version.slug)}
       sidebarOverride={
         <SidebarWithDefaults
           currentSlug={slug}


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/1531
- parent PR
    - https://github.com/zudolab/zudo-doc/pull/669

---

## Summary

Implements all actionable findings from the #1530 parity-check report against PR #669. 4 code-level fixes + 1 deploy-config redirect fix, plus 2 confirmations (no code change required).

Closes #1530, #1531, #1532, #1533, #1534, #1535, #1536, #1537, #1538.

## Wave 1 — Implementation

| # | Topic | Decision | Commit |
|---|---|---|---|
| #1532 | JA \`/ja/docs/getting-started/navigation-design/\` 404 | Verified false positive — current code already generates correct links via \`<CategoryNav>\` slug derivation | (no commit) |
| #1533 | \`/favicon.ico\` 404 | Shipped 301 redirect to \`/pj/zudo-doc/favicon.svg\` via deploy-workflow root \`_redirects\` | \`e2c28ee\` |
| #1534 | Version switcher placement | Reverted to prod's inline placement — added \`rightSlot\` prop on \`<Breadcrumb>\` | \`86eb4fc\` |
| #1535 | Next/Prev pager card position | Reverted to prod's ordering (pager before View-source / DocHistory) on all 4 doc routes | \`e6cc159\` |
| #1536 | Changelog \`/010/\` → \`/0.1.0/\` redirect | Shipped — 4 rules (EN/JA × with/without slash) via deploy-workflow root \`_redirects\` | \`d65972c\` |
| #1537 | Doc-history meta label change | Confirmed intentional (preview's \`Created <per-page-git-date>\` is correct; old prod's \`Updated <fallback-date>\` was a shallow-clone artifact) | (no code change) |

## Wave 2 — Acceptance gate (#1538)

10-page parity re-walk on the deployed preview: **ALL_PASS**.

- All 7 #1530 action items verified resolved on preview
- #1530 item 5 (sidebar overlap on prod \`/docs/getting-started/\`) NOT_REPRODUCED on preview
- Zero console errors across 10 pages × 2 viewports (4 pages also sampled at mobile 375x812)
- No new visual regressions

Verification artifacts: \`__inbox/parity-pr-1539/\` (28-record capture, screenshots, probe data).

## Verification (curl on deployed preview)

\`\`\`text
/favicon.ico                                          → 301 → /pj/zudo-doc/favicon.svg
/pj/zudo-doc/docs/changelog/010                       → 301 → /pj/zudo-doc/docs/changelog/0.1.0/
/pj/zudo-doc/docs/changelog/010/                      → 301 → /pj/zudo-doc/docs/changelog/0.1.0/
/pj/zudo-doc/ja/docs/changelog/010/                   → 301 → /pj/zudo-doc/ja/docs/changelog/0.1.0/
/pj/zudo-doc/docs/changelog/0.1.0/                    → 200
/pj/zudo-doc/ja/docs/getting-started/structuring-navigations/ → 200
/pj/zudo-doc/ja/docs/getting-started/navigation-design/      → 404 (correctly gone)
\`\`\`

## Files changed

- \`.github/workflows/main-deploy.yml\` — 6-rule \`deploy/_redirects\` (favicon + changelog redirects)
- \`.github/workflows/preview-deploy.yml\` — same
- \`.github/workflows/pr-checks.yml\` — same
- \`packages/zudo-doc-v2/src/breadcrumb/breadcrumb.tsx\` — \`rightSlot\` prop for inline content (e.g. version switcher)
- \`pages/docs/[...slug].tsx\` — pager before DocHistoryArea; switcher via \`rightSlot\`
- \`pages/[locale]/docs/[...slug].tsx\` — same
- \`pages/v/[version]/docs/[...slug].tsx\` — same
- \`pages/v/[version]/ja/docs/[...slug].tsx\` — same
- \`pages/lib/_inline-version-switcher.tsx\` — refactor to be passed via \`rightSlot\`

## Test plan

- [x] \`pnpm build\` (verified by Wave 1 child agents on isolated branches)
- [x] \`pnpm check\` (pre-existing local-only \`__inbox/astro-clone/\` errors — not affected by this PR)
- [x] CI green (8/8 checks passed on PR #1539)
- [x] Preview deployed; structural curl checks pass on all 7 acceptance URLs
- [x] Visual parity walk against prod (10 pages × desktop + 4 pages × mobile) — no new regressions