### PR TITLE
fix(review): full-project aggressive review loop — route/history bugs + ai-chat hardening

### DIFF
--- a/packages/create-zudo-doc/templates/base/pages/lib/route-enumerators.ts
+++ b/packages/create-zudo-doc/templates/base/pages/lib/route-enumerators.ts
@@ -73,7 +73,9 @@ export function enumerateDocsRoutes(locale: string): string[] {
     const allDocs = [...localeDocs, ...fallbackDocs] as DocsEntry[];
 
     for (const doc of allDocs) {
-      urls.push(docsUrl(doc.data.slug ?? doc.id, locale as string));
+      // Mirror the default-locale branch (L61): fall back through toRouteSlug
+      // so a top-level locale index.mdx maps to "" not "index".
+      urls.push(docsUrl(doc.data.slug ?? toRouteSlug(doc.id), locale as string));
     }
 
     const localeConfig = (

--- a/packages/create-zudo-doc/templates/base/src/utils/base.ts
+++ b/packages/create-zudo-doc/templates/base/src/utils/base.ts
@@ -86,7 +86,7 @@ export function getPathForLocale(
 ): string {
   let relativePath = stripBase(path);
   if (currentLang !== defaultLocale) {
-    relativePath = relativePath.replace(new RegExp(`^/${currentLang}/`), "/");
+    relativePath = relativePath.replace(new RegExp(`^/${currentLang}(?:/|$)`), "/");
   }
   if (targetLang !== defaultLocale) {
     relativePath = `/${targetLang}${relativePath}`;
@@ -98,7 +98,7 @@ export function getPathForLocale(
 export function buildLocaleLinks(currentPath: string, currentLang: Locale): LocaleLink[] {
   let defaultLocalePath = stripBase(currentPath);
   if (currentLang !== defaultLocale) {
-    defaultLocalePath = defaultLocalePath.replace(new RegExp(`^/${currentLang}/`), "/");
+    defaultLocalePath = defaultLocalePath.replace(new RegExp(`^/${currentLang}(?:/|$)`), "/");
   }
   if (isDefaultLocaleOnlyPath(defaultLocalePath)) {
     return [{

--- a/packages/create-zudo-doc/templates/base/src/utils/content-files.ts
+++ b/packages/create-zudo-doc/templates/base/src/utils/content-files.ts
@@ -54,6 +54,10 @@ export function collectMdFiles(
     for (const entry of entries) {
       const fullPath = join(currentDir, entry.name);
       if (entry.isDirectory()) {
+        // Skip `_`-prefixed dirs to match the Content Collections convention
+        // (and zfb's routing): docs under them are not built as pages, so
+        // indexing them would yield search results whose links 404.
+        if (entry.name.startsWith("_")) continue;
         walk(fullPath, baseDir);
       } else if (/\.mdx?$/.test(entry.name) && !entry.name.startsWith("_")) {
         const rel = relative(baseDir, fullPath)

--- a/packages/create-zudo-doc/templates/base/src/utils/docs.ts
+++ b/packages/create-zudo-doc/templates/base/src/utils/docs.ts
@@ -98,8 +98,10 @@ export function buildNavTree(
     const parts = slug.split("/");
 
     if (parts.length <= 1) {
-      // Category index: Astro 5 stripped /index → single segment like "guides"
-      const segment = doc.id;
+      // Category index: Astro 5 stripped /index → single segment like "guides".
+      // Key by the route slug (honors a custom frontmatter `slug`), not the raw
+      // id — otherwise the sidebar/breadcrumb link diverges from the built route.
+      const segment = parts[0] || doc.id;
       if (!root.children.has(segment)) {
         root.children.set(segment, {
           segment,

--- a/packages/doc-history-server/src/git-history.ts
+++ b/packages/doc-history-server/src/git-history.ts
@@ -57,10 +57,15 @@ export function getFileCommits(
 /**
  * Get the oldest commit hash that touched a file (the file's "first" commit).
  *
- * Uses --follow + --reverse + --max-count=1. Note that git still has to walk
- * the file's full history once before applying --reverse, so this is O(history)
- * for that file path, not O(1). Acceptable here because the caller is a
- * build-time helper run once per content file, not a hot path.
+ * Uses --follow + --reverse and takes the first emitted line (the oldest
+ * commit). We must NOT pass --max-count=1: git applies the count limit during
+ * its newest-first traversal *before* --reverse is applied, so the combination
+ * emits nothing (verified empirically on git 2.43.0) — which previously made
+ * this function return null for every file, collapsing created==updated dates
+ * and attributing every page to its latest committer. git still walks the
+ * file's full history once, so this is O(history) for that path, not O(1).
+ * Acceptable because the caller is a build-time helper run once per content
+ * file, not a hot path.
  *
  * Returns null when the file has no git history (untracked / not yet committed).
  */
@@ -73,7 +78,6 @@ export function getFirstCommit(filePath: string): string | null {
         "--follow",
         "--reverse",
         "--format=%H",
-        "--max-count=1",
         "--",
         filePath,
       ],
@@ -81,7 +85,7 @@ export function getFirstCommit(filePath: string): string | null {
     ).trim();
     if (!output) return null;
     // git log can emit additional follow-related lines on some platforms;
-    // the first non-empty line is the commit hash we want.
+    // the first non-empty line is the oldest commit hash we want.
     const first = output.split("\n")[0]?.trim();
     return first ? first : null;
   } catch {

--- a/packages/search-worker/src/__tests__/index.test.ts
+++ b/packages/search-worker/src/__tests__/index.test.ts
@@ -128,7 +128,7 @@ describe("worker handler", () => {
     expect(body).toHaveProperty("results");
     expect(body).toHaveProperty("query", "getting started");
     expect(body).toHaveProperty("total");
-    expect(Array.isArray(body.results)).toBe(true);
+    expect(Array.isArray((body as { results?: unknown }).results)).toBe(true);
     expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
   });
 

--- a/packages/search-worker/src/search.ts
+++ b/packages/search-worker/src/search.ts
@@ -20,7 +20,11 @@ async function fetchSearchIndex(url: string): Promise<SearchIndexEntry[]> {
   if (!res.ok) {
     throw new Error(`Failed to fetch search index: ${res.status} ${res.statusText}`);
   }
-  return (await res.json()) as SearchIndexEntry[];
+  const parsed = await res.json();
+  if (!Array.isArray(parsed)) {
+    throw new Error("Search index is not an array");
+  }
+  return parsed as SearchIndexEntry[];
 }
 
 async function buildIndex(url: string): Promise<MiniSearch<SearchIndexEntry>> {

--- a/packages/zudo-doc/src/integrations/llms-txt/load.ts
+++ b/packages/zudo-doc/src/integrations/llms-txt/load.ts
@@ -42,6 +42,10 @@ export function collectMdFiles(
     for (const entry of entries) {
       const fullPath = join(currentDir, entry.name);
       if (entry.isDirectory()) {
+        // Skip `_`-prefixed dirs to match the Content Collections convention
+        // (and zfb's routing): docs under them are not built as pages, so
+        // emitting them here would yield entries whose links 404.
+        if (entry.name.startsWith("_")) continue;
         walk(fullPath, baseDir);
       } else if (/\.mdx?$/.test(entry.name) && !entry.name.startsWith("_")) {
         const rel = relative(baseDir, fullPath)

--- a/packages/zudo-doc/src/integrations/search-index/content-files.ts
+++ b/packages/zudo-doc/src/integrations/search-index/content-files.ts
@@ -67,6 +67,10 @@ export function collectMdFiles(
     for (const entry of entries) {
       const fullPath = join(currentDir, entry.name);
       if (entry.isDirectory()) {
+        // Skip `_`-prefixed dirs to match the Content Collections convention
+        // (and zfb's routing): docs under them are not built as pages, so
+        // indexing them would yield search results whose links 404.
+        if (entry.name.startsWith("_")) continue;
         walk(fullPath, baseDir);
       } else if (/\.mdx?$/.test(entry.name) && !entry.name.startsWith("_")) {
         const rel = relative(baseDir, fullPath)

--- a/pages/api/ai-chat.tsx
+++ b/pages/api/ai-chat.tsx
@@ -378,6 +378,22 @@ export default async function AiChatHandler(): Promise<Response> {
   const clientIp = request.headers.get("cf-connecting-ip") ?? "unknown";
   const ipHash = await hashIp(clientIp);
 
+  // Rate limit FIRST — before parsing the body, running validation, or writing
+  // any audit-log entry. Every audit write touches KV, so gating audits behind
+  // the limiter is what stops an unauthenticated flood from amplifying into
+  // unbounded KV writes (and from exploiting the fail-open limiter). The
+  // tradeoff is deliberate: a malformed request from a legitimate caller also
+  // consumes quota. The rate-limited path writes no audit entry, so a blocked
+  // request performs no KV writes at all.
+  const rateLimit = await checkRateLimit(ipHash, env);
+  if (!rateLimit.allowed) {
+    return jsonResponse(
+      { error: "Too many requests" },
+      429,
+      { "Retry-After": String(rateLimit.retryAfter ?? 60) },
+    );
+  }
+
   /** Fire-and-forget audit entry via ctx.waitUntil. */
   function audit(
     message: string,
@@ -415,24 +431,13 @@ export default async function AiChatHandler(): Promise<Response> {
       );
     }
 
-    // Screen for prompt injection *before* rate limiting so injection attempts
-    // don't consume the caller's rate limit quota.
+    // Screen for prompt injection. Rate limiting already ran above, so a flood
+    // of injection attempts cannot amplify audit-log KV writes.
     if (!screenInput(body.message)) {
       audit(body.message, { blocked: true, blockReason: "prompt_injection" });
       return jsonResponse(
         { error: "I can only help with questions about the documentation." },
         400,
-      );
-    }
-
-    // Rate limit *after* validation so malformed requests don't consume quota.
-    const rateLimit = await checkRateLimit(ipHash, env);
-    if (!rateLimit.allowed) {
-      audit(body.message, { blocked: true, blockReason: "rate_limit" });
-      return jsonResponse(
-        { error: "Too many requests" },
-        429,
-        { "Retry-After": String(rateLimit.retryAfter ?? 60) },
       );
     }
 

--- a/pages/api/ai-chat.tsx
+++ b/pages/api/ai-chat.tsx
@@ -318,6 +318,9 @@ async function callClaude(
   }
 
   const data: ClaudeApiResponse = await response.json();
+  if (!Array.isArray(data.content)) {
+    throw new Error("Unexpected Claude API response: missing content array");
+  }
   const textBlock = data.content.find((b): b is ClaudeTextBlock => b.type === "text");
   if (!textBlock) throw new Error("No text response from Claude");
   return textBlock.text;

--- a/pages/lib/route-enumerators.ts
+++ b/pages/lib/route-enumerators.ts
@@ -73,7 +73,9 @@ export function enumerateDocsRoutes(locale: string): string[] {
     const allDocs = [...localeDocs, ...fallbackDocs] as DocsEntry[];
 
     for (const doc of allDocs) {
-      urls.push(docsUrl(doc.data.slug ?? doc.id, locale as string));
+      // Mirror the default-locale branch (L61): fall back through toRouteSlug
+      // so a top-level locale index.mdx maps to "" not "index".
+      urls.push(docsUrl(doc.data.slug ?? toRouteSlug(doc.id), locale as string));
     }
 
     const localeConfig = (

--- a/src/components/doc-history.tsx
+++ b/src/components/doc-history.tsx
@@ -472,6 +472,9 @@ export function DocHistory({ slug, locale, basePath = "/" }: DocHistoryProps) {
         throw new Error(`Failed to load history (${res.status})`);
       }
       const json: DocHistoryData = await res.json();
+      if (!json || !Array.isArray(json.entries)) {
+        throw new Error("Malformed history response");
+      }
       setData(json);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load history");

--- a/src/utils/base.ts
+++ b/src/utils/base.ts
@@ -86,7 +86,7 @@ export function getPathForLocale(
 ): string {
   let relativePath = stripBase(path);
   if (currentLang !== defaultLocale) {
-    relativePath = relativePath.replace(new RegExp(`^/${currentLang}/`), "/");
+    relativePath = relativePath.replace(new RegExp(`^/${currentLang}(?:/|$)`), "/");
   }
   if (targetLang !== defaultLocale) {
     relativePath = `/${targetLang}${relativePath}`;
@@ -98,7 +98,7 @@ export function getPathForLocale(
 export function buildLocaleLinks(currentPath: string, currentLang: Locale): LocaleLink[] {
   let defaultLocalePath = stripBase(currentPath);
   if (currentLang !== defaultLocale) {
-    defaultLocalePath = defaultLocalePath.replace(new RegExp(`^/${currentLang}/`), "/");
+    defaultLocalePath = defaultLocalePath.replace(new RegExp(`^/${currentLang}(?:/|$)`), "/");
   }
   if (isDefaultLocaleOnlyPath(defaultLocalePath)) {
     return [{

--- a/src/utils/content-files.ts
+++ b/src/utils/content-files.ts
@@ -54,6 +54,10 @@ export function collectMdFiles(
     for (const entry of entries) {
       const fullPath = join(currentDir, entry.name);
       if (entry.isDirectory()) {
+        // Skip `_`-prefixed dirs to match the Content Collections convention
+        // (and zfb's routing): docs under them are not built as pages, so
+        // indexing them would yield search results whose links 404.
+        if (entry.name.startsWith("_")) continue;
         walk(fullPath, baseDir);
       } else if (/\.mdx?$/.test(entry.name) && !entry.name.startsWith("_")) {
         const rel = relative(baseDir, fullPath)

--- a/src/utils/docs.ts
+++ b/src/utils/docs.ts
@@ -98,8 +98,10 @@ export function buildNavTree(
     const parts = slug.split("/");
 
     if (parts.length <= 1) {
-      // Category index: Astro 5 stripped /index → single segment like "guides"
-      const segment = doc.id;
+      // Category index: Astro 5 stripped /index → single segment like "guides".
+      // Key by the route slug (honors a custom frontmatter `slug`), not the raw
+      // id — otherwise the sidebar/breadcrumb link diverges from the built route.
+      const segment = parts[0] || doc.id;
       if (!root.children.has(segment)) {
         root.children.set(segment, {
           segment,


### PR DESCRIPTION
Output of `/review-loop 5 --aggressive` (full-project mode). 6 Opus reviewers per pass; codex was rate-limited this session. Ran 3 review rounds + 1 user-approved security fix, then early-exited (round 3 found no new bugs and disproved several candidates). Disciplined `--aggressive`: applied verified bugs/security freely, declined churn-heavy refactors on this live, published-package codebase.

## Fixes by round

**Round 1 — latent route bugs + response-shape guards** (`fd529c9d`)
- `buildNavTree` keyed single-segment nav by raw `doc.id` instead of the route slug → custom-`slug` docs diverge sidebar/breadcrumb from the built route. (src + create-zudo-doc template)
- Locale-strip regex required a trailing slash → malformed locale-switch hrefs for slashless paths like `/ja`; corrected to `(?:/|$)` (handles the default `trailingSlash:true` cleanly). (src + template)
- Response-shape guards: `ai-chat` `data.content`, doc-history island JSON, search-worker `MiniSearch.addAll` input; fixed a pre-existing strict-mode error in the search-worker test.

**Round 2 — doc-history first-commit + underscore-dir indexing** (`2414eb51`)
- **`getFirstCommit` always returned `null`** (`git log --follow --reverse --max-count=1` emits nothing on git 2.43.0 — `--max-count` truncates before `--reverse`). Every doc page's build-time meta collapsed to `createdDate == updatedDate` and was attributed to the latest committer. Verified end-to-end: **122/189 entries now carry distinct created/updated dates.**
- Content walkers (search-index, llms-txt, host + template `content-files.ts`) recursed into `_`-prefixed dirs while excluding `_`-prefixed files → docs under `_drafts/`-style dirs were indexed but not routed (dead 404 links). Now skip `_`-dirs too.

**Round 3 — sitemap slug consistency** (`36753191`)
- Non-default-locale sitemap URLs built from bare `doc.id`; normalized to `doc.data.slug ?? toRouteSlug(doc.id)` to match the default-locale branch (closes a top-level-locale-`index` edge). Round 3 otherwise found no new bugs.

**Round 4 — ai-chat rate-limit ordering (security, user-approved)** (`9b5b8610`)
- Audit-log KV writes fired on every pre-rate-limit reject **before** the limiter ran → unauthenticated write-amplification, compounded by the fail-open limiter (latent: endpoint gated off via `aiChatDemoMode`, live for downstream consumers with a real key). Rate-limit is now the first gate; the blocked path writes no audit entry, bounding all audit writes by the per-IP limit. Deliberate tradeoff: malformed requests now also consume quota.

## Verification
`pnpm b4push` — all automated steps green (format, template-drift, tags audit, design-token lint, typecheck, build 250 pages, link check, HTML validation, preview smoke 6/6; only the *manual interactive* step is skippable). Unit tests: root 356, create-zudo-doc 253, doc-history-server 22, search-worker 30. Package `dist/` rebuilt locally (gitignored; CI rebuilds from source).

## Reported, not applied (out of scope for an aggressive-but-disciplined pass)
- **doc-history build-time N+1** (`1+2N` git subprocesses/file) — real perf win but rewrites correctness-sensitive git parsing with no deterministic test coverage; needs its own PR + tests.
- **claude-resources generator**: dead `items.sort()` (sidebar order baked in traversal order, not sorted) and a contrived slug collision (`/`→`--`). Minor; multi-copy + changes generated output.
- **Generator search = "Pagefind"** (`scaffold.ts` devDep + `claude-md-gen.ts` string) while the framework uses MiniSearch — possible drift or intentional divergence; has a passing test asserting current behavior, so needs a decision before changing.
- Dead rename-fallback branch in `git-history.ts` (no runtime harm); large route-body DRY extractions (`DocPageView`/`DocPager`) touching 4 template-mirrored files; `settings.ts` `as`→`satisfies` idiom — all churn-heavy on a live codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/1820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782624737&installation_id=130359969&pr_number=1820&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F1820&signature=df9e45fbbda12b29745814931f7aec1e041d4b354786aad826015e0b31406fee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->