### PR TITLE
fix(zdtp): bump pin to e5249698 — fixes header palette click-twice-after-close

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -96,7 +96,7 @@ env:
   # Pinned zdtp commit — keep in sync with the zdtp pin block in zfb.config.ts,
   # the file: spec in package.json, and the same env in pr-checks.yml /
   # preview-deploy.yml. All three sources must be bumped together.
-  ZDTP_PINNED_SHA: e23fc86fe61405a76b893ba18644eb08be5ecbdc
+  ZDTP_PINNED_SHA: e5249698a2dc95aae2c1061463677ce7a5a0755a
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -78,7 +78,7 @@ env:
   # Pinned zdtp commit — keep in sync with the zdtp pin block in zfb.config.ts,
   # the file: spec in package.json, and the same env in main-deploy.yml /
   # preview-deploy.yml. All three sources must be bumped together.
-  ZDTP_PINNED_SHA: e23fc86fe61405a76b893ba18644eb08be5ecbdc
+  ZDTP_PINNED_SHA: e5249698a2dc95aae2c1061463677ce7a5a0755a
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -69,7 +69,7 @@ env:
   # Pinned zdtp commit — keep in sync with the zdtp pin block in zfb.config.ts,
   # the file: spec in package.json, and the same env in main-deploy.yml /
   # pr-checks.yml. All three sources must be bumped together.
-  ZDTP_PINNED_SHA: e23fc86fe61405a76b893ba18644eb08be5ecbdc
+  ZDTP_PINNED_SHA: e5249698a2dc95aae2c1061463677ce7a5a0755a
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/zfb.config.ts
+++ b/zfb.config.ts
@@ -411,9 +411,12 @@
  * base-path (see zudo-doc#1564 LESSON CONTEXT).
  *
  * Current pin:
- *   SHA: e23fc86fe61405a76b893ba18644eb08be5ecbdc
+ *   SHA: e5249698a2dc95aae2c1061463677ce7a5a0755a
  *   Repo: Takazudo/zudo-design-token-panel
- *   Context: initial zdtp wiring — epic zudolab/zudo-doc#1564 sub-issue #1566
+ *   Context: pulls upstream zdtp PR #54 — consolidates the panel toggle
+ *   ownership into a single source of truth (`localStorage[OPEN_KEY]`),
+ *   eliminating the dual-listener race that caused "1st click does nothing,
+ *   2nd click opens" after the in-panel X button was used.
  */
 
 // zfb.config.ts — entry-point config consumed by the zfb engine.


### PR DESCRIPTION
## Summary

Bumps `ZDTP_PINNED_SHA` from `e23fc86` to `e5249698` (Takazudo/zudo-design-token-panel#54) to fix the regression where the header palette button required two clicks to open the design-token panel — first click did nothing, second click opened. Same pattern repeated after every close.

## Root cause (upstream)

zdtp's toggle event had **two listeners** for `toggle-design-token-panel`:

- Module-scope `onMaybeMount` — short-circuited when the panel root div existed.
- In-component `useEffect` window listener — toggled internal `open` state via `setOpen((prev) => !prev)`.

After mount the toggle relied entirely on the in-component listener. It attaches only after Preact flushes effects on `requestAnimationFrame`, and this project's deferred Island + SSR shim + astro-bridge stack created windows where the listener was stale or half-installed between renders. The click reached the module-scope handler, which returned early, and the event was silently dropped — user saw "1st click does nothing, 2nd click opens."

The previous consumer-side fix (PR #1626 / commit `2ee5143` — eager CSS + first-click shim + bridge guards) addressed the **pre-hydration** case but did not touch the post-mount / post-close click cycle the user reported here.

## Upstream fix

Takazudo/zudo-design-token-panel#54 consolidates open-state authority into `localStorage[OPEN_KEY]`:

- The module-scope handler writes OPEN_KEY itself on every dispatched toggle event (mounted or not) and emits a new internal `__zdtp:open-state-changed` sync event.
- The panel's `useEffect` listener now listens for `__zdtp:open-state-changed` and re-reads OPEN_KEY — no `prev`-based arithmetic, no dual-listener race.
- Public API (`showDesignTokenPanel` / `hideDesignTokenPanel` / `toggleDesignPanel`) routes the same way.

Single source of truth, no dependency on the in-component listener winning the dispatch race. The public DOM contract (`toggle-design-token-panel` window event) is unchanged.

## Pin bump

Per the canonical pattern documented in `zfb.config.ts`, the bump touches three sources in lockstep:

- `.github/workflows/main-deploy.yml`
- `.github/workflows/preview-deploy.yml`
- `.github/workflows/pr-checks.yml`
- `zfb.config.ts` (reference comment, mirrored to all of the above)

The `@takazudo/zudo-design-token-panel` `file:` dep path is unchanged — pnpm hard-copies the dist at install, so CI rebuilds zdtp at the new SHA before installing.

## Consumer-side wiring (unchanged)

The SSR shim in `pages/lib/_body-end-islands.tsx` and the astro-bridge in `src/lib/design-token-panel-bootstrap.ts` are intentionally left in place — they handle pre-hydration clicks and SPA-nav lifecycle, which the upstream fix does not address (those are separate concerns, tracked in #1631 for SPA-nav re-arm).

## Test plan

- [x] Rebuilt zdtp locally (`pnpm build` in `../zdtp/packages/zudo-design-token-panel`)
- [x] Re-installed in this repo (`pnpm install`)
- [x] `pnpm check` — typecheck clean
- [x] `pnpm build` — 219 pages built successfully
- [x] Verified `__zdtp:open-state-changed` (the new sync event) is present in the installed dist
- [ ] Manual smoke: click palette → opens, click X → closes, click palette → opens with single click (please verify on the deployed preview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/1632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->