### PR TITLE
chore(zdtp): bump zdtp pin to 4f9d3799 — center default panel position on first open

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -96,7 +96,7 @@ env:
   # Pinned zdtp commit — keep in sync with the zdtp pin block in zfb.config.ts,
   # the file: spec in package.json, and the same env in pr-checks.yml /
   # preview-deploy.yml. All three sources must be bumped together.
-  ZDTP_PINNED_SHA: 75a567349943a3beb80a209d47f087824f3b82c8
+  ZDTP_PINNED_SHA: 4f9d3799bbf3c08c54cd84b7f0e209745b11493f
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -78,7 +78,7 @@ env:
   # Pinned zdtp commit — keep in sync with the zdtp pin block in zfb.config.ts,
   # the file: spec in package.json, and the same env in main-deploy.yml /
   # preview-deploy.yml. All three sources must be bumped together.
-  ZDTP_PINNED_SHA: 75a567349943a3beb80a209d47f087824f3b82c8
+  ZDTP_PINNED_SHA: 4f9d3799bbf3c08c54cd84b7f0e209745b11493f
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -69,7 +69,7 @@ env:
   # Pinned zdtp commit — keep in sync with the zdtp pin block in zfb.config.ts,
   # the file: spec in package.json, and the same env in main-deploy.yml /
   # pr-checks.yml. All three sources must be bumped together.
-  ZDTP_PINNED_SHA: 75a567349943a3beb80a209d47f087824f3b82c8
+  ZDTP_PINNED_SHA: 4f9d3799bbf3c08c54cd84b7f0e209745b11493f
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/zfb.config.ts
+++ b/zfb.config.ts
@@ -411,14 +411,18 @@
  * base-path (see zudo-doc#1564 LESSON CONTEXT).
  *
  * Current pin:
- *   SHA: 75a567349943a3beb80a209d47f087824f3b82c8
+ *   SHA: 4f9d3799bbf3c08c54cd84b7f0e209745b11493f
  *   Repo: Takazudo/zudo-design-token-panel
- *   Context: pulls upstream zdtp PR #55 — forces `willBeOpen=true` in
- *   `handleExternalToggleEvent` when the panel root is absent, fixing the
- *   "1st click does nothing, 2nd click opens" regression that surfaced after
- *   SPA-nav from an open panel (downstream zudolab/zudo-doc#1633 / #1640 /
- *   #1631). The fresh-mount path no longer trusts a possibly-stale OPEN_KEY
- *   to derive toggle direction.
+ *   Context: pulls upstream zdtp PR #56 — replaces the static
+ *   `DEFAULT_POSITION = { top: 60, right: 20 }` fallback with a runtime
+ *   viewport-centered position via a new `defaultPosition()` helper, so
+ *   `loadPosition()` returns a centered position on fresh localStorage
+ *   instead of dropping the panel in the upper-right corner. Saved-position
+ *   behaviour is unchanged: existing `zudo-doc-tweak-position` entries still
+ *   load verbatim. Downstream epic zudolab/zudo-doc#1645, sub-issue #1646
+ *   (W1). W2b (#1648) mirrors the same shape into this repo's `main` branch
+ *   (legacy in-tree panel) so users on `main` get the same fix before the
+ *   post-zfb-migration cutover.
  */
 
 // zfb.config.ts — entry-point config consumed by the zfb engine.


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/1647 (W2a)
    - https://github.com/zudolab/zudo-doc/issues/1645 (epic)
- upstream PR
    - https://github.com/Takazudo/zudo-design-token-panel/pull/56 (merged)
- siblings
    - https://github.com/zudolab/zudo-doc/issues/1646 (W1 — done)
    - https://github.com/zudolab/zudo-doc/issues/1648 (W2b — main legacy panel mirror)

---

## Summary

Bump the four zudo-doc2 zdtp pin sources from `75a56734…` to `4f9d3799…` (the merge commit of upstream PR Takazudo/zudo-design-token-panel#56). This brings in the centered-default panel position fix on this branch so CI + preview deploy + `pnpm dev` all render the panel centered on first open.

## Files touched (atomic single commit)

All four bumped in lockstep so partial drift never reaches `main-deploy.yml`:

- `.github/workflows/main-deploy.yml` — `ZDTP_PINNED_SHA`
- `.github/workflows/preview-deploy.yml` — `ZDTP_PINNED_SHA`
- `.github/workflows/pr-checks.yml` — `ZDTP_PINNED_SHA`
- `zfb.config.ts` — SHA in the canonical pin comment block AND surrounding Context: paragraph (rewritten to describe the centered-default fix)

## Ancestor check

\`\`\`
git -C ~/repos/myoss/zdtp merge-base --is-ancestor \\
  75a567349943a3beb80a209d47f087824f3b82c8 \\
  4f9d3799bbf3c08c54cd84b7f0e209745b11493f
\`\`\`

**PASS** — current pin is an ancestor of the new pin, no commits dropped.

## Post-merge action items scanned

None in PR #56's body / CHANGELOG.

## Local verification

- `pnpm install` (postinstall + `zdtp-link.mjs`): clean.
- `pnpm b4push` (with `B4PUSH_SKIP_MANUAL_SMOKE=1`; preview smoke run separately): **11/11 checks passed** — format, template drift, fixture settings drift, tags audit, design token lint, typecheck, build, link check, HTML validate.
- `pnpm smoke:preview`: **6/6 checks passed**.
- Manual local check via `pnpm dev` deferred to #1649 (W3), which runs the full `/headless-browser` check suite on the deployed preview.

## What this picks up (upstream PR #56)

- Adds `defaultPosition()` helper computing runtime viewport-centered position.
- Switches `loadPosition()`'s no-save fallback from the static `DEFAULT_POSITION = {top:60, right:20}` constant to `defaultPosition()`.
- Saved-position behaviour unchanged — existing `zudo-doc-tweak-position` localStorage entries still load verbatim.
- Public API surface unchanged (`DEFAULT_POSITION` still exported as SSR fallback).
- 9 new upstream unit tests; 232/232 total tests passing upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/1650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->