### PR TITLE
[Doc Quality Cleanup] T1-T7: dead code, dedup, drift checker, link/regex fixes, JA translations, Claude index

### DIFF
--- a/.check-links-allowlist
+++ b/.check-links-allowlist
@@ -32,9 +32,6 @@
 #   - Either remove the JA `ai-chat-worker.mdx` page's references
 #     to those 2 EN-only siblings, OR add JA mirrors for them.
 
-dist/ja/docs/reference/ai-chat-worker/index.html:603:./ai-assistant-api/
-dist/ja/docs/reference/ai-chat-worker/index.html:621:../guides/ai-assistant/
-
 # ----- Absolute Links Bypassing Base Path (5 entries) ------------
 #
 # Cannot be auto-converted to relative `.mdx` because the targets

--- a/.check-links-allowlist
+++ b/.check-links-allowlist
@@ -35,24 +35,11 @@
 dist/ja/docs/reference/ai-chat-worker/index.html:603:./ai-assistant-api/
 dist/ja/docs/reference/ai-chat-worker/index.html:621:../guides/ai-assistant/
 
-# ----- Absolute Links Bypassing Base Path (5 entries) ------------
+# ----- Absolute Links Bypassing Base Path (0 entries) ------------
 #
-# Cannot be auto-converted to relative `.mdx` because the targets
-# are either (a) inline-code teaching examples, or (b) runtime-
-# generated routes with no MDX source.
-
-# Inline-code example in a `<Note>` callout that documents what
-# NOT to do — `[link text](/docs/some-page)` inside backticks.
-# The check-links MDX-source regex doesn't skip backtick-wrapped
-# code, so this false-positive is permanent until the regex is
-# upgraded.
-src/content/docs/guides/configuration.mdx:105:/docs/some-page
-
-# Runtime-generated tags index (`pages/docs/tags/...`) — has no
-# MDX source so a relative `.mdx` link can't resolve to it.
-src/content/docs/guides/frontmatter.mdx:163:/docs/tags/
-src/content/docs/guides/tags.mdx:56:/docs/tags/
-src/content/docs/guides/tags.mdx:72:/docs/tags/
-
-# Runtime-generated versions index — same shape as `/docs/tags/`.
-src/content/docs/guides/versioning.mdx:98:/docs/versions/
+# Previously held 5 entries; all removed after T4 (#1612):
+#   - inline-code false-positive: extractMdxAbsoluteLinks now strips
+#     inline-code spans before running the link regex (Fix A).
+#   - runtime-generated routes (/docs/tags/, /docs/versions/):
+#     checkMdxLinks now cross-checks against dist/ via resolveLink
+#     and drops warnings for hrefs that resolve to built routes (Fix B).

--- a/.fixture-settings-drift-allowlist
+++ b/.fixture-settings-drift-allowlist
@@ -1,0 +1,169 @@
+# .fixture-settings-drift-allowlist
+#
+# Each entry is a snapshot of a pre-existing *intentional* omission in an
+# e2e fixture's settings.ts, not a general escape hatch.
+#
+# Convention (enforced by review, not tooling):
+#   - SEED ONCE: entries are added when the checker is introduced, for keys
+#     whose absence is genuinely intentional (feature not exercised by fixture).
+#   - NEW KEYS: when src/config/settings.ts gains a new key, the gate fires
+#     for any fixture that lacks it.  To resolve: either (a) add the key to
+#     all five fixtures in the same commit, OR (b) add one entry per fixture
+#     here with a "# reason: ..." comment in the preceding line.
+#   - NO SILENT EXTENSIONS: every new allowlist entry needs a # reason: comment.
+#
+# Format: one entry per line — {fixture-name}:{key}
+# Comments: lines starting with # are ignored. Blank lines are ignored.
+# Exact-match only (no globs, no wildcards).
+#
+
+# ── trailingSlash ──────────────────────────────────────────────────────────────
+# reason: fixtures serve at base "/" so trailing-slash behaviour is irrelevant to E2E
+sidebar:trailingSlash
+i18n:trailingSlash
+theme:trailingSlash
+smoke:trailingSlash
+versioning:trailingSlash
+
+# ── githubUrl ─────────────────────────────────────────────────────────────────
+# reason: github-link component is only tested in the smoke fixture
+sidebar:githubUrl
+i18n:githubUrl
+theme:githubUrl
+versioning:githubUrl
+
+# ── tagPlacement ──────────────────────────────────────────────────────────────
+# reason: tag UI is not exercised in any fixture (docTags: false everywhere)
+sidebar:tagPlacement
+i18n:tagPlacement
+theme:tagPlacement
+smoke:tagPlacement
+versioning:tagPlacement
+
+# ── tagGovernance ─────────────────────────────────────────────────────────────
+# reason: tag governance enforcement is not tested in fixtures
+sidebar:tagGovernance
+i18n:tagGovernance
+theme:tagGovernance
+smoke:tagGovernance
+versioning:tagGovernance
+
+# ── tagVocabulary ─────────────────────────────────────────────────────────────
+# reason: tag vocabulary lookup is not tested in fixtures
+sidebar:tagVocabulary
+i18n:tagVocabulary
+theme:tagVocabulary
+smoke:tagVocabulary
+versioning:tagVocabulary
+
+# ── llmsTxt ───────────────────────────────────────────────────────────────────
+# reason: llms.txt generation is not exercised in these fixtures
+sidebar:llmsTxt
+i18n:llmsTxt
+theme:llmsTxt
+smoke:llmsTxt
+
+# ── cjkFriendly ───────────────────────────────────────────────────────────────
+# reason: CJK line-break behaviour is not tested in fixtures
+sidebar:cjkFriendly
+i18n:cjkFriendly
+theme:cjkFriendly
+smoke:cjkFriendly
+versioning:cjkFriendly
+
+# ── onBrokenMarkdownLinks ─────────────────────────────────────────────────────
+# reason: broken-link reporting mode is a build-time setting not observable in E2E
+sidebar:onBrokenMarkdownLinks
+i18n:onBrokenMarkdownLinks
+theme:onBrokenMarkdownLinks
+smoke:onBrokenMarkdownLinks
+versioning:onBrokenMarkdownLinks
+
+# ── aiAssistant ───────────────────────────────────────────────────────────────
+# reason: AI chat modal is only tested in the smoke fixture
+sidebar:aiAssistant
+i18n:aiAssistant
+theme:aiAssistant
+versioning:aiAssistant
+
+# ── designTokenPanel ──────────────────────────────────────────────────────────
+# reason: fixtures that test the panel use the deprecated colorTweakPanel alias;
+#         designTokenPanel (the new key) is not yet needed in fixtures
+sidebar:designTokenPanel
+i18n:designTokenPanel
+theme:designTokenPanel
+smoke:designTokenPanel
+versioning:designTokenPanel
+
+# ── sidebarResizer ────────────────────────────────────────────────────────────
+# reason: sidebar resizer feature is not exercised in any fixture
+sidebar:sidebarResizer
+i18n:sidebarResizer
+theme:sidebarResizer
+smoke:sidebarResizer
+versioning:sidebarResizer
+
+# ── sidebarToggle ─────────────────────────────────────────────────────────────
+# reason: sidebar toggle (mobile) feature is not exercised in any fixture
+sidebar:sidebarToggle
+i18n:sidebarToggle
+theme:sidebarToggle
+smoke:sidebarToggle
+versioning:sidebarToggle
+
+# ── imageEnlarge ──────────────────────────────────────────────────────────────
+# reason: image enlarge feature is only tested in the smoke fixture
+sidebar:imageEnlarge
+i18n:imageEnlarge
+theme:imageEnlarge
+versioning:imageEnlarge
+
+# ── frontmatterPreview ────────────────────────────────────────────────────────
+# reason: frontmatter preview panel is only tested in the smoke fixture
+sidebar:frontmatterPreview
+i18n:frontmatterPreview
+theme:frontmatterPreview
+versioning:frontmatterPreview
+
+# ── bodyFootUtilArea ──────────────────────────────────────────────────────────
+# reason: body-foot utility area (doc history link, view-source link) is only
+#         tested in the smoke fixture
+sidebar:bodyFootUtilArea
+i18n:bodyFootUtilArea
+theme:bodyFootUtilArea
+versioning:bodyFootUtilArea
+
+# ── htmlPreview ───────────────────────────────────────────────────────────────
+# reason: HTML preview component is only tested in the smoke fixture
+sidebar:htmlPreview
+i18n:htmlPreview
+theme:htmlPreview
+versioning:htmlPreview
+
+# ── versions ──────────────────────────────────────────────────────────────────
+# reason: version switcher is only tested in the versioning fixture
+sidebar:versions
+i18n:versions
+theme:versions
+smoke:versions
+
+# ── colorTweakPanel ───────────────────────────────────────────────────────────
+# reason: deprecated alias for designTokenPanel; only the fixtures that test the
+#         panel need it (theme, smoke); absent in sidebar/i18n/versioning
+sidebar:colorTweakPanel
+i18n:colorTweakPanel
+versioning:colorTweakPanel
+
+# ── footer ────────────────────────────────────────────────────────────────────
+# reason: footer content is not exercised in any fixture
+sidebar:footer
+i18n:footer
+theme:footer
+smoke:footer
+versioning:footer
+
+# ── headerRightItems ──────────────────────────────────────────────────────────
+# reason: header-right slot (version switcher, theme toggle, etc.) is not tested
+#         in the sidebar and i18n fixtures
+sidebar:headerRightItems
+i18n:headerRightItems

--- a/.template-drift-allowlist
+++ b/.template-drift-allowlist
@@ -21,6 +21,7 @@ src/styles/global.css
 # generator/escape helpers; production consumes the same logic re-exported
 # from @zudo-doc/zudo-doc-v2/integrations/claude-resources, so prod has no
 # matching paths under src/integrations/claude-resources/.
+src/integrations/claude-resources/__tests__/escape-for-mdx.test.ts
 src/integrations/claude-resources/__tests__/generate.test.ts
 src/integrations/claude-resources/escape-for-mdx.ts
 src/integrations/claude-resources/generate.ts

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "// ── Linting ─────────────────────────────────────": "",
     "lint:tokens": "design-token-lint",
     "check:template-drift": "bash scripts/check-template-drift.sh",
+    "check:fixture-settings-drift": "node scripts/check-fixture-settings-drift.mjs",
     "// ── Tags ────────────────────────────────────────": "",
     "tags:audit": "tsx scripts/tags-audit.ts",
     "tags:suggest": "tsx scripts/tags-suggest.ts"

--- a/packages/create-zudo-doc/templates/features/claudeResources/files/src/integrations/claude-resources/__tests__/escape-for-mdx.test.ts
+++ b/packages/create-zudo-doc/templates/features/claudeResources/files/src/integrations/claude-resources/__tests__/escape-for-mdx.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { escapeForMdx } from "../escape-for-mdx";
+
+describe("escapeForMdx", () => {
+  // ---------------------------------------------------------------------------
+  // Path-like angle bracket sequences (not self-closing JSX)
+  // ---------------------------------------------------------------------------
+
+  it("escapes path-like <name>/suffix sequences", () => {
+    expect(escapeForMdx("<foo>/bar")).toBe("&lt;foo&gt;/bar");
+  });
+
+  it("escapes path-like angle brackets in prose", () => {
+    expect(escapeForMdx("binary at <repo>/target/release/zfb")).toBe(
+      "binary at &lt;repo&gt;/target/release/zfb",
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Allowlisted HTML tags must pass through unchanged
+  // ---------------------------------------------------------------------------
+
+  it("preserves allowlisted HTML tags followed by a path separator", () => {
+    expect(escapeForMdx("<div>/path")).toBe("<div>/path");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Self-closing non-allowlisted tags must still be escaped
+  // ---------------------------------------------------------------------------
+
+  it("escapes self-closing non-allowlisted component tags", () => {
+    expect(escapeForMdx("<Component />")).toMatch(/&lt;Component\s*\/&gt;/);
+  });
+});

--- a/packages/create-zudo-doc/templates/features/claudeResources/files/src/integrations/claude-resources/__tests__/generate.test.ts
+++ b/packages/create-zudo-doc/templates/features/claudeResources/files/src/integrations/claude-resources/__tests__/generate.test.ts
@@ -139,7 +139,7 @@ describe("generateClaudeResourcesDocs", () => {
         path.join(docsDir, "claude", "index.mdx"),
         "utf8",
       );
-      expect(overview).toContain('<CategoryNav category="claude" />');
+      expect(overview).toContain('<CategoryNav categories={');
     });
 
     it("skill page has correct frontmatter", () => {

--- a/packages/create-zudo-doc/templates/features/claudeResources/files/src/integrations/claude-resources/escape-for-mdx.ts
+++ b/packages/create-zudo-doc/templates/features/claudeResources/files/src/integrations/claude-resources/escape-for-mdx.ts
@@ -53,7 +53,7 @@ export function escapeForMdx(content: string): string {
       let escaped = withInlinePlaceholders
         // Escape opening tags: <Name>, <Name attr="val">
         .replace(
-          /<([A-Za-z][A-Za-z0-9_-]*)(\s[^>]*)?>(?!\/)/g,
+          /<([A-Za-z][A-Za-z0-9_-]*)(\s[^>]*)?>/g,
           (match, name: string) => {
             if (htmlTags.has(name.toLowerCase())) return match;
             return match.replace(/</g, "&lt;").replace(/>/g, "&gt;");

--- a/packages/create-zudo-doc/templates/features/claudeResources/files/src/integrations/claude-resources/generate.ts
+++ b/packages/create-zudo-doc/templates/features/claudeResources/files/src/integrations/claude-resources/generate.ts
@@ -512,10 +512,30 @@ ${escapeForMdx(parsed.content.trim())}
 // Main
 // ---------------------------------------------------------------------------
 
-function generateOverviewIndex(config: ClaudeResourcesConfig) {
+function generateOverviewIndex(
+  config: ClaudeResourcesConfig,
+  {
+    hasCommands,
+    hasSkills,
+    hasAgents,
+    hasClaudemd,
+  }: { hasCommands: boolean; hasSkills: boolean; hasAgents: boolean; hasClaudemd: boolean },
+) {
   const outputDir = path.join(config.docsDir, "claude");
   cleanDir(outputDir);
   ensureDir(outputDir);
+
+  // Build the explicit slug list from whichever sub-categories were generated.
+  // CategoryNav with `categories` renders cards for each slug by resolving
+  // the node in the nav tree (including noPage auto-index categories) and
+  // falling back to docsUrl(slug, locale) for the href when noPage=true.
+  const categorySlugs: string[] = [];
+  if (hasClaudemd) categorySlugs.push("claude-md");
+  if (hasSkills) categorySlugs.push("claude-skills");
+  if (hasAgents) categorySlugs.push("claude-agents");
+  if (hasCommands) categorySlugs.push("claude-commands");
+
+  const categoriesAttr = JSON.stringify(categorySlugs);
 
   const index = `---
 title: "Claude"
@@ -528,7 +548,7 @@ Claude Code configuration reference.
 
 ## Resources
 
-<CategoryNav category="claude" />
+<CategoryNav categories={${categoriesAttr}} />
 `;
   fs.writeFileSync(path.join(outputDir, "index.mdx"), index);
 }
@@ -539,7 +559,12 @@ export function generateClaudeResourcesDocs(config: ClaudeResourcesConfig) {
   const skills = generateSkillsDocs(config);
   const agents = generateAgentsDocs(config);
 
-  generateOverviewIndex(config);
+  generateOverviewIndex(config, {
+    hasClaudemd: claudemds.length > 0,
+    hasCommands: commands.length > 0,
+    hasSkills: skills.length > 0,
+    hasAgents: agents.length > 0,
+  });
 
   return {
     claudemd: claudemds.length,

--- a/packages/zudo-doc-v2/src/integrations/claude-resources/__tests__/escape-for-mdx.test.ts
+++ b/packages/zudo-doc-v2/src/integrations/claude-resources/__tests__/escape-for-mdx.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { escapeForMdx } from "../escape-for-mdx";
+
+describe("escapeForMdx", () => {
+  // ---------------------------------------------------------------------------
+  // Path-like angle bracket sequences (not self-closing JSX)
+  // ---------------------------------------------------------------------------
+
+  it("escapes path-like <name>/suffix sequences", () => {
+    expect(escapeForMdx("<foo>/bar")).toBe("&lt;foo&gt;/bar");
+  });
+
+  it("escapes path-like angle brackets in prose", () => {
+    expect(escapeForMdx("binary at <repo>/target/release/zfb")).toBe(
+      "binary at &lt;repo&gt;/target/release/zfb",
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Allowlisted HTML tags must pass through unchanged
+  // ---------------------------------------------------------------------------
+
+  it("preserves allowlisted HTML tags followed by a path separator", () => {
+    expect(escapeForMdx("<div>/path")).toBe("<div>/path");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Self-closing non-allowlisted tags must still be escaped
+  // ---------------------------------------------------------------------------
+
+  it("escapes self-closing non-allowlisted component tags", () => {
+    expect(escapeForMdx("<Component />")).toMatch(/&lt;Component\s*\/&gt;/);
+  });
+});

--- a/packages/zudo-doc-v2/src/integrations/claude-resources/__tests__/generate.test.ts
+++ b/packages/zudo-doc-v2/src/integrations/claude-resources/__tests__/generate.test.ts
@@ -139,7 +139,7 @@ describe("generateClaudeResourcesDocs", () => {
         path.join(docsDir, "claude", "index.mdx"),
         "utf8",
       );
-      expect(overview).toContain('<CategoryNav category="claude" />');
+      expect(overview).toContain('<CategoryNav categories={');
     });
 
     it("skill page has correct frontmatter", () => {

--- a/packages/zudo-doc-v2/src/integrations/claude-resources/escape-for-mdx.ts
+++ b/packages/zudo-doc-v2/src/integrations/claude-resources/escape-for-mdx.ts
@@ -53,7 +53,7 @@ export function escapeForMdx(content: string): string {
       let escaped = withInlinePlaceholders
         // Escape opening tags: <Name>, <Name attr="val">
         .replace(
-          /<([A-Za-z][A-Za-z0-9_-]*)(\s[^>]*)?>(?!\/)/g,
+          /<([A-Za-z][A-Za-z0-9_-]*)(\s[^>]*)?>/g,
           (match, name: string) => {
             if (htmlTags.has(name.toLowerCase())) return match;
             return match.replace(/</g, "&lt;").replace(/>/g, "&gt;");

--- a/packages/zudo-doc-v2/src/integrations/claude-resources/generate.ts
+++ b/packages/zudo-doc-v2/src/integrations/claude-resources/generate.ts
@@ -512,10 +512,30 @@ ${escapeForMdx(parsed.content.trim())}
 // Main
 // ---------------------------------------------------------------------------
 
-function generateOverviewIndex(config: ClaudeResourcesConfig) {
+function generateOverviewIndex(
+  config: ClaudeResourcesConfig,
+  {
+    hasCommands,
+    hasSkills,
+    hasAgents,
+    hasClaudemd,
+  }: { hasCommands: boolean; hasSkills: boolean; hasAgents: boolean; hasClaudemd: boolean },
+) {
   const outputDir = path.join(config.docsDir, "claude");
   cleanDir(outputDir);
   ensureDir(outputDir);
+
+  // Build the explicit slug list from whichever sub-categories were generated.
+  // CategoryNav with `categories` renders cards for each slug by resolving
+  // the node in the nav tree (including noPage auto-index categories) and
+  // falling back to docsUrl(slug, locale) for the href when noPage=true.
+  const categorySlugs: string[] = [];
+  if (hasClaudemd) categorySlugs.push("claude-md");
+  if (hasSkills) categorySlugs.push("claude-skills");
+  if (hasAgents) categorySlugs.push("claude-agents");
+  if (hasCommands) categorySlugs.push("claude-commands");
+
+  const categoriesAttr = JSON.stringify(categorySlugs);
 
   const index = `---
 title: "Claude"
@@ -528,7 +548,7 @@ Claude Code configuration reference.
 
 ## Resources
 
-<CategoryNav category="claude" />
+<CategoryNav categories={${categoriesAttr}} />
 `;
   fs.writeFileSync(path.join(outputDir, "index.mdx"), index);
 }
@@ -539,7 +559,12 @@ export function generateClaudeResourcesDocs(config: ClaudeResourcesConfig) {
   const skills = generateSkillsDocs(config);
   const agents = generateAgentsDocs(config);
 
-  generateOverviewIndex(config);
+  generateOverviewIndex(config, {
+    hasClaudemd: claudemds.length > 0,
+    hasCommands: commands.length > 0,
+    hasSkills: skills.length > 0,
+    hasAgents: agents.length > 0,
+  });
 
   return {
     claudemd: claudemds.length,

--- a/pages/lib/_category-nav.tsx
+++ b/pages/lib/_category-nav.tsx
@@ -17,6 +17,7 @@
 
 import type { JSX } from "preact";
 import { CategoryNav as CategoryNavV2 } from "@zudo-doc/zudo-doc-v2/nav-indexing";
+import type { NavNode as V2NavNode } from "@zudo-doc/zudo-doc-v2/nav-indexing/types";
 import {
   buildNavTree,
   findNode,
@@ -25,6 +26,7 @@ import {
 } from "@/utils/docs";
 import { settings } from "@/config/settings";
 import { defaultLocale, type Locale } from "@/config/i18n";
+import { docsUrl } from "@/utils/base";
 import { loadDocs } from "../_data";
 
 export interface CategoryNavWrapperProps {
@@ -32,7 +34,18 @@ export interface CategoryNavWrapperProps {
    * Slug of the category whose immediate children should be listed, e.g.
    * "getting-started" or "guides/layout-demos".
    */
-  category: string;
+  category?: string;
+  /**
+   * Explicit list of top-level category slugs to render as cards. Use this
+   * when the target categories are not children of a single parent node in
+   * the nav tree (e.g. "claude-md", "claude-skills" are top-level siblings
+   * of "claude", not children). Each slug is resolved to its nav node; nodes
+   * not found in the tree are silently skipped.
+   *
+   * For nodes with noPage=true (no index.mdx), the href falls back to the
+   * auto-generated category index URL via docsUrl(slug, lang).
+   */
+  categories?: string[];
   /**
    * Active locale. Injected via createMdxComponents() closure.
    * Defaults to defaultLocale when not provided.
@@ -80,11 +93,19 @@ function loadNavSource(
  * MDX wrapper for CategoryNav. Resolves nav tree data host-side and forwards
  * the resolved category children into the v2 CategoryNav component.
  *
- * Returns null when the category is not found or has no visible children —
- * matching the original Astro component's guard.
+ * Supports two modes:
+ * - `category`: resolves immediate children of a single category node.
+ * - `categories`: resolves an explicit list of top-level slugs as cards.
+ *   Use this when the target categories are siblings in the nav tree rather
+ *   than children of a common parent (e.g. claude-md / claude-skills are
+ *   top-level peers of claude, not children of it). Nodes with noPage=true
+ *   get their href computed via docsUrl() since auto-index pages exist.
+ *
+ * Returns null when no visible children are resolved.
  */
 export function CategoryNavWrapper({
   category,
+  categories,
   lang = defaultLocale,
   class: className,
 }: CategoryNavWrapperProps): JSX.Element | null {
@@ -94,8 +115,32 @@ export function CategoryNavWrapper({
   const navDocs = docs.filter(isNavVisible);
   const tree = buildNavTree(navDocs, locale, categoryMeta);
 
-  const categoryNode = findNode(tree, category);
-  const children = categoryNode?.children.filter((c) => c.hasPage) ?? [];
+  let children: V2NavNode[];
+
+  if (categories !== undefined) {
+    // Explicit slug list mode: resolve each slug to its nav node and build
+    // a card for it. noPage nodes have no href in the tree but their
+    // auto-generated category index page is reachable via docsUrl().
+    children = categories
+      .map((slug): V2NavNode | null => {
+        const node = findNode(tree, slug);
+        if (!node) return null;
+        const href = node.href ?? docsUrl(slug, locale);
+        return {
+          label: node.label,
+          description: node.description,
+          href,
+          hasPage: true,
+          children: [],
+        };
+      })
+      .filter((n): n is V2NavNode => n !== null);
+  } else if (category !== undefined) {
+    const categoryNode = findNode(tree, category);
+    children = (categoryNode?.children.filter((c) => c.hasPage) ?? []) as V2NavNode[];
+  } else {
+    return null;
+  }
 
   if (children.length === 0) return null;
 

--- a/pages/lib/_header-with-defaults.tsx
+++ b/pages/lib/_header-with-defaults.tsx
@@ -56,27 +56,29 @@ import ThemeToggle from "@/components/theme-toggle";
 import SidebarToggle from "@/components/sidebar-toggle";
 import { settings } from "@/config/settings";
 import { defaultLocale, locales, t, type Locale } from "@/config/i18n";
-import { buildLocaleLinks, docsUrl, isDefaultLocaleOnlyPath, navHref, versionedDocsUrl, withBase } from "@/utils/base";
+import { buildLocaleLinks, docsUrl, navHref, versionedDocsUrl, withBase } from "@/utils/base";
 import {
   isNavVisible,
-  loadCategoryMeta,
-  type CategoryMeta,
   type NavNode,
 } from "@/utils/docs";
 import { buildSidebarForSection } from "@/utils/sidebar";
-import type { DocsEntry } from "@/types/docs-entry";
-import { loadDocs } from "../_data";
 import { SearchWidget } from "./_search-widget";
+import { loadNavSourceDocs } from "./_nav-source-docs";
 
 // ---------------------------------------------------------------------------
-// Internal helpers — duplicated from _sidebar-with-defaults.tsx so that
-// module stays self-contained and this wrapper owns its own data-prep.
+// Internal helpers
 // ---------------------------------------------------------------------------
 
 /**
- * Rewrite versioned hrefs — same logic as _sidebar-with-defaults.tsx.
- * The nav tree always emits hrefs via docsUrl(); when the active route lives
- * under /v/{version}/... we need the same nodes pointing at the versioned URL.
+ * Walk the nav tree and rewrite each node's `href` to its versioned form.
+ *
+ * `buildNavTree` always emits hrefs via `docsUrl()`; when the active route
+ * lives under `/v/{version}/...` we need the same nodes pointing at the
+ * versioned URL so internal nav clicks stay inside the version. Skips
+ * nodes without an href (link-only or category placeholders).
+ *
+ * Intentionally kept as a local copy in this module (not extracted) —
+ * T2 only dedupes loadNavSourceDocs; remapVersionedHrefs is out of scope.
  */
 function remapVersionedHrefs(
   nodes: NavNode[],
@@ -96,51 +98,6 @@ function remapVersionedHrefs(
     const newHref = versionedDocsUrl(node.slug, version, nodeLang);
     return { ...node, href: newHref, children };
   });
-}
-
-/**
- * Pick the right loadDocs() collection for the (locale, version) pair —
- * same merge strategy as _sidebar-with-defaults.tsx.
- */
-function loadNavSourceDocs(
-  lang: Locale,
-  currentVersion: string | undefined,
-): { docs: DocsEntry[]; categoryMeta: Map<string, CategoryMeta> } {
-  if (currentVersion) {
-    const collectionName = `docs-v-${currentVersion}`;
-    const versionConfig = settings.versions?.find((v) => v.slug === currentVersion);
-    const docs = loadDocs(collectionName).filter((d) => !d.data.draft);
-    const categoryMeta = loadCategoryMeta(versionConfig?.docsDir ?? settings.docsDir);
-    return { docs, categoryMeta };
-  }
-
-  if (lang === defaultLocale) {
-    const docs = loadDocs("docs").filter((d) => !d.data.draft);
-    const categoryMeta = loadCategoryMeta(settings.docsDir);
-    return { docs, categoryMeta };
-  }
-
-  // Non-default locale: locale-first merge with EN fallback.
-  // Mirror T4's filter from `_sidebar-with-defaults.tsx` so the mobile
-  // SidebarToggle island's tree matches the desktop sidebar tree —
-  // default-locale-only fallback paths must NOT leak into JA URL space.
-  const localeDocs = loadDocs(`docs-${lang}`).filter((d) => !d.data.draft);
-  const baseDocs = loadDocs("docs").filter((d) => !d.data.draft);
-  const localeSlugSet = new Set(localeDocs.map((d) => d.data.slug ?? d.id));
-  const fallbackDocs = baseDocs
-    .filter((d) => !localeSlugSet.has(d.data.slug ?? d.id))
-    .filter((d) => !isDefaultLocaleOnlyPath(docsUrl(d.data.slug ?? d.id)));
-  const allDocs = [...localeDocs, ...fallbackDocs];
-
-  const localeDir =
-    (settings.locales as Record<string, { dir?: string }>)[lang]?.dir ??
-    settings.docsDir;
-  const categoryMeta = new Map<string, CategoryMeta>([
-    ...loadCategoryMeta(settings.docsDir),
-    ...loadCategoryMeta(localeDir),
-  ]);
-
-  return { docs: allDocs, categoryMeta };
 }
 
 // ---------------------------------------------------------------------------

--- a/pages/lib/_nav-source-docs.ts
+++ b/pages/lib/_nav-source-docs.ts
@@ -1,0 +1,68 @@
+// Shared helper — pick the right loadDocs() collection and category-meta dir
+// for the active (locale, version) pair, applying the locale-first + EN-fallback
+// merge that pages/[locale]/docs/[...slug].tsx uses in its own paths() pass so
+// the sidebar tree mirrors what those pages enumerate.
+//
+// Used by _sidebar-with-defaults.tsx (desktop sidebar) and
+// _header-with-defaults.tsx (mobile SidebarToggle) so both nav surfaces apply
+// the same defaultLocaleOnlyPrefixes filter and stay in sync.
+
+import { defaultLocale, type Locale } from "@/config/i18n";
+import { settings } from "@/config/settings";
+import { docsUrl, isDefaultLocaleOnlyPath } from "@/utils/base";
+import { loadCategoryMeta, type CategoryMeta } from "@/utils/docs";
+import type { DocsEntry } from "@/types/docs-entry";
+import { loadDocs } from "../_data";
+
+export type NavSourceDocs = {
+  docs: DocsEntry[];
+  categoryMeta: Map<string, CategoryMeta>;
+};
+
+/**
+ * Pick the right `loadDocs(...)` collection name and category-meta dir
+ * for the active (locale, version) pair, applying the same locale-first
+ * + EN-fallback merge that `pages/[locale]/docs/[...slug].tsx` performs
+ * in its own `paths()` so the sidebar tree mirrors what those pages
+ * enumerate.
+ */
+export function loadNavSourceDocs(
+  lang: Locale,
+  currentVersion: string | undefined,
+): NavSourceDocs {
+  if (currentVersion) {
+    const collectionName = `docs-v-${currentVersion}`;
+    const versionConfig = settings.versions?.find((v) => v.slug === currentVersion);
+    const docs = loadDocs(collectionName).filter((d) => !d.data.draft);
+    const categoryMeta = loadCategoryMeta(versionConfig?.docsDir ?? settings.docsDir);
+    return { docs, categoryMeta };
+  }
+
+  if (lang === defaultLocale) {
+    const docs = loadDocs("docs").filter((d) => !d.data.draft);
+    const categoryMeta = loadCategoryMeta(settings.docsDir);
+    return { docs, categoryMeta };
+  }
+
+  // Non-default locale: locale-first merge with EN fallback so docs the
+  // active locale has not yet translated still appear in the tree.
+  const localeDocs = loadDocs(`docs-${lang}`).filter((d) => !d.data.draft);
+  const baseDocs = loadDocs("docs").filter((d) => !d.data.draft);
+  const localeSlugSet = new Set(localeDocs.map((d) => d.data.slug ?? d.id));
+  const fallbackDocs = baseDocs
+    .filter((d) => !localeSlugSet.has(d.data.slug ?? d.id))
+    .filter((d) => !isDefaultLocaleOnlyPath(docsUrl(d.data.slug ?? d.id)));
+  const allDocs = [...localeDocs, ...fallbackDocs];
+
+  const localeDir =
+    (settings.locales as Record<string, { dir?: string }>)[lang]?.dir ??
+    settings.docsDir;
+  // Base meta first, locale meta wins on overlapping keys — same merge
+  // order [locale]/docs/[...slug].tsx uses in its paths() pass.
+  const categoryMeta = new Map<string, CategoryMeta>([
+    ...loadCategoryMeta(settings.docsDir),
+    ...loadCategoryMeta(localeDir),
+  ]);
+
+  return { docs: allDocs, categoryMeta };
+}

--- a/pages/lib/_sidebar-with-defaults.tsx
+++ b/pages/lib/_sidebar-with-defaults.tsx
@@ -38,16 +38,13 @@ import { Island } from "@takazudo/zfb";
 import SidebarTree from "@/components/sidebar-tree";
 import { settings } from "@/config/settings";
 import { defaultLocale, locales, t, type Locale } from "@/config/i18n";
-import { buildLocaleLinks, docsUrl, isDefaultLocaleOnlyPath, navHref, versionedDocsUrl } from "@/utils/base";
+import { buildLocaleLinks, navHref, versionedDocsUrl } from "@/utils/base";
 import {
   isNavVisible,
-  loadCategoryMeta,
-  type CategoryMeta,
   type NavNode,
 } from "@/utils/docs";
 import { buildSidebarForSection } from "@/utils/sidebar";
-import type { DocsEntry } from "@/types/docs-entry";
-import { loadDocs } from "../_data";
+import { loadNavSourceDocs } from "./_nav-source-docs";
 
 export interface SidebarWithDefaultsProps {
   /** Slug of the active doc page, used to highlight the current entry. */
@@ -92,54 +89,6 @@ function remapVersionedHrefs(
     const newHref = versionedDocsUrl(node.slug, version, nodeLang);
     return { ...node, href: newHref, children };
   });
-}
-
-/**
- * Pick the right `loadDocs(...)` collection name and category-meta dir
- * for the active (locale, version) pair, applying the same locale-first
- * + EN-fallback merge that `pages/[locale]/docs/[...slug].tsx` performs
- * in its own `paths()` so the sidebar tree mirrors what those pages
- * enumerate.
- */
-function loadNavSourceDocs(
-  lang: Locale,
-  currentVersion: string | undefined,
-): { docs: DocsEntry[]; categoryMeta: Map<string, CategoryMeta> } {
-  if (currentVersion) {
-    const collectionName = `docs-v-${currentVersion}`;
-    const versionConfig = settings.versions?.find((v) => v.slug === currentVersion);
-    const docs = loadDocs(collectionName).filter((d) => !d.data.draft);
-    const categoryMeta = loadCategoryMeta(versionConfig?.docsDir ?? settings.docsDir);
-    return { docs, categoryMeta };
-  }
-
-  if (lang === defaultLocale) {
-    const docs = loadDocs("docs").filter((d) => !d.data.draft);
-    const categoryMeta = loadCategoryMeta(settings.docsDir);
-    return { docs, categoryMeta };
-  }
-
-  // Non-default locale: locale-first merge with EN fallback so docs the
-  // active locale has not yet translated still appear in the tree.
-  const localeDocs = loadDocs(`docs-${lang}`).filter((d) => !d.data.draft);
-  const baseDocs = loadDocs("docs").filter((d) => !d.data.draft);
-  const localeSlugSet = new Set(localeDocs.map((d) => d.data.slug ?? d.id));
-  const fallbackDocs = baseDocs
-    .filter((d) => !localeSlugSet.has(d.data.slug ?? d.id))
-    .filter((d) => !isDefaultLocaleOnlyPath(docsUrl(d.data.slug ?? d.id)));
-  const allDocs = [...localeDocs, ...fallbackDocs];
-
-  const localeDir =
-    (settings.locales as Record<string, { dir?: string }>)[lang]?.dir ??
-    settings.docsDir;
-  // Base meta first, locale meta wins on overlapping keys — same merge
-  // order [locale]/docs/[...slug].tsx uses in its paths() pass.
-  const categoryMeta = new Map<string, CategoryMeta>([
-    ...loadCategoryMeta(settings.docsDir),
-    ...loadCategoryMeta(localeDir),
-  ]);
-
-  return { docs: allDocs, categoryMeta };
 }
 
 /**

--- a/pages/lib/locale-merge.ts
+++ b/pages/lib/locale-merge.ts
@@ -19,31 +19,6 @@ import { loadDocs } from "../_data";
 import type { DocsEntry } from "@/types/docs-entry";
 
 /**
- * Enumerate merged doc slugs for a locale — the URL-list slice of the merge.
- *
- * Locale docs take priority; base EN docs fill in slugs not covered by the
- * locale collection. Only drafts are filtered — unlisted pages ARE included
- * because they have real URLs and should appear in the sitemap.
- *
- * Returns raw route slugs (e.g. "getting-started/intro") for
- * route-enumerators.ts to convert into full URLs.
- */
-export function enumerateMergedDocsSlugs(locale: string): string[] {
-  const localeDocs = loadDocs(`docs-${locale}`).filter((d) => !d.data.draft);
-  const baseDocs = loadDocs("docs").filter((d) => !d.data.draft);
-
-  const localeSlugSet = new Set(localeDocs.map((d) => d.data.slug ?? d.id));
-  const fallbackDocs = baseDocs.filter(
-    (d) => !localeSlugSet.has(d.data.slug ?? d.id),
-  );
-
-  return [
-    ...localeDocs.map((d) => d.data.slug ?? d.id),
-    ...fallbackDocs.map((d) => d.data.slug ?? d.id),
-  ];
-}
-
-/**
  * Merge locale docs with base-locale fallbacks.
  *
  * Locale docs take priority; base docs fill in slugs not covered by the

--- a/pages/lib/route-enumerators.ts
+++ b/pages/lib/route-enumerators.ts
@@ -40,8 +40,10 @@ import {
  * Enumerate all doc page URLs for a locale.
  *
  * For the default locale: loads the "docs" collection directly.
- * For non-default locales: locale-first merge using enumerateMergedDocsSlugs
- * (regular pages) plus a nav-tree pass for auto-generated category index pages.
+ * For non-default locales: inlines a locale-first merge — locale docs take
+ * priority; base EN docs fill in slugs not covered by the locale collection,
+ * with default-locale-only paths excluded. A nav-tree pass then adds
+ * auto-generated category index pages.
  *
  * Applies toRouteSlug so "category/index" entries become "category/" URLs.
  * Returns deduplicated URL strings with base prefix and trailing slash.

--- a/scripts/check-fixture-settings-drift.mjs
+++ b/scripts/check-fixture-settings-drift.mjs
@@ -58,7 +58,32 @@ function loadAllowlist(allowlistPath) {
 }
 
 const canonicalKeys = extractSettingsKeys(resolve(ROOT, CANONICAL_PATH));
+const canonicalKeySet = new Set(canonicalKeys);
+const fixtureSet = new Set(FIXTURES);
 const allowed = loadAllowlist(resolve(ROOT, ALLOWLIST_PATH));
+
+// Validate allowlist entries reference real fixtures and real canonical keys.
+// A stale entry (fixture or key no longer exists) is reported as an error so
+// the allowlist stays accurate rather than silently masking nothing.
+let anyError = false;
+for (const entry of allowed) {
+  const colon = entry.indexOf(":");
+  if (colon === -1) {
+    console.error(`[fixture-settings-drift] bad allowlist entry (no colon): ${entry}`);
+    anyError = true;
+    continue;
+  }
+  const fixture = entry.slice(0, colon);
+  const key = entry.slice(colon + 1);
+  if (!fixtureSet.has(fixture)) {
+    console.error(`[fixture-settings-drift] allowlist references unknown fixture: ${entry}`);
+    anyError = true;
+  }
+  if (!canonicalKeySet.has(key)) {
+    console.error(`[fixture-settings-drift] allowlist references unknown canonical key: ${entry}`);
+    anyError = true;
+  }
+}
 
 let anyDrift = false;
 
@@ -92,6 +117,9 @@ if (anyDrift) {
   console.error(
     "entry to .fixture-settings-drift-allowlist (with # reason: comment)."
   );
+}
+
+if (anyError || anyDrift) {
   process.exit(1);
 } else {
   console.log("fixture-settings drift check passed.");

--- a/scripts/check-fixture-settings-drift.mjs
+++ b/scripts/check-fixture-settings-drift.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+// check-fixture-settings-drift.mjs
+//
+// Verifies that every top-level key in src/config/settings.ts (canonical)
+// is either present in each e2e fixture's settings.ts or explicitly listed
+// in .fixture-settings-drift-allowlist.
+//
+// Usage: node scripts/check-fixture-settings-drift.mjs
+// Exit 0 = no unallowlisted drift. Exit 1 = drift detected.
+
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+
+const FIXTURES = ["sidebar", "i18n", "theme", "smoke", "versioning"];
+const CANONICAL_PATH = "src/config/settings.ts";
+const ALLOWLIST_PATH = ".fixture-settings-drift-allowlist";
+
+/** Extract top-level keys from `export const settings = { ... }` block. */
+function extractSettingsKeys(filePath) {
+  const content = readFileSync(filePath, "utf8");
+  const startMatch = content.match(/export const settings = \{/);
+  if (!startMatch) {
+    throw new Error(`No "export const settings = {" found in ${filePath}`);
+  }
+  const afterOpen = content.slice(
+    (startMatch.index ?? 0) + startMatch[0].length
+  );
+  const keys = [];
+  for (const line of afterOpen.split("\n")) {
+    // Top-level key lines: exactly 2 spaces of indent, then word chars, then colon+space
+    const m = line.match(/^  (\w+):\s/);
+    if (m) keys.push(m[1]);
+    // Stop at the closing of the top-level object literal
+    if (line.match(/^\};/) || line.match(/^} (satisfies|as) /)) break;
+  }
+  return keys;
+}
+
+/** Load allowlist. Returns a Set of "fixture:key" strings. */
+function loadAllowlist(allowlistPath) {
+  let content;
+  try {
+    content = readFileSync(allowlistPath, "utf8");
+  } catch {
+    return new Set();
+  }
+  const allowed = new Set();
+  for (const rawLine of content.split("\n")) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    allowed.add(line);
+  }
+  return allowed;
+}
+
+const canonicalKeys = extractSettingsKeys(resolve(ROOT, CANONICAL_PATH));
+const allowed = loadAllowlist(resolve(ROOT, ALLOWLIST_PATH));
+
+let anyDrift = false;
+
+for (const fixture of FIXTURES) {
+  const fixturePath = resolve(
+    ROOT,
+    `e2e/fixtures/${fixture}/src/config/settings.ts`
+  );
+  const fixtureKeys = extractSettingsKeys(fixturePath);
+  const fixtureKeySet = new Set(fixtureKeys);
+
+  const missing = canonicalKeys.filter((k) => {
+    if (fixtureKeySet.has(k)) return false;
+    if (allowed.has(`${fixture}:${k}`)) return false;
+    return true;
+  });
+
+  if (missing.length > 0) {
+    anyDrift = true;
+    console.error(`\n[fixture-settings-drift] ${fixture}:`);
+    for (const key of missing) {
+      console.error(`  missing key: ${key}`);
+    }
+  }
+}
+
+if (anyDrift) {
+  console.error(
+    "\nDrift detected. Add missing keys to all five fixtures, OR add an allowlist"
+  );
+  console.error(
+    "entry to .fixture-settings-drift-allowlist (with # reason: comment)."
+  );
+  process.exit(1);
+} else {
+  console.log("fixture-settings drift check passed.");
+}

--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -161,6 +161,19 @@ export async function resolveLink(href, distDir, basePath = "/", fileDir = "") {
 
 // --- MDX Source Scan ---
 
+/**
+ * Strip inline-code spans from a line before running link regexes.
+ * Handles double-backtick spans (``...``) and single-backtick spans (`...`).
+ * Escaped backticks (\`) are ignored.
+ */
+export function stripInlineCode(line) {
+  // Replace double-backtick spans first to avoid partial single-backtick matches
+  let result = line.replace(/(?<!\\)``[^`]*(?:``|$)/g, (m) => " ".repeat(m.length));
+  // Replace single-backtick spans
+  result = result.replace(/(?<!\\)`[^`]*(?:`|$)/g, (m) => " ".repeat(m.length));
+  return result;
+}
+
 export function extractMdxAbsoluteLinks(content) {
   const issues = [];
   const lines = content.split("\n");
@@ -175,16 +188,18 @@ export function extractMdxAbsoluteLinks(content) {
     }
     if (inCodeBlock) continue;
 
+    const searchLine = stripInlineCode(line);
+
     // Markdown link syntax: [text](/docs/...) or [text](/ja/docs/...)
     const mdRegex = /\]\((\/(?:ja\/)?docs\/[^)]*)\)/g;
     let match;
-    while ((match = mdRegex.exec(line)) !== null) {
+    while ((match = mdRegex.exec(searchLine)) !== null) {
       issues.push({ href: match[1], line: i + 1 });
     }
 
     // JSX href attributes: href="/docs/..." or href="/ja/docs/..."
     const jsxRegex = /href="(\/(?:ja\/)?docs\/[^"]*)"/g;
-    while ((match = jsxRegex.exec(line)) !== null) {
+    while ((match = jsxRegex.exec(searchLine)) !== null) {
       issues.push({ href: match[1], line: i + 1 });
     }
   }
@@ -271,7 +286,7 @@ export async function checkTrailingSlashLinks(distDir, rootDir, basePath = "/", 
   return warnings;
 }
 
-export async function checkMdxLinks(contentDirs, rootDir) {
+export async function checkMdxLinks(contentDirs, rootDir, distDir = null, basePath = "/") {
   const warnings = [];
 
   for (const dir of contentDirs) {
@@ -283,6 +298,8 @@ export async function checkMdxLinks(contentDirs, rootDir) {
       const issues = extractMdxAbsoluteLinks(content);
 
       for (const { href, line } of issues) {
+        // If dist/ is available, drop warnings for hrefs that resolve to built routes
+        if (distDir && (await resolveLink(href, distDir, basePath))) continue;
         warnings.push({ file: relative(rootDir, file), line, href });
       }
     }
@@ -392,7 +409,7 @@ async function main() {
 
   const checks = [
     checkHtmlLinks(distDir, rootDir, basePath, excludePatterns),
-    checkMdxLinks(contentDirs, rootDir),
+    checkMdxLinks(contentDirs, rootDir, distDir, basePath),
   ];
 
   if (trailingSlash) {

--- a/scripts/run-b4push.sh
+++ b/scripts/run-b4push.sh
@@ -6,26 +6,27 @@ set -euo pipefail
 # Step order (cheap → expensive):
 #   1. Format check (mdx)
 #   2. Template drift check
-#   3. Tags audit (--ci)
-#   4. Design token lint
-#   5. Type checking (zfb check)
-#   6. Build (zfb build)
-#   7. Link check
-#   8. HTML validation (html-validate dist/**/*.html)
-#   9. Automated preview smoke (blocking)
-#  10. Manual interactive smoke (operator-driven)
+#   3. Fixture settings drift check
+#   4. Tags audit (--ci)
+#   5. Design token lint
+#   6. Type checking (zfb check)
+#   7. Build (zfb build)
+#   8. Link check
+#   9. HTML validation (html-validate dist/**/*.html)
+#  10. Automated preview smoke (blocking)
+#  11. Manual interactive smoke (operator-driven)
 #
 # CI parity (Playwright E2E + GitHub Actions) is intentionally parked
 # to E9b until the post-cutover migration window closes.
 #
 # Env overrides for non-interactive use:
-#   B4PUSH_SKIP_HTML_VALIDATE=1  — skip HTML validation (step 8)
+#   B4PUSH_SKIP_HTML_VALIDATE=1  — skip HTML validation (step 9)
 #   B4PUSH_SKIP_PREVIEW_SMOKE=1  — skip the automated preview smoke
 #   B4PUSH_SKIP_MANUAL_SMOKE=1   — skip the manual interactive smoke
 
 START_TIME=$(date +%s)
 FAILURES=()
-TOTAL_STEPS=10
+TOTAL_STEPS=11
 CURRENT_STEP=0
 
 step() {
@@ -58,7 +59,15 @@ else
   fail "Template drift check"
 fi
 
-# ── Step 3: Tags audit ────────────────────────────────
+# ── Step 3: Fixture settings drift check ─────────────
+step "Fixture settings drift check"
+if (cd "$ROOT_DIR" && pnpm check:fixture-settings-drift); then
+  pass "Fixture settings drift check passed"
+else
+  fail "Fixture settings drift check"
+fi
+
+# ── Step 4: Tags audit ────────────────────────────────
 step "Tags audit (tags:audit --ci)"
 if (cd "$ROOT_DIR" && pnpm tags:audit --ci); then
   pass "Tags audit passed"
@@ -66,7 +75,7 @@ else
   fail "Tags audit"
 fi
 
-# ── Step 4: Design token lint ────────────────────────
+# ── Step 5: Design token lint ────────────────────────
 step "Design token lint"
 if (cd "$ROOT_DIR" && pnpm lint:tokens); then
   pass "Design token lint passed"
@@ -74,7 +83,7 @@ else
   fail "Design token lint"
 fi
 
-# ── Step 5: Type checking ─────────────────────────────
+# ── Step 6: Type checking ─────────────────────────────
 # Prefer `zfb check` (the post-cutover entry point). If it fails to
 # start (e.g. binary not yet built), fall back to `tsc --noEmit` so the
 # typecheck still gates pushes.
@@ -87,7 +96,7 @@ else
   fail "Type checking"
 fi
 
-# ── Step 6: Build ─────────────────────────────────────
+# ── Step 7: Build ─────────────────────────────────────
 step "Build (zfb build)"
 if (cd "$ROOT_DIR" && pnpm build); then
   pass "Build passed"
@@ -95,7 +104,7 @@ else
   fail "Build"
 fi
 
-# ── Step 7: Link check ────────────────────────────────
+# ── Step 8: Link check ────────────────────────────────
 #
 # Strict on broken links + absolute MDX-source warnings (real 404s
 # / sub-path bypass). Trailing-slash warnings stay warn-only — they
@@ -115,7 +124,7 @@ else
   fail "Link check"
 fi
 
-# ── Step 8: HTML validation ───────────────────────────
+# ── Step 9: HTML validation ───────────────────────────
 step "HTML validation (html-validate)"
 if [[ "${B4PUSH_SKIP_HTML_VALIDATE:-}" == "1" ]]; then
   skip "HTML validation (B4PUSH_SKIP_HTML_VALIDATE=1)"
@@ -127,7 +136,7 @@ else
   fi
 fi
 
-# ── Step 9: Automated preview smoke (blocking) ───────
+# ── Step 10: Automated preview smoke (blocking) ──────
 step "Preview smoke (automated)"
 if [[ "${B4PUSH_SKIP_PREVIEW_SMOKE:-}" == "1" ]]; then
   skip "Preview smoke (B4PUSH_SKIP_PREVIEW_SMOKE=1)"
@@ -139,7 +148,7 @@ else
   fi
 fi
 
-# ── Step 10: Manual interactive smoke ────────────────
+# ── Step 11: Manual interactive smoke ────────────────
 step "Manual interactive smoke"
 if [[ "${B4PUSH_SKIP_MANUAL_SMOKE:-}" == "1" ]]; then
   skip "Manual smoke (B4PUSH_SKIP_MANUAL_SMOKE=1)"

--- a/src/content/docs-ja/claude/index.mdx
+++ b/src/content/docs-ja/claude/index.mdx
@@ -1,15 +1,10 @@
 ---
 title: Claude
-description: Claude Code リソースビューア (英語版のみ)
 sidebar_position: 899
 hide_sidebar: true
 hide_toc: true
 ---
 
-## このカテゴリーについて
+This section is only available in English (the default locale).
 
-Claudeカテゴリーは、`.claude/` ディレクトリ配下の Claude Code リソース（CLAUDE.md、スキル、エージェント、コマンド）を閲覧するためのビューアです。コンテンツの性質上、デフォルト言語（英語）でのみ提供しています。
-
-## 英語版を見る
-
-→ [英語版の Claude カテゴリーを開く](../../docs/claude/index.mdx)
+[View the Claude category in English](/docs/claude/)

--- a/src/content/docs-ja/guides/ai-assistant.mdx
+++ b/src/content/docs-ja/guides/ai-assistant.mdx
@@ -1,0 +1,131 @@
+---
+title: AI Assistant
+description: ドキュメントに関する質問に答える、組み込みのチャットアシスタント。
+sidebar_position: 16
+tags:
+  - ai
+---
+
+## 概要
+
+AIアシスタントは、ドキュメントサイトにチャットダイアログを追加します。ユーザーはヘッダーのスパークルアイコンをクリックしてダイアログを開き、ドキュメントの内容について質問できます。
+
+アシスタントは[llms.txtインテグレーション](./llms-txt.mdx)で生成されたドキュメント全文をコンテキストとして利用するため、サイト上のあらゆるページに関する質問に答えられます。
+
+## アシスタントの有効化
+
+`src/config/settings.ts`で`aiAssistant`を`true`に設定します：
+
+```ts title="src/config/settings.ts"
+export const settings = {
+  aiAssistant: true,
+  // ...
+};
+```
+
+有効にすると：
+
+- ヘッダーバーにスパークルアイコンが表示されます
+- `POST /api/ai-chat`エンドポイントがCloudflare PagesのSSRルートとして利用可能になります
+
+## 環境設定
+
+チャットエンドポイントはCloudflare PagesのSSRルート（`pages/api/ai-chat.tsx`）として動作し、設定は`wrangler.toml`に定義されたCloudflare環境バインディングから読み込みます。
+
+### 必要なCFバインディング
+
+**シークレット** — `wrangler secret put ANTHROPIC_API_KEY`で設定します：
+
+```env
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+**変数** — `wrangler.toml`で設定します：
+
+```toml title="wrangler.toml"
+[vars]
+DOCS_SITE_URL = "https://your-docs-site.pages.dev"
+RATE_LIMIT_PER_MINUTE = "10"
+RATE_LIMIT_PER_DAY = "100"
+```
+
+**KV名前空間** — レート制限と監査ログ用：
+
+```sh
+wrangler kv namespace create RATE_LIMIT
+```
+
+返却された`id`を`wrangler.toml`の`[[kv_namespaces]]`ブロックに貼り付けます。
+
+応答の高速性とコストを抑えるため、`claude-haiku-4-5-20251001`を使用しています。
+
+## チャットダイアログ
+
+ダイアログはネイティブの`<dialog>`要素を使ったPreactアイランド（`src/components/ai-chat-modal.tsx`）です。
+
+### レイアウト
+
+- **狭いビューポート**（`lg`/1024px未満）：ビューポートの幅と高さいっぱいに表示
+- **広いビューポート**（1024px以上）：中央配置、90vw/90vhでmax-widthは52.5rem、ボーダー付き
+
+### 機能
+
+- 吹き出し風のメッセージバブル（ユーザーは右、アシスタントは左）
+- アシスタント応答内のマークダウンレンダリング（太字、イタリック、コード、リスト、リンク）
+- API呼び出し中の「Thinking...」インジケーター
+- エラーメッセージのインライン表示
+- 背景クリックまたはEscapeキーで閉じる
+- ダイアログを閉じると会話はリセットされる
+
+## MSWモック（開発時のみ）
+
+実際のバックエンドなしでUI開発を行うには、MSW（Mock Service Worker）を有効にします。MSWは**開発環境専用**で、本番ビルドでは決して動作しません。
+
+**セットアップ：**
+
+1. サービスワーカーファイルを生成（初回のみ）：
+
+   ```bash
+   npx msw init public/ --save
+   ```
+
+2. 環境変数を設定：
+
+   ```env title=".env"
+   PUBLIC_ENABLE_MOCKS=true
+   ```
+
+3. 開発サーバーを起動（`pnpm dev`）。
+
+モックハンドラ（`src/mocks/handlers.ts`）は、シミュレートされた遅延付きで定義済みのレスポンスを返します。APIクレジットを消費せずにチャットUIのスタイリングや動作確認を行うのに便利です。
+
+<Note>
+
+MSWを使うには設定で`aiAssistant: true`である必要があります。生成される`public/mockServiceWorker.js`ファイルはgitignore対象です — 各開発者がローカルで生成します。
+
+</Note>
+
+## APIリファレンス
+
+エンドポイントの詳細仕様（リクエスト／レスポンスの型、エラーコード、環境変数）は[AI Assistant APIリファレンス](../reference/ai-assistant-api.mdx)を参照してください。
+
+## ファイル構成
+
+```
+src/
+├── components/
+│   ├── ai-chat-modal.tsx       # Preact island — chat dialog UI
+│   └── mock-init.tsx           # MSW initializer (dev only)
+├── mocks/
+│   ├── handlers.ts             # MSW mock response handlers
+│   ├── browser.ts              # MSW browser worker setup
+│   ├── server.ts               # MSW node server setup
+│   └── init.ts                 # Conditional MSW initialization
+├── types/
+│   └── ai-chat.ts              # ChatMessage, AiChatRequest/Response types
+└── utils/
+    └── render-markdown.ts      # Lightweight markdown-to-HTML renderer
+pages/
+└── api/
+    └── ai-chat.tsx             # CF Pages SSR endpoint (prerender = false)
+```

--- a/src/content/docs-ja/reference/ai-assistant-api.mdx
+++ b/src/content/docs-ja/reference/ai-assistant-api.mdx
@@ -1,0 +1,101 @@
+---
+title: AI Assistant API
+sidebar_position: 5
+tags:
+  - ai
+---
+
+AIアシスタントのチャットエンドポイントのAPI仕様です。
+
+## エンドポイント
+
+```
+POST /api/ai-chat
+Content-Type: application/json
+```
+
+### リクエストボディ
+
+```ts
+interface AiChatRequest {
+  message: string;
+  history: ChatMessage[];
+}
+
+interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+```
+
+| フィールド | 型              | 必須 | 説明                                                                 |
+| ---------- | --------------- | ---- | -------------------------------------------------------------------- |
+| `message`  | `string`        | はい | ユーザーの現在のメッセージ。空でないこと。                           |
+| `history`  | `ChatMessage[]` | はい | 過去の会話メッセージ。無効なエントリーは静かに除外されます。         |
+
+### 成功レスポンス (200)
+
+```ts
+interface AiChatResponse {
+  response: string;
+}
+```
+
+`response`フィールドはアシスタントの返答をマークダウン文字列として含みます。
+
+**例：**
+
+```json
+// Request
+{
+  "message": "How do I add a new page?",
+  "history": []
+}
+
+// Response
+{
+  "response": "Create an MDX file in `src/content/docs/`:\n\n1. Add frontmatter with `title`\n2. Write your content in MDX\n3. The page appears in the sidebar automatically"
+}
+```
+
+### エラーレスポンス (400 / 500)
+
+```ts
+interface AiChatErrorResponse {
+  error: string;
+}
+```
+
+| ステータス | 条件                                                            |
+| ---------- | --------------------------------------------------------------- |
+| 400        | 無効なJSONボディ                                                |
+| 400        | `message`が空でない文字列ではない                               |
+| 400        | `message`が4000文字の制限を超えている                           |
+| 400        | 入力スクリーニング（プロンプトインジェクションガード）で拒否された |
+| 429        | レート制限超過（`Retry-After`ヘッダーを含む）                   |
+| 500        | Anthropic APIコール失敗                                         |
+
+## CF環境バインディング
+
+| バインディング          | 種別          | 必須 | 説明                                                                       |
+| ----------------------- | ------------- | ---- | -------------------------------------------------------------------------- |
+| `ANTHROPIC_API_KEY`     | secret        | はい | Anthropic APIキー                                                          |
+| `DOCS_SITE_URL`         | var           | はい | デプロイ済みのドキュメントサイトURL（`llms-full.txt`の取得に使用）         |
+| `RATE_LIMIT`            | KV namespace  | はい | レート制限のカウンタと監査ログを保存                                       |
+| `RATE_LIMIT_PER_MINUTE` | var           | いいえ | IPあたりの1分間の最大リクエスト数（デフォルト`10`）                        |
+| `RATE_LIMIT_PER_DAY`    | var           | いいえ | IPあたりの1日の最大リクエスト数（デフォルト`100`）                         |
+| `PUBLIC_ENABLE_MOCKS`   | var           | いいえ | `"true"`に設定するとMSWのモックレスポンスが有効になる（開発モードのみ）    |
+
+## セキュリティ
+
+このエンドポイントは、レガシーのスタンドアロンWorkerから移植された多層的な防御を備えています：
+
+- **ハードニングされたシステムプロンプト** — XMLタグでコンテキストを区切り、明示的なガードレールによってモデルが設定情報を漏洩したり、トピック外の指示に従ったりすることを防ぎます
+- **入力スクリーニング** — 一般的なプロンプトインジェクションパターンを正規表現の事前フィルタで弾き、Claude APIに到達する前に拒否します。レート制限の枠は消費しません
+- **レート制限** — `RATE_LIMIT` KVを使ったIPごとの制限（ベストエフォート、KV障害時はフェイルオープン）
+- **監査ログ** — すべてのインタラクションを`audit:`プレフィックスで`RATE_LIMIT` KVに記録（7日のTTL、ファイア・アンド・フォーゲット）
+- **メッセージ長制限** — 4000文字を超えるメッセージはAPIに到達する前に拒否されます
+
+## ドキュメントコンテキスト
+
+このエンドポイントは、[llms.txtインテグレーション](../guides/llms-txt.mdx)で生成された`llms-full.txt`を`DOCS_SITE_URL`から取得し、CF Workersのアイソレートが生きている間メモリにキャッシュします（ベストエフォート、約1時間）。取得したコンテンツはシステムプロンプトに`<documentation>`XMLコンテキストとして含められます。


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/1608

---

## Summary

Tail-cleanup batch from recent epics, planned via `/big-plan` and implemented via `/x-wt-teams` as 7 sub-tasks across 2 waves. Targets `base/zfb-migration-parity` (the parity work merges to `main` separately).

- Three follow-ups from the Claude Category Default-Locale-Only epic (#1592): T1, T2, T3.
- Two link-cleanup follow-ups from #1581: T4, T6.
- One older `escape-for-mdx` regex bug from claude-resources: T5.
- One auto-generated `/docs/claude/` category index page UI/content fix: T7.

Supersedes: #1607, #1606, #1605, #1604, #1590, #1589, #1509.

## Changes

### T1 — Delete dead `enumerateMergedDocsSlugs` (supersedes #1606)
- Removed unused exported function from `pages/lib/locale-merge.ts` (inlined into all 4 call sites by #1596).
- Updated stale docstring in `pages/lib/route-enumerators.ts`.

### T2 — Dedupe `loadNavSourceDocs` into shared module (supersedes #1604)
- Extracted byte-identical copies from `_sidebar-with-defaults.tsx` and `_header-with-defaults.tsx` into new `pages/lib/_nav-source-docs.ts`. Both wrappers import from it. The `defaultLocaleOnlyPrefixes` filter behavior is preserved on both desktop sidebar and mobile SidebarToggle.

### T3 — Add e2e fixture-settings drift checker (supersedes #1605)
- New `scripts/check-fixture-settings-drift.mjs` (Node helper, regex-based key extraction).
- New `.fixture-settings-drift-allowlist` (seeded with intentional per-fixture omissions, each with `# reason:` comment; header documents the allowlist convention).
- Wired into `pnpm b4push` between `template-drift` and `tags:audit`. Allowlist entries are validated against real fixture names and canonical keys (stale entries surface as errors).

### T4 — Refine `scripts/check-links.js` (supersedes #1590)
- **Fix A**: `extractMdxAbsoluteLinks` now strips inline-code spans (single, double, fenced) before applying the absolute-link regex.
- **Fix B**: `checkMdxLinks` cross-checks absolute warnings against `dist/` via `resolveLink`; warnings whose href resolves to a built route are dropped.
- Removed 5 entries from `.check-links-allowlist` (now resolved by the new logic).

### T5 — Fix `escape-for-mdx` `(?!\/)` lookahead (supersedes #1509)
- Dropped `(?!\/)` from the opening-tag branch. The self-closing branch already handles `<Foo />` independently and runs idempotently. Path-like sequences (`<repo>/target/...`) are now correctly escaped instead of crashing MDX.
- Mirrored in both `packages/zudo-doc-v2/...` and `packages/create-zudo-doc/templates/...` per the Feature Change Checklist.
- Added 4 new test cases in `__tests__/escape-for-mdx.test.ts` (path-like + self-closing preservation), mirrored to template.

### T6 — Translate `ai-assistant-api` and `ai-assistant` into JA (supersedes #1589)
- New `src/content/docs-ja/reference/ai-assistant-api.mdx` and `src/content/docs-ja/guides/ai-assistant.mdx`. Code blocks identical to EN, frontmatter shape preserved, prose translated in です／ます style matching existing JA docs.
- Removed 2 entries from `.check-links-allowlist` (now resolve through the new JA mirrors).

### T7 — Claude category page (supersedes #1607)
- **EN cards**: Extended `pages/lib/_category-nav.tsx` `CategoryNavWrapper` with a `categories?: string[]` prop that resolves slugs directly from the nav tree (instead of finding a parent's children). For `noPage` nodes, falls back to `docsUrl(slug, locale)` since auto-generated category index pages exist in dist.
- Updated the `claude-resources` generator (host + template) to emit `<CategoryNav categories={[...]} />` with the slugs that were actually generated.
- **JA stub**: Replaced `src/content/docs-ja/claude/index.mdx` JA prose + broken relative `.mdx` link with a minimal English-only fallback note + absolute `/docs/claude/` route link (per the principle from #1607: auto-generated default-locale-only categories should not contain locale-specific prose).
- **Sidebar toggle layout (7-C)**: Investigated; no code change needed. The mobile `SidebarToggle` (`lg:hidden`) is already in the sticky header on both EN and JA. The element in the original screenshot was `DesktopSidebarToggle` (`fixed bottom-vsp-xl, hidden lg:flex`), the desktop sidebar collapse tab — already correctly positioned by design.

## Test Plan

- [x] `pnpm check` (typecheck) passes
- [x] `pnpm build` succeeds (219 pages)
- [x] `pnpm b4push` passes (format check, template drift, fixture-settings drift, tags audit, design token lint, typecheck, build, link check, HTML validation, preview smoke)
- [x] `pnpm check:links --strict-absolute --allowlist=.check-links-allowlist` exits 0 (T4 verification)
- [x] `pnpm check:links --strict-broken --allowlist=.check-links-allowlist` exits 0 (T6 verification)
- [x] `pnpm check:template-drift` exits 0 (T5 mirror verification)
- [x] `pnpm test --filter zudo-doc-v2` — 35 test files / 389 tests pass (T5)
- [x] T3 synthetic detection: temporarily added `bogusFlag: false` to canonical settings, confirmed all 5 fixtures flagged, reverted
- [x] Cross-topic regression: `find dist -path "*ja/docs/claude*" -name "*.html"` = 1 (JA stub only); `grep -rIE '/ja/docs/claude-(md|skills|agents|commands)' dist/` = 0 (filter from #1592 preserved by T2 and T7)
- [x] EN `/docs/claude/` renders 4-card grid (claude-md, claude-skills, claude-agents, claude-commands)
- [x] JA `/ja/docs/claude/` shows English-only fallback + working `/docs/claude/` link
- [x] `/gcoc-review` deep review — no actionable issues

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/1616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->