### PR TITLE
fix: gate og:image / twitter:image emission on non-empty siteUrl

### DIFF
--- a/packages/create-zudo-doc/templates/base/pages/lib/_head-with-defaults.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_head-with-defaults.tsx
@@ -77,9 +77,16 @@ export function HeadWithDefaults({
   canonical,
 }: HeadWithDefaultsProps): JSX.Element {
   // og:image / twitter:image must be absolute URLs — crawlers silently drop
-  // relative og:image values. Computed as siteUrl (no trailing slash) + the
-  // base-prefixed asset path.
-  const ogImageUrl = `${settings.siteUrl.replace(/\/$/, "")}${withBase("/img/ogp.png")}`;
+  // relative og:image values. Compute as siteUrl (no trailing slash) + the
+  // base-prefixed asset path, and skip emission entirely when siteUrl is
+  // empty (e.g. a freshly scaffolded create-zudo-doc project that hasn't
+  // configured siteUrl yet) so we never ship a useless relative og:image.
+  // OgTags / TwitterCard already gate their image emission on the prop being
+  // defined; the og:image:* companion tags below are gated explicitly because
+  // they would dangle without the parent og:image.
+  const ogImageUrl = settings.siteUrl
+    ? `${settings.siteUrl.replace(/\/$/, "")}${withBase("/img/ogp.png")}`
+    : undefined;
 
   // Resolve the palette CSS body once per page render (the v2 component
   // is pure SSR — no caching needed).
@@ -97,10 +104,15 @@ export function HeadWithDefaults({
       />
       {/* og:image:width / og:image:height / og:image:alt — not in OgTags API;
           emitted here directly to avoid expanding the shared HeadProps surface.
-          Standard 1200×630 social preview dimensions. */}
-      <meta property="og:image:width" content="1200" />
-      <meta property="og:image:height" content="630" />
-      <meta property="og:image:alt" content={composeMetaTitle(title)} />
+          Standard 1200×630 social preview dimensions. Gated on ogImageUrl so
+          the companion tags don't dangle when og:image itself was suppressed. */}
+      {ogImageUrl !== undefined && (
+        <>
+          <meta property="og:image:width" content="1200" />
+          <meta property="og:image:height" content="630" />
+          <meta property="og:image:alt" content={composeMetaTitle(title)} />
+        </>
+      )}
       <TwitterCard card="summary_large_image" image={ogImageUrl} />
       <ColorSchemeProvider cssText={cssText} colorMode={colorMode} />
       {/* favicon set — withBase() handles the configured base path prefix */}

--- a/pages/lib/_head-with-defaults.tsx
+++ b/pages/lib/_head-with-defaults.tsx
@@ -77,9 +77,16 @@ export function HeadWithDefaults({
   canonical,
 }: HeadWithDefaultsProps): JSX.Element {
   // og:image / twitter:image must be absolute URLs — crawlers silently drop
-  // relative og:image values. Computed as siteUrl (no trailing slash) + the
-  // base-prefixed asset path.
-  const ogImageUrl = `${settings.siteUrl.replace(/\/$/, "")}${withBase("/img/ogp.png")}`;
+  // relative og:image values. Compute as siteUrl (no trailing slash) + the
+  // base-prefixed asset path, and skip emission entirely when siteUrl is
+  // empty (e.g. a freshly scaffolded create-zudo-doc project that hasn't
+  // configured siteUrl yet) so we never ship a useless relative og:image.
+  // OgTags / TwitterCard already gate their image emission on the prop being
+  // defined; the og:image:* companion tags below are gated explicitly because
+  // they would dangle without the parent og:image.
+  const ogImageUrl = settings.siteUrl
+    ? `${settings.siteUrl.replace(/\/$/, "")}${withBase("/img/ogp.png")}`
+    : undefined;
 
   // Resolve the palette CSS body once per page render (the v2 component
   // is pure SSR — no caching needed).
@@ -97,10 +104,15 @@ export function HeadWithDefaults({
       />
       {/* og:image:width / og:image:height / og:image:alt — not in OgTags API;
           emitted here directly to avoid expanding the shared HeadProps surface.
-          Standard 1200×630 social preview dimensions. */}
-      <meta property="og:image:width" content="1200" />
-      <meta property="og:image:height" content="630" />
-      <meta property="og:image:alt" content={composeMetaTitle(title)} />
+          Standard 1200×630 social preview dimensions. Gated on ogImageUrl so
+          the companion tags don't dangle when og:image itself was suppressed. */}
+      {ogImageUrl !== undefined && (
+        <>
+          <meta property="og:image:width" content="1200" />
+          <meta property="og:image:height" content="630" />
+          <meta property="og:image:alt" content={composeMetaTitle(title)} />
+        </>
+      )}
       <TwitterCard card="summary_large_image" image={ogImageUrl} />
       <ColorSchemeProvider cssText={cssText} colorMode={colorMode} />
       {/* favicon set — withBase() handles the configured base path prefix */}


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/1722

---

## Summary

When `settings.siteUrl` is empty, the host's `_head-with-defaults.tsx` was emitting `og:image` / `twitter:image` with a relative URL (`/img/ogp.png` rather than an absolute `https://…/img/ogp.png`). Social-media crawlers silently drop relative `og:image` values, so the meta tag is effectively useless in that state and only creates noise in the HTML.

For `zudo-doc` itself there is no live bug (`siteUrl` is always set), but the same file ships verbatim in the `create-zudo-doc` generated template, where a freshly scaffolded project may not have configured `siteUrl` yet.

This PR gates the social-image meta tags on a non-empty `siteUrl` and applies the identical change to both the host file and the template counterpart.

## Changes

- `pages/lib/_head-with-defaults.tsx` — compute `ogImageUrl` as `undefined` when `settings.siteUrl` is empty (instead of a useless `"" + withBase("/img/ogp.png")` relative URL). Let the existing `props.ogImage !== undefined` guard inside `<OgTags>` and `props.image !== undefined` guard inside `<TwitterCard>` suppress emission. Wrap the three companion meta tags (`og:image:width` / `og:image:height` / `og:image:alt`) in an explicit `{ogImageUrl !== undefined && ...}` block so they don't dangle when their parent `og:image` is suppressed.
- `packages/create-zudo-doc/templates/base/pages/lib/_head-with-defaults.tsx` — identical change (the file is the template counterpart of the host file and is **not** on the `.template-drift-allowlist`, so the two must stay byte-for-byte identical).

Net delta: +38 / -14 across two files, no API changes, no new dependencies.

## Test Plan

Local pre-push verification (all pass):

- `pnpm check` — typecheck passes (`zfb check` → `tsc --noEmit`).
- `pnpm check:template-drift` — confirms the two head-emitter files remain byte-identical.
- `diff -u` between host and template files — exit 0.
- `/gcoc-review` against the diff — no actionable findings (one "high" was a hallucination by the cheap model; one "medium" suggested stricter `siteUrl` validation that would diverge from existing project patterns and is out of scope of issue #1722).

Behavioural verification:

- With `siteUrl = "https://zudo-doc.takazudomodular.com"` (this repo's setting): output is identical to before — `og:image`, `og:image:width/height/alt`, and `twitter:image` all emit with the absolute URL.
- With `siteUrl = ""` (a freshly scaffolded create-zudo-doc project): `og:image`, the three `og:image:*` companion tags, and `twitter:image` are all suppressed. `twitter:card` and all non-image meta still emit normally.

## CI Status

⚠️ **GitHub Actions was experiencing a confirmed [Actions/Pages incident](https://www.githubstatus.com/) starting around 10:57Z UTC on the day of this PR**, so the post-push `PR Checks` workflow never fired despite multiple push/close-reopen attempts. The empty `chore: retrigger CI` commit (`a9d52258`) is a CI-retrigger attempt left behind because force-push is forbidden by repo policy. Local pre-push checks already cover the changed code paths (typecheck + template drift + diff review); CI is expected to fire normally on the next push or after the GitHub incident clears.

Closes #1722