### PR TITLE
Gen CLI Test Audit & Bug Hunt (epic #1768)

### DIFF
--- a/.claude/skills/l-generator-cli-tester/SKILL.md
+++ b/.claude/skills/l-generator-cli-tester/SKILL.md
@@ -29,7 +29,7 @@ Where `<pattern>` is one of the test patterns listed below.
 | `i18n` | Only i18n enabled |
 | `sidebar-filter` | Only sidebar filter enabled |
 | `claude-resources` | Only claude resources enabled |
-| `design-token-panel` | Only design token panel enabled (uses API) |
+| `design-token-panel` | Only design token panel enabled (uses --design-token-panel CLI flag) |
 | `light-dark` | Light-dark color mode |
 | `lang-ja` | Japanese as default language |
 | `all-features` | Everything ON |
@@ -63,6 +63,7 @@ Set `REPO_ROOT` to the repository root (absolute path). Run the generator from w
 cd __inbox/generator-test-barebone && \
   node $REPO_ROOT/packages/create-zudo-doc/dist/index.js test-project --yes \
   --no-search --no-sidebar-filter --no-i18n --no-claude-resources \
+  --no-image-enlarge --no-tag-governance \
   --color-scheme-mode single --scheme "Default Dark" --no-install
 ```
 
@@ -93,7 +94,7 @@ cd __inbox/generator-test-sidebar-filter && \
   --color-scheme-mode single --scheme "Default Dark" --no-install
 ```
 
-> Note: Sidebar filter stripping is not yet implemented (TODO in strip.ts). The filter is built into `sidebar-tree.tsx` and is always included regardless of the flag. This test mainly verifies the flag doesn't cause errors.
+> Note: `sidebarFilter` is built into `sidebar-tree.tsx` and ships in base by design (see `src/features/index.ts:37`); it is NOT tracked in `settings.ts` (no field emitted). `--no-sidebar-filter` currently has no structural effect. This test verifies the flag does not cause errors.
 
 **claude-resources:**
 
@@ -106,22 +107,12 @@ cd __inbox/generator-test-claude-resources && \
 
 **design-token-panel:**
 
-> `designTokenPanel` has NO CLI flag. Use the programmatic API instead:
-
 ```bash
 cd __inbox/generator-test-design-token-panel && \
-  node --input-type=module -e "
-import { createZudoDoc } from '$REPO_ROOT/packages/create-zudo-doc/dist/api.js';
-await createZudoDoc({
-  projectName: 'test-project',
-  colorSchemeMode: 'single',
-  singleScheme: 'Default Dark',
-  features: ['designTokenPanel'],
-  packageManager: 'pnpm',
-  install: false,
-});
-console.log('Scaffolding complete.');
-"
+  node $REPO_ROOT/packages/create-zudo-doc/dist/index.js test-project --yes \
+  --no-search --no-sidebar-filter --no-i18n --no-claude-resources \
+  --no-image-enlarge --no-tag-governance --design-token-panel \
+  --color-scheme-mode single --scheme "Default Dark" --no-install
 ```
 
 **light-dark:**
@@ -147,24 +138,16 @@ cd __inbox/generator-test-lang-ja && \
 
 ```bash
 cd __inbox/generator-test-all-features && \
-  node --input-type=module -e "
-import { createZudoDoc } from '$REPO_ROOT/packages/create-zudo-doc/dist/api.js';
-await createZudoDoc({
-  projectName: 'test-project',
-  colorSchemeMode: 'light-dark',
-  lightScheme: 'Default Light',
-  darkScheme: 'Default Dark',
-  defaultMode: 'dark',
-  respectPrefersColorScheme: true,
-  features: ['i18n', 'search', 'sidebarFilter', 'claudeResources', 'designTokenPanel'],
-  packageManager: 'pnpm',
-  install: false,
-});
-console.log('Scaffolding complete.');
-"
+  node $REPO_ROOT/packages/create-zudo-doc/dist/index.js test-project --yes \
+  --i18n --search --sidebar-filter --claude-resources --claude-skills \
+  --design-token-panel --sidebar-resizer --sidebar-toggle --versioning \
+  --doc-history --body-foot-util --llms-txt --skill-symlinker \
+  --footer-nav-group --image-enlarge --footer-copyright --changelog \
+  --tag-governance --doc-tags --footer-taglist \
+  --color-scheme-mode light-dark --light-scheme "Default Light" \
+  --dark-scheme "Default Dark" --default-mode dark \
+  --github-url "https://github.com/example/test-project" --no-install
 ```
-
-> Note: `all-features` uses the API because `designTokenPanel` has no CLI flag.
 
 ## Step 3: Install Dependencies
 
@@ -222,10 +205,9 @@ Use these tables to verify. Check each file with `test -e <path>`.
 |------|----------|
 | `src/content/docs-ja/` | ABSENT |
 | `src/integrations/claude-resources/` | ABSENT |
-| `src/components/doc-history.tsx` | ABSENT |
+| `src/components/doc-history.tsx` | PRESENT (ships in base unconditionally, runtime-gated by the `docHistory` setting) |
 | `src/lib/design-token-panel-bootstrap.ts` | ABSENT |
 | `src/config/design-token-panel-config.ts` | ABSENT |
-| `src/utils/design-token-serde.ts` | ABSENT |
 | `src/content/docs/` | PRESENT |
 | `src/config/settings.ts` | PRESENT |
 | `zfb.config.ts` | PRESENT |
@@ -239,7 +221,7 @@ Use these tables to verify. Check each file with `test -e <path>`.
 | `src/content/docs/` | PRESENT |
 | `src/config/settings.ts` | PRESENT |
 
-> Note: the `search` feature wires Pagefind via the zfb config and `package.json` deps; it does not copy a dedicated search component file to `src/components/`. Verify search is enabled by checking `package.json` for `"@pagefind/default-ui"` or checking `zfb.config.ts` for pagefind plugin wiring.
+> Note: the `search` feature wires search via the zfb config and `package.json` deps; it does not copy a dedicated search component file to `src/components/`. Verify search is enabled by checking `package.json` devDependencies for `"pagefind"` and dependencies for `"minisearch"`; check `zfb.config.ts` for `search-index-plugin.mjs`.
 
 **i18n:**
 
@@ -259,7 +241,7 @@ Use these tables to verify. Check each file with `test -e <path>`.
 | `src/integrations/claude-resources/` | ABSENT |
 | `src/config/design-token-panel-config.ts` | ABSENT |
 
-> Note: `sidebar-tree.tsx` always ships with the base template; the `sidebarFilter` flag controls whether filtering UI is active at runtime. Check the `sidebarFilter` setting in `src/config/settings.ts` to confirm the flag was applied.
+> Note: `sidebar-tree.tsx` always ships with the base template; the `sidebarFilter` flag controls whether filtering UI is active at runtime. `sidebarFilter` is NOT emitted as a field in `settings.ts` (no field). Confirm via `zfb.config.ts` or runtime behavior — not a settings field.
 
 **claude-resources:**
 
@@ -277,8 +259,7 @@ Use these tables to verify. Check each file with `test -e <path>`.
 | `src/config/design-token-panel-config.ts` | PRESENT |
 | `src/config/design-tokens-manifest.ts` | PRESENT |
 | `src/lib/design-token-panel-bootstrap.ts` | PRESENT |
-| `src/utils/design-token-serde.ts` | PRESENT |
-| `src/utils/design-token-types.ts` | PRESENT |
+| `src/components/design-token-panel-bootstrap.tsx` | PRESENT |
 | `src/integrations/claude-resources/` | ABSENT |
 
 **light-dark:**
@@ -303,17 +284,20 @@ Use these tables to verify. Check each file with `test -e <path>`.
 |------|----------|
 | `src/content/docs-ja/getting-started/index.mdx` | PRESENT |
 | `src/content/docs/getting-started/index.mdx` | PRESENT |
+| `src/content/docs/changelog/index.mdx` | PRESENT |
 | `src/integrations/claude-resources/generate.ts` | PRESENT |
 | `src/integrations/claude-resources/escape-for-mdx.ts` | PRESENT |
 | `src/components/theme-toggle.tsx` | PRESENT |
 | `src/config/design-token-panel-config.ts` | PRESENT |
 | `src/lib/design-token-panel-bootstrap.ts` | PRESENT |
-| `src/utils/design-token-serde.ts` | PRESENT |
 | `src/components/doc-history.tsx` | PRESENT |
 | `src/components/desktop-sidebar-toggle.tsx` | PRESENT |
 | `src/scripts/sidebar-resizer.ts` | PRESENT |
 | `src/components/image-enlarge.tsx` | PRESENT |
 | `src/utils/github.ts` | PRESENT |
+| `scripts/tags-audit.ts` | PRESENT |
+| `scripts/tags-suggest.ts` | PRESENT |
+| `pages/docs/tags/index.tsx` | PRESENT |
 
 ## Step 7: Verify Settings
 
@@ -326,6 +310,9 @@ Read `__inbox/generator-test-<pattern>/test-project/src/config/settings.ts` and 
 - `colorScheme: "Default Dark"`
 - `colorMode: false`
 - `locales: {}` (empty)
+- `imageEnlarge: false`
+- `tagGovernance: "off"` (no `tags:audit`/`tags:suggest` scripts, no string-similarity/pluralize devDeps)
+- `tagVocabulary: false`
 - `designTokenPanel: false`
 - `claudeResources: false`
 
@@ -461,10 +448,9 @@ Provide a clear pass/fail report:
 ## Important Notes
 
 - Always `cd` back to the repo root between major steps (use absolute paths)
-- The `--yes` flag auto-fills all unspecified options with defaults. Feature defaults with `--yes`: search=true, sidebarFilter=true, i18n=false, claudeResources=false, designTokenPanel=false
+- The `--yes` flag auto-fills all unspecified options with defaults. Feature defaults with `--yes`: search=true, sidebarFilter=true, imageEnlarge=true, tagGovernance=true, i18n=false, claudeResources=false, designTokenPanel=false (all other features false)
 - Use `--no-install` with CLI to prevent auto-install, then install manually for better error visibility
-- Sidebar filter stripping is TODO — the filter is always included regardless of the `--sidebar-filter` flag
-- `designTokenPanel` has no CLI flag — use the API approach for `design-token-panel` and `all-features` patterns
+- `sidebarFilter` is built into `sidebar-tree.tsx` by design (not a TODO); no strip step exists in the additive architecture
 - The dev server smoke test uses `pnpm dev` (generated projects have a single `dev` script)
 - If any step fails, still report all steps attempted before stopping
 - The `--headless` flag enables Step 8.5 (headless browser visual check). Without it, only process-level checks are performed

--- a/.claude/skills/l-run-generator-cli-whole-test/SKILL.md
+++ b/.claude/skills/l-run-generator-cli-whole-test/SKILL.md
@@ -10,7 +10,7 @@ Run ALL `create-zudo-doc` generator patterns end-to-end, fix any failures, and v
 ## When to Use
 
 - Before releasing a new version of `create-zudo-doc`
-- After modifying generator source files (`scaffold.ts`, `strip.ts`, `settings-gen.ts`)
+- After modifying generator source files (`scaffold.ts`, `compose.ts`, `features/*.ts`, `settings-gen.ts`, `zfb-config-gen.ts`, `constants.ts`, `cli.ts`, `api.ts`)
 - After adding/removing features from the main zudo-doc project
 - User says "run all generator tests", "whole test", "l-run-generator-cli-whole-test"
 
@@ -41,10 +41,12 @@ Run in this order (CLI flags and details are defined in `/l-generator-cli-tester
 3. **`i18n`** — Only i18n enabled
 4. **`sidebar-filter`** — Only sidebar filter enabled
 5. **`claude-resources`** — Only Claude Resources enabled
-6. **`design-token-panel`** — Only design token panel enabled (uses API, no CLI flag)
+6. **`design-token-panel`** — Only design token panel enabled (uses `--design-token-panel` CLI flag)
 7. **`light-dark`** — Light-dark color scheme mode
 8. **`lang-ja`** — Japanese as default language
-9. **`all-features`** — Everything ON, maximum complexity (uses API)
+9. **`all-features`** — Everything ON, maximum complexity (uses the enumerated CLI invocation)
+
+> **Note:** These 9 patterns are valid manual smoke tests. The authoritative bug-hunt pattern matrix (15 patterns across Waves 4, 5, and 5b) lives in the Wave 2 spec (`__inbox/gen-cli-audit-spec/spec.md`) and the associated bug-hunt issues. Do not delete or rename these 9 patterns — they remain useful standalone checks.
 
 ### Running each pattern
 
@@ -82,11 +84,11 @@ For each failing pattern:
 - Determine which phase failed: scaffold, build, dev, or feature check
 - Common failure categories:
   - **Build error: missing module** — dependency not in generated `package.json` → fix `scaffold.ts` `generatePackageJson()`
-  - **Build error: import not found** — import not stripped for disabled feature → fix `strip.ts`
+  - **Build error: import not found** — in the additive architecture dead imports cannot arise from stripping; diagnose: missing import injection in `src/features/<name>.ts`, or missing feature files in `templates/features/<name>/files/`
   - **Build error: type error in settings.ts** — settings field missing/wrong → fix `settings-gen.ts`
-  - **Build error: component references stripped component** — template usage not stripped → fix `strip.ts` patch patterns
+  - **Build error: component references missing component** — base template references a component only added by a feature; fix the base template (remove the unconditional import) or the feature module
   - **Dev server crash** — runtime error in generated code → read the generated file and trace the issue to the source
-  - **Feature check fail** — feature file exists when it should be removed, or missing when it should exist → fix `strip.ts`
+  - **Feature check fail** — files are never removed (additive); "file missing when it should exist" means `templates/features/<name>/files/` is incomplete or the feature module omits a copy
 
 ### 2b. Read the generator source files
 
@@ -95,8 +97,10 @@ The key files to examine:
 | File | Role |
 |------|------|
 | `packages/create-zudo-doc/src/scaffold.ts` | Copies template, generates `package.json` |
-| `packages/create-zudo-doc/src/strip.ts` | Removes features/imports based on options |
+| `packages/create-zudo-doc/src/compose.ts` | Composition engine: injection system, anchor cleanup, feature resolution |
+| `packages/create-zudo-doc/src/features/*.ts` | Per-feature injection specs + post-processing (additive architecture) |
 | `packages/create-zudo-doc/src/settings-gen.ts` | Generates `settings.ts` |
+| `packages/create-zudo-doc/src/zfb-config-gen.ts` | Generates `zfb.config.ts` |
 | `packages/create-zudo-doc/src/constants.ts` | Feature definitions and color schemes |
 | `packages/create-zudo-doc/src/cli.ts` | CLI argument parsing |
 | `packages/create-zudo-doc/src/api.ts` | Programmatic API |
@@ -200,8 +204,8 @@ Output a final report:
 ### Fixes Applied
 
 1. `scaffold.ts`: Added missing `minisearch` dependency for search pattern
-2. `strip.ts`: Fixed claude-resources import stripping regex
-3. `strip.ts`: Fixed all-features light-dark theme-toggle handling
+2. `features/claude-resources.ts`: added missing import injection
+3. `settings-gen.ts`: fixed light-dark colorMode emission
 
 ### Final Status: ALL PASS
 ```

--- a/packages/create-zudo-doc/src/__tests__/preset-swap.slow.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/preset-swap.slow.test.ts
@@ -22,7 +22,7 @@
  * ## Tier
  *
  * This test scaffolds a real project, runs `pnpm install` against the public
- * registry (with hard-link cache), and runs a full Astro build. Local
+ * registry (with hard-link cache), and runs a full zfb build. Local
  * runtime is on the order of 60–120 seconds, well past the default unit
  * test budget. It therefore lives in the **slow tier** (`pnpm test:slow`)
  * and is excluded from `pnpm test` and `pnpm b4push`. Run it manually

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -1874,8 +1874,6 @@ describe("scaffold — framework TS error fixes (sub #410)", () => {
 // ALL tests in this describe block depend on:
 //   - topic-config-generators  (zfb-config-gen.ts that emits zfb.config.ts)
 //   - topic-template-files     (base template retarget to zfb layout)
-//
-// They will fail until those sibling topics merge into base/astro-zfb-migration-scaffold.
 // ---------------------------------------------------------------------------
 
 describe("scaffold — zfb.config.ts shape (topic-config-generators)", () => {

--- a/packages/create-zudo-doc/templates/base/src/plugins/rehype-heading-links.ts
+++ b/packages/create-zudo-doc/templates/base/src/plugins/rehype-heading-links.ts
@@ -10,10 +10,10 @@ import { extractText } from "./hast-utils";
  *   <a href="#id" class="hash-link" aria-label="Direct link to ..."></a>
  *
  * The "#" symbol is rendered via CSS ::after to avoid polluting
- * Astro's heading text extraction (used for TOC).
+ * heading text extraction (used for TOC).
  *
- * Runs before Astro's built-in heading ID plugin, so it sets IDs itself.
- * Astro's plugin will skip headings that already have an ID.
+ * Sets heading IDs itself (via github-slugger); skips headings that already
+ * have an ID assigned upstream.
  */
 
 const headingTags = new Set(["h2", "h3", "h4", "h5", "h6"]);

--- a/packages/create-zudo-doc/templates/base/src/types/locale.ts
+++ b/packages/create-zudo-doc/templates/base/src/types/locale.ts
@@ -1,6 +1,6 @@
 /**
  * Represents a locale switcher link.
- * Used by both SidebarFooter (Preact) and language-switcher (Astro).
+ * Used by both SidebarFooter (Preact) and language-switcher (Preact).
  */
 export interface LocaleLink {
   code: string;

--- a/packages/create-zudo-doc/templates/features/tauri/files/src/components/find-in-page-init.tsx
+++ b/packages/create-zudo-doc/templates/features/tauri/files/src/components/find-in-page-init.tsx
@@ -30,7 +30,7 @@ export default function FindInPageInit() {
     return () => document.removeEventListener("keydown", handler);
   }, [isTauri]);
 
-  // Clear search on Astro page navigation
+  // Clear search on zfb page navigation
   useEffect(() => {
     const handler = () => {
       findInPageRef.current.stop();

--- a/packages/create-zudo-doc/vitest.slow.config.ts
+++ b/packages/create-zudo-doc/vitest.slow.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vitest/config";
 
 /**
  * Slow tier: integration tests that scaffold a real project, install
- * dependencies, and run a full Astro build. Runtime per test can exceed a
+ * dependencies, and run a full zfb build. Runtime per test can exceed a
  * minute, so they are excluded from the default `pnpm test` run and gated
  * behind `pnpm test:slow`.
  *
@@ -12,7 +12,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["src/__tests__/**/*.slow.test.ts"],
-    // 5 minutes per test — scaffold + pnpm install + astro build can be slow
+    // 5 minutes per test — scaffold + pnpm install + zfb build can be slow
     // on a cold pnpm store.
     testTimeout: 5 * 60 * 1000,
     hookTimeout: 5 * 60 * 1000,

--- a/src/types/locale.ts
+++ b/src/types/locale.ts
@@ -1,6 +1,6 @@
 /**
  * Represents a locale switcher link.
- * Used by both SidebarFooter (Preact) and language-switcher (Astro).
+ * Used by both SidebarFooter (Preact) and language-switcher (Preact).
  */
 export interface LocaleLink {
   code: string;


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/1768

---

## Summary

Epic #1768 — **Gen CLI Test Audit & Bug Hunt**. Audited the zfb-era `create-zudo-doc` generator tests + AI-agent test skills, then ran an AI-driven CLI bug-hunt across 15 patterns. Ran as an adapted 6-wave accumulating chain.

### Committed code in this PR (Wave 3 only)
- De-staled 2 AI-agent test skills: `l-generator-cli-tester` (16 edits) + `l-run-generator-cli-whole-test` (8 edits) — purged non-existent `strip.ts` refs, corrected the `--design-token-panel` CLI flag, fixed the barebone default-trap, all-features REDEFINED, search package name.
- Reworded 6 generator source/template/config files off stale Astro prose (migration guards + intentional historical context preserved).

The rest of the epic's value is **GitHub issues + verdict** (analysis artifacts are gitignored `__inbox/`):

### Status Verdict (Wave 6)
- **Astro-era tests exist?** No — fully migrated to zfb, 6 migration guards active.
- **Properly migrated?** Yes — only cosmetic prose residue, fixed in Wave 3.
- **CLI-binary E2E coverage?** Zero in the automated suite — the slow tier builds from `scaffold()` output, never the CLI binary. This hunt was the first CLI-binary + build run across the matrix and immediately surfaced a Critical universal build blocker the whole Vitest suite passes through.

### Generator bugs filed (follow-up /big-plan fix epic)
- 🔴 **#1793 (Critical)** — base template imports unexported `SidebarResizerRestore`; every generated project fails `pnpm build`.
- 🟠 **#1794 (High)** — `--doc-tags` scaffolds files but `settings-gen.ts:100` hardcodes `docTags: false`.
- 🟡 **#1795 (Low)** — `--body-foot-util` silently overrides explicit `--no-doc-history`.

### Recommendation
Add a CLI-binary E2E test tier (`scaffold via binary → pnpm install --ignore-workspace → pnpm build`) — would have caught #1793.

## Waves

- [x] Wave 1 — audits (#1769, #1770, #1771) ✅
- [x] Wave 2 — spec consolidation + lock downstream issues (#1772) ✅
- [x] Wave 3 — staleness fixes (#1773, #1774, #1775) ✅ *(committed code)*
- [x] Wave 4 — bug hunt Group A (#1776–#1780) ✅
- [x] Wave 5 — bug hunt Group B (#1781–#1786) ✅
- [x] Wave 5b — bug hunt extras (#1789–#1792) ✅
- [x] Wave 6 — bug consolidation + Status Verdict (#1787) ✅