### PR TITLE
fix(create-zudo-doc): drop leading ./ from bin path (npm pkg fix)

### DIFF
--- a/packages/create-zudo-doc/package.json
+++ b/packages/create-zudo-doc/package.json
@@ -30,7 +30,7 @@
   },
   "type": "module",
   "bin": {
-    "create-zudo-doc": "./bin/create-zudo-doc.js"
+    "create-zudo-doc": "bin/create-zudo-doc.js"
   },
   "main": "./dist/api.js",
   "exports": {


### PR DESCRIPTION
One-line `npm pkg fix` — drops the leading `./` from the `bin` path so `npm publish` stops warning:

```
npm warn publish errors corrected:
npm warn publish "bin[create-zudo-doc]" script name bin/create-zudo-doc.js was invalid and removed
```

npm silently auto-corrects on publish, so the v0.1.0 tarball is already in the canonical form on the registry. This commit makes the repo match what npm actually ships, so future `npm pack --dry-run` and `npm publish --dry-run` runs are warning-free.

Surfaced during the #1719 pre-release verification re-run on main (see https://github.com/zudolab/zudo-doc/issues/1719#issuecomment-4544160222 "Non-blocking observations").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/1745"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782392547&installation_id=130359969&pr_number=1745&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F1745&signature=f1aa6ee18701fd1885844e3ef5a42966040c27c7ef02c81bd051997649da8d22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->