### PR TITLE
Triage 0513: T1 TOC tweak + T2 page-level tags chip

### DIFF
--- a/packages/zudo-doc-v2/src/toc/__tests__/toc-ssg.test.tsx
+++ b/packages/zudo-doc-v2/src/toc/__tests__/toc-ssg.test.tsx
@@ -45,16 +45,19 @@ describe("Toc — SSG HTML presence", () => {
     expect(html).toContain("Configuration");
   });
 
-  it("renders section title in static HTML", () => {
+  it("does not render a visible title <p> in static HTML (desktop heading removed, issue #1655/T1)", () => {
     const html = render(<Toc headings={SAMPLE_HEADINGS} title="On this page" />);
-    expect(html).toContain("On this page");
+    // Desktop Toc no longer emits a visible heading — the nav landmark is the
+    // accessible section boundary for screen readers.
+    expect(html).not.toContain("On this page");
+    // The aria-label landmark must still be present.
+    expect(html).toContain('aria-label="Table of contents"');
   });
 
-  it("renders locale title even when headings array is empty", () => {
+  it("renders no content when headings array is empty (title <p> absent)", () => {
     const html = render(<Toc headings={[]} title="目次" />);
-    // Title must be present for migration-check parity.
-    expect(html).toContain("目次");
-    // No spurious anchor links when there are no headings.
+    // No visible title and no anchor links when there are no headings.
+    expect(html).not.toContain("目次");
     expect(html).not.toContain('href="#');
   });
 

--- a/packages/zudo-doc-v2/src/toc/toc.tsx
+++ b/packages/zudo-doc-v2/src/toc/toc.tsx
@@ -14,11 +14,10 @@ import { cx } from "./cx";
 export interface TocProps {
   headings: readonly HeadingItem[];
   /**
-   * Section label rendered as a static h2 above the outline list.
-   * Defaults to "On this page" (English). Pass the i18n-resolved
-   * equivalent (e.g. "目次" for Japanese) from the caller so SSG HTML
-   * always contains the correct locale string — required for
-   * migration-check parity on non-EN routes.
+   * Section label used by MobileToc. The desktop Toc no longer renders
+   * a visible heading (issue #1655 / T1) but the prop is kept so callers
+   * can share a single title value for both desktop and mobile surfaces.
+   * Defaults to "On this page" (English).
    */
   title?: string;
 }
@@ -56,10 +55,10 @@ export interface TocProps {
  * historical behavior — the page title (h1) is rendered separately by
  * the layout and h5+ are deemed too granular for the TOC.
  *
- * The section `title` h2 is always rendered even when there are no
- * qualifying headings — this preserves the "On this page" / locale
- * string in the SSG HTML for migration-check parity. When headings are
- * absent the `<ul>` is omitted so no empty list appears to users.
+ * The `title` prop is kept on the signature (MobileToc and callers still
+ * use it) but the desktop Toc no longer renders a visible heading — the
+ * `<nav aria-label="Table of contents">` landmark provides the section
+ * semantics for screen readers. Issue #1655 / T1.
  */
 export function Toc({ headings, title = "On this page" }: TocProps): VNode {
   const filtered = useMemo(
@@ -79,18 +78,8 @@ export function Toc({ headings, title = "On this page" }: TocProps): VNode {
         "h-[calc(100vh-3.5rem)]",
       )}
     >
-      {/* Non-heading label so the TOC title does not appear in the page
-          heading outline. The reference site (takazudomodular.com) emits
-          this as non-heading markup; using <h2> added an extra entry to
-          every doc page's outline and a structural diff vs the reference.
-          The <nav aria-label="Table of contents"> landmark provides the
-          section semantics for screen readers — a heading is redundant.
-          Wave 2 parity fix: zudolab/zudo-doc#1478. */}
-      <p className="mb-vsp-xs pl-hsp-lg text-small font-medium text-fg">
-        {title}
-      </p>
       {filtered.length > 0 && (
-        <ul className="border-l border-muted pl-hsp-lg overflow-y-auto flex-1 min-h-0">
+        <ul className="border-l border-muted pl-hsp-lg overflow-y-auto">
           {filtered.map((heading, index) => {
             const isActive = heading.slug === activeId;
             return (

--- a/pages/[locale]/docs/[...slug].tsx
+++ b/pages/[locale]/docs/[...slug].tsx
@@ -50,6 +50,7 @@ import { FooterWithDefaults } from "../../lib/_footer-with-defaults";
 import { DocHistoryArea } from "../../lib/_doc-history-area";
 import { BodyEndIslands } from "../../lib/_body-end-islands";
 import { DocMetainfoArea } from "../../lib/_doc-metainfo-area";
+import { DocTagsArea } from "../../lib/_doc-tags-area";
 import { SidebarWithDefaults } from "../../lib/_sidebar-with-defaults";
 import { HeaderWithDefaults } from "../../lib/_header-with-defaults";
 import { HeadWithDefaults } from "../../lib/_head-with-defaults";
@@ -355,6 +356,9 @@ export default function LocaleDocsPage({ params, entry, autoIndex, contentDir, i
               Astro `doc-metainfo.astro` placement — between <h1> and description.
               Data from `.zfb/doc-history-meta.json` (esbuild-inlined, no fs). */}
           <DocMetainfoArea slug={slug} locale={locale} />
+
+          {/* Page-level tag chips — mirroring doc-tags.astro placement (#1658). */}
+          <DocTagsArea slug={slug} locale={locale} tags={entry!.data.tags} />
 
           {/* Fallback notice for non-translated pages */}
           {isFallback && !entry!.data.generated && (

--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -49,6 +49,7 @@ import { createMdxComponents } from "../_mdx-components";
 import { FooterWithDefaults } from "../lib/_footer-with-defaults";
 import { DocHistoryArea } from "../lib/_doc-history-area";
 import { DocMetainfoArea } from "../lib/_doc-metainfo-area";
+import { DocTagsArea } from "../lib/_doc-tags-area";
 import { BodyEndIslands } from "../lib/_body-end-islands";
 import { SidebarWithDefaults } from "../lib/_sidebar-with-defaults";
 import { HeaderWithDefaults } from "../lib/_header-with-defaults";
@@ -337,6 +338,9 @@ export default function DocsPage({ entry, autoIndex, breadcrumbs, prev, next, he
               Astro `doc-metainfo.astro` placement — between <h1> and description.
               Data from `.zfb/doc-history-meta.json` (esbuild-inlined, no fs). */}
           <DocMetainfoArea slug={slug} locale={locale} />
+
+          {/* Page-level tag chips — mirroring doc-tags.astro placement (#1658). */}
+          <DocTagsArea slug={slug} locale={locale} tags={entry!.data.tags} />
 
           {entry!.data.description && (
             <p class="mb-vsp-lg text-subheading text-muted">

--- a/pages/lib/_doc-tags-area.tsx
+++ b/pages/lib/_doc-tags-area.tsx
@@ -1,0 +1,89 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+// Locale-aware DocTags area wrapper for the zfb doc pages.
+//
+// Renders the page-level tag chips (e.g. "Tags: #customization") between
+// the DocMetainfo block and the description paragraph, mirroring the
+// position of the legacy `doc-tags.astro` in the Astro layout.
+//
+// Restoration of a Astro→zfb migration regression: the DocTags component
+// was correctly ported into @zudo-doc/zudo-doc-v2/metainfo/doc-tags.tsx
+// but no page template wired it up (#1658, closes #1508).
+//
+// tagHref logic: inlined from _footer-with-defaults.tsx (the `tagHref`
+// helper there). Extraction was considered but would cause ripple in the
+// footer file and its callers — per the spec's "no opportunistic refactor"
+// rule, a local copy is used here instead.
+//
+// i18n: both `doc.tags` and `doc.taggedWith` are confirmed present for all
+// project locales (en, ja, de) in src/config/i18n.ts — no fallback needed.
+
+import type { VNode } from "preact";
+import { settings } from "@/config/settings";
+import { defaultLocale, t } from "@/config/i18n";
+import { withBase } from "@/utils/base";
+import { resolvePageTags } from "@/utils/tags";
+import { DocTags } from "@zudo-doc/zudo-doc-v2/metainfo";
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the base-prefixed tag detail page href for the given locale.
+ *
+ * Inlined from _footer-with-defaults.tsx `tagHref` — not extracted to avoid
+ * ripple (spec rule: no opportunistic refactor on tagHref extraction).
+ */
+function tagHref(tag: string, locale: string): string {
+  const path =
+    locale === defaultLocale
+      ? `/docs/tags/${tag}`
+      : `/${locale}/docs/tags/${tag}`;
+  return withBase(path);
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface DocTagsAreaProps {
+  /** Page slug, e.g. "guides/sidebar". */
+  slug: string;
+  /** Active locale string, e.g. "en", "ja". */
+  locale: string;
+  /** Raw tag strings from the page frontmatter (entry.data.tags). */
+  tags: readonly string[] | undefined;
+}
+
+/**
+ * Renders the page-level tag chip block when `settings.docTags` is enabled
+ * and the page has at least one resolved (non-deprecated) tag.
+ *
+ * Returns null when `docTags` is disabled, the page has no tags, or all
+ * raw tags resolve to deprecated entries.
+ *
+ * Placement is "after-title" to match the legacy `doc-tags.astro` position
+ * (between the date block and description paragraph).
+ */
+export function DocTagsArea({ locale, tags }: DocTagsAreaProps): VNode | null {
+  if (!settings.docTags) return null;
+
+  const rawTags = tags ?? [];
+  const canonicalTags = resolvePageTags(rawTags);
+  if (canonicalTags.length === 0) return null;
+
+  const resolvedTags = canonicalTags.map((tag) => ({
+    tag,
+    href: tagHref(tag, locale),
+  }));
+
+  return (
+    <DocTags
+      placement="after-title"
+      tags={resolvedTags}
+      tagsLabel={t("doc.tags", locale)}
+      taggedWithLabel={t("doc.taggedWith", locale)}
+    />
+  );
+}

--- a/pages/v/[version]/docs/[...slug].tsx
+++ b/pages/v/[version]/docs/[...slug].tsx
@@ -53,6 +53,7 @@ import { HeaderWithDefaults } from "../../../lib/_header-with-defaults";
 import { HeadWithDefaults } from "../../../lib/_head-with-defaults";
 import { DocHistoryArea } from "../../../lib/_doc-history-area";
 import { DocMetainfoArea } from "../../../lib/_doc-metainfo-area";
+import { DocTagsArea } from "../../../lib/_doc-tags-area";
 import { BodyEndIslands } from "../../../lib/_body-end-islands";
 import { buildFrontmatterPreviewEntries } from "../../../lib/_frontmatter-preview-data";
 import { composeMetaTitle } from "../../../lib/_compose-meta-title";
@@ -358,6 +359,9 @@ export default function VersionedDocsPage({ entry, autoIndex, version, breadcrum
               Astro `doc-metainfo.astro` placement — between <h1> and description.
               Data from `.zfb/doc-history-meta.json` (esbuild-inlined, no fs). */}
           <DocMetainfoArea slug={slug} locale={locale} />
+
+          {/* Page-level tag chips — mirroring doc-tags.astro placement (#1658). */}
+          <DocTagsArea slug={slug} locale={locale} tags={entry!.data.tags} />
 
           {entry!.data.description && (
             <p class="mb-vsp-lg text-subheading text-muted">

--- a/pages/v/[version]/ja/docs/[...slug].tsx
+++ b/pages/v/[version]/ja/docs/[...slug].tsx
@@ -52,6 +52,7 @@ import { HeaderWithDefaults } from "../../../../lib/_header-with-defaults";
 import { HeadWithDefaults } from "../../../../lib/_head-with-defaults";
 import { DocHistoryArea } from "../../../../lib/_doc-history-area";
 import { DocMetainfoArea } from "../../../../lib/_doc-metainfo-area";
+import { DocTagsArea } from "../../../../lib/_doc-tags-area";
 import { BodyEndIslands } from "../../../../lib/_body-end-islands";
 import { buildFrontmatterPreviewEntries } from "../../../../lib/_frontmatter-preview-data";
 import { composeMetaTitle } from "../../../../lib/_compose-meta-title";
@@ -387,6 +388,9 @@ export default function VersionedJaDocsPage({ entry, autoIndex, version, isFallb
               Astro `doc-metainfo.astro` placement — between <h1> and description.
               Data from `.zfb/doc-history-meta.json` (esbuild-inlined, no fs). */}
           <DocMetainfoArea slug={slug} locale={locale} />
+
+          {/* Page-level tag chips — mirroring doc-tags.astro placement (#1658). */}
+          <DocTagsArea slug={slug} locale={locale} tags={entry!.data.tags} />
 
           {/* Fallback notice for non-translated pages */}
           {isFallback && !entry!.data.generated && (


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/1656

---

## Summary

Wave 1 of the Triage 0513 epic (#1656). Two file-independent topics shipped in parallel and merged onto `base/triage-0513`:

- **T1 (#1657)** — drop the desktop TOC "On this page" heading and stop the left border from overrunning past the outline list (Closes #1655, conditionally).
- **T2 (#1658)** — restore the page-level `Tags: #foo` chip block that was lost in the Astro → zfb migration; wire `<DocTags>` into all four `[...slug].tsx` page templates via a shared `pages/lib/_doc-tags-area.tsx` wrapper (Closes #1508, conditionally).

`doc-layout.tsx` is intentionally **not** touched — the slot-driven contract is correct, the regression was at the page-template layer.

## Changes

### T1 — TOC tweak

- `packages/zudo-doc-v2/src/toc/toc.tsx` — remove the visible `<p>` "On this page" title node; drop `flex-1 min-h-0` from the inner `<ul>` so the left border ends at the outline list bottom. `overflow-y-auto` and `h-[calc(100vh-3.5rem)]` are kept (load-bearing for sticky-scroll on long-TOC pages). `title` prop kept on the function signature — `MobileToc` still needs it.
- `packages/zudo-doc-v2/src/toc/__tests__/toc-ssg.test.tsx` — assertions updated: the title `<p>` is now expected to be absent while `aria-label="Table of contents"` is preserved.
- No migration-check parity allowlist needed — config already has `stripTocHeadingDom=true` which strips the heading symmetrically from both sides.

### T2 — page-level tags chip

- **New** `pages/lib/_doc-tags-area.tsx` — locale-aware wrapper that reads `entry.data.tags`, canonicalises via `resolvePageTags`, maps to `{ tag, href: tagHref(tag, locale) }` (inline copy of `tagHref` — no opportunistic refactor of `_footer-with-defaults.tsx`), and renders `<DocTags placement="after-title" …>`. Returns `null` when `!settings.docTags` or resolved-tags array is empty.
- `pages/docs/[...slug].tsx`, `pages/[locale]/docs/[...slug].tsx`, `pages/v/[version]/docs/[...slug].tsx`, `pages/v/[version]/ja/docs/[...slug].tsx` — `<DocTagsArea>` inserted between `<DocMetainfoArea>` and the description `<p>` block in the regular-doc branch only. Auto-index branch untouched (no `entry.data.tags` there).
- i18n keys `doc.tags` and `doc.taggedWith` confirmed present for both `en` and `ja` (`タグ付きページ` for JA).

## Test Plan

Local quality gates (run on the merged base branch):

- [x] `pnpm check` — typecheck (one pre-existing TS error in `src/config/design-token-panel-config.ts`, unrelated to this PR).
- [x] `pnpm build` — 200 pages built successfully.
- [x] `pnpm exec vitest run --config packages/zudo-doc-v2/vitest.config.ts` — 389/389 PASS.
- [x] SSG-string probe — built HTML contains `<a href="/pj/zudo-doc/docs/tags/customization/">` on the EN tagged page and `<a href="/pj/zudo-doc/ja/docs/tags/i18n/">` on the JA tagged page.
- [x] `/gcoc-review` (gpt-4.1 reviewer) on the merged diff — clean, no findings.

User visual verification on the preview deployment:

- [ ] `/docs/getting-started/installation/` — short-TOC page; no "On this page" heading; border ends at the bottom of the outline list.
- [ ] A long-TOC page (e.g. `/docs/components/`) — sticky-scroll-inside-TOC still works; TOC does not overflow the right rail.
- [ ] `/docs/guides/sidebar/` — `Tags: #customization` chip is present between metainfo and description.
- [ ] `/ja/docs/guides/i18n/` — `タグ: #i18n` chip is present in the same position.
- [ ] An untagged page renders no chip block.

## Acceptance criteria (from epic #1656)

- [x] Both sub-issues' implementations passing local gates.
- [ ] User visually confirms on deployed preview, then closes #1655 / #1508 (or comments "still failing").
- [x] PR `base/triage-0513` → `base/zfb-migration-parity` ready for review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/1659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->