### PR TITLE
Release Process Hardening: gate package suites in PR CI + internal pin-parity guard

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -105,6 +105,49 @@ jobs:
         run: pnpm check
 
   # ---------------------------------------------------------------------------
+  # Job 1.5: Package unit suites
+  # ---------------------------------------------------------------------------
+  # Guards the gap from #1851: package-scoped vitest suites previously ran
+  # only inside publish workflows, so a broken suite was invisible until a
+  # publish attempt. This job runs all 5 package suites on every PR so a
+  # broken suite turns the PR red instead of hiding until release day.
+  #
+  # Build step precedes the test run for clean-runner parity: @takazudo/zudo-doc
+  # ships compiled dist/ (built by tsup). The publish workflow runs
+  # `pnpm --filter @takazudo/zudo-doc build` before its test step for the same
+  # reason — a fresh CI runner has no pre-existing dist/ and the suite may
+  # import it.
+  package-tests:
+    name: Package Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
+        with:
+          dest: ~/setup-pnpm-${{ github.job }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Build @takazudo/zudo-doc before testing — clean-runner parity; the
+      # suite may import built dist/ which does not exist on a fresh runner.
+      - name: Build @takazudo/zudo-doc
+        run: pnpm --filter @takazudo/zudo-doc build
+
+      - name: Run package unit tests
+        run: pnpm test:packages
+
+  # ---------------------------------------------------------------------------
   # Job 2: Build the zfb docs site (full clone — needed for SSG meta dates)
   # ---------------------------------------------------------------------------
   # fetch-depth: 0 is required so the doc-history preBuild step can call

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "// ── Quality ──────────────────────────────────────": "",
     "check": "zfb check",
     "test:unit": "vitest run",
+    "test:packages": "pnpm -r --filter './packages/*' run test",
     "test:e2e": "bash e2e/setup-fixtures.sh && playwright test",
     "test:e2e:ci": "bash e2e/setup-fixtures.sh && playwright test --grep-invert @local-only",
     "check:links": "node scripts/check-links.js",

--- a/scripts/check-pin-parity.mjs
+++ b/scripts/check-pin-parity.mjs
@@ -185,9 +185,13 @@ function main() {
     }
     console.error("");
   }
+  console.error("Fix — align the pin(s) in:");
+  console.error(`  - ${ROOT_PKG_PATH}`);
   console.error(
-    "Fix: align both sites to the intended version, then re-run this check.",
+    `      external pins live in "dependencies"; the internal release version is the "version" field`,
   );
+  console.error(`  - ${SCAFFOLD_TS_PATH}`);
+  console.error("then re-run this check.");
   return 1;
 }
 

--- a/scripts/check-pin-parity.mjs
+++ b/scripts/check-pin-parity.mjs
@@ -19,6 +19,9 @@
 // older zfb than the showcase site they were modeled on. This script
 // makes that drift a CI/b4push error.
 //
+// Also checks internal @takazudo/zudo-doc* pins (#1850 / #1854): the scaffold
+// emits pins for this repo's own packages; they must match the root version.
+//
 // Wired into:
 //   - scripts/run-b4push.sh (Step 2.5, cheap pre-typecheck check)
 //   - .github/workflows/pr-checks.yml (own lightweight job)
@@ -37,22 +40,45 @@ const SCAFFOLD_TS_PATH = resolve(
   "packages/create-zudo-doc/src/scaffold.ts",
 );
 
+// External upstream packages: scaffold pin must equal root dependencies[pkg].
 const PINNED_PACKAGES = [
   "@takazudo/zfb",
   "@takazudo/zfb-runtime",
   "@takazudo/zfb-adapter-cloudflare",
 ];
 
+// Internal packages published from this monorepo: scaffold pin (caret/tilde
+// stripped) must equal root package.json `version` (the lockstep release
+// version). These are NOT in root dependencies — they ARE root.
+//
+// Cross-reference: scripts/release-create-zudo-doc.sh Step 2c (colon form)
+// and Step 2d (bracket-assignment form) are the source of truth that WRITES
+// these pins on every release bump. Keep this list in sync with those steps
+// so any future 3rd internal pin gets guarded here too.
+const INTERNAL_PINNED_PACKAGES = [
+  "@takazudo/zudo-doc",
+  "@takazudo/zudo-doc-history-server",
+];
+
 /**
- * Extract the literal version string for `pkgName` from scaffold.ts. The
- * scaffold.ts source has lines like:
- *   "@takazudo/zfb": "0.1.0-next.6",
- * We match the JSON-ish key/value pair anywhere in the file (the file is
- * TypeScript, not JSON, so we can't `JSON.parse` it).
+ * Extract the literal version string for `pkgName` from scaffold.ts.
+ *
+ * scaffold.ts uses two forms for package pins:
+ *   Colon form (object literal):
+ *     "@takazudo/zudo-doc": "^0.2.0-next.1",
+ *   Bracket-assignment form:
+ *     deps["@takazudo/zudo-doc-history-server"] = "^0.2.0-next.1";
+ *
+ * The regex handles both by accepting either `:` or `] =` as the separator.
+ * The closing quote immediately after the key name is what prevents
+ * `@takazudo/zudo-doc` from matching inside `@takazudo/zudo-doc-history-server`
+ * (no closing quote follows `zudo-doc` in the longer name).
  */
 function readScaffoldPin(scaffoldSrc, pkgName) {
   const escaped = pkgName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const re = new RegExp(`["']${escaped}["']\\s*:\\s*["']([^"']+)["']`);
+  const re = new RegExp(
+    `["']${escaped}["']\\s*(?::|\\]\\s*=)\\s*["']([^"']+)["']`,
+  );
   const match = scaffoldSrc.match(re);
   return match ? match[1] : null;
 }
@@ -63,6 +89,7 @@ function main() {
 
   const mismatches = [];
 
+  // ── External pins: scaffold literal must equal root dependencies[pkg] ──────
   for (const pkgName of PINNED_PACKAGES) {
     const rootPin = rootPkg.dependencies?.[pkgName];
     const scaffoldPin = readScaffoldPin(scaffoldSrc, pkgName);
@@ -73,6 +100,7 @@ function main() {
         reason: `Missing in root package.json dependencies`,
         rootPin,
         scaffoldPin,
+        kind: "external",
       });
       continue;
     }
@@ -82,6 +110,7 @@ function main() {
         reason: `Missing in packages/create-zudo-doc/src/scaffold.ts (could not locate the literal pin line)`,
         rootPin,
         scaffoldPin,
+        kind: "external",
       });
       continue;
     }
@@ -91,16 +120,50 @@ function main() {
         reason: `Pin drift between root and scaffold.ts`,
         rootPin,
         scaffoldPin,
+        kind: "external",
+      });
+    }
+  }
+
+  // ── Internal pins: scaffold pin (stripped) must equal root version ─────────
+  const releaseVersion = rootPkg.version;
+  for (const pkgName of INTERNAL_PINNED_PACKAGES) {
+    const scaffoldPin = readScaffoldPin(scaffoldSrc, pkgName);
+
+    if (scaffoldPin === null) {
+      mismatches.push({
+        pkg: pkgName,
+        reason: `Missing in packages/create-zudo-doc/src/scaffold.ts (could not locate the literal pin line)`,
+        rootPin: releaseVersion,
+        scaffoldPin,
+        kind: "internal",
+      });
+      continue;
+    }
+    const strippedPin = scaffoldPin.replace(/^[\^~]/, "");
+    if (strippedPin !== releaseVersion) {
+      mismatches.push({
+        pkg: pkgName,
+        reason: `Internal pin drift — scaffold emits ${scaffoldPin} but release version is ${releaseVersion}`,
+        rootPin: releaseVersion,
+        scaffoldPin,
+        kind: "internal",
       });
     }
   }
 
   if (mismatches.length === 0) {
     console.log(
-      `OK — pin parity verified for ${PINNED_PACKAGES.length} package(s):`,
+      `OK — pin parity verified for ${PINNED_PACKAGES.length} external + ${INTERNAL_PINNED_PACKAGES.length} internal package(s):`,
     );
     for (const pkgName of PINNED_PACKAGES) {
       console.log(`  ${pkgName} = ${rootPkg.dependencies[pkgName]}`);
+    }
+    for (const pkgName of INTERNAL_PINNED_PACKAGES) {
+      const scaffoldPin = readScaffoldPin(scaffoldSrc, pkgName);
+      console.log(
+        `  ${pkgName} = ${scaffoldPin} (matches release ${releaseVersion})`,
+      );
     }
     return 0;
   }
@@ -110,16 +173,16 @@ function main() {
     "Pin parity check FAILED — failure mode: W1A §5#4 (three pin sources, only one bumped).",
   );
   console.error("");
-  console.error(
-    "The same upstream version must be pinned identically in BOTH:",
-  );
-  console.error(`  - ${ROOT_PKG_PATH} (dependencies)`);
-  console.error(`  - ${SCAFFOLD_TS_PATH} (generatePackageJson literals)`);
-  console.error("");
   for (const m of mismatches) {
-    console.error(`  [${m.pkg}]  ${m.reason}`);
-    console.error(`    root:        ${m.rootPin ?? "(missing)"}`);
-    console.error(`    scaffold.ts: ${m.scaffoldPin ?? "(missing)"}`);
+    if (m.kind === "external") {
+      console.error(`  [${m.pkg}]  ${m.reason}`);
+      console.error(`    root dependencies: ${m.rootPin ?? "(missing)"}`);
+      console.error(`    scaffold.ts:       ${m.scaffoldPin ?? "(missing)"}`);
+    } else {
+      console.error(`  [${m.pkg}]  ${m.reason}`);
+      console.error(`    expected (release version): ${m.rootPin}`);
+      console.error(`    scaffold.ts:                ${m.scaffoldPin ?? "(missing)"}`);
+    }
     console.error("");
   }
   console.error(


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/1852

---

## Summary

Release-process hardening — two preventive guards from epic #1852 (both close `agent-found` follow-ups discovered during the 0.2.0-next.1 release):

### 1. Run publishable package unit suites in PR CI (#1853 → closes #1851)
- New `package-tests` job in `.github/workflows/pr-checks.yml` (mirrors the `typecheck` job: same pinned action SHAs, Node 22, 10-min timeout).
- New root script `test:packages` = `pnpm -r --filter './packages/*' run test` (auto-covers every package that defines a `test` script; 5 today).
- Builds `@takazudo/zudo-doc` before testing for **clean-runner parity** (the suite imports built `dist/`; mirrors the publish workflow's build-then-test order).
- Closes the gap where package suites ran **only** at publish time — a broken suite (the `react/jsx-runtime` failure) hid for ~a week until a release was attempted.

### 2. Guard internal scaffold pins against drift (#1854 → closes #1850)
- Extends `scripts/check-pin-parity.mjs` to assert each internal `@takazudo/zudo-doc*` pin in `scaffold.ts` equals the root `version` (caret/tilde-stripped).
- Generalizes `readScaffoldPin` to read **both** the colon form and the bracket-assignment form (`deps["…"] = "…"`) — the latter is the exact history-server pin #1850 was about, which the old regex silently failed to read.
- Inherits both existing enforcement points (b4push + the `Pin Parity Check` PR job) with zero new wiring; external `@takazudo/zfb*` / `@takazudo/zdtp` pins stay excluded.

## Verification
- `node scripts/check-pin-parity.mjs` → green, reads all 3 external + 2 internal pins; scratch-edit of the bracket-form pin correctly fails.
- `pnpm test:packages` → **788 tests across 5 suites** pass after the build step.
- Full PR CI green (incl. the new `Package Unit Tests` + `Pin Parity Check` jobs).

## ⚠️ ACTION FOR HUMAN (merge-gating)
The new `Package Unit Tests` job **runs and goes red on failure but is not merge-blocking** until added as a **required status check** in `main`'s branch protection. This PR deliberately does **not** mutate branch protection (shared repo-governance change, out of scope for the agent). Please add `Package Unit Tests` to `main`'s required status checks to make the gate truly block merges.

## Out of scope (raised separately)
- #1856 — root `test:unit` suite (root `src/` + `scripts/`) is gated by neither CI nor b4push. A distinct, adjacent gap; raised as `agent-found` for a follow-up.

## Topic PRs
Merged locally into the base branch (subagents-path worktrees), closed for documentation. Branches deleted post-merge.

Closes #1850, #1851.