### PR TITLE
Epic: ZDTP Panel Centered Default — zdtp pin bump (W2a) on base/zfb-migration-parity

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -96,7 +96,7 @@ env:
   # Pinned zdtp commit — keep in sync with the zdtp pin block in zfb.config.ts,
   # the file: spec in package.json, and the same env in pr-checks.yml /
   # preview-deploy.yml. All three sources must be bumped together.
-  ZDTP_PINNED_SHA: 75a567349943a3beb80a209d47f087824f3b82c8
+  ZDTP_PINNED_SHA: 4f9d3799bbf3c08c54cd84b7f0e209745b11493f
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -78,7 +78,7 @@ env:
   # Pinned zdtp commit — keep in sync with the zdtp pin block in zfb.config.ts,
   # the file: spec in package.json, and the same env in main-deploy.yml /
   # preview-deploy.yml. All three sources must be bumped together.
-  ZDTP_PINNED_SHA: 75a567349943a3beb80a209d47f087824f3b82c8
+  ZDTP_PINNED_SHA: 4f9d3799bbf3c08c54cd84b7f0e209745b11493f
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -69,7 +69,7 @@ env:
   # Pinned zdtp commit — keep in sync with the zdtp pin block in zfb.config.ts,
   # the file: spec in package.json, and the same env in main-deploy.yml /
   # pr-checks.yml. All three sources must be bumped together.
-  ZDTP_PINNED_SHA: 75a567349943a3beb80a209d47f087824f3b82c8
+  ZDTP_PINNED_SHA: 4f9d3799bbf3c08c54cd84b7f0e209745b11493f
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/zfb.config.ts
+++ b/zfb.config.ts
@@ -411,14 +411,18 @@
  * base-path (see zudo-doc#1564 LESSON CONTEXT).
  *
  * Current pin:
- *   SHA: 75a567349943a3beb80a209d47f087824f3b82c8
+ *   SHA: 4f9d3799bbf3c08c54cd84b7f0e209745b11493f
  *   Repo: Takazudo/zudo-design-token-panel
- *   Context: pulls upstream zdtp PR #55 — forces `willBeOpen=true` in
- *   `handleExternalToggleEvent` when the panel root is absent, fixing the
- *   "1st click does nothing, 2nd click opens" regression that surfaced after
- *   SPA-nav from an open panel (downstream zudolab/zudo-doc#1633 / #1640 /
- *   #1631). The fresh-mount path no longer trusts a possibly-stale OPEN_KEY
- *   to derive toggle direction.
+ *   Context: pulls upstream zdtp PR #56 — replaces the static
+ *   `DEFAULT_POSITION = { top: 60, right: 20 }` fallback with a runtime
+ *   viewport-centered position via a new `defaultPosition()` helper, so
+ *   `loadPosition()` returns a centered position on fresh localStorage
+ *   instead of dropping the panel in the upper-right corner. Saved-position
+ *   behaviour is unchanged: existing `zudo-doc-tweak-position` entries still
+ *   load verbatim. Downstream epic zudolab/zudo-doc#1645, sub-issue #1646
+ *   (W1). W2b (#1648) mirrors the same shape into this repo's `main` branch
+ *   (legacy in-tree panel) so users on `main` get the same fix before the
+ *   post-zfb-migration cutover.
  */
 
 // zfb.config.ts — entry-point config consumed by the zfb engine.


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/1645 (epic)
    - https://github.com/zudolab/zudo-doc/issues/1647 (W2a — merged into this epic base)
- upstream PR (merged)
    - https://github.com/Takazudo/zudo-design-token-panel/pull/56
- sibling sub-issues
    - https://github.com/zudolab/zudo-doc/issues/1646 (W1 — done)
    - https://github.com/zudolab/zudo-doc/issues/1648 (W2b — merged separately into main via PR #1651)
    - https://github.com/zudolab/zudo-doc/issues/1649 (W3 — deployed preview verification)

---

## Summary

Roll the centered-default zdtp pin bump from epic base `base/zdtp-panel-centered-default` into `base/zfb-migration-parity`. Single topic (W2a #1647 — pin bump) has been merged into the epic base. This PR promotes the epic base onto the parent migration branch so `base/zfb-migration-parity` and its downstream consumers consume the centered-default fix from CI and `pnpm dev`.

## What this picks up

- W2a (#1647): atomic 4-file zdtp pin bump from `75a56734…` → `4f9d3799…` (the merge commit of upstream PR Takazudo/zudo-design-token-panel#56).
- Files touched (same atomic commit, all in lockstep):
  * `.github/workflows/main-deploy.yml` — `ZDTP_PINNED_SHA`
  * `.github/workflows/preview-deploy.yml` — `ZDTP_PINNED_SHA`
  * `.github/workflows/pr-checks.yml` — `ZDTP_PINNED_SHA`
  * `zfb.config.ts` — SHA in canonical pin block + Context: paragraph

## Verification status

- W2a PR #1650 (merged): all CI checks passed — Template Drift, Build Doc History, Build zfb Binary, Type Check, Build Site, HTML validate, Preview Deploy, E2E Tests.
- gcoc review on W2a: clean, no issues.
- Ancestor check: `git -C ~/repos/myoss/zdtp merge-base --is-ancestor 75a567349943a3beb80a209d47f087824f3b82c8 4f9d3799bbf3c08c54cd84b7f0e209745b11493f` → PASS.

## Wave 3 (#1649) follows after merge

W3's `/headless-browser` checks A–D will run on the deployed preview for this PR (Preview 1) and on `main` after W2b merges (Preview 2 — already merged via #1651). 8 data points total. Verdict gates epic closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/1652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->