### PR TITLE
fix(sidebar-resizer): restore persisted width on page load via pre-paint script

### DIFF
--- a/.claude/skills/test-flow-sidebar-width-restore/SKILL.md
+++ b/.claude/skills/test-flow-sidebar-width-restore/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: test-flow-sidebar-width-restore
+description: "AI-judged verification that the docs-page sidebar's persisted drag-width is restored on page reload before first paint, with no visible flash to the CSS-default width. Use when /verify-ui-ai dispatches a subagent for sidebar-resizer width-restore verification. Procedure drives the local dev server at http://localhost:3000/docs/guides/i18n/ via /headless-browser playwright-cli, mutates `localStorage[\"zudo-doc-sidebar-width\"]`, reloads, measures `#desktop-sidebar` via `getBoundingClientRect()` plus computed `--zd-sidebar-w`, and visually checks the captured screenshot."
+---
+
+# Test flow: sidebar-resizer width restore on reload
+
+## Background
+
+`@takazudo/zudo-doc/sidebar-resizer` writes the user-chosen sidebar width
+to `localStorage["zudo-doc-sidebar-width"]`. A sibling
+`SidebarResizerRestore` component emits a pre-paint inline `<script>` in
+`<head>` that reads the persisted value, validates and clamps it to
+`[192, 448]`, and sets `--zd-sidebar-w` on `:root.style` before first
+paint. The docs layout consumes `--zd-sidebar-w` via the sidebar's
+`w-[var(--zd-sidebar-w)]` and the content wrapper's
+`ml-[var(--zd-sidebar-w)]` classes.
+
+The bug under verification: prior to the fix, reload after a drag
+showed the CSS-default width (`clamp(14rem, 20vw, 22rem)`) instead of
+the persisted value — the value existed in localStorage but nothing
+applied it.
+
+## Scenario
+
+All steps run against the local dev server at the URL passed in
+`Inputs.previewUrl` (default
+`http://localhost:3000/docs/guides/i18n/`). The page must include the
+desktop sidebar (it does on `/docs/...` routes at viewport widths
+≥ Tailwind `lg` ≥ 1024px). Use viewport `1400 x 900` (or the size in
+`Inputs.viewport`).
+
+For each scenario below, capture a screenshot AND measure the live DOM
+right after reload settles.
+
+### Scenario A — baseline (no persisted value)
+
+1. Open `previewUrl` at the configured viewport.
+2. Clear: `localStorage.removeItem("zudo-doc-sidebar-width")`.
+3. Reload the page; wait for `domcontentloaded` plus a 200 ms settle.
+4. Capture screenshot to `baselineScreenshot`.
+5. Measure:
+   - `inline = document.documentElement.style.getPropertyValue("--zd-sidebar-w")`
+   - `computed = getComputedStyle(document.documentElement).getPropertyValue("--zd-sidebar-w").trim()`
+   - `rectWidth = document.getElementById("desktop-sidebar").getBoundingClientRect().width`
+
+### Scenario B — restored to 400 px
+
+1. Set: `localStorage.setItem("zudo-doc-sidebar-width", "400")`.
+2. Reload; wait as above.
+3. Capture screenshot to `restored400Screenshot`.
+4. Measure the same three fields as Scenario A; record into the
+   `restored400` block of the output.
+
+### Scenario C — out-of-range clamp (`99999`)
+
+1. Set: `localStorage.setItem("zudo-doc-sidebar-width", "99999")`.
+2. Reload; wait as above.
+3. Capture screenshot to `clamp448Screenshot`.
+4. Measure the same three fields; record into `clamp448`.
+
+### Scenario D — garbage value falls through (`NaN-garbage`)
+
+1. Set: `localStorage.setItem("zudo-doc-sidebar-width", "NaN-garbage")`.
+2. Reload; wait as above.
+3. Capture screenshot to `garbageFallbackScreenshot`.
+4. Measure the same three fields; record into `garbageFallback`.
+
+After all scenarios, restore a clean state with
+`localStorage.removeItem("zudo-doc-sidebar-width")` and close the
+browser session.
+
+## Verdict criteria
+
+All four scenarios must pass. Each scenario is a mechanical-plus-visual
+check; the mechanical numbers are the source of truth, the screenshot
+is the human-verifiable confirmation.
+
+### Scenario A (baseline)
+
+- Mechanical: `inline === ""` AND `computed === "clamp(14rem, 20vw, 22rem)"`
+  AND `rectWidth ∈ [224, 352]` (the clamp's resolved band at any
+  reasonable viewport).
+- Visual: the sidebar fills a clearly NARROW column relative to the
+  Scenario B screenshot; the Guides nav items wrap into the column at
+  the default width.
+
+### Scenario B (restored 400 px) — THE PRIMARY ASSERTION
+
+- Mechanical: `inline === "400px"` AND `computed === "400px"` AND
+  `|rectWidth − 400| ≤ 1` (one-pixel sub-pixel tolerance).
+- Visual: the sidebar is VISIBLY WIDER than in Scenario A. The
+  restored width must look the same as what the user got immediately
+  after dragging to 400 px, NOT the narrower default.
+
+### Scenario C (clamp to MAX_W = 448)
+
+- Mechanical: `inline === "448px"` AND `computed === "448px"` AND
+  `|rectWidth − 448| ≤ 1`.
+- Visual: the sidebar is the widest of all four scenarios.
+
+### Scenario D (garbage falls through to default)
+
+- Mechanical: same as Scenario A (inline empty, computed is the clamp
+  string, rectWidth in `[224, 352]`).
+- Visual: indistinguishable from Scenario A — the script silently no-ops
+  on a non-numeric value, so the page renders exactly the default.
+
+### Overall verdict
+
+`PASS` if all four scenarios pass their own criteria. `FAIL` otherwise.
+Include in `summary` a one-line human-readable result, e.g.
+`"PASS: 400/448 px persisted widths visually restored on reload;
+baseline + garbage values fall through to the CSS default"` or, for a
+fail, `"FAIL: Scenario B rectWidth=224 (expected 400) — restore script
+did not apply"`.
+
+## Tools
+
+- Primary: `/headless-browser` — Playwright CLI for `goto`, `eval`,
+  `reload`, `screenshot`, `resize`, `close-all`. This task is
+  multi-step interactive so `/verify-ui` (single-page computed-style
+  reads) does not fit.
+- The Playwright CLI does NOT accept a `--viewport-size` flag on
+  `open` — use the `resize <w> <h>` subcommand AFTER `open`.
+
+## Inputs (passed from the parent agent)
+
+- `previewUrl` — full URL to drive (default
+  `http://localhost:3000/docs/guides/i18n/`).
+- `viewport` — `WxH` (default `1400x900`).
+- `screenshotDir` — directory to write screenshots into (default
+  `$HOME/cclogs/zudo-doc/headless-screenshots/`).
+
+## Output schema
+
+Return a single structured result with EXACTLY these fields:
+
+```
+{
+  baseline: { inline, computed, rectWidth, screenshot },
+  restored400: { inline, computed, rectWidth, screenshot },
+  clamp448: { inline, computed, rectWidth, screenshot },
+  garbageFallback: { inline, computed, rectWidth, screenshot },
+  verdict: "PASS" | "FAIL",
+  summary: "<one-line verdict>",
+  toolUsed: "headless-browser"
+}
+```
+
+`screenshot` is the absolute file path written by `npx
+@playwright/cli@latest screenshot --filename <path>`. The four paths
+should be distinct.
+
+## Don'ts
+
+- Don't change the verdict tolerance numbers — they are locked here.
+- Don't skip scenarios — all four are required for a PASS verdict.
+- Don't restart the dev server — assume it is already running at the
+  URL provided in `Inputs.previewUrl`.
+- Don't post anywhere — return the structured result to the parent;
+  the parent decides how to surface it.

--- a/packages/create-zudo-doc/templates/base/pages/lib/_head-with-defaults.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_head-with-defaults.tsx
@@ -20,6 +20,7 @@
 
 import type { JSX } from "preact";
 import { OgTags, TwitterCard } from "@takazudo/zudo-doc/head";
+import { SidebarResizerRestore } from "@takazudo/zudo-doc/sidebar-resizer";
 // Don't import ColorSchemeProvider from "@takazudo/zudo-doc/theme" — that
 // barrel also re-exports DesignTokenTweakPanel + ColorTweakExportModal, which
 // transitively pull `src/components/design-token-tweak/*` and the v2 panel
@@ -112,6 +113,12 @@ export function HeadWithDefaults({
       )}
       <TwitterCard card="summary_large_image" image={ogImageUrl} />
       <ColorSchemeProvider cssText={cssText} colorMode={colorMode} />
+      {/* Pre-paint inline script: restore persisted sidebar width to
+          --zd-sidebar-w on :root before first paint, so a reload after
+          drag-resizing the sidebar doesn't snap back to the CSS default
+          clamp() width. Mirrors the sibling sidebar-toggle restore
+          script emitted from the page's afterSidebar slot. */}
+      {settings.sidebarResizer && <SidebarResizerRestore />}
       {/* favicon set — withBase() handles the configured base path prefix */}
       <link rel="icon" href={withBase("/favicon.ico")} sizes="any" />
       <link rel="icon" type="image/png" sizes="32x32" href={withBase("/favicon-32x32.png")} />

--- a/packages/zudo-doc/src/sidebar-resizer/index.ts
+++ b/packages/zudo-doc/src/sidebar-resizer/index.ts
@@ -260,4 +260,9 @@ export function initSidebarResizer(): void {
   sidebar.appendChild(handle);
 }
 
-export { SidebarResizerInit, SIDEBAR_RESIZER_INIT_SCRIPT } from "./sidebar-resizer-init.js";
+export {
+  SidebarResizerInit,
+  SIDEBAR_RESIZER_INIT_SCRIPT,
+  SidebarResizerRestore,
+  SIDEBAR_RESIZER_RESTORE_SCRIPT,
+} from "./sidebar-resizer-init.js";

--- a/packages/zudo-doc/src/sidebar-resizer/sidebar-resizer-init.tsx
+++ b/packages/zudo-doc/src/sidebar-resizer/sidebar-resizer-init.tsx
@@ -17,6 +17,20 @@
 // post-swap re-init. The body itself is replaced on each nav, so the per-
 // instance handle DOM is rebuilt each time and the existing-handle guard
 // (`sidebar.querySelector("["+HANDLE_MARKER+"]")`) keeps re-runs idempotent.
+//
+// Pre-paint restore (SidebarResizerRestore / SIDEBAR_RESIZER_RESTORE_SCRIPT):
+// the init script above only mutates `--zd-sidebar-w` in response to user
+// input. Without a separate pre-paint reader, a page reload after a drag
+// shows the CSS-default width (`clamp(14rem, 20vw, 22rem)`) instead of the
+// persisted value — the saved width exists in localStorage but nothing
+// applies it before paint. The Restore component emits a tiny synchronous
+// `<script>` intended for `<head>` that reads `zudo-doc-sidebar-width`,
+// validates it against the same [MIN_W, MAX_W] bounds the runtime uses,
+// and sets `--zd-sidebar-w` on `:root` before first paint to avoid a FOUC.
+// The bounds are duplicated as literals (not imported) because the script
+// body is a static string emitted into HTML — sharing the constants would
+// require a build step. Keep these in sync with MIN_W / MAX_W / LS_KEY /
+// CSS_PROP in sidebar-resizer/index.ts.
 
 import type { JSX } from "preact";
 import { AFTER_NAVIGATE_EVENT } from "../transitions/page-events.js";
@@ -153,3 +167,40 @@ export function SidebarResizerInit(): JSX.Element {
 }
 
 export default SidebarResizerInit;
+
+// Pre-paint inline script: reads the persisted sidebar width from
+// localStorage and applies it to `--zd-sidebar-w` on `:root` BEFORE
+// first paint, so a reload after a manual resize doesn't flash to the
+// CSS-default width and then "stick" at the default. Parallels the
+// sibling sidebar-toggle pre-paint script that restores
+// `zudo-doc-sidebar-visible`.
+//
+// MIN_W (192) / MAX_W (448) are duplicated here as literals — see the
+// header comment for why. The clamp keeps a corrupted localStorage value
+// from producing a sidebar wider than the layout supports.
+export const SIDEBAR_RESIZER_RESTORE_SCRIPT = `(function(){try{var w=localStorage.getItem("zudo-doc-sidebar-width");if(!w)return;var n=parseFloat(w);if(!isFinite(n))return;if(n<192)n=192;else if(n>448)n=448;document.documentElement.style.setProperty("--zd-sidebar-w",n+"px");}catch(e){}})();`;
+
+/**
+ * Drop-in JSX `<head>` script that restores the persisted sidebar width
+ * before first paint.
+ *
+ * Include once in the page `<head>` (gated on `settings.sidebarResizer`)
+ * — placement in `<head>` is what makes this run before the body is
+ * parsed, eliminating the resize-flash on reload. Body-end placement is
+ * too late: the browser will have already painted at the CSS default.
+ *
+ * The script is a tiny synchronous IIFE that:
+ *   - reads `localStorage["zudo-doc-sidebar-width"]`,
+ *   - validates it as a finite number clamped to [MIN_W, MAX_W],
+ *   - sets `--zd-sidebar-w` on `document.documentElement.style`.
+ *
+ * It silently no-ops in privacy / disabled-storage modes (try/catch),
+ * matches the resilience of the runtime `applyWidth` writer.
+ */
+export function SidebarResizerRestore(): JSX.Element {
+  return (
+    <script
+      dangerouslySetInnerHTML={{ __html: SIDEBAR_RESIZER_RESTORE_SCRIPT }}
+    />
+  );
+}

--- a/pages/lib/_head-with-defaults.tsx
+++ b/pages/lib/_head-with-defaults.tsx
@@ -20,6 +20,7 @@
 
 import type { JSX } from "preact";
 import { OgTags, TwitterCard } from "@takazudo/zudo-doc/head";
+import { SidebarResizerRestore } from "@takazudo/zudo-doc/sidebar-resizer";
 // Don't import ColorSchemeProvider from "@takazudo/zudo-doc/theme" — that
 // barrel also re-exports DesignTokenTweakPanel + ColorTweakExportModal, which
 // transitively pull `src/components/design-token-tweak/*` and the v2 panel
@@ -112,6 +113,12 @@ export function HeadWithDefaults({
       )}
       <TwitterCard card="summary_large_image" image={ogImageUrl} />
       <ColorSchemeProvider cssText={cssText} colorMode={colorMode} />
+      {/* Pre-paint inline script: restore persisted sidebar width to
+          --zd-sidebar-w on :root before first paint, so a reload after
+          drag-resizing the sidebar doesn't snap back to the CSS default
+          clamp() width. Mirrors the sibling sidebar-toggle restore
+          script emitted from the page's afterSidebar slot. */}
+      {settings.sidebarResizer && <SidebarResizerRestore />}
       {/* favicon set — withBase() handles the configured base path prefix */}
       <link rel="icon" href={withBase("/favicon.ico")} sizes="any" />
       <link rel="icon" type="image/png" sizes="32x32" href={withBase("/favicon-32x32.png")} />


### PR DESCRIPTION
## Summary

Fix a bug where the sidebar width set by dragging is not restored on page reload. The drag handler wrote `zudo-doc-sidebar-width` to `localStorage` but no consuming layout ever read it back — so on reload the sidebar snapped back to the CSS default `clamp(14rem, 20vw, 22rem)` and the user's choice appeared lost.

The original `sidebar-resizer` module's header comment already anticipated this and delegated the restore to the layout:

> The persisted value is read indirectly: the consuming layout is expected to apply the saved `--zd-sidebar-w` before paint (e.g. via an inline pre-hydration script).

…the layout side of that contract was just missing. The sibling `sidebar-toggle` feature has the analogous pre-paint script for its `zudo-doc-sidebar-visible` flag — this PR follows the same pattern for width.

## Changes

- `packages/zudo-doc/src/sidebar-resizer/sidebar-resizer-init.tsx` — new `SidebarResizerRestore` Preact component + `SIDEBAR_RESIZER_RESTORE_SCRIPT` constant: a tiny synchronous `<script>` for `<head>` that reads `localStorage["zudo-doc-sidebar-width"]`, validates with `parseFloat` + `isFinite`, clamps to the same `[192, 448]` bounds the runtime uses, and sets `--zd-sidebar-w` on `:root.style` before first paint. Silently no-ops in privacy / disabled-storage modes (`try/catch`).
- `packages/zudo-doc/src/sidebar-resizer/index.ts` — re-export the new component + script.
- `pages/lib/_head-with-defaults.tsx` — emit `<SidebarResizerRestore />` in `<head>`, gated on `settings.sidebarResizer`.
- `packages/create-zudo-doc/templates/base/pages/lib/_head-with-defaults.tsx` — same wiring in the generator template so scaffolded projects inherit the fix.
- `.claude/skills/test-flow-sidebar-width-restore/SKILL.md` — project-scope `/verify-ui-ai` test-flow skill capturing the four-scenario verdict procedure (baseline / restored 400 / clamp to 448 / garbage falls through).

The legacy `src/scripts/sidebar-resizer.ts` and its template counterpart are dead code (no imports), so they are left untouched and the template-drift check stays clean.

## Test Plan

Mechanically verified at the local dev server (`http://localhost:3000/docs/guides/i18n/`, 1400×900 viewport):

| Scenario | localStorage | `--zd-sidebar-w` after reload | `#desktop-sidebar` width | Verdict |
|---|---|---|---|---|
| Baseline | (cleared) | `clamp(14rem, 20vw, 22rem)` | 280 px | default ✓ |
| Restored 400 px | `"400"` | `400px` | 400 px | restored ✓ |
| Clamp to max | `"99999"` | `448px` | 448 px | clamped ✓ |
| Garbage value | `"NaN-garbage"` | `clamp(14rem, 20vw, 22rem)` | 280 px | falls through ✓ |

Also passed:

- `pnpm check` (zfb check → tsc --noEmit)
- AI verification subagent via `/verify-ui-ai` (PASS across all 4 scenarios both mechanically and visually)
- `/codex-review` — no correctness or regression issues
- `/gcoc-review` — no bugs, security, or performance issues