### PR TITLE
docs(skills): replace stale Astro tooling refs with zfb equivalents (#1709)

### DIFF
--- a/.claude/skills/l-generator-cli-tester/SKILL.md
+++ b/.claude/skills/l-generator-cli-tester/SKILL.md
@@ -232,7 +232,7 @@ Use these tables to verify. Check each file with `test -e <path>`.
 | `src/pages/docs/` | PRESENT |
 | `src/content/docs/` | PRESENT |
 | `src/config/settings.ts` | PRESENT |
-| `astro.config.ts` | PRESENT |
+| `zfb.config.ts` | PRESENT |
 
 **search:**
 
@@ -359,7 +359,7 @@ Read `__inbox/generator-test-<pattern>/test-project/src/config/settings.ts` and 
 
 - `colorScheme: "Default Dark"`
 - Check `src/config/i18n.ts` for `defaultLocale = "ja"`
-- Check `astro.config.ts` for `defaultLocale: "ja"`
+- Check `zfb.config.ts` for `defaultLocale: "ja"`
 
 **all-features:**
 
@@ -387,7 +387,7 @@ Start the dev server and use `/headless-browser` (Tier 1: headless-check.js) to 
 
 ```bash
 cd __inbox/generator-test-<pattern>/test-project
-npx astro dev --port 14350 &
+pnpm dev --port 14350 &
 DEV_PID=$!
 sleep 6
 ```

--- a/.claude/skills/l-update-generator/SKILL.md
+++ b/.claude/skills/l-update-generator/SKILL.md
@@ -12,7 +12,7 @@ Detect and fix drift between the main zudo-doc project and the `create-zudo-doc`
 The generator uses **additive composition** — not copy-then-strip:
 
 1. A minimal **base template** (`templates/base/`) is copied first
-2. **Programmatic generators** create config files from user choices (`astro-config-gen.ts`, `content-config-gen.ts`, `settings-gen.ts`)
+2. **Programmatic generators** create config files from user choices (`zfb-config-gen.ts`, `settings-gen.ts`)
 3. **Feature modules** (`src/features/*.ts`) inject code into anchor points (`@slot:`) in shared files and copy feature-specific files
 4. `compose.ts` orchestrates feature file copying, injection, and anchor cleanup
 5. Some features have **postProcess hooks** that mutate or remove generated files (e.g., `i18n.ts` patches locale strings and may delete `src/pages/ja/`)
@@ -24,7 +24,7 @@ The generator uses **additive composition** — not copy-then-strip:
 - Periodically to verify generator health
 - User says "update generator", "sync generator", "check generator drift", "l-update-generator", or the old name "l-sync-create-zudo-doc"
 
-**Quick pre-check**: Run `pnpm check:template-drift` first to get an automated summary of base template drift. Then proceed with the full workflow below for settings, dependency, astro config, and feature composition drift.
+**Quick pre-check**: Run `pnpm check:template-drift` first to get an automated summary of base template drift. Then proceed with the full workflow below for settings, dependency, zfb config, and feature composition drift.
 
 ## Step 1: Analyze Drift
 
@@ -48,16 +48,16 @@ Compare dependencies:
 
 Check for packages used in base template files and feature files that are not included in the generated package.json.
 
-### 1c. Astro config drift
+### 1c. zfb config drift
 
-Compare the main project's `astro.config.ts` with what the generator produces:
+Compare the main project's `zfb.config.ts` with what the generator produces:
 
-- **Main**: `astro.config.ts` — all imports and integrations
-- **Generator**: `packages/create-zudo-doc/src/astro-config-gen.ts` — programmatic generation
+- **Main**: `zfb.config.ts` — all imports and integrations
+- **Generator**: `packages/create-zudo-doc/src/zfb-config-gen.ts` — programmatic generation
 
-For each integration in the main astro.config.ts, verify that either:
+For each integration in the main zfb.config.ts, verify that either:
 
-1. It is unconditionally included in `astro-config-gen.ts`, OR
+1. It is unconditionally included in `zfb-config-gen.ts`, OR
 2. It is conditionally included based on the correct feature selection
 
 ### 1d. Feature composition drift
@@ -86,7 +86,7 @@ Check that non-feature-specific files in the base template reflect the latest ch
 
 **Automated first check**: Run `pnpm check:template-drift` before doing manual analysis. This runs `scripts/check-template-drift.sh` and quickly identifies files that differ between the main project and the base template.
 
-**Allowlist note**: Some files are listed in `.template-drift-allowlist` (e.g., `global.css`, `header.astro`, `doc-layout.astro`) and are skipped entirely by the automated script because they contain slot sections that intentionally differ. These files **still require manual review** — check that any non-slot-section changes in the main project are reflected in the template counterpart.
+**Allowlist note**: Some files are listed in `.template-drift-allowlist` (e.g., `global.css`) and are skipped entirely by the automated script because they contain slot sections that intentionally differ. These files **still require manual review** — check that any non-slot-section changes in the main project are reflected in the template counterpart.
 
 ## Step 2: Report Findings
 
@@ -101,8 +101,8 @@ Present a clear drift report:
 - Missing from generated package.json: packageX (used by featureY)
 - Unnecessary in generated package.json: packageZ (feature disabled)
 
-## Astro Config Drift
-- Missing integration: integrationX (present in main, absent from astro-config-gen.ts)
+## zfb Config Drift
+- Missing integration: integrationX (present in main, absent from zfb-config-gen.ts)
 - Missing conditional: integrationY should be gated by feature "Z"
 
 ## Feature Composition Drift
@@ -111,7 +111,7 @@ Present a clear drift report:
 - Missing anchor: feature "X" injects at @slot:Y but anchor not found in base template
 
 ## Base Template Drift
-- Stale file: templates/base/src/components/foo.astro differs from main src/components/foo.astro
+- Stale file: templates/base/src/components/foo.tsx differs from main src/components/foo.tsx
 
 ## No Drift Detected
 (if everything is in sync)
@@ -123,7 +123,7 @@ For each drift item found:
 
 1. **Settings drift** → Update `settings-gen.ts` to add missing fields with sensible defaults
 2. **Dependency drift** → Update `scaffold.ts` `generatePackageJson()` to add/remove deps
-3. **Astro config drift** → Update `astro-config-gen.ts` to add/remove imports and integrations
+3. **zfb config drift** → Update `zfb-config-gen.ts` to add/remove imports and integrations
 4. **Feature composition drift** → Create/update feature module in `src/features/`, add template files, add anchors to base template
 5. **Base template drift** → Update the stale file in `templates/base/`
 
@@ -138,10 +138,9 @@ After fixes:
 | File | Role |
 |------|------|
 | `src/config/settings.ts` | Canonical settings (source of truth) |
-| `astro.config.ts` | Main project astro config (reference for generator) |
+| `zfb.config.ts` | Main project zfb config (reference for generator) |
 | `packages/create-zudo-doc/src/settings-gen.ts` | Generates settings.ts |
-| `packages/create-zudo-doc/src/astro-config-gen.ts` | Generates astro.config.ts programmatically |
-| `packages/create-zudo-doc/src/content-config-gen.ts` | Generates content.config.ts programmatically |
+| `packages/create-zudo-doc/src/zfb-config-gen.ts` | Generates zfb.config.ts programmatically (content-collection schemas live inline — there is no separate content config) |
 | `packages/create-zudo-doc/src/compose.ts` | Additive composition engine (injections, anchors) |
 | `packages/create-zudo-doc/src/features/*.ts` | Feature modules (injections + file lists) |
 | `packages/create-zudo-doc/src/scaffold.ts` | Orchestrates generation pipeline, generates package.json |

--- a/.claude/skills/zudo-doc-translate/SKILL.md
+++ b/.claude/skills/zudo-doc-translate/SKILL.md
@@ -21,7 +21,7 @@ Translate documentation between English and Japanese following project-specific 
 - Japanese docs: `src/content/docs-ja/` — routes at `/ja/docs/...`
 - Directory structures must mirror each other exactly (same filenames, same folder hierarchy)
 - Locale settings: `locales` in `src/config/settings.ts`
-- Astro i18n config: `astro.config.ts` with `prefixDefaultLocale: false` (English has no prefix, Japanese uses `/ja/`)
+- zfb i18n config: `zfb.config.ts` with `prefixDefaultLocale: false` (English has no prefix, Japanese uses `/ja/`)
 
 ## Translation Rules
 


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/1709

---

## Summary

Three tracked `.claude/skills/*/SKILL.md` files still described pre-migration Astro tooling as current. This PR replaces those references with their verified zfb equivalents. Because these skill docs are also surfaced as generated pages under `/docs/claude-skills/`, fixing the sources fixes those pages too.

All replacements were verified against the actual generator output in `packages/create-zudo-doc/src/` (which emits `zfb-config-gen.ts` → `zfb.config.ts`; there is no `astro-config-gen.ts` / `content-config-gen.ts` / `astro.config.ts`).

## Changes

- **l-update-generator/SKILL.md**: `astro.config.ts` → `zfb.config.ts`, `astro-config-gen.ts` → `zfb-config-gen.ts`; dropped the `content-config-gen.ts` table row (consolidated into `zfb-config-gen.ts` per that file's own header comment — content-collection schemas live inline in `zfb.config.ts`); `.astro` example extensions → `.tsx`; trimmed the allowlist example to the real entry `global.css`.
- **l-generator-cli-tester/SKILL.md**: `astro.config.ts` → `zfb.config.ts` (barebone presence check + lang-ja settings check); `npx astro dev --port 14350` → `pnpm dev --port 14350` (zfb dev supports `--port`).
- **zudo-doc-translate/SKILL.md**: i18n config reference `astro.config.ts` → `zfb.config.ts`.

## Out of scope (separate issue)

`l-generator-cli-tester` carries deeper table drift unrelated to the Astro→zfb rename — `.astro` component paths and `search`/`i18n` feature-pattern names that no longer match the current generator's feature set. Raised separately as an `agent-found` issue.

## Test Plan

- `pnpm check` (typecheck) — docs-only change, should be unaffected
- `grep -i astro` over the three files confirms only the out-of-scope `.astro` table entries remain

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/1710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782310310&installation_id=130359969&pr_number=1710&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F1710&signature=64a761109088673ca6926c49ae80db2315bc8bf6f9e2eb4d1e8a4c596f1c939f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->