### PR TITLE
fix(sidebar): commit dragend even if lostpointercapture wins race

### DIFF
--- a/packages/create-zudo-doc/templates/features/sidebarResizer/files/src/scripts/sidebar-resizer.ts
+++ b/packages/create-zudo-doc/templates/features/sidebarResizer/files/src/scripts/sidebar-resizer.ts
@@ -129,6 +129,7 @@ export function initSidebarResizer() {
     ghost.style.left = (sidebarLeft + sidebarRect.width) + "px";
     document.body.appendChild(ghost);
     let targetWidth = 0;
+    let cleaned = false;
 
     const onMove = (ev: PointerEvent) => {
       targetWidth = Math.max(MIN_W, Math.min(MAX_W, ev.clientX - sidebarLeft));
@@ -136,6 +137,8 @@ export function initSidebarResizer() {
     };
 
     const cleanup = () => {
+      if (cleaned) return;
+      cleaned = true;
       dragging = false;
       updateHandleVisual();
       document.documentElement.style.cursor = "";
@@ -144,17 +147,30 @@ export function initSidebarResizer() {
       handle.removeEventListener("pointermove", onMove);
       handle.removeEventListener("pointerup", onUp);
       handle.removeEventListener("pointercancel", onCancel);
-      handle.removeEventListener("lostpointercapture", onCancel);
+      handle.removeEventListener("lostpointercapture", onLost);
     };
 
-    const onUp = (ev: PointerEvent) => {
-      handle.releasePointerCapture(ev.pointerId);
+    const commit = () => {
+      if (targetWidth > 0) applyWidth(targetWidth);
+    };
+
+    // pointerup: normal end-of-drag. Commit, then teardown.
+    const onUp = () => {
+      commit();
       cleanup();
-      if (targetWidth > 0) {
-        applyWidth(targetWidth);
-      }
     };
 
+    // lostpointercapture: per spec fires AFTER pointerup, but browsers reorder
+    // these in edge cases (cursor near y-scrollbar, fast drags, OS handoff).
+    // Commit here too so a real drag still applies if pointerup is dropped.
+    // Idempotent with onUp via the `cleaned` guard.
+    const onLost = () => {
+      commit();
+      cleanup();
+    };
+
+    // pointercancel: actual user/OS cancellation (touch interrupted, etc.).
+    // Do NOT commit — caller intent was to abort.
     const onCancel = () => {
       cleanup();
     };
@@ -162,7 +178,7 @@ export function initSidebarResizer() {
     handle.addEventListener("pointermove", onMove);
     handle.addEventListener("pointerup", onUp);
     handle.addEventListener("pointercancel", onCancel);
-    handle.addEventListener("lostpointercapture", onCancel);
+    handle.addEventListener("lostpointercapture", onLost);
   });
 
   sidebar.appendChild(handle);

--- a/packages/zudo-doc-v2/src/sidebar-resizer/index.ts
+++ b/packages/zudo-doc-v2/src/sidebar-resizer/index.ts
@@ -202,6 +202,7 @@ export function initSidebarResizer(): void {
     ghost.style.left = sidebarLeft + sidebarRect.width + "px";
     document.body.appendChild(ghost);
     let targetWidth = 0;
+    let cleaned = false;
 
     const onMove = (ev: PointerEvent) => {
       targetWidth = Math.max(
@@ -212,6 +213,8 @@ export function initSidebarResizer(): void {
     };
 
     const cleanup = () => {
+      if (cleaned) return;
+      cleaned = true;
       dragging = false;
       updateHandleVisual();
       document.documentElement.style.cursor = "";
@@ -220,17 +223,30 @@ export function initSidebarResizer(): void {
       handle.removeEventListener("pointermove", onMove);
       handle.removeEventListener("pointerup", onUp);
       handle.removeEventListener("pointercancel", onCancel);
-      handle.removeEventListener("lostpointercapture", onCancel);
+      handle.removeEventListener("lostpointercapture", onLost);
     };
 
-    const onUp = (ev: PointerEvent) => {
-      handle.releasePointerCapture(ev.pointerId);
+    const commit = () => {
+      if (targetWidth > 0) applyWidth(targetWidth);
+    };
+
+    // pointerup: normal end-of-drag. Commit, then teardown.
+    const onUp = () => {
+      commit();
       cleanup();
-      if (targetWidth > 0) {
-        applyWidth(targetWidth);
-      }
     };
 
+    // lostpointercapture: per spec fires AFTER pointerup, but browsers reorder
+    // these in edge cases (cursor near y-scrollbar, fast drags, OS handoff).
+    // Commit here too so a real drag still applies if pointerup is dropped.
+    // Idempotent with onUp via the `cleaned` guard.
+    const onLost = () => {
+      commit();
+      cleanup();
+    };
+
+    // pointercancel: actual user/OS cancellation (touch interrupted, etc.).
+    // Do NOT commit — caller intent was to abort.
     const onCancel = () => {
       cleanup();
     };
@@ -238,7 +254,7 @@ export function initSidebarResizer(): void {
     handle.addEventListener("pointermove", onMove);
     handle.addEventListener("pointerup", onUp);
     handle.addEventListener("pointercancel", onCancel);
-    handle.addEventListener("lostpointercapture", onCancel);
+    handle.addEventListener("lostpointercapture", onLost);
   });
 
   sidebar.appendChild(handle);

--- a/packages/zudo-doc-v2/src/sidebar-resizer/sidebar-resizer-init.tsx
+++ b/packages/zudo-doc-v2/src/sidebar-resizer/sidebar-resizer-init.tsx
@@ -98,8 +98,10 @@ export const SIDEBAR_RESIZER_INIT_SCRIPT = `(function(){
       ghost.style.left=sidebarLeft+sidebarRect.width+"px";
       document.body.appendChild(ghost);
       var targetWidth=0;
+      var cleaned=false;
       function onMove(ev){targetWidth=Math.max(MIN_W,Math.min(MAX_W,ev.clientX-sidebarLeft));ghost.style.left=sidebarLeft+targetWidth+"px";}
       function cleanup(){
+        if(cleaned)return;cleaned=true;
         dragging=false;updateHandleVisual();
         document.documentElement.style.cursor="";
         document.documentElement.style.userSelect="";
@@ -107,14 +109,23 @@ export const SIDEBAR_RESIZER_INIT_SCRIPT = `(function(){
         handle.removeEventListener("pointermove",onMove);
         handle.removeEventListener("pointerup",onUp);
         handle.removeEventListener("pointercancel",onCancel);
-        handle.removeEventListener("lostpointercapture",onCancel);
+        handle.removeEventListener("lostpointercapture",onLost);
       }
-      function onUp(ev){handle.releasePointerCapture(ev.pointerId);cleanup();if(targetWidth>0)applyWidth(targetWidth);}
+      function commit(){if(targetWidth>0)applyWidth(targetWidth);}
+      // pointerup: normal end-of-drag. Commit then teardown.
+      function onUp(){commit();cleanup();}
+      // lostpointercapture: per spec fires AFTER pointerup, but browsers reorder
+      // these in edge cases (cursor near y-scrollbar, fast drags, OS handoff).
+      // Commit here too so a real drag still applies if pointerup is dropped.
+      // Idempotent with onUp via the cleaned guard.
+      function onLost(){commit();cleanup();}
+      // pointercancel: actual user/OS cancellation (touch interrupted, etc.).
+      // Do NOT commit — caller intent was to abort.
       function onCancel(){cleanup();}
       handle.addEventListener("pointermove",onMove);
       handle.addEventListener("pointerup",onUp);
       handle.addEventListener("pointercancel",onCancel);
-      handle.addEventListener("lostpointercapture",onCancel);
+      handle.addEventListener("lostpointercapture",onLost);
     });
     sidebar.appendChild(handle);
   }

--- a/src/scripts/sidebar-resizer.ts
+++ b/src/scripts/sidebar-resizer.ts
@@ -129,6 +129,7 @@ export function initSidebarResizer() {
     ghost.style.left = (sidebarLeft + sidebarRect.width) + "px";
     document.body.appendChild(ghost);
     let targetWidth = 0;
+    let cleaned = false;
 
     const onMove = (ev: PointerEvent) => {
       targetWidth = Math.max(MIN_W, Math.min(MAX_W, ev.clientX - sidebarLeft));
@@ -136,6 +137,8 @@ export function initSidebarResizer() {
     };
 
     const cleanup = () => {
+      if (cleaned) return;
+      cleaned = true;
       dragging = false;
       updateHandleVisual();
       document.documentElement.style.cursor = "";
@@ -144,17 +147,30 @@ export function initSidebarResizer() {
       handle.removeEventListener("pointermove", onMove);
       handle.removeEventListener("pointerup", onUp);
       handle.removeEventListener("pointercancel", onCancel);
-      handle.removeEventListener("lostpointercapture", onCancel);
+      handle.removeEventListener("lostpointercapture", onLost);
     };
 
-    const onUp = (ev: PointerEvent) => {
-      handle.releasePointerCapture(ev.pointerId);
+    const commit = () => {
+      if (targetWidth > 0) applyWidth(targetWidth);
+    };
+
+    // pointerup: normal end-of-drag. Commit, then teardown.
+    const onUp = () => {
+      commit();
       cleanup();
-      if (targetWidth > 0) {
-        applyWidth(targetWidth);
-      }
     };
 
+    // lostpointercapture: per spec fires AFTER pointerup, but browsers reorder
+    // these in edge cases (cursor near y-scrollbar, fast drags, OS handoff).
+    // Commit here too so a real drag still applies if pointerup is dropped.
+    // Idempotent with onUp via the `cleaned` guard.
+    const onLost = () => {
+      commit();
+      cleanup();
+    };
+
+    // pointercancel: actual user/OS cancellation (touch interrupted, etc.).
+    // Do NOT commit — caller intent was to abort.
     const onCancel = () => {
       cleanup();
     };
@@ -162,7 +178,7 @@ export function initSidebarResizer() {
     handle.addEventListener("pointermove", onMove);
     handle.addEventListener("pointerup", onUp);
     handle.addEventListener("pointercancel", onCancel);
-    handle.addEventListener("lostpointercapture", onCancel);
+    handle.addEventListener("lostpointercapture", onLost);
   });
 
   sidebar.appendChild(handle);


### PR DESCRIPTION
## Summary

Follow-up to #1661 (which widened the resize handle to 20px). After that change users reported that **dragend sometimes does not apply the new sidebar width** — intermittent / random-feeling.

## Root cause

The pointerdown handler wired three drag-end events:

- `pointerup` → `onUp` → commits `targetWidth` via `applyWidth(...)`, then cleans up listeners
- `pointercancel` → `onCancel` → cleanup only (no commit)
- `lostpointercapture` → `onCancel` → cleanup only (no commit)

Per the Pointer Events spec, `lostpointercapture` should fire **after** `pointerup`. In practice browsers can reorder these — especially during fast drags, when the pointer crosses the native y-scrollbar (which the wider 20px handle now sits adjacent to), or under capture-loss heuristics. When `lostpointercapture` fires **first**:

1. `onCancel` runs → `cleanup()` removes the `pointerup` listener.
2. `pointerup` arrives → no handler → `applyWidth` never runs.

Result: visible drag, ghost line moved, user releases — and the sidebar snaps back to the previous width. Random because it depends on UA event ordering.

## Fix

- Commit `targetWidth` from **both** `pointerup` and `lostpointercapture`. Keep `pointercancel` as a true cancellation (no commit) — that one really means "user / OS aborted, don't apply".
- Make `cleanup()` idempotent via a `cleaned` flag so duplicate end-events don't fight.
- Drop the redundant explicit `handle.releasePointerCapture(ev.pointerId)` in `onUp` — the browser already releases capture implicitly on `pointerup`, and the explicit call can throw `InvalidPointerId` if capture was released earlier.

Applied identically to all four mirrors of the resizer (matches PR #1661's update pattern):

- `packages/zudo-doc-v2/src/sidebar-resizer/sidebar-resizer-init.tsx` — the inline `dangerouslySetInnerHTML` script that actually runs at runtime
- `packages/zudo-doc-v2/src/sidebar-resizer/index.ts` — source-of-truth TS module
- `src/scripts/sidebar-resizer.ts` — legacy mirror
- `packages/create-zudo-doc/templates/features/sidebarResizer/files/src/scripts/sidebar-resizer.ts` — generator template mirror

## Test Plan

- [x] CI: \`Type Check\` — passes
- [x] CI: \`Template Drift Check\` — passes (mirrors stay in sync)
- [x] CI: \`Build Site\` / \`Build Doc History\` / \`Build zfb Binary\` — all pass
- [x] CI: \`E2E Tests\` — pass
- [x] CI: \`HTML validate\` / \`Preview Deploy\` — pass
- [ ] Manual drag: open \`pnpm dev\`, drag the sidebar handle multiple times in quick succession; every release commits the width
- [ ] Drag past the y-scrollbar area; width still commits
- [ ] Click handle without dragging (zero-move): no width change — click-only is correctly ignored, guarded by \`targetWidth > 0\`
- [ ] Keyboard arrows still adjust width (independent path, untouched)