### PR TITLE
fix(panel): center default position on first open — legacy in-tree panel mirror

### DIFF
--- a/packages/create-zudo-doc/templates/features/designTokenPanel/files/src/components/design-token-tweak/__tests__/load-position.test.ts
+++ b/packages/create-zudo-doc/templates/features/designTokenPanel/files/src/components/design-token-tweak/__tests__/load-position.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Centered-default behaviour for the legacy in-tree panel's first-open position.
+ *
+ * Pre-fix: `DEFAULT_POSITION` was a hard-coded `{ top: 60, right: 20 }` static
+ * constant, so fresh-localStorage installs always landed the panel in the
+ * upper-right corner — far from where the user expects it.
+ *
+ * Post-fix: `defaultPosition()` computes a runtime viewport-centered position
+ * (panelW = min(1200, 0.8 * innerWidth), centered both axes), and
+ * `loadPosition()` falls back to that instead of `DEFAULT_POSITION` when no
+ * saved value exists or the saved value is malformed.
+ *
+ * Mirrors the upstream zdtp shape (Takazudo/zudo-design-token-panel#56). The
+ * eventual `main` → zfb cutover will replace this in-tree panel with the
+ * upstream package — the centered-default fix must be byte-equivalent on both
+ * sides so no behaviour drift survives the migration.
+ *
+ * Saved-value behaviour is UNCHANGED — a valid `{top, right}` entry in
+ * localStorage still loads verbatim, so existing users keep their dragged
+ * position exactly as today.
+ *
+ * The tests stub `window` and `localStorage` manually rather than running
+ * under jsdom, because the project's vitest config defaults to a node
+ * environment (no jsdom dep installed) and the existing test files in this
+ * directory follow the same in-process-mock pattern.
+ */
+
+import {
+  DEFAULT_POSITION,
+  defaultPosition,
+  loadPosition,
+  POSITION_KEY,
+  type PanelPosition,
+} from "../state/tweak-state";
+
+function makeLocalStorageMock(): Storage {
+  const entries = new Map<string, string>();
+  return {
+    get length() {
+      return entries.size;
+    },
+    clear() {
+      entries.clear();
+    },
+    getItem(key: string) {
+      return entries.has(key) ? (entries.get(key) as string) : null;
+    },
+    key(index: number) {
+      return Array.from(entries.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      entries.delete(key);
+    },
+    setItem(key: string, value: string) {
+      entries.set(key, String(value));
+    },
+  };
+}
+
+function setViewport(w: number, h: number): void {
+  vi.stubGlobal("window", { innerWidth: w, innerHeight: h });
+}
+
+beforeEach(() => {
+  vi.stubGlobal("localStorage", makeLocalStorageMock());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("defaultPosition", () => {
+  it("returns the viewport center for a 1440×900 viewport (panel 1152×720)", () => {
+    setViewport(1440, 900);
+    const pos = defaultPosition();
+    // panelW = min(1200, 0.8*1440) = min(1200, 1152) = 1152
+    // panelH = min(800, 0.8*900)   = min(800, 720)   = 720
+    // top   = round((900 - 720) / 2) = 90
+    // right = round((1440 - 1152) / 2) = 144
+    expect(pos.top).toBeGreaterThanOrEqual(88);
+    expect(pos.top).toBeLessThanOrEqual(92);
+    expect(pos.right).toBeGreaterThanOrEqual(142);
+    expect(pos.right).toBeLessThanOrEqual(146);
+  });
+
+  it("returns the viewport center for a 1920×1080 viewport (panel capped at 1200×800)", () => {
+    setViewport(1920, 1080);
+    const pos = defaultPosition();
+    // panelW = min(1200, 0.8*1920) = 1200
+    // panelH = min(800, 0.8*1080) = 800
+    // top   = round((1080 - 800) / 2) = 140
+    // right = round((1920 - 1200) / 2) = 360
+    expect(pos.top).toBeGreaterThanOrEqual(138);
+    expect(pos.top).toBeLessThanOrEqual(142);
+    expect(pos.right).toBeGreaterThanOrEqual(358);
+    expect(pos.right).toBeLessThanOrEqual(362);
+  });
+
+  it("returns {top:0, right:0} on a degenerate 0×0 viewport (no negative offsets)", () => {
+    setViewport(0, 0);
+    const pos = defaultPosition();
+    expect(pos.top).toBe(0);
+    expect(pos.right).toBe(0);
+  });
+
+  it("returns deterministic non-negative offsets for a narrow viewport (375×667)", () => {
+    setViewport(375, 667);
+    const pos = defaultPosition();
+    // panelW = min(1200, 0.8*375) = 300
+    // panelH = min(800, 0.8*667) = 533.6
+    // top   = round((667 - 533.6) / 2) ≈ 67
+    // right = round((375 - 300) / 2) ≈ 38
+    expect(pos.top).toBeGreaterThanOrEqual(65);
+    expect(pos.top).toBeLessThanOrEqual(69);
+    expect(pos.right).toBeGreaterThanOrEqual(36);
+    expect(pos.right).toBeLessThanOrEqual(40);
+  });
+});
+
+describe("loadPosition", () => {
+  beforeEach(() => {
+    setViewport(1440, 900);
+  });
+
+  it("returns defaultPosition() (centered) when localStorage is empty (no saved entry)", () => {
+    const pos = loadPosition();
+    const expected = defaultPosition();
+    expect(pos.top).toBe(expected.top);
+    expect(pos.right).toBe(expected.right);
+    // Sanity: centered values, not the static {60, 20}.
+    expect(pos.top).not.toBe(DEFAULT_POSITION.top);
+    expect(pos.right).not.toBe(DEFAULT_POSITION.right);
+  });
+
+  it("returns the saved value verbatim when localStorage has a valid entry", () => {
+    const saved: PanelPosition = { top: 300, right: 400 };
+    localStorage.setItem(POSITION_KEY, JSON.stringify(saved));
+    const pos = loadPosition();
+    expect(pos.top).toBe(300);
+    expect(pos.right).toBe(400);
+  });
+
+  it("returns defaultPosition() when the saved entry is malformed JSON", () => {
+    localStorage.setItem(POSITION_KEY, "{not valid json");
+    const pos = loadPosition();
+    const expected = defaultPosition();
+    expect(pos.top).toBe(expected.top);
+    expect(pos.right).toBe(expected.right);
+  });
+
+  it("returns defaultPosition() when the saved entry has non-numeric fields", () => {
+    localStorage.setItem(POSITION_KEY, JSON.stringify({ top: "oops", right: 20 }));
+    const pos = loadPosition();
+    const expected = defaultPosition();
+    expect(pos.top).toBe(expected.top);
+    expect(pos.right).toBe(expected.right);
+  });
+
+  it("returns defaultPosition() when the saved entry is a JSON literal with the wrong shape", () => {
+    localStorage.setItem(POSITION_KEY, JSON.stringify({ unrelated: "field" }));
+    const pos = loadPosition();
+    const expected = defaultPosition();
+    expect(pos.top).toBe(expected.top);
+    expect(pos.right).toBe(expected.right);
+  });
+});

--- a/packages/create-zudo-doc/templates/features/designTokenPanel/files/src/components/design-token-tweak/state/tweak-state.ts
+++ b/packages/create-zudo-doc/templates/features/designTokenPanel/files/src/components/design-token-tweak/state/tweak-state.ts
@@ -23,7 +23,37 @@ export interface PanelPosition {
   right: number;
 }
 
+/**
+ * SSR-safe static fallback. Kept exported so SSR call sites (where `window`
+ * is undefined) still get a deterministic value. Runtime callers should
+ * prefer `defaultPosition()`, which returns a viewport-centered position
+ * when `window` is available.
+ */
 export const DEFAULT_POSITION: PanelPosition = { top: 60, right: 20 };
+
+/**
+ * Compute a viewport-centered default panel position for first-open behaviour.
+ *
+ * The panel sizes itself up to 1200×800 but caps at 80% of the viewport, so
+ * we mirror the same min/0.8x rule here. The resulting `top` / `right` place
+ * the panel at the geometric center of the viewport.
+ *
+ * Falls back to the static `DEFAULT_POSITION` when `window` is undefined
+ * (e.g. SSR / node test setup without jsdom). Real browsers + jsdom-backed
+ * tests get the centered position.
+ *
+ * Mirrors the upstream zdtp shape (Takazudo/zudo-design-token-panel#56).
+ * Kept here byte-equivalent with the main zudo-doc copy so the template +
+ * production code never diverge.
+ */
+export function defaultPosition(): PanelPosition {
+  if (typeof window === "undefined") return DEFAULT_POSITION;
+  const panelW = Math.min(1200, 0.8 * window.innerWidth);
+  const panelH = Math.min(800, 0.8 * window.innerHeight);
+  const top = Math.max(0, Math.round((window.innerHeight - panelH) / 2));
+  const right = Math.max(0, Math.round((window.innerWidth - panelW) / 2));
+  return { top, right };
+}
 
 export function loadPosition(): PanelPosition {
   try {
@@ -35,7 +65,7 @@ export function loadPosition(): PanelPosition {
       }
     }
   } catch { /* ignore */ }
-  return DEFAULT_POSITION;
+  return defaultPosition();
 }
 
 export function savePosition(pos: PanelPosition) {

--- a/src/components/design-token-tweak/__tests__/load-position.test.ts
+++ b/src/components/design-token-tweak/__tests__/load-position.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Centered-default behaviour for the legacy in-tree panel's first-open position.
+ *
+ * Pre-fix: `DEFAULT_POSITION` was a hard-coded `{ top: 60, right: 20 }` static
+ * constant, so fresh-localStorage installs always landed the panel in the
+ * upper-right corner — far from where the user expects it.
+ *
+ * Post-fix: `defaultPosition()` computes a runtime viewport-centered position
+ * (panelW = min(1200, 0.8 * innerWidth), centered both axes), and
+ * `loadPosition()` falls back to that instead of `DEFAULT_POSITION` when no
+ * saved value exists or the saved value is malformed.
+ *
+ * Mirrors the upstream zdtp shape (Takazudo/zudo-design-token-panel#56). The
+ * eventual `main` → zfb cutover will replace this in-tree panel with the
+ * upstream package — the centered-default fix must be byte-equivalent on both
+ * sides so no behaviour drift survives the migration.
+ *
+ * Saved-value behaviour is UNCHANGED — a valid `{top, right}` entry in
+ * localStorage still loads verbatim, so existing users keep their dragged
+ * position exactly as today.
+ *
+ * The tests stub `window` and `localStorage` manually rather than running
+ * under jsdom, because the project's vitest config defaults to a node
+ * environment (no jsdom dep installed) and the existing test files in this
+ * directory follow the same in-process-mock pattern.
+ */
+
+import {
+  DEFAULT_POSITION,
+  defaultPosition,
+  loadPosition,
+  POSITION_KEY,
+  type PanelPosition,
+} from "../state/tweak-state";
+
+function makeLocalStorageMock(): Storage {
+  const entries = new Map<string, string>();
+  return {
+    get length() {
+      return entries.size;
+    },
+    clear() {
+      entries.clear();
+    },
+    getItem(key: string) {
+      return entries.has(key) ? (entries.get(key) as string) : null;
+    },
+    key(index: number) {
+      return Array.from(entries.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      entries.delete(key);
+    },
+    setItem(key: string, value: string) {
+      entries.set(key, String(value));
+    },
+  };
+}
+
+function setViewport(w: number, h: number): void {
+  vi.stubGlobal("window", { innerWidth: w, innerHeight: h });
+}
+
+beforeEach(() => {
+  vi.stubGlobal("localStorage", makeLocalStorageMock());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("defaultPosition", () => {
+  it("returns the viewport center for a 1440×900 viewport (panel 1152×720)", () => {
+    setViewport(1440, 900);
+    const pos = defaultPosition();
+    // panelW = min(1200, 0.8*1440) = min(1200, 1152) = 1152
+    // panelH = min(800, 0.8*900)   = min(800, 720)   = 720
+    // top   = round((900 - 720) / 2) = 90
+    // right = round((1440 - 1152) / 2) = 144
+    expect(pos.top).toBeGreaterThanOrEqual(88);
+    expect(pos.top).toBeLessThanOrEqual(92);
+    expect(pos.right).toBeGreaterThanOrEqual(142);
+    expect(pos.right).toBeLessThanOrEqual(146);
+  });
+
+  it("returns the viewport center for a 1920×1080 viewport (panel capped at 1200×800)", () => {
+    setViewport(1920, 1080);
+    const pos = defaultPosition();
+    // panelW = min(1200, 0.8*1920) = 1200
+    // panelH = min(800, 0.8*1080) = 800
+    // top   = round((1080 - 800) / 2) = 140
+    // right = round((1920 - 1200) / 2) = 360
+    expect(pos.top).toBeGreaterThanOrEqual(138);
+    expect(pos.top).toBeLessThanOrEqual(142);
+    expect(pos.right).toBeGreaterThanOrEqual(358);
+    expect(pos.right).toBeLessThanOrEqual(362);
+  });
+
+  it("returns {top:0, right:0} on a degenerate 0×0 viewport (no negative offsets)", () => {
+    setViewport(0, 0);
+    const pos = defaultPosition();
+    expect(pos.top).toBe(0);
+    expect(pos.right).toBe(0);
+  });
+
+  it("returns deterministic non-negative offsets for a narrow viewport (375×667)", () => {
+    setViewport(375, 667);
+    const pos = defaultPosition();
+    // panelW = min(1200, 0.8*375) = 300
+    // panelH = min(800, 0.8*667) = 533.6
+    // top   = round((667 - 533.6) / 2) ≈ 67
+    // right = round((375 - 300) / 2) ≈ 38
+    expect(pos.top).toBeGreaterThanOrEqual(65);
+    expect(pos.top).toBeLessThanOrEqual(69);
+    expect(pos.right).toBeGreaterThanOrEqual(36);
+    expect(pos.right).toBeLessThanOrEqual(40);
+  });
+});
+
+describe("loadPosition", () => {
+  beforeEach(() => {
+    setViewport(1440, 900);
+  });
+
+  it("returns defaultPosition() (centered) when localStorage is empty (no saved entry)", () => {
+    const pos = loadPosition();
+    const expected = defaultPosition();
+    expect(pos.top).toBe(expected.top);
+    expect(pos.right).toBe(expected.right);
+    // Sanity: centered values, not the static {60, 20}.
+    expect(pos.top).not.toBe(DEFAULT_POSITION.top);
+    expect(pos.right).not.toBe(DEFAULT_POSITION.right);
+  });
+
+  it("returns the saved value verbatim when localStorage has a valid entry", () => {
+    const saved: PanelPosition = { top: 300, right: 400 };
+    localStorage.setItem(POSITION_KEY, JSON.stringify(saved));
+    const pos = loadPosition();
+    expect(pos.top).toBe(300);
+    expect(pos.right).toBe(400);
+  });
+
+  it("returns defaultPosition() when the saved entry is malformed JSON", () => {
+    localStorage.setItem(POSITION_KEY, "{not valid json");
+    const pos = loadPosition();
+    const expected = defaultPosition();
+    expect(pos.top).toBe(expected.top);
+    expect(pos.right).toBe(expected.right);
+  });
+
+  it("returns defaultPosition() when the saved entry has non-numeric fields", () => {
+    localStorage.setItem(POSITION_KEY, JSON.stringify({ top: "oops", right: 20 }));
+    const pos = loadPosition();
+    const expected = defaultPosition();
+    expect(pos.top).toBe(expected.top);
+    expect(pos.right).toBe(expected.right);
+  });
+
+  it("returns defaultPosition() when the saved entry is a JSON literal with the wrong shape", () => {
+    localStorage.setItem(POSITION_KEY, JSON.stringify({ unrelated: "field" }));
+    const pos = loadPosition();
+    const expected = defaultPosition();
+    expect(pos.top).toBe(expected.top);
+    expect(pos.right).toBe(expected.right);
+  });
+});

--- a/src/components/design-token-tweak/state/tweak-state.ts
+++ b/src/components/design-token-tweak/state/tweak-state.ts
@@ -23,7 +23,37 @@ export interface PanelPosition {
   right: number;
 }
 
+/**
+ * SSR-safe static fallback. Kept exported so SSR call sites (where `window`
+ * is undefined) still get a deterministic value. Runtime callers should
+ * prefer `defaultPosition()`, which returns a viewport-centered position
+ * when `window` is available.
+ */
 export const DEFAULT_POSITION: PanelPosition = { top: 60, right: 20 };
+
+/**
+ * Compute a viewport-centered default panel position for first-open behaviour.
+ *
+ * The panel sizes itself up to 1200×800 but caps at 80% of the viewport, so
+ * we mirror the same min/0.8x rule here. The resulting `top` / `right` place
+ * the panel at the geometric center of the viewport.
+ *
+ * Falls back to the static `DEFAULT_POSITION` when `window` is undefined
+ * (e.g. SSR / node test setup without jsdom). Real browsers + jsdom-backed
+ * tests get the centered position.
+ *
+ * Mirrors the upstream zdtp shape (Takazudo/zudo-design-token-panel#56).
+ * Kept here byte-equivalent with the main zudo-doc copy so the template +
+ * production code never diverge.
+ */
+export function defaultPosition(): PanelPosition {
+  if (typeof window === "undefined") return DEFAULT_POSITION;
+  const panelW = Math.min(1200, 0.8 * window.innerWidth);
+  const panelH = Math.min(800, 0.8 * window.innerHeight);
+  const top = Math.max(0, Math.round((window.innerHeight - panelH) / 2));
+  const right = Math.max(0, Math.round((window.innerWidth - panelW) / 2));
+  return { top, right };
+}
 
 export function loadPosition(): PanelPosition {
   try {
@@ -35,7 +65,7 @@ export function loadPosition(): PanelPosition {
       }
     }
   } catch { /* ignore */ }
-  return DEFAULT_POSITION;
+  return defaultPosition();
 }
 
 export function savePosition(pos: PanelPosition) {


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/1648 (W2b)
    - https://github.com/zudolab/zudo-doc/issues/1645 (epic)
- upstream PR (merged)
    - https://github.com/Takazudo/zudo-design-token-panel/pull/56
- siblings
    - https://github.com/zudolab/zudo-doc/issues/1646 (W1 — done)
    - https://github.com/zudolab/zudo-doc/issues/1647 (W2a — pin bump on base/zfb-migration-parity)

**This PR targets `main` directly (NOT the epic base)** — this is a one-shot legacy-code fix per #1648's `Base branch: main` marker. `main` is pre-zfb-migration and still ships the panel as in-tree code, so it does not flow through the epic base.

---

## Summary

Mirror upstream zdtp PR Takazudo/zudo-design-token-panel#56's centered-default behaviour into `main`'s legacy in-tree panel at `src/components/design-token-tweak/state/tweak-state.ts`, byte-equivalent to the upstream shape so the eventual `main` → zfb cutover migrates cleanly with zero behaviour drift.

## Changes (mirrored to create-zudo-doc template per Feature Change Checklist)

- Add `defaultPosition()` helper computing runtime viewport-centered position (panel sized via `min(1200, 0.8*innerWidth) × min(800, 0.8*innerHeight)`).
- Switch `loadPosition()`'s no-save fallback from the static `DEFAULT_POSITION` `{top:60, right:20}` constant to `defaultPosition()`.
- Keep `DEFAULT_POSITION` exported as SSR fallback inside `defaultPosition()` (`typeof window === 'undefined'` branch). Public API surface unchanged.
- Saved-position behaviour unchanged — existing `zudo-doc-tweak-position` localStorage entries still load verbatim.

## Files touched

- `src/components/design-token-tweak/state/tweak-state.ts` (local)
- `src/components/design-token-tweak/__tests__/load-position.test.ts` (local, new)
- `packages/create-zudo-doc/templates/features/designTokenPanel/files/src/components/design-token-tweak/state/tweak-state.ts` (template mirror, **byte-equivalent** to local)
- `packages/create-zudo-doc/templates/features/designTokenPanel/files/src/components/design-token-tweak/__tests__/load-position.test.ts` (template mirror, byte-equivalent to local)

## Tests

9 new unit tests, jsdom-free (`vi.stubGlobal` pattern matching the existing in-tree `__tests__/` which run under the node environment):

- `defaultPosition` center math for 1440×900, 1920×1080, 375×667, 0×0 viewports.
- `loadPosition` centered fallback on empty / malformed / wrong-shape storage.
- `loadPosition` returns saved value verbatim when entry is valid.

## Local verification

- `npx vitest run src/components/design-token-tweak/__tests__/load-position.test.ts` — **9/9 passing**.
- `pnpm check:template-drift` — **zero drift**.
- `pnpm check` (`astro check`) — clean.
- `pnpm build` locally fails on **pre-existing** dual-Preact-instance worktree quirk (`preact-render-to-string` resolves to the parent checkout's `node_modules` while `preact` resolves to the worktree's). Verified the same failure occurs without these edits via `git stash && pnpm build`. CI does a clean checkout so this does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/1651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->