### PR TITLE
fix(zdtp): eager CSS + first-click shim + bridge guard, mirrored to generator (#1626)

### DIFF
--- a/.template-drift-allowlist
+++ b/.template-drift-allowlist
@@ -89,7 +89,8 @@ src/components/doc-history.tsx
 src/components/image-enlarge.tsx
 src/components/find-in-page-init.tsx
 
-# zdtp panel template variants — intentionally differ from production in two ways:
+# zdtp panel template variants — intentionally differ from production in the
+# following ways:
 #  1. design-token-panel-config.ts: template uses generic placeholder IDs/storage
 #     keys ("my-doc-tweak", "myDoc", etc.) and an empty colorPresets map, while
 #     production has zudo-doc-specific values and imports colorTweakPresets. The
@@ -100,6 +101,9 @@ src/components/find-in-page-init.tsx
 #     dep. Production imports BEFORE_NAVIGATE_EVENT / AFTER_NAVIGATE_EVENT from
 #     @zudo-doc/zudo-doc-v2/transitions. Reconcile if/when create-zudo-doc
 #     migrates onto the v2 transitions module.
+#     Both template and production now include the queue-drain (__zdtpReadyClicks)
+#     and bridge idempotency guard (__zdtpAstroBridgeInstalled) added in #1627.
+#     Both omit the JS-side CSS import (moved to global.css @slot injection in #1629).
 #  3. design-token-types.ts: template has fewer comments (zudo-doc-specific
 #     migration context stripped; upstream issue notes retained).
 src/config/design-token-panel-config.ts

--- a/packages/create-zudo-doc/src/features/design-token-panel.ts
+++ b/packages/create-zudo-doc/src/features/design-token-panel.ts
@@ -4,6 +4,16 @@ export const designTokenPanelFeature: FeatureModule = () => ({
   name: "designTokenPanel",
   injections: [
     {
+      // Panel chrome CSS — imported here so the rules land in the main page
+      // CSS bundle (not a deferred chunk), ensuring the panel renders
+      // correctly on first click. Vite library mode strips the source CSS
+      // import from the emitted JS, so this CSS-side import is the required
+      // pull point. See @takazudo/zudo-design-token-panel PORTABLE-CONTRACT.md §7.
+      file: "src/styles/global.css",
+      anchor: "/* @slot:global-css:feature-styles */",
+      content: `@import "@takazudo/zudo-design-token-panel/styles.css";`,
+    },
+    {
       // Bootstrap the zdtp panel as a side-effect dynamic import.
       // The import is gated on the feature flag so the zdtp bundle is excluded
       // from pages that disable the panel. No Island wrapper is needed — zdtp

--- a/packages/create-zudo-doc/templates/features/designTokenPanel/files/src/lib/design-token-panel-bootstrap.ts
+++ b/packages/create-zudo-doc/templates/features/designTokenPanel/files/src/lib/design-token-panel-bootstrap.ts
@@ -14,20 +14,37 @@
  */
 
 import { configurePanel } from "@takazudo/zudo-design-token-panel";
-import "@takazudo/zudo-design-token-panel/styles";
+// CSS is pulled via `@import "@takazudo/zudo-design-token-panel/styles.css"` in
+// src/styles/global.css so the panel chrome lands in the main page CSS bundle
+// (not a deferred chunk). Vite library mode strips the source CSS import from
+// the emitted JS, so the explicit CSS-side import is the required pull point.
 import { designTokenPanelConfig } from "@/config/design-token-panel-config";
 
 configurePanel(designTokenPanelConfig);
 
-// Lifecycle bridge: re-dispatch Astro lifecycle event names for zdtp's
-// internal listeners when zfb navigation events fire.
+// Drain the pre-hydration click queue. If the user clicked the palette button
+// before this module evaluated, a pre-hydration shim captured the event as a
+// single boolean flag. Calling __zdtpReadyClicks() here removes the shim
+// listener and re-dispatches once (at most) so the now-registered zdtp
+// listener picks it up and mounts the panel.
+if (typeof window !== "undefined") {
+  (window as { __zdtpReadyClicks?: () => void }).__zdtpReadyClicks?.();
+}
+
+// Idempotency guard: the two document.addEventListener calls below must be
+// installed at most once per page lifecycle. Module caching usually guarantees
+// this, but a future refactor could re-evaluate the module. The flag makes it
+// provably one-shot.
 // zfb fires "zfb:before-preparation" (before nav) and "zfb:after-swap" (after nav).
 // Adjust these event names if your zfb version uses different names.
 if (typeof document !== "undefined") {
-  document.addEventListener("zfb:before-preparation", () => {
-    document.dispatchEvent(new Event("astro:before-swap"));
-  });
-  document.addEventListener("zfb:after-swap", () => {
-    document.dispatchEvent(new Event("astro:page-load"));
-  });
+  if (!(document as Document & { __zdtpAstroBridgeInstalled?: boolean }).__zdtpAstroBridgeInstalled) {
+    (document as Document & { __zdtpAstroBridgeInstalled?: boolean }).__zdtpAstroBridgeInstalled = true;
+    document.addEventListener("zfb:before-preparation", () => {
+      document.dispatchEvent(new Event("astro:before-swap"));
+    });
+    document.addEventListener("zfb:after-swap", () => {
+      document.dispatchEvent(new Event("astro:page-load"));
+    });
+  }
 }

--- a/pages/lib/_body-end-islands.tsx
+++ b/pages/lib/_body-end-islands.tsx
@@ -63,6 +63,37 @@ import { PageLoadingOverlay } from "@zudo-doc/zudo-doc-v2/page-loading";
  */
 const DEFAULT_AI_CHAT_BODY_LABEL = "Ask a question about the documentation.";
 
+/**
+ * SSR-emitted inline script that acts as a pre-hydration shim for the
+ * `toggle-design-token-panel` window event. Because the
+ * DesignTokenPanelBootstrap Island is deferred, zdtp's real
+ * `toggle-design-token-panel` listener (registered in index.tsx at
+ * module init) is not yet installed when the user clicks the header
+ * palette button. This shim:
+ *
+ *  1. Records the first (and only meaningful) click as a boolean flag.
+ *  2. Exposes `window.__zdtpReadyClicks` so the bootstrap Island can
+ *     drain the queue and re-dispatch a single event once the real
+ *     listener is live.
+ *  3. Guards against double-installation across any re-evaluation path
+ *     (SPA body swap, HMR, etc.) via `__zdtpToggleShimInstalled`.
+ *
+ * A single boolean (not an array) is used because the panel is a toggle —
+ * any number of pre-hydration clicks should result in at most one open.
+ */
+const ZDTP_TOGGLE_SHIM_SRC = `(function(){
+if(window.__zdtpToggleShimInstalled)return;
+window.__zdtpToggleShimInstalled=true;
+var pending=false;
+function shim(){pending=true;}
+window.addEventListener('toggle-design-token-panel',shim);
+window.__zdtpReadyClicks=function(){
+window.removeEventListener('toggle-design-token-panel',shim);
+delete window.__zdtpReadyClicks;
+if(pending){pending=false;window.dispatchEvent(new CustomEvent('toggle-design-token-panel'));}
+};
+})();`;
+
 /** Props for {@link BodyEndIslands}. */
 export interface BodyEndIslandsProps {
   /** Base path the AI chat modal uses to construct API URLs. */
@@ -111,12 +142,25 @@ export function BodyEndIslands({
   // the `toggle-design-token-panel` window listener is registered before
   // the user can click the header trigger. Renders nothing visually —
   // the zdtp panel self-mounts as a side-effect (zudolab/zudo-doc#1623).
+  //
+  // The inline <script> emitted alongside the Island is the pre-hydration
+  // toggle shim (zudolab/zudo-doc#1627 Part B). It captures the first
+  // click as a boolean flag and exposes window.__zdtpReadyClicks so the
+  // bootstrap module can drain and re-dispatch once the real zdtp listener
+  // is registered. Mirrors the PageLoadingOverlay SSR-script pattern.
   const designTokenPanelBootstrap =
     settings.designTokenPanel || settings.colorTweakPanel
-      ? (Island({
-          when: "load",
-          children: <DesignTokenPanelBootstrap />,
-        }) as unknown as VNode)
+      ? (
+          <>
+            <script
+              dangerouslySetInnerHTML={{ __html: ZDTP_TOGGLE_SHIM_SRC }}
+            />
+            {Island({
+              when: "load",
+              children: <DesignTokenPanelBootstrap />,
+            }) as unknown as VNode}
+          </>
+        )
       : null;
 
   // Use a visually-hidden paragraph as the AiChatModal SSR fallback so

--- a/src/lib/design-token-panel-bootstrap.ts
+++ b/src/lib/design-token-panel-bootstrap.ts
@@ -14,7 +14,10 @@
  */
 
 import { configurePanel } from "@takazudo/zudo-design-token-panel";
-import "@takazudo/zudo-design-token-panel/styles";
+// CSS is pulled via `@import "@takazudo/zudo-design-token-panel/styles.css"` in
+// src/styles/global.css so the panel chrome lands in the main page CSS bundle
+// (not a deferred chunk). Vite library mode strips the source CSS import from
+// the emitted JS, so the explicit CSS-side import is the required pull point.
 import { designTokenPanelConfig } from "@/config/design-token-panel-config";
 import {
   BEFORE_NAVIGATE_EVENT,
@@ -23,11 +26,27 @@ import {
 
 configurePanel(designTokenPanelConfig);
 
+// Drain the pre-hydration click queue. If the user clicked the palette button
+// before this Island evaluated, the SSR shim in _body-end-islands.tsx captured
+// the event as a single boolean flag. Calling __zdtpReadyClicks() here removes
+// the shim listener and re-dispatches once (at most) so the now-registered zdtp
+// listener picks it up and mounts the panel.
+if (typeof window !== "undefined") {
+  (window as { __zdtpReadyClicks?: () => void }).__zdtpReadyClicks?.();
+}
+
+// Idempotency guard: the two document.addEventListener calls below must be
+// installed at most once per page lifecycle. Module caching usually guarantees
+// this, but a future refactor could re-evaluate the module. The flag makes it
+// provably one-shot.
 if (typeof document !== "undefined") {
-  document.addEventListener(BEFORE_NAVIGATE_EVENT, () => {
-    document.dispatchEvent(new Event("astro:before-swap"));
-  });
-  document.addEventListener(AFTER_NAVIGATE_EVENT, () => {
-    document.dispatchEvent(new Event("astro:page-load"));
-  });
+  if (!(document as Document & { __zdtpAstroBridgeInstalled?: boolean }).__zdtpAstroBridgeInstalled) {
+    (document as Document & { __zdtpAstroBridgeInstalled?: boolean }).__zdtpAstroBridgeInstalled = true;
+    document.addEventListener(BEFORE_NAVIGATE_EVENT, () => {
+      document.dispatchEvent(new Event("astro:before-swap"));
+    });
+    document.addEventListener(AFTER_NAVIGATE_EVENT, () => {
+      document.dispatchEvent(new Event("astro:page-load"));
+    });
+  }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,12 @@
 @import "tailwindcss/preflight";
 @import "tailwindcss/utilities";
+/* Design token panel chrome — the panel package's bundled stylesheet defines
+   the panel shell and modal chrome. Imported here so the rules land in the
+   main page CSS bundle (not a deferred chunk), ensuring the panel renders
+   correctly on first click. Vite library mode strips the source CSS import
+   from the emitted JS, so this CSS-side import is the required pull point.
+   See @takazudo/zudo-design-token-panel PORTABLE-CONTRACT.md §7. */
+@import "@takazudo/zudo-design-token-panel/styles.css";
 
 /* ========================================
  * Tailwind v4 content sources


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/1626
- parent PR
    - https://github.com/zudolab/zudo-doc/pull/669

---

## Summary

Fixes the two zdtp header palette icon symptoms reported in #1626:

1. **First click no-op** — the \`toggle-design-token-panel\` window listener was registered only inside a deferred Island chunk; until the chunk evaluated, no listener existed.
2. **Unstyled \"ON Apply Reset\" text on second click** — the panel CSS import lived in the same deferred Island chunk, so chrome rules never landed in the main page CSS bundle.

Implemented as three sub-issues across two implementation waves plus one verification wave:

- **#1627 (wave 1)** — Combined code fix: eager CSS load, idempotent SSR first-click shim, astro-event bridge idempotency guard.
- **#1628 (wave 2)** — Browser verification with /headless-browser and /verify-ui. PASSED on all core criteria. One non-blocking finding (SPA-nav re-arm gap) filed as #1631.
- **#1629 (wave 3)** — Mirror the fix into \`create-zudo-doc\` generator templates so downstream projects don't reproduce the bug.

## Changes

### Wave 1 — production code (commit 2ee5143)

- \`src/styles/global.css\` — append \`@import \"@takazudo/zudo-design-token-panel/styles.css\";\` near the top alongside Tailwind imports. zfb's CSS engine routes this through the synthesized Tailwind entry CSS so the panel chrome lands in the main page CSS bundle. Build grep confirms the rule appears in \`dist/assets/styles-4548faba.css\` (top-level page CSS), not only in deferred chunks.
- \`src/lib/design-token-panel-bootstrap.ts\` —
  - Drop the \`import \"@takazudo/zudo-design-token-panel/styles\";\` line (now handled at the CSS layer).
  - After \`configurePanel(designTokenPanelConfig)\`, call \`window.__zdtpReadyClicks?.()\` to drain the pre-hydration click queue.
  - Wrap the two \`document.addEventListener\` calls in an \`__zdtpAstroBridgeInstalled\` idempotency guard so the bridge is provably one-shot across any re-evaluation path.
- \`pages/lib/_body-end-islands.tsx\` — emit a synchronous SSR \`<script>\` block alongside the \`<DesignTokenPanelBootstrap />\` Island. The shim:
  - Uses a single boolean flag (not an array queue) so multiple pre-hydration clicks result in at most one open. Avoids the \"user spams the button 5 times → panel toggles 5 times\" hazard.
  - Guards against double-installation via \`window.__zdtpToggleShimInstalled\`.
  - Exposes \`window.__zdtpReadyClicks\` for the bootstrap module to drain on Island hydration.

### Wave 3 — generator mirror (commit 1944cdd)

- \`packages/create-zudo-doc/templates/features/designTokenPanel/files/src/lib/design-token-panel-bootstrap.ts\` — mirror the production module's queue drain, bridge guard, and styles-import removal. The generator still uses an Astro doc-layout dynamic import (not a deferred Island), so the SSR shim from Wave 1 Part B has no template counterpart and was intentionally not mirrored.
- \`packages/create-zudo-doc/src/features/design-token-panel.ts\` — inject \`@import \"@takazudo/zudo-design-token-panel/styles.css\";\` into the scaffolded project's \`src/styles/global.css\` via the \`@slot:global-css:feature-styles\` slot.
- \`.template-drift-allowlist\` — updated zdtp panel comment so the allowlist reflects the shared shape.

## Verification

- \`pnpm check\` — passed.
- \`pnpm b4push\` — all 10 automated steps passed (format check, template drift, tags audit, design token lint, typecheck, build, link check, HTML validation, preview smoke).
- \`pnpm check:template-drift\` — clean.
- \`/l-update-generator\` — clean (settings, deps, zfb config, feature composition in sync; create-zudo-doc tests 209/209 passed).
- \`/gcoc-review\` (Wave 1, Wave 3, and root) — clean.
- Browser verification (Wave 2):
  - First click opens the panel with full chrome (verified computed styles: \`position: fixed\`, real \`backgroundColor\`, real \`border\`, real \`boxShadow\`).
  - Toggle (open → close → open) works steady-state.
  - JA route \`/ja/docs/getting-started/\` opens the panel correctly.
  - Screenshots saved under \`$HOME/cclogs/zudolab-zudo-doc/headless-screenshots/\`.

## Test Plan

1. \`pnpm dev:zfb\` (or \`pnpm dev:stable\` if HMR misbehaves).
2. Load \`/docs/develop/\` on a fresh browser session.
3. Click the header palette icon ONCE — panel opens with full chrome (background, border, sliders, swatches), not bare \"ON Apply Reset\" text.
4. Click again — panel closes. Click third time — panel reopens.
5. Open the panel, navigate to the JA route — panel renders correctly there too.
6. \`pnpm build && grep -rln \"tokenpanel-shell\" dist/\` — rule must appear in the main page CSS bundle (e.g., \`dist/assets/styles-*.css\`), not only in chunk subdirectories.

## Out of Scope

- **#1631** — SPA-nav re-arm gap (panel doesn't re-mount after sidebar nav). Filed as a separate issue; the toggle event still dispatches after SPA nav, but zdtp's internal state machine doesn't re-mount. The first-load chrome reliability covered by this PR is fully working.

Closes #1626, #1627, #1628, #1629.