### PR TITLE
ci: register publish workflows on main (3 files)

### DIFF
--- a/.github/workflows/publish-create-zudo-doc.yml
+++ b/.github/workflows/publish-create-zudo-doc.yml
@@ -1,0 +1,196 @@
+# Publish create-zudo-doc to npm.
+#
+# Trigger (two paths):
+#   1. release: published — fires when a human publishes a GitHub Draft Release.
+#      Publishing the draft is the irreversible human gate; CI does the actual
+#      `npm publish` only after all safeguards pass.
+#   2. workflow_dispatch with dry_run: true — proves the token and safeguards
+#      pass without touching npm. Use this before the first real release to
+#      verify NPM_TOKEN is wired correctly.
+#
+# NPM_TOKEN must be an Automation token (type: "Automation" in npmjs.com).
+# Automation tokens bypass npm's 2FA for `npm publish`, which is required
+# for CI-driven publishing. Classic Publish tokens with 2FA enabled would
+# fail at the publish step with an OTP error.
+#
+# OIDC provenance:
+#   id-token: write is required so npm can request an OIDC identity token
+#   and attach provenance metadata to the published package. The repo must
+#   be public (zudolab/zudo-doc is public) for provenance to be recorded
+#   in the npm transparency log.
+
+name: Publish create-zudo-doc
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run — verify auth and safeguards only; skip npm publish'
+        type: boolean
+        required: false
+        default: false
+
+# Least-privilege: read for checkout, id-token for OIDC provenance.
+permissions:
+  contents: read
+  id-token: write
+
+# Prevent concurrent publish runs. Never cancel in-progress publishes —
+# aborting mid-publish could leave a partial upload, so allow the run to
+# complete even if a second trigger arrives.
+concurrency:
+  group: publish-create-zudo-doc
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      # ── Checkout at the exact release tag ──────────────────────────────────
+      # Explicit ref ensures we always build from the tagged commit even when
+      # triggered via workflow_dispatch (which defaults to the default branch).
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.event.release.tag_name || github.ref }}
+
+      # ── Safeguard 1/4: Tag must start with "v" ─────────────────────────────
+      # Reject accidental triggers from non-version tags (e.g. "latest",
+      # "stable", or typos). Pure shell — runs before any tooling setup so
+      # bad tags fail fast with a clear message.
+      - name: '[Safeguard 1/4] Reject non-v* release tags'
+        shell: bash
+        run: |
+          TAG="${{ github.event.release.tag_name || github.ref_name }}"
+          echo "Release tag: $TAG"
+          if [[ "$TAG" != v* ]]; then
+            echo "::error::Release tag '$TAG' does not start with 'v'."
+            echo "::error::Only version tags (e.g. v1.2.3, v1.2.3-next.1) trigger this workflow."
+            exit 1
+          fi
+          # Strip the leading "v" for use in later steps.
+          VERSION="${TAG#v}"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "TAG=$TAG" >> "$GITHUB_ENV"
+
+      # ── Setup toolchain ────────────────────────────────────────────────────
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
+        with:
+          dest: ~/setup-pnpm-publish
+
+      # registry-url is required for setup-node to write the .npmrc that
+      # wires NODE_AUTH_TOKEN → npm auth. Without it, `npm publish` ignores
+      # the env var and falls back to unauthenticated (or interactive 2FA).
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      # ── Safeguard 2/4: package.json version must match the tag ─────────────
+      # Prevents a publish where the tag was pushed without a matching version
+      # bump (or vice-versa). Uses the VERSION env set by Safeguard 1.
+      - name: '[Safeguard 2/4] Assert package.json version matches tag'
+        shell: bash
+        run: |
+          PKG_VERSION=$(node -p "require('./packages/create-zudo-doc/package.json').version")
+          echo "Tag version:     $VERSION"
+          echo "package.json:    $PKG_VERSION"
+          if [[ "$PKG_VERSION" != "$VERSION" ]]; then
+            echo "::error::packages/create-zudo-doc/package.json .version is '$PKG_VERSION' but tag is 'v$VERSION'."
+            echo "::error::Bump the version with scripts/release-create-zudo-doc.sh before tagging."
+            exit 1
+          fi
+
+      # ── Safeguard 3/4: Version must not already be published ───────────────
+      # npm publish is irreversible (unpublish is locked after 72 h for
+      # packages with dependents). Guard against accidental double-publish.
+      # We check stdout: `npm view` prints the version string if it exists
+      # and exits 0; it prints nothing and exits non-zero if absent.
+      # We treat non-empty stdout as "already published".
+      - name: '[Safeguard 3/4] Assert version not yet published to npm'
+        shell: bash
+        run: |
+          EXISTING=$(npm view "create-zudo-doc@$VERSION" version 2>/dev/null || true)
+          if [[ -n "$EXISTING" ]]; then
+            echo "::error::create-zudo-doc@$VERSION is already published on npm (found: $EXISTING)."
+            echo "::error::npm publish is irreversible — aborting to prevent a duplicate-version error."
+            exit 1
+          fi
+          echo "OK: create-zudo-doc@$VERSION does not yet exist on npm."
+
+      # ── Install dependencies ───────────────────────────────────────────────
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # ── Build and test ────────────────────────────────────────────────────
+      - name: Build create-zudo-doc
+        run: pnpm --filter create-zudo-doc build
+
+      - name: Test create-zudo-doc
+        run: pnpm --filter create-zudo-doc test
+
+      # ── Compute dist-tag ───────────────────────────────────────────────────
+      # ANY semver prerelease (a hyphen after the X.Y.Z core — e.g. -next.1,
+      # -beta.2, -rc.1, -alpha.1, or a bare -beta) publishes under --tag next
+      # so it never becomes the default "latest" install. Only a clean X.Y.Z
+      # release gets --tag latest. (VERSION is the tag with the leading "v"
+      # stripped, set by Safeguard 1.)
+      - name: Compute npm dist-tag
+        shell: bash
+        run: |
+          if [[ "$VERSION" == *-* ]]; then
+            DIST_TAG=next
+          else
+            DIST_TAG=latest
+          fi
+          echo "DIST_TAG=$DIST_TAG" >> "$GITHUB_ENV"
+          echo "Dist tag: $DIST_TAG (version: $VERSION)"
+
+      # ── Safeguard 4/4: Dry-run path ────────────────────────────────────────
+      # When dry_run is true (workflow_dispatch only), prove the secret
+      # authenticates and print what would be published — then stop.
+      # NOTE: `npm publish --dry-run` does NOT prove auth; it skips network
+      # calls entirely and never contacts the registry. Running `npm whoami`
+      # with NODE_AUTH_TOKEN is the only way to confirm the token is valid
+      # before the real publish.
+      - name: '[Safeguard 4/4] Dry-run: verify auth then stop (skip real publish)'
+        if: ${{ inputs.dry_run == true }}
+        shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          echo "=== DRY RUN MODE — npm publish will NOT be executed ==="
+          echo ""
+          echo "Verifying NPM_TOKEN authenticates against registry.npmjs.org..."
+          npm whoami
+          echo ""
+          echo "Would publish:"
+          echo "  Package : create-zudo-doc"
+          echo "  Version : $VERSION"
+          echo "  Dist-tag: $DIST_TAG"
+          echo "  Flags   : --access public --provenance"
+          echo ""
+          echo "Dry run complete. Remove dry_run input or set it to false to publish for real."
+
+      # ── Real publish ───────────────────────────────────────────────────────
+      # Only runs when dry_run is false (or the workflow was triggered by
+      # a release event, which has no dry_run input).
+      - name: Publish to npm
+        if: ${{ inputs.dry_run != true }}
+        shell: bash
+        working-directory: packages/create-zudo-doc
+        env:
+          # NPM_TOKEN must be an Automation token (bypasses 2FA for CI).
+          # Set it at: github.com/zudolab/zudo-doc → Settings → Secrets → Actions.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          echo "Publishing create-zudo-doc@$VERSION with --tag $DIST_TAG..."
+          npm publish --access public --provenance --tag "$DIST_TAG"
+          echo "Published: https://www.npmjs.com/package/create-zudo-doc/v/$VERSION"

--- a/.github/workflows/publish-zudo-doc-history-server.yml
+++ b/.github/workflows/publish-zudo-doc-history-server.yml
@@ -1,0 +1,194 @@
+# Publish @takazudo/zudo-doc-history-server to npm.
+#
+# Trigger (two paths):
+#   1. release: published — fires when a human publishes a GitHub Draft Release
+#      whose tag matches the zudo-doc-history-server- prefix.
+#   2. workflow_dispatch with dry_run: true — proves the token and safeguards
+#      pass without touching npm.
+#
+# Tag prefix choice — `zudo-doc-history-server-X.Y.Z`:
+#   Both this workflow and publish-zudo-doc.yml use prefixed tag namespaces
+#   so a single tag fires exactly one publish workflow. The bare `v*` namespace
+#   belongs to publish-create-zudo-doc.yml; this one uses
+#   `zudo-doc-history-server-`, and the sibling zudo-doc workflow uses
+#   `zudo-doc-v`. Safeguard 1 below uses an anchored regex (not a bash glob)
+#   so future siblings under `@takazudo/zudo-doc-history-server-*` cannot
+#   accidentally trigger this workflow.
+#
+# Workflow_dispatch caveat:
+#   When dispatching manually, choose a zudo-doc-history-server- prefixed tag
+#   as the ref — Safeguard 1 rejects refs that don't match. Dispatching from
+#   `main` will fail-fast with a clear message.
+#
+# NPM_TOKEN must be an Automation token (type: "Automation" in npmjs.com).
+#
+# OIDC provenance:
+#   id-token: write is required so npm can request an OIDC identity token
+#   and attach provenance metadata to the published package. The repo must
+#   be public (zudolab/zudo-doc is public) for provenance to be recorded
+#   in the npm transparency log.
+#
+# Build step IS required:
+#   doc-history-server ships compiled dist/*.js + dist/*.d.ts (see
+#   packages/doc-history-server/package.json `exports` pointing at dist/).
+#   The package's `prepare` hook (tsup) already runs on `pnpm install`,
+#   but we keep an explicit build step here for clarity and to survive
+#   any future prepare-hook removal.
+
+name: Publish zudo-doc-history-server
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run — verify auth and safeguards only; skip npm publish'
+        type: boolean
+        required: false
+        default: false
+
+# Least-privilege: read for checkout, id-token for OIDC provenance.
+permissions:
+  contents: read
+  id-token: write
+
+# Prevent concurrent publish runs for THIS package only. Distinct from
+# publish-create-zudo-doc and publish-zudo-doc so the three release
+# workflows can run in parallel.
+concurrency:
+  group: publish-zudo-doc-history-server
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      # ── Checkout at the exact release tag ──────────────────────────────────
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.event.release.tag_name || github.ref }}
+
+      # ── Safeguard 1/4: Tag must match "zudo-doc-history-server-X.Y.Z" ─────
+      # Anchored regex pins the version core so a stray tag like
+      # `zudo-doc-history-server-foo` is rejected.
+      - name: '[Safeguard 1/4] Reject non-zudo-doc-history-server-* release tags'
+        shell: bash
+        run: |
+          TAG="${{ github.event.release.tag_name || github.ref_name }}"
+          echo "Release tag: $TAG"
+          if [[ ! "$TAG" =~ ^zudo-doc-history-server-[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Release tag '$TAG' does not match zudo-doc-history-server-X.Y.Z[-prerelease]."
+            echo "::error::Only zudo-doc-history-server-prefixed semver tags (e.g. zudo-doc-history-server-0.1.0) trigger this workflow."
+            echo "::error::For workflow_dispatch dry runs, choose a zudo-doc-history-server-prefixed tag/ref."
+            exit 1
+          fi
+          VERSION="${TAG#zudo-doc-history-server-}"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "TAG=$TAG" >> "$GITHUB_ENV"
+
+      # ── Setup toolchain ────────────────────────────────────────────────────
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
+        with:
+          dest: ~/setup-pnpm-publish-zudo-doc-history-server
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      # ── Safeguard 2/4: package.json version must match the tag ─────────────
+      - name: '[Safeguard 2/4] Assert package.json version matches tag'
+        shell: bash
+        run: |
+          PKG_VERSION=$(node -p "require('./packages/doc-history-server/package.json').version")
+          echo "Tag version:     $VERSION"
+          echo "package.json:    $PKG_VERSION"
+          if [[ "$PKG_VERSION" != "$VERSION" ]]; then
+            echo "::error::packages/doc-history-server/package.json .version is '$PKG_VERSION' but tag is 'zudo-doc-history-server-$VERSION'."
+            echo "::error::Bump the version with scripts/release-create-zudo-doc.sh before tagging."
+            exit 1
+          fi
+
+      # ── Safeguard 3/4: Version must not already be published ───────────────
+      - name: '[Safeguard 3/4] Assert version not yet published to npm'
+        shell: bash
+        run: |
+          EXISTING=$(npm view "@takazudo/zudo-doc-history-server@$VERSION" version 2>/dev/null || true)
+          if [[ -n "$EXISTING" ]]; then
+            echo "::error::@takazudo/zudo-doc-history-server@$VERSION is already published on npm (found: $EXISTING)."
+            echo "::error::npm publish is irreversible — aborting to prevent a duplicate-version error."
+            exit 1
+          fi
+          echo "OK: @takazudo/zudo-doc-history-server@$VERSION does not yet exist on npm."
+
+      # ── Install dependencies ───────────────────────────────────────────────
+      # pnpm install auto-runs the package's `prepare` script (tsup), which
+      # produces dist/. We keep an explicit build step below for defensive
+      # clarity in case the prepare hook is ever removed.
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # ── Build (explicit, defensive) ───────────────────────────────────────
+      - name: Build zudo-doc-history-server
+        run: pnpm --filter @takazudo/zudo-doc-history-server build
+
+      # ── Run tests ─────────────────────────────────────────────────────────
+      - name: Test zudo-doc-history-server
+        run: pnpm --filter @takazudo/zudo-doc-history-server test
+
+      # ── Compute dist-tag ───────────────────────────────────────────────────
+      - name: Compute npm dist-tag
+        shell: bash
+        run: |
+          if [[ "$VERSION" == *-* ]]; then
+            DIST_TAG=next
+          else
+            DIST_TAG=latest
+          fi
+          echo "DIST_TAG=$DIST_TAG" >> "$GITHUB_ENV"
+          echo "Dist tag: $DIST_TAG (version: $VERSION)"
+
+      # ── Safeguard 4/4: Dry-run path ────────────────────────────────────────
+      - name: '[Safeguard 4/4] Dry-run: verify auth then stop (skip real publish)'
+        if: ${{ inputs.dry_run == true }}
+        shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          echo "=== DRY RUN MODE — npm publish will NOT be executed ==="
+          echo ""
+          echo "Verifying NPM_TOKEN authenticates against registry.npmjs.org..."
+          npm whoami
+          echo ""
+          echo "Would publish:"
+          echo "  Package : @takazudo/zudo-doc-history-server"
+          echo "  Version : $VERSION"
+          echo "  Dist-tag: $DIST_TAG"
+          echo "  Flags   : --access public --provenance --no-git-checks"
+          echo ""
+          echo "Dry run complete. Remove dry_run input or set it to false to publish for real."
+
+      # ── Real publish ───────────────────────────────────────────────────────
+      # Uses `pnpm publish` (not `npm publish`) for consistency with the
+      # other workspace publish workflows. --no-git-checks is required for
+      # CI's detached-HEAD checkout.
+      - name: Publish to npm
+        if: ${{ inputs.dry_run != true }}
+        shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          echo "Publishing @takazudo/zudo-doc-history-server@$VERSION with --tag $DIST_TAG..."
+          pnpm --filter @takazudo/zudo-doc-history-server publish \
+            --access public \
+            --provenance \
+            --no-git-checks \
+            --tag "$DIST_TAG"
+          echo "Published: https://www.npmjs.com/package/@takazudo/zudo-doc-history-server/v/$VERSION"

--- a/.github/workflows/publish-zudo-doc.yml
+++ b/.github/workflows/publish-zudo-doc.yml
@@ -1,0 +1,243 @@
+# Publish @takazudo/zudo-doc to npm.
+#
+# Trigger (two paths):
+#   1. release: published — fires when a human publishes a GitHub Draft Release
+#      whose tag matches the zudo-doc-v prefix. Publishing the draft is the
+#      irreversible human gate; CI does the actual `npm publish` only after
+#      all safeguards pass.
+#   2. workflow_dispatch with dry_run: true — proves the token and safeguards
+#      pass without touching npm. Use this before the first real release to
+#      verify NPM_TOKEN is wired correctly.
+#
+# Tag prefix choice — `zudo-doc-vX.Y.Z` (e.g. zudo-doc-v0.1.0, zudo-doc-v0.2.0-next.1):
+#   The `zudo-doc-v` prefix avoids collision with create-zudo-doc's bare `v*`
+#   tags (publish-create-zudo-doc.yml) and with the sibling
+#   `zudo-doc-history-server-` tag namespace (publish-zudo-doc-history-server.yml).
+#   Safeguard 1 below uses an anchored regex (not a bash glob) so future
+#   sibling packages under `@takazudo/zudo-doc-*` cannot accidentally trigger
+#   this workflow.
+#
+# Workflow_dispatch caveat:
+#   When dispatching manually, choose a zudo-doc-v prefixed tag (or branch
+#   that has one) as the ref — Safeguard 1 below rejects refs that don't
+#   match. Dispatching from `main` will fail-fast with a clear message rather
+#   than silently publishing the wrong version.
+#
+# NPM_TOKEN must be an Automation token (type: "Automation" in npmjs.com).
+# Automation tokens bypass npm's 2FA for `npm publish`, which is required
+# for CI-driven publishing. Classic Publish tokens with 2FA enabled would
+# fail at the publish step with an OTP error.
+#
+# OIDC provenance:
+#   id-token: write is required so npm can request an OIDC identity token
+#   and attach provenance metadata to the published package. The repo must
+#   be public (zudolab/zudo-doc is public) for provenance to be recorded
+#   in the npm transparency log.
+#
+# Build step IS required:
+#   zudo-doc ships compiled dist/*.js + dist/*.d.ts (see
+#   packages/zudo-doc/package.json `exports` and `files: ["dist", "README.md"]`).
+#   The compile pipeline is tsup with bundle:false — see
+#   packages/zudo-doc/tsup.config.ts for the rationale (zfb's island scanner
+#   reads "use client" directives, which esbuild strips during true bundling;
+#   per-file output preserves them, plus cross-entry component identity).
+#   The package's `prepare` hook (tsup) auto-runs on `pnpm install`, but we
+#   keep an explicit build step below for clarity and to survive any future
+#   prepare-hook removal — see Wave 8 Blocker 2 resolution (#1724).
+
+name: Publish zudo-doc
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run — verify auth and safeguards only; skip npm publish'
+        type: boolean
+        required: false
+        default: false
+
+# Least-privilege: read for checkout, id-token for OIDC provenance.
+permissions:
+  contents: read
+  id-token: write
+
+# Prevent concurrent publish runs for THIS package only. Distinct from
+# publish-create-zudo-doc and publish-zudo-doc-history-server so the three
+# release workflows can run in parallel.
+concurrency:
+  group: publish-zudo-doc
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      # ── Checkout at the exact release tag ──────────────────────────────────
+      # Explicit ref ensures we always build from the tagged commit even when
+      # triggered via workflow_dispatch (which defaults to the default branch).
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.event.release.tag_name || github.ref }}
+
+      # ── Safeguard 1/4: Tag must match "zudo-doc-vX.Y.Z" exactly ────────────
+      # Anchored regex (not bash glob) rejects any ref that does not use this
+      # specific tag shape. This protects against future sibling packages
+      # under `@takazudo/zudo-doc-*` whose tag prefixes could collide with a
+      # bash glob (e.g. publish-zudo-doc-history-server uses
+      # `zudo-doc-history-server-*`). The regex pins the version core so a
+      # stray tag like `zudo-doc-vintage-1.0.0` is rejected.
+      - name: '[Safeguard 1/4] Reject non-zudo-doc-v* release tags'
+        shell: bash
+        run: |
+          TAG="${{ github.event.release.tag_name || github.ref_name }}"
+          echo "Release tag: $TAG"
+          if [[ ! "$TAG" =~ ^zudo-doc-v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Release tag '$TAG' does not match zudo-doc-vX.Y.Z[-prerelease]."
+            echo "::error::Only zudo-doc-v-prefixed semver tags (e.g. zudo-doc-v0.1.0, zudo-doc-v0.2.0-next.1) trigger this workflow."
+            echo "::error::For workflow_dispatch dry runs, choose a zudo-doc-v-prefixed tag/ref."
+            exit 1
+          fi
+          # Strip the leading "zudo-doc-v" for use in later steps.
+          VERSION="${TAG#zudo-doc-v}"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "TAG=$TAG" >> "$GITHUB_ENV"
+
+      # ── Setup toolchain ────────────────────────────────────────────────────
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
+        with:
+          dest: ~/setup-pnpm-publish-zudo-doc
+
+      # registry-url is required for setup-node to write the .npmrc that
+      # wires NODE_AUTH_TOKEN → npm auth. Without it, `npm publish` ignores
+      # the env var and falls back to unauthenticated (or interactive 2FA).
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      # ── Safeguard 2/4: package.json version must match the tag ─────────────
+      # Prevents a publish where the tag was pushed without a matching version
+      # bump (or vice-versa). Uses the VERSION env set by Safeguard 1.
+      - name: '[Safeguard 2/4] Assert package.json version matches tag'
+        shell: bash
+        run: |
+          PKG_VERSION=$(node -p "require('./packages/zudo-doc/package.json').version")
+          echo "Tag version:     $VERSION"
+          echo "package.json:    $PKG_VERSION"
+          if [[ "$PKG_VERSION" != "$VERSION" ]]; then
+            echo "::error::packages/zudo-doc/package.json .version is '$PKG_VERSION' but tag is 'zudo-doc-v$VERSION'."
+            echo "::error::Bump the version with scripts/release-create-zudo-doc.sh before tagging."
+            exit 1
+          fi
+
+      # ── Safeguard 3/4: Version must not already be published ───────────────
+      # npm publish is irreversible (unpublish is locked after 72 h for
+      # packages with dependents). Guard against accidental double-publish.
+      # We check stdout: `npm view` prints the version string if it exists
+      # and exits 0; it prints nothing and exits non-zero if absent.
+      # We treat non-empty stdout as "already published".
+      - name: '[Safeguard 3/4] Assert version not yet published to npm'
+        shell: bash
+        run: |
+          EXISTING=$(npm view "@takazudo/zudo-doc@$VERSION" version 2>/dev/null || true)
+          if [[ -n "$EXISTING" ]]; then
+            echo "::error::@takazudo/zudo-doc@$VERSION is already published on npm (found: $EXISTING)."
+            echo "::error::npm publish is irreversible — aborting to prevent a duplicate-version error."
+            exit 1
+          fi
+          echo "OK: @takazudo/zudo-doc@$VERSION does not yet exist on npm."
+
+      # ── Install dependencies ───────────────────────────────────────────────
+      # pnpm install auto-runs the package's `prepare` script (tsup), which
+      # produces packages/zudo-doc/dist/. We keep an explicit build step
+      # below for defensive clarity in case the prepare hook is ever removed.
+      # Doc-history-server's prepare script also runs here, populating its
+      # dist/ so the workspace's @takazudo/zudo-doc → @takazudo/zudo-doc-history-server
+      # peer link resolves cleanly.
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # ── Build (explicit, defensive) ───────────────────────────────────────
+      - name: Build zudo-doc
+        run: pnpm --filter @takazudo/zudo-doc build
+
+      # ── Run tests ─────────────────────────────────────────────────────────
+      - name: Test zudo-doc
+        run: pnpm --filter @takazudo/zudo-doc test
+
+      # ── Compute dist-tag ───────────────────────────────────────────────────
+      # ANY semver prerelease (a hyphen after the X.Y.Z core — e.g. -next.1,
+      # -beta.2, -rc.1, -alpha.1) publishes under --tag next so it never
+      # becomes the default "latest" install. Only a clean X.Y.Z release gets
+      # --tag latest.
+      - name: Compute npm dist-tag
+        shell: bash
+        run: |
+          if [[ "$VERSION" == *-* ]]; then
+            DIST_TAG=next
+          else
+            DIST_TAG=latest
+          fi
+          echo "DIST_TAG=$DIST_TAG" >> "$GITHUB_ENV"
+          echo "Dist tag: $DIST_TAG (version: $VERSION)"
+
+      # ── Safeguard 4/4: Dry-run path ────────────────────────────────────────
+      # When dry_run is true (workflow_dispatch only), prove the secret
+      # authenticates and print what would be published — then stop.
+      # NOTE: `npm publish --dry-run` does NOT prove auth; it skips network
+      # calls entirely and never contacts the registry. Running `npm whoami`
+      # with NODE_AUTH_TOKEN is the only way to confirm the token is valid
+      # before the real publish.
+      - name: '[Safeguard 4/4] Dry-run: verify auth then stop (skip real publish)'
+        if: ${{ inputs.dry_run == true }}
+        shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          echo "=== DRY RUN MODE — npm publish will NOT be executed ==="
+          echo ""
+          echo "Verifying NPM_TOKEN authenticates against registry.npmjs.org..."
+          npm whoami
+          echo ""
+          echo "Would publish:"
+          echo "  Package : @takazudo/zudo-doc"
+          echo "  Version : $VERSION"
+          echo "  Dist-tag: $DIST_TAG"
+          echo "  Flags   : --access public --provenance --no-git-checks"
+          echo ""
+          echo "Dry run complete. Remove dry_run input or set it to false to publish for real."
+
+      # ── Real publish ───────────────────────────────────────────────────────
+      # Only runs when dry_run is false (or the workflow was triggered by
+      # a release event, which has no dry_run input).
+      #
+      # Uses `pnpm publish` (not `npm publish`) so workspace: protocol in
+      # peerDependencies (@takazudo/zudo-doc-history-server: workspace:^) is
+      # rewritten to the actual version range at publish time. `npm publish`
+      # would ship the literal workspace: string and break consumers.
+      # `--no-git-checks` is required because GitHub Actions checks out a
+      # detached HEAD; pnpm would otherwise refuse to publish from a
+      # non-branch ref.
+      - name: Publish to npm
+        if: ${{ inputs.dry_run != true }}
+        shell: bash
+        env:
+          # NPM_TOKEN must be an Automation token (bypasses 2FA for CI).
+          # Set it at: github.com/zudolab/zudo-doc → Settings → Secrets → Actions.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          echo "Publishing @takazudo/zudo-doc@$VERSION with --tag $DIST_TAG..."
+          pnpm --filter @takazudo/zudo-doc publish \
+            --access public \
+            --provenance \
+            --no-git-checks \
+            --tag "$DIST_TAG"
+          echo "Published: https://www.npmjs.com/package/@takazudo/zudo-doc/v/$VERSION"


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/1724

---

## Why this PR exists

GitHub Actions only fires `workflow_dispatch` and `release: published` for workflows whose YAML lives on the **default branch**. The three publish workflows for `@takazudo/zudo-doc`, `@takazudo/zudo-doc-history-server`, and `create-zudo-doc` were added during W4A + W8 hygiene of epic #1724 but have lived only on the `base/zudo-doc-v1` lineage — never on `main`. So today `gh workflow run --ref zudo-doc-v0.1.0` returns 404 and publishing the first GitHub Release would silently fire nothing.

This is the discovery from the publish dry-run attempt on commit `32848de5` (now part of `base/zudo-doc-v1` via merged PR #1740).

## What this PR does

Lands the 3 publish workflow YAMLs on `main` as **standalone infra**. Nothing else moves — no package sources, no scripts. The package code still lives on `base/zudo-doc-v1` and will flow to main with the eventual v1 release merge.

| File | Tag prefix | Package |
|---|---|---|
| `publish-zudo-doc.yml` | `zudo-doc-vX.Y.Z` | `@takazudo/zudo-doc` |
| `publish-zudo-doc-history-server.yml` | `zudo-doc-history-server-X.Y.Z` | `@takazudo/zudo-doc-history-server` |
| `publish-create-zudo-doc.yml` | `vX.Y.Z` | `create-zudo-doc` |

All three are cherry-picked verbatim from `32848de5` (the latest validated version — post-rename `@takazudo/*`, post-stale-comment-refresh, post-explicit-build-step for zudo-doc).

## Runtime model

The YAML on main is what GitHub reads at trigger time, but the very first workflow step is:

```yaml
- uses: actions/checkout@v5
  with:
    ref: ${{ github.event.release.tag_name || github.ref }}
```

So all subsequent steps (`pnpm install`, `build`, `test`, `publish`) run against the **tag's** tree — which lives on the publish lineage and carries the correct package layout. Main's own tree is irrelevant to publish-time behavior. We just need GitHub to know the workflow exists.

## Safeguards (identical across all three)

1. Anchored regex on the tag — rejects refs that don't match the package-specific prefix
2. `package.json .version` must equal the tag's version core
3. `npm view <pkg>@<version>` must be empty (no double-publish)
4. `dry_run` input — runs `npm whoami` to prove `NPM_TOKEN` authenticates, then stops

## After this merges

1. `gh workflow run publish-zudo-doc-history-server.yml --ref zudo-doc-history-server-0.1.0 -f dry_run=true`
2. `gh workflow run publish-zudo-doc.yml --ref zudo-doc-v0.1.0 -f dry_run=true`
3. `gh workflow run publish-create-zudo-doc.yml --ref v0.1.0 -f dry_run=true`

All three tags already exist on origin (pushed earlier in this session, pointing at commit `32848de5` on the `base/zudo-doc-v1` lineage). Once dry-runs pass, the maintainer publishes 3 draft GitHub Releases against those tags — each fires the matching workflow and produces a real npm publish.

## Not in this PR (intentional)

- `scripts/release-create-zudo-doc.sh` — referenced by workflows in error messages only, not invoked by them. Lands with the v1 release merge.
- Any package source — already on `base/zudo-doc-v1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/1741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782372568&installation_id=130359969&pr_number=1741&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F1741&signature=6ea223c4fbef5c42756709f070f9ed9320e5d785296ddcca2c5ebdc5160cba4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->