### PR TITLE
fix(image-enlarge): move enlarge-dialog close button to the page top-right and shrink it to 2/3

### DIFF
--- a/e2e/smoke-image-enlarge.spec.ts
+++ b/e2e/smoke-image-enlarge.spec.ts
@@ -177,8 +177,8 @@ test.describe("Image Enlarge: browser behavior @local-only", () => {
     await expect(dialog).toBeVisible({ timeout: 3000 });
 
     // Click at viewport (0, 0) — outside the centered dialog content
-    // The dialog is centered via position:fixed with transform, so top-left
-    // viewport corner is outside its bounding rect.
+    // The dialog is centered via position:fixed with inset:0; margin:auto, so
+    // the top-left viewport corner is outside its bounding rect.
     await page.mouse.click(0, 0);
     await expect(dialog).toBeHidden({ timeout: 3000 });
   });

--- a/packages/create-zudo-doc/templates/base/src/styles/global.css
+++ b/packages/create-zudo-doc/templates/base/src/styles/global.css
@@ -1074,7 +1074,10 @@ dialog.zd-enlarge-dialog::backdrop {
 }
 
 /* Close button is positioned to the VIEWPORT corner (not the dialog) so it
- * stays visually distinct against any image, regardless of the dialog's size. */
+ * stays visually distinct against any image, regardless of the dialog's size.
+ * This relies on the dialog being transform-free (see DIALOG_STYLE in
+ * image-enlarge.tsx) — a transform on the dialog would re-anchor this fixed
+ * button to the dialog corner. */
 .zd-enlarge-dialog-close {
   position: fixed;
   top: 4px;
@@ -1111,7 +1114,7 @@ dialog.zd-enlarge-dialog::backdrop {
   fill: currentColor;
 }
 
-/* Wide viewport: ~3× larger close button to read clearly against any image. */
+/* Wide viewport: ~2× larger close button to read clearly against any image. */
 @media (min-width: 1024px) {
   .zd-enlarge-dialog-close {
     top: 10px;
@@ -1119,8 +1122,8 @@ dialog.zd-enlarge-dialog::backdrop {
   }
 
   .zd-enlarge-dialog-close > svg {
-    width: calc(var(--spacing-icon-lg) * 3);
-    height: calc(var(--spacing-icon-lg) * 3);
+    width: calc(var(--spacing-icon-lg) * 2);
+    height: calc(var(--spacing-icon-lg) * 2);
   }
 }
 

--- a/packages/create-zudo-doc/templates/features/imageEnlarge/files/src/components/image-enlarge.tsx
+++ b/packages/create-zudo-doc/templates/features/imageEnlarge/files/src/components/image-enlarge.tsx
@@ -18,11 +18,16 @@ interface ImageData {
 // flashes. Sourcing both from the same constants closes the drift gap.
 const DIALOG_CLASS =
   "zd-enlarge-dialog mx-auto max-h-[90vh] max-w-[90vw] overflow-hidden border border-muted bg-surface p-0";
+// Center the modal with `inset: 0; margin: auto` rather than a transform.
+// A `transform` on the dialog would establish a containing block for its
+// `position: fixed` descendants, which would trap the `.zd-enlarge-dialog-close`
+// button at the dialog's corner instead of the viewport's — see the close
+// button's fixed positioning in global.css. Auto-margin centering keeps the
+// dialog transform-free so the close button anchors to the page top-right.
 const DIALOG_STYLE = {
   position: "fixed",
-  top: "50%",
-  left: "50%",
-  transform: "translate(-50%, -50%)",
+  inset: "0",
+  margin: "auto",
 } as const;
 
 export default function ImageEnlarge() {

--- a/src/components/image-enlarge.tsx
+++ b/src/components/image-enlarge.tsx
@@ -29,11 +29,16 @@ interface ImageData {
 // constants closes the drift gap GCO flagged in light-review.
 const DIALOG_CLASS =
   "zd-enlarge-dialog mx-auto max-h-[90vh] max-w-[90vw] overflow-hidden border border-muted bg-surface p-0";
+// Center the modal with `inset: 0; margin: auto` rather than a transform.
+// A `transform` on the dialog would establish a containing block for its
+// `position: fixed` descendants, which would trap the `.zd-enlarge-dialog-close`
+// button at the dialog's corner instead of the viewport's — see the close
+// button's fixed positioning in global.css. Auto-margin centering keeps the
+// dialog transform-free so the close button anchors to the page top-right.
 const DIALOG_STYLE = {
   position: "fixed",
-  top: "50%",
-  left: "50%",
-  transform: "translate(-50%, -50%)",
+  inset: "0",
+  margin: "auto",
 } as const;
 
 export default function ImageEnlarge() {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1140,7 +1140,10 @@ dialog.zd-enlarge-dialog::backdrop {
 }
 
 /* Close button is positioned to the VIEWPORT corner (not the dialog) so it
- * stays visually distinct against any image, regardless of the dialog's size. */
+ * stays visually distinct against any image, regardless of the dialog's size.
+ * This relies on the dialog being transform-free (see DIALOG_STYLE in
+ * image-enlarge.tsx) — a transform on the dialog would re-anchor this fixed
+ * button to the dialog corner. */
 .zd-enlarge-dialog-close {
   position: fixed;
   top: 4px;
@@ -1177,7 +1180,7 @@ dialog.zd-enlarge-dialog::backdrop {
   fill: currentColor;
 }
 
-/* Wide viewport: ~3× larger close button to read clearly against any image. */
+/* Wide viewport: ~2× larger close button to read clearly against any image. */
 @media (min-width: 1024px) {
   .zd-enlarge-dialog-close {
     top: 10px;
@@ -1185,8 +1188,8 @@ dialog.zd-enlarge-dialog::backdrop {
   }
 
   .zd-enlarge-dialog-close > svg {
-    width: calc(var(--spacing-icon-lg) * 3);
-    height: calc(var(--spacing-icon-lg) * 3);
+    width: calc(var(--spacing-icon-lg) * 2);
+    height: calc(var(--spacing-icon-lg) * 2);
   }
 }
 


### PR DESCRIPTION
## Summary

In the image-enlarge fullscreen dialog, the close (X) button was **too large** and sat at the **top-right of the enlarged image** instead of the page.

**Root cause:** the button is `position: fixed` and intended to anchor to the viewport (per its CSS comment, *"positioned to the VIEWPORT corner (not the dialog)"*). But the dialog centered itself with `transform: translate(-50%, -50%)`, and a `transform` on an ancestor establishes a **containing block for `position: fixed` descendants** — so the button was silently trapped at the *dialog's* corner. The stated intent and the actual behavior had diverged.

## Changes

- **Position** — `DIALOG_STYLE` now centers the modal `<dialog>` via `inset: 0; margin: auto` (the native modal-centering mechanism) instead of `top/left/transform`. With no transform on the dialog, the fixed close button finally anchors to the **viewport → page top-right**. The shared `DIALOG_CLASS`/`DIALOG_STYLE` constants keep the live dialog and `ImageEnlargeSsrFallback` in sync (no SSR/hydration drift).
- **Size** — desktop close-button icon reduced from `calc(var(--spacing-icon-lg) * 3)` (72px) to `* 2` (48px) — exactly 2/3.
- **Comment** — added a one-liner near `DIALOG_STYLE` explaining *why* the dialog must stay transform-free, and refreshed the now-accurate `global.css` comments.
- **Template sync** — mirrored both edits into the `create-zudo-doc` template counterparts (component + `global.css`), per the Feature Change Checklist.
- **Test comment** — corrected a stale centering comment in `e2e/smoke-image-enlarge.spec.ts` (logic unchanged).

## Test Plan

- ✅ `pnpm check` (tsc) passes.
- ✅ Browser verification (Playwright, 1280×800): close button `getBoundingClientRect()` measured at **10px from the viewport top and right** — beyond the dialog's right edge (dialog right=1185, button right=1270) — confirming it anchors to the **page corner**, not the image. SVG measured at **48px**. `getComputedStyle(dialog).transform === "none"`. Screenshot confirms placement + size.
- ✅ 3× Opus deep-review: no blocking issues; template parity verified byte-identical.

Closes the visual issue shown in the reported screenshot (oversized X at the image corner).