### PR TITLE
chore(deps): bump zfb upstream pin to c93a7ec

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -92,7 +92,7 @@ permissions:
 env:
   # Pinned zfb commit — keep in sync with the zfb pin comment at the
   # top of zfb.config.ts and the same env in pr-checks.yml.
-  ZFB_PINNED_SHA: 195be73f6716ab48c0c32a3a464e70126ea94937
+  ZFB_PINNED_SHA: c93a7ece29e3e3d5e6140d69bab7a11924d03dcf
   # Pinned zdtp commit — keep in sync with the zdtp pin block in zfb.config.ts,
   # the file: spec in package.json, and the same env in pr-checks.yml /
   # preview-deploy.yml. All three sources must be bumped together.

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -74,7 +74,7 @@ env:
   # Pinned zfb commit — keep in sync with the zfb pin comment at the
   # top of zfb.config.ts. Updating the pin here without updating that
   # comment (or vice versa) will silently desync local dev from CI.
-  ZFB_PINNED_SHA: 195be73f6716ab48c0c32a3a464e70126ea94937
+  ZFB_PINNED_SHA: c93a7ece29e3e3d5e6140d69bab7a11924d03dcf
   # Pinned zdtp commit — keep in sync with the zdtp pin block in zfb.config.ts,
   # the file: spec in package.json, and the same env in main-deploy.yml /
   # preview-deploy.yml. All three sources must be bumped together.

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -65,7 +65,7 @@ permissions:
 env:
   # Pinned zfb commit — keep in sync with the zfb pin comment at the
   # top of zfb.config.ts and the same env in pr-checks.yml.
-  ZFB_PINNED_SHA: 195be73f6716ab48c0c32a3a464e70126ea94937
+  ZFB_PINNED_SHA: c93a7ece29e3e3d5e6140d69bab7a11924d03dcf
   # Pinned zdtp commit — keep in sync with the zdtp pin block in zfb.config.ts,
   # the file: spec in package.json, and the same env in main-deploy.yml /
   # pr-checks.yml. All three sources must be bumped together.

--- a/zfb.config.ts
+++ b/zfb.config.ts
@@ -1,8 +1,25 @@
 /**
  * zfb pin (canonical, shared with E2/E4):
- *   commit: 195be73 (main — `feat(content): add include / exclude /
- *           idStripSuffix to CollectionDef` (#286) atop a stack of
- *           bundler / plugin / adapter fixes:
+ *   commit: c93a7ec (main — Merge #288 islands env defines):
+ *             - c93a7ec Merge #288 islands env defines
+ *             - d438061 fix(zfb-islands): define
+ *               `import.meta.env.{PROD,DEV}` in esbuild args
+ *           Closes the latent hydration-crash path on this consumer:
+ *           `src/components/mock-init.tsx` (a `"use client"` island)
+ *           dynamically imports `src/mocks/init.ts`, which references
+ *           `import.meta.env.DEV`. Before this fix the islands esbuild
+ *           pipeline shipped that read verbatim into
+ *           `assets/islands.js`, where `import.meta.env` is undefined
+ *           at runtime and the first access would throw
+ *           `TypeError: Cannot read properties of undefined`. The fix
+ *           mirrors the `bundler.rs` PROD/DEV defines into
+ *           `crates/zfb-islands/src/esbuild.rs`, so both pipelines
+ *           fold the value at bundle time. Ancestor check confirmed
+ *           195be73 is on origin/main, no carries lost.
+ *           Bumped 2026-05-20 in topic/bump-zfb-c93a7ec.
+ *           Previous pin 195be73 (main — `feat(content): add include /
+ *           exclude / idStripSuffix to CollectionDef` (#286) atop a
+ *           stack of bundler / plugin / adapter fixes:
  *             - 195be73 Merge #286 collection-filters
  *             - a7491a2 feat(content): add include / exclude /
  *               idStripSuffix to CollectionDef
@@ -16,11 +33,7 @@
  *               routes for deploy adapters (#283)
  *             - 0774318 Merge #282 zzmod-wave2 papercuts
  *             - d49bd39 fix(jsx-types): widen VNode.type to accept
- *               class components
- *           No consumer-side runtime-shape changes expected; new
- *           collection / plugin fields are additive. Ancestor check
- *           confirmed 0f7aa62 is on origin/main, no carries lost.
- *           Bumped 2026-05-19 in topic/bump-zfb-upstream-latest.
+ *               class components).
  *           Previous pin 0f7aa62 (main — `build: add x-wt-teams
  *           worktree push-guard scaffold`, picked up at zudo-doc2
  *           introduction).


### PR DESCRIPTION
- parent PR
    - https://github.com/zudolab/zudo-doc/pull/669

---

## Summary

Bump `ZFB_PINNED_SHA` from `195be73` to `c93a7ec` (current upstream Takazudo/zudo-front-builder main HEAD), atomically across the three workflow YAMLs and the canonical pin doc-comment in `zfb.config.ts`.

Picks up:

- `c93a7ec` Merge #288 islands env defines
- `d438061` fix(zfb-islands): define `import.meta.env.{PROD,DEV}` in esbuild args

The `d438061` fix is directly relevant to this consumer: `src/components/mock-init.tsx` (a `"use client"` island) dynamically imports `src/mocks/init.ts`, which references `import.meta.env.DEV`. Before the fix the islands esbuild pipeline shipped that read verbatim into `assets/islands.js`, where `import.meta.env` is undefined at runtime — first access would throw `TypeError: Cannot read properties of undefined`.

## Changes

- `.github/workflows/pr-checks.yml` — `ZFB_PINNED_SHA` bumped
- `.github/workflows/main-deploy.yml` — `ZFB_PINNED_SHA` bumped
- `.github/workflows/preview-deploy.yml` — `ZFB_PINNED_SHA` bumped
- `zfb.config.ts` — canonical pin doc-comment updated (new pin entry on top, old demoted to "Previous pin")

## Test Plan

- [x] `pnpm setup:upstream` — checked out new zfb pin and rebuilt the binary (`cargo build -p zfb --release`)
- [x] `pnpm b4push` automated steps 1-10 green:
  - format, template-drift, fixture-settings-drift, tags audit
  - design-token lint
  - typecheck (`zfb check`)
  - build (200 pages in 102s)
  - link check, html-validate
  - preview smoke (6/6)
- [x] Verified d438061 fix took effect: `grep -c 'import.meta.env.DEV' dist/assets/islands*.js` → 0 (esbuild folded all refs at bundle time)
- [x] PR CI: 8/8 checks green