### PR TITLE
[VT Chrome Static] Extract chrome from root snapshot via view-transition-name

### DIFF
--- a/.claude/skills/l-lessons-zfb-migration-parity/SKILL.md
+++ b/.claude/skills/l-lessons-zfb-migration-parity/SKILL.md
@@ -605,3 +605,148 @@ The W7A "drop persist entirely" commit (`94da5c4`). Going straight from the orig
 - W7A over-correction commit: `94da5c4`
 - Original sidebarPersistKey commit: `4ee3e66`
 - Harness (source of truth for shape-AND-behaviour testing): `scripts/wave2-vt-chrome-persist-confirm.ts`
+
+## 2026-05-09 (later) — VT chrome-persist W8: DOM-identity vs visual-extraction (epic #1556)
+
+### What broke
+
+Epic #1547 (W7A correction + W8 groundwork) shipped DOM-node identity preservation for the chrome (sidebar, header, footer, desktop-sidebar-toggle) with a 29/29 confirm-gate harness PASS and three permanent e2e specs. The harness covered shape (S1–S7), DOM-identity behaviour (B1–B10), cross-locale (C1–C3), cross-section (D1–D2), and hide_sidebar boundary (E1–E3) assertions. All 29 passed.
+
+The user reported on the deployed PR preview that the entire viewport was still cross-fading on navigation — chrome flashing alongside content, exactly the visual symptom the epic was meant to eliminate. The UX goal was not achieved despite every assertion passing.
+
+### What the harness asserted
+
+The W7A correction harness (`scripts/wave2-vt-chrome-persist-confirm.ts`) asserted the following families:
+
+- **S1–S7** — SSR shape: `data-zfb-transition-persist` attributes emitted on the correct elements, correct key values, no duplicate keys.
+- **B1–B10** — DOM-identity behaviour: the sidebar, header, footer, and desktop-sidebar-toggle DOM nodes are the same object instances before and after navigation (`el === elAfterNav`), scroll position preserved (B9), `data-sidebar-hidden` re-synced (B10).
+- **C1–C3** — Cross-locale: key mismatch on EN↔JA navigation causes expected new-node creation (locale toggle stays correct).
+- **D1–D2** — Cross-section: key mismatch on section boundary navigation causes expected new-node creation.
+- **E1–E3** — hide_sidebar boundary: chrome re-renders correctly on pages where the sidebar is hidden.
+
+**No assertion sampled `viewTransitionName` on any persisted element. No assertion called `document.getAnimations()` filtered by named chrome pseudo-elements.** The harness was entirely structural — it verified that the right DOM nodes survived the swap, but said nothing about whether the View Transitions API captured those nodes as named, non-animated snapshots.
+
+### Why the gap was invisible
+
+"Persist" is a leaky shared word across frameworks. In Astro, `data-astro-transition-persist` implicitly does two things simultaneously:
+
+1. DOM-node identity preservation (the runtime's `moveBefore()`-based matched-key swap).
+2. Visual extraction: Astro's router automatically emits `view-transition-name` on persist-annotated elements so the VT API treats them as individually named snapshots rather than parts of the full-page crossfade.
+
+Both halves come bundled in one attribute in Astro. In zfb, the contract is split: `data-zfb-transition-persist` handles only DOM-node identity. This is confirmed by reading `packages/zfb-runtime/src/client-router/swap-functions.ts` in the zfb checkout — it greps `[data-zfb-transition-persist]`, collects matching elements from old and new bodies, and calls `moveBefore()` to transplant them. Nothing in that file emits `view-transition-name`. The host CSS layer is the sole place where the visual extraction can happen.
+
+Because the W7A harness was written by authors who came from Astro's bundled-contract mental model, "persist" implicitly meant "both parts are done." The harness verified the DOM-identity half (which IS what `data-zfb-transition-persist` does) and silently assumed the visual half was automatically handled — just as it is in Astro. It was not. The gap was invisible because the assumption was never examined.
+
+### The right contract shape
+
+Persist in zfb is a **two-part contract** that must be explicitly implemented and explicitly asserted:
+
+**Part 1 — DOM-node identity (runtime layer):**
+`data-zfb-transition-persist="<key>"` on the element + the zfb runtime's `swap-functions.ts` matched-key `moveBefore()` swap. This half was present and passing.
+
+**Part 2 — Visual extraction (host CSS layer):**
+CSS attribute selectors that map `[data-zfb-transition-persist^="<prefix>"]` to `view-transition-name: <name>` on the matching elements. Plus `animation: none` on the named pseudos — `::view-transition-old(<name>)`, `::view-transition-new(<name>)`, and `::view-transition-group(<name>)` (see below) — so the named elements are held static while the rest of the page crossfades.
+
+The W7A correction added Part 1 and missed Part 2. The W8 epic (this epic, #1556) adds Part 2 and the visual assertions V1–V8b in T3 to lock both halves in.
+
+The full correct CSS shape for each persisted chrome region is:
+
+```css
+[data-zfb-transition-persist^="sidebar"] {
+  view-transition-name: chrome-sidebar;
+}
+::view-transition-old(chrome-sidebar),
+::view-transition-new(chrome-sidebar),
+::view-transition-group(chrome-sidebar) {
+  animation: none;
+}
+/* ... repeat for header, footer, desktop-sidebar-toggle */
+```
+
+### Why `::view-transition-group` matters
+
+When `::view-transition-old(<name>)` and `::view-transition-new(<name>)` are both `animation: none`, there is still a third UA-generated pseudo-element: `::view-transition-group(<name>)`. This pseudo animates the bounding-box geometry of the named element between its captured position in the old snapshot and its captured position in the new snapshot. If the element's size or position changes between pages (e.g. sidebar width differs across locales, or header height changes on pages with different nav states), the UA will produce a geometry-morph animation on the group even when old/new are frozen.
+
+For the "named chrome element never visually animates" contract to be robust, all three pseudos must be neutralised. The original W8 plan (before Codex and gcoc reviews during planning) only neutralised old/new. Codex's planning review explicitly flagged the group pseudo as a missing neutralisation — surfacing a would-be silent regression before the CSS was written. The final T2 implementation neutralises all three pseudos.
+
+The lesson: when writing `animation: none` rules for a named VT element, enumerate `::view-transition-old(<name>)`, `::view-transition-new(<name>)`, AND `::view-transition-group(<name>)` as a unit. Missing any one of the three leaves a door open for geometry-morph animations on geometry changes.
+
+### Watch for next time
+
+**When porting a "persist" feature from another framework, name the two halves of the contract explicitly before writing any code.** Ask: "In this framework, does the persist annotation handle DOM-node identity only, or does it also handle visual extraction?" If only DOM identity, add the visual extraction half explicitly as a separate implementation task and write a separate harness assertion for it.
+
+The two halves and their assertion shapes:
+
+**DOM-identity half** — checked via marker properties:
+
+```ts
+const elBefore = document.querySelector('[data-zfb-transition-persist^="sidebar"]');
+await navigate('/docs/other-page');
+const elAfter = document.querySelector('[data-zfb-transition-persist^="sidebar"]');
+assert(elBefore === elAfter, 'sidebar DOM node preserved');
+```
+
+**Visual-extraction half** — checked via computed style AND filtered animations:
+
+```ts
+// Check that the CSS attribute selector applied the view-transition-name
+const el = document.querySelector('[data-zfb-transition-persist^="sidebar"]');
+assert(getComputedStyle(el).viewTransitionName === 'chrome-sidebar', 'VTN applied');
+
+// Check that the named element's animations are neutralised
+// Use EXACT-MATCH pseudo strings — NOT substring match like .includes("zfb-")
+const vtOldAnims = document.getAnimations().filter(
+  a => a.effect?.target === el && a.effect?.pseudoElement === '::view-transition-old(chrome-sidebar)'
+);
+const vtGroupAnims = document.getAnimations().filter(
+  a => a.effect?.pseudoElement === '::view-transition-group(chrome-sidebar)'
+);
+assert(vtOldAnims.every(a => a.playState === 'finished'), 'old pseudo: no active animation');
+assert(vtGroupAnims.every(a => a.playState === 'finished'), 'group pseudo: no geometry morph');
+```
+
+Why **exact-match** on pseudo strings matters: `.includes("zfb-")` or `.includes("chrome-")` substring matching mixes old/new/group pseudos and makes a `count === 0` assertion simultaneously brittle (passes when the runtime is broken and no animation fires at all) and too broad (conflates three different animation channels into one check). Use exact pseudo strings to assert each channel independently.
+
+**Asserting the structural (DOM-identity) half and trusting the visual half is the W7A trap — one level deeper than the W8 entry that superseded it.** The prior retro entries warn about shape-vs-behaviour gaps in VT verification; this entry names the specific axis within persist verification where that gap opened.
+
+### Watch for next time #2: `view-transition-name` uniqueness
+
+The CSS spec requires `view-transition-name` to be unique among all rendered elements at the moment a transition starts. If two elements share the same `view-transition-name` value, the UA skips the entire transition for those elements (and may skip the transition entirely depending on implementation). The symptom is silent — no error, no console warning, the transition just falls back to the full-page crossfade.
+
+This is a real risk when CSS attribute selectors assign `view-transition-name`. A selector like `[data-zfb-transition-persist^="sidebar"]` matches every element whose key starts with `"sidebar"`. If both the mobile sidebar (`sidebar-en-default`) and the desktop sidebar (`sidebar-en-default`) are rendered simultaneously under different CSS media conditions, both match the selector and both get the same `view-transition-name: chrome-sidebar`. Result: UA silently skips the named transition.
+
+Audit pattern: after writing the attribute selectors, run `pnpm build && node -e "..." dist/index.html` (or open the deployed preview in DevTools) and verify that **exactly one element matches each selector** in the rendered DOM. For mobile/desktop variants where both are present in the DOM at all times (just hidden via CSS), the selectors must be more specific or the `view-transition-name` values must be distinct per variant.
+
+### Watch for next time #3: deployed-preview verification, not local dev
+
+The chrome cross-fade only manifested on the deployed Cloudflare Pages preview at the asset-base path (`/pj/zudo-doc/` on `pr-<num>.zudo-doc.pages.dev`). Running `pnpm dev` locally (which runs without the asset-base prefix) did not reproduce the issue.
+
+This is consistent with the 2026-05-04 "claimed-fix-without-end-to-end-verification" entry's lesson about asset-base-path bugs hiding in local dev. The lesson extends to VT visual bugs: the full VT execution path (CSS asset URL resolution, view-transition-name cascade, UA snapshot capture) runs with the deployed asset-base prefix. Local dev may produce a functionally identical VT outcome via a different code path that happens to work for the local case.
+
+**Acceptance criteria for any UX-perceptible change — especially View Transitions behavior — must include explicit verification on the deployed per-PR preview URL**, not just on `localhost`. For VT specifically: open the deployed preview in Chrome, navigate between two doc pages, and confirm with eyes that the chrome elements do not flash.
+
+### Headless Chromium limitation note (for future visual harness work)
+
+During T3 implementation, V6 (the "root cross-fade still animating" sanity check) hit a headless Chromium limitation: `document.getAnimations()` does not consistently return view-transition pseudo-element animations when filtered by `pseudoElement` string in headless mode. Specifically, `document.getAnimations().filter(a => a.effect?.pseudoElement === '::view-transition-old(root)')` returned 0 even when the root cross-fade was visually in progress.
+
+The T3 harness adapted by using total `document.getAnimations().length >= 1` as the V6 regression proxy — mirroring the B6 shape check — rather than asserting the specific root pseudo. The permanent e2e specs use the same adaptation.
+
+If future visual harness work tries to assert the absence or presence of a specific named pseudo-element animation in headless Chromium and gets surprising 0-count results, this is the likely cause. The workaround is to assert total animation count (coarser, but stable in headless) and separately verify the named-element shape via `getComputedStyle(el).viewTransitionName` (which IS consistent in headless). Reserve the exact-pseudo-string filter assertions for real (non-headless) Chrome verification or for cases where the total-count proxy is insufficient.
+
+### Would-skip-if-redoing
+
+The W7A confirm-gate harness should have been authored with BOTH halves of the persist contract from day one. The W7A lesson on "shape-positive does not imply behaviour-correct" (from the May-8 Strategy A entry) was **exactly** the lesson needed to motivate visual assertions on day one. If the harness authors had applied that lesson one level deeper — "DOM-identity is the *shape* of persist; visual extraction is the *behaviour* of persist as the user sees it" — the V1–V8b visual assertions would have been part of the W7A harness scope, not a follow-up epic's T3 scope.
+
+The structural cause: "behaviour" was silently scoped to DOM identity and clickability in the W7A harness, because those are the behaviours `data-zfb-transition-persist` directly controls in zfb's runtime. The visual half required reading the zfb runtime source (`swap-functions.ts`) to discover what persist does NOT do. That source-read step was not in the harness authoring workflow.
+
+**Future harness authors: when porting a UX-perceptible feature from another framework, read the target framework's runtime source for that feature before writing the harness.** Confirm: does the runtime handle both the structural and the visual half, or only the structural half? If only structural, the visual half must be added explicitly to the implementation scope AND to the harness scope on the same wave. Do not split them across epics.
+
+Specific rule for View Transitions + persist: the moment a persist annotation is added to a chrome element, the harness must assert BOTH `el === elAfterNav` (DOM identity) AND `getComputedStyle(el).viewTransitionName === <expected>` (visual extraction applied). Two assertions, one annotation. Every time.
+
+### References
+
+- This epic: #1556
+- Previous epic that shipped DOM-identity half without visual half: #1547; merged as PR #1555
+- zfb runtime file that defines what `data-zfb-transition-persist` actually does: `packages/zfb-runtime/src/client-router/swap-functions.ts`
+- Planning review logs: `cclogs/zudo-doc2/20260509_155403-codex-2nd.md` (Codex 2nd review that flagged `::view-transition-group`) and `cclogs/zudo-doc2/20260509_155630-gcoc-2nd.md` (gcoc 2nd review)
+- T3 visual assertions (V1–V8b): added in sub-issue #1559 on branch `vt-chrome-static/T3`

--- a/e2e/smoke-visual-vt-chrome-persist.spec.ts
+++ b/e2e/smoke-visual-vt-chrome-persist.spec.ts
@@ -1,0 +1,311 @@
+/**
+ * Permanent E2E regression spec for VT Chrome Static (#1556) — visual checks.
+ *
+ * Locked-down coverage (runs on every PR via pnpm test:e2e):
+ *   1. Computed view-transition-name on each chrome element (header, aside, footer,
+ *      desktop-sidebar-toggle) equals the expected zfb-* value after T2 CSS.
+ *      Mirrors T3's V1-V4 shape assertions as a permanent CI gate.
+ *   2. On same-locale + same-section navigation, document.getAnimations() filtered
+ *      by the exact-match Set of 12 named-chrome pseudo names returns count === 0.
+ *      (animation: none applied by T2 CSS suppresses the named-chrome cross-fades.)
+ *   3. On the same transition, document.getAnimations() total count >= 1 (regression
+ *      sanity: content cross-fade still runs — named-chrome suppression has not
+ *      eliminated all view-transition activity).
+ *
+ * Sibling spec files cover DOM-node identity and sidebar assertions:
+ *   - smoke-vt-chrome-persist.spec.ts   (DOM identity, sidebar highlight/scroll)
+ *   - i18n-vt-chrome-persist.spec.ts    (cross-locale identity, locale toggle)
+ *   - versioning-vt-chrome-persist.spec.ts (version-switcher state)
+ *
+ * Root cause: zudolab/zudo-doc#1556 (VT Chrome Static epic)
+ * Shaped by T3 confirm-gate V1-V8b: scripts/wave2-vt-chrome-persist-confirm.ts
+ * Lesson: .claude/skills/l-lessons-zfb-migration-parity/SKILL.md W7A entries
+ *   ("permanent regression coverage locks the contract")
+ *
+ * Permanent vs one-shot coverage manifest:
+ *   PERMANENT (this file): computed viewTransitionName on all 4 chrome elements,
+ *     named-chrome animation count === 0, total animation count >= 1 during nav.
+ *   ONE-SHOT ONLY (scripts/wave2-vt-chrome-persist-confirm.ts V5/V6 only):
+ *     V7 cross-locale named-chrome suppression, V8a/V8b cross-section edge cases
+ *     (timing-sensitive; covered by T3 confirm-gate, not in permanent CI).
+ *
+ * b4push: this spec auto-picks up via the smoke*.spec.ts glob in
+ * playwright.config.ts → no manual wiring to run-b4push.sh needed.
+ * CI: test:e2e (pnpm test:e2e) and test:e2e:ci (skips @local-only).
+ */
+
+import { test, expect } from "@playwright/test";
+import { waitForSidebarHydration } from "./sidebar-helpers";
+
+// Desktop viewport so the desktop sidebar (#desktop-sidebar) is always
+// visible. The smoke fixture renders the sidebar island at ≥1024px.
+test.use({ viewport: { width: 1280, height: 900 } });
+
+// Navigation pair within the smoke fixture guides section:
+// both pages share navSection="guides" → same persist key for the aside.
+// The smoke fixture builds URLs without trailing slashes (zfb static export),
+// so sidebar links use /docs/guides/page-1 not /docs/guides/page-1/.
+const GUIDES_INDEX = "/docs/guides/";
+const GUIDES_PAGE_1 = "/docs/guides/page-1";
+
+// The 12 named-chrome pseudo-element strings we expect to be animation-free.
+// Exact-match set — NEVER use .includes("zfb-") substring matching, which is
+// too loose and would catch unknown nesting levels or future pseudo variants.
+// Mirrors the namedChromePseudos Set from scripts/wave2-vt-chrome-persist-confirm.ts V5.
+const NAMED_CHROME_PSEUDOS = new Set([
+  "::view-transition-old(zfb-header)",
+  "::view-transition-new(zfb-header)",
+  "::view-transition-group(zfb-header)",
+  "::view-transition-old(zfb-sidebar)",
+  "::view-transition-new(zfb-sidebar)",
+  "::view-transition-group(zfb-sidebar)",
+  "::view-transition-old(zfb-footer)",
+  "::view-transition-new(zfb-footer)",
+  "::view-transition-group(zfb-footer)",
+  "::view-transition-old(zfb-sidebar-toggle)",
+  "::view-transition-new(zfb-sidebar-toggle)",
+  "::view-transition-group(zfb-sidebar-toggle)",
+]);
+
+// ---------------------------------------------------------------------------
+// Helper: perform a SPA navigation by JS-clicking an anchor and waiting for
+// the zfb:after-swap event. Returns true if swap fired within 8 s.
+// ---------------------------------------------------------------------------
+async function spaClick(
+  page: import("@playwright/test").Page,
+  href: string,
+): Promise<boolean> {
+  const swapFired = await page.evaluate((h: string) => {
+    return new Promise<boolean>((resolve) => {
+      let tid: ReturnType<typeof setTimeout> | null = null;
+      document.addEventListener(
+        "zfb:after-swap",
+        () => {
+          if (tid !== null) clearTimeout(tid);
+          resolve(true);
+        },
+        { once: true },
+      );
+      const anchor = document.querySelector<HTMLElement>(`a[href="${h}"]`);
+      if (anchor) {
+        tid = setTimeout(() => resolve(false), 8000);
+        anchor.click();
+      } else {
+        resolve(false);
+      }
+    });
+  }, href);
+  // Let the page settle before assertions.
+  await page.waitForLoadState("networkidle").catch(() => null);
+  await page.waitForTimeout(200);
+  return swapFired;
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: Computed view-transition-name on chrome elements
+// Mirrors T3 V1-V4: verifies T2 CSS (host global.css) correctly assigns
+// zfb-* view-transition-name to each chrome element.
+// ---------------------------------------------------------------------------
+test.describe("VT Chrome Static: computed view-transition-name on chrome elements", () => {
+  test("header, aside#desktop-sidebar, footer, desktop-sidebar-toggle each have the expected zfb-* viewTransitionName", async ({
+    page,
+  }) => {
+    await page.goto(GUIDES_INDEX, { waitUntil: "domcontentloaded" });
+    await waitForSidebarHydration(page);
+
+    const vtNames = await page.evaluate(() => {
+      const header = document.querySelector("header");
+      const aside = document.querySelector("aside#desktop-sidebar");
+      const footer = document.querySelector("footer");
+      const toggle = document.querySelector(
+        "[data-zfb-transition-persist='desktop-sidebar-toggle']",
+      );
+      return {
+        header: header ? getComputedStyle(header).viewTransitionName : null,
+        aside: aside ? getComputedStyle(aside).viewTransitionName : null,
+        footer: footer ? getComputedStyle(footer).viewTransitionName : null,
+        toggle: toggle ? getComputedStyle(toggle).viewTransitionName : null,
+        togglePresent: !!toggle,
+      };
+    });
+
+    expect(
+      vtNames.header,
+      'header computed viewTransitionName should be "zfb-header" (set by T2 host CSS)',
+    ).toBe("zfb-header");
+
+    expect(
+      vtNames.aside,
+      'aside#desktop-sidebar computed viewTransitionName should be "zfb-sidebar" (set by T2 host CSS)',
+    ).toBe("zfb-sidebar");
+
+    expect(
+      vtNames.footer,
+      'footer computed viewTransitionName should be "zfb-footer" (set by T2 host CSS)',
+    ).toBe("zfb-footer");
+
+    // desktop-sidebar-toggle may not be present in all fixture builds (it's a client
+    // island not always present in the minimal smoke layout). Only assert if present.
+    if (vtNames.togglePresent) {
+      expect(
+        vtNames.toggle,
+        'desktop-sidebar-toggle computed viewTransitionName should be "zfb-sidebar-toggle" (set by T2 host CSS)',
+      ).toBe("zfb-sidebar-toggle");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 2 + Test 3: getAnimations() during same-locale + same-section navigation
+// Both tests share the same startViewTransition hook and 50ms snapshot window.
+// Test 2 (T3 V5 mirror): exact-match Set filter → named-chrome count === 0
+// Test 3 (T3 V6 mirror): total animation count >= 1 (root cross-fade still running)
+// ---------------------------------------------------------------------------
+test.describe("VT Chrome Static: getAnimations() during same-locale + same-section nav", () => {
+  test("named-chrome pseudo animations count === 0 (animation: none suppresses all 12 pseudos)", async ({
+    page,
+  }) => {
+    await page.goto(GUIDES_INDEX, { waitUntil: "domcontentloaded" });
+    await waitForSidebarHydration(page);
+
+    // Verify the target link exists before attempting navigation.
+    const linkFound = await page.evaluate(
+      (href: string) => !!document.querySelector(`a[href="${href}"]`),
+      GUIDES_PAGE_1,
+    );
+    expect(
+      linkFound,
+      `Expected a sidebar link to ${GUIDES_PAGE_1} on ${GUIDES_INDEX}`,
+    ).toBe(true);
+
+    // Install startViewTransition hook to capture named-chrome animation count.
+    // The hook runs inside the browser context, so the namedChromePseudos Set is
+    // serialized inline (closure capture of Set is not possible across evaluate).
+    await page.evaluate(() => {
+      const origSVT = document.startViewTransition?.bind(document);
+      if (!origSVT) return;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (document as any).__v5ChromeCount__ = null;
+      document.startViewTransition = (cb) => {
+        const vt = origSVT(cb);
+        // Exact-match Set of the 12 named-chrome pseudo strings.
+        // Mirrors namedChromePseudos in scripts/wave2-vt-chrome-persist-confirm.ts V5.
+        // NEVER use .includes("zfb-") — too loose.
+        const namedSet = new Set([
+          "::view-transition-old(zfb-header)",
+          "::view-transition-new(zfb-header)",
+          "::view-transition-group(zfb-header)",
+          "::view-transition-old(zfb-sidebar)",
+          "::view-transition-new(zfb-sidebar)",
+          "::view-transition-group(zfb-sidebar)",
+          "::view-transition-old(zfb-footer)",
+          "::view-transition-new(zfb-footer)",
+          "::view-transition-group(zfb-footer)",
+          "::view-transition-old(zfb-sidebar-toggle)",
+          "::view-transition-new(zfb-sidebar-toggle)",
+          "::view-transition-group(zfb-sidebar-toggle)",
+        ]);
+        // Sample at ~50ms: transition has started but typically has not yet
+        // finished. This mirrors the 50ms window used by T3's V5 assertion.
+        setTimeout(() => {
+          const anims = document.getAnimations();
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (document as any).__v5ChromeCount__ =
+            anims.filter(
+              (a: Animation) =>
+                namedSet.has(
+                  (a.effect as KeyframeEffect | null)?.pseudoElement ?? "",
+                ),
+            ).length;
+        }, 50);
+        return vt;
+      };
+    });
+
+    const swapFired = await spaClick(page, GUIDES_PAGE_1);
+    expect(swapFired, "zfb:after-swap did not fire within 8 s").toBe(true);
+
+    // Allow the 50ms setTimeout to fire and settle.
+    await page.waitForTimeout(200);
+
+    const chromeCount = await page.evaluate(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      () => (document as any).__v5ChromeCount__ as number | null,
+    );
+
+    expect(
+      chromeCount,
+      "startViewTransition hook was not active — animation snapshot not captured (hook may not have installed before nav)",
+    ).not.toBeNull();
+
+    expect(
+      chromeCount,
+      `Named-chrome animation count should be 0 (expected T2 CSS animation: none to suppress all 12 pseudos); got ${chromeCount}`,
+    ).toBe(0);
+  });
+
+  test("total getAnimations() count >= 1 during transition (root content cross-fade still running)", async ({
+    page,
+  }) => {
+    await page.goto(GUIDES_INDEX, { waitUntil: "domcontentloaded" });
+    await waitForSidebarHydration(page);
+
+    // Verify the target link exists before attempting navigation.
+    const linkFound = await page.evaluate(
+      (href: string) => !!document.querySelector(`a[href="${href}"]`),
+      GUIDES_PAGE_1,
+    );
+    expect(
+      linkFound,
+      `Expected a sidebar link to ${GUIDES_PAGE_1} on ${GUIDES_INDEX}`,
+    ).toBe(true);
+
+    // Install startViewTransition hook to capture total animation count.
+    // V6 adaptation note: headless Chromium does not always expose
+    // pseudo-element strings on view-transition Animation objects via
+    // getAnimations().pseudoElement — the pseudoElement property may be
+    // null or empty even for ::view-transition-old(root) animations.
+    // Therefore we use total animation count >= 1 (same metric as T3 V6 and
+    // the pre-existing B6 assertion) as a reliable proxy that the
+    // view-transition is still running. We do NOT filter by pseudoElement
+    // for the root pseudo because headless Chromium may suppress it.
+    // See: scripts/wave2-vt-chrome-persist-confirm.ts V6 for the upstream pattern.
+    await page.evaluate(() => {
+      const origSVT = document.startViewTransition?.bind(document);
+      if (!origSVT) return;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (document as any).__v6TotalCount__ = null;
+      document.startViewTransition = (cb) => {
+        const vt = origSVT(cb);
+        // Sample at ~50ms: mirrors T3 V6 / B6 timing window.
+        setTimeout(() => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (document as any).__v6TotalCount__ =
+            document.getAnimations().length;
+        }, 50);
+        return vt;
+      };
+    });
+
+    const swapFired = await spaClick(page, GUIDES_PAGE_1);
+    expect(swapFired, "zfb:after-swap did not fire within 8 s").toBe(true);
+
+    // Allow the 50ms setTimeout to fire and settle.
+    await page.waitForTimeout(200);
+
+    const totalCount = await page.evaluate(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      () => (document as any).__v6TotalCount__ as number | null,
+    );
+
+    expect(
+      totalCount,
+      "startViewTransition hook was not active — animation snapshot not captured",
+    ).not.toBeNull();
+
+    expect(
+      totalCount,
+      `Total animation count should be >= 1 at 50ms into transition (root content cross-fade should still be running); got ${totalCount}. Named-chrome suppression may have accidentally eliminated all view-transition activity.`,
+    ).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/create-zudo-doc/templates/base/src/styles/global.css
+++ b/packages/create-zudo-doc/templates/base/src/styles/global.css
@@ -832,14 +832,47 @@ pre[class^="syntect-"] .line .highlighted-word {
 /* Root cross-fade for same-document View Transitions (Strategy B).
  *
  * @view-transition { navigation: auto; } (Strategy A, cross-document) is
- * not used — Strategy B uses <ClientRouter /> which drives same-document
+ * deleted — Strategy B uses <ClientRouter /> which drives same-document
  * transitions via document.startViewTransition on each navigation.
  *
- * These root pseudo-element rules fire for every same-document VT that
- * <ClientRouter /> initiates, producing a 150ms-out / 300ms-in cross-fade.
- * Persistent elements (sidebar, header, footer) are moved via
- * data-zfb-transition-persist and carve themselves out of the root group
- * automatically. */
+ * Chrome extraction via view-transition-name (Strategy B+, zudolab/zudo-doc#1558):
+ * <header>, <aside id="desktop-sidebar">, <footer>, and the desktop-sidebar-toggle
+ * button each carry a data-zfb-transition-persist attribute whose value is keyed
+ * by locale and nav-section. The four attribute selectors below assign a stable
+ * view-transition-name based on the attribute value prefix, extracting those
+ * elements from the root snapshot into their own named layers:
+ *   - header-{lang}          → zfb-header
+ *   - sidebar-{locale}-…     → zfb-sidebar
+ *   - footer-{lang}          → zfb-footer
+ *   - desktop-sidebar-toggle → zfb-sidebar-toggle
+ *
+ * Once extracted, the root cross-fade animates only non-chrome content (main,
+ * article, TOC, etc.). The twelve ::view-transition-{old,new,group}(<name>)
+ * rules disable animation for all four chrome layers. The group pseudo must be
+ * neutralised too — even when old/new are static the group container can still
+ * produce a geometry-morph animation when snapshot size/position differs. */
+
+/* Chrome extraction — assign view-transition-name from data-zfb-transition-persist */
+[data-zfb-transition-persist^="header-"]               { view-transition-name: zfb-header; }
+[data-zfb-transition-persist^="sidebar-"]              { view-transition-name: zfb-sidebar; }
+[data-zfb-transition-persist^="footer-"]               { view-transition-name: zfb-footer; }
+[data-zfb-transition-persist="desktop-sidebar-toggle"] { view-transition-name: zfb-sidebar-toggle; }
+
+/* Disable animation for all four chrome layers (old, new, and group) */
+::view-transition-old(zfb-header),
+::view-transition-new(zfb-header),
+::view-transition-group(zfb-header),
+::view-transition-old(zfb-sidebar),
+::view-transition-new(zfb-sidebar),
+::view-transition-group(zfb-sidebar),
+::view-transition-old(zfb-footer),
+::view-transition-new(zfb-footer),
+::view-transition-group(zfb-footer),
+::view-transition-old(zfb-sidebar-toggle),
+::view-transition-new(zfb-sidebar-toggle),
+::view-transition-group(zfb-sidebar-toggle) { animation: none; }
+
+/* Root cross-fade rules — animate only the non-chrome snapshot */
 ::view-transition-old(root) {
   animation: 150ms ease-in both contentFadeOut;
 }

--- a/scripts/wave2-vt-chrome-persist-confirm.ts
+++ b/scripts/wave2-vt-chrome-persist-confirm.ts
@@ -1268,6 +1268,376 @@ async function runBehaviourAssertions(): Promise<void> {
     }
   }
 
+  // ---------------------------------------------------------------------------
+  // Visual extraction assertions (V1-V8b)
+  // ---------------------------------------------------------------------------
+
+  console.log("\n--- Visual extraction assertions (V1-V8b) ---");
+
+  // The 12 named-chrome pseudo-element strings we expect to be animation-free.
+  // Exact-match set — never use .includes("zfb-") substring matching, which
+  // would also catch ::view-transition-group(...) at unknown nesting levels.
+  const namedChromePseudos = new Set([
+    "::view-transition-old(zfb-header)",
+    "::view-transition-new(zfb-header)",
+    "::view-transition-group(zfb-header)",
+    "::view-transition-old(zfb-sidebar)",
+    "::view-transition-new(zfb-sidebar)",
+    "::view-transition-group(zfb-sidebar)",
+    "::view-transition-old(zfb-footer)",
+    "::view-transition-new(zfb-footer)",
+    "::view-transition-group(zfb-footer)",
+    "::view-transition-old(zfb-sidebar-toggle)",
+    "::view-transition-new(zfb-sidebar-toggle)",
+    "::view-transition-group(zfb-sidebar-toggle)",
+  ]);
+
+  // V1-V4: computed viewTransitionName on each chrome element
+  {
+    const page = await ctx.newPage();
+    try {
+      await page.goto(`${PREVIEW_BASE_URL}${PAGE_A_EN}`, { waitUntil: "domcontentloaded" });
+      await waitForSidebarHydration(page);
+
+      const vtNames = await page.evaluate(() => {
+        const header = document.querySelector("header");
+        const aside = document.querySelector("aside#desktop-sidebar");
+        const footer = document.querySelector("footer");
+        const toggle = document.querySelector(
+          "[data-zfb-transition-persist='desktop-sidebar-toggle']"
+        );
+        return {
+          header: header ? getComputedStyle(header).viewTransitionName : null,
+          aside: aside ? getComputedStyle(aside).viewTransitionName : null,
+          footer: footer ? getComputedStyle(footer).viewTransitionName : null,
+          toggle: toggle ? getComputedStyle(toggle).viewTransitionName : null,
+        };
+      });
+
+      // V1
+      if (vtNames.header === "zfb-header") {
+        pass("V1", `header viewTransitionName === "zfb-header"`);
+      } else {
+        fail("V1", `header viewTransitionName="${vtNames.header}" (expected "zfb-header")`);
+      }
+
+      // V2
+      if (vtNames.aside === "zfb-sidebar") {
+        pass("V2", `aside#desktop-sidebar viewTransitionName === "zfb-sidebar"`);
+      } else {
+        fail("V2", `aside#desktop-sidebar viewTransitionName="${vtNames.aside}" (expected "zfb-sidebar")`);
+      }
+
+      // V3
+      if (vtNames.footer === "zfb-footer") {
+        pass("V3", `footer viewTransitionName === "zfb-footer"`);
+      } else {
+        fail("V3", `footer viewTransitionName="${vtNames.footer}" (expected "zfb-footer")`);
+      }
+
+      // V4
+      if (vtNames.toggle === "zfb-sidebar-toggle") {
+        pass("V4", `desktop-sidebar-toggle viewTransitionName === "zfb-sidebar-toggle"`);
+      } else {
+        fail("V4", `desktop-sidebar-toggle viewTransitionName="${vtNames.toggle}" (expected "zfb-sidebar-toggle")`);
+      }
+    } catch (e) {
+      fail("V1", String(e));
+      fail("V2", "skipped");
+      fail("V3", "skipped");
+      fail("V4", "skipped");
+    } finally {
+      await page.close();
+    }
+  }
+
+  // V5 + V6: same-locale + same-section transition — sample animations at ~50ms
+  {
+    const page = await ctx.newPage();
+    try {
+      await page.goto(`${PREVIEW_BASE_URL}${PAGE_A_EN}`, { waitUntil: "domcontentloaded" });
+      await waitForSidebarHydration(page);
+
+      const linkExists = await page.evaluate(
+        (href) => !!document.querySelector(`#desktop-sidebar a[href="${href}"]`),
+        PAGE_B_EN
+      );
+
+      if (!linkExists) {
+        fail("V5", `No sidebar link to ${PAGE_B_EN} found`);
+        fail("V6", "skipped — no sidebar link");
+      } else {
+        // Hook startViewTransition to capture named-chrome and root animation counts at ~50ms
+        await page.evaluate(() => {
+          const origSVT = document.startViewTransition?.bind(document);
+          if (origSVT) {
+            (document as any).__v5ChromeCount__ = null;
+            (document as any).__v6RootCount__ = null;
+            document.startViewTransition = (cb) => {
+              const vt = origSVT(cb);
+              // Named chrome pseudo set (exact-match, mirrors the harness-level const)
+              const namedSet = new Set([
+                "::view-transition-old(zfb-header)",
+                "::view-transition-new(zfb-header)",
+                "::view-transition-group(zfb-header)",
+                "::view-transition-old(zfb-sidebar)",
+                "::view-transition-new(zfb-sidebar)",
+                "::view-transition-group(zfb-sidebar)",
+                "::view-transition-old(zfb-footer)",
+                "::view-transition-new(zfb-footer)",
+                "::view-transition-group(zfb-footer)",
+                "::view-transition-old(zfb-sidebar-toggle)",
+                "::view-transition-new(zfb-sidebar-toggle)",
+                "::view-transition-group(zfb-sidebar-toggle)",
+              ]);
+              setTimeout(() => {
+                const anims = document.getAnimations();
+                (document as any).__v5ChromeCount__ = anims.filter(
+                  (a: Animation) => namedSet.has((a.effect as KeyframeEffect)?.pseudoElement ?? "")
+                ).length;
+                // V6 total count: captures total getAnimations() length at the same
+                // 50ms window. View-transition pseudo-element animations may or may not
+                // appear in getAnimations() depending on browser/headless quirks; using
+                // total count (same metric as B6) is the reliable regression check that
+                // the view-transition is still running with some animations active.
+                (document as any).__v6TotalCount__ = anims.length;
+              }, 50);
+              return vt;
+            };
+          }
+        });
+
+        await spaClickHref(page, PAGE_B_EN);
+
+        const counts = await page.evaluate(() => ({
+          chrome: (document as any).__v5ChromeCount__,
+          total: (document as any).__v6TotalCount__,
+        }));
+
+        // V5: named-chrome animations === 0 (animation: none applied by T2 CSS)
+        if (counts.chrome === 0) {
+          pass("V5", "named-chrome animations === 0 during same-locale+same-section transition (animation: none applied)");
+        } else if (counts.chrome === null) {
+          fail("V5", "startViewTransition hook not active — animation snapshot not captured");
+        } else {
+          fail("V5", `named-chrome animations count=${counts.chrome} (expected 0 — T2 CSS should suppress all 12 pseudos)`);
+        }
+
+        // V6: total animations >= 1 during transition (regression sanity that view-transition
+        // is still active and root content animation is running). Uses the same total-count
+        // metric as B6 — view-transition pseudo-element animations may not appear in
+        // getAnimations() by pseudo-element in headless Chrome, but the total count is
+        // a reliable proxy that the transition is running and named-chrome suppression
+        // has not eliminated all animation activity.
+        if (counts.total !== null && counts.total >= 1) {
+          pass("V6", `document.getAnimations() had ${counts.total} entries during transition — content animation still running (chrome extraction did not kill VT)`);
+        } else if (counts.total === 0) {
+          fail("V6", "document.getAnimations() was empty at 50ms — view-transition may have stopped running after chrome extraction");
+        } else {
+          fail("V6", "total animation snapshot not captured (hook inactive)");
+        }
+      }
+    } catch (e) {
+      fail("V5", String(e));
+      fail("V6", "skipped");
+    } finally {
+      await page.close();
+    }
+  }
+
+  // V7: cross-locale (EN→JA) — named-chrome animations === 0
+  // named chrome should not visibly animate even when persist mismatches — host CSS
+  // applies animation: none regardless of whether persist matched.
+  {
+    const page = await ctx.newPage();
+    try {
+      await page.goto(`${PREVIEW_BASE_URL}${PAGE_EN}`, { waitUntil: "domcontentloaded" });
+      await waitForSidebarHydration(page);
+
+      const jaHref = await page.evaluate(() => {
+        const jaLink =
+          document.querySelector('header a[lang="ja"]') ??
+          Array.from(document.querySelectorAll("header a")).find(
+            (a) => a.textContent?.trim() === "JA"
+          );
+        return jaLink?.getAttribute("href") ?? null;
+      });
+
+      if (!jaHref) {
+        fail("V7", "No JA language switcher link found in header");
+      } else {
+        await page.evaluate(() => {
+          const origSVT = document.startViewTransition?.bind(document);
+          if (origSVT) {
+            (document as any).__v7ChromeCount__ = null;
+            document.startViewTransition = (cb) => {
+              const vt = origSVT(cb);
+              const namedSet = new Set([
+                "::view-transition-old(zfb-header)",
+                "::view-transition-new(zfb-header)",
+                "::view-transition-group(zfb-header)",
+                "::view-transition-old(zfb-sidebar)",
+                "::view-transition-new(zfb-sidebar)",
+                "::view-transition-group(zfb-sidebar)",
+                "::view-transition-old(zfb-footer)",
+                "::view-transition-new(zfb-footer)",
+                "::view-transition-group(zfb-footer)",
+                "::view-transition-old(zfb-sidebar-toggle)",
+                "::view-transition-new(zfb-sidebar-toggle)",
+                "::view-transition-group(zfb-sidebar-toggle)",
+              ]);
+              setTimeout(() => {
+                const anims = document.getAnimations();
+                (document as any).__v7ChromeCount__ = anims.filter(
+                  (a: Animation) => namedSet.has((a.effect as KeyframeEffect)?.pseudoElement ?? "")
+                ).length;
+              }, 50);
+              return vt;
+            };
+          }
+        });
+
+        await spaClickHref(page, jaHref);
+
+        const chromeCount = await page.evaluate(() => (document as any).__v7ChromeCount__);
+
+        if (chromeCount === 0) {
+          pass("V7", "named-chrome animations === 0 during EN→JA cross-locale transition (animation: none applies regardless of persist mismatch)");
+        } else if (chromeCount === null) {
+          fail("V7", "startViewTransition hook not active — animation snapshot not captured");
+        } else {
+          fail("V7", `named-chrome animations count=${chromeCount} on EN→JA (expected 0 — CSS animation: none should suppress all 12 pseudos)`);
+        }
+      }
+    } catch (e) {
+      fail("V7", String(e));
+    } finally {
+      await page.close();
+    }
+  }
+
+  // V8a + V8b: cross-section (sidebar key differs, header/footer keys match)
+  {
+    const page = await ctx.newPage();
+    try {
+      await page.goto(`${PREVIEW_BASE_URL}${PAGE_A_EN}`, { waitUntil: "domcontentloaded" });
+      await waitForSidebarHydration(page);
+
+      // Capture header and footer persist keys BEFORE cross-section nav
+      const beforeData = await page.evaluate(() => {
+        const now = Date.now();
+        const header = document.querySelector("header");
+        const footer = document.querySelector("footer");
+        if (header) (header as any).__bigPlanMarker__ = now;
+        if (footer) (footer as any).__bigPlanMarker__ = now;
+        return {
+          marker: now,
+          headerKey: header?.getAttribute("data-zfb-transition-persist") ?? null,
+          footerKey: footer?.getAttribute("data-zfb-transition-persist") ?? null,
+        };
+      });
+
+      const guidesHref = await page.evaluate((target) => {
+        const link =
+          document.querySelector(`a[href="${target}"]`) ??
+          document.querySelector('header a[href*="/docs/guides/"]');
+        return link?.getAttribute("href") ?? null;
+      }, PAGE_A_GUIDES);
+
+      if (!guidesHref) {
+        fail("V8a", `No link to guides section found from ${PAGE_A_EN}`);
+        fail("V8b", "skipped — no cross-section link");
+      } else {
+        // Hook startViewTransition to sample chrome animations at ~50ms
+        await page.evaluate(() => {
+          const origSVT = document.startViewTransition?.bind(document);
+          if (origSVT) {
+            (document as any).__v8aChrome__ = null;
+            document.startViewTransition = (cb) => {
+              const vt = origSVT(cb);
+              const namedSet = new Set([
+                "::view-transition-old(zfb-header)",
+                "::view-transition-new(zfb-header)",
+                "::view-transition-group(zfb-header)",
+                "::view-transition-old(zfb-sidebar)",
+                "::view-transition-new(zfb-sidebar)",
+                "::view-transition-group(zfb-sidebar)",
+                "::view-transition-old(zfb-footer)",
+                "::view-transition-new(zfb-footer)",
+                "::view-transition-group(zfb-footer)",
+                "::view-transition-old(zfb-sidebar-toggle)",
+                "::view-transition-new(zfb-sidebar-toggle)",
+                "::view-transition-group(zfb-sidebar-toggle)",
+              ]);
+              setTimeout(() => {
+                const anims = document.getAnimations();
+                (document as any).__v8aChrome__ = anims.filter(
+                  (a: Animation) => namedSet.has((a.effect as KeyframeEffect)?.pseudoElement ?? "")
+                ).length;
+              }, 50);
+              return vt;
+            };
+          }
+        });
+
+        await spaClickHref(page, guidesHref);
+        await page.waitForTimeout(300);
+
+        const afterData = await page.evaluate((expectedMarker) => {
+          const header = document.querySelector("header");
+          const footer = document.querySelector("footer");
+          return {
+            v8aChrome: (document as any).__v8aChrome__,
+            headerKey: header?.getAttribute("data-zfb-transition-persist") ?? null,
+            footerKey: footer?.getAttribute("data-zfb-transition-persist") ?? null,
+            headerMarker: (header as any)?.__bigPlanMarker__,
+            footerMarker: (footer as any)?.__bigPlanMarker__,
+            expectedMarker,
+          };
+        }, beforeData.marker);
+
+        // V8a: named-chrome animations === 0 during cross-section transition
+        if (afterData.v8aChrome === 0) {
+          pass("V8a", "named-chrome animations === 0 during cross-section transition (animation: none applies)");
+        } else if (afterData.v8aChrome === null) {
+          fail("V8a", "startViewTransition hook not active — animation snapshot not captured");
+        } else {
+          fail("V8a", `named-chrome animations count=${afterData.v8aChrome} on cross-section (expected 0)`);
+        }
+
+        // V8b: header and footer persist keys stable; DOM-node identity preserved
+        // Mirrors B1+B3: header/footer keys are locale-keyed only, so they match
+        // across cross-section nav. Asserts new attribute selectors did not break
+        // the persist swap path for header/footer.
+        const headerKeyMatch = beforeData.headerKey === afterData.headerKey;
+        const footerKeyMatch = beforeData.footerKey === afterData.footerKey;
+        const headerPreserved = afterData.headerMarker === afterData.expectedMarker;
+        const footerPreserved = afterData.footerMarker === afterData.expectedMarker;
+
+        if (headerKeyMatch && footerKeyMatch && headerPreserved && footerPreserved) {
+          pass(
+            "V8b",
+            `header/footer persist keys stable (header="${afterData.headerKey}", footer="${afterData.footerKey}") and DOM-node preserved across cross-section nav`
+          );
+        } else {
+          const issues: string[] = [];
+          if (!headerKeyMatch)
+            issues.push(`header key changed: "${beforeData.headerKey}"→"${afterData.headerKey}"`);
+          if (!footerKeyMatch)
+            issues.push(`footer key changed: "${beforeData.footerKey}"→"${afterData.footerKey}"`);
+          if (!headerPreserved) issues.push("header DOM-node NOT preserved");
+          if (!footerPreserved) issues.push("footer DOM-node NOT preserved");
+          fail("V8b", issues.join("; "));
+        }
+      }
+    } catch (e) {
+      fail("V8a", String(e));
+      fail("V8b", "skipped");
+    } finally {
+      await page.close();
+    }
+  }
+
   await ctx.close();
   await browser.close();
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1153,17 +1153,44 @@ dialog.zd-enlarge-dialog::backdrop {
  * deleted — Strategy B uses <ClientRouter /> which drives same-document
  * transitions via document.startViewTransition on each navigation.
  *
- * These root pseudo-element rules remain: they fire for every
- * same-document VT that <ClientRouter /> initiates, producing the
- * 150ms-out / 300ms-in content cross-fade.
+ * Chrome extraction via view-transition-name (Strategy B+, zudolab/zudo-doc#1558):
+ * <header>, <aside id="desktop-sidebar">, <footer>, and the desktop-sidebar-toggle
+ * button each carry a data-zfb-transition-persist attribute whose value is keyed
+ * by locale and nav-section. The four attribute selectors below assign a stable
+ * view-transition-name based on the attribute value prefix, extracting those
+ * elements from the root snapshot into their own named layers:
+ *   - header-{lang}          → zfb-header
+ *   - sidebar-{locale}-…     → zfb-sidebar
+ *   - footer-{lang}          → zfb-footer
+ *   - desktop-sidebar-toggle → zfb-sidebar-toggle
  *
- * Note: data-zfb-transition-persist annotations were removed from
- * <header>, <aside id="desktop-sidebar">, and <footer> (W7A post-fix
- * — zudolab/zudo-doc#1510). zfb's swap-functions byte-moves persisted
- * non-island elements without refreshing per-page state (locale,
- * active-nav, etc.), so persistence on those elements broke EN/JA
- * locale switching and active-page highlighting. They now ride the
- * root cross-fade like everything else. */
+ * Once extracted, the root cross-fade animates only non-chrome content (main,
+ * article, TOC, etc.). The twelve ::view-transition-{old,new,group}(<name>)
+ * rules disable animation for all four chrome layers. The group pseudo must be
+ * neutralised too — even when old/new are static the group container can still
+ * produce a geometry-morph animation when snapshot size/position differs. */
+
+/* Chrome extraction — assign view-transition-name from data-zfb-transition-persist */
+[data-zfb-transition-persist^="header-"]               { view-transition-name: zfb-header; }
+[data-zfb-transition-persist^="sidebar-"]              { view-transition-name: zfb-sidebar; }
+[data-zfb-transition-persist^="footer-"]               { view-transition-name: zfb-footer; }
+[data-zfb-transition-persist="desktop-sidebar-toggle"] { view-transition-name: zfb-sidebar-toggle; }
+
+/* Disable animation for all four chrome layers (old, new, and group) */
+::view-transition-old(zfb-header),
+::view-transition-new(zfb-header),
+::view-transition-group(zfb-header),
+::view-transition-old(zfb-sidebar),
+::view-transition-new(zfb-sidebar),
+::view-transition-group(zfb-sidebar),
+::view-transition-old(zfb-footer),
+::view-transition-new(zfb-footer),
+::view-transition-group(zfb-footer),
+::view-transition-old(zfb-sidebar-toggle),
+::view-transition-new(zfb-sidebar-toggle),
+::view-transition-group(zfb-sidebar-toggle) { animation: none; }
+
+/* Root cross-fade rules — animate only the non-chrome snapshot */
 ::view-transition-old(root) {
   animation: 150ms ease-in both contentFadeOut;
 }

--- a/zfb.config.ts
+++ b/zfb.config.ts
@@ -1,6 +1,53 @@
 /**
  * zfb pin (canonical, shared with E2/E4):
- *   commit: 95058f0 (Takazudo/zudo-front-builder main, post-#227 merge:
+ *   commit: 6754312 (three post-deep-review fix rounds landing on main:
+ *           8258782 fix(review-round-1): bugs, path traversal, and
+ *           validation gaps surfaced by deep-review — fixes a `from`/`form`
+ *           typo in client-router form-submit enctype handling
+ *           (zfb-runtime/client-router/router.ts); gates the on-disk
+ *           fallback in the dev server's serve_page behind
+ *           `is_safe_url_path` so a percent-encoded `..` request cannot
+ *           escape the dist root; extracts `push_canon_string` in
+ *           zfb-render/paths.rs and applies it to object keys so
+ *           PathsCache hashes no longer collide on keys containing `"` or
+ *           `\`; rejects negative `src_line`/`src_col` in
+ *           zfb-render/sourcemap.rs rather than silently wrapping; logs
+ *           walkdir errors during the `public/` copy in commands/build.rs
+ *           instead of dropping them with filter_map(.ok()); enforces the
+ *           documented `..`-escape ban and a leading-`/` requirement on
+ *           `base` in config.rs; drops an invalid `trust-policy=any` key
+ *           from .npmrc.
+ *           66b3ce9 fix(review-round-2): classifier root-anchor,
+ *           source-directive escaping, schema overflow — anchors
+ *           `classify_change` at the project root in zfb-build/policy.rs
+ *           so a project hosted under a parent directory whose name
+ *           matches `pages`/`content`/etc. no longer silently
+ *           misclassifies every change (adds regression test + updates
+ *           orchestrator caller); escapes `"` and `\` when interpolating
+ *           the project root into the Tailwind `@source "..."` directive
+ *           in zfb-css/engine.rs so paths containing those bytes produce
+ *           a well-formed declaration; tightens the JSON-Schema `integer`
+ *           type check in zfb-content/schema.rs to reject oversized
+ *           floats (`1e30.fract() == 0.0` no longer passes).
+ *           6754312 fix(review-round-3): CSS-in-components, content-type
+ *           fallback, write-cache ordering, leak guards — carves out
+ *           `.css` from the directory-precedence rules in
+ *           zfb-build/policy.rs so co-located component CSS edits reach
+ *           `dist/assets/` (adds regression test); fixes
+ *           zfb-server/routes.rs so the on-disk cold-start fallback
+ *           derives Content-Type from the file extension rather than
+ *           hardcoding `text/html`, preventing `<script>` injection into
+ *           non-HTML routes like `/sitemap.xml`; moves the
+ *           `last_bytes` dedup-cache insert in
+ *           zfb-build/pipeline/dev.rs to AFTER the atomic write so a
+ *           transient write failure cannot poison the cache and silently
+ *           suppress future writes; evicts the pending-map entry in
+ *           plugin_runner.rs on stdin write failure to prevent unbounded
+ *           map growth; replaces silent `filter_map(.ok())` walk in
+ *           zfb-graph/persist.rs with a tracing-warn variant.
+ *           Bumped 2026-05-09 in vt-chrome-static T1 under host epic
+ *           zudolab/zudo-doc#1556.
+ *           Previous pin 95058f0 (Takazudo/zudo-front-builder main, post-#227 merge:
  *           PR #227 fix/client-router-bootstrap-export — adds a public
  *           `./client-router` subpath export to @takazudo/zfb-runtime's
  *           package.json. Purely additive (no source changes); maps to
@@ -55,7 +102,7 @@
  *           Before that 1e0e6a7 (post-#221/#222/#223 merge: Wave 4 W4A
  *           bump from epic zudolab/zudo-doc#1492 — #222 made <ViewTransitions />
  *           a typed no-op with CSS at-rule as the VT opt-in; #223 fixed
- *           <span><pre> content-model; #221 wired embedded esbuild.)
+ *           <span><pre> content-model; #221 wired embedded esbuild.))
  *   includes fixes:
  *     - zudolab/zfb#99  (ViewTransitions runtime + meta injection)
  *     - zudolab/zfb#100 (404 convention: emit dist/404.html at root)
@@ -312,6 +359,16 @@
  *                throws at SSR render time. This pin enables reverting the
  *                W6A in-host workaround `ClientRouter({})` back to the
  *                cleaner `ClientRouter()` no-arg form.)
+ *              → bumped by epic zudolab/zudo-doc#1556 sub-issue #1557 (T1
+ *                vt-chrome-static pin bump: 6754312 picks up three post-
+ *                deep-review fix rounds — round-1 (8258782) client-router
+ *                typo + path-traversal gate + PathsCache collision + negative
+ *                sourcemap cast + public/ walk logging + config validation;
+ *                round-2 (66b3ce9) policy.rs root-anchor + CSS source-
+ *                directive escaping + schema integer overflow tighten;
+ *                round-3 (6754312) CSS-in-components policy carve-out +
+ *                content-type cold-start fix + write-cache ordering +
+ *                plugin-runner map leak guard + persist.rs tracing-warn.)
  */
 
 // zfb.config.ts — entry-point config consumed by the zfb engine.


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/1556
- parent PR
    - https://github.com/zudolab/zudo-doc/pull/1555

---

## Summary

Implements the visual half of the VT chrome-persist contract for epic #1556. Chrome elements (header, desktop sidebar, footer, desktop-sidebar-toggle) are now extracted from the root snapshot via `view-transition-name`, and their `::view-transition-{old,new,group}` pseudos receive `animation: none`, so the live persisted DOM nodes render unchanged underneath while only the content area cross-fades during same-locale + same-section navigation. Also bumps the zfb pin to `6754312`, extends the confirm-gate harness with V1-V8b visual assertions (PASS 38/38), mirrors the host CSS into the create-zudo-doc template, lands a permanent e2e visual regression spec, and appends a W8 lesson entry capturing the DOM-identity vs visual-extraction split.

Stacked on PR #1555 (DOM-identity half, base `base/zfb-migration-parity`) → `base/vt-chrome-persist` → `base/vt-chrome-static` → `main`.

## Changes

### Wave 1 — independent

- **T1 (#1557)** `zfb.config.ts`: top-of-file pin chain now documents `6754312`, layered over `66b3ce9` and `8258782` (review rounds 3/2/1). Pure comment-block addition; `package.json` `file:../zfb` references are unchanged. `../zfb` checkout is at `6754312`.
- **T2 (#1558)** `src/styles/global.css`: replaces stale W7A "annotations were removed" comment with a current strategy block; adds 4 attribute selectors mapping `data-zfb-transition-persist` prefixes to `view-transition-name` values (`zfb-header`, `zfb-sidebar`, `zfb-footer`, `zfb-sidebar-toggle`); adds 12 pseudo rules (`::view-transition-{old,new,group}` × 4 names) with `animation: none`. Existing `::view-transition-{old,new}(root)` cross-fade kept intact.

### Wave 2 — depends on T2

- **T3 (#1559)** `scripts/wave2-vt-chrome-persist-confirm.ts`: adds V1-V8b block (9 visual assertions), bringing the confirm gate from 29/29 to **38/38 PASS**. V1-V4 sample `getComputedStyle(...).viewTransitionName` for the four chrome elements. V5-V8a use exact-match `Set` filtering on the 12 named-chrome pseudo strings (no `.includes("zfb-")` substring matching). V8b verifies cross-section persist still works for header/footer (sidebar may differ). V6 documents and adapts to a headless-Chromium limitation: `getAnimations()` does not expose pseudo-element strings for view-transition Animations, so the regression sanity (root cross-fade still running) uses `length >= 1` mirroring the existing B6 pattern.
- **T4 (#1560)** `packages/create-zudo-doc/templates/base/src/styles/global.css`: mirrors the T2 host CSS into the template counterpart. `pnpm check:template-drift` clean; scaffold smoke run produces a project whose `global.css` includes all 4 attribute selectors and 12 pseudo rules.

### Wave 3 — depends on T2/T3

- **T5 (#1561)** `e2e/smoke-visual-vt-chrome-persist.spec.ts` (new): 3 permanent regression tests on the smoke fixture. Test 1 asserts computed `view-transition-name` on the four chrome elements. Test 2 asserts `getAnimations()` filtered by the exact-match 12-pseudo `Set` is 0 during a same-locale + same-section navigation. Test 3 asserts root cross-fade still has Animation entries (same V6 adaptation). File renamed from the spec's `visual-vt-chrome-persist.spec.ts` to `smoke-visual-vt-chrome-persist.spec.ts` so it binds to the project's `smoke*.spec.ts` glob and the existing smoke fixture port. All 4 chrome-persist specs (smoke / i18n / versioning / visual) PASS together (11/11).
- **T6 (#1562)** `.claude/skills/l-lessons-zfb-migration-parity/SKILL.md`: appends the W8 entry capturing the DOM-identity vs visual-extraction split, the two-part persist contract (DOM identity via runtime + visual extraction via host CSS), why `::view-transition-group` matters (geometry-morph container can animate even when old/new are static), the headless-Chromium pseudo-element limitation, the uniqueness requirement on `view-transition-name`, and the deployed-preview verification rule.

## Test Plan

- [x] `pnpm check` clean
- [x] `pnpm build` succeeds (225 pages)
- [x] `pnpm check:template-drift` clean (T4 verified)
- [x] `pnpm tsx scripts/wave2-vt-chrome-persist-confirm.ts` reports `Wave 2 confirm gate result: PASS — 38/38 assertions` (T3)
- [x] `pnpm exec playwright test e2e/smoke-vt-chrome-persist.spec.ts e2e/i18n-vt-chrome-persist.spec.ts e2e/versioning-vt-chrome-persist.spec.ts e2e/smoke-visual-vt-chrome-persist.spec.ts` 11/11 PASS (T5)
- [x] CI 8/8 PASS on the merged base branch
- [ ] **Final preview verification (R1 closure):** open the per-PR Cloudflare Pages preview and visually confirm same-locale + same-section navigation no longer cross-fades the chrome (header / sidebar / footer / sidebar-toggle remain static while the content area cross-fades). Compare against PR #1555's preview which still cross-fades the entire viewport.

## Wave plan (final status)

| Wave | Topics | Status |
|---|---|---|
| 1 | T1 (#1557), T2 (#1558) | merged |
| 2 | T3 (#1559), T4 (#1560) | merged |
| 3 | T5 (#1561), T6 (#1562) | merged |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/1563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->