### PR TITLE
Release Dual-Tag: dual-tag latest+next self-disabling + version-scheme parity

### DIFF
--- a/.claude/skills/l-release-create-zudo-doc/SKILL.md
+++ b/.claude/skills/l-release-create-zudo-doc/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   (2) User wants to publish a new version of the create-zudo-doc npm package.
 user-invocable: true
 disable-model-invocation: false
-argument-description: "Optional: the exact version string (e.g. 0.2.0, 1.0.0-next.1)"
+argument-description: "Optional: version string or bump mode (e.g. 0.2.0, 1.0.0-next.1, minor, stable)"
 ---
 
 # /l-release-create-zudo-doc
@@ -30,6 +30,52 @@ downstream contract. This skill wraps and extends the same release flow for the
 
 The existing `/zudo-doc-version-bump` skill is **not modified** by this flow.
 
+## Version scheme
+
+The release script auto-derives the next version from the current one, or accepts
+explicit bump modes and version strings:
+
+| Current version   | Mode / arg       | Result              |
+|-------------------|------------------|---------------------|
+| `X.Y.Z` (stable)  | _(no arg / auto)_ | `X.(Y+1).0-next.1` |
+| `X.Y.Z-next.N`    | _(no arg / auto)_ | `X.Y.Z-next.(N+1)` |
+| any               | `major`          | `(X+1).0.0-next.1` |
+| any               | `minor`          | `X.(Y+1).0-next.1` |
+| any               | `patch`          | `X.Y.(Z+1)-next.1` |
+| `X.Y.Z` (stable)  | `next`           | `X.(Y+1).0-next.1` |
+| `X.Y.Z-next.N`    | `next`           | `X.Y.Z-next.(N+1)` |
+| `X.Y.Z-next.N`    | `stable`         | `X.Y.Z`            |
+| already stable    | `stable`         | _(error)_           |
+| any               | `<semver>`       | use exactly that    |
+
+All keyword modes except `stable` produce a prerelease version (with `-next.1` suffix).
+Stable is always an explicit promotion — never auto-derived from a stable base.
+
+### Dry path (compute-only, no mutations)
+
+```bash
+# Test auto-derive from a specific version without touching package.json:
+DRY=1 FROM=0.1.0 ./scripts/release-create-zudo-doc.sh
+# → next version: 0.2.0-next.1 / pin string: ^0.2.0-next.1
+
+DRY=1 FROM=0.2.0-next.1 ./scripts/release-create-zudo-doc.sh
+# → next version: 0.2.0-next.2 / pin string: ^0.2.0-next.2
+
+DRY=1 FROM=0.2.0-next.3 ./scripts/release-create-zudo-doc.sh stable
+# → next version: 0.2.0 / pin string: ^0.2.0
+```
+
+## One-time bootstrap (first release from a fresh repo)
+
+Before the very first release, if npm has never seen `@takazudo/zudo-doc` and the
+`latest` dist-tag is not yet set, run the bootstrap helper to seed it:
+
+```bash
+node scripts/release-bootstrap-latest.mjs <version>
+```
+
+This is a one-time operation — subsequent releases use the normal release script.
+
 ## Preconditions
 
 Verify ALL of the following before proceeding. If any check fails, stop and tell the user.
@@ -47,7 +93,9 @@ git tag -l 'v*' --sort=-v:refname | head -1
 
 ## Step 1 — Propose the new version
 
-If the user passed a version argument, use it directly. Otherwise:
+If the user passed an explicit version string (`0.2.0`, `1.0.0-next.1`), use it directly.
+If the user passed a bump mode keyword (`major`, `minor`, `patch`, `next`, `stable`), pass
+it to the script. Otherwise:
 
 ```bash
 git log <last-tag>..HEAD --oneline
@@ -55,26 +103,38 @@ git log <last-tag>..HEAD --oneline
 
 Categorize commits by conventional-commit prefix and propose:
 
-- Breaking changes (`feat!`, `BREAKING CHANGE`) → **major** bump
-- Features (`feat:`) → **minor** bump
-- Otherwise → **patch** bump
+- Breaking changes (`feat!`, `BREAKING CHANGE`) → `major` bump
+- Features (`feat:`) → `minor` bump
+- Otherwise → `patch` bump
 
-For prerelease candidates, use the `-next.N`, `-beta.N`, or `-rc.N` suffix as
-appropriate. Present the proposal and **wait for user confirmation**.
+For prerelease candidates, propose the appropriate keyword (`next`, or explicit `-next.N`).
+To preview the computed version without touching any files, use the dry path:
+
+```bash
+DRY=1 ./scripts/release-create-zudo-doc.sh [<version>|<mode>]
+```
+
+Present the proposal and **wait for user confirmation**.
 
 ## Step 2 — Run the release script
 
 ```bash
-./scripts/release-create-zudo-doc.sh <NEW_VERSION>
+./scripts/release-create-zudo-doc.sh [<version>|<mode>]
 ```
 
 This script (sibling to `version-bump.sh`, does NOT modify it):
 
-1. Validates the version format (accepts prerelease suffixes)
-2. Bumps `package.json` at the root
-3. Bumps `packages/create-zudo-doc/package.json`
-4. Scaffolds `src/content/docs/changelog/<NEW_VERSION>.mdx` (EN)
-5. Scaffolds `src/content/docs-ja/changelog/<NEW_VERSION>.mdx` (JA)
+1. Computes the next version from the arg or auto-derives it (see "Version scheme" above)
+2. Validates the version format (accepts prerelease suffixes)
+3. Bumps `package.json` at the root
+4. Bumps `packages/create-zudo-doc/package.json`
+5. Bumps `packages/zudo-doc/package.json` (W4A — #1732)
+6. Bumps `packages/doc-history-server/package.json` (W4A — #1732)
+7. Rewrites `@takazudo/zudo-doc` pin in `scaffold.ts` to `^<new-version>` — including
+   prerelease versions (e.g. `^0.2.0-next.1`) so a fresh downstream scaffold resolves
+   the version being released
+8. Scaffolds `src/content/docs/changelog/<NEW_VERSION>.mdx` (EN)
+9. Scaffolds `src/content/docs-ja/changelog/<NEW_VERSION>.mdx` (JA)
 
 ## Step 3 — Fill in the changelog
 
@@ -129,6 +189,9 @@ Stage and commit all changed files:
 ```bash
 git add package.json \
         packages/create-zudo-doc/package.json \
+        packages/zudo-doc/package.json \
+        packages/doc-history-server/package.json \
+        packages/create-zudo-doc/src/scaffold.ts \
         src/content/docs/changelog/<NEW_VERSION>.mdx \
         src/content/docs-ja/changelog/<NEW_VERSION>.mdx
 # Add any formatting fixes from b4push:
@@ -195,14 +258,22 @@ Publishing the draft releases `create-zudo-doc@<NEW_VERSION>` to npm — this is
 the human gate that cannot be undone after 72 hours (npm unpublish lock). Review
 carefully before clicking.
 
-## Dist-tag reference (CI determines this from the tag name)
+## Dual-tag behavior: `latest` and `next`
 
-| Tag pattern         | npm dist-tag |
-|---------------------|--------------|
-| `v1.2.3`            | `latest`     |
-| `v1.2.3-next.1`     | `next`       |
-| `v1.2.3-beta.2`     | `next`       |
-| `v1.2.3-rc.3`       | `next`       |
+Each package is published to npm with a dist-tag determined by the version string. CI
+reads the tag name and selects the tag automatically — the maintainer does NOT specify
+`--tag` manually. Publishing the DRAFT is the only irreversible step.
+
+| Tag pattern         | npm dist-tag | Who resolves it                  |
+|---------------------|--------------|----------------------------------|
+| `v1.2.3`            | `latest`     | `pnpm install create-zudo-doc`   |
+| `v1.2.3-next.1`     | `next`       | `pnpm install create-zudo-doc@next` |
+| `v1.2.3-beta.2`     | `next`       | `pnpm install create-zudo-doc@next` |
+| `v1.2.3-rc.3`       | `next`       | `pnpm install create-zudo-doc@next` |
+
+Prerelease versions (any tag containing a `-`) are published under `next`. Stable
+versions (no `-`) are published under `latest`. This ensures `npm install` / `pnpm dlx`
+without a dist-tag always pulls the last stable release, not a prerelease.
 
 ## Files involved (pin sources)
 

--- a/.github/workflows/publish-create-zudo-doc.yml
+++ b/.github/workflows/publish-create-zudo-doc.yml
@@ -8,6 +8,15 @@
 #      pass without touching npm. Use this before the first real release to
 #      verify NPM_TOKEN is wired correctly.
 #
+# Workflow_dispatch caveat:
+#   The job-level `if:` requires the ref/tag to start with `v` (create-zudo-doc's
+#   namespace). Dispatching from `main` (or any non-`v` ref) makes this job skip
+#   NEUTRAL — it does not run, rather than failing red. For a dry-run auth smoke,
+#   dispatch with a candidate `v`-prefixed tag as the ref — NOT an already-published
+#   tag, since Safeguard 3 ("version not already published") runs before the dry-run
+#   auth check and would abort first. Safeguard 1 remains as defense-in-depth for a
+#   matching-prefix-but-invalid-semver ref.
+#
 # NPM_TOKEN must be an Automation token (type: "Automation" in npmjs.com).
 # Automation tokens bypass npm's 2FA for `npm publish`, which is required
 # for CI-driven publishing. Classic Publish tokens with 2FA enabled would
@@ -179,7 +188,7 @@ jobs:
           echo "  Package : create-zudo-doc"
           echo "  Version : $VERSION"
           echo "  Dist-tag: $DIST_TAG"
-          echo "  Flags   : --access public --provenance"
+          echo "  Flags   : --access public --provenance --tag $DIST_TAG"
           echo ""
           echo "Dry run complete. Remove dry_run input or set it to false to publish for real."
 

--- a/.github/workflows/publish-create-zudo-doc.yml
+++ b/.github/workflows/publish-create-zudo-doc.yml
@@ -49,6 +49,10 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Only run when the triggering tag starts with "v" (create-zudo-doc namespace).
+    # zudo-doc-v… and zudo-doc-history-server-… do not start with bare "v", so
+    # those releases skip this job NEUTRAL instead of failing RED.
+    if: ${{ startsWith(github.event.release.tag_name || github.ref_name, 'v') }}
 
     steps:
       # ── Checkout at the exact release tag ──────────────────────────────────
@@ -194,3 +198,77 @@ jobs:
           echo "Publishing create-zudo-doc@$VERSION with --tag $DIST_TAG..."
           npm publish --access public --provenance --tag "$DIST_TAG"
           echo "Published: https://www.npmjs.com/package/create-zudo-doc/v/$VERSION"
+
+      # ── Dual-tag: advance "latest" when publishing a prerelease ───────────
+      # Only runs for real publishes (not dry-run) and only when DIST_TAG=next.
+      # Policy: advance latest iff the registry's current latest is empty (first
+      # publish ever) or is itself a prerelease (contains "-"). This is
+      # self-disabling once a stable version holds "latest".
+      #
+      # Probe MUST fail CLOSED: a registry/network error must NOT be read as
+      # "empty latest". Stdout and stderr are captured separately; on non-zero
+      # exit the probe retries 3 times, then fails closed (dual-tag skipped).
+      - name: 'Dual-tag: advance latest → ${{ env.VERSION }} (prerelease only)'
+        if: ${{ inputs.dry_run != true && env.DIST_TAG == 'next' }}
+        shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          PKG="create-zudo-doc"
+          echo "DIST_TAG=next — checking whether to advance 'latest' for $PKG..."
+
+          # Probe the registry for the current latest dist-tag.
+          # Capture stdout and exit status separately; stderr goes to a log file.
+          # GHA runs bash with -eo pipefail, so use if-form to avoid aborting on
+          # non-zero exit (the if-form is exempt from -e).
+          PROBE_OUT=""
+          PROBE_STATUS=1
+          for ATTEMPT in 1 2 3; do
+            if PROBE_OUT=$(npm view "$PKG" dist-tags.latest 2>/tmp/probe-err.log); then
+              PROBE_STATUS=0
+              break
+            else
+              PROBE_STATUS=$?
+              echo "Probe attempt $ATTEMPT failed (exit $PROBE_STATUS):"
+              cat /tmp/probe-err.log || true
+              if [[ $ATTEMPT -lt 3 ]]; then
+                echo "Retrying in 5s..."
+                sleep 5
+              fi
+            fi
+          done
+
+          if [[ $PROBE_STATUS -ne 0 ]]; then
+            echo "::warning::All 3 probe attempts failed — failing closed, dual-tag skipped."
+            echo "::warning::Registry may be temporarily unavailable. Retry the workflow or run manually:"
+            echo "::warning::  npm dist-tag add $PKG@$VERSION latest"
+            exit 0
+          fi
+
+          # Trim whitespace from stdout only (stderr was separated above).
+          CURRENT_LATEST=$(printf '%s' "$PROBE_OUT" | tr -d '[:space:]')
+          echo "Current latest: '${CURRENT_LATEST:-<empty>}'"
+
+          # Enable dual-tag iff latest is empty (never published) or is a prerelease.
+          if [[ -n "$CURRENT_LATEST" && "$CURRENT_LATEST" != *-* ]]; then
+            echo "latest is a stable release ('$CURRENT_LATEST') — self-disabled, skipping dual-tag."
+            exit 0
+          fi
+
+          echo "Advancing 'latest' → $PKG@$VERSION ..."
+          # Retry up to 5 times with exponential backoff (5, 10, 20, 40 s).
+          DELAY=5
+          for ATTEMPT in 1 2 3 4 5; do
+            if npm dist-tag add "$PKG@$VERSION" latest; then
+              echo "OK: dist-tag add succeeded on attempt $ATTEMPT."
+              exit 0
+            fi
+            if [[ $ATTEMPT -lt 5 ]]; then
+              echo "dist-tag add failed (attempt $ATTEMPT), retrying in ${DELAY}s..."
+              sleep "$DELAY"
+              DELAY=$((DELAY * 2))
+            fi
+          done
+
+          echo "::error::Manual remediation: npm dist-tag add $PKG@$VERSION latest"
+          exit 1

--- a/.github/workflows/publish-zudo-doc-history-server.yml
+++ b/.github/workflows/publish-zudo-doc-history-server.yml
@@ -16,9 +16,14 @@
 #   accidentally trigger this workflow.
 #
 # Workflow_dispatch caveat:
-#   When dispatching manually, choose a zudo-doc-history-server- prefixed tag
-#   as the ref — Safeguard 1 rejects refs that don't match. Dispatching from
-#   `main` will fail-fast with a clear message.
+#   The job-level `if:` requires the ref/tag to start with
+#   `zudo-doc-history-server-`. Dispatching from `main` (or any non-matching
+#   ref) makes this job skip NEUTRAL — it does not run, rather than failing
+#   red. For a dry-run auth smoke, dispatch with a candidate
+#   `zudo-doc-history-server-` prefixed tag as the ref — NOT an already-published
+#   tag, since Safeguard 3 ("version not already published") runs before the
+#   dry-run auth check and would abort first. Safeguard 1's anchored regex
+#   remains as defense-in-depth for a matching-prefix-but-invalid-semver ref.
 #
 # NPM_TOKEN must be an Automation token (type: "Automation" in npmjs.com).
 #
@@ -175,7 +180,7 @@ jobs:
           echo "  Package : @takazudo/zudo-doc-history-server"
           echo "  Version : $VERSION"
           echo "  Dist-tag: $DIST_TAG"
-          echo "  Flags   : --access public --provenance --no-git-checks"
+          echo "  Flags   : --access public --provenance --no-git-checks --tag $DIST_TAG"
           echo ""
           echo "Dry run complete. Remove dry_run input or set it to false to publish for real."
 

--- a/.github/workflows/publish-zudo-doc-history-server.yml
+++ b/.github/workflows/publish-zudo-doc-history-server.yml
@@ -65,6 +65,10 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Only run when the triggering tag starts with "zudo-doc-history-server-".
+    # bare v* (create-zudo-doc) and zudo-doc-v* (@takazudo/zudo-doc) do not
+    # start with "zudo-doc-history-server-", so those releases skip NEUTRAL.
+    if: ${{ startsWith(github.event.release.tag_name || github.ref_name, 'zudo-doc-history-server-') }}
 
     steps:
       # ── Checkout at the exact release tag ──────────────────────────────────
@@ -192,3 +196,77 @@ jobs:
             --no-git-checks \
             --tag "$DIST_TAG"
           echo "Published: https://www.npmjs.com/package/@takazudo/zudo-doc-history-server/v/$VERSION"
+
+      # ── Dual-tag: advance "latest" when publishing a prerelease ───────────
+      # Only runs for real publishes (not dry-run) and only when DIST_TAG=next.
+      # Policy: advance latest iff the registry's current latest is empty (first
+      # publish ever) or is itself a prerelease (contains "-"). This is
+      # self-disabling once a stable version holds "latest".
+      #
+      # Probe MUST fail CLOSED: a registry/network error must NOT be read as
+      # "empty latest". Stdout and stderr are captured separately; on non-zero
+      # exit the probe retries 3 times, then fails closed (dual-tag skipped).
+      - name: 'Dual-tag: advance latest → ${{ env.VERSION }} (prerelease only)'
+        if: ${{ inputs.dry_run != true && env.DIST_TAG == 'next' }}
+        shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          PKG="@takazudo/zudo-doc-history-server"
+          echo "DIST_TAG=next — checking whether to advance 'latest' for $PKG..."
+
+          # Probe the registry for the current latest dist-tag.
+          # Capture stdout and exit status separately; stderr goes to a log file.
+          # GHA runs bash with -eo pipefail, so use if-form to avoid aborting on
+          # non-zero exit (the if-form is exempt from -e).
+          PROBE_OUT=""
+          PROBE_STATUS=1
+          for ATTEMPT in 1 2 3; do
+            if PROBE_OUT=$(npm view "$PKG" dist-tags.latest 2>/tmp/probe-err.log); then
+              PROBE_STATUS=0
+              break
+            else
+              PROBE_STATUS=$?
+              echo "Probe attempt $ATTEMPT failed (exit $PROBE_STATUS):"
+              cat /tmp/probe-err.log || true
+              if [[ $ATTEMPT -lt 3 ]]; then
+                echo "Retrying in 5s..."
+                sleep 5
+              fi
+            fi
+          done
+
+          if [[ $PROBE_STATUS -ne 0 ]]; then
+            echo "::warning::All 3 probe attempts failed — failing closed, dual-tag skipped."
+            echo "::warning::Registry may be temporarily unavailable. Retry the workflow or run manually:"
+            echo "::warning::  npm dist-tag add $PKG@$VERSION latest"
+            exit 0
+          fi
+
+          # Trim whitespace from stdout only (stderr was separated above).
+          CURRENT_LATEST=$(printf '%s' "$PROBE_OUT" | tr -d '[:space:]')
+          echo "Current latest: '${CURRENT_LATEST:-<empty>}'"
+
+          # Enable dual-tag iff latest is empty (never published) or is a prerelease.
+          if [[ -n "$CURRENT_LATEST" && "$CURRENT_LATEST" != *-* ]]; then
+            echo "latest is a stable release ('$CURRENT_LATEST') — self-disabled, skipping dual-tag."
+            exit 0
+          fi
+
+          echo "Advancing 'latest' → $PKG@$VERSION ..."
+          # Retry up to 5 times with exponential backoff (5, 10, 20, 40 s).
+          DELAY=5
+          for ATTEMPT in 1 2 3 4 5; do
+            if npm dist-tag add "$PKG@$VERSION" latest; then
+              echo "OK: dist-tag add succeeded on attempt $ATTEMPT."
+              exit 0
+            fi
+            if [[ $ATTEMPT -lt 5 ]]; then
+              echo "dist-tag add failed (attempt $ATTEMPT), retrying in ${DELAY}s..."
+              sleep "$DELAY"
+              DELAY=$((DELAY * 2))
+            fi
+          done
+
+          echo "::error::Manual remediation: npm dist-tag add $PKG@$VERSION latest"
+          exit 1

--- a/.github/workflows/publish-zudo-doc.yml
+++ b/.github/workflows/publish-zudo-doc.yml
@@ -75,6 +75,10 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Only run when the triggering tag starts with "zudo-doc-v" (@takazudo/zudo-doc namespace).
+    # bare v* (create-zudo-doc) and zudo-doc-history-server-* do not start with "zudo-doc-v",
+    # so those releases skip this job NEUTRAL instead of failing RED.
+    if: ${{ startsWith(github.event.release.tag_name || github.ref_name, 'zudo-doc-v') }}
 
     steps:
       # ── Checkout at the exact release tag ──────────────────────────────────
@@ -241,3 +245,77 @@ jobs:
             --no-git-checks \
             --tag "$DIST_TAG"
           echo "Published: https://www.npmjs.com/package/@takazudo/zudo-doc/v/$VERSION"
+
+      # ── Dual-tag: advance "latest" when publishing a prerelease ───────────
+      # Only runs for real publishes (not dry-run) and only when DIST_TAG=next.
+      # Policy: advance latest iff the registry's current latest is empty (first
+      # publish ever) or is itself a prerelease (contains "-"). This is
+      # self-disabling once a stable version holds "latest".
+      #
+      # Probe MUST fail CLOSED: a registry/network error must NOT be read as
+      # "empty latest". Stdout and stderr are captured separately; on non-zero
+      # exit the probe retries 3 times, then fails closed (dual-tag skipped).
+      - name: 'Dual-tag: advance latest → ${{ env.VERSION }} (prerelease only)'
+        if: ${{ inputs.dry_run != true && env.DIST_TAG == 'next' }}
+        shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          PKG="@takazudo/zudo-doc"
+          echo "DIST_TAG=next — checking whether to advance 'latest' for $PKG..."
+
+          # Probe the registry for the current latest dist-tag.
+          # Capture stdout and exit status separately; stderr goes to a log file.
+          # GHA runs bash with -eo pipefail, so use if-form to avoid aborting on
+          # non-zero exit (the if-form is exempt from -e).
+          PROBE_OUT=""
+          PROBE_STATUS=1
+          for ATTEMPT in 1 2 3; do
+            if PROBE_OUT=$(npm view "$PKG" dist-tags.latest 2>/tmp/probe-err.log); then
+              PROBE_STATUS=0
+              break
+            else
+              PROBE_STATUS=$?
+              echo "Probe attempt $ATTEMPT failed (exit $PROBE_STATUS):"
+              cat /tmp/probe-err.log || true
+              if [[ $ATTEMPT -lt 3 ]]; then
+                echo "Retrying in 5s..."
+                sleep 5
+              fi
+            fi
+          done
+
+          if [[ $PROBE_STATUS -ne 0 ]]; then
+            echo "::warning::All 3 probe attempts failed — failing closed, dual-tag skipped."
+            echo "::warning::Registry may be temporarily unavailable. Retry the workflow or run manually:"
+            echo "::warning::  npm dist-tag add $PKG@$VERSION latest"
+            exit 0
+          fi
+
+          # Trim whitespace from stdout only (stderr was separated above).
+          CURRENT_LATEST=$(printf '%s' "$PROBE_OUT" | tr -d '[:space:]')
+          echo "Current latest: '${CURRENT_LATEST:-<empty>}'"
+
+          # Enable dual-tag iff latest is empty (never published) or is a prerelease.
+          if [[ -n "$CURRENT_LATEST" && "$CURRENT_LATEST" != *-* ]]; then
+            echo "latest is a stable release ('$CURRENT_LATEST') — self-disabled, skipping dual-tag."
+            exit 0
+          fi
+
+          echo "Advancing 'latest' → $PKG@$VERSION ..."
+          # Retry up to 5 times with exponential backoff (5, 10, 20, 40 s).
+          DELAY=5
+          for ATTEMPT in 1 2 3 4 5; do
+            if npm dist-tag add "$PKG@$VERSION" latest; then
+              echo "OK: dist-tag add succeeded on attempt $ATTEMPT."
+              exit 0
+            fi
+            if [[ $ATTEMPT -lt 5 ]]; then
+              echo "dist-tag add failed (attempt $ATTEMPT), retrying in ${DELAY}s..."
+              sleep "$DELAY"
+              DELAY=$((DELAY * 2))
+            fi
+          done
+
+          echo "::error::Manual remediation: npm dist-tag add $PKG@$VERSION latest"
+          exit 1

--- a/.github/workflows/publish-zudo-doc.yml
+++ b/.github/workflows/publish-zudo-doc.yml
@@ -18,10 +18,14 @@
 #   this workflow.
 #
 # Workflow_dispatch caveat:
-#   When dispatching manually, choose a zudo-doc-v prefixed tag (or branch
-#   that has one) as the ref — Safeguard 1 below rejects refs that don't
-#   match. Dispatching from `main` will fail-fast with a clear message rather
-#   than silently publishing the wrong version.
+#   The job-level `if:` requires the ref/tag to start with `zudo-doc-v`.
+#   Dispatching from `main` (or any non-matching ref) makes this job skip
+#   NEUTRAL — it does not run, rather than failing red. For a dry-run auth
+#   smoke, dispatch with a candidate `zudo-doc-v` prefixed tag as the ref —
+#   NOT an already-published tag, since Safeguard 3 ("version not already
+#   published") runs before the dry-run auth check and would abort first.
+#   Safeguard 1's anchored regex remains as defense-in-depth for a
+#   matching-prefix-but-invalid-semver ref.
 #
 # NPM_TOKEN must be an Automation token (type: "Automation" in npmjs.com).
 # Automation tokens bypass npm's 2FA for `npm publish`, which is required
@@ -215,7 +219,7 @@ jobs:
           echo "  Package : @takazudo/zudo-doc"
           echo "  Version : $VERSION"
           echo "  Dist-tag: $DIST_TAG"
-          echo "  Flags   : --access public --provenance --no-git-checks"
+          echo "  Flags   : --access public --provenance --no-git-checks --tag $DIST_TAG"
           echo ""
           echo "Dry run complete. Remove dry_run input or set it to false to publish for real."
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,152 @@
+# Release Runbook
+
+Maintainer reference for publishing packages to npm.
+
+---
+
+## Release channels
+
+| Release type | Version pattern | npm dist-tag |
+|---|---|---|
+| Stable | `X.Y.Z` (no suffix) | `latest` |
+| Prerelease | `X.Y.Z-next.N`, `X.Y.Z-beta.N`, `X.Y.Z-rc.N` | `next` |
+
+Stable releases are the default install (`npm install <pkg>`).
+Prerelease releases are opt-in (`npm install <pkg>@next`).
+
+---
+
+## dist-tag table
+
+| Git tag pattern | Package | npm dist-tag |
+|---|---|---|
+| `v1.2.3` | `create-zudo-doc` | `latest` |
+| `v1.2.3-next.1` | `create-zudo-doc` | `next` |
+| `zudo-doc-v1.2.3` | `@takazudo/zudo-doc` | `latest` |
+| `zudo-doc-v1.2.3-next.1` | `@takazudo/zudo-doc` | `next` |
+| `zudo-doc-history-server-1.2.3` | `@takazudo/zudo-doc-history-server` | `latest` |
+| `zudo-doc-history-server-1.2.3-next.1` | `@takazudo/zudo-doc-history-server` | `next` |
+
+The CI publish workflow computes the dist-tag from the version string: any
+version containing `-` gets `--tag next`; a clean `X.Y.Z` gets `--tag latest`.
+
+---
+
+## Dual-tag self-disabling policy
+
+During a prerelease cycle the publish workflow also advances the `latest` dist-tag
+alongside `next`. This **dual-tag behaviour** activates only when the registry's
+current `latest` for that package is either:
+
+- absent (package newly created), or
+- itself a prerelease (contains `-`).
+
+It **self-disables** once a real stable version (`X.Y.Z` with no suffix) holds
+`latest`. After that, stable publishes update `latest` through the normal single-tag
+path and prerelease publishes touch only `next`.
+
+### Manual remediation
+
+If the workflow's automatic dual-tag retries exhaust (e.g. a transient npm registry
+error), run these commands manually:
+
+```sh
+npm dist-tag add create-zudo-doc@<ver> latest
+npm dist-tag add @takazudo/zudo-doc@<ver> latest
+npm dist-tag add @takazudo/zudo-doc-history-server@<ver> latest
+```
+
+Replace `<ver>` with the exact version string (no leading `v`), e.g. `0.2.0-next.1`.
+
+---
+
+## Dry-run auth smoke
+
+Each publish workflow supports a `workflow_dispatch` with `dry_run: true`. In this
+mode the workflow verifies that `NPM_TOKEN` authenticates against the registry via
+`npm whoami`, then stops without publishing anything.
+
+**Caveat:** the dry-run must target the *candidate* tag or ref — NOT `main` and NOT
+an already-published tag. The reason is ordering: the workflow runs a "version not
+already published" safeguard (Safeguard 3) *before* the dry-run/auth step
+(Safeguard 4). An already-published tag triggers a hard failure at Safeguard 3 and
+the auth smoke is never reached. Similarly, dispatching from `main` fails at
+Safeguard 1 (tag-shape check) before auth is tested.
+
+Correct dry-run target: a tag or branch pointing at the candidate commit whose
+version has been bumped in `package.json` but not yet published to npm.
+
+---
+
+## Publish order
+
+**Always publish `@takazudo/zudo-doc-history-server` and `@takazudo/zudo-doc`
+before `create-zudo-doc`.**
+
+The scaffold tool pins a specific `@takazudo/zudo-doc` version in the generated
+downstream `package.json`. If `create-zudo-doc` is published first and a user runs
+the scaffold before the peer packages land on npm, `pnpm install` in the new project
+fails with a 404 on the pinned `@takazudo/zudo-doc` version.
+
+Recommended sequence when all three packages change in the same release:
+
+1. Tag `zudo-doc-history-server-X.Y.Z` and publish the GitHub Draft Release for
+   `@takazudo/zudo-doc-history-server`. Wait for the CI publish to succeed.
+2. Tag `zudo-doc-vX.Y.Z` and publish the Draft Release for `@takazudo/zudo-doc`.
+   Wait for the CI publish to succeed.
+3. Tag `vX.Y.Z` and publish the Draft Release for `create-zudo-doc`.
+
+If only one or two packages changed, skip the unchanged packages — but still
+maintain the order above for any that do change.
+
+---
+
+## Tag namespaces and Draft Release model
+
+Each package has its own tag namespace and its own publish workflow. Publishing a
+GitHub Draft Release fires exactly one workflow — the one whose Safeguard 1 tag
+pattern matches the tag:
+
+| Package | Tag namespace | Example tag |
+|---|---|---|
+| `create-zudo-doc` | `v*` | `v0.2.0-next.1` |
+| `@takazudo/zudo-doc` | `zudo-doc-v*` | `zudo-doc-v0.2.0-next.1` |
+| `@takazudo/zudo-doc-history-server` | `zudo-doc-history-server-*` | `zudo-doc-history-server-0.2.0-next.1` |
+
+The `zudo-doc-v` prefix keeps `@takazudo/zudo-doc` tags distinct from the bare `v*`
+namespace so a single tag dispatch always fires exactly one workflow. The anchored
+regex in each workflow's Safeguard 1 rejects tags that match a sibling namespace.
+
+Create one GitHub Draft Release per package. The draft is the human gate: reviewing
+the draft and clicking "Publish release" is the irreversible action that triggers CI
+to call `npm publish`. An unpublished draft fires no workflow.
+
+---
+
+## One-time stale-`latest` bootstrap
+
+After publishing the very first new prerelease (e.g. `0.2.0-next.1`) via CI, the
+`latest` dist-tag for all three packages may still point at the old stable version
+(`0.1.0`). Until `latest` is moved to a prerelease string, the dual-tag probe in the
+publish workflow sees a stable `latest` and self-disables — so subsequent prerelease
+publishes never advance `latest`.
+
+Run the bootstrap helper **once** after the first new prerelease lands on npm:
+
+```sh
+node scripts/release-bootstrap-latest.mjs <version>
+```
+
+Example:
+
+```sh
+node scripts/release-bootstrap-latest.mjs 0.2.0-next.1
+```
+
+This moves `latest` for all three packages to the given prerelease version. The
+workflow's dual-tag probe then re-enables itself: from that point on, every
+subsequent prerelease publish automatically advances `latest` alongside `next`, and
+once a real stable version is published the policy self-heals — `latest` will hold
+a stable version and the probe disables itself permanently.
+
+The script is idempotent: re-running it with the same version is safe.

--- a/scripts/release-bootstrap-latest.mjs
+++ b/scripts/release-bootstrap-latest.mjs
@@ -32,6 +32,14 @@ if (!version) {
   process.exit(1);
 }
 
+// Fail fast on a malformed version (e.g. a leading "v" or a typo) rather than
+// retrying `npm dist-tag add` 5× per package against a version that cannot exist.
+if (!/^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/.test(version)) {
+  console.error(`Invalid version '${version}'.`);
+  console.error('  Expected semver WITHOUT a leading "v" (e.g. 0.2.0-next.1).');
+  process.exit(1);
+}
+
 /**
  * Sleep for `ms` milliseconds.
  * @param {number} ms

--- a/scripts/release-bootstrap-latest.mjs
+++ b/scripts/release-bootstrap-latest.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+// One-time migration nudge to move npm `latest` off the stale stable `0.1.0`
+// onto the first new prerelease. Once `latest` points at a prerelease version
+// (one containing `-`), the publish-workflow dual-tag probe re-enables itself
+// for every subsequent `next.N` publish and advances `latest` automatically.
+//
+// Idempotent: re-pointing `latest` to the same version is a no-op on npm —
+// safe to re-run if the previous run partially failed.
+//
+// This script only manipulates dist-tags (npm dist-tag add). It does NOT
+// publish anything to the registry.
+//
+// Usage: node scripts/release-bootstrap-latest.mjs <version>
+//   version — semver string WITHOUT a leading "v" (e.g. 0.2.0-next.1)
+
+import { execFileSync } from 'node:child_process';
+
+const PACKAGES = [
+  'create-zudo-doc',
+  '@takazudo/zudo-doc',
+  '@takazudo/zudo-doc-history-server',
+];
+
+const MAX_ATTEMPTS = 5;
+const BASE_DELAY_MS = 1000;
+
+const version = process.argv[2];
+
+if (!version) {
+  console.error('Usage: node scripts/release-bootstrap-latest.mjs <version>');
+  console.error('  version — semver string without a leading "v" (e.g. 0.2.0-next.1)');
+  process.exit(1);
+}
+
+/**
+ * Sleep for `ms` milliseconds.
+ * @param {number} ms
+ */
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Run `npm dist-tag add <pkg>@<version> latest` with up to MAX_ATTEMPTS retries
+ * and exponential backoff.
+ *
+ * @param {string} pkg - npm package name
+ * @returns {Promise<boolean>} true on success, false if all attempts exhausted
+ */
+async function addLatestTag(pkg) {
+  const spec = `${pkg}@${version}`;
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      execFileSync('npm', ['dist-tag', 'add', spec, 'latest'], {
+        stdio: 'pipe',
+      });
+      console.log(`[OK]  ${pkg}@${version} → latest (attempt ${attempt})`);
+      return true;
+    } catch (/** @type {any} */ err) {
+      const stderr = err.stderr?.toString().trim() ?? '';
+      const msg = stderr || err.message;
+
+      if (attempt < MAX_ATTEMPTS) {
+        const delayMs = BASE_DELAY_MS * 2 ** (attempt - 1);
+        console.warn(
+          `[WARN] ${pkg}: attempt ${attempt} failed — ${msg}. Retrying in ${delayMs}ms…`,
+        );
+        await sleep(delayMs);
+      } else {
+        console.error(
+          `[FAIL] ${pkg}: all ${MAX_ATTEMPTS} attempts failed — ${msg}`,
+        );
+      }
+    }
+  }
+
+  return false;
+}
+
+async function main() {
+  console.log(`Bootstrapping npm \`latest\` dist-tag → ${version}`);
+  console.log('');
+
+  /** @type {string[]} */
+  const failed = [];
+
+  for (const pkg of PACKAGES) {
+    const ok = await addLatestTag(pkg);
+    if (!ok) {
+      failed.push(pkg);
+    }
+  }
+
+  if (failed.length > 0) {
+    console.error('');
+    console.error(
+      `${failed.length} package(s) failed after ${MAX_ATTEMPTS} attempts.`,
+    );
+    console.error('Run the following commands manually to remediate:');
+    for (const pkg of failed) {
+      console.error(`  npm dist-tag add ${pkg}@${version} latest`);
+    }
+    process.exit(1);
+  }
+
+  console.log('');
+  console.log('Done. All packages now have latest → ' + version);
+  console.log(
+    'The publish workflow dual-tag probe will self-enable for the next prerelease publish.',
+  );
+}
+
+main();

--- a/scripts/release-create-zudo-doc.sh
+++ b/scripts/release-create-zudo-doc.sh
@@ -14,14 +14,38 @@ set -euo pipefail
 #   (e.g. 1.0.0-next.1) which version-bump.sh's strict regex would reject.
 #
 # Usage:
-#   ./scripts/release-create-zudo-doc.sh <new-version>
+#   ./scripts/release-create-zudo-doc.sh [<new-version>|major|minor|patch|next|stable]
+#
+# Named bump modes:
+#   major   — (X+1).0.0-next.1  (from current, whatever it is)
+#   minor   — X.(Y+1).0-next.1  (from current)
+#   patch   — X.Y.(Z+1)-next.1  (from current)
+#   next    — from stable X.Y.Z → X.(Y+1).0-next.1
+#             from prerelease X.Y.Z-next.N → X.Y.Z-next.(N+1)  (same as auto)
+#   stable  — X.Y.Z (strip -next.N suffix; error if already stable)
+#   <semver>— use exactly this version (original explicit-version mode)
+#   (none)  — auto-derive: stable → minor+next.1; prerelease → N+1
+#
+# Dry / compute-only path (no mutations, no git):
+#   DRY=1 ./scripts/release-create-zudo-doc.sh [mode]
+#   FROM=<current> DRY=1 ./scripts/release-create-zudo-doc.sh [mode]
+#     FROM overrides the version read from package.json — useful for testing
+#     all acceptance cases without actually changing package.json.
+#   Prints:
+#     next version: <computed>
+#     pin string:   ^<computed>
+#   Then exits 0. No files are modified.
 #
 # Examples:
-#   ./scripts/release-create-zudo-doc.sh 0.2.0
-#   ./scripts/release-create-zudo-doc.sh 1.0.0-next.1
+#   ./scripts/release-create-zudo-doc.sh 0.2.0           # stable release (explicit)
+#   ./scripts/release-create-zudo-doc.sh 1.0.0-next.1    # prerelease (explicit)
+#   ./scripts/release-create-zudo-doc.sh minor            # X.(Y+1).0-next.1
+#   ./scripts/release-create-zudo-doc.sh stable           # strip -next.N suffix
+#   DRY=1 FROM=0.1.0 ./scripts/release-create-zudo-doc.sh         # 0.2.0-next.1
+#   DRY=1 FROM=0.2.0-next.1 ./scripts/release-create-zudo-doc.sh  # 0.2.0-next.2
 #
-# What it does:
-#   1. Validates version format (semver + optional prerelease suffix)
+# What it does (non-dry path):
+#   1. Validates/computes version format (semver + optional prerelease suffix)
 #   2. Bumps version in root package.json
 #   3. Bumps version in packages/create-zudo-doc/package.json
 #   4. Bumps version in packages/zudo-doc/package.json  (W4A — #1732)
@@ -41,28 +65,111 @@ ZUDO_DOC_PKG_JSON="$ROOT_DIR/packages/zudo-doc/package.json"
 DHS_PKG_JSON="$ROOT_DIR/packages/doc-history-server/package.json"
 SCAFFOLD_TS="$ROOT_DIR/packages/create-zudo-doc/src/scaffold.ts"
 
+# ── Version computation ───────────────────────────────────────────────────────
+#
+# compute_next_version <current> <mode>
+#   current — the existing version string (e.g. "0.1.0" or "0.2.0-next.1")
+#   mode    — one of: major | minor | patch | next | stable | auto
+#             "auto" applies the default derivation rule:
+#               - stable   → X.(Y+1).0-next.1
+#               - prerelease → X.Y.Z-next.(N+1)
+# Prints the computed next version to stdout and returns 0.
+# Exits non-zero on error (e.g. "stable" when already stable).
+compute_next_version() {
+  local cur="$1"
+  local mode="$2"
+
+  # Split into core (X.Y.Z) and prerelease (everything after the first "-")
+  local core pre_part
+  if echo "$cur" | grep -q -- '-'; then
+    core="${cur%%-*}"
+    pre_part="${cur#*-}"
+  else
+    core="$cur"
+    pre_part=""
+  fi
+
+  # Parse X, Y, Z from core
+  local IFS_SAVE="$IFS"
+  IFS='.' read -r ver_major ver_minor ver_patch <<< "$core"
+  IFS="$IFS_SAVE"
+
+  local is_prerelease=false
+  [ -n "$pre_part" ] && is_prerelease=true
+
+  case "$mode" in
+    major)
+      echo "$(( ver_major + 1 )).0.0-next.1"
+      ;;
+    minor)
+      echo "${ver_major}.$(( ver_minor + 1 )).0-next.1"
+      ;;
+    patch)
+      echo "${ver_major}.${ver_minor}.$(( ver_patch + 1 ))-next.1"
+      ;;
+    stable)
+      if [ "$is_prerelease" = false ]; then
+        echo "Error: current version '$cur' is already stable — nothing to strip" >&2
+        exit 1
+      fi
+      echo "$core"
+      ;;
+    next|auto)
+      if [ "$is_prerelease" = true ]; then
+        # X.Y.Z-next.N → X.Y.Z-next.(N+1)
+        # Extract the numeric suffix after the last dot in pre_part
+        local pre_label pre_n
+        pre_label="${pre_part%.*}"
+        pre_n="${pre_part##*.}"
+        echo "${core}-${pre_label}.$(( pre_n + 1 ))"
+      else
+        # stable → X.(Y+1).0-next.1  (both "next" keyword and "auto" default)
+        echo "${ver_major}.$(( ver_minor + 1 )).0-next.1"
+      fi
+      ;;
+    *)
+      # Explicit semver string passed in — validate and pass through
+      if ! echo "$mode" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[0-9]+)*)?$'; then
+        echo "Error: Version must be semver format with optional prerelease suffix." >&2
+        echo "  Valid:   0.2.0  1.0.0-next.1  2.0.0-beta.2  3.0.0-rc.1" >&2
+        echo "  Invalid: 1.0  v1.0.0  1.0.0.0" >&2
+        exit 1
+      fi
+      echo "$mode"
+      ;;
+  esac
+}
+
 # ── Parse arguments ──────────────────────────────────────────────────────────
 
-if [ $# -lt 1 ]; then
-  echo "Usage: $0 <new-version>"
-  echo ""
-  echo "Examples:"
-  echo "  $0 0.2.0           # stable release"
-  echo "  $0 1.0.0-next.1    # prerelease"
-  exit 1
+MODE="${1:-auto}"
+
+# ── Resolve current version (FROM env overrides package.json — for dry testing) ─
+
+if [ -n "${FROM:-}" ]; then
+  CURRENT_VERSION="$FROM"
+else
+  CURRENT_VERSION=$(node -p "require('$PKG_JSON').version" 2>/dev/null)
 fi
 
-NEW_VERSION="$1"
+# ── Compute target version ────────────────────────────────────────────────────
 
-# Validate: semver with optional prerelease (e.g. 1.0.0, 1.0.0-next.1, 1.0.0-beta.2, 1.0.0-rc.3)
-if ! echo "$NEW_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[0-9]+)*)?$'; then
-  echo "Error: Version must be semver format with optional prerelease suffix."
-  echo "  Valid:   0.2.0  1.0.0-next.1  2.0.0-beta.2  3.0.0-rc.1"
-  echo "  Invalid: 1.0  v1.0.0  1.0.0.0"
-  exit 1
+NEW_VERSION=$(compute_next_version "$CURRENT_VERSION" "$MODE")
+
+# ── Dry path ─────────────────────────────────────────────────────────────────
+#
+# DRY=1 prints the computed version and pin string, then exits without any
+# mutations to package.json, scaffold.ts, or the git tree.
+
+if [ "${DRY:-0}" = "1" ]; then
+  echo "current version: $CURRENT_VERSION"
+  echo "mode:            $MODE"
+  echo "next version:    $NEW_VERSION"
+  echo "pin string:      ^$NEW_VERSION"
+  exit 0
 fi
 
-# ── Read current versions ─────────────────────────────────────────────────────
+# ── Read current versions (real run) ─────────────────────────────────────────
 
 OLD_ROOT_VERSION=$(node -p "require('$PKG_JSON').version" 2>/dev/null)
 OLD_CREATE_VERSION=$(node -p "require('$CREATE_PKG_JSON').version" 2>/dev/null)
@@ -131,11 +238,12 @@ node -e "
 echo "  ✓ $DHS_PKG_JSON → $NEW_VERSION"
 
 # ── Step 2c: Align @takazudo/zudo-doc pin in scaffold.ts (W4A — #1732) ────
-# The generated downstream package.json pins ^X.Y.Z of @takazudo/zudo-doc;
+# The generated downstream package.json pins ^X.Y.Z(-next.N)? of @takazudo/zudo-doc;
 # when zudo-doc bumps, the pin must move with it so a fresh scaffold gets
-# the version we just published. The two zfb pins on adjacent lines are NOT
-# touched — those track the upstream zfb release cadence and are gated by
-# scripts/check-pin-parity.mjs against the root package.json.
+# the version we just published — including prerelease versions.
+# The regex matches both stable (^X.Y.Z) and prerelease (^X.Y.Z-next.N) pins.
+# The two zfb pins on adjacent lines are NOT touched — those track the upstream
+# zfb release cadence and are gated by scripts/check-pin-parity.mjs.
 
 echo ""
 echo "▶ Aligning @takazudo/zudo-doc pin in scaffold.ts..."


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/1844

---

## Summary
Enhances the existing 3-workflow npm publish system (Option B — preserves the deliberate per-package architecture) with a reference-grade release-channel policy. **No npm publish happens in this PR** — release-system build only; verification is static. The maintainer cuts the actual release as a follow-up.

### What changed
- **Dual-tag latest+next self-disabling** (#1845) in all 3 publish workflows: a `--tag next` publish also advances `latest` **iff** the registry `latest` is empty or itself a prerelease (contains `-`); self-disables once a real stable holds `latest`. The probe **fails closed** (a registry error never reads as "empty latest"); `npm dist-tag add` retries 5× with backoff + a manual-remediation message on exhaustion.
- **Release-routing fix** (#1845): job-level `if:` `startsWith` guards so each release runs **exactly one** workflow; the other two skip NEUTRAL instead of failing RED. (Verified 3×3 truth table.)
- **Stale-`latest` bootstrap** (#1846): one-time idempotent `scripts/release-bootstrap-latest.mjs <version>` (dist-tag-only, no publish) + a maintainer `RELEASE.md` runbook (channel policy, dist-tag table, dual-tag remediation, dry-run-target caveat, publish order, bootstrap). Needed because all 3 packages already hold a stale stable `latest=0.1.0`.
- **Version-scheme parity** (#1847) in `scripts/release-create-zudo-doc.sh`: stable `X.Y.Z` → `X.(Y+1).0-next.1`, prerelease → `next.(N+1)`, + major/minor/patch/next/stable args, with a compute-only dry path; scaffold `@takazudo/zudo-doc` pin syncs to `^<version>` incl. prerelease; `l-release-create-zudo-doc` skill updated. `version-bump.sh` untouched.
- **Validation** (#1848): typecheck, template-drift, all scripts + workflow run-blocks (`bash -n`), dry-path, and the 3×3 truth table all green on the merged base. 2 reviewers + 3 inline review fixes (`e79a6186`).

## Topic PRs
Merged locally into the base branch (subagents workflow): #1845, #1846, #1847, #1848.