### PR TITLE
Palette Click-Once: fix header palette 2-click after SPA-nav + triage 7 open issues

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -96,7 +96,7 @@ env:
   # Pinned zdtp commit — keep in sync with the zdtp pin block in zfb.config.ts,
   # the file: spec in package.json, and the same env in pr-checks.yml /
   # preview-deploy.yml. All three sources must be bumped together.
-  ZDTP_PINNED_SHA: e5249698a2dc95aae2c1061463677ce7a5a0755a
+  ZDTP_PINNED_SHA: 75a567349943a3beb80a209d47f087824f3b82c8
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -78,7 +78,7 @@ env:
   # Pinned zdtp commit — keep in sync with the zdtp pin block in zfb.config.ts,
   # the file: spec in package.json, and the same env in main-deploy.yml /
   # preview-deploy.yml. All three sources must be bumped together.
-  ZDTP_PINNED_SHA: e5249698a2dc95aae2c1061463677ce7a5a0755a
+  ZDTP_PINNED_SHA: 75a567349943a3beb80a209d47f087824f3b82c8
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -69,7 +69,7 @@ env:
   # Pinned zdtp commit — keep in sync with the zdtp pin block in zfb.config.ts,
   # the file: spec in package.json, and the same env in main-deploy.yml /
   # pr-checks.yml. All three sources must be bumped together.
-  ZDTP_PINNED_SHA: e5249698a2dc95aae2c1061463677ce7a5a0755a
+  ZDTP_PINNED_SHA: 75a567349943a3beb80a209d47f087824f3b82c8
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/packages/ai-chat-worker/CLAUDE.md
+++ b/packages/ai-chat-worker/CLAUDE.md
@@ -1,5 +1,9 @@
 # ai-chat-worker
 
+:::warning[Deprecated]
+The `@zudo-doc/ai-chat-worker` package was migrated to a Cloudflare Pages Functions / SSR endpoint at `pages/api/ai-chat.tsx`. The package source has been removed; this doc is retained for historical reference only.
+:::
+
 Standalone Cloudflare Worker sub-package for the AI chat API. Independent of the Astro docs site.
 
 ## Tech Stack

--- a/playwright.palette.config.ts
+++ b/playwright.palette.config.ts
@@ -1,0 +1,34 @@
+/**
+ * Playwright config for the palette-click-once regression spec.
+ *
+ * This config is SEPARATE from the main `playwright.config.ts` (which wires
+ * the fixture-based e2e suite). The palette spec targets the main zudo-doc
+ * dev/preview server directly and is NOT part of the b4push or CI gate — E2E
+ * parity is parked under E9b until the post-cutover migration window closes.
+ *
+ * Manual run:
+ *   # Start the dev server first (in a separate terminal):
+ *   pnpm dev:zfb
+ *   # Then run the spec:
+ *   pnpm exec playwright test tests/e2e/specs/palette-click-once.spec.ts \
+ *     --config playwright.palette.config.ts --reporter=list
+ *   # Or target a different server:
+ *   PLAYWRIGHT_BASE_URL=http://localhost:3000 pnpm exec playwright test ...
+ */
+
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e/specs",
+  fullyParallel: false,
+  retries: 0,
+  workers: 1,
+  use: {
+    // Default target: `pnpm dev:zfb` (zfb dev server, port 3000).
+    // Override via PLAYWRIGHT_BASE_URL for a different server.
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+});

--- a/src/content/docs-ja/reference/ai-chat-worker.mdx
+++ b/src/content/docs-ja/reference/ai-chat-worker.mdx
@@ -6,6 +6,10 @@ tags:
   - cloudflare-worker
 ---
 
+:::warning[非推奨]
+`@zudo-doc/ai-chat-worker` パッケージは Cloudflare Pages Functions / SSR エンドポイント (`pages/api/ai-chat.tsx`) に移行されました。パッケージのソースは削除されており、このドキュメントは歴史的参照用に残されています。
+:::
+
 ドキュメントサイト本体から独立して、AIチャットAPIエンドポイントを提供するスタンドアロンのCloudflare Workerです。
 
 ## 概要

--- a/src/content/docs/reference/ai-chat-worker.mdx
+++ b/src/content/docs/reference/ai-chat-worker.mdx
@@ -6,6 +6,10 @@ tags:
   - cloudflare-worker
 ---
 
+:::warning[Deprecated]
+The `@zudo-doc/ai-chat-worker` package was migrated to a Cloudflare Pages Functions / SSR endpoint at `pages/api/ai-chat.tsx`. The package source has been removed; this doc is retained for historical reference only.
+:::
+
 Standalone Cloudflare Worker that provides an AI chat API endpoint, independent of the Astro documentation site.
 
 ## Overview

--- a/tests/e2e/specs/palette-click-once.spec.ts
+++ b/tests/e2e/specs/palette-click-once.spec.ts
@@ -1,0 +1,151 @@
+// Gated regression spec — NOT wired into b4push or pr-checks (E2E parity is parked under E9b).
+// Manual run: pnpm exec playwright test tests/e2e/specs/palette-click-once.spec.ts --config playwright.palette.config.ts --reporter=list
+// Requires `pnpm dev:zfb` running first (port 3000), or set PLAYWRIGHT_BASE_URL.
+
+/**
+ * Regression spec for the palette-click-once bug (epic #1633).
+ *
+ * Causal proof: R1b (`__inbox/palette-repro/r1b-causal.md`, now deleted).
+ * The bug: after opening the design token panel on page A and SPA-navigating
+ * to page B, the first click on the palette button does NOT open the panel.
+ * `handleExternalToggleEvent` reads the stale `OPEN_KEY='1'` left by
+ * `unmountForSwap` and incorrectly decides the user wants to CLOSE, mounts
+ * the panel in the closed state, and returns. The user perceives nothing
+ * happened. A second click is needed.
+ *
+ * Scenario G1 (primary / user-reported):
+ *   Open panel on page A → SPA-navigate to page B via sidebar click → click
+ *   palette button → panel must be visible after ONE click.
+ *
+ * Target server: `pnpm dev:zfb` (port 3000).
+ * The zfb dev server serves at the configured base path `/pj/zudo-doc/`.
+ * Doc pages (not the root) include the islands bundle so the
+ * DesignTokenPanelBootstrap island hydrates correctly.
+ */
+
+import { test, expect, type Browser, type BrowserContext, type Page } from "@playwright/test";
+
+// zfb dev server base (port 3000) with site base path.
+// Override via PLAYWRIGHT_BASE_URL for a different server.
+const BASE_URL =
+  (process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000").replace(/\/$/, "");
+
+// PAGE_A must be a doc page (not root) so the islands bundle loads and
+// DesignTokenPanelBootstrap hydrates — the home page omits the islands script.
+const PAGE_A_PATH = "/pj/zudo-doc/docs/getting-started/";
+const PAGE_B_PATTERN = /\/docs\//;
+const PALETTE_BTN_SEL = '[aria-label="Toggle design token panel"]';
+const PANEL_SHELL_SEL = `#zudo-doc-tweak-root .tokenpanel-shell`;
+
+/** Return true when the panel shell is visually present and has non-zero size. */
+async function isPanelOpen(page: Page): Promise<boolean> {
+  const shell = page.locator(PANEL_SHELL_SEL);
+  const count = await shell.count();
+  if (count === 0) return false;
+  const bbox = await shell.boundingBox();
+  return bbox !== null && bbox.width > 0 && bbox.height > 0;
+}
+
+test.describe("Palette click-once regression @local-only", () => {
+  let browser: Browser;
+  let context: BrowserContext;
+  let page: Page;
+
+  test.beforeEach(async ({ browser: b }) => {
+    browser = b;
+    // Fresh context (clean localStorage) for each scenario.
+    context = await browser.newContext();
+    page = await context.newPage();
+  });
+
+  test.afterEach(async () => {
+    await context.close();
+  });
+
+  // ---------------------------------------------------------------------------
+  // G1 — SPA-nav-from-open-panel (primary user-reported bug)
+  // ---------------------------------------------------------------------------
+
+  test("G1: one click opens panel after SPA-nav from page with open panel", async () => {
+    // Step 1 — Navigate to page A (home / any doc page).
+    await page.goto(`${BASE_URL}${PAGE_A_PATH}`, {
+      waitUntil: "load",
+      timeout: 30_000,
+    });
+    // Allow island hydration to settle before interacting.
+    await page.waitForTimeout(1_500);
+
+    // Step 2 — Open the design token panel on page A.
+    const paletteOnA = page.locator(PALETTE_BTN_SEL).first();
+    await paletteOnA.scrollIntoViewIfNeeded({ timeout: 10_000 });
+    await paletteOnA.click();
+    await expect(page.locator(PANEL_SHELL_SEL)).toBeVisible({ timeout: 5_000 });
+
+    // Step 3 — SPA-navigate to page B by clicking an internal doc anchor.
+    // Dispatch a synthetic click so the router handles it (same as the R1b
+    // CJS runner). This replicates the real user flow of clicking a sidebar
+    // link without leaving the SPA context.
+    // We look for a doc link that is NOT the current page so we actually navigate.
+    const navResult = await page.evaluate(() => {
+      const currentHref = location.pathname;
+      const a = Array.from(document.querySelectorAll<HTMLAnchorElement>("a")).find(
+        (el) => {
+          const href = el.getAttribute("href") ?? "";
+          return href.includes("/docs/") && !href.endsWith(currentHref) && href !== currentHref;
+        },
+      );
+      if (!a) return { ok: false as const, reason: "no-anchor" };
+      a.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, button: 0 }));
+      return { ok: true as const, href: a.getAttribute("href") ?? "" };
+    });
+
+    expect(navResult.ok, `SPA nav failed: ${(navResult as { reason?: string }).reason ?? ""}`).toBe(true);
+    await page.waitForURL(PAGE_B_PATTERN, { timeout: 15_000 });
+    // Allow the SPA swap + island re-hydration to settle.
+    await page.waitForTimeout(2_500);
+
+    // Step 4 — Click the palette button on page B. Must open after ONE click.
+    const paletteOnB = page.locator(PALETTE_BTN_SEL).first();
+    await paletteOnB.scrollIntoViewIfNeeded({ timeout: 5_000 });
+    await paletteOnB.click();
+
+    // The regression: without the fix, the panel mounts closed and this
+    // assertion fails — the shell never becomes visible after 1 click.
+    await expect(page.locator(PANEL_SHELL_SEL)).toBeVisible({ timeout: 5_000 });
+    expect(await isPanelOpen(page), "Panel must be visually open after 1 click on page B").toBe(true);
+  });
+
+  // ---------------------------------------------------------------------------
+  // B1 — Pre-seeded OPEN_KEY + hard reload (secondary hardening scenario).
+  //
+  // When OPEN_KEY='1' is present in localStorage and the user does a hard
+  // reload, the panel should open after exactly one click. This scenario
+  // is less critical than G1 (it cannot be reached through normal user flow
+  // without manually setting localStorage), but it is a useful guard against
+  // regressions of the toggle-direction logic.
+  // ---------------------------------------------------------------------------
+
+  test("B1: one click opens panel when OPEN_KEY pre-seeded before hard reload @local-only", async () => {
+    const OPEN_KEY = "zudo-doc-tweak-open";
+
+    // Pre-seed OPEN_KEY before first navigation (simulates a "stale open" state).
+    await page.addInitScript((key: string) => {
+      localStorage.setItem(key, "1");
+    }, OPEN_KEY);
+
+    await page.goto(`${BASE_URL}${PAGE_A_PATH}`, {
+      waitUntil: "load",
+      timeout: 30_000,
+    });
+    // Allow island hydration to settle before interacting.
+    await page.waitForTimeout(1_500);
+
+    // One click must open the panel.
+    const paletteBtn = page.locator(PALETTE_BTN_SEL).first();
+    await paletteBtn.scrollIntoViewIfNeeded({ timeout: 10_000 });
+    await paletteBtn.click();
+
+    await expect(page.locator(PANEL_SHELL_SEL)).toBeVisible({ timeout: 5_000 });
+    expect(await isPanelOpen(page), "Panel must be visually open after 1 click when OPEN_KEY is pre-seeded").toBe(true);
+  });
+});

--- a/zfb.config.ts
+++ b/zfb.config.ts
@@ -411,12 +411,14 @@
  * base-path (see zudo-doc#1564 LESSON CONTEXT).
  *
  * Current pin:
- *   SHA: e5249698a2dc95aae2c1061463677ce7a5a0755a
+ *   SHA: 75a567349943a3beb80a209d47f087824f3b82c8
  *   Repo: Takazudo/zudo-design-token-panel
- *   Context: pulls upstream zdtp PR #54 — consolidates the panel toggle
- *   ownership into a single source of truth (`localStorage[OPEN_KEY]`),
- *   eliminating the dual-listener race that caused "1st click does nothing,
- *   2nd click opens" after the in-panel X button was used.
+ *   Context: pulls upstream zdtp PR #55 — forces `willBeOpen=true` in
+ *   `handleExternalToggleEvent` when the panel root is absent, fixing the
+ *   "1st click does nothing, 2nd click opens" regression that surfaced after
+ *   SPA-nav from an open panel (downstream zudolab/zudo-doc#1633 / #1640 /
+ *   #1631). The fresh-mount path no longer trusts a possibly-stale OPEN_KEY
+ *   to derive toggle direction.
  */
 
 // zfb.config.ts — entry-point config consumed by the zfb engine.


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/1633
- parent PR
    - https://github.com/zudolab/zudo-doc/pull/669

---

## Summary

Fourth-attempt fix for "header palette icon needs 2 clicks to open the panel" plus triage of 7 most-recent open issues. Per epic #1633.

**Root cause (R1b causal proof):** `handleExternalToggleEvent` in zdtp `packages/zudo-design-token-panel/src/index.tsx:444-452`. After SPA-nav unmounts the panel root, `OPEN_KEY='1'` is left stale. The next palette click reads the stale key via `isPanelCurrentlyOpen()`, computes `willBeOpen=false`, mounts the panel in the closed state, and short-circuits before any sync event. Second click needed.

**Fix:** Force `willBeOpen=true` when `isFreshMount===true` — the user's intent on a fresh mount is unambiguously "open". Shipped in upstream zdtp PR Takazudo/zudo-design-token-panel#55. ZDTP_PINNED_SHA bumped in this repo: `e5249698` → `75a567349943a3beb80a209d47f087824f3b82c8`.

## What's in this PR

- **`.github/workflows/{main-deploy,pr-checks,preview-deploy}.yml`** — `ZDTP_PINNED_SHA` bump to `75a56734...`
- **`zfb.config.ts`** — refreshed canonical reference comment block with the new SHA + fix context
- **`packages/ai-chat-worker/CLAUDE.md`** + **`src/content/docs{,-ja}/reference/ai-chat-worker.mdx`** — `:::warning[Deprecated]` banners (D1, resolves #1488)
- **`tests/e2e/specs/palette-click-once.spec.ts`** + **`playwright.palette.config.ts`** — permanent regression spec covering G1 (SPA-nav) + B1 (stale OPEN_KEY) scenarios. Gated — E2E parity parked under E9b until post-cutover window closes (per CLAUDE.md).

## Sub-issues closed by this PR

- #1631 — same root cause as the 2-click bug (SPA-nav re-arm gap)
- #1488 — ai-chat-worker doc deprecation (Option 3 banner)
- #1507 — version dropdown placement (verified fixed during migration parity)
- #1634 R1a, #1635 V1, #1636 V2, #1637 D1, #1638 T1 (Wave 1)
- #1639 R1b (Wave 2)
- #1640 F1 (Wave 3)
- #1641 F2 — no-op, F1 was upstream-only (Wave 4)
- #1642 F3 (Wave 4)
- #1643 C1 (Wave 5)

## Sub-issues kept open by design

- #1508 — tags chip absent on PR-669 preview; verified still broken, but out of scope for this epic (V2 verdict)
- #1527, #1529 — explicitly deferred per T1; defer comments posted
- #1618 — T5 confirmation comment posted; user decides closure pending T1-T4 status

## Verification

- **R1b reduced spec (local zfb dev):** 10/10 PASS after F1 lands
- **C1 agent pre-validation against deployed pr-1644 preview:** G1 10/10 PASS, B1 5/5 PASS
- **CI on this PR:** all 8 checks green (Build Site, Build Doc History, Build zfb Binary, E2E Tests, HTML validate, Preview Deploy, Template Drift Check, Type Check)
- **`/gcoc-review`** on the combined diff: clean

## Bug-attempt history (epic context)

| # | PR | Targeted scenario | Outcome |
|---|---|---|---|
| 1 | #1623 | T5 — palette did nothing (bootstrap dynamic import server-only). Added `"use client"` island. | Panel opens at all. |
| 2 | #1630 | wave1 zdtp-panel-wiring-fix — eager CSS, first-click shim, bridge guard. | First-click before hydration captured. |
| 3 | #1632 | Bumped zdtp pin to `e5249698` (upstream PR #54 click-twice-after-close). | User STILL sees 2 clicks. |
| 4 | THIS PR + zdtp#55 | G1 (SPA-nav from open panel) — fresh-mount-forces-open in `handleExternalToggleEvent` | Agent verified 10/10 G1 + 5/5 B1 on pr-1644 deploy. Awaiting user confirmation. |

## Deployed preview for verification

https://pr-1644.zudo-doc.pages.dev/pj/zudo-doc/