### PR TITLE
fix: sidebar resize handle spans full height when sidebar scrolls (#1821)

### DIFF
--- a/packages/create-zudo-doc/templates/features/sidebarResizer/files/src/scripts/sidebar-resizer.ts
+++ b/packages/create-zudo-doc/templates/features/sidebarResizer/files/src/scripts/sidebar-resizer.ts
@@ -4,7 +4,7 @@ export function initSidebarResizer() {
   // Only attach to the real fixed desktop panel. On hide_sidebar pages the
   // aside renders sr-only (position:absolute) purely for the ARIA landmark; a
   // position:fixed handle would escape sr-only's clip and show a stray strip
-  // (below lg the panel is display:none, also non-fixed). zudolab/zudo-doc#1821
+  // (below lg the panel is display:none but still fixed — handle appended, not rendered). zudolab/zudo-doc#1821
   if (getComputedStyle(sidebar).position !== "fixed") return;
 
   // Resizer allows a wider range (192–448px) than the CSS default

--- a/packages/create-zudo-doc/templates/features/sidebarResizer/files/src/scripts/sidebar-resizer.ts
+++ b/packages/create-zudo-doc/templates/features/sidebarResizer/files/src/scripts/sidebar-resizer.ts
@@ -31,16 +31,24 @@ export function initSidebarResizer() {
   handle.setAttribute("aria-valuemin", String(MIN_W));
   handle.setAttribute("aria-valuemax", String(MAX_W));
   handle.setAttribute("aria-valuenow", String(Math.round(cachedWidth)));
-  // 20px is wider than every common native y-scrollbar (~12-17px on
-  // Win/Linux classic; 0 on macOS overlay) so a draggable strip always remains
-  // visible to the LEFT of the scrollbar when sidebar content overflows.
-  // zudolab/zudo-doc#1660
+  // position:fixed (not absolute) pins the handle to the viewport so it spans
+  // the sidebar's full height even while #desktop-sidebar scrolls. As an
+  // absolute child of the overflow-y:auto sidebar the handle scrolled away with
+  // the content and its height:100% only resolved to the visible padding box,
+  // so the bottom of the sidebar lost its grab strip once scrolled. zudolab/zudo-doc#1821
+  //
+  // top:3.5rem + left:calc mirror the doc-layout #desktop-sidebar geometry
+  // (top-[3.5rem], left:0, width:var(--zd-sidebar-w)) — those layout constants
+  // live in the same package's doc-layout.tsx. 20px is wider than every common
+  // native y-scrollbar (~12-17px on Win/Linux classic; 0 on macOS overlay) so a
+  // draggable strip always remains visible to the LEFT of the scrollbar when
+  // sidebar content overflows. zudolab/zudo-doc#1660
   Object.assign(handle.style, {
-    position: "absolute",
-    top: "0",
-    right: "0",
+    position: "fixed",
+    top: "3.5rem",
+    bottom: "0",
+    left: "calc(var(--zd-sidebar-w) - 20px)",
     width: "20px",
-    height: "100%",
     cursor: "col-resize",
     zIndex: "10",
     transition: "background 0.15s",

--- a/packages/create-zudo-doc/templates/features/sidebarResizer/files/src/scripts/sidebar-resizer.ts
+++ b/packages/create-zudo-doc/templates/features/sidebarResizer/files/src/scripts/sidebar-resizer.ts
@@ -1,6 +1,11 @@
 export function initSidebarResizer() {
   const sidebar = document.getElementById("desktop-sidebar");
   if (!sidebar || sidebar.querySelector("[data-sidebar-resizer]")) return;
+  // Only attach to the real fixed desktop panel. On hide_sidebar pages the
+  // aside renders sr-only (position:absolute) purely for the ARIA landmark; a
+  // position:fixed handle would escape sr-only's clip and show a stray strip
+  // (below lg the panel is display:none, also non-fixed). zudolab/zudo-doc#1821
+  if (getComputedStyle(sidebar).position !== "fixed") return;
 
   // Resizer allows a wider range (192–448px) than the CSS default
   // (clamp(14rem, 20vw, 22rem) = 224–352px at 16px base).

--- a/packages/zudo-doc/src/sidebar-resizer/index.ts
+++ b/packages/zudo-doc/src/sidebar-resizer/index.ts
@@ -14,7 +14,7 @@
 //
 // What the resizer does
 // ---------------------
-// Finds `#desktop-sidebar` and grafts a 6px-wide drag handle onto its
+// Finds `#desktop-sidebar` and grafts a 20px-wide drag handle onto its
 // right edge. The handle:
 //
 //   * is keyboard-accessible (tab into it, then Arrow keys / Home / End
@@ -79,6 +79,12 @@ export function initSidebarResizer(): void {
 
   const sidebar = document.getElementById(SIDEBAR_ID);
   if (!sidebar || sidebar.querySelector(`[${HANDLE_MARKER}]`)) return;
+
+  // Only attach to the real fixed desktop panel. On hide_sidebar pages the
+  // aside renders sr-only (position:absolute) purely for the ARIA landmark; a
+  // position:fixed handle would escape sr-only's clip and show a stray strip
+  // (below lg the panel is display:none, also non-fixed). zudolab/zudo-doc#1821
+  if (getComputedStyle(sidebar).position !== "fixed") return;
 
   function readCurrentWidth(): number {
     const raw = getComputedStyle(document.documentElement).getPropertyValue(

--- a/packages/zudo-doc/src/sidebar-resizer/index.ts
+++ b/packages/zudo-doc/src/sidebar-resizer/index.ts
@@ -98,16 +98,24 @@ export function initSidebarResizer(): void {
   handle.setAttribute("aria-valuemin", String(MIN_W));
   handle.setAttribute("aria-valuemax", String(MAX_W));
   handle.setAttribute("aria-valuenow", String(Math.round(cachedWidth)));
-  // 20px is wider than every common native y-scrollbar (~12-17px on
-  // Win/Linux classic; 0 on macOS overlay) so a draggable strip always remains
-  // visible to the LEFT of the scrollbar when sidebar content overflows.
-  // zudolab/zudo-doc#1660
+  // position:fixed (not absolute) pins the handle to the viewport so it spans
+  // the sidebar's full height even while #desktop-sidebar scrolls. As an
+  // absolute child of the overflow-y:auto sidebar the handle scrolled away with
+  // the content and its height:100% only resolved to the visible padding box,
+  // so the bottom of the sidebar lost its grab strip once scrolled. zudolab/zudo-doc#1821
+  //
+  // top:3.5rem + left:calc mirror the doc-layout #desktop-sidebar geometry
+  // (top-[3.5rem], left:0, width:var(--zd-sidebar-w)) — those layout constants
+  // live in the same package's doc-layout.tsx. 20px is wider than every common
+  // native y-scrollbar (~12-17px on Win/Linux classic; 0 on macOS overlay) so a
+  // draggable strip always remains visible to the LEFT of the scrollbar when
+  // sidebar content overflows. zudolab/zudo-doc#1660
   Object.assign(handle.style, {
-    position: "absolute",
-    top: "0",
-    right: "0",
+    position: "fixed",
+    top: "3.5rem",
+    bottom: "0",
+    left: "calc(var(--zd-sidebar-w) - 20px)",
     width: "20px",
-    height: "100%",
     cursor: "col-resize",
     zIndex: "10",
     transition: "background 0.15s",

--- a/packages/zudo-doc/src/sidebar-resizer/index.ts
+++ b/packages/zudo-doc/src/sidebar-resizer/index.ts
@@ -83,7 +83,7 @@ export function initSidebarResizer(): void {
   // Only attach to the real fixed desktop panel. On hide_sidebar pages the
   // aside renders sr-only (position:absolute) purely for the ARIA landmark; a
   // position:fixed handle would escape sr-only's clip and show a stray strip
-  // (below lg the panel is display:none, also non-fixed). zudolab/zudo-doc#1821
+  // (below lg the panel is display:none but still fixed — handle appended, not rendered). zudolab/zudo-doc#1821
   if (getComputedStyle(sidebar).position !== "fixed") return;
 
   function readCurrentWidth(): number {

--- a/packages/zudo-doc/src/sidebar-resizer/sidebar-resizer-init.tsx
+++ b/packages/zudo-doc/src/sidebar-resizer/sidebar-resizer-init.tsx
@@ -53,6 +53,11 @@ export const SIDEBAR_RESIZER_INIT_SCRIPT = `(function(){
     if(typeof document==="undefined")return;
     var sidebar=document.getElementById(SIDEBAR_ID);
     if(!sidebar||sidebar.querySelector("["+HANDLE_MARKER+"]"))return;
+    // Only attach to the real fixed desktop panel. On hide_sidebar pages the
+    // aside renders sr-only (position:absolute) purely for the ARIA landmark; a
+    // position:fixed handle would escape sr-only's clip and show a stray strip
+    // (below lg the panel is display:none, also non-fixed). zudolab/zudo-doc#1821
+    if(getComputedStyle(sidebar).position!=="fixed")return;
 
     function readCurrentWidth(){
       var raw=getComputedStyle(document.documentElement).getPropertyValue(CSS_PROP);

--- a/packages/zudo-doc/src/sidebar-resizer/sidebar-resizer-init.tsx
+++ b/packages/zudo-doc/src/sidebar-resizer/sidebar-resizer-init.tsx
@@ -69,9 +69,15 @@ export const SIDEBAR_RESIZER_INIT_SCRIPT = `(function(){
     handle.setAttribute("aria-valuemin",String(MIN_W));
     handle.setAttribute("aria-valuemax",String(MAX_W));
     handle.setAttribute("aria-valuenow",String(Math.round(cachedWidth)));
-    // 20px hit area > native y-scrollbar (~12-17px) so a draggable strip stays
-    // visible to the LEFT of the scrollbar when sidebar overflows. zudolab/zudo-doc#1660
-    Object.assign(handle.style,{position:"absolute",top:"0",right:"0",width:"20px",height:"100%",cursor:"col-resize",zIndex:"10",transition:"background 0.15s"});
+    // position:fixed (not absolute) pins the handle to the viewport so it spans
+    // the sidebar's full height even while #desktop-sidebar scrolls. As an
+    // absolute child of the overflow-y:auto sidebar it scrolled away with the
+    // content and height:100% only covered the visible padding box. zudolab/zudo-doc#1821
+    // top:3.5rem + left:calc mirror the layout's #desktop-sidebar geometry
+    // (top-[3.5rem], left:0, width:var(--zd-sidebar-w)). 20px hit area > native
+    // y-scrollbar (~12-17px) keeps a draggable strip left of the scrollbar when
+    // the sidebar overflows. zudolab/zudo-doc#1660
+    Object.assign(handle.style,{position:"fixed",top:"3.5rem",bottom:"0",left:"calc(var(--zd-sidebar-w) - 20px)",width:"20px",cursor:"col-resize",zIndex:"10",transition:"background 0.15s"});
 
     var dragging=false,focused=false;
 

--- a/packages/zudo-doc/src/sidebar-resizer/sidebar-resizer-init.tsx
+++ b/packages/zudo-doc/src/sidebar-resizer/sidebar-resizer-init.tsx
@@ -56,7 +56,7 @@ export const SIDEBAR_RESIZER_INIT_SCRIPT = `(function(){
     // Only attach to the real fixed desktop panel. On hide_sidebar pages the
     // aside renders sr-only (position:absolute) purely for the ARIA landmark; a
     // position:fixed handle would escape sr-only's clip and show a stray strip
-    // (below lg the panel is display:none, also non-fixed). zudolab/zudo-doc#1821
+    // (below lg the panel is display:none but still fixed — handle appended, not rendered). zudolab/zudo-doc#1821
     if(getComputedStyle(sidebar).position!=="fixed")return;
 
     function readCurrentWidth(){

--- a/src/scripts/sidebar-resizer.ts
+++ b/src/scripts/sidebar-resizer.ts
@@ -4,7 +4,7 @@ export function initSidebarResizer() {
   // Only attach to the real fixed desktop panel. On hide_sidebar pages the
   // aside renders sr-only (position:absolute) purely for the ARIA landmark; a
   // position:fixed handle would escape sr-only's clip and show a stray strip
-  // (below lg the panel is display:none, also non-fixed). zudolab/zudo-doc#1821
+  // (below lg the panel is display:none but still fixed — handle appended, not rendered). zudolab/zudo-doc#1821
   if (getComputedStyle(sidebar).position !== "fixed") return;
 
   // Resizer allows a wider range (192–448px) than the CSS default

--- a/src/scripts/sidebar-resizer.ts
+++ b/src/scripts/sidebar-resizer.ts
@@ -31,16 +31,24 @@ export function initSidebarResizer() {
   handle.setAttribute("aria-valuemin", String(MIN_W));
   handle.setAttribute("aria-valuemax", String(MAX_W));
   handle.setAttribute("aria-valuenow", String(Math.round(cachedWidth)));
-  // 20px is wider than every common native y-scrollbar (~12-17px on
-  // Win/Linux classic; 0 on macOS overlay) so a draggable strip always remains
-  // visible to the LEFT of the scrollbar when sidebar content overflows.
-  // zudolab/zudo-doc#1660
+  // position:fixed (not absolute) pins the handle to the viewport so it spans
+  // the sidebar's full height even while #desktop-sidebar scrolls. As an
+  // absolute child of the overflow-y:auto sidebar the handle scrolled away with
+  // the content and its height:100% only resolved to the visible padding box,
+  // so the bottom of the sidebar lost its grab strip once scrolled. zudolab/zudo-doc#1821
+  //
+  // top:3.5rem + left:calc mirror the doc-layout #desktop-sidebar geometry
+  // (top-[3.5rem], left:0, width:var(--zd-sidebar-w)) — those layout constants
+  // live in the same package's doc-layout.tsx. 20px is wider than every common
+  // native y-scrollbar (~12-17px on Win/Linux classic; 0 on macOS overlay) so a
+  // draggable strip always remains visible to the LEFT of the scrollbar when
+  // sidebar content overflows. zudolab/zudo-doc#1660
   Object.assign(handle.style, {
-    position: "absolute",
-    top: "0",
-    right: "0",
+    position: "fixed",
+    top: "3.5rem",
+    bottom: "0",
+    left: "calc(var(--zd-sidebar-w) - 20px)",
     width: "20px",
-    height: "100%",
     cursor: "col-resize",
     zIndex: "10",
     transition: "background 0.15s",

--- a/src/scripts/sidebar-resizer.ts
+++ b/src/scripts/sidebar-resizer.ts
@@ -1,6 +1,11 @@
 export function initSidebarResizer() {
   const sidebar = document.getElementById("desktop-sidebar");
   if (!sidebar || sidebar.querySelector("[data-sidebar-resizer]")) return;
+  // Only attach to the real fixed desktop panel. On hide_sidebar pages the
+  // aside renders sr-only (position:absolute) purely for the ARIA landmark; a
+  // position:fixed handle would escape sr-only's clip and show a stray strip
+  // (below lg the panel is display:none, also non-fixed). zudolab/zudo-doc#1821
+  if (getComputedStyle(sidebar).position !== "fixed") return;
 
   // Resizer allows a wider range (192–448px) than the CSS default
   // (clamp(14rem, 20vw, 22rem) = 224–352px at 16px base).


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/1821

---

## Summary

Fixes #1821. When the desktop sidebar (`#desktop-sidebar`) had enough nav items to scroll, the drag-to-resize handle did not cover the full visible height. The handle was a `position: absolute; top:0; height:100%` child of the `overflow-y: auto` scroll container, so it **scrolled away with the content** and its `height:100%` only resolved to the visible padding box — scrolling down left the bottom of the sidebar with no grab strip.

## Changes

**Pin the handle to the viewport (pure CSS).** The handle is now:

```
position: fixed;
top: 3.5rem;                              /* matches the layout's header offset */
bottom: 0;
left: calc(var(--zd-sidebar-w) - 20px);  /* flush to the sidebar's right edge */
width: 20px;
```

The browser tracks `--zd-sidebar-w` and the viewport height natively, so the handle stays at full height regardless of scroll — **no scroll/resize listeners**, and the `#desktop-sidebar` scroll-preservation machinery is untouched.

**Guard against `hide_sidebar` pages (caught in review).** On `hide_sidebar: true` pages the layout still renders the `<aside>` as `sr-only` (for the ARIA landmark). The old absolute handle was clipped to ~1px and invisible; `position: fixed` escaped that clip and would have drawn a stray full-height strip. Added `if (getComputedStyle(sidebar).position !== "fixed") return;` — sr-only is `position: absolute` and bails; the shown panel (`fixed`) proceeds.

Applied to all four parallel copies of the handle logic (live inline script, canonical `index.ts`, and the host + `create-zudo-doc` template `src/scripts` copies, kept byte-identical). Also corrected a stale "6px-wide" comment in `index.ts` (the handle is 20px since #1660).

## Test Plan

Verified on the live dev server with Playwright (deterministic rect measurement):

- **Normal page, scrolled to bottom**: handle spans full height (`top:56, bottom:720`), `position:fixed` — was `top:-301, bottom:363` before the fix.
- **Drag & keyboard resize**: still commit (`--zd-sidebar-w` + localStorage update) and the handle auto-tracks the new width.
- **Sidebar hide-toggle** (`data-sidebar-hidden`): handle still hidden (transform + `visibility:hidden`).
- **`hide_sidebar` demo page**: handle no longer created (no stray strip).
- **SPA nav** (normal → hide_sidebar → back): handle appears → absent → reappears, single instance, no stray/duplicate.
- `pnpm check`, `pnpm lint:tokens`, `pnpm check:template-drift`, and `pnpm build` (250 pages) all pass.