### PR TITLE
chore(deps): bump zfb pin to 195be73 + zfb-link cargo target-dir fix

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -92,7 +92,7 @@ permissions:
 env:
   # Pinned zfb commit — keep in sync with the zfb pin comment at the
   # top of zfb.config.ts and the same env in pr-checks.yml.
-  ZFB_PINNED_SHA: 0f7aa62a21f327c3205d98127ab3be43320350a2
+  ZFB_PINNED_SHA: 195be73f6716ab48c0c32a3a464e70126ea94937
   # Pinned zdtp commit — keep in sync with the zdtp pin block in zfb.config.ts,
   # the file: spec in package.json, and the same env in pr-checks.yml /
   # preview-deploy.yml. All three sources must be bumped together.

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -74,7 +74,7 @@ env:
   # Pinned zfb commit — keep in sync with the zfb pin comment at the
   # top of zfb.config.ts. Updating the pin here without updating that
   # comment (or vice versa) will silently desync local dev from CI.
-  ZFB_PINNED_SHA: 0f7aa62a21f327c3205d98127ab3be43320350a2
+  ZFB_PINNED_SHA: 195be73f6716ab48c0c32a3a464e70126ea94937
   # Pinned zdtp commit — keep in sync with the zdtp pin block in zfb.config.ts,
   # the file: spec in package.json, and the same env in main-deploy.yml /
   # preview-deploy.yml. All three sources must be bumped together.

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -65,7 +65,7 @@ permissions:
 env:
   # Pinned zfb commit — keep in sync with the zfb pin comment at the
   # top of zfb.config.ts and the same env in pr-checks.yml.
-  ZFB_PINNED_SHA: 0f7aa62a21f327c3205d98127ab3be43320350a2
+  ZFB_PINNED_SHA: 195be73f6716ab48c0c32a3a464e70126ea94937
   # Pinned zdtp commit — keep in sync with the zdtp pin block in zfb.config.ts,
   # the file: spec in package.json, and the same env in main-deploy.yml /
   # pr-checks.yml. All three sources must be bumped together.

--- a/scripts/zfb-link.mjs
+++ b/scripts/zfb-link.mjs
@@ -24,7 +24,31 @@ import {
   readdirSync,
   constants,
 } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { dirname, join, resolve } from "node:path";
+
+/**
+ * Query `cargo metadata` for the workspace's target_directory. This respects
+ * the standard precedence order (CARGO_TARGET_DIR env, --target-dir flag,
+ * [build].target-dir in ~/.cargo/config.toml, then workspace-relative
+ * `target/`). Falls back to `<repoPath>/target` if cargo isn't available or
+ * the call fails — matching the behaviour of `scripts/setup-upstream.mjs`.
+ */
+function cargoTargetDir(repoPath) {
+  const result = spawnSync(
+    "cargo",
+    ["metadata", "--format-version", "1", "--no-deps"],
+    { cwd: repoPath, encoding: "utf8" },
+  );
+  if (result.status !== 0) return resolve(repoPath, "target");
+  try {
+    const meta = JSON.parse(result.stdout);
+    if (typeof meta.target_directory === "string") return meta.target_directory;
+  } catch {
+    // fall through to fallback
+  }
+  return resolve(repoPath, "target");
+}
 
 function findZfbBinary() {
   // pnpm hard-copies `file:` deps into node_modules/.pnpm/, so we
@@ -48,9 +72,13 @@ function findZfbBinary() {
   const pkgDir = resolve(projectRoot, spec.slice("file:".length));
   // pkgDir: <zfb-checkout>/packages/zfb
   const zfbCheckout = resolve(pkgDir, "..", "..");
+  // Resolve the cargo target dir via `cargo metadata` so we respect
+  // CARGO_TARGET_DIR / [build].target-dir overrides. Same fix pattern
+  // as setup-upstream.mjs (commit cd246b9).
+  const targetDir = cargoTargetDir(zfbCheckout);
   const candidates = [
-    join(zfbCheckout, "target", "release", "zfb"),
-    join(zfbCheckout, "target", "debug", "zfb"),
+    join(targetDir, "release", "zfb"),
+    join(targetDir, "debug", "zfb"),
   ];
   for (const candidate of candidates) {
     try {

--- a/zfb.config.ts
+++ b/zfb.config.ts
@@ -1,14 +1,39 @@
 /**
  * zfb pin (canonical, shared with E2/E4):
- *   commit: aa8e9ac (main — `build: commit Cargo.lock so transitive dep
- *           resolution is reproducible`. Removes Cargo.lock from
- *           .gitignore and ships a checked-in workspace lockfile so the
- *           consumer's `Build zfb Binary` job stops drifting against
- *           the cached `target/` on each CI run. Closes the follow-up
- *           called out in 9dcae3f and root-causes the rusty_v8
- *           link-failure surfaced when the partial-rebuild path tries
- *           to re-link v8 against a librusty_v8.a path that no longer
- *           exists in OUT_DIR after rust-cache restore.
+ *   commit: 195be73 (main — `feat(content): add include / exclude /
+ *           idStripSuffix to CollectionDef` (#286) atop a stack of
+ *           bundler / plugin / adapter fixes:
+ *             - 195be73 Merge #286 collection-filters
+ *             - a7491a2 feat(content): add include / exclude /
+ *               idStripSuffix to CollectionDef
+ *             - 67358cd Merge #285 sitemap prerender field
+ *             - f053186 feat(plugins): expose prerender on postBuild
+ *               route manifest
+ *             - fd708ea Merge #284 cf-adapter prerender filter
+ *             - 24ef06d test(zfb): new BundlerInput fields in
+ *               framework_packages_no_pnpm fixture
+ *             - 97864ee feat(bundler): trim runtime bundle to SSR-only
+ *               routes for deploy adapters (#283)
+ *             - 0774318 Merge #282 zzmod-wave2 papercuts
+ *             - d49bd39 fix(jsx-types): widen VNode.type to accept
+ *               class components
+ *           No consumer-side runtime-shape changes expected; new
+ *           collection / plugin fields are additive. Ancestor check
+ *           confirmed 0f7aa62 is on origin/main, no carries lost.
+ *           Bumped 2026-05-19 in topic/bump-zfb-upstream-latest.
+ *           Previous pin 0f7aa62 (main — `build: add x-wt-teams
+ *           worktree push-guard scaffold`, picked up at zudo-doc2
+ *           introduction).
+ *           Previous pin aa8e9ac (main — `build: commit Cargo.lock so
+ *           transitive dep resolution is reproducible`. Removes
+ *           Cargo.lock from .gitignore and ships a checked-in
+ *           workspace lockfile so the consumer's `Build zfb Binary`
+ *           job stops drifting against the cached `target/` on each CI
+ *           run. Closes the follow-up called out in 9dcae3f and
+ *           root-causes the rusty_v8 link-failure surfaced when the
+ *           partial-rebuild path tries to re-link v8 against a
+ *           librusty_v8.a path that no longer exists in OUT_DIR after
+ *           rust-cache restore.
  *           Previous pin 6be1f38 (base/link-cleanup-zfb — link-pipeline parity:
  *           same content as c371e4c (parent commit) PLUS the TS-side
  *           type defs for `ZfbConfig.resolveMarkdownLinks` and


### PR DESCRIPTION
## Summary

- Bump `ZFB_PINNED_SHA` from `0f7aa62` to `195be73` (current upstream `Takazudo/zudo-front-builder` main HEAD) atomically across `pr-checks.yml`, `main-deploy.yml`, and `preview-deploy.yml` + the canonical pin doc-comment in `zfb.config.ts`.
- Fix `scripts/zfb-link.mjs` to respect cargo's custom target-dir config (CARGO_TARGET_DIR env, `[build].target-dir` in `~/.cargo/config.toml`). Same pattern as `scripts/setup-upstream.mjs` (commit `cd246b9`). Bug surfaced on dev machines with a global cargo target-dir; postinstall warned "no compiled zfb binary at …" even though `cargo build -p zfb` had just finished.

## Upstream zfb commits picked up (9)

- 195be73 Merge #286 collection-filters
- a7491a2 `feat(content): add include / exclude / idStripSuffix to CollectionDef`
- 67358cd Merge #285 sitemap prerender field
- f053186 `feat(plugins): expose prerender on postBuild route manifest`
- fd708ea Merge #284 cf-adapter prerender filter
- 24ef06d `test(zfb): new BundlerInput fields in framework_packages_no_pnpm fixture`
- 97864ee `feat(bundler): trim runtime bundle to SSR-only routes for deploy adapters` (#283)
- 0774318 Merge #282 zzmod-wave2 papercuts
- d49bd39 `fix(jsx-types): widen VNode.type to accept class components`

No consumer-side runtime-shape changes required — the new `CollectionDef` filter fields, the `prerender` field on the `postBuild` route manifest, and the `VNode.type` widening are all additive. Ancestor check (`git merge-base --is-ancestor 0f7aa62 195be73`) confirmed the old pin is on origin/main, so no carries from a diverged branch are lost.

## Changes

- `.github/workflows/pr-checks.yml`, `main-deploy.yml`, `preview-deploy.yml`: bumped `ZFB_PINNED_SHA` to `195be73f6716ab48c0c32a3a464e70126ea94937` atomically (single source of truth per `CLAUDE.md`).
- `zfb.config.ts`: prepended a new pin doc-comment entry citing the 9 picked-up commits; preserved the prior pin chain.
- `scripts/zfb-link.mjs`: added `cargoTargetDir()` helper that queries `cargo metadata --format-version 1 --no-deps` for `target_directory`, with the same JSON-guarded fallback pattern used in `setup-upstream.mjs`. Resolved candidate paths now use the helper's output instead of hardcoded `<repo>/target/release/zfb`.

## Test Plan

- [x] `pnpm setup:upstream` checked out zfb at the new SHA cleanly.
- [x] `cargo build -p zfb --release` rebuilt the binary against the new SHA (47s incremental).
- [x] `pnpm install` re-linked the binary via the patched `zfb-link.mjs` — postinstall now reports the wrapper path and the resolved esbuild / tailwind binaries.
- [x] `pnpm check` — 0 TypeScript errors against the new zfb types.
- [x] `pnpm b4push` — all 11 checks passed:
  1. Format check (mdx)
  2. Template drift check
  3. Fixture settings drift check
  4. Tags audit
  5. Design token lint
  6. Type check (`zfb check`)
  7. Build (200 pages in 96s, no broken-link warnings outside the intentionally-broken `packages/md-plugins/__fixtures__/`)
  8. Link check (`--strict-broken --strict-absolute`)
  9. HTML validation
  10. Preview smoke (6/6)
  11. Manual interactive smoke (skipped — auto-mode)
- [ ] CI green on PR.

## Review

- `/gcoc-review` (Copilot, gpt-4.1): no issues found.
- `/deep-review -op` (3 Claude Opus reviewers — bugs, structure, quality): approve. Minor non-blocking observations (duplicate `cargoTargetDir()` across two scripts is acceptable given the drift-cleanup would need a separate PR touching `setup-upstream.mjs`; doc-comment matches the canonical pattern there).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/1668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->