### PR TITLE
fix(sidebar): widen resize hit area so it survives the y-scrollbar (#1660)

### DIFF
--- a/packages/create-zudo-doc/templates/features/sidebarResizer/files/src/scripts/sidebar-resizer.ts
+++ b/packages/create-zudo-doc/templates/features/sidebarResizer/files/src/scripts/sidebar-resizer.ts
@@ -31,11 +31,15 @@ export function initSidebarResizer() {
   handle.setAttribute("aria-valuemin", String(MIN_W));
   handle.setAttribute("aria-valuemax", String(MAX_W));
   handle.setAttribute("aria-valuenow", String(Math.round(cachedWidth)));
+  // 20px is wider than every common native y-scrollbar (~12-17px on
+  // Win/Linux classic; 0 on macOS overlay) so a draggable strip always remains
+  // visible to the LEFT of the scrollbar when sidebar content overflows.
+  // zudolab/zudo-doc#1660
   Object.assign(handle.style, {
     position: "absolute",
     top: "0",
     right: "0",
-    width: "6px",
+    width: "20px",
     height: "100%",
     cursor: "col-resize",
     zIndex: "10",

--- a/packages/zudo-doc-v2/src/sidebar-resizer/index.ts
+++ b/packages/zudo-doc-v2/src/sidebar-resizer/index.ts
@@ -98,11 +98,15 @@ export function initSidebarResizer(): void {
   handle.setAttribute("aria-valuemin", String(MIN_W));
   handle.setAttribute("aria-valuemax", String(MAX_W));
   handle.setAttribute("aria-valuenow", String(Math.round(cachedWidth)));
+  // 20px is wider than every common native y-scrollbar (~12-17px on
+  // Win/Linux classic; 0 on macOS overlay) so a draggable strip always remains
+  // visible to the LEFT of the scrollbar when sidebar content overflows.
+  // zudolab/zudo-doc#1660
   Object.assign(handle.style, {
     position: "absolute",
     top: "0",
     right: "0",
-    width: "6px",
+    width: "20px",
     height: "100%",
     cursor: "col-resize",
     zIndex: "10",

--- a/packages/zudo-doc-v2/src/sidebar-resizer/sidebar-resizer-init.tsx
+++ b/packages/zudo-doc-v2/src/sidebar-resizer/sidebar-resizer-init.tsx
@@ -55,7 +55,9 @@ export const SIDEBAR_RESIZER_INIT_SCRIPT = `(function(){
     handle.setAttribute("aria-valuemin",String(MIN_W));
     handle.setAttribute("aria-valuemax",String(MAX_W));
     handle.setAttribute("aria-valuenow",String(Math.round(cachedWidth)));
-    Object.assign(handle.style,{position:"absolute",top:"0",right:"0",width:"6px",height:"100%",cursor:"col-resize",zIndex:"10",transition:"background 0.15s"});
+    // 20px hit area > native y-scrollbar (~12-17px) so a draggable strip stays
+    // visible to the LEFT of the scrollbar when sidebar overflows. zudolab/zudo-doc#1660
+    Object.assign(handle.style,{position:"absolute",top:"0",right:"0",width:"20px",height:"100%",cursor:"col-resize",zIndex:"10",transition:"background 0.15s"});
 
     var dragging=false,focused=false;
 

--- a/src/scripts/sidebar-resizer.ts
+++ b/src/scripts/sidebar-resizer.ts
@@ -31,11 +31,15 @@ export function initSidebarResizer() {
   handle.setAttribute("aria-valuemin", String(MIN_W));
   handle.setAttribute("aria-valuemax", String(MAX_W));
   handle.setAttribute("aria-valuenow", String(Math.round(cachedWidth)));
+  // 20px is wider than every common native y-scrollbar (~12-17px on
+  // Win/Linux classic; 0 on macOS overlay) so a draggable strip always remains
+  // visible to the LEFT of the scrollbar when sidebar content overflows.
+  // zudolab/zudo-doc#1660
   Object.assign(handle.style, {
     position: "absolute",
     top: "0",
     right: "0",
-    width: "6px",
+    width: "20px",
     height: "100%",
     cursor: "col-resize",
     zIndex: "10",


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/1660
- parent PR
    - https://github.com/zudolab/zudo-doc/pull/669

---

## Summary

Fixes zudolab/zudo-doc#1660 — the sidebar's 6px right-edge resize handle was fully occluded by the native vertical scrollbar (~12-17px wide on Win/Linux classic) when the sidebar's content overflowed, leaving the sidebar non-resizable in exactly the case users most want to widen it.

## Approach

Widen the resize handle's hit area from 6px → 20px. 20px is wider than every common native y-scrollbar, so a draggable strip always remains visible to the LEFT of the scrollbar.

The visible hover/focus accent band thickens correspondingly — an acceptable trade-off and arguably clearer drag affordance. (The handle is invisible by default; the change only affects the on-hover / drag state and the keyboard-focus outline.)

## Changes

Updated all four mirrored copies of the resizer so the fix is consistent everywhere:

- `packages/zudo-doc-v2/src/sidebar-resizer/sidebar-resizer-init.tsx` — the **inline `<script>` string that actually runs at runtime** on every doc page
- `packages/zudo-doc-v2/src/sidebar-resizer/index.ts` — the canonical TS source (kept in sync with the inline script)
- `src/scripts/sidebar-resizer.ts` — Astro-era leftover (dead code post-zfb-migration, but kept in sync per project drift policy)
- `packages/create-zudo-doc/templates/features/sidebarResizer/files/src/scripts/sidebar-resizer.ts` — template copied to scaffolded downstream projects

Each diff is the same one-line change (`width: "6px"` → `width: "20px"`) plus a short comment citing the issue.

## Test Plan

- [x] `pnpm check:template-drift` — passes
- [x] `pnpm build` — emitted `dist/**/*.html` contains `width:"20px"` (verified `dist/docs/guides/tags-suggest/index.html` and `dist/ja/docs/guides/tag-governance/index.html`)
- [ ] Smoke on the deployed preview: on a doc page where the sidebar overflows, the resize handle is grabbable in the leftmost ~5px of the right edge (i.e., immediately to the left of the scrollbar)
- [ ] No regression when the sidebar has no scrollbar — handle works identically to before (just slightly thicker on hover)

`pnpm check` (TypeScript) was not run as part of this PR — it currently fails on `src/config/design-token-panel-config.ts` on the `base/zfb-migration-parity` branch as well, i.e., this is a pre-existing in-flight item on the parent branch, unrelated to this change.

<!-- codesmith:footer -->
---
<a href=\"https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/1661\"><picture><source media=\"(prefers-color-scheme: dark)\" srcset=\"https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg\"><source media=\"(prefers-color-scheme: light)\" srcset=\"https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg\"><img alt=\"View in Codesmith\" src=\"https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg\"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->