### PR TITLE
ci: gate root `test:unit` in PR CI + b4push (fix #1856)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -148,6 +148,53 @@ jobs:
         run: pnpm test:packages
 
   # ---------------------------------------------------------------------------
+  # Job 1.6: Root unit suite
+  # ---------------------------------------------------------------------------
+  # Guards the gap from #1856: the root `test:unit` suite (vitest run, backed
+  # by the root vitest.config.ts — src/**/__tests__ and scripts/__tests__) ran
+  # in no CI workflow and was not in `pnpm b4push`, so a broken root-src/scripts
+  # test could land on a PR (and main) without turning anything red. This is a
+  # distinct scope from package-tests (#1851), which only gates packages/*.
+  #
+  # Kept as a separate named check (not folded into Package Unit Tests) so the
+  # `Package Unit Tests` context name stays stable for branch-protection /
+  # ruleset required-checks (#1857).
+  #
+  # Build step precedes the test run for clean-runner parity: the suite imports
+  # @takazudo/zudo-doc/theme, whose compiled dist/ (built by tsup) does not
+  # exist on a fresh runner — same reason package-tests builds it first.
+  root-tests:
+    name: Root Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
+        with:
+          dest: ~/setup-pnpm-${{ github.job }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Build @takazudo/zudo-doc before testing — clean-runner parity; the root
+      # suite imports built dist/ (@takazudo/zudo-doc/theme) which does not
+      # exist on a fresh runner.
+      - name: Build @takazudo/zudo-doc
+        run: pnpm --filter @takazudo/zudo-doc build
+
+      - name: Run root unit tests
+        run: pnpm test:unit
+
+  # ---------------------------------------------------------------------------
   # Job 2: Build the zfb docs site (full clone — needed for SSG meta dates)
   # ---------------------------------------------------------------------------
   # fetch-depth: 0 is required so the doc-history preBuild step can call

--- a/scripts/run-b4push.sh
+++ b/scripts/run-b4push.sh
@@ -11,11 +11,12 @@ set -euo pipefail
 #   5. Tags audit (--ci)
 #   6. Design token lint
 #   7. Type checking (zfb check)
-#   8. Build (zfb build)
-#   9. Link check
-#  10. HTML validation (html-validate dist/**/*.html)
-#  11. Automated preview smoke (blocking)
-#  12. Manual interactive smoke (operator-driven)
+#   8. Root unit tests (test:unit)
+#   9. Build (zfb build)
+#  10. Link check
+#  11. HTML validation (html-validate dist/**/*.html)
+#  12. Automated preview smoke (blocking)
+#  13. Manual interactive smoke (operator-driven)
 #
 # CI parity (Playwright E2E + GitHub Actions) is intentionally parked
 # to E9b until the post-cutover migration window closes.
@@ -27,7 +28,7 @@ set -euo pipefail
 
 START_TIME=$(date +%s)
 FAILURES=()
-TOTAL_STEPS=12
+TOTAL_STEPS=13
 CURRENT_STEP=0
 
 step() {
@@ -108,7 +109,20 @@ else
   fail "Type checking"
 fi
 
-# ── Step 8: Build ─────────────────────────────────────
+# ── Step 8: Root unit tests ───────────────────────────
+# Root `test:unit` (vitest) guards src/**/__tests__ and scripts/__tests__,
+# which previously ran in no local gate and no CI workflow (#1856). Runs
+# before the expensive build for fast logic-level feedback. Assumes the
+# @takazudo/zudo-doc dist is present (same assumption as the build step
+# below); `pnpm dev` keeps it fresh via tsup --watch.
+step "Root unit tests (test:unit)"
+if (cd "$ROOT_DIR" && pnpm test:unit); then
+  pass "Root unit tests passed"
+else
+  fail "Root unit tests"
+fi
+
+# ── Step 9: Build ─────────────────────────────────────
 step "Build (zfb build)"
 if (cd "$ROOT_DIR" && pnpm build); then
   pass "Build passed"
@@ -116,7 +130,7 @@ else
   fail "Build"
 fi
 
-# ── Step 9: Link check ────────────────────────────────
+# ── Step 10: Link check ───────────────────────────────
 #
 # Strict on broken links + absolute MDX-source warnings (real 404s
 # / sub-path bypass). Trailing-slash warnings stay warn-only — they
@@ -136,7 +150,7 @@ else
   fail "Link check"
 fi
 
-# ── Step 10: HTML validation ──────────────────────────
+# ── Step 11: HTML validation ──────────────────────────
 step "HTML validation (html-validate)"
 if [[ "${B4PUSH_SKIP_HTML_VALIDATE:-}" == "1" ]]; then
   skip "HTML validation (B4PUSH_SKIP_HTML_VALIDATE=1)"
@@ -148,7 +162,7 @@ else
   fi
 fi
 
-# ── Step 11: Automated preview smoke (blocking) ──────
+# ── Step 12: Automated preview smoke (blocking) ──────
 step "Preview smoke (automated)"
 if [[ "${B4PUSH_SKIP_PREVIEW_SMOKE:-}" == "1" ]]; then
   skip "Preview smoke (B4PUSH_SKIP_PREVIEW_SMOKE=1)"
@@ -160,7 +174,7 @@ else
   fi
 fi
 
-# ── Step 12: Manual interactive smoke ────────────────
+# ── Step 13: Manual interactive smoke ────────────────
 step "Manual interactive smoke"
 if [[ "${B4PUSH_SKIP_MANUAL_SMOKE:-}" == "1" ]]; then
   skip "Manual smoke (B4PUSH_SKIP_MANUAL_SMOKE=1)"

--- a/scripts/run-b4push.sh
+++ b/scripts/run-b4push.sh
@@ -112,11 +112,15 @@ fi
 # ── Step 8: Root unit tests ───────────────────────────
 # Root `test:unit` (vitest) guards src/**/__tests__ and scripts/__tests__,
 # which previously ran in no local gate and no CI workflow (#1856). Runs
-# before the expensive build for fast logic-level feedback. Assumes the
-# @takazudo/zudo-doc dist is present (same assumption as the build step
-# below); `pnpm dev` keeps it fresh via tsup --watch.
+# before the expensive site build for fast logic-level feedback.
+#
+# Build @takazudo/zudo-doc first: several root suites import
+# @takazudo/zudo-doc/theme, whose compiled dist/ does not exist on a fresh
+# clone (`pnpm install` does not run the package's tsup build). CI's package
+# and root test jobs build it for the same reason. Building here also leaves
+# dist/ ready for the site build in the next step.
 step "Root unit tests (test:unit)"
-if (cd "$ROOT_DIR" && pnpm test:unit); then
+if (cd "$ROOT_DIR" && pnpm --filter @takazudo/zudo-doc build && pnpm test:unit); then
   pass "Root unit tests passed"
 else
   fail "Root unit tests"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,19 @@ export default defineConfig({
   resolve: {
     alias: {
       "@/": resolve(__dirname, "src") + "/",
+      // React → Preact compat aliases. This project runs Preact in React-compat
+      // mode (the production zfb/vite build aliases these too). The precompiled
+      // zfb island runtime (@takazudo/zfb/dist/island.js) hardcodes
+      // `import { jsx } from "react/jsx-runtime"`; without these aliases any test
+      // that transitively loads it (e.g. src/config/__tests__/design-token-panel-config)
+      // fails with "Cannot find package 'react'" since this is a Preact project.
+      // Most-specific keys first so `react/jsx-runtime` is not swallowed by `react`.
+      // Mirrors packages/zudo-doc/vitest.config.ts.
+      "react/jsx-runtime": "preact/jsx-runtime",
+      "react/jsx-dev-runtime": "preact/jsx-runtime",
+      "react-dom/test-utils": "preact/test-utils",
+      "react-dom": "preact/compat",
+      react: "preact/compat",
     },
   },
   test: {
@@ -12,5 +25,16 @@ export default defineConfig({
       "src/**/__tests__/**/*.test.ts",
       "scripts/__tests__/**/*.test.ts",
     ],
+    server: {
+      deps: {
+        // Inline the zfb island runtime so vite transforms it through the
+        // resolve.alias pipeline above. Externalized node_modules deps are
+        // loaded by Node's native resolver, which bypasses the react →
+        // preact/compat aliases — so @takazudo/zfb/dist/island.js's
+        // `import "react/jsx-runtime"` would otherwise fail with
+        // "Cannot find package 'react'".
+        inline: [/@takazudo\/zfb/],
+      },
+    },
   },
 });


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/1856

---

## Summary

The root `test:unit` suite (`vitest run` — ~356 tests under `src/**/__tests__` and `scripts/__tests__`) ran in **no** CI workflow and was **not** part of `pnpm b4push`. Same coverage-gap class as #1851/#1853 (PR #1855), but distinct scope: that work gated the publishable `packages/*` suites; the **root project's own** suite stayed ungated, so a broken root test could land on a PR (and `main`) without turning anything red.

This PR closes that gap. It first fixes a **latent failure** in the suite (it was already red), then gates it in PR CI and locally in b4push.

## Changes

**1. `vitest.config.ts` — make `test:unit` green**
`design-token-panel-config.test.ts` was failing with `Cannot find package 'react'`: it transitively loads `@takazudo/zfb/dist/island.js`, whose precompiled runtime imports `react/jsx-runtime`. This is a Preact-compat project, so the production build aliases `react → preact/compat`, but the root vitest config did not. Ported the alias block + `server.deps.inline: [/@takazudo\/zfb/]` from `packages/zudo-doc/vitest.config.ts` (the package config already solved exactly this). Result: **18/18 suites green (356 tests)**, up from 17/18.

**2. `.github/workflows/pr-checks.yml` — new `Root Unit Tests` job**
Runs `pnpm test:unit` (checkout → pnpm → node → install → build `@takazudo/zudo-doc` → test), mirroring the existing `Package Unit Tests` job. Kept as a **separate, distinctly-named** check — the `Package Unit Tests` context name is intentionally left unchanged so the branch-ruleset required-checks follow-up (#1857) stays valid.

**3. `scripts/run-b4push.sh` — new `test:unit` step**
Added as step 8 (before the site build, for fast logic-level feedback) and renumbered the script (`TOTAL_STEPS=13`). Builds `@takazudo/zudo-doc` first, since on a fresh clone `pnpm install` does not run the package's tsup build and the dist would be absent (per codex review).

**Template drift:** verified clean. The `create-zudo-doc` scaffold ships no downstream `vitest.config.ts`, no CI workflow, and no `test:unit` script (downstream b4push is `<pm> check && <pm> build`), so there is no template counterpart to sync — this is host-only CI/test-infra hardening (same category as tags-audit / link-check / preview-smoke).

## Test Plan
- `pnpm test:unit` → 18/18 suites, 356 tests pass locally.
- `pnpm --filter @takazudo/zudo-doc build && pnpm test:unit` (the exact b4push step) → passes.
- `pnpm check` (typecheck) → no errors.
- `bash scripts/check-template-drift.sh` → no drift.
- CI on this PR: **all checks green**, including the new `Root Unit Tests` job (1m10s).

Closes #1856.