### PR TITLE
Gen CLI Bugfix Trio: fix three create-zudo-doc generator bugs (#1793 #1794 #1795)

### DIFF
--- a/packages/create-zudo-doc/src/__tests__/bugfix-1793-sidebar-restore.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/bugfix-1793-sidebar-restore.test.ts
@@ -1,0 +1,55 @@
+// Regression test for #1793: generated projects must not import
+// SidebarResizerRestore from @takazudo/zudo-doc/sidebar-resizer because the
+// published 0.1.0 dist does not export it. The fix inlines the restore
+// script as a local constant (SIDEBAR_RESIZER_RESTORE_SCRIPT) instead.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs-extra";
+import os from "os";
+import path from "path";
+import type { UserChoices } from "../prompts.js";
+import { scaffold } from "../scaffold.js";
+
+const TEMP_PREFIX = "create-zudo-doc-bugfix-1793-";
+
+let tempDir: string;
+let originalCwd: string;
+
+beforeEach(async () => {
+  originalCwd = process.cwd();
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), TEMP_PREFIX));
+  process.chdir(tempDir);
+});
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  await fs.remove(tempDir);
+});
+
+describe("bugfix #1793 — sidebar restore script inlined, not imported", () => {
+  const choices: UserChoices = {
+    projectName: "test-bugfix-1793",
+    defaultLang: "en",
+    colorSchemeMode: "single",
+    singleScheme: "Default Dark",
+    features: ["search"],
+    packageManager: "pnpm",
+  };
+
+  it("generated _head-with-defaults.tsx does NOT import SidebarResizerRestore", async () => {
+    await scaffold(choices);
+    const content = await fs.readFile(
+      path.join(tempDir, "test-bugfix-1793", "pages/lib/_head-with-defaults.tsx"),
+      "utf-8",
+    );
+    expect(content).not.toContain("import { SidebarResizerRestore }");
+  });
+
+  it("generated _head-with-defaults.tsx DOES contain inlined SIDEBAR_RESIZER_RESTORE_SCRIPT constant", async () => {
+    await scaffold(choices);
+    const content = await fs.readFile(
+      path.join(tempDir, "test-bugfix-1793", "pages/lib/_head-with-defaults.tsx"),
+      "utf-8",
+    );
+    expect(content).toContain("SIDEBAR_RESIZER_RESTORE_SCRIPT");
+  });
+});

--- a/packages/create-zudo-doc/src/__tests__/bugfix-1794-doc-tags.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/bugfix-1794-doc-tags.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs-extra";
+import os from "os";
+import path from "path";
+import type { UserChoices } from "../prompts.js";
+import { scaffold } from "../scaffold.js";
+
+const TEMP_PREFIX = "create-zudo-doc-bugfix-1794-";
+
+let tempDir: string;
+let originalCwd: string;
+
+beforeEach(async () => {
+  originalCwd = process.cwd();
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), TEMP_PREFIX));
+  process.chdir(tempDir);
+});
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  await fs.remove(tempDir);
+});
+
+/** Helper: read settings.ts content from the scaffolded project */
+async function readSettings(projectName: string): Promise<string> {
+  return fs.readFile(
+    path.join(tempDir, projectName, "src/config/settings.ts"),
+    "utf-8",
+  );
+}
+
+describe("bugfix #1794 — docTags setting reflects feature selection", () => {
+  it("emits docTags: true when docTags feature is selected", async () => {
+    const choices: UserChoices = {
+      projectName: "test-doc-tags-on",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search", "docTags"],
+      packageManager: "pnpm",
+    };
+    await scaffold(choices);
+    const content = await readSettings("test-doc-tags-on");
+    expect(content).toContain("docTags: true");
+    expect(content).not.toContain("docTags: false");
+  });
+
+  it("emits docTags: false when docTags feature is NOT selected", async () => {
+    const choices: UserChoices = {
+      projectName: "test-doc-tags-off",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search"],
+      packageManager: "pnpm",
+    };
+    await scaffold(choices);
+    const content = await readSettings("test-doc-tags-off");
+    expect(content).toContain("docTags: false");
+    expect(content).not.toContain("docTags: true");
+  });
+});

--- a/packages/create-zudo-doc/src/__tests__/bugfix-1795-doc-history-warn.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/bugfix-1795-doc-history-warn.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "fs-extra";
+import os from "os";
+import path from "path";
+import type { UserChoices } from "../prompts.js";
+import { scaffold } from "../scaffold.js";
+
+const TEMP_PREFIX = "create-zudo-doc-test-1795-";
+
+let tempDir: string;
+let originalCwd: string;
+
+beforeEach(async () => {
+  originalCwd = process.cwd();
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), TEMP_PREFIX));
+  process.chdir(tempDir);
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  process.chdir(originalCwd);
+  await fs.remove(tempDir);
+});
+
+describe("bugfix #1795 — body-foot-util warns when --no-doc-history was explicit", () => {
+  it("emits console.warn and still enables docHistory when explicitlyDisabledFeatures includes docHistory", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const choices: UserChoices = {
+      projectName: "test-1795-warn",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search", "bodyFootUtil"],
+      // bodyFootUtil is enabled but user explicitly passed --no-doc-history
+      explicitlyDisabledFeatures: ["docHistory"],
+      packageManager: "pnpm",
+    };
+
+    await scaffold(choices);
+
+    // Warning must be emitted
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy.mock.calls[0]![0]).toContain(
+      "body-foot-util requires doc-history",
+    );
+
+    // Auto-enable must still be applied — docHistory ends up in generated settings
+    const content = await fs.readFile(
+      path.join(tempDir, "test-1795-warn", "src/config/settings.ts"),
+      "utf-8",
+    );
+    expect(content).toContain("docHistory: true");
+  });
+
+  it("does NOT emit console.warn when docHistory was not explicitly disabled", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const choices: UserChoices = {
+      projectName: "test-1795-no-warn",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search", "bodyFootUtil"],
+      // explicitlyDisabledFeatures omitted — user never passed --no-doc-history
+      packageManager: "pnpm",
+    };
+
+    await scaffold(choices);
+
+    // No warning expected
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    // Auto-enable still applied silently
+    const content = await fs.readFile(
+      path.join(tempDir, "test-1795-no-warn", "src/config/settings.ts"),
+      "utf-8",
+    );
+    expect(content).toContain("docHistory: true");
+  });
+});

--- a/packages/create-zudo-doc/src/index.ts
+++ b/packages/create-zudo-doc/src/index.ts
@@ -69,6 +69,14 @@ async function main() {
   if (Object.keys(featureFlags).length > 0) {
     prefilled.features = { ...prefilled.features, ...featureFlags };
   }
+  // Record which features were explicitly disabled via --no-<flag> so
+  // scaffold.ts can warn when an auto-enable overrides that explicit choice.
+  const explicitlyDisabled = Object.entries(featureFlags)
+    .filter(([, v]) => v === false)
+    .map(([k]) => k);
+  if (explicitlyDisabled.length > 0) {
+    prefilled.explicitlyDisabledFeatures = explicitlyDisabled;
+  }
 
   // With --yes or --preset: fill all unspecified options with defaults
   if (args.yes || args.preset) {

--- a/packages/create-zudo-doc/src/prompts.ts
+++ b/packages/create-zudo-doc/src/prompts.ts
@@ -15,6 +15,10 @@ export interface UserChoices {
   defaultMode?: "light" | "dark";
   // Features
   features: string[];
+  // Feature values explicitly disabled via --no-<flag> on the CLI. Used to
+  // emit a warning when an auto-enable (e.g. bodyFootUtil forces docHistory)
+  // overrides an explicit user choice. Never populated by interactive prompts.
+  explicitlyDisabledFeatures?: string[];
   // GitHub repository URL — drives the GitHub link in the header and the
   // "View source on GitHub" link in the body-foot util area. Empty = disabled.
   githubUrl?: string;
@@ -40,6 +44,9 @@ export interface PartialChoices {
   respectPrefersColorScheme?: boolean;
   defaultMode?: "light" | "dark";
   features?: Partial<Record<string, boolean>>;
+  // Feature values explicitly disabled via --no-<flag> on the CLI. Threaded
+  // through to UserChoices so scaffold.ts can warn on forced auto-enables.
+  explicitlyDisabledFeatures?: string[];
   githubUrl?: string;
   cjkFriendly?: boolean;
   packageManager?: "pnpm" | "npm" | "yarn" | "bun";
@@ -284,6 +291,7 @@ export async function runPrompts(
     respectPrefersColorScheme,
     defaultMode,
     features,
+    explicitlyDisabledFeatures: prefilled.explicitlyDisabledFeatures,
     githubUrl,
     cjkFriendly: prefilled.cjkFriendly,
     packageManager,

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -104,11 +104,16 @@ export async function scaffold(choices: UserChoices): Promise<void> {
   // body-foot-util-area.tsx ships the DocHistory component inline (byte-
   // identical to main/src/components/body-foot-util-area.tsx). Selecting
   // bodyFootUtil without docHistory would leave an unresolved import, so we
-  // silently co-enable docHistory.
+  // co-enable docHistory. Warn when this overrides an explicit --no-doc-history.
   if (
     choices.features.includes("bodyFootUtil") &&
     !choices.features.includes("docHistory")
   ) {
+    if (choices.explicitlyDisabledFeatures?.includes("docHistory")) {
+      console.warn(
+        "body-foot-util requires doc-history; enabling it despite --no-doc-history",
+      );
+    }
     choices.features = [...choices.features, "docHistory"];
   }
 

--- a/packages/create-zudo-doc/src/settings-gen.ts
+++ b/packages/create-zudo-doc/src/settings-gen.ts
@@ -97,7 +97,7 @@ export function generateSettingsFile(choices: UserChoices): string {
   lines.push(`  mermaid: true,`);
   lines.push(`  sitemap: false,`);
   lines.push(`  docMetainfo: false,`);
-  lines.push(`  docTags: false,`);
+  lines.push(`  docTags: ${choices.features.includes("docTags")},`);
   lines.push(`  tagPlacement: "after-title" as TagPlacement,`);
   if (choices.features.includes("tagGovernance")) {
     lines.push(`  tagGovernance: "warn" as TagGovernanceMode,`);

--- a/packages/create-zudo-doc/templates/base/pages/lib/_head-with-defaults.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_head-with-defaults.tsx
@@ -20,7 +20,8 @@
 
 import type { JSX } from "preact";
 import { OgTags, TwitterCard } from "@takazudo/zudo-doc/head";
-import { SidebarResizerRestore } from "@takazudo/zudo-doc/sidebar-resizer";
+// Inlined from @takazudo/zudo-doc sidebar-resizer-init.tsx (SIDEBAR_RESIZER_RESTORE_SCRIPT) — the published 0.1.0 dist doesn't export it yet; keep in sync if the clamp bounds [192,448] change.
+const SIDEBAR_RESIZER_RESTORE_SCRIPT = `(function(){try{var w=localStorage.getItem("zudo-doc-sidebar-width");if(!w)return;var n=parseFloat(w);if(!isFinite(n))return;if(n<192)n=192;else if(n>448)n=448;document.documentElement.style.setProperty("--zd-sidebar-w",n+"px");}catch(e){}})();`;
 // Don't import ColorSchemeProvider from "@takazudo/zudo-doc/theme" — that
 // barrel also re-exports DesignTokenTweakPanel + ColorTweakExportModal, which
 // transitively pull `src/components/design-token-tweak/*` and the v2 panel
@@ -118,7 +119,7 @@ export function HeadWithDefaults({
           drag-resizing the sidebar doesn't snap back to the CSS default
           clamp() width. Mirrors the sibling sidebar-toggle restore
           script emitted from the page's afterSidebar slot. */}
-      {settings.sidebarResizer && <SidebarResizerRestore />}
+      {settings.sidebarResizer && <script dangerouslySetInnerHTML={{ __html: SIDEBAR_RESIZER_RESTORE_SCRIPT }} />}
       {/* favicon set — withBase() handles the configured base path prefix */}
       <link rel="icon" href={withBase("/favicon.ico")} sizes="any" />
       <link rel="icon" type="image/png" sizes="32x32" href={withBase("/favicon-32x32.png")} />

--- a/pages/lib/_head-with-defaults.tsx
+++ b/pages/lib/_head-with-defaults.tsx
@@ -20,7 +20,8 @@
 
 import type { JSX } from "preact";
 import { OgTags, TwitterCard } from "@takazudo/zudo-doc/head";
-import { SidebarResizerRestore } from "@takazudo/zudo-doc/sidebar-resizer";
+// Inlined from @takazudo/zudo-doc sidebar-resizer-init.tsx (SIDEBAR_RESIZER_RESTORE_SCRIPT) — the published 0.1.0 dist doesn't export it yet; keep in sync if the clamp bounds [192,448] change.
+const SIDEBAR_RESIZER_RESTORE_SCRIPT = `(function(){try{var w=localStorage.getItem("zudo-doc-sidebar-width");if(!w)return;var n=parseFloat(w);if(!isFinite(n))return;if(n<192)n=192;else if(n>448)n=448;document.documentElement.style.setProperty("--zd-sidebar-w",n+"px");}catch(e){}})();`;
 // Don't import ColorSchemeProvider from "@takazudo/zudo-doc/theme" — that
 // barrel also re-exports DesignTokenTweakPanel + ColorTweakExportModal, which
 // transitively pull `src/components/design-token-tweak/*` and the v2 panel
@@ -118,7 +119,7 @@ export function HeadWithDefaults({
           drag-resizing the sidebar doesn't snap back to the CSS default
           clamp() width. Mirrors the sibling sidebar-toggle restore
           script emitted from the page's afterSidebar slot. */}
-      {settings.sidebarResizer && <SidebarResizerRestore />}
+      {settings.sidebarResizer && <script dangerouslySetInnerHTML={{ __html: SIDEBAR_RESIZER_RESTORE_SCRIPT }} />}
       {/* favicon set — withBase() handles the configured base path prefix */}
       <link rel="icon" href={withBase("/favicon.ico")} sizes="any" />
       <link rel="icon" type="image/png" sizes="32x32" href={withBase("/favicon-32x32.png")} />


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/1796

---

## Summary

Fixes three create-zudo-doc generator bugs surfaced by the Gen CLI Test Audit & Bug Hunt epic #1768. Implemented via /x-wt-teams under epic #1796.

### #1793 (Critical) — every generated project failed `pnpm build`
The base head wrapper imported `SidebarResizerRestore` from `@takazudo/zudo-doc/sidebar-resizer`, a symbol the published `@takazudo/zudo-doc@0.1.0` does not export (its dist predates the restore script). Inlined the tiny pre-paint restore `<script>` constant directly in the wrapper, removing the dependency on the unpublished symbol — **no npm publish needed**. Applied byte-identically to both the generator template and the drift-checked host copy.
- `packages/create-zudo-doc/templates/base/pages/lib/_head-with-defaults.tsx`
- `pages/lib/_head-with-defaults.tsx`

### #1794 (High) — `--doc-tags` was runtime-disabled
`settings-gen.ts` hardcoded `docTags: false`. Made it conditional on the selected feature so `--doc-tags` projects emit `docTags: true`.

### #1795 (Low) — silent override of `--no-doc-history`
`scaffold.ts` auto-enables docHistory when bodyFootUtil is selected (correct, retained), but silently discarded an explicit `--no-doc-history`. Threaded an `explicitlyDisabledFeatures` signal (`prompts.ts` → `index.ts` → `scaffold.ts`) and added a `console.warn` when the override happens.

## Verification
- 249 create-zudo-doc unit tests pass (6 new regression tests across 3 dedicated test files)
- Host `pnpm check` clean; package tsc clean; template drift clean
- **CLI-binary end-to-end (#1800):** scaffolded barebone / `--doc-tags` / `--body-foot-util --no-doc-history` patterns against the **published** package — all `pnpm build` exit 0, `docTags: true` present, warning emitted
- All 8 PR CI checks green (Type Check, Template Drift, Build Site, Build Doc History, E2E, HTML validate, Pin Parity, Preview Deploy)

## Sub-issues
- #1797 (#1793), #1798 (#1794), #1799 (#1795), #1800 (Wave-2 confirm)