### PR TITLE
chore(gitignore): ignore W1 favicon symlinks under e2e/fixtures/*/public/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,10 @@ e2e/fixtures/*/wrangler.toml
 # are not. These mirror the entries in the repo-root public/ (img, favicon.svg);
 # add a line if a new root public/ entry is introduced.
 e2e/fixtures/*/public/img
+e2e/fixtures/*/public/favicon.ico
 e2e/fixtures/*/public/favicon.svg
+e2e/fixtures/*/public/favicon-16x16.png
+e2e/fixtures/*/public/favicon-32x32.png
 e2e/fixtures/*/public/mockServiceWorker.js
 
 # migration-check harness workspace (throwaway build artifacts)


### PR DESCRIPTION
`e2e/setup-fixtures.sh` (L146-160) symlinks every top-level entry from the repo's `public/` into each fixture's `public/` so `/img/logo.svg`, `/favicon.ico`, etc. resolve when E2E runs against the fixture.

The existing `.gitignore` block at L75-80 already ignores these symlinks for `img/` and `favicon.svg`, with an inline comment:

```
# Public dir: fixture-specific entries are kept in git, root-mirror symlinks
# are not. ... add a line if a new root public/ entry is introduced.
e2e/fixtures/*/public/img
e2e/fixtures/*/public/favicon.svg
e2e/fixtures/*/public/mockServiceWorker.js
```

That block pre-dates W1 (#1714), which added `favicon.ico`, `favicon-16x16.png`, and `favicon-32x32.png` to the repo's `public/`. After W1, `setup-fixtures.sh` symlinks those three files into every fixture's `public/`, but they show as untracked in `git status` because no gitignore rule covers them. Their targets are machine-specific absolute paths (`/home/<user>/repos/.../public/favicon.ico`) — regenerable, not portable.

Add the three missing entries, matching the existing pattern. After this change, `git status` is clean on a working tree that ran `setup-fixtures.sh`.

Surfaced during the #1719 verification pass on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/1746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782392933&installation_id=130359969&pr_number=1746&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F1746&signature=3d416f1abde68ea625d4be419ec2cd0e0f14136fb165f4146a4b01dae74d17e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->