### PR TITLE
chore(deps): bump zfb + zdtp pins to latest main + setup:upstream bootstrap

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -92,11 +92,11 @@ permissions:
 env:
   # Pinned zfb commit — keep in sync with the zfb pin comment at the
   # top of zfb.config.ts and the same env in pr-checks.yml.
-  ZFB_PINNED_SHA: aa8e9ac7c68786ac90b2ca1628dea3bae54dc57f
+  ZFB_PINNED_SHA: 0f7aa62a21f327c3205d98127ab3be43320350a2
   # Pinned zdtp commit — keep in sync with the zdtp pin block in zfb.config.ts,
   # the file: spec in package.json, and the same env in pr-checks.yml /
   # preview-deploy.yml. All three sources must be bumped together.
-  ZDTP_PINNED_SHA: 4f9d3799bbf3c08c54cd84b7f0e209745b11493f
+  ZDTP_PINNED_SHA: b2882939f4160d6121bceb8991d06e5d6255c6a4
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -74,11 +74,11 @@ env:
   # Pinned zfb commit — keep in sync with the zfb pin comment at the
   # top of zfb.config.ts. Updating the pin here without updating that
   # comment (or vice versa) will silently desync local dev from CI.
-  ZFB_PINNED_SHA: aa8e9ac7c68786ac90b2ca1628dea3bae54dc57f
+  ZFB_PINNED_SHA: 0f7aa62a21f327c3205d98127ab3be43320350a2
   # Pinned zdtp commit — keep in sync with the zdtp pin block in zfb.config.ts,
   # the file: spec in package.json, and the same env in main-deploy.yml /
   # preview-deploy.yml. All three sources must be bumped together.
-  ZDTP_PINNED_SHA: 4f9d3799bbf3c08c54cd84b7f0e209745b11493f
+  ZDTP_PINNED_SHA: b2882939f4160d6121bceb8991d06e5d6255c6a4
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -65,11 +65,11 @@ permissions:
 env:
   # Pinned zfb commit — keep in sync with the zfb pin comment at the
   # top of zfb.config.ts and the same env in pr-checks.yml.
-  ZFB_PINNED_SHA: aa8e9ac7c68786ac90b2ca1628dea3bae54dc57f
+  ZFB_PINNED_SHA: 0f7aa62a21f327c3205d98127ab3be43320350a2
   # Pinned zdtp commit — keep in sync with the zdtp pin block in zfb.config.ts,
   # the file: spec in package.json, and the same env in main-deploy.yml /
   # pr-checks.yml. All three sources must be bumped together.
-  ZDTP_PINNED_SHA: 4f9d3799bbf3c08c54cd84b7f0e209745b11493f
+  ZDTP_PINNED_SHA: b2882939f4160d6121bceb8991d06e5d6255c6a4
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,28 @@ Minimal documentation framework built with zfb, MDX, Tailwind CSS v4, and Preact
 - `pnpm check` — type checking (runs `zfb check`, which delegates to `tsc --noEmit`)
 - `pnpm b4push` — pre-push validation: format check → template drift check → tags audit (`tags:audit --ci`) → design token lint → typecheck → build → link check → preview smoke (E2E parity is parked under E9b until the post-cutover migration window closes)
 
+## First-time setup on a new machine
+
+This project consumes `../zfb` and `../zdtp` as sibling git checkouts via `file:` deps in `package.json`. On a new machine, clone them and build their artifacts before running `pnpm install`.
+
+One command handles everything:
+
+```sh
+pnpm setup:upstream
+```
+
+The script (`scripts/setup-upstream.mjs`):
+
+1. Reads pinned SHAs from `.github/workflows/pr-checks.yml` (`ZFB_PINNED_SHA`, `ZDTP_PINNED_SHA`) — single source of truth.
+2. Clones `../zfb` and `../zdtp` if missing, or checks out the pinned SHA if they already exist.
+3. Refuses to touch a sibling with uncommitted changes (pass `--force-checkout` to override).
+4. Builds artifacts: `cargo build -p zfb --release` for zfb; `pnpm install` + zdtp build for zdtp. Skips if already built at the pinned SHA.
+5. Runs `pnpm install` in this consumer.
+
+**Flags:** `--force-checkout` (discard dirty upstream changes), `--skip-install` (skip final consumer install), `--dry-run` (preview only), `--help`.
+
+See `$HOME/.claude/skills/dev-wip-package-refer/SKILL.md` for the generic pattern this follows.
+
 ## Automation
 
 These run automatically — be aware when working in this repo:

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "zdtp:link": "node scripts/zdtp-link.mjs",
     "// ── Assets ───────────────────────────────────────": "",
     "generate:logo": "pnpm dlx @takazudo/kumiko-gen \"$(node -p \"require('./package.json').name\")-$(date +%s)\" --size 200 --zoom 5 --stroke-width 0.2 --fg \"#000000\" --bg transparent --out public/img/logo.svg",
+    "// ── Setup ───────────────────────────────────────": "",
+    "setup:upstream": "node scripts/setup-upstream.mjs",
     "// ── Skills ──────────────────────────────────────": "",
     "setup:doc-skill": "bash scripts/setup-doc-skill.sh",
     "setup:zudo-doc-wisdom": "bash scripts/setup-zudo-doc-wisdom.sh",

--- a/packages/create-zudo-doc/templates/features/designTokenPanel/files/src/config/design-tokens-manifest.ts
+++ b/packages/create-zudo-doc/templates/features/designTokenPanel/files/src/config/design-tokens-manifest.ts
@@ -4,17 +4,15 @@
  * so they survive the W3-2 deletion of the panel component tree.
  *
  * Imported by:
- *  - src/config/design-token-panel-config.ts  (new zdtp PanelConfig)
- *  - (W3-2: legacy re-export src/components/design-token-tweak/tokens/manifest.ts deleted)
+ *  - src/config/design-token-panel-config.ts  (groups items into TabConfig.tiers)
+ *  - src/utils/design-token-serde.ts          (cssVar ↔ id lookup for JSON I/O)
  *
- * Type strategy: the zdtp `TokenDef` interface (group: string) and the local
- * legacy `TokenDef` interface (group: TokenGroup closed union) are structurally
- * compatible — every group value in the arrays is a member of both. Arrays are
- * typed using the zdtp `TokenDef` so `design-token-panel-config.ts` can pass
- * them directly to `PanelConfig.tokens` without any cast. The legacy
- * `manifest.ts` re-exports them; TypeScript allows assigning `TokenDef[]`
- * (group: string) elements to the local narrower union via assignment since all
- * literal group values satisfy both types.
+ * Type strategy: arrays are typed `readonly TokenDef[]` for back-compat with
+ * the consumer serde and tests. `design-token-panel-config.ts` partitions the
+ * flat arrays by the `group` field into the new zdtp `TabConfig.tiers` shape.
+ * `TokenDef.advanced` was dropped upstream (zdtp 8abb1e4) — items previously
+ * gated behind an "Advanced" disclosure now live in their own tier ("Scale —
+ * advanced") so the tier acts as the disclosure container.
  */
 import type { TokenDef } from "@takazudo/zudo-design-token-panel";
 
@@ -70,9 +68,14 @@ export const SPACING_TOKENS: readonly TokenDef[] = [
  * Font tokens from `global.css`.
  *
  * Tier 2 semantic tokens (sizes, line-heights, weights, families) are exposed
- * as primary rows; Tier 1 abstract scale (`--text-scale-*`) is surfaced under
- * an Advanced disclosure so designers who tweak the scale see the tokens that
- * the semantic sizes resolve from.
+ * as primary tiers; Tier 1 abstract scale (`--text-scale-*`) lives in its own
+ * `font-scale` tier so designers who tweak the scale see the tokens that the
+ * semantic sizes resolve from.
+ *
+ * (Note: `TokenDef.advanced` was dropped upstream in zdtp 8abb1e4. The
+ * progressive-disclosure container is now the tier itself; the
+ * panel-config groups by `group` and presents each tier as a separate
+ * section under the Font tab.)
  *
  * Defaults mirror `global.css` resolved values: font-size tokens are recorded
  * as their resolved rem (`--text-body` → `1.2rem`) rather than their `var()`
@@ -104,14 +107,15 @@ export const FONT_TOKENS: readonly TokenDef[] = [
   { id: "font-sans", cssVar: "--font-sans", label: "font-sans", group: "font-family", default: "system-ui, sans-serif",    min: 0, max: 0, step: 1, unit: "", control: "text" },
   { id: "font-mono", cssVar: "--font-mono", label: "font-mono", group: "font-family", default: "ui-monospace, monospace",  min: 0, max: 0, step: 1, unit: "", control: "text" },
 
-  // --- Advanced: Tier 1 abstract scale (reveals behind <details>) ---
-  { id: "text-scale-2xs", cssVar: "--text-scale-2xs", label: "text-scale-2xs", group: "font-scale", default: "0.75rem",  min: 0.5, max: 5, step: 0.05, unit: "rem", advanced: true },
-  { id: "text-scale-xs",  cssVar: "--text-scale-xs",  label: "text-scale-xs",  group: "font-scale", default: "0.875rem", min: 0.5, max: 5, step: 0.05, unit: "rem", advanced: true },
-  { id: "text-scale-sm",  cssVar: "--text-scale-sm",  label: "text-scale-sm",  group: "font-scale", default: "1rem",     min: 0.5, max: 5, step: 0.05, unit: "rem", advanced: true },
-  { id: "text-scale-md",  cssVar: "--text-scale-md",  label: "text-scale-md",  group: "font-scale", default: "1.2rem",   min: 0.5, max: 5, step: 0.05, unit: "rem", advanced: true },
-  { id: "text-scale-lg",  cssVar: "--text-scale-lg",  label: "text-scale-lg",  group: "font-scale", default: "1.4rem",   min: 0.5, max: 5, step: 0.05, unit: "rem", advanced: true },
-  { id: "text-scale-xl",  cssVar: "--text-scale-xl",  label: "text-scale-xl",  group: "font-scale", default: "3rem",     min: 0.5, max: 5, step: 0.05, unit: "rem", advanced: true },
-  { id: "text-scale-2xl", cssVar: "--text-scale-2xl", label: "text-scale-2xl", group: "font-scale", default: "3.75rem",  min: 0.5, max: 5, step: 0.05, unit: "rem", advanced: true },
+  // --- Tier 1 abstract scale (was "Advanced" disclosure in v1 of the panel;
+  //     now lives in its own font-scale tier). ---
+  { id: "text-scale-2xs", cssVar: "--text-scale-2xs", label: "text-scale-2xs", group: "font-scale", default: "0.75rem",  min: 0.5, max: 5, step: 0.05, unit: "rem" },
+  { id: "text-scale-xs",  cssVar: "--text-scale-xs",  label: "text-scale-xs",  group: "font-scale", default: "0.875rem", min: 0.5, max: 5, step: 0.05, unit: "rem" },
+  { id: "text-scale-sm",  cssVar: "--text-scale-sm",  label: "text-scale-sm",  group: "font-scale", default: "1rem",     min: 0.5, max: 5, step: 0.05, unit: "rem" },
+  { id: "text-scale-md",  cssVar: "--text-scale-md",  label: "text-scale-md",  group: "font-scale", default: "1.2rem",   min: 0.5, max: 5, step: 0.05, unit: "rem" },
+  { id: "text-scale-lg",  cssVar: "--text-scale-lg",  label: "text-scale-lg",  group: "font-scale", default: "1.4rem",   min: 0.5, max: 5, step: 0.05, unit: "rem" },
+  { id: "text-scale-xl",  cssVar: "--text-scale-xl",  label: "text-scale-xl",  group: "font-scale", default: "3rem",     min: 0.5, max: 5, step: 0.05, unit: "rem" },
+  { id: "text-scale-2xl", cssVar: "--text-scale-2xl", label: "text-scale-2xl", group: "font-scale", default: "3.75rem",  min: 0.5, max: 5, step: 0.05, unit: "rem" },
 ];
 
 /**
@@ -161,8 +165,10 @@ export const SIZE_TOKENS: readonly TokenDef[] = [
 ];
 
 /**
- * Color tokens — empty because color is cluster-driven in zudo-doc.
- * zdtp uses `colorCluster` for all color editing; this array satisfies the
- * `TokenManifest.color` field requirement.
+ * Color tokens — kept as an empty array for back-compat with the consumer
+ * serde, which historically iterated `COLOR_TOKENS` symmetric with the other
+ * three arrays. Color is cluster-driven in zudo-doc and is constructed in
+ * `design-token-panel-config.ts` from `colorSchemes` + `SEMANTIC_*` —
+ * not from this array.
  */
 export const COLOR_TOKENS: readonly TokenDef[] = [];

--- a/scripts/setup-upstream.mjs
+++ b/scripts/setup-upstream.mjs
@@ -1,0 +1,449 @@
+#!/usr/bin/env node
+// Bootstrap script for multi-machine consistency.
+//
+// Ensures all `file:../{upstream}/...` sibling dependencies are:
+//   1. Cloned at the pinned SHA (from pr-checks.yml env vars)
+//   2. Built (Rust binary for zfb, dist/ for zdtp)
+//   3. Followed by a `pnpm install` in this consumer
+//
+// Canonical workflow: on a new machine, run `pnpm setup:upstream` once.
+// See CLAUDE.md "First-time setup on a new machine" for details.
+//
+// DO NOT add this to postinstall — the script runs `pnpm install` itself
+// and would create an infinite loop.
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// ---------------------------------------------------------------------------
+// Upstream config
+// ---------------------------------------------------------------------------
+
+const UPSTREAMS = {
+  zfb: {
+    url: "https://github.com/Takazudo/zudo-front-builder.git",
+    // env var name in .github/workflows/pr-checks.yml
+    shaEnvVar: "ZFB_PINNED_SHA",
+    // path relative to sibling root to check if build is present
+    buildCheckPath: "target/release/zfb",
+    build: {
+      // single command: cargo build -p zfb --release
+      type: "single",
+      cmd: "cargo",
+      args: ["build", "-p", "zfb", "--release"],
+    },
+  },
+  zdtp: {
+    url: "https://github.com/Takazudo/zudo-design-token-panel.git",
+    shaEnvVar: "ZDTP_PINNED_SHA",
+    // directory relative to sibling root to check if build is present
+    buildCheckPath: "packages/zudo-design-token-panel/dist",
+    build: {
+      // two sequential commands
+      type: "sequence",
+      cmds: [
+        { cmd: "pnpm", args: ["install"] },
+        { cmd: "pnpm", args: ["--filter", "@takazudo/zudo-design-token-panel", "build"] },
+      ],
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+const args = process.argv.slice(2);
+
+if (args.includes("--help") || args.includes("-h")) {
+  printHelp();
+  process.exit(0);
+}
+
+const DRY_RUN = args.includes("--dry-run");
+const FORCE_CHECKOUT = args.includes("--force-checkout");
+const SKIP_INSTALL = args.includes("--skip-install");
+
+function printHelp() {
+  console.log(`
+pnpm setup:upstream — Bootstrap sibling upstream repos for local development
+
+USAGE
+  pnpm setup:upstream [flags]
+
+WHAT IT DOES
+  1. Reads file:../ deps from package.json to discover sibling upstreams
+  2. Reads pinned SHAs from .github/workflows/pr-checks.yml
+  3. For each upstream:
+     - Clones it if missing
+     - Checks out the pinned SHA (refuses if tree is dirty, unless --force-checkout)
+     - Builds artifacts if not already built at that SHA
+  4. Runs pnpm install in this consumer (unless --skip-install)
+
+FLAGS
+  --force-checkout   Override dirty-tree safety check (discards uncommitted upstream work)
+  --skip-install     Do everything except the final consumer pnpm install
+  --dry-run          Print what would happen without actually doing anything
+  --help, -h         Print this message and exit
+
+SIBLING LAYOUT
+  ../zfb   — Takazudo/zudo-front-builder (zfb Rust CLI + npm packages)
+  ../zdtp  — Takazudo/zudo-design-token-panel (zdtp dist/)
+`.trim());
+}
+
+// ---------------------------------------------------------------------------
+// Shell execution helper — all subprocess calls go through here
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a command. In dry-run mode, prints the command and returns { skipped: true }.
+ * Returns { ok: true } on success, { ok: false, error } on failure.
+ */
+function run(cmd, args, { cwd = process.cwd(), label = "" } = {}) {
+  const displayCmd = [cmd, ...args].join(" ");
+  const displayCwd = cwd;
+  if (DRY_RUN) {
+    console.log(`  [dry-run] $ ${displayCmd}  (in ${displayCwd})`);
+    return { skipped: true };
+  }
+  if (label) console.log(`  $ ${displayCmd}  (in ${displayCwd})`);
+  try {
+    execFileSync(cmd, args, {
+      cwd,
+      stdio: "inherit",
+      env: process.env,
+    });
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err.message };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Git helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the current HEAD SHA in a git repo, or null on failure.
+ */
+function gitHead(repoPath) {
+  const result = spawnSync("git", ["-C", repoPath, "rev-parse", "HEAD"], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) return null;
+  return result.stdout.trim();
+}
+
+/**
+ * Returns true if the repo has uncommitted changes to tracked files.
+ * Ignores untracked files — build artifacts (target/, dist/) are gitignored
+ * and shouldn't trigger the dirty check.
+ */
+function isRepoDirty(repoPath) {
+  const result = spawnSync(
+    "git",
+    ["-C", repoPath, "status", "--porcelain", "--untracked-files=no"],
+    { encoding: "utf8" },
+  );
+  if (result.status !== 0) return false; // can't tell — treat as clean
+  return result.stdout.trim().length > 0;
+}
+
+// ---------------------------------------------------------------------------
+// SHA extraction from pr-checks.yml
+// ---------------------------------------------------------------------------
+
+function readPinnedShas(projectRoot) {
+  const workflowPath = resolve(projectRoot, ".github/workflows/pr-checks.yml");
+  let content;
+  try {
+    content = readFileSync(workflowPath, "utf8");
+  } catch (err) {
+    throw new Error(`Cannot read ${workflowPath}: ${err.message}`);
+  }
+  const shas = {};
+  for (const [key, cfg] of Object.entries(UPSTREAMS)) {
+    // Match workflow-level env block lines: "  ZFB_PINNED_SHA: <40-char-sha>"
+    const pattern = new RegExp(`^\\s*${cfg.shaEnvVar}:\\s*([0-9a-f]{40})\\s*$`, "m");
+    const match = content.match(pattern);
+    if (!match) {
+      throw new Error(`Could not find ${cfg.shaEnvVar} in ${workflowPath}`);
+    }
+    shas[key] = match[1];
+  }
+  return shas;
+}
+
+// ---------------------------------------------------------------------------
+// file: dep discovery
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads package.json and returns a map of upstream name → sibling dir name.
+ * e.g. { zfb: "../zfb", zdtp: "../zdtp" }
+ * Only includes upstreams that match the UPSTREAMS keys.
+ */
+function discoverSiblings(projectRoot) {
+  let pkg;
+  try {
+    pkg = JSON.parse(readFileSync(resolve(projectRoot, "package.json"), "utf8"));
+  } catch (err) {
+    throw new Error(`Cannot read package.json: ${err.message}`);
+  }
+  const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
+  const found = new Set();
+  for (const spec of Object.values(allDeps)) {
+    if (typeof spec !== "string" || !spec.startsWith("file:../")) continue;
+    // "file:../zfb/packages/zfb" → "../zfb"
+    const parts = spec.slice("file:".length).split("/");
+    const siblingRef = `${parts[0]}/${parts[1]}`; // e.g. "../zfb"
+    // Strip ".." to get the dir name, match against UPSTREAMS keys
+    const name = parts[1]; // "zfb" or "zdtp"
+    if (UPSTREAMS[name]) found.add(name);
+  }
+  return found;
+}
+
+// ---------------------------------------------------------------------------
+// Per-upstream logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Process one upstream. Returns a status object describing what happened.
+ */
+async function processUpstream(name, cfg, { projectRoot, pinnedSha }) {
+  const siblingPath = resolve(projectRoot, `../${name}`);
+  const status = {
+    name,
+    siblingPath,
+    pinnedSha,
+    action: "unknown",
+    buildAction: "unknown",
+    error: null,
+  };
+
+  console.log(`\n[setup:upstream] === ${name} ===`);
+  console.log(`  URL:        ${cfg.url}`);
+  console.log(`  Pinned SHA: ${pinnedSha}`);
+  console.log(`  Local path: ${siblingPath}`);
+
+  // ── 1. Ensure the repo exists ──────────────────────────────────────────
+  if (!existsSync(siblingPath)) {
+    console.log(`  Not found — cloning...`);
+    if (DRY_RUN) {
+      console.log(`  [dry-run] $ git clone ${cfg.url} ${siblingPath}`);
+      console.log(`  [dry-run] $ git -C ${siblingPath} checkout ${pinnedSha}`);
+      status.action = "would-clone";
+      status.buildAction = "would-build";
+      return status;
+    }
+    const cloneResult = run("git", ["clone", cfg.url, siblingPath]);
+    if (!cloneResult.ok) {
+      status.action = "clone-failed";
+      status.error = cloneResult.error;
+      return status;
+    }
+    const checkoutResult = run("git", ["-C", siblingPath, "checkout", pinnedSha]);
+    if (!checkoutResult.ok) {
+      status.action = "checkout-failed";
+      status.error = checkoutResult.error;
+      return status;
+    }
+    status.action = "cloned";
+  } else {
+    // ── 2. Repo exists — check HEAD and tree cleanliness ────────────────
+    const currentHead = gitHead(siblingPath);
+    console.log(`  Current HEAD: ${currentHead ?? "(unknown)"}`);
+
+    if (currentHead === pinnedSha) {
+      console.log(`  Already at pinned SHA.`);
+      status.action = "up-to-date";
+    } else {
+      // Need to switch SHA
+      const dirty = isRepoDirty(siblingPath);
+      if (dirty && !FORCE_CHECKOUT) {
+        const msg =
+          `  ERROR: ${siblingPath} has uncommitted changes to tracked files.\n` +
+          `  Resolve them first, or pass --force-checkout to discard them.`;
+        console.error(msg);
+        status.action = "refused-dirty";
+        status.error = "dirty tree";
+        return status;
+      }
+      if (dirty && FORCE_CHECKOUT) {
+        console.log(`  Dirty tree detected — force-checkout requested, proceeding.`);
+      }
+      console.log(`  Fetching + checking out pinned SHA...`);
+      const fetchResult = run("git", ["-C", siblingPath, "fetch", "origin"]);
+      if (!fetchResult.ok && !fetchResult.skipped) {
+        status.action = "fetch-failed";
+        status.error = fetchResult.error;
+        return status;
+      }
+      const checkoutArgs = FORCE_CHECKOUT
+        ? ["-C", siblingPath, "checkout", "-f", pinnedSha]
+        : ["-C", siblingPath, "checkout", pinnedSha];
+      const checkoutResult = run("git", checkoutArgs);
+      if (!checkoutResult.ok && !checkoutResult.skipped) {
+        status.action = "checkout-failed";
+        status.error = checkoutResult.error;
+        return status;
+      }
+      status.action = DRY_RUN ? "would-checkout" : "checked-out";
+    }
+  }
+
+  // ── 3. Build artifacts if needed ────────────────────────────────────────
+  const buildCheckFull = resolve(siblingPath, cfg.buildCheckPath);
+  // Read HEAD from disk (read-only; safe in dry-run too). For repos that were
+  // just would-cloned in dry-run mode, siblingPath doesn't exist yet, so fall
+  // back to pinnedSha to let the rest of the logic reason about the ideal state.
+  const headAfterCheckout = existsSync(siblingPath) ? gitHead(siblingPath) : pinnedSha;
+  const buildAlreadyPresent = existsSync(buildCheckFull);
+  const headMatchesPinned = headAfterCheckout === pinnedSha;
+
+  if (buildAlreadyPresent && headMatchesPinned) {
+    console.log(`  Build artifact present and HEAD matches pinned SHA — skipping build.`);
+    status.buildAction = "skipped";
+  } else {
+    if (DRY_RUN) {
+      if (!buildAlreadyPresent) {
+        console.log(`  [dry-run] Build artifact not found — would build ${name}.`);
+      } else {
+        console.log(`  [dry-run] HEAD differs from pinned SHA — would rebuild ${name}.`);
+      }
+      if (cfg.build.type === "single") {
+        console.log(`  [dry-run] $ ${cfg.build.cmd} ${cfg.build.args.join(" ")}  (in ${siblingPath})`);
+      } else {
+        for (const { cmd, args } of cfg.build.cmds) {
+          console.log(`  [dry-run] $ ${cmd} ${args.join(" ")}  (in ${siblingPath})`);
+        }
+      }
+      status.buildAction = "would-build";
+      return status;
+    }
+
+    if (!buildAlreadyPresent) {
+      console.log(`  Build artifact not found — building...`);
+    } else {
+      console.log(`  HEAD changed — rebuilding...`);
+    }
+
+    if (cfg.build.type === "single") {
+      const result = run(cfg.build.cmd, cfg.build.args, { cwd: siblingPath });
+      if (!result.ok) {
+        status.buildAction = "build-failed";
+        status.error = result.error;
+        return status;
+      }
+    } else {
+      for (const { cmd, args } of cfg.build.cmds) {
+        const result = run(cmd, args, { cwd: siblingPath });
+        if (!result.ok) {
+          status.buildAction = "build-failed";
+          status.error = result.error;
+          return status;
+        }
+      }
+    }
+    status.buildAction = "built";
+  }
+
+  return status;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const projectRoot = process.cwd();
+
+  console.log("[setup:upstream] Starting upstream bootstrap");
+  if (DRY_RUN) console.log("[setup:upstream] DRY-RUN mode — no changes will be made");
+  if (FORCE_CHECKOUT) console.log("[setup:upstream] FORCE-CHECKOUT mode — dirty trees will be discarded");
+  if (SKIP_INSTALL) console.log("[setup:upstream] SKIP-INSTALL mode — final pnpm install will be skipped");
+
+  // Discover which upstreams are referenced by this consumer's package.json
+  let discovered;
+  try {
+    discovered = discoverSiblings(projectRoot);
+  } catch (err) {
+    console.error(`[setup:upstream] ERROR: ${err.message}`);
+    process.exit(1);
+  }
+  if (discovered.size === 0) {
+    console.log("[setup:upstream] No file:../<upstream> deps found in package.json — nothing to do.");
+    process.exit(0);
+  }
+  console.log(`[setup:upstream] Discovered upstreams: ${[...discovered].join(", ")}`);
+
+  // Read pinned SHAs from workflow file
+  let pinnedShas;
+  try {
+    pinnedShas = readPinnedShas(projectRoot);
+  } catch (err) {
+    console.error(`[setup:upstream] ERROR: ${err.message}`);
+    process.exit(1);
+  }
+
+  // Process each upstream
+  const results = [];
+  let anyError = false;
+  for (const name of discovered) {
+    const cfg = UPSTREAMS[name];
+    const pinnedSha = pinnedShas[name];
+    try {
+      const status = await processUpstream(name, cfg, { projectRoot, pinnedSha });
+      results.push(status);
+      if (status.error) anyError = true;
+    } catch (err) {
+      console.error(`[setup:upstream] Unexpected error processing ${name}: ${err.message}`);
+      results.push({ name, action: "error", buildAction: "skipped", error: err.message });
+      anyError = true;
+    }
+  }
+
+  // Consumer pnpm install
+  let installStatus = "skipped";
+  if (!SKIP_INSTALL && !anyError) {
+    console.log(`\n[setup:upstream] Running pnpm install in consumer...`);
+    const result = run("pnpm", ["install"], { cwd: projectRoot });
+    if (result.skipped) {
+      installStatus = "dry-run";
+    } else if (result.ok) {
+      installStatus = "ok";
+    } else {
+      installStatus = "failed";
+      anyError = true;
+    }
+  } else if (anyError) {
+    console.log(`\n[setup:upstream] Skipping pnpm install — upstream errors must be resolved first.`);
+    installStatus = "skipped-due-to-errors";
+  } else {
+    console.log(`\n[setup:upstream] pnpm install skipped (--skip-install).`);
+  }
+
+  // Summary
+  console.log(`\n[setup:upstream] ═══ Summary ═══`);
+  for (const r of results) {
+    const build = r.buildAction;
+    const repo = r.action;
+    const errNote = r.error ? ` (${r.error})` : "";
+    console.log(`  ${r.name}: repo=${repo}, build=${build}${errNote}`);
+  }
+  console.log(`  pnpm install: ${installStatus}`);
+  console.log(`[setup:upstream] ════════════════`);
+
+  if (anyError) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(`[setup:upstream] Fatal: ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/setup-upstream.mjs
+++ b/scripts/setup-upstream.mjs
@@ -26,8 +26,13 @@ const UPSTREAMS = {
     url: "https://github.com/Takazudo/zudo-front-builder.git",
     // env var name in .github/workflows/pr-checks.yml
     shaEnvVar: "ZFB_PINNED_SHA",
-    // path relative to sibling root to check if build is present
-    buildCheckPath: "target/release/zfb",
+    // Resolver — returns absolute path to the build artifact. Uses
+    // `cargo metadata` so it respects custom CARGO_TARGET_DIR env vars and
+    // ~/.cargo/config.toml [build].target-dir overrides. Without this, the
+    // build-skip check would miss the binary on dev machines that share a
+    // single cargo target dir across workspaces.
+    resolveBuildArtifact: (siblingPath) =>
+      resolve(cargoTargetDir(siblingPath), "release", "zfb"),
     build: {
       // single command: cargo build -p zfb --release
       type: "single",
@@ -38,8 +43,8 @@ const UPSTREAMS = {
   zdtp: {
     url: "https://github.com/Takazudo/zudo-design-token-panel.git",
     shaEnvVar: "ZDTP_PINNED_SHA",
-    // directory relative to sibling root to check if build is present
-    buildCheckPath: "packages/zudo-design-token-panel/dist",
+    resolveBuildArtifact: (siblingPath) =>
+      resolve(siblingPath, "packages", "zudo-design-token-panel", "dist"),
     build: {
       // two sequential commands
       type: "sequence",
@@ -50,6 +55,34 @@ const UPSTREAMS = {
     },
   },
 };
+
+// ---------------------------------------------------------------------------
+// Cargo target-dir resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Query `cargo metadata` for the workspace's target_directory. This respects
+ * the standard precedence order (CARGO_TARGET_DIR env, --target-dir flag,
+ * [build].target-dir in ~/.cargo/config.toml, then workspace-relative
+ * `target/`). Falls back to `<repoPath>/target` if cargo isn't available or
+ * the call fails (the caller's `cargo build` step will surface the real
+ * error in that case).
+ */
+function cargoTargetDir(repoPath) {
+  const result = spawnSync(
+    "cargo",
+    ["metadata", "--format-version", "1", "--no-deps"],
+    { cwd: repoPath, encoding: "utf8" },
+  );
+  if (result.status !== 0) return resolve(repoPath, "target");
+  try {
+    const meta = JSON.parse(result.stdout);
+    if (typeof meta.target_directory === "string") return meta.target_directory;
+  } catch {
+    // fall through to fallback
+  }
+  return resolve(repoPath, "target");
+}
 
 // ---------------------------------------------------------------------------
 // Argument parsing
@@ -301,7 +334,7 @@ async function processUpstream(name, cfg, { projectRoot, pinnedSha }) {
   }
 
   // ── 3. Build artifacts if needed ────────────────────────────────────────
-  const buildCheckFull = resolve(siblingPath, cfg.buildCheckPath);
+  const buildCheckFull = cfg.resolveBuildArtifact(siblingPath);
   // Read HEAD from disk (read-only; safe in dry-run too). For repos that were
   // just would-cloned in dry-run mode, siblingPath doesn't exist yet, so fall
   // back to pinnedSha to let the rest of the logic reason about the ideal state.

--- a/scripts/setup-upstream.mjs
+++ b/scripts/setup-upstream.mjs
@@ -138,14 +138,18 @@ function gitHead(repoPath) {
 }
 
 /**
- * Returns true if the repo has uncommitted changes to tracked files.
- * Ignores untracked files — build artifacts (target/, dist/) are gitignored
- * and shouldn't trigger the dirty check.
+ * Returns true if the repo has uncommitted changes OR new untracked files.
+ *
+ * Build artifacts (target/, dist/, node_modules/) are already gitignored, so
+ * default `git status --porcelain` (untracked-files=normal) does not list
+ * them. The check fires on tracked-file modifications AND on untracked
+ * source files not yet `git add`-ed — without the latter, `--force-checkout`
+ * would silently discard new uncommitted work the user hasn't staged yet.
  */
 function isRepoDirty(repoPath) {
   const result = spawnSync(
     "git",
-    ["-C", repoPath, "status", "--porcelain", "--untracked-files=no"],
+    ["-C", repoPath, "status", "--porcelain"],
     { encoding: "utf8" },
   );
   if (result.status !== 0) return false; // can't tell — treat as clean

--- a/src/config/__tests__/design-token-panel-config.test.ts
+++ b/src/config/__tests__/design-token-panel-config.test.ts
@@ -11,13 +11,32 @@ describe("designTokenPanelConfig", () => {
     expect(designTokenPanelConfig.storagePrefix).toBe("zudo-doc-tweak");
   });
 
-  it("paletteCssVarTemplate produces '--zd-0' when '{n}' is replaced with '0'", () => {
-    const template = designTokenPanelConfig.colorCluster.paletteCssVarTemplate;
-    expect(template.replace("{n}", "0")).toBe("--zd-0");
+  it("color tab's palette tier writes --zd-0..--zd-15 (drives the derived paletteCssVarTemplate)", () => {
+    // In the new tabs[] API the palette CSS-var template is no longer a
+    // literal field — zdtp derives it from the first palette item's cssVar
+    // (replacing the trailing digit run with `{n}`). We assert the items
+    // directly to pin the bridge's input.
+    const colorTab = designTokenPanelConfig.tabs.find((t) => t.id === "color");
+    expect(colorTab).toBeDefined();
+    const paletteTier = colorTab!.tiers.find((t) => t.id === "palette");
+    expect(paletteTier).toBeDefined();
+    expect(paletteTier!.items).toHaveLength(16);
+    expect(paletteTier!.items[0].cssVar).toBe("--zd-0");
+    expect(paletteTier!.items[15].cssVar).toBe("--zd-15");
   });
 
-  it("tokens.color is an empty array — color is cluster-driven, not per-token", () => {
-    expect(designTokenPanelConfig.tokens.color).toEqual([]);
+  it("color tab carries colorExtras with the cluster id 'zudo-doc'", () => {
+    const colorTab = designTokenPanelConfig.tabs.find((t) => t.id === "color");
+    expect(colorTab?.colorExtras?.id).toBe("zudo-doc");
+  });
+
+  it("ships exactly four tabs: color, font, spacing, size", () => {
+    expect(designTokenPanelConfig.tabs.map((t) => t.id)).toEqual([
+      "color",
+      "font",
+      "spacing",
+      "size",
+    ]);
   });
 
   it("every key in colorTweakPresets round-trips through JSON.stringify", () => {

--- a/src/config/design-token-panel-config.ts
+++ b/src/config/design-token-panel-config.ts
@@ -2,30 +2,47 @@
  * zdtp (zudo-design-token-panel) PanelConfig for zudo-doc.
  *
  * This config object is the single source of truth that will be passed to
- * `configurePanel(designTokenPanelConfig)` in the host adapter (W3-1b).
+ * `configurePanel(designTokenPanelConfig)` in the host adapter.
+ *
+ * Migration note (Wave 1 / zdtp b288293)
+ * --------------------------------------
+ * zdtp dropped the legacy `tokens: TokenManifest` + `colorCluster` shape in
+ * favor of a flat `tabs: TabConfig[]` array, plus `colorExtras` (carrying
+ * non-tier cluster metadata) on the color tab. The cluster's palette and
+ * semantic data now live as `TierItem` entries inside the color tab:
+ *
+ *  - Palette tier: 16 items with `kind: 'color'`, cssVars `--zd-0`..`--zd-15`.
+ *    The bridge in zdtp's `resolveColorClusterFromTab` derives
+ *    `paletteCssVarTemplate` by replacing the trailing digit run on the first
+ *    item's cssVar with `{n}` (`--zd-0` → `--zd-{n}`).
+ *  - Semantic tier: items with `kind: 'color'` and `referencesTier` pointing
+ *    at the palette tier; each item's `default` is the palette item id it
+ *    refers to (which the bridge looks up to materialise the index).
  *
  * Type notes:
  * - zdtp's `ColorScheme` requires a `shikiTheme: string` field that is not
  *   present in zudo-doc's local `ColorScheme` type or data. The cast below
  *   (`as unknown as Record<string, ZdtpColorScheme>`) is intentional: zdtp
  *   uses `shikiTheme` only for the code-block preview inside the panel; when
- *   absent at runtime it falls back to `colorCluster.defaultShikiTheme`. No
- *   user-visible regression results from the missing field.
+ *   absent at runtime it falls back to `colorExtras.defaultShikiTheme`.
  * - Do NOT add `legacyIdRenameMap` here. The upstream typography-id rename
- *   map bug (zdtp issue filed in W1-1) maps zudo-doc's canonical ids
- *   (text-caption, text-body, …) to non-existent keys. Until the upstream fix
- *   ships, keep zdtp on its default empty rename map by omitting the field.
+ *   map maps zudo-doc's canonical ids (text-caption, text-body, …) to
+ *   non-existent keys. Omit the field so zdtp keeps its empty rename map.
  */
 
 import type {
   PanelConfig,
+  TabConfig,
+  TierConfig,
+  TierItem,
+  ColorClusterExtras,
   ColorScheme as ZdtpColorScheme,
+  TokenDef,
 } from "@takazudo/zudo-design-token-panel";
 import {
   SPACING_TOKENS,
   FONT_TOKENS,
   SIZE_TOKENS,
-  COLOR_TOKENS,
 } from "./design-tokens-manifest";
 import { colorSchemes } from "./color-schemes";
 import { SEMANTIC_DEFAULTS, SEMANTIC_CSS_NAMES } from "./color-scheme-utils";
@@ -35,9 +52,8 @@ import { DESIGN_TOKEN_SCHEMA } from "@/utils/design-token-serde";
 
 /**
  * Base-role fallback indices derived from the legacy `initColorFromSchemeData`
- * in `state/tweak-state.ts`. These are the hard-coded palette-index defaults
- * used when a scheme's ColorRef is not a number (e.g. a direct hex string).
- * `colorRefToIndex(scheme.background, palette, 0)` → background defaults to 0.
+ * in zdtp's `state/tweak-state.ts`. Hard-coded palette-index defaults used
+ * when a scheme's ColorRef is not a number.
  */
 const BASE_DEFAULTS = {
   background: 0,
@@ -48,14 +64,227 @@ const BASE_DEFAULTS = {
 } as const;
 
 /**
- * Fallback Shiki theme used when a color scheme's `shikiTheme` field is absent.
- * zudo-doc's local `ColorScheme` type does not have `shikiTheme`; the zdtp
- * panel uses this default for its client-side code-block preview. The value
- * is set to "github-dark" as a generic dark-theme fallback — the actual
- * static-page syntax highlighting is handled by syntect (via zfb's Rust
- * pipeline) and is unaffected by this field.
+ * Fallback Shiki theme when a color scheme lacks one. zudo-doc's local
+ * `ColorScheme` type doesn't carry `shikiTheme`; the zdtp panel uses this
+ * default for its client-side code-block preview. Static syntax
+ * highlighting (syntect via zfb's Rust pipeline) is unaffected.
  */
 const DEFAULT_SHIKI_THEME = "github-dark";
+
+/**
+ * Initial palette taken from the configured active scheme. The 16 colors
+ * are surfaced as palette items in the color tab so the bridge can build a
+ * 16-slot `ColorClusterDataConfig`. Live tweaks still flow through zdtp's
+ * tweak-state — these defaults are only the seed.
+ */
+function getInitialPalette(): readonly string[] {
+  const scheme = colorSchemes[settings.colorScheme];
+  if (!scheme) {
+    throw new Error(
+      `Unknown color scheme: "${settings.colorScheme}". Available: ${Object.keys(colorSchemes).join(", ")}`,
+    );
+  }
+  return scheme.palette;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — partition flat manifest arrays into TabConfig.tiers by group.
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a flat `TokenDef` to a `TierItem` (the new zdtp tier-model shape).
+ *
+ * The mapping rules:
+ *  - `control: "select"` → `type: { kind: 'select', options }`
+ *  - `control: "text"`   → `type: { kind: 'text' }`
+ *  - (default slider)    → `type: { kind: 'length', min, max, step, unit }`
+ *
+ * `pill` and `readonly` pass through unchanged.
+ */
+function toTierItem(t: TokenDef): TierItem {
+  let kind;
+  if (t.control === "select") {
+    kind = { kind: "select" as const, options: t.options ?? [] };
+  } else if (t.control === "text") {
+    kind = { kind: "text" as const };
+  } else {
+    kind = {
+      kind: "length" as const,
+      min: t.min,
+      max: t.max,
+      step: t.step,
+      unit: t.unit,
+    };
+  }
+  const item: TierItem = {
+    id: t.id,
+    cssVar: t.cssVar,
+    label: t.label,
+    default: t.default,
+    type: kind,
+  };
+  if (t.pill) item.pill = t.pill;
+  if (t.readonly) item.readonly = true;
+  return item;
+}
+
+/**
+ * Build a tier from the subset of `tokens` whose `group` matches `groupId`.
+ * The tier's items share the same kind by construction (all items in a
+ * group share the same slider/select/text shape in zudo-doc's manifest).
+ * zdtp's `assertValidTabs` validator requires this.
+ */
+function tierFromGroup(
+  tokens: readonly TokenDef[],
+  groupId: string,
+  label: string,
+): TierConfig {
+  return {
+    id: groupId,
+    label,
+    items: tokens
+      .filter((t) => t.group === groupId)
+      .map(toTierItem),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Color tab — palette and semantic tiers + colorExtras for cluster metadata.
+// ---------------------------------------------------------------------------
+
+const PALETTE_TIER_ID = "palette";
+
+/**
+ * 16 palette items. The bridge in zdtp's `resolveColorClusterFromTab` reads
+ * the first item's `cssVar` and replaces the trailing digit run with `{n}`
+ * (`--zd-0` → `--zd-{n}`), reconstructing the legacy
+ * `paletteCssVarTemplate` for the apply pipeline.
+ */
+function buildPaletteTier(): TierConfig {
+  const initial = getInitialPalette();
+  const items: TierItem[] = [];
+  for (let i = 0; i < 16; i++) {
+    items.push({
+      id: `p${i}`,
+      cssVar: `--zd-${i}`,
+      label: `p${i}`,
+      default: initial[i] ?? "#808080",
+      type: { kind: "color" },
+    });
+  }
+  return {
+    id: PALETTE_TIER_ID,
+    label: "Palette",
+    items,
+  };
+}
+
+/**
+ * Semantic tier — items that reference the palette tier. Each item's
+ * `default` is a palette item id (e.g. `"p0"`); the bridge looks the id up
+ * and emits `paletteIdToIndex[id]` as the numeric default for
+ * `semanticDefaults`. cssVars come straight from `SEMANTIC_CSS_NAMES` so
+ * the apply pipeline keeps writing the same `--zd-*` custom properties.
+ */
+function buildSemanticTier(): TierConfig {
+  const items: TierItem[] = [];
+  for (const [key, cssVar] of Object.entries(SEMANTIC_CSS_NAMES)) {
+    const idx = SEMANTIC_DEFAULTS[key];
+    if (idx === undefined) continue;
+    items.push({
+      id: key,
+      cssVar,
+      label: key,
+      default: `p${idx}`,
+      type: { kind: "color" },
+    });
+  }
+  return {
+    id: "semantic",
+    label: "Semantic",
+    items,
+    referencesTier: PALETTE_TIER_ID,
+  };
+}
+
+const COLOR_EXTRAS: ColorClusterExtras = {
+  id: "zudo-doc",
+  label: "Zudo Doc",
+  baseRoles: {
+    background: "--zd-bg",
+    foreground: "--zd-fg",
+    cursor: "--zd-cursor",
+    selectionBg: "--zd-sel-bg",
+    selectionFg: "--zd-sel-fg",
+  },
+  baseDefaults: BASE_DEFAULTS,
+  defaultShikiTheme: DEFAULT_SHIKI_THEME,
+  // Local ColorScheme lacks shikiTheme; cast is safe — zdtp falls back to
+  // defaultShikiTheme when shikiTheme is absent at runtime.
+  colorSchemes: colorSchemes as unknown as Record<string, ZdtpColorScheme>,
+  panelSettings: {
+    colorScheme: settings.colorScheme,
+    // colorMode: strip off respectPrefersColorScheme (not in zdtp's shape).
+    colorMode: settings.colorMode
+      ? {
+          defaultMode: settings.colorMode.defaultMode,
+          lightScheme: settings.colorMode.lightScheme,
+          darkScheme: settings.colorMode.darkScheme,
+        }
+      : false,
+  },
+};
+
+const COLOR_TAB: TabConfig = {
+  id: "color",
+  label: "Color",
+  tiers: [buildPaletteTier(), buildSemanticTier()],
+  colorExtras: COLOR_EXTRAS,
+};
+
+// ---------------------------------------------------------------------------
+// Font tab — five tiers grouped by the manifest's `group` field.
+// ---------------------------------------------------------------------------
+
+const FONT_TAB: TabConfig = {
+  id: "font",
+  label: "Font",
+  tiers: [
+    tierFromGroup(FONT_TOKENS, "font-size", "Font size"),
+    tierFromGroup(FONT_TOKENS, "line-height", "Line height"),
+    tierFromGroup(FONT_TOKENS, "font-weight", "Font weight"),
+    tierFromGroup(FONT_TOKENS, "font-family", "Font family"),
+    tierFromGroup(FONT_TOKENS, "font-scale", "Scale (advanced)"),
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Spacing tab — four tiers grouped by the manifest's `group` field.
+// ---------------------------------------------------------------------------
+
+const SPACING_TAB: TabConfig = {
+  id: "spacing",
+  label: "Spacing",
+  tiers: [
+    tierFromGroup(SPACING_TOKENS, "hsp", "Horizontal spacing"),
+    tierFromGroup(SPACING_TOKENS, "vsp", "Vertical spacing"),
+    tierFromGroup(SPACING_TOKENS, "icon", "Icons"),
+    tierFromGroup(SPACING_TOKENS, "layout", "Layout"),
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Size tab — two tiers grouped by the manifest's `group` field.
+// ---------------------------------------------------------------------------
+
+const SIZE_TAB: TabConfig = {
+  id: "size",
+  label: "Size",
+  tiers: [
+    tierFromGroup(SIZE_TOKENS, "radius", "Radius"),
+    tierFromGroup(SIZE_TOKENS, "transition", "Transition"),
+  ],
+};
 
 export const designTokenPanelConfig: PanelConfig = {
   storagePrefix: "zudo-doc-tweak",
@@ -65,46 +294,7 @@ export const designTokenPanelConfig: PanelConfig = {
   // JSON files exported by the legacy panel remain importable after migration.
   schemaId: DESIGN_TOKEN_SCHEMA,
   exportFilenameBase: "zudo-doc-design-tokens",
-  tokens: {
-    spacing: SPACING_TOKENS,
-    // TokenManifest uses "typography" (not "font") per zdtp's §3.1 contract.
-    typography: FONT_TOKENS,
-    size: SIZE_TOKENS,
-    // Empty — color is cluster-driven; zdtp reads palette via colorCluster.
-    color: COLOR_TOKENS,
-  },
-  colorCluster: {
-    id: "zudo-doc",
-    label: "Zudo Doc",
-    paletteSize: 16,
-    // {n} placeholder replaced by resolvePaletteCssVar(cluster, i) at use time.
-    paletteCssVarTemplate: "--zd-{n}",
-    baseRoles: {
-      background: "--zd-bg",
-      foreground: "--zd-fg",
-      cursor: "--zd-cursor",
-      selectionBg: "--zd-sel-bg",
-      selectionFg: "--zd-sel-fg",
-    },
-    semanticDefaults: SEMANTIC_DEFAULTS,
-    semanticCssNames: SEMANTIC_CSS_NAMES,
-    baseDefaults: BASE_DEFAULTS,
-    defaultShikiTheme: DEFAULT_SHIKI_THEME,
-    // Local ColorScheme lacks shikiTheme (not in zudo-doc's type). Cast is safe:
-    // zdtp falls back to defaultShikiTheme when shikiTheme is absent at runtime.
-    colorSchemes: colorSchemes as unknown as Record<string, ZdtpColorScheme>,
-    panelSettings: {
-      colorScheme: settings.colorScheme,
-      // colorMode: strip off respectPrefersColorScheme (not in zdtp's shape).
-      colorMode: settings.colorMode
-        ? {
-            defaultMode: settings.colorMode.defaultMode,
-            lightScheme: settings.colorMode.lightScheme,
-            darkScheme: settings.colorMode.darkScheme,
-          }
-        : false,
-    },
-  },
+  tabs: [COLOR_TAB, FONT_TAB, SPACING_TAB, SIZE_TAB],
   // colorTweakPresets also lacks shikiTheme; same cast reasoning as colorSchemes.
   colorPresets: colorTweakPresets as unknown as Record<string, ZdtpColorScheme>,
 };

--- a/src/config/design-tokens-manifest.ts
+++ b/src/config/design-tokens-manifest.ts
@@ -4,17 +4,15 @@
  * so they survive the W3-2 deletion of the panel component tree.
  *
  * Imported by:
- *  - src/config/design-token-panel-config.ts  (new zdtp PanelConfig)
- *  - (W3-2: legacy re-export src/components/design-token-tweak/tokens/manifest.ts deleted)
+ *  - src/config/design-token-panel-config.ts  (groups items into TabConfig.tiers)
+ *  - src/utils/design-token-serde.ts          (cssVar ↔ id lookup for JSON I/O)
  *
- * Type strategy: the zdtp `TokenDef` interface (group: string) and the local
- * legacy `TokenDef` interface (group: TokenGroup closed union) are structurally
- * compatible — every group value in the arrays is a member of both. Arrays are
- * typed using the zdtp `TokenDef` so `design-token-panel-config.ts` can pass
- * them directly to `PanelConfig.tokens` without any cast. The legacy
- * `manifest.ts` re-exports them; TypeScript allows assigning `TokenDef[]`
- * (group: string) elements to the local narrower union via assignment since all
- * literal group values satisfy both types.
+ * Type strategy: arrays are typed `readonly TokenDef[]` for back-compat with
+ * the consumer serde and tests. `design-token-panel-config.ts` partitions the
+ * flat arrays by the `group` field into the new zdtp `TabConfig.tiers` shape.
+ * `TokenDef.advanced` was dropped upstream (zdtp 8abb1e4) — items previously
+ * gated behind an "Advanced" disclosure now live in their own tier ("Scale —
+ * advanced") so the tier acts as the disclosure container.
  */
 import type { TokenDef } from "@takazudo/zudo-design-token-panel";
 
@@ -70,9 +68,14 @@ export const SPACING_TOKENS: readonly TokenDef[] = [
  * Font tokens from `global.css`.
  *
  * Tier 2 semantic tokens (sizes, line-heights, weights, families) are exposed
- * as primary rows; Tier 1 abstract scale (`--text-scale-*`) is surfaced under
- * an Advanced disclosure so designers who tweak the scale see the tokens that
- * the semantic sizes resolve from.
+ * as primary tiers; Tier 1 abstract scale (`--text-scale-*`) lives in its own
+ * `font-scale` tier so designers who tweak the scale see the tokens that the
+ * semantic sizes resolve from.
+ *
+ * (Note: `TokenDef.advanced` was dropped upstream in zdtp 8abb1e4. The
+ * progressive-disclosure container is now the tier itself; the
+ * panel-config groups by `group` and presents each tier as a separate
+ * section under the Font tab.)
  *
  * Defaults mirror `global.css` resolved values: font-size tokens are recorded
  * as their resolved rem (`--text-body` → `1.2rem`) rather than their `var()`
@@ -104,14 +107,15 @@ export const FONT_TOKENS: readonly TokenDef[] = [
   { id: "font-sans", cssVar: "--font-sans", label: "font-sans", group: "font-family", default: "system-ui, sans-serif",    min: 0, max: 0, step: 1, unit: "", control: "text" },
   { id: "font-mono", cssVar: "--font-mono", label: "font-mono", group: "font-family", default: "ui-monospace, monospace",  min: 0, max: 0, step: 1, unit: "", control: "text" },
 
-  // --- Advanced: Tier 1 abstract scale (reveals behind <details>) ---
-  { id: "text-scale-2xs", cssVar: "--text-scale-2xs", label: "text-scale-2xs", group: "font-scale", default: "0.75rem",  min: 0.5, max: 5, step: 0.05, unit: "rem", advanced: true },
-  { id: "text-scale-xs",  cssVar: "--text-scale-xs",  label: "text-scale-xs",  group: "font-scale", default: "0.875rem", min: 0.5, max: 5, step: 0.05, unit: "rem", advanced: true },
-  { id: "text-scale-sm",  cssVar: "--text-scale-sm",  label: "text-scale-sm",  group: "font-scale", default: "1rem",     min: 0.5, max: 5, step: 0.05, unit: "rem", advanced: true },
-  { id: "text-scale-md",  cssVar: "--text-scale-md",  label: "text-scale-md",  group: "font-scale", default: "1.2rem",   min: 0.5, max: 5, step: 0.05, unit: "rem", advanced: true },
-  { id: "text-scale-lg",  cssVar: "--text-scale-lg",  label: "text-scale-lg",  group: "font-scale", default: "1.4rem",   min: 0.5, max: 5, step: 0.05, unit: "rem", advanced: true },
-  { id: "text-scale-xl",  cssVar: "--text-scale-xl",  label: "text-scale-xl",  group: "font-scale", default: "3rem",     min: 0.5, max: 5, step: 0.05, unit: "rem", advanced: true },
-  { id: "text-scale-2xl", cssVar: "--text-scale-2xl", label: "text-scale-2xl", group: "font-scale", default: "3.75rem",  min: 0.5, max: 5, step: 0.05, unit: "rem", advanced: true },
+  // --- Tier 1 abstract scale (was "Advanced" disclosure in v1 of the panel;
+  //     now lives in its own font-scale tier). ---
+  { id: "text-scale-2xs", cssVar: "--text-scale-2xs", label: "text-scale-2xs", group: "font-scale", default: "0.75rem",  min: 0.5, max: 5, step: 0.05, unit: "rem" },
+  { id: "text-scale-xs",  cssVar: "--text-scale-xs",  label: "text-scale-xs",  group: "font-scale", default: "0.875rem", min: 0.5, max: 5, step: 0.05, unit: "rem" },
+  { id: "text-scale-sm",  cssVar: "--text-scale-sm",  label: "text-scale-sm",  group: "font-scale", default: "1rem",     min: 0.5, max: 5, step: 0.05, unit: "rem" },
+  { id: "text-scale-md",  cssVar: "--text-scale-md",  label: "text-scale-md",  group: "font-scale", default: "1.2rem",   min: 0.5, max: 5, step: 0.05, unit: "rem" },
+  { id: "text-scale-lg",  cssVar: "--text-scale-lg",  label: "text-scale-lg",  group: "font-scale", default: "1.4rem",   min: 0.5, max: 5, step: 0.05, unit: "rem" },
+  { id: "text-scale-xl",  cssVar: "--text-scale-xl",  label: "text-scale-xl",  group: "font-scale", default: "3rem",     min: 0.5, max: 5, step: 0.05, unit: "rem" },
+  { id: "text-scale-2xl", cssVar: "--text-scale-2xl", label: "text-scale-2xl", group: "font-scale", default: "3.75rem",  min: 0.5, max: 5, step: 0.05, unit: "rem" },
 ];
 
 /**
@@ -161,8 +165,10 @@ export const SIZE_TOKENS: readonly TokenDef[] = [
 ];
 
 /**
- * Color tokens — empty because color is cluster-driven in zudo-doc.
- * zdtp uses `colorCluster` for all color editing; this array satisfies the
- * `TokenManifest.color` field requirement.
+ * Color tokens — kept as an empty array for back-compat with the consumer
+ * serde, which historically iterated `COLOR_TOKENS` symmetric with the other
+ * three arrays. Color is cluster-driven in zudo-doc and is constructed in
+ * `design-token-panel-config.ts` from `colorSchemes` + `SEMANTIC_*` —
+ * not from this array.
  */
 export const COLOR_TOKENS: readonly TokenDef[] = [];


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/1663

---

## Summary

Bump pinned upstream framework SHAs to current `origin/main` HEAD and add a `pnpm setup:upstream` bootstrap script for multi-machine consistency.

- **zfb pin**: `aa8e9ac` → `0f7aa62a21f327c3205d98127ab3be43320350a2` (84 commits ahead, ancestor-clean)
- **zdtp pin**: `4f9d379` → `b2882939f4160d6121bceb8991d06e5d6255c6a4` (192 commits ahead, ancestor-clean)
- Consumer migration to zdtp's new `tabs: TabConfig[]` API (required by upstream PR dropping `PanelConfig.tokens`)
- New `scripts/setup-upstream.mjs` + `pnpm setup:upstream` script that clones/checkouts/builds sibling upstreams from a single command

Closes #1664, #1666, #1665.

## Changes

### Pin bumps (atomic, 3 workflow files)
- `.github/workflows/main-deploy.yml`, `preview-deploy.yml`, `pr-checks.yml` — `ZFB_PINNED_SHA` + `ZDTP_PINNED_SHA` env values

### zdtp consumer migration (required by upstream API change)
- `src/config/design-token-panel-config.ts` — rewrite from `tokens: TokenManifest` + `colorCluster` to `tabs: TabConfig[]` + `colorExtras`. New shape:
  - Color tab: 16-item palette tier (ids `p0`..`p15`, cssVars `--zd-0`..`--zd-15`, `kind: 'color'`) + semantic tier (`referencesTier: 'palette'`, items' `default` are palette ids like `"p5"`) + `colorExtras` carrying `baseRoles`, `baseDefaults`, `defaultShikiTheme`, `colorSchemes`, `panelSettings`.
  - Font / Spacing / Size tabs: tiers partitioned by the manifest's `group:` field.
- `src/config/design-tokens-manifest.ts` — drop `TokenDef.advanced` field (zdtp `8abb1e4`); the `font-scale` tier now serves as the disclosure container.
- `src/config/__tests__/design-token-panel-config.test.ts` — updated to new shape.
- `packages/create-zudo-doc/templates/features/designTokenPanel/files/src/config/design-tokens-manifest.ts` — synced per the project's Feature Change Checklist.

### `pnpm setup:upstream` bootstrap (#1666)
- `scripts/setup-upstream.mjs` — new ESM script. Reads pinned SHAs from `.github/workflows/pr-checks.yml`, for each sibling (`../zfb`, `../zdtp`):
  - Clones if missing, fetches+checkouts pinned SHA if clean, refuses if dirty (unless `--force-checkout`)
  - Builds artifacts only when needed (`cargo build -p zfb --release` for zfb, `pnpm install` + `pnpm --filter @takazudo/zudo-design-token-panel build` for zdtp)
  - Build-skip detection uses `cargo metadata --format-version 1 --no-deps` for `target_directory`, so it respects `CARGO_TARGET_DIR` env and `[build].target-dir` in `~/.cargo/config.toml`
  - Dirty-tree check includes untracked-but-not-gitignored files (per gcoc review) so `--force-checkout` can't silently destroy unstaged source
  - Final step runs `pnpm install` in the consumer (skippable via `--skip-install`)
- Flags: `--force-checkout`, `--skip-install`, `--dry-run`, `--help`
- `package.json` — `"setup:upstream": "node scripts/setup-upstream.mjs"` entry
- `CLAUDE.md` — new "First-time setup on a new machine" section cross-referencing the `dev-wip-package-refer` skill pattern

## Verification

- `pnpm check` (typecheck) — passes
- `pnpm test:unit` — 798/801 pass; the 3 failures are pre-existing on `base/zfb-migration-parity` (worktree-symlink test in `setup-doc-skill`, SIGTERM-handling flake in `serve-snapshots`)
- `pnpm check:template-drift` — clean after template sync
- `pnpm setup:upstream --dry-run` — clean no-op (both upstreams already at pinned SHA, `build=skipped`)
- gcoc review — applied HIGH-2 fix (untracked-file detection); HIGH-1 (semantic tier id-vs-index mapping) verified safe against zdtp's `resolveColorClusterFromTab` bridge source.
- Bootstrap smoke test (Wave 3 Part A): force-rebuilt zdtp dist via `rm -rf dist/`; ran `pnpm setup:upstream` end-to-end; cargo built zfb (~2 min), zdtp built fresh dist (95KB), consumer `pnpm install` ok. Re-run dry-run no-op clean.
- CI on this PR — all 8 checks green (Template Drift Check, Build zfb Binary, Build Doc History, plus the deploy-preview and link-check job set).

## Test plan

Per the user-handoff comment on epic #1663 — 6-URL side-by-side table (main vs preview), 5 bump-impacted areas to focus on (palette open/close, panel resizable, panel section redesign, doc rendering, bridge tabs[] migration). The manager does NOT claim parity; the visual verdict belongs to the user.