### PR TITLE
review-loop: fix versioned-locale 404s, package typecheck gap, and review findings

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     ]
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.79.0",
     "@shikijs/transformers": "^4.0.1",
     "@takazudo/zdtp": "0.2.0-next.2",
     "@takazudo/zfb": "0.1.0-next.28",

--- a/packages/create-zudo-doc/package.json
+++ b/packages/create-zudo-doc/package.json
@@ -46,6 +46,7 @@
     "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
     "build": "pnpm clean && tsc",
     "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:slow": "vitest run --config vitest.slow.config.ts",
     "prepublishOnly": "pnpm build && pnpm test"

--- a/packages/create-zudo-doc/templates/base/src/utils/base.ts
+++ b/packages/create-zudo-doc/templates/base/src/utils/base.ts
@@ -60,9 +60,9 @@ export function resolveHref(href: string): string {
 
 /**
  * Build a localized, versioned nav href.
- * Note: uses /{lang}/v/{version}/... ordering (for header/sidebar nav links).
- * This differs from versionedDocsUrl() which uses /v/{version}/{lang}/... (for doc page links).
- * Both orderings are handled by the routing layer.
+ * Uses /v/{version}/{lang}/... ordering — the only shape the routing layer
+ * serves (pages/v/[version]/ja/docs/...), matching versionedDocsUrl().
+ * The /{lang}/v/{version}/... ordering has no route and 404s.
  */
 export function navHref(
   path: string,
@@ -73,7 +73,7 @@ export function navHref(
   const versionPrefix = currentVersion ? `/v/${currentVersion}` : "";
   return withBase(
     isNonDefaultLocale
-      ? `/${lang}${versionPrefix}${path}`
+      ? `${versionPrefix}/${lang}${path}`
       : `${versionPrefix}${path}`,
   );
 }

--- a/packages/create-zudo-doc/templates/base/src/utils/base.ts
+++ b/packages/create-zudo-doc/templates/base/src/utils/base.ts
@@ -78,25 +78,36 @@ export function navHref(
   );
 }
 
+/**
+ * Split a leading /v/{version} prefix off a base-stripped path.
+ * Versioned routes nest the locale AFTER the version (/v/1.0/ja/docs/...),
+ * so locale stripping/prefixing must operate on the remainder only.
+ */
+function splitVersionPrefix(path: string): { versionPrefix: string; rest: string } {
+  const m = path.match(/^(\/v\/[^/]+)(\/.*|$)/);
+  return m ? { versionPrefix: m[1], rest: m[2] || "/" } : { versionPrefix: "", rest: path };
+}
+
 /** Build a locale-switched path from the current page path. */
 export function getPathForLocale(
   path: string,
   currentLang: Locale,
   targetLang: Locale,
 ): string {
-  let relativePath = stripBase(path);
+  const { versionPrefix, rest } = splitVersionPrefix(stripBase(path));
+  let relativePath = rest;
   if (currentLang !== defaultLocale) {
     relativePath = relativePath.replace(new RegExp(`^/${currentLang}(?:/|$)`), "/");
   }
   if (targetLang !== defaultLocale) {
     relativePath = `/${targetLang}${relativePath}`;
   }
-  return withBase(relativePath);
+  return withBase(`${versionPrefix}${relativePath}`);
 }
 
 /** Build locale links for locale switcher UI components. */
 export function buildLocaleLinks(currentPath: string, currentLang: Locale): LocaleLink[] {
-  let defaultLocalePath = stripBase(currentPath);
+  let defaultLocalePath = splitVersionPrefix(stripBase(currentPath)).rest;
   if (currentLang !== defaultLocale) {
     defaultLocalePath = defaultLocalePath.replace(new RegExp(`^/${currentLang}(?:/|$)`), "/");
   }

--- a/packages/create-zudo-doc/templates/features/claudeResources/files/src/integrations/claude-resources/generate.ts
+++ b/packages/create-zudo-doc/templates/features/claudeResources/files/src/integrations/claude-resources/generate.ts
@@ -156,35 +156,37 @@ function generateClaudemdDocs(
   const items: ClaudeMdItem[] = [];
 
   for (const filePath of files) {
-    const content = fs.readFileSync(filePath, "utf8");
     const relPath = path.relative(projectRoot, filePath);
     const displayPath = `/${relPath}`;
     const dirPart = path.dirname(relPath);
     const slug = dirPart === "." ? "root" : dirPart.replace(/\//g, "--");
-
     items.push({ displayPath, slug, relPath });
-
-    const pos = items.length + 1;
-    const mdx = `---
-title: "${escapeTitle(displayPath)}"
-description: "CLAUDE.md at ${escapeTitle(displayPath)}"
-sidebar_position: ${pos}
-sidebar_label: "${escapeTitle(relPath)}"
-generated: true
----
-
-**Path:** \`${relPath}\`
-
-${escapeForMdx(content.trim())}
-`;
-    fs.writeFileSync(path.join(outputDir, `${slug}.mdx`), mdx);
   }
 
-  // Sort: root first, then alphabetically
+  // Sort BEFORE writing: sidebar_position is baked into each generated .mdx,
+  // so the root-first/alphabetical order must be applied first — sorting after
+  // the write loop would leave positions in filesystem-walk order.
   items.sort((a, b) => {
     if (a.slug === "root") return -1;
     if (b.slug === "root") return 1;
     return a.displayPath.localeCompare(b.displayPath);
+  });
+
+  items.forEach((item, index) => {
+    const content = fs.readFileSync(path.join(projectRoot, item.relPath), "utf8");
+    const mdx = `---
+title: "${escapeTitle(item.displayPath)}"
+description: "CLAUDE.md at ${escapeTitle(item.displayPath)}"
+sidebar_position: ${index + 1}
+sidebar_label: "${escapeTitle(item.relPath)}"
+generated: true
+---
+
+**Path:** \`${item.relPath}\`
+
+${escapeForMdx(content.trim())}
+`;
+    fs.writeFileSync(path.join(outputDir, `${item.slug}.mdx`), mdx);
   });
 
   writeCategoryMeta(outputDir, "CLAUDE.md", 900, "Project-specific instructions");

--- a/packages/create-zudo-doc/templates/features/versioning/files/pages/[locale]/docs/versions.tsx
+++ b/packages/create-zudo-doc/templates/features/versioning/files/pages/[locale]/docs/versions.tsx
@@ -73,7 +73,9 @@ export default function LocaleVersionsPage({ params }: PageArgs): JSX.Element {
     ? settings.versions.map((v) => ({
         slug: v.slug,
         label: v.label ?? v.slug,
-        docsHref: withBase(`/${locale}/v/${v.slug}/docs/getting-started/`),
+        // Version prefix comes BEFORE the locale — the only routed shape is
+        // pages/v/[version]/{locale}/docs/...; /{locale}/v/... has no route.
+        docsHref: withBase(`/v/${v.slug}/${locale}/docs/getting-started/`),
         banner: v.banner as "unmaintained" | "unreleased" | undefined,
       }))
     : [];

--- a/packages/doc-history-server/src/__tests__/server.test.ts
+++ b/packages/doc-history-server/src/__tests__/server.test.ts
@@ -156,6 +156,16 @@ describe("Server routes", () => {
     expect(data!.error).toContain("No doc found");
   });
 
+  it("GET /doc-history/getting-started.json?cachebust=1 ignores the query string", async () => {
+    // Regression: the route used to match against raw req.url, so any query
+    // string failed the $-anchored regex and fell through to 404.
+    const { res, data } = await fetchJson(
+      `${baseUrl}/doc-history/getting-started.json?cachebust=1`,
+    );
+    expect(res.status).toBe(200);
+    expect(data!.slug).toBe("getting-started");
+  });
+
   it("OPTIONS /anything returns 204 with CORS headers", async () => {
     const res = await fetch(`${baseUrl}/anything`, { method: "OPTIONS" });
     expect(res.status).toBe(204);

--- a/packages/doc-history-server/src/args.ts
+++ b/packages/doc-history-server/src/args.ts
@@ -95,9 +95,10 @@ export function parseCommonArgs(
         locales.push(parseLocaleArg(next()));
         break;
       case "--max-entries": {
-        const n = Number(next());
+        const raw = next();
+        const n = Number(raw);
         if (Number.isNaN(n) || n < 1) {
-          console.error(`Invalid --max-entries value: ${args[i]}`);
+          console.error(`Invalid --max-entries value: ${raw}`);
           process.exit(1);
         }
         maxEntries = n;

--- a/packages/doc-history-server/src/server.ts
+++ b/packages/doc-history-server/src/server.ts
@@ -86,16 +86,17 @@ export function startServer(options: ServerOptions): void {
       return;
     }
 
+    // Match routes against the pathname only — req.url includes any query
+    // string, which would make exact/$-anchored matches reject e.g. ?cachebust=1.
+    const pathname = url.split(/[?#]/, 1)[0];
+
     // Health check
-    if (url === "/health") {
+    if (pathname === "/health") {
       sendJson(res, 200, { status: "ok" });
       return;
     }
 
     // Doc history routes: /doc-history/{slug}.json
-    // Match against the pathname only — req.url includes any query string,
-    // which would make the $-anchored regex reject e.g. ?cachebust=1.
-    const pathname = url.split(/[?#]/, 1)[0];
     const match = pathname.match(/^\/doc-history\/(.+)\.json$/);
     if (match) {
       try {

--- a/packages/doc-history-server/src/server.ts
+++ b/packages/doc-history-server/src/server.ts
@@ -93,7 +93,10 @@ export function startServer(options: ServerOptions): void {
     }
 
     // Doc history routes: /doc-history/{slug}.json
-    const match = url.match(/^\/doc-history\/(.+)\.json$/);
+    // Match against the pathname only — req.url includes any query string,
+    // which would make the $-anchored regex reject e.g. ?cachebust=1.
+    const pathname = url.split(/[?#]/, 1)[0];
+    const match = pathname.match(/^\/doc-history\/(.+)\.json$/);
     if (match) {
       try {
         const requestedSlug = decodeURIComponent(match[1]);

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -163,10 +163,14 @@
     "preact": "^10.29.1",
     "@takazudo/zfb": "^0.1.0-next.28",
     "@takazudo/zfb-runtime": "^0.1.0-next.28",
-    "@takazudo/zudo-doc-history-server": "workspace:^"
+    "@takazudo/zudo-doc-history-server": "workspace:^",
+    "@takazudo/zdtp": "^0.2.0-next.2"
   },
   "peerDependenciesMeta": {
     "@takazudo/zudo-doc-history-server": {
+      "optional": true
+    },
+    "@takazudo/zdtp": {
       "optional": true
     }
   },

--- a/packages/zudo-doc/src/integrations/claude-resources/generate.ts
+++ b/packages/zudo-doc/src/integrations/claude-resources/generate.ts
@@ -156,35 +156,37 @@ function generateClaudemdDocs(
   const items: ClaudeMdItem[] = [];
 
   for (const filePath of files) {
-    const content = fs.readFileSync(filePath, "utf8");
     const relPath = path.relative(projectRoot, filePath);
     const displayPath = `/${relPath}`;
     const dirPart = path.dirname(relPath);
     const slug = dirPart === "." ? "root" : dirPart.replace(/\//g, "--");
-
     items.push({ displayPath, slug, relPath });
-
-    const pos = items.length + 1;
-    const mdx = `---
-title: "${escapeTitle(displayPath)}"
-description: "CLAUDE.md at ${escapeTitle(displayPath)}"
-sidebar_position: ${pos}
-sidebar_label: "${escapeTitle(relPath)}"
-generated: true
----
-
-**Path:** \`${relPath}\`
-
-${escapeForMdx(content.trim())}
-`;
-    fs.writeFileSync(path.join(outputDir, `${slug}.mdx`), mdx);
   }
 
-  // Sort: root first, then alphabetically
+  // Sort BEFORE writing: sidebar_position is baked into each generated .mdx,
+  // so the root-first/alphabetical order must be applied first — sorting after
+  // the write loop would leave positions in filesystem-walk order.
   items.sort((a, b) => {
     if (a.slug === "root") return -1;
     if (b.slug === "root") return 1;
     return a.displayPath.localeCompare(b.displayPath);
+  });
+
+  items.forEach((item, index) => {
+    const content = fs.readFileSync(path.join(projectRoot, item.relPath), "utf8");
+    const mdx = `---
+title: "${escapeTitle(item.displayPath)}"
+description: "CLAUDE.md at ${escapeTitle(item.displayPath)}"
+sidebar_position: ${index + 1}
+sidebar_label: "${escapeTitle(item.relPath)}"
+generated: true
+---
+
+**Path:** \`${item.relPath}\`
+
+${escapeForMdx(content.trim())}
+`;
+    fs.writeFileSync(path.join(outputDir, `${item.slug}.mdx`), mdx);
   });
 
   writeCategoryMeta(outputDir, "CLAUDE.md", 900, "Project-specific instructions");

--- a/packages/zudo-doc/src/theme/__tests__/design-token-serde.test.ts
+++ b/packages/zudo-doc/src/theme/__tests__/design-token-serde.test.ts
@@ -8,7 +8,7 @@
 // (`hsp-md`, `vsp-sm`, `text-body`, `radius-DEFAULT`). Adding new
 // assertions? Extend the fixture rather than reaching back into host config.
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { type TokenDef } from "@takazudo/zdtp";
+import type { TokenDef } from "@takazudo/zdtp";
 import {
   DESIGN_TOKEN_SCHEMA,
   DesignTokenSchemaError,

--- a/packages/zudo-doc/src/theme/__tests__/design-token-serde.test.ts
+++ b/packages/zudo-doc/src/theme/__tests__/design-token-serde.test.ts
@@ -23,17 +23,17 @@ import type {
 } from "../design-token-types.js";
 
 const SPACING: readonly TokenDef[] = [
-  { id: "hsp-md", cssVar: "--spacing-hsp-md", label: "hsp-md", group: "hsp", default: "0.75rem", min: 0, max: 3, step: 0.025, unit: "rem" },
-  { id: "vsp-sm", cssVar: "--spacing-vsp-sm", label: "vsp-sm", group: "vsp", default: "1.25rem", min: 0, max: 4, step: 0.025, unit: "rem" },
+  { id: "hsp-md", cssVar: "--spacing-hsp-md", label: "hsp-md", group: "hsp", default: "0.75rem", step: 0.025, unit: "rem" },
+  { id: "vsp-sm", cssVar: "--spacing-vsp-sm", label: "vsp-sm", group: "vsp", default: "1.25rem", step: 0.025, unit: "rem" },
 ];
 
 const FONT: readonly TokenDef[] = [
-  { id: "text-body", cssVar: "--text-body", label: "text-body", group: "font-size", default: "1.2rem", min: 0.5, max: 5, step: 0.05, unit: "rem" },
+  { id: "text-body", cssVar: "--text-body", label: "text-body", group: "font-size", default: "1.2rem", step: 0.05, unit: "rem" },
 ];
 
 const SIZE: readonly TokenDef[] = [
-  { id: "radius-DEFAULT", cssVar: "--radius-DEFAULT", label: "radius-DEFAULT", group: "radius", default: "4px", min: 0, max: 100, step: 1, unit: "px" },
-  { id: "radius-lg", cssVar: "--radius-lg", label: "radius-lg", group: "radius", default: "8px", min: 0, max: 100, step: 1, unit: "px" },
+  { id: "radius-DEFAULT", cssVar: "--radius-DEFAULT", label: "radius-DEFAULT", group: "radius", default: "4px", step: 1, unit: "px" },
+  { id: "radius-lg", cssVar: "--radius-lg", label: "radius-lg", group: "radius", default: "8px", step: 1, unit: "px" },
 ];
 
 const MANIFEST: DesignTokenManifest = { spacing: SPACING, font: FONT, size: SIZE };

--- a/packages/zudo-doc/src/theme/design-token-serde.ts
+++ b/packages/zudo-doc/src/theme/design-token-serde.ts
@@ -33,7 +33,11 @@
  * `DeserializeOptions.manifest`, preserving consumer override hooks.
  */
 
-import { type TokenDef } from "@takazudo/zdtp";
+// `import type` (not `import { type ... }`) — esbuild only erases the whole
+// statement in the former shape; the latter leaves a runtime
+// `import {} from "@takazudo/zdtp"` in dist, breaking consumers that don't
+// install zdtp themselves (zdtp is a types-only optional peer here).
+import type { TokenDef } from "@takazudo/zdtp";
 import {
   emptyOverrides,
   type ColorTweakState,

--- a/pages/[locale]/docs/versions.tsx
+++ b/pages/[locale]/docs/versions.tsx
@@ -73,7 +73,9 @@ export default function LocaleVersionsPage({ params }: PageArgs): JSX.Element {
     ? settings.versions.map((v) => ({
         slug: v.slug,
         label: v.label ?? v.slug,
-        docsHref: withBase(`/${locale}/v/${v.slug}/docs/getting-started/`),
+        // Version prefix comes BEFORE the locale — the only routed shape is
+        // pages/v/[version]/{locale}/docs/...; /{locale}/v/... has no route.
+        docsHref: withBase(`/v/${v.slug}/${locale}/docs/getting-started/`),
         banner: v.banner as "unmaintained" | "unreleased" | undefined,
       }))
     : [];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@anthropic-ai/sdk':
-        specifier: ^0.79.0
-        version: 0.79.0(zod@4.3.6)
       '@shikijs/transformers':
         specifier: ^4.0.1
         version: 4.0.1
@@ -285,6 +282,9 @@ importers:
 
   packages/zudo-doc:
     dependencies:
+      '@takazudo/zdtp':
+        specifier: ^0.2.0-next.2
+        version: 0.2.0-next.2(preact@10.29.2)
       '@takazudo/zudo-doc-history-server':
         specifier: workspace:^
         version: link:../doc-history-server
@@ -324,19 +324,6 @@ packages:
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
-
-  '@anthropic-ai/sdk@0.79.0':
-    resolution: {integrity: sha512-ietmtM6glcnnrWq26H+BZm8J07iay9Cob6hRzDTr/A9QWF1m2T//TQhFO4MTKcZht2/7LS8bG9wUYEhcizKRnA==}
-    hasBin: true
-    peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
-    peerDependenciesMeta:
-      zod:
-        optional: true
-
-  '@babel/runtime@7.29.2':
-    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
-    engines: {node: '>=6.9.0'}
 
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
@@ -2542,10 +2529,6 @@ packages:
     resolution: {integrity: sha512-lR4MXjGNgkJc7tkQ97kb2nuEMnNCyU//XYVH0MKTGcXEiSudQ5MKGKen3C5QubYy0vmq+JGitUg92uuywGEwIA==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  json-schema-to-ts@3.1.1:
-    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
-    engines: {node: '>=16'}
-
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
@@ -3381,9 +3364,6 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
-  ts-algebra@2.0.0:
-    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
-
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
@@ -3770,14 +3750,6 @@ snapshots:
     dependencies:
       package-manager-detector: 1.6.0
       tinyexec: 1.0.2
-
-  '@anthropic-ai/sdk@0.79.0(zod@4.3.6)':
-    dependencies:
-      json-schema-to-ts: 3.1.1
-    optionalDependencies:
-      zod: 4.3.6
-
-  '@babel/runtime@7.29.2': {}
 
   '@braintree/sanitize-url@7.1.2': {}
 
@@ -5733,11 +5705,6 @@ snapshots:
 
   json-parse-even-better-errors@4.0.0: {}
 
-  json-schema-to-ts@3.1.1:
-    dependencies:
-      '@babel/runtime': 7.29.2
-      ts-algebra: 2.0.0
-
   json-schema-traverse@1.0.0: {}
 
   jsonfile@6.2.0:
@@ -6850,8 +6817,6 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
-
-  ts-algebra@2.0.0: {}
 
   ts-dedent@2.2.0: {}
 

--- a/scripts/run-b4push.sh
+++ b/scripts/run-b4push.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 #   4. Fixture settings drift check
 #   5. Tags audit (--ci)
 #   6. Design token lint
-#   7. Type checking (zfb check)
+#   7. Type checking (zfb check + workspace package typechecks)
 #   8. Root unit tests (test:unit)
 #   9. Build (zfb build)
 #  10. Link check
@@ -100,13 +100,23 @@ fi
 # Prefer `zfb check` (the post-cutover entry point). If it fails to
 # start (e.g. binary not yet built), fall back to `tsc --noEmit` so the
 # typecheck still gates pushes.
-step "Type checking (zfb check)"
+step "Type checking (zfb check + packages)"
 if (cd "$ROOT_DIR" && pnpm check); then
   pass "Type checking passed (zfb check)"
 elif (cd "$ROOT_DIR" && pnpm exec tsc --noEmit); then
   pass "Type checking passed (tsc --noEmit fallback)"
 else
   fail "Type checking"
+fi
+
+# Workspace package typechecks: `zfb check` only covers the root tsconfig
+# (packages/ are excluded), so a red package typecheck was invisible to
+# every gate until review-loop 2026-06-05 found one. Runs each package's
+# own `typecheck` script (packages without one are skipped by pnpm).
+if (cd "$ROOT_DIR" && pnpm -r --filter './packages/*' typecheck); then
+  pass "Package typechecks passed"
+else
+  fail "Package typechecks"
 fi
 
 # ── Step 8: Root unit tests ───────────────────────────

--- a/src/components/ai-chat-modal.tsx
+++ b/src/components/ai-chat-modal.tsx
@@ -5,7 +5,7 @@
 // components in this Preact app (configured project-wide). preact/compat
 // re-exports the same hooks under the React-compat names plus the `React.*`
 // type namespace this file references for event handlers.
-import { useState, useEffect, useRef, useCallback } from "preact/compat";
+import { useState, useEffect, useRef, useCallback, memo } from "preact/compat";
 import type { ChatMessage } from "@/types/ai-chat";
 import { renderMarkdown } from "@/utils/render-markdown";
 import { SmartBreak } from "@/utils/smart-break";
@@ -14,6 +14,28 @@ import { BEFORE_NAVIGATE_EVENT } from "@takazudo/zudo-doc/transitions";
 interface AiChatModalProps {
   basePath: string;
 }
+
+// Memoized row: message objects are immutable once appended, so rows skip
+// re-rendering on unrelated state changes — without this, every keystroke
+// (input state) re-runs renderMarkdown for every assistant message.
+const ChatMessageRow = memo(function ChatMessageRow({ msg }: { msg: ChatMessage }) {
+  return (
+    <div
+      className={`mb-vsp-xs flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
+    >
+      {msg.role === "user" ? (
+        <div className="max-w-[85%] rounded-t-[1rem] rounded-bl-[1rem] rounded-br-[0.25rem] bg-chat-user-bg px-hsp-md py-vsp-2xs text-small leading-relaxed text-chat-user-text">
+          <SmartBreak>{msg.content}</SmartBreak>
+        </div>
+      ) : (
+        <div
+          className="ai-chat-md max-w-[85%] rounded-t-[1rem] rounded-br-[1rem] rounded-bl-[0.25rem] bg-chat-assistant-bg px-hsp-md py-vsp-2xs text-small leading-relaxed text-chat-assistant-text"
+          dangerouslySetInnerHTML={{ __html: renderMarkdown(msg.content) }}
+        />
+      )}
+    </div>
+  );
+});
 
 export default function AiChatModal({ basePath }: AiChatModalProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
@@ -169,22 +191,10 @@ export default function AiChatModal({ basePath }: AiChatModalProps) {
               Ask a question about the documentation.
             </p>
           )}
+          {/* Index keys are stable here: the list is append-only and only
+              resets wholesale on dialog close. */}
           {messages.map((msg, i) => (
-            <div
-              key={i}
-              className={`mb-vsp-xs flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
-            >
-              {msg.role === "user" ? (
-                <div className="max-w-[85%] rounded-t-[1rem] rounded-bl-[1rem] rounded-br-[0.25rem] bg-chat-user-bg px-hsp-md py-vsp-2xs text-small leading-relaxed text-chat-user-text">
-                  <SmartBreak>{msg.content}</SmartBreak>
-                </div>
-              ) : (
-                <div
-                  className="ai-chat-md max-w-[85%] rounded-t-[1rem] rounded-br-[1rem] rounded-bl-[0.25rem] bg-chat-assistant-bg px-hsp-md py-vsp-2xs text-small leading-relaxed text-chat-assistant-text"
-                  dangerouslySetInnerHTML={{ __html: renderMarkdown(msg.content) }}
-                />
-              )}
-            </div>
+            <ChatMessageRow key={i} msg={msg} />
           ))}
           {loading && (
             <div className="mb-vsp-xs flex justify-start">

--- a/src/utils/__tests__/base.test.ts
+++ b/src/utils/__tests__/base.test.ts
@@ -46,9 +46,9 @@ describe("navHref", () => {
   });
 
   describe("with both locale and version", () => {
-    it("inserts locale before version prefix", () => {
+    it("inserts version prefix before locale (matching the /v/[version]/[lang] routes)", () => {
       expect(navHref("/docs/getting-started", "ja", "1.0")).toBe(
-        "/ja/v/1.0/docs/getting-started/",
+        "/v/1.0/ja/docs/getting-started/",
       );
     });
   });

--- a/src/utils/__tests__/base.test.ts
+++ b/src/utils/__tests__/base.test.ts
@@ -131,6 +131,26 @@ describe("getPathForLocale", () => {
       ).toBe("/ja/docs/guides/");
     });
   });
+
+  describe("versioned paths (locale nests AFTER /v/{version})", () => {
+    it("adds locale after the version prefix (en → ja)", () => {
+      expect(
+        getPathForLocale("/v/1.0/docs/getting-started/", "en", "ja"),
+      ).toBe("/v/1.0/ja/docs/getting-started/");
+    });
+
+    it("removes locale after the version prefix (ja → en)", () => {
+      expect(
+        getPathForLocale("/v/1.0/ja/docs/getting-started/", "ja", "en"),
+      ).toBe("/v/1.0/docs/getting-started/");
+    });
+
+    it("keeps a versioned JA path intact for ja → ja (regression: used to emit /ja/v/1.0/ja/...)", () => {
+      expect(
+        getPathForLocale("/v/1.0/ja/docs/getting-started/", "ja", "ja"),
+      ).toBe("/v/1.0/ja/docs/getting-started/");
+    });
+  });
 });
 
 describe("buildLocaleLinks", () => {
@@ -165,5 +185,14 @@ describe("buildLocaleLinks", () => {
     expect(links).toHaveLength(1);
     expect(links[0].code).toBe("ja");
     expect(links[0].active).toBe(true);
+  });
+
+  it("builds routed hrefs on a versioned JA page (regression: switcher used to 404)", () => {
+    const links = buildLocaleLinks("/v/1.0/ja/docs/getting-started/", "ja");
+    const en = links.find((l) => l.code === "en");
+    const ja = links.find((l) => l.code === "ja");
+    expect(en?.href).toBe("/v/1.0/docs/getting-started/");
+    expect(ja?.href).toBe("/v/1.0/ja/docs/getting-started/");
+    expect(ja?.active).toBe(true);
   });
 });

--- a/src/utils/base.ts
+++ b/src/utils/base.ts
@@ -60,9 +60,9 @@ export function resolveHref(href: string): string {
 
 /**
  * Build a localized, versioned nav href.
- * Note: uses /{lang}/v/{version}/... ordering (for header/sidebar nav links).
- * This differs from versionedDocsUrl() which uses /v/{version}/{lang}/... (for doc page links).
- * Both orderings are handled by the routing layer.
+ * Uses /v/{version}/{lang}/... ordering — the only shape the routing layer
+ * serves (pages/v/[version]/ja/docs/...), matching versionedDocsUrl().
+ * The /{lang}/v/{version}/... ordering has no route and 404s.
  */
 export function navHref(
   path: string,
@@ -73,7 +73,7 @@ export function navHref(
   const versionPrefix = currentVersion ? `/v/${currentVersion}` : "";
   return withBase(
     isNonDefaultLocale
-      ? `/${lang}${versionPrefix}${path}`
+      ? `${versionPrefix}/${lang}${path}`
       : `${versionPrefix}${path}`,
   );
 }

--- a/src/utils/base.ts
+++ b/src/utils/base.ts
@@ -78,25 +78,36 @@ export function navHref(
   );
 }
 
+/**
+ * Split a leading /v/{version} prefix off a base-stripped path.
+ * Versioned routes nest the locale AFTER the version (/v/1.0/ja/docs/...),
+ * so locale stripping/prefixing must operate on the remainder only.
+ */
+function splitVersionPrefix(path: string): { versionPrefix: string; rest: string } {
+  const m = path.match(/^(\/v\/[^/]+)(\/.*|$)/);
+  return m ? { versionPrefix: m[1], rest: m[2] || "/" } : { versionPrefix: "", rest: path };
+}
+
 /** Build a locale-switched path from the current page path. */
 export function getPathForLocale(
   path: string,
   currentLang: Locale,
   targetLang: Locale,
 ): string {
-  let relativePath = stripBase(path);
+  const { versionPrefix, rest } = splitVersionPrefix(stripBase(path));
+  let relativePath = rest;
   if (currentLang !== defaultLocale) {
     relativePath = relativePath.replace(new RegExp(`^/${currentLang}(?:/|$)`), "/");
   }
   if (targetLang !== defaultLocale) {
     relativePath = `/${targetLang}${relativePath}`;
   }
-  return withBase(relativePath);
+  return withBase(`${versionPrefix}${relativePath}`);
 }
 
 /** Build locale links for locale switcher UI components. */
 export function buildLocaleLinks(currentPath: string, currentLang: Locale): LocaleLink[] {
-  let defaultLocalePath = stripBase(currentPath);
+  let defaultLocalePath = splitVersionPrefix(stripBase(currentPath)).rest;
   if (currentLang !== defaultLocale) {
     defaultLocalePath = defaultLocalePath.replace(new RegExp(`^/${currentLang}(?:/|$)`), "/");
   }


### PR DESCRIPTION
## Summary

Three-round `/review-loop 3 -co` over `main` (round 1: full-project scan by 6 Opus reviewers + codex standard + codex adversarial; rounds 2–3: diff reviews of the accumulated fixes by 3 Opus reviewers + both codex passes each round).

- **Versioned non-default-locale URLs were broken in three places** — every constructor that interleaved locale and version used the unrouted `/{lang}/v/{version}/...` shape (only `/v/{version}/{lang}/...` has a route): `navHref()` (header/sidebar nav links), `getPathForLocale()`/`buildLocaleLinks()` (locale switcher), and the JA versions page. All three now emit the routed shape; a source-wide audit of every `/v/` URL constructor confirms no fourth instance, and the rebuilt dist contains zero locale-first version links.
- **`@takazudo/zudo-doc` was silently red** — 5× TS2353 in test fixtures (upstream zdtp dropped `min`/`max` from `TokenDef`) that no CI job or local gate covered, plus a runtime `import {} from "@takazudo/zdtp"` shipping in dist that breaks consumers who don't install zdtp. Fixed both; zdtp is now a declared optional types-only peer.
- **The gate gap is closed twice over** — b4push step 7 now runs every workspace package's `typecheck`, and `create-zudo-doc` (which had no such script — the gate's own blind spot, flagged by 4 of 5 round-2 reviewers) got one.

## Changes

**Bugs**
- `src/utils/base.ts` (+ template): `navHref()` emits `/v/{version}/{lang}/...`; `getPathForLocale()`/`buildLocaleLinks()` split the `/v/{version}` prefix before locale handling (regression tests for both)
- `pages/[locale]/docs/versions.tsx` (+ template): versions-page links use the routed ordering
- `packages/zudo-doc/src/integrations/claude-resources/generate.ts` (+ template): sort CLAUDE.md items **before** baking `sidebar_position` (was filesystem-walk order)
- `packages/doc-history-server`: routes match the pathname (query strings no longer 404, incl. `/health`); `--max-entries` error message interpolates the captured value

**Types / deps**
- `packages/zudo-doc`: TS2353 fixture fix, `import type` for zdtp (erases the runtime import from dist — verified), optional `@takazudo/zdtp` peer declaration
- Removed unused `@anthropic-ai/sdk` (ai-chat uses raw `fetch`; the dep tripped GHSA-p7fg-763f-g4gf for nothing)

**Perf**
- `src/components/ai-chat-modal.tsx`: memoized `ChatMessageRow` — keystrokes no longer re-run `renderMarkdown` on every message

**Gates**
- `scripts/run-b4push.sh` step 7 runs `pnpm -r --filter './packages/*' typecheck`; `create-zudo-doc` gains a `typecheck` script (all 5 packages green)
- New regression tests: query-string route (doc-history-server), versioned-path locale switching (base.test.ts)

## Test Plan

- [x] `pnpm check` + all 5 package typechecks green
- [x] Test suites: root 351, zudo-doc 404, doc-history-server 23 (incl. new), create-zudo-doc 255
- [x] `pnpm check:template-drift` clean (all template counterparts synced)
- [x] Full `pnpm build` (252 pages); dist grep: zero unrouted `/{lang}/v/` links, versioned JA pages link `/v/1.0/ja/docs/...`
- [ ] CI on this PR (b4push script itself not run end-to-end locally — its new command verified in isolation)

## Known issues left on record (not addressed here)

- Root `index.mdx` slug divergence (5 independent strip implementations; sitemap advertises a 404 `/docs/` for downstream projects with a root index) — needs a canonical-URL design decision, dedicated PR
- `pages/v/[version]/ja/` hardcodes `ja` — a third locale would 404 on versioned pages (latent; showcase is en+ja)
- Shiki/diff not code-split from the islands bundle (likely upstream zfb), doc-history git N+1, mermaid transitive-dep advisories, orphaned `src/components/content/` duplicates + dead `src/plugins/` shims (template-allowlist traps)

Review logs: `/mnt/c/Users/takaz/Dropbox/cclogs/zudo-doc/` (15 reviewer logs, 2026-06-05)

🤖 Generated with [Claude Code](https://claude.com/claude-code)