### PR TITLE
Apply zfb 0.1.0-next.30 upgrade + canonical /docs/ root (#1891)

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,9 +67,9 @@
   "dependencies": {
     "@shikijs/transformers": "^4.0.1",
     "@takazudo/zdtp": "0.2.0-next.2",
-    "@takazudo/zfb": "0.1.0-next.28",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.28",
-    "@takazudo/zfb-runtime": "0.1.0-next.28",
+    "@takazudo/zfb": "0.1.0-next.29",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.29",
+    "@takazudo/zfb-runtime": "0.1.0-next.29",
     "@types/hast": "^3.0.4",
     "@takazudo/zudo-doc-md-plugins": "workspace:*",
     "@takazudo/zudo-doc": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -67,9 +67,9 @@
   "dependencies": {
     "@shikijs/transformers": "^4.0.1",
     "@takazudo/zdtp": "0.2.0-next.2",
-    "@takazudo/zfb": "0.1.0-next.29",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.29",
-    "@takazudo/zfb-runtime": "0.1.0-next.29",
+    "@takazudo/zfb": "0.1.0-next.30",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.30",
+    "@takazudo/zfb-runtime": "0.1.0-next.30",
     "@types/hast": "^3.0.4",
     "@takazudo/zudo-doc-md-plugins": "workspace:*",
     "@takazudo/zudo-doc": "workspace:*",

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -2698,7 +2698,7 @@ describe("scaffold — W7C versioning feature pages (#1738)", () => {
   });
 });
 
-describe("scaffold — zfb next.29 pin bump (PR #1910)", () => {
+describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
   /**
    * S6 (#1808) pinned all three zfb packages at next.13. #1817 bumped them to
    * 0.1.0-next.14. #1824 bumped them to 0.1.0-next.19 — next.18 hard-removed
@@ -2720,13 +2720,17 @@ describe("scaffold — zfb next.29 pin bump (PR #1910)", () => {
    * extension strip, embedded-V8 worker console capture). next.27 is skipped
    * deliberately — its published adapter tarball omitted emit-worker.mjs and
    * crashes every adapter consumer (Takazudo/zudo-front-builder#794; fixed in
-   * next.28). Now bumped to 0.1.0-next.29 (PR #1910): islands code-splitting
+   * next.28). next.29 (PR #1910): islands code-splitting
    * (dynamic import() boundaries become self-hashed chunks), dev-server route
-   * pruning/SSR-reload fixes, and a symlink-safe outdir wipe at build start —
-   * no consumer-facing breaking change. Generated package.json must pin all
-   * three.
+   * pruning/SSR-reload fixes, and a symlink-safe outdir wipe at build start.
+   * Now bumped to 0.1.0-next.30 (PR #1910): adds Next.js-style `[[...slug]]`
+   * optional-catchall route syntax (Takazudo/zudo-front-builder#812) and raises
+   * the zfb-runtime hono floor to ^4.12.23, clearing 9 known advisories (#813);
+   * plus two router hardening fixes (overlapping-sibling rejection #816,
+   * per-segment rank sort for dev/prod parity) — no consumer-facing breaking
+   * change. Generated package.json must pin all three.
    */
-  it("pins @takazudo/zfb at 0.1.0-next.29", async () => {
+  it("pins @takazudo/zfb at 0.1.0-next.30", async () => {
     const choices: UserChoices = {
       projectName: "test-pin-bump",
       defaultLang: "en",
@@ -2737,10 +2741,10 @@ describe("scaffold — zfb next.29 pin bump (PR #1910)", () => {
     };
     await scaffold(choices);
     const pkg = await fs.readJson(projectPath("test-pin-bump", "package.json"));
-    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.29");
-    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.29");
+    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.30");
+    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.30");
     expect(pkg.dependencies["@takazudo/zfb-adapter-cloudflare"]).toBe(
-      "0.1.0-next.29",
+      "0.1.0-next.30",
     );
   });
 });

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -2591,7 +2591,7 @@ describe("scaffold — W7C docTags feature pages (#1738)", () => {
 });
 
 describe("scaffold — W7C versioning feature pages (#1738)", () => {
-  it("emits docs/versions.tsx + v/[version]/docs/[...slug].tsx when versioning is selected (i18n off)", async () => {
+  it("emits docs/versions.tsx + v/[version]/docs/[[...slug]].tsx when versioning is selected (i18n off)", async () => {
     const choices: UserChoices = {
       projectName: "test-versioning-pages-only",
       defaultLang: "en",
@@ -2610,7 +2610,7 @@ describe("scaffold — W7C versioning feature pages (#1738)", () => {
       await fs.pathExists(
         projectPath(
           "test-versioning-pages-only",
-          "pages/v/[version]/docs/[...slug].tsx",
+          "pages/v/[version]/docs/[[...slug]].tsx",
         ),
       ),
     ).toBe(true);
@@ -2641,7 +2641,7 @@ describe("scaffold — W7C versioning feature pages (#1738)", () => {
     ).toBe(false);
   });
 
-  it("emits [locale]/docs/versions.tsx + v/[version]/[locale]/docs/[...slug].tsx when versioning + i18n are both selected", async () => {
+  it("emits [locale]/docs/versions.tsx + v/[version]/[locale]/docs/[[...slug]].tsx when versioning + i18n are both selected", async () => {
     const choices: UserChoices = {
       projectName: "test-versioning-i18n",
       defaultLang: "en",
@@ -2663,7 +2663,7 @@ describe("scaffold — W7C versioning feature pages (#1738)", () => {
       await fs.pathExists(
         projectPath(
           "test-versioning-i18n",
-          "pages/v/[version]/[locale]/docs/[...slug].tsx",
+          "pages/v/[version]/[locale]/docs/[[...slug]].tsx",
         ),
       ),
     ).toBe(true);
@@ -2769,10 +2769,10 @@ describe("scaffold — W7C cross-feature union (i18n + docTags + versioning) (#1
       "pages/[locale]/docs/tags/index.tsx",
       // versioning — unconditional pair
       "pages/docs/versions.tsx",
-      "pages/v/[version]/docs/[...slug].tsx",
+      "pages/v/[version]/docs/[[...slug]].tsx",
       // versioning — locale pair
       "pages/[locale]/docs/versions.tsx",
-      "pages/v/[version]/[locale]/docs/[...slug].tsx",
+      "pages/v/[version]/[locale]/docs/[[...slug]].tsx",
     ];
     for (const rel of expected) {
       expect(
@@ -2790,7 +2790,7 @@ describe("scaffold — S8 versioned locale route generalization (#1892)", () => 
    * paths() must loop Object.keys(settings.locales) and emit params.locale;
    * the component must read locale from params, not hardcode "ja".
    * A project with a non-ja locale (e.g. fr) must get a
-   * v/[version]/[locale]/docs/[...slug].tsx route, not a dead 404.
+   * v/[version]/[locale]/docs/[[...slug]].tsx route, not a dead 404.
    */
   it("generated v/[version]/[locale] route uses params.locale — not hardcoded 'ja'", async () => {
     const choices: UserChoices = {
@@ -2804,11 +2804,11 @@ describe("scaffold — S8 versioned locale route generalization (#1892)", () => 
     await scaffold(choices);
     const routeFile = projectPath(
       "test-s8-locale-generic",
-      "pages/v/[version]/[locale]/docs/[...slug].tsx",
+      "pages/v/[version]/[locale]/docs/[[...slug]].tsx",
     );
     expect(
       await fs.pathExists(routeFile),
-      "v/[version]/[locale]/docs/[...slug].tsx should exist",
+      "v/[version]/[locale]/docs/[[...slug]].tsx should exist",
     ).toBe(true);
     const src = await fs.readFile(routeFile, "utf8");
     // Route must NOT hardcode "ja" as the locale

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -2133,7 +2133,7 @@ describe("scaffold — W6A page mirror (templates/base/pages)", () => {
     "pages/sitemap.xml.tsx",
     "pages/_data.ts",
     "pages/_mdx-components.ts",
-    "pages/docs/[...slug].tsx",
+    "pages/docs/[[...slug]].tsx",
     "pages/lib/_body-end-islands.tsx",
     "pages/lib/_category-nav.tsx",
     "pages/lib/_category-tree-nav.tsx",
@@ -2403,7 +2403,7 @@ describe("scaffold — W7A zfb plugin .mjs files exist after composition (#1736)
 });
 
 // W7B (#1737) — i18n feature emits the locale-prefixed page set
-// (pages/[locale]/index.tsx + pages/[locale]/docs/[...slug].tsx) when
+// (pages/[locale]/index.tsx + pages/[locale]/docs/[[...slug]].tsx) when
 // selected, and zero pages/[locale]/** files when not selected. Both
 // emitted files must be byte-identical to their feature templates.
 //
@@ -2415,7 +2415,7 @@ describe("scaffold — W7A zfb plugin .mjs files exist after composition (#1736)
 describe("scaffold — W7B i18n feature pages (templates/features/i18n)", () => {
   const I18N_PAGE_FILES = [
     "pages/[locale]/index.tsx",
-    "pages/[locale]/docs/[...slug].tsx",
+    "pages/[locale]/docs/[[...slug]].tsx",
   ];
 
   const I18N_ON: UserChoices = {
@@ -2445,7 +2445,7 @@ describe("scaffold — W7B i18n feature pages (templates/features/i18n)", () => 
     "templates/features/i18n/files/pages",
   );
 
-  it("emits pages/[locale]/index.tsx + pages/[locale]/docs/[...slug].tsx when i18n is selected", async () => {
+  it("emits pages/[locale]/index.tsx + pages/[locale]/docs/[[...slug]].tsx when i18n is selected", async () => {
     await scaffold(I18N_ON);
     for (const rel of I18N_PAGE_FILES) {
       expect(
@@ -2477,14 +2477,14 @@ describe("scaffold — W7B i18n feature pages (templates/features/i18n)", () => 
     expect(emitted).toEqual(template);
   });
 
-  it("emitted pages/[locale]/docs/[...slug].tsx is byte-identical to the feature template", async () => {
+  it("emitted pages/[locale]/docs/[[...slug]].tsx is byte-identical to the feature template", async () => {
     await scaffold(I18N_ON);
     const emitted = await fs.readFile(
-      projectPath("test-w7b-i18n-on", "pages/[locale]/docs/[...slug].tsx"),
+      projectPath("test-w7b-i18n-on", "pages/[locale]/docs/[[...slug]].tsx"),
       "utf-8",
     );
     const template = await fs.readFile(
-      path.join(FEATURE_PAGES_DIR, "[locale]/docs/[...slug].tsx"),
+      path.join(FEATURE_PAGES_DIR, "[locale]/docs/[[...slug]].tsx"),
       "utf-8",
     );
     expect(emitted).toEqual(template);

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -2698,7 +2698,7 @@ describe("scaffold — W7C versioning feature pages (#1738)", () => {
   });
 });
 
-describe("scaffold — zfb next.28 pin bump (#1870)", () => {
+describe("scaffold — zfb next.29 pin bump (PR #1910)", () => {
   /**
    * S6 (#1808) pinned all three zfb packages at next.13. #1817 bumped them to
    * 0.1.0-next.14. #1824 bumped them to 0.1.0-next.19 — next.18 hard-removed
@@ -2714,15 +2714,19 @@ describe("scaffold — zfb next.28 pin bump (#1870)", () => {
    * to 0.1.0-next.25 (#1840): BREAKING — next.25 removes `admonitionsPreset`
    * entirely (hard-errors at load); replaced by the generic
    * `markdown.features.directives` map. Host zfb.config.ts migrated in #1840;
-   * generated projects must also pin next.25. Now bumped to 0.1.0-next.28:
+   * generated projects must also pin next.25. #1870 bumped to 0.1.0-next.28:
    * next.26/next.28 are fix/feature releases with no consumer-facing breaking
    * change (UTF-8 preserved in directive quoted attrs, `.mdx` route-template
    * extension strip, embedded-V8 worker console capture). next.27 is skipped
    * deliberately — its published adapter tarball omitted emit-worker.mjs and
    * crashes every adapter consumer (Takazudo/zudo-front-builder#794; fixed in
-   * next.28). Generated package.json must pin all three.
+   * next.28). Now bumped to 0.1.0-next.29 (PR #1910): islands code-splitting
+   * (dynamic import() boundaries become self-hashed chunks), dev-server route
+   * pruning/SSR-reload fixes, and a symlink-safe outdir wipe at build start —
+   * no consumer-facing breaking change. Generated package.json must pin all
+   * three.
    */
-  it("pins @takazudo/zfb at 0.1.0-next.28", async () => {
+  it("pins @takazudo/zfb at 0.1.0-next.29", async () => {
     const choices: UserChoices = {
       projectName: "test-pin-bump",
       defaultLang: "en",
@@ -2733,10 +2737,10 @@ describe("scaffold — zfb next.28 pin bump (#1870)", () => {
     };
     await scaffold(choices);
     const pkg = await fs.readJson(projectPath("test-pin-bump", "package.json"));
-    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.28");
-    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.28");
+    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.29");
+    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.29");
     expect(pkg.dependencies["@takazudo/zfb-adapter-cloudflare"]).toBe(
-      "0.1.0-next.28",
+      "0.1.0-next.29",
     );
   });
 });

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -317,11 +317,11 @@ function generatePackageJson(choices: UserChoices) {
     // so render failures surface `console.*` output. next.27 is unusable
     // for adapter consumers — its tarball omitted emit-worker.mjs
     // (Takazudo/zudo-front-builder#794, fixed in next.28) — so never pin 27.
-    "@takazudo/zfb": "0.1.0-next.28",
-    "@takazudo/zfb-runtime": "0.1.0-next.28",
+    "@takazudo/zfb": "0.1.0-next.29",
+    "@takazudo/zfb-runtime": "0.1.0-next.29",
     // zfb-adapter-cloudflare — required for any route with `prerender = false`.
     // Pinned in lockstep with @takazudo/zfb.
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.28",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.29",
     // @takazudo/zudo-doc — published from this monorepo via
     // .github/workflows/publish-zudo-doc.yml. The pin here is bumped in
     // lockstep by scripts/release-create-zudo-doc.sh whenever zudo-doc's

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -317,11 +317,16 @@ function generatePackageJson(choices: UserChoices) {
     // so render failures surface `console.*` output. next.27 is unusable
     // for adapter consumers — its tarball omitted emit-worker.mjs
     // (Takazudo/zudo-front-builder#794, fixed in next.28) — so never pin 27.
-    "@takazudo/zfb": "0.1.0-next.29",
-    "@takazudo/zfb-runtime": "0.1.0-next.29",
+    // Bumped to next.30 — adds Next.js-style `[[...slug]]` optional-catchall
+    // route syntax (Takazudo/zudo-front-builder#812) and raises the zfb-runtime
+    // hono floor to ^4.12.23, clearing 9 advisories (#813); also two router
+    // hardening fixes (overlapping-sibling rejection #816, per-segment rank
+    // sort for dev/prod parity). No consumer-facing breaking change.
+    "@takazudo/zfb": "0.1.0-next.30",
+    "@takazudo/zfb-runtime": "0.1.0-next.30",
     // zfb-adapter-cloudflare — required for any route with `prerender = false`.
     // Pinned in lockstep with @takazudo/zfb.
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.29",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.30",
     // @takazudo/zudo-doc — published from this monorepo via
     // .github/workflows/publish-zudo-doc.yml. The pin here is bumped in
     // lockstep by scripts/release-create-zudo-doc.sh whenever zudo-doc's

--- a/packages/create-zudo-doc/templates/base/pages/_data.ts
+++ b/packages/create-zudo-doc/templates/base/pages/_data.ts
@@ -13,6 +13,7 @@
 import { getCollection } from "zfb/content";
 import type { CollectionEntry } from "zfb/content";
 import type { DocsEntry } from "@/types/docs-entry";
+import { toRouteSlug } from "@/utils/slug";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -92,9 +93,14 @@ export function getDocs(collectionName: string): ZfbDocsEntry[] {
   }));
 }
 
+// The `id` field bridged onto every entry is the canonical route slug, so it
+// routes through the one shared rule (`toRouteSlug` in @/utils/slug) — bare
+// root `index` → "" (URL /docs/), nested `x/index` → "x". Previously this was
+// a standalone copy of the strip logic (the lone "" dissenter of the five
+// index-stripping sites); consolidating it here means there is one source of
+// truth. See @/utils/slug for the canonical-root rationale (#1891 / #1873).
 function stripIndexSuffix(slug: string): string {
-  if (slug === "index") return "";
-  return slug.endsWith("/index") ? slug.slice(0, -"/index".length) : slug;
+  return toRouteSlug(slug);
 }
 
 /**

--- a/packages/create-zudo-doc/templates/base/pages/docs/[[...slug]].tsx
+++ b/packages/create-zudo-doc/templates/base/pages/docs/[[...slug]].tsx
@@ -11,11 +11,16 @@
 //   params: { slug: string[] }   — e.g. ["getting-started", "intro"]
 //   props:  { entry, autoIndex, breadcrumbs, prev, next }
 //
+// Route is the OPTIONAL catchall `[[...slug]]` so a bare root index.mdx can
+// build at `/docs/` (canonical root URL — #1891). The root entry emits
+// `params.slug = []` (zero segments) via `toSlugParams`; a required `[...slug]`
+// catchall rejects an empty array and would drop the whole route.
+//
 // The catchall slug is an array per zfb spec — the component joins it when
 // deriving the string form (e.g. for Content lookups, breadcrumbs, etc.).
 //
 // Locale: defaultLocale (EN). Non-default locales are handled by
-// pages/[locale]/docs/[...slug].tsx.
+// pages/[locale]/docs/[[...slug]].tsx.
 
 import type { DocsEntry } from "@/types/docs-entry";
 import { settings } from "@/config/settings";
@@ -30,7 +35,7 @@ import {
   type NavNode,
 } from "@/utils/docs";
 import { getNavSectionForSlug, getNavSubtree } from "@/utils/nav-scope";
-import { toRouteSlug } from "@/utils/slug";
+import { toRouteSlug, toSlugParams } from "@/utils/slug";
 import { DocLayoutWithDefaults } from "@takazudo/zudo-doc/doclayout";
 import { Breadcrumb } from "@takazudo/zudo-doc/breadcrumb";
 import { NavCardGrid } from "@takazudo/zudo-doc/nav-indexing";
@@ -125,7 +130,7 @@ export function paths(): Array<{
     }
 
     result.push({
-      params: { slug: slug.split("/") },
+      params: { slug: toSlugParams(slug) },
       props: {
         kind: "entry",
         entry,
@@ -140,7 +145,7 @@ export function paths(): Array<{
   // Auto-generated index pages for categories without index.mdx
   for (const node of collectAutoIndexNodes(tree)) {
     result.push({
-      params: { slug: node.slug.split("/") },
+      params: { slug: toSlugParams(node.slug) },
       props: {
         kind: "autoIndex",
         autoIndex: node as AutoIndexNode,

--- a/packages/create-zudo-doc/templates/base/pages/lib/_doc-history-area.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_doc-history-area.tsx
@@ -29,6 +29,7 @@ import { defaultLocale, t } from "@/config/i18n";
 import { BodyFootUtilArea } from "@takazudo/zudo-doc/body-foot-util";
 import { buildGitHubSourceUrl } from "@/utils/github";
 import { DocHistory } from "@/components/doc-history";
+import { toHistorySlug } from "@/utils/slug";
 // SSR author + date metadata comes from `.zfb/doc-history-meta.json`, a
 // build-time manifest emitted by `scripts/zfb-prebuild.mjs` (step 2:
 // doc-history-meta) before `zfb build` runs. esbuild inlines the JSON
@@ -95,10 +96,21 @@ export function DocHistoryArea({
 }: DocHistoryAreaProps): VNode | null {
   if (!settings.docHistory) return null;
 
+  // Doc-history storage sentinel ("" -> "index"): a root index page has the
+  // canonical route slug "" (→ /docs/), but doc-history JSON and the meta
+  // manifest store/serve the root entry under "index" (an empty path segment
+  // is unroutable — the server regex and the prebuild key composition both
+  // reject ""). Apply the sentinel to the slug segment BEFORE locale
+  // composition so root pages resolve to e.g. /doc-history/index.json and the
+  // meta key "ja/index". See @/utils/slug `toHistorySlug` and the
+  // collectContentFiles walk in packages/doc-history-server. (#1891)
+  const historySlug = toHistorySlug(slug);
+
   // Look up the build-time manifest entry for this page. The composedSlug
   // matches the key written by the prebuild step: bare slug for the default
   // locale, "<localeKey>/<slug>" for non-default locales.
-  const composedSlug = locale === defaultLocale ? slug : `${locale}/${slug}`;
+  const composedSlug =
+    locale === defaultLocale ? historySlug : `${locale}/${historySlug}`;
   type MetaEntry = { author: string; createdDate: string; updatedDate: string };
   const meta = (docHistoryMeta as Record<string, MetaEntry>)[composedSlug];
 
@@ -146,7 +158,7 @@ export function DocHistoryArea({
     ssrFallback: fallback,
     children: (
       <DocHistory
-        slug={slug}
+        slug={historySlug}
         locale={docHistoryLocale}
         basePath={docHistoryBasePath}
       />

--- a/packages/create-zudo-doc/templates/base/pages/lib/_doc-metainfo-area.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_doc-metainfo-area.tsx
@@ -24,6 +24,7 @@ import type { VNode } from "preact";
 import { settings } from "@/config/settings";
 import { defaultLocale, t } from "@/config/i18n";
 import { DocMetainfo } from "@takazudo/zudo-doc/metainfo";
+import { toHistorySlug } from "@/utils/slug";
 // SSR author + date metadata comes from `.zfb/doc-history-meta.json`, a
 // build-time manifest emitted by `scripts/zfb-prebuild.mjs` (step 2:
 // doc-history-meta) before `zfb build` runs. esbuild inlines the JSON
@@ -78,9 +79,18 @@ interface DocMetainfoAreaProps {
 export function DocMetainfoArea({ slug, locale }: DocMetainfoAreaProps): VNode | null {
   if (!settings.docMetainfo) return null;
 
+  // Doc-history storage sentinel ("" -> "index"): a root index page has the
+  // canonical route slug "" (→ /docs/), but the prebuild keys the root entry
+  // under "index" (collectContentFiles keeps the bare root; an empty path
+  // segment is unroutable). Apply the sentinel BEFORE locale composition so
+  // the visible Created/Updated/Author block resolves for a root page — see
+  // @/utils/slug `toHistorySlug` and _doc-history-area.tsx. (#1891)
+  const historySlug = toHistorySlug(slug);
+
   // Key format: bare slug for default locale, "<locale>/<slug>" for others.
-  // Matches the prebuild step's composedSlug logic in scripts/zfb-prebuild.mjs.
-  const composedSlug = locale === defaultLocale ? slug : `${locale}/${slug}`;
+  // Matches the prebuild step's composedSlug logic (pre-build.ts).
+  const composedSlug =
+    locale === defaultLocale ? historySlug : `${locale}/${historySlug}`;
 
   type MetaEntry = { author: string; createdDate: string; updatedDate: string };
   const meta = (docHistoryMeta as Record<string, MetaEntry>)[composedSlug];

--- a/packages/create-zudo-doc/templates/base/pages/lib/route-enumerators.ts
+++ b/packages/create-zudo-doc/templates/base/pages/lib/route-enumerators.ts
@@ -60,7 +60,13 @@ export function enumerateDocsRoutes(locale: string): string[] {
   const tree = buildNavTree(navDocs, locale as Locale, categoryMeta);
 
   for (const doc of allDocs) {
-    // toRouteSlug fallback so a top-level index.mdx maps to "" not "index".
+    // Canonical route slug via the one shared rule (@/utils/slug). `doc.id` is
+    // already `toRouteSlug(doc.slug)` (bridged through stripIndexSuffix in
+    // pages/_data.ts), so a bare root index.mdx is "" here → `/docs/` — the
+    // canonical root URL (#1891). The `toRouteSlug` fallback is a redundant
+    // safety re-application of the same rule (idempotent on the already-
+    // stripped id); kept so this enumerator's slug derivation reads as a
+    // single explicit call to the canonical helper.
     urls.push(docsUrl(doc.data.slug ?? toRouteSlug(doc.id), locale as string));
   }
   for (const node of collectAutoIndexNodes(tree)) {

--- a/packages/create-zudo-doc/templates/base/src/utils/slug.ts
+++ b/packages/create-zudo-doc/templates/base/src/utils/slug.ts
@@ -1,5 +1,48 @@
+// Canonical root-slug rule (zudolab/zudo-doc#1891, closes #1873).
+//
+// A doc collection's bare root `index.mdx` must resolve to the canonical
+// URL `/docs/` — i.e. an EMPTY route slug `""` — NOT `/docs/index/`.
+// Five independent index-stripping sites historically disagreed on what a
+// bare root `index` becomes; this helper is the single source of truth they
+// all route through (the standalone doc-history-server package duplicates the
+// one-liner with a pointer comment back here — it cannot import across the
+// package boundary; see its CLAUDE.md).
+//
+// Rule:
+//   - bare root  "index"      → ""   (URL /docs/)
+//   - nested     "x/index"    → "x"  (URL /docs/x/)
+//   - everything else         → unchanged
+//
+// doc-history storage uses the OPPOSITE convention: the per-page JSON and the
+// build-time meta manifest key the root entry under "index" (an empty path
+// segment is unroutable — the server regex /^\/doc-history\/(.+)\.json$/ and
+// the `<locale>/<slug>.json` composition both reject ""). `toHistorySlug`
+// applies the `"" -> "index"` sentinel so the doc-history client fetch path
+// and the meta-manifest lookup land on the stored key. See `toHistorySlug`.
 export function toRouteSlug(id: string): string {
+  if (id === "index") return "";
   return id.replace(/\/index$/, "");
+}
+
+// Doc-history storage sentinel — the inverse of the bare-root case of
+// `toRouteSlug`. The canonical route slug for a root index is "" (→ /docs/),
+// but doc-history JSON is stored/served under "index" (an empty path segment
+// is unroutable). Apply this to the route slug BEFORE composing the
+// doc-history fetch path and the meta-manifest key so root pages resolve to
+// e.g. /doc-history/index.json and /doc-history/<locale>/index.json.
+// Non-empty slugs pass through unchanged.
+export function toHistorySlug(routeSlug: string): string {
+  return routeSlug === "" ? "index" : routeSlug;
+}
+
+// Convert a canonical route slug into the `params.slug` array zfb's
+// optional-catchall route (`[[...slug]]`) expects. The bare root ("") maps to
+// `[]` (zero segments → /docs/); a naive `"".split("/")` yields `[""]`, which
+// zfb's catchall router REJECTS (empty array element), silently dropping the
+// entire route. Every `.split("/")` at a docs route's paths() site must go
+// through this helper.
+export function toSlugParams(routeSlug: string): string[] {
+  return routeSlug === "" ? [] : routeSlug.split("/");
 }
 
 export function toTitleCase(str: string): string {

--- a/packages/create-zudo-doc/templates/features/docHistory/files/src/components/doc-history.tsx
+++ b/packages/create-zudo-doc/templates/features/docHistory/files/src/components/doc-history.tsx
@@ -416,9 +416,15 @@ export function DocHistory({ slug, locale, basePath = "/" }: DocHistoryProps) {
   );
 
   const base = basePath.replace(/\/+$/, "");
+  // Doc-history storage sentinel ("" -> "index"): a root index page has the
+  // canonical route slug "" (-> /docs/), but the per-page JSON is stored/served
+  // under "index" because an empty path segment is unroutable (the server regex
+  // /^\/doc-history\/(.+)\.json$/ rejects ""). Map "" back to "index" so the
+  // fetch path is well-formed.
+  const historySlug = slug === "" ? "index" : slug;
   const fetchPath = locale
-    ? `${base}/doc-history/${locale}/${slug}.json`
-    : `${base}/doc-history/${slug}.json`;
+    ? `${base}/doc-history/${locale}/${historySlug}.json`
+    : `${base}/doc-history/${historySlug}.json`;
 
   const fetchHistory = useCallback(async () => {
     if (data) return; // already loaded

--- a/packages/create-zudo-doc/templates/features/i18n/files/pages/[locale]/docs/[[...slug]].tsx
+++ b/packages/create-zudo-doc/templates/features/i18n/files/pages/[locale]/docs/[[...slug]].tsx
@@ -10,8 +10,15 @@
 //   params: { locale: string; slug: string[] }
 //   props:  { entry, autoIndex, contentDir, isFallback, breadcrumbs, prev, next }
 //
+// Route is the OPTIONAL catchall `[[...slug]]` so a locale root index.mdx can
+// build at `/{locale}/docs/` (canonical root URL — #1891). The root entry
+// emits `params.slug = []` via `toSlugParams`; a required `[...slug]` catchall
+// rejects an empty array and would drop the ENTIRE locale route (the EN-root
+// index leaks in via the locale-first EN fallback, so this fires even before a
+// locale-specific root index exists — probe-observed page-count collapse).
+//
 // i18n / locale routing:
-//   - Default locale (EN) is handled by pages/docs/[...slug].tsx
+//   - Default locale (EN) is handled by pages/docs/[[...slug]].tsx
 //     (prefixDefaultLocale: false).
 //   - Non-default locales emit /{locale}/docs/{slug}.
 //   - Locale-first merge: locale docs take priority; base EN docs fill in
@@ -29,7 +36,7 @@ import {
   type NavNode,
 } from "@/utils/docs";
 import { getNavSectionForSlug, getNavSubtree } from "@/utils/nav-scope";
-import { toRouteSlug } from "@/utils/slug";
+import { toRouteSlug, toSlugParams } from "@/utils/slug";
 import { DocLayoutWithDefaults } from "@takazudo/zudo-doc/doclayout";
 import { Breadcrumb } from "@takazudo/zudo-doc/breadcrumb";
 import { NavCardGrid } from "@takazudo/zudo-doc/nav-indexing";
@@ -123,7 +130,13 @@ export function paths(): Array<{
 
     // Regular doc pages
     for (const entry of allDocs) {
-      const slug = entry.data.slug ?? entry.id;
+      // Canonical route slug via the one shared rule (@/utils/slug). `entry.id`
+      // is already `toRouteSlug(entry.slug)` (bridgeEntries → stripIndexSuffix →
+      // toRouteSlug), so this is identical to the previous `entry.id` form for
+      // every entry — but stating it explicitly removes the historical id-vs-
+      // toRouteSlug asymmetry with the EN route and the component below, all of
+      // which now yield "" for a root index (URL /{locale}/docs/ — #1891).
+      const slug = entry.data.slug ?? toRouteSlug(entry.slug);
       const isFallback = fallbackSlugs.has(slug);
       const entryContentDir = isFallback ? settings.docsDir : contentDir;
 
@@ -153,7 +166,7 @@ export function paths(): Array<{
       }
 
       result.push({
-        params: { locale, slug: slug.split("/") },
+        params: { locale, slug: toSlugParams(slug) },
         props: {
           kind: "entry",
           entry: entry as unknown as DocPageEntry,
@@ -170,7 +183,7 @@ export function paths(): Array<{
     // Auto-generated index pages for categories without index.mdx
     for (const node of collectAutoIndexNodes(tree)) {
       result.push({
-        params: { locale, slug: node.slug.split("/") },
+        params: { locale, slug: toSlugParams(node.slug) },
         props: {
           kind: "autoIndex",
           autoIndex: node as AutoIndexNode,

--- a/packages/create-zudo-doc/templates/features/versioning/files/pages/v/[version]/[locale]/docs/[[...slug]].tsx
+++ b/packages/create-zudo-doc/templates/features/versioning/files/pages/v/[version]/[locale]/docs/[[...slug]].tsx
@@ -2,6 +2,9 @@
 /** @jsxImportSource preact */
 // Page module for the versioned non-default-locale docs route.
 //
+// Optional-catchall [[...slug]] so slug=[] (empty) routes to /v/<ver>/<locale>/docs/
+// when a versioned locale root index.mdx exists — toSlugParams("") returns [].
+//
 // Versioned locale docs route. paths() cross-products settings.versions ×
 // configured per-version locales with a locale-first merge strategy:
 // locale-specific collection (`docs-v-${version.slug}-${locale}`) takes
@@ -31,7 +34,7 @@ import {
   type NavNode,
 } from "@/utils/docs";
 import { getNavSectionForSlug, getNavSubtree } from "@/utils/nav-scope";
-import { toRouteSlug } from "@/utils/slug";
+import { toRouteSlug, toSlugParams } from "@/utils/slug";
 import { DocLayoutWithDefaults } from "@takazudo/zudo-doc/doclayout";
 import { Breadcrumb } from "@takazudo/zudo-doc/breadcrumb";
 import { NavCardGrid } from "@takazudo/zudo-doc/nav-indexing";
@@ -118,17 +121,20 @@ export function paths(): Array<{
           keepUnlisted: true,
         });
       // isFallback: page came from base docs, not the locale collection.
+      // toRouteSlug keeps Set keys and lookup keys in lockstep — a versioned
+      // root index has entry.slug="index" (storage form) but route slug="" so
+      // d.id would diverge from the lookup key after the #1891 toRouteSlug flip.
       const fallbackSlugs = new Set(
         allDocs
-          .filter((d) => !localeSlugSet.has(d.data.slug ?? d.id))
-          .map((d) => d.data.slug ?? d.id),
+          .filter((d) => !localeSlugSet.has(d.data.slug ?? toRouteSlug(d.slug)))
+          .map((d) => d.data.slug ?? toRouteSlug(d.slug)),
       );
 
       const tree = buildNavTree(navDocs as unknown as DocsEntry[], locale, categoryMeta);
 
       // Regular doc pages
       for (const entry of allDocs) {
-        const slug = entry.data.slug ?? entry.id;
+        const slug = entry.data.slug ?? toRouteSlug(entry.slug);
         const isFallback = fallbackSlugs.has(slug);
         const entryContentDir = isFallback ? version.docsDir : (localeDir ?? version.docsDir);
 
@@ -158,7 +164,7 @@ export function paths(): Array<{
         }
 
         result.push({
-          params: { version: version.slug, locale, slug: slug.split("/") },
+          params: { version: version.slug, locale, slug: toSlugParams(slug) },
           props: {
             kind: "entry",
             entry: entry as unknown as DocPageEntry,
@@ -181,7 +187,7 @@ export function paths(): Array<{
       // Auto-generated index pages for categories without index.mdx
       for (const node of collectAutoIndexNodes(tree)) {
         result.push({
-          params: { version: version.slug, locale, slug: node.slug.split("/") },
+          params: { version: version.slug, locale, slug: toSlugParams(node.slug) },
           props: {
             kind: "autoIndex",
             autoIndex: {

--- a/packages/create-zudo-doc/templates/features/versioning/files/pages/v/[version]/docs/[[...slug]].tsx
+++ b/packages/create-zudo-doc/templates/features/versioning/files/pages/v/[version]/docs/[[...slug]].tsx
@@ -2,6 +2,9 @@
 /** @jsxImportSource preact */
 // Page module for the versioned EN docs route.
 //
+// Optional-catchall [[...slug]] so slug=[] (empty) routes to /v/<ver>/docs/
+// when a versioned root index.mdx exists — toSlugParams("") returns [].
+//
 // Versioned EN docs route. paths() enumerates one route per (version, slug)
 // combination using the `docs-v-${version.slug}` collection for each version
 // configured in settings.versions.
@@ -31,7 +34,7 @@ import {
   type NavNode,
 } from "@/utils/docs";
 import { getNavSectionForSlug, getNavSubtree } from "@/utils/nav-scope";
-import { toRouteSlug } from "@/utils/slug";
+import { toRouteSlug, toSlugParams } from "@/utils/slug";
 import { DocLayoutWithDefaults } from "@takazudo/zudo-doc/doclayout";
 import { Breadcrumb } from "@takazudo/zudo-doc/breadcrumb";
 import { NavCardGrid } from "@takazudo/zudo-doc/nav-indexing";
@@ -134,7 +137,7 @@ export function paths(): Array<{
       }
 
       result.push({
-        params: { version: version.slug, slug: slug.split("/") },
+        params: { version: version.slug, slug: toSlugParams(slug) },
         props: {
           kind: "entry",
           entry,
@@ -155,7 +158,7 @@ export function paths(): Array<{
     // Auto-generated index pages for categories without index.mdx
     for (const node of collectAutoIndexNodes(tree)) {
       result.push({
-        params: { version: version.slug, slug: node.slug.split("/") },
+        params: { version: version.slug, slug: toSlugParams(node.slug) },
         props: {
           kind: "autoIndex",
           autoIndex: {

--- a/packages/doc-history-server/src/git-history.ts
+++ b/packages/doc-history-server/src/git-history.ts
@@ -465,6 +465,16 @@ export function collectContentFiles(
       if (entry.isDirectory()) {
         walk(fullPath, baseDir);
       } else if (/\.mdx?$/.test(entry.name) && !entry.name.startsWith("_")) {
+        // Storage half of the doc-history "" <-> "index" sentinel (#1891).
+        // The leading-slash regex strips nested `x/index` → `x` but
+        // deliberately KEEPS a bare root `index` as `index` (no leading slash
+        // to match): doc-history JSON is stored/served under "index" because an
+        // empty path segment is unroutable (server regex below + the
+        // `<locale>/<slug>.json` composition both reject ""). The canonical
+        // ROUTE slug for the same page is "" (→ /docs/) — see
+        // src/utils/slug.ts `toRouteSlug` / `toHistorySlug` in the host repo;
+        // this package cannot import across the boundary (see its CLAUDE.md),
+        // so the one-line rule is duplicated here with this pointer.
         const rel = relative(baseDir, fullPath)
           .replace(/\.mdx?$/, "")
           .replace(/\/index$/, "");

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -165,8 +165,8 @@
   ],
   "peerDependencies": {
     "preact": "^10.29.1",
-    "@takazudo/zfb": "^0.1.0-next.29",
-    "@takazudo/zfb-runtime": "^0.1.0-next.29",
+    "@takazudo/zfb": "^0.1.0-next.30",
+    "@takazudo/zfb-runtime": "^0.1.0-next.30",
     "@takazudo/zudo-doc-history-server": "workspace:^",
     "@takazudo/zdtp": "^0.2.0-next.2"
   },
@@ -189,7 +189,7 @@
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
     "vitest": "^3.0.0",
-    "@takazudo/zfb": "0.1.0-next.29",
-    "@takazudo/zfb-runtime": "0.1.0-next.29"
+    "@takazudo/zfb": "0.1.0-next.30",
+    "@takazudo/zfb-runtime": "0.1.0-next.30"
   }
 }

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -165,8 +165,8 @@
   ],
   "peerDependencies": {
     "preact": "^10.29.1",
-    "@takazudo/zfb": "^0.1.0-next.28",
-    "@takazudo/zfb-runtime": "^0.1.0-next.28",
+    "@takazudo/zfb": "^0.1.0-next.29",
+    "@takazudo/zfb-runtime": "^0.1.0-next.29",
     "@takazudo/zudo-doc-history-server": "workspace:^",
     "@takazudo/zdtp": "^0.2.0-next.2"
   },
@@ -189,7 +189,7 @@
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
     "vitest": "^3.0.0",
-    "@takazudo/zfb": "0.1.0-next.28",
-    "@takazudo/zfb-runtime": "0.1.0-next.28"
+    "@takazudo/zfb": "0.1.0-next.29",
+    "@takazudo/zfb-runtime": "0.1.0-next.29"
   }
 }

--- a/packages/zudo-doc/src/integrations/llms-txt/load.ts
+++ b/packages/zudo-doc/src/integrations/llms-txt/load.ts
@@ -48,9 +48,15 @@ export function collectMdFiles(
         if (entry.name.startsWith("_")) continue;
         walk(fullPath, baseDir);
       } else if (/\.mdx?$/.test(entry.name) && !entry.name.startsWith("_")) {
+        // Canonical route slug (zudo-doc#1891): nested `x/index` → `x` AND
+        // bare root `index` → "" so the llms-txt entry links to `/docs/` (the
+        // built page) instead of `/docs/index/` (which is never built). The
+        // host route, sitemap, and search-index all canonicalize the same way;
+        // see src/utils/slug.ts `toRouteSlug` in the consuming repo (one rule).
         const rel = relative(baseDir, fullPath)
           .replace(/\.mdx?$/, "")
-          .replace(/\/index$/, "");
+          .replace(/\/index$/, "")
+          .replace(/^index$/, "");
         results.push({ filePath: fullPath, slug: rel });
       }
     }

--- a/packages/zudo-doc/src/integrations/search-index/content-files.ts
+++ b/packages/zudo-doc/src/integrations/search-index/content-files.ts
@@ -73,9 +73,15 @@ export function collectMdFiles(
         if (entry.name.startsWith("_")) continue;
         walk(fullPath, baseDir);
       } else if (/\.mdx?$/.test(entry.name) && !entry.name.startsWith("_")) {
+        // Canonical route slug (zudo-doc#1891): nested `x/index` → `x` AND
+        // bare root `index` → "" so the search result links to `/docs/` (the
+        // built page) instead of `/docs/index/` (which is never built). The
+        // host route, sitemap, and llms-txt all canonicalize the same way; see
+        // src/utils/slug.ts `toRouteSlug` in the consuming repo (the one rule).
         const rel = relative(baseDir, fullPath)
           .replace(/\.mdx?$/, "")
-          .replace(/\/index$/, "");
+          .replace(/\/index$/, "")
+          .replace(/^index$/, "");
         results.push({ filePath: fullPath, slug: rel });
       }
     }

--- a/pages/[locale]/docs/[[...slug]].tsx
+++ b/pages/[locale]/docs/[[...slug]].tsx
@@ -10,8 +10,15 @@
 //   params: { locale: string; slug: string[] }
 //   props:  { entry, autoIndex, contentDir, isFallback, breadcrumbs, prev, next }
 //
+// Route is the OPTIONAL catchall `[[...slug]]` so a locale root index.mdx can
+// build at `/{locale}/docs/` (canonical root URL — #1891). The root entry
+// emits `params.slug = []` via `toSlugParams`; a required `[...slug]` catchall
+// rejects an empty array and would drop the ENTIRE locale route (the EN-root
+// index leaks in via the locale-first EN fallback, so this fires even before a
+// locale-specific root index exists — probe-observed page-count collapse).
+//
 // i18n / locale routing:
-//   - Default locale (EN) is handled by pages/docs/[...slug].tsx
+//   - Default locale (EN) is handled by pages/docs/[[...slug]].tsx
 //     (prefixDefaultLocale: false).
 //   - Non-default locales emit /{locale}/docs/{slug}.
 //   - Locale-first merge: locale docs take priority; base EN docs fill in
@@ -29,7 +36,7 @@ import {
   type NavNode,
 } from "@/utils/docs";
 import { getNavSectionForSlug, getNavSubtree } from "@/utils/nav-scope";
-import { toRouteSlug } from "@/utils/slug";
+import { toRouteSlug, toSlugParams } from "@/utils/slug";
 import { DocLayoutWithDefaults } from "@takazudo/zudo-doc/doclayout";
 import { Breadcrumb } from "@takazudo/zudo-doc/breadcrumb";
 import { NavCardGrid } from "@takazudo/zudo-doc/nav-indexing";
@@ -123,7 +130,13 @@ export function paths(): Array<{
 
     // Regular doc pages
     for (const entry of allDocs) {
-      const slug = entry.data.slug ?? entry.id;
+      // Canonical route slug via the one shared rule (@/utils/slug). `entry.id`
+      // is already `toRouteSlug(entry.slug)` (bridgeEntries → stripIndexSuffix →
+      // toRouteSlug), so this is identical to the previous `entry.id` form for
+      // every entry — but stating it explicitly removes the historical id-vs-
+      // toRouteSlug asymmetry with the EN route and the component below, all of
+      // which now yield "" for a root index (URL /{locale}/docs/ — #1891).
+      const slug = entry.data.slug ?? toRouteSlug(entry.slug);
       const isFallback = fallbackSlugs.has(slug);
       const entryContentDir = isFallback ? settings.docsDir : contentDir;
 
@@ -153,7 +166,7 @@ export function paths(): Array<{
       }
 
       result.push({
-        params: { locale, slug: slug.split("/") },
+        params: { locale, slug: toSlugParams(slug) },
         props: {
           kind: "entry",
           entry: entry as unknown as DocPageEntry,
@@ -170,7 +183,7 @@ export function paths(): Array<{
     // Auto-generated index pages for categories without index.mdx
     for (const node of collectAutoIndexNodes(tree)) {
       result.push({
-        params: { locale, slug: node.slug.split("/") },
+        params: { locale, slug: toSlugParams(node.slug) },
         props: {
           kind: "autoIndex",
           autoIndex: node as AutoIndexNode,

--- a/pages/_data.ts
+++ b/pages/_data.ts
@@ -13,6 +13,7 @@
 import { getCollection } from "zfb/content";
 import type { CollectionEntry } from "zfb/content";
 import type { DocsEntry } from "@/types/docs-entry";
+import { toRouteSlug } from "@/utils/slug";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -92,9 +93,14 @@ export function getDocs(collectionName: string): ZfbDocsEntry[] {
   }));
 }
 
+// The `id` field bridged onto every entry is the canonical route slug, so it
+// routes through the one shared rule (`toRouteSlug` in @/utils/slug) — bare
+// root `index` → "" (URL /docs/), nested `x/index` → "x". Previously this was
+// a standalone copy of the strip logic (the lone "" dissenter of the five
+// index-stripping sites); consolidating it here means there is one source of
+// truth. See @/utils/slug for the canonical-root rationale (#1891 / #1873).
 function stripIndexSuffix(slug: string): string {
-  if (slug === "index") return "";
-  return slug.endsWith("/index") ? slug.slice(0, -"/index".length) : slug;
+  return toRouteSlug(slug);
 }
 
 /**

--- a/pages/docs/[[...slug]].tsx
+++ b/pages/docs/[[...slug]].tsx
@@ -11,11 +11,16 @@
 //   params: { slug: string[] }   — e.g. ["getting-started", "intro"]
 //   props:  { entry, autoIndex, breadcrumbs, prev, next }
 //
+// Route is the OPTIONAL catchall `[[...slug]]` so a bare root index.mdx can
+// build at `/docs/` (canonical root URL — #1891). The root entry emits
+// `params.slug = []` (zero segments) via `toSlugParams`; a required `[...slug]`
+// catchall rejects an empty array and would drop the whole route.
+//
 // The catchall slug is an array per zfb spec — the component joins it when
 // deriving the string form (e.g. for Content lookups, breadcrumbs, etc.).
 //
 // Locale: defaultLocale (EN). Non-default locales are handled by
-// pages/[locale]/docs/[...slug].tsx.
+// pages/[locale]/docs/[[...slug]].tsx.
 
 import type { DocsEntry } from "@/types/docs-entry";
 import { settings } from "@/config/settings";
@@ -30,7 +35,7 @@ import {
   type NavNode,
 } from "@/utils/docs";
 import { getNavSectionForSlug, getNavSubtree } from "@/utils/nav-scope";
-import { toRouteSlug } from "@/utils/slug";
+import { toRouteSlug, toSlugParams } from "@/utils/slug";
 import { DocLayoutWithDefaults } from "@takazudo/zudo-doc/doclayout";
 import { Breadcrumb } from "@takazudo/zudo-doc/breadcrumb";
 import { NavCardGrid } from "@takazudo/zudo-doc/nav-indexing";
@@ -125,7 +130,7 @@ export function paths(): Array<{
     }
 
     result.push({
-      params: { slug: slug.split("/") },
+      params: { slug: toSlugParams(slug) },
       props: {
         kind: "entry",
         entry,
@@ -140,7 +145,7 @@ export function paths(): Array<{
   // Auto-generated index pages for categories without index.mdx
   for (const node of collectAutoIndexNodes(tree)) {
     result.push({
-      params: { slug: node.slug.split("/") },
+      params: { slug: toSlugParams(node.slug) },
       props: {
         kind: "autoIndex",
         autoIndex: node as AutoIndexNode,

--- a/pages/lib/_doc-history-area.tsx
+++ b/pages/lib/_doc-history-area.tsx
@@ -29,6 +29,7 @@ import { defaultLocale, t } from "@/config/i18n";
 import { BodyFootUtilArea } from "@takazudo/zudo-doc/body-foot-util";
 import { buildGitHubSourceUrl } from "@/utils/github";
 import { DocHistory } from "@/components/doc-history";
+import { toHistorySlug } from "@/utils/slug";
 // SSR author + date metadata comes from `.zfb/doc-history-meta.json`, a
 // build-time manifest emitted by `scripts/zfb-prebuild.mjs` (step 2:
 // doc-history-meta) before `zfb build` runs. esbuild inlines the JSON
@@ -95,10 +96,21 @@ export function DocHistoryArea({
 }: DocHistoryAreaProps): VNode | null {
   if (!settings.docHistory) return null;
 
+  // Doc-history storage sentinel ("" -> "index"): a root index page has the
+  // canonical route slug "" (→ /docs/), but doc-history JSON and the meta
+  // manifest store/serve the root entry under "index" (an empty path segment
+  // is unroutable — the server regex and the prebuild key composition both
+  // reject ""). Apply the sentinel to the slug segment BEFORE locale
+  // composition so root pages resolve to e.g. /doc-history/index.json and the
+  // meta key "ja/index". See @/utils/slug `toHistorySlug` and the
+  // collectContentFiles walk in packages/doc-history-server. (#1891)
+  const historySlug = toHistorySlug(slug);
+
   // Look up the build-time manifest entry for this page. The composedSlug
   // matches the key written by the prebuild step: bare slug for the default
   // locale, "<localeKey>/<slug>" for non-default locales.
-  const composedSlug = locale === defaultLocale ? slug : `${locale}/${slug}`;
+  const composedSlug =
+    locale === defaultLocale ? historySlug : `${locale}/${historySlug}`;
   type MetaEntry = { author: string; createdDate: string; updatedDate: string };
   const meta = (docHistoryMeta as Record<string, MetaEntry>)[composedSlug];
 
@@ -146,7 +158,7 @@ export function DocHistoryArea({
     ssrFallback: fallback,
     children: (
       <DocHistory
-        slug={slug}
+        slug={historySlug}
         locale={docHistoryLocale}
         basePath={docHistoryBasePath}
       />

--- a/pages/lib/_doc-metainfo-area.tsx
+++ b/pages/lib/_doc-metainfo-area.tsx
@@ -24,6 +24,7 @@ import type { VNode } from "preact";
 import { settings } from "@/config/settings";
 import { defaultLocale, t } from "@/config/i18n";
 import { DocMetainfo } from "@takazudo/zudo-doc/metainfo";
+import { toHistorySlug } from "@/utils/slug";
 // SSR author + date metadata comes from `.zfb/doc-history-meta.json`, a
 // build-time manifest emitted by `scripts/zfb-prebuild.mjs` (step 2:
 // doc-history-meta) before `zfb build` runs. esbuild inlines the JSON
@@ -78,9 +79,18 @@ interface DocMetainfoAreaProps {
 export function DocMetainfoArea({ slug, locale }: DocMetainfoAreaProps): VNode | null {
   if (!settings.docMetainfo) return null;
 
+  // Doc-history storage sentinel ("" -> "index"): a root index page has the
+  // canonical route slug "" (→ /docs/), but the prebuild keys the root entry
+  // under "index" (collectContentFiles keeps the bare root; an empty path
+  // segment is unroutable). Apply the sentinel BEFORE locale composition so
+  // the visible Created/Updated/Author block resolves for a root page — see
+  // @/utils/slug `toHistorySlug` and _doc-history-area.tsx. (#1891)
+  const historySlug = toHistorySlug(slug);
+
   // Key format: bare slug for default locale, "<locale>/<slug>" for others.
-  // Matches the prebuild step's composedSlug logic in scripts/zfb-prebuild.mjs.
-  const composedSlug = locale === defaultLocale ? slug : `${locale}/${slug}`;
+  // Matches the prebuild step's composedSlug logic (pre-build.ts).
+  const composedSlug =
+    locale === defaultLocale ? historySlug : `${locale}/${historySlug}`;
 
   type MetaEntry = { author: string; createdDate: string; updatedDate: string };
   const meta = (docHistoryMeta as Record<string, MetaEntry>)[composedSlug];

--- a/pages/lib/route-enumerators.ts
+++ b/pages/lib/route-enumerators.ts
@@ -60,7 +60,13 @@ export function enumerateDocsRoutes(locale: string): string[] {
   const tree = buildNavTree(navDocs, locale as Locale, categoryMeta);
 
   for (const doc of allDocs) {
-    // toRouteSlug fallback so a top-level index.mdx maps to "" not "index".
+    // Canonical route slug via the one shared rule (@/utils/slug). `doc.id` is
+    // already `toRouteSlug(doc.slug)` (bridged through stripIndexSuffix in
+    // pages/_data.ts), so a bare root index.mdx is "" here → `/docs/` — the
+    // canonical root URL (#1891). The `toRouteSlug` fallback is a redundant
+    // safety re-application of the same rule (idempotent on the already-
+    // stripped id); kept so this enumerator's slug derivation reads as a
+    // single explicit call to the canonical helper.
     urls.push(docsUrl(doc.data.slug ?? toRouteSlug(doc.id), locale as string));
   }
   for (const node of collectAutoIndexNodes(tree)) {

--- a/pages/v/[version]/[locale]/docs/[[...slug]].tsx
+++ b/pages/v/[version]/[locale]/docs/[[...slug]].tsx
@@ -2,6 +2,9 @@
 /** @jsxImportSource preact */
 // Page module for the versioned non-default-locale docs route.
 //
+// Optional-catchall [[...slug]] so slug=[] (empty) routes to /v/<ver>/<locale>/docs/
+// when a versioned locale root index.mdx exists — toSlugParams("") returns [].
+//
 // Versioned locale docs route. paths() cross-products settings.versions ×
 // configured per-version locales with a locale-first merge strategy:
 // locale-specific collection (`docs-v-${version.slug}-${locale}`) takes
@@ -31,7 +34,7 @@ import {
   type NavNode,
 } from "@/utils/docs";
 import { getNavSectionForSlug, getNavSubtree } from "@/utils/nav-scope";
-import { toRouteSlug } from "@/utils/slug";
+import { toRouteSlug, toSlugParams } from "@/utils/slug";
 import { DocLayoutWithDefaults } from "@takazudo/zudo-doc/doclayout";
 import { Breadcrumb } from "@takazudo/zudo-doc/breadcrumb";
 import { NavCardGrid } from "@takazudo/zudo-doc/nav-indexing";
@@ -118,17 +121,20 @@ export function paths(): Array<{
           keepUnlisted: true,
         });
       // isFallback: page came from base docs, not the locale collection.
+      // toRouteSlug keeps Set keys and lookup keys in lockstep — a versioned
+      // root index has entry.slug="index" (storage form) but route slug="" so
+      // d.id would diverge from the lookup key after the #1891 toRouteSlug flip.
       const fallbackSlugs = new Set(
         allDocs
-          .filter((d) => !localeSlugSet.has(d.data.slug ?? d.id))
-          .map((d) => d.data.slug ?? d.id),
+          .filter((d) => !localeSlugSet.has(d.data.slug ?? toRouteSlug(d.slug)))
+          .map((d) => d.data.slug ?? toRouteSlug(d.slug)),
       );
 
       const tree = buildNavTree(navDocs as unknown as DocsEntry[], locale, categoryMeta);
 
       // Regular doc pages
       for (const entry of allDocs) {
-        const slug = entry.data.slug ?? entry.id;
+        const slug = entry.data.slug ?? toRouteSlug(entry.slug);
         const isFallback = fallbackSlugs.has(slug);
         const entryContentDir = isFallback ? version.docsDir : (localeDir ?? version.docsDir);
 
@@ -158,7 +164,7 @@ export function paths(): Array<{
         }
 
         result.push({
-          params: { version: version.slug, locale, slug: slug.split("/") },
+          params: { version: version.slug, locale, slug: toSlugParams(slug) },
           props: {
             kind: "entry",
             entry: entry as unknown as DocPageEntry,
@@ -181,7 +187,7 @@ export function paths(): Array<{
       // Auto-generated index pages for categories without index.mdx
       for (const node of collectAutoIndexNodes(tree)) {
         result.push({
-          params: { version: version.slug, locale, slug: node.slug.split("/") },
+          params: { version: version.slug, locale, slug: toSlugParams(node.slug) },
           props: {
             kind: "autoIndex",
             autoIndex: {

--- a/pages/v/[version]/docs/[[...slug]].tsx
+++ b/pages/v/[version]/docs/[[...slug]].tsx
@@ -2,6 +2,9 @@
 /** @jsxImportSource preact */
 // Page module for the versioned EN docs route.
 //
+// Optional-catchall [[...slug]] so slug=[] (empty) routes to /v/<ver>/docs/
+// when a versioned root index.mdx exists — toSlugParams("") returns [].
+//
 // Versioned EN docs route. paths() enumerates one route per (version, slug)
 // combination using the `docs-v-${version.slug}` collection for each version
 // configured in settings.versions.
@@ -31,7 +34,7 @@ import {
   type NavNode,
 } from "@/utils/docs";
 import { getNavSectionForSlug, getNavSubtree } from "@/utils/nav-scope";
-import { toRouteSlug } from "@/utils/slug";
+import { toRouteSlug, toSlugParams } from "@/utils/slug";
 import { DocLayoutWithDefaults } from "@takazudo/zudo-doc/doclayout";
 import { Breadcrumb } from "@takazudo/zudo-doc/breadcrumb";
 import { NavCardGrid } from "@takazudo/zudo-doc/nav-indexing";
@@ -134,7 +137,7 @@ export function paths(): Array<{
       }
 
       result.push({
-        params: { version: version.slug, slug: slug.split("/") },
+        params: { version: version.slug, slug: toSlugParams(slug) },
         props: {
           kind: "entry",
           entry,
@@ -155,7 +158,7 @@ export function paths(): Array<{
     // Auto-generated index pages for categories without index.mdx
     for (const node of collectAutoIndexNodes(tree)) {
       result.push({
-        params: { version: version.slug, slug: node.slug.split("/") },
+        params: { version: version.slug, slug: toSlugParams(node.slug) },
         props: {
           kind: "autoIndex",
           autoIndex: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,14 +20,14 @@ importers:
         specifier: 0.2.0-next.2
         version: 0.2.0-next.2(preact@10.29.2)
       '@takazudo/zfb':
-        specifier: 0.1.0-next.28
-        version: 0.1.0-next.28
+        specifier: 0.1.0-next.29
+        version: 0.1.0-next.29
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.28
-        version: 0.1.0-next.28
+        specifier: 0.1.0-next.29
+        version: 0.1.0-next.29
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.28
-        version: 0.1.0-next.28(@takazudo/zfb@0.1.0-next.28)
+        specifier: 0.1.0-next.29
+        version: 0.1.0-next.29(@takazudo/zfb@0.1.0-next.29)
       '@takazudo/zudo-doc':
         specifier: workspace:*
         version: link:packages/zudo-doc
@@ -298,11 +298,11 @@ importers:
         version: 4.0.3
     devDependencies:
       '@takazudo/zfb':
-        specifier: 0.1.0-next.28
-        version: 0.1.0-next.28
+        specifier: 0.1.0-next.29
+        version: 0.1.0-next.29
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.28
-        version: 0.1.0-next.28(@takazudo/zfb@0.1.0-next.28)
+        specifier: 0.1.0-next.29
+        version: 0.1.0-next.29(@takazudo/zfb@0.1.0-next.29)
       '@types/node':
         specifier: ^25.3.5
         version: 25.3.5
@@ -1593,44 +1593,44 @@ packages:
     peerDependencies:
       preact: ^10.29.1
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.28':
-    resolution: {integrity: sha512-GlFHUWQ9OOhBATJeeJWSsK8VzAslxwPY+3dJNQ65rS1KWCEXpLqv+YjLJr0G0GyVSTsKGnBit/C7O/Fxf0qRjA==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.29':
+    resolution: {integrity: sha512-I7Bj3JxImNDDhioiwN93kbofe8eRv62Cpec1D+TFkZZOusZH0njlknLi18ASwOEnPIi90WyNgzQ/8W0YKRpwUA==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.28':
-    resolution: {integrity: sha512-YN+TPBTkWWeh6AkMvYCr5c1Q2/EC0ICoHTDZKAXIdQo6RUPiggn85iBbQFRwKLpsRRB3GwnVfm4ZkbNczLhklQ==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.29':
+    resolution: {integrity: sha512-VKtcxbjGaNVfg0uVU6pVN5T0DeCc9cIFne7r4qI/+aUBaqO5Am2doRMtnGmO/D01gDqWEikr8G/1CCIdvrFKQA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.28':
-    resolution: {integrity: sha512-BHEjau348S2uVCO74RHy3Dlmf3MvykqHKlkQj/j+3WRfBI6zITybR8NhyJuXM8lhijvbS4F9yjEogiiXQHMGGQ==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.29':
+    resolution: {integrity: sha512-5UxVN7398s84IFQtG6rOnDAzpTaYNNzTTlqO4dcS1EIHGio8LY4DQ6NxQJJcsFAwhphCxeVTjwZm+MLQnH+WJw==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.28':
-    resolution: {integrity: sha512-KeIDrIci9swLR9oh9pYZoeMm352QvGKU1Po0XmdUPhzfOJIl5P+GoaPN+u0+VYGw6S0O5Qsuxo6GuI5Im/WQ2A==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.29':
+    resolution: {integrity: sha512-xlvKgioK0Abizl+bCAgtEa19rzgtKTnRAkE8acXOcO9SB3eEITpohtxfIbx+faaW+EpMmIWPdcQGXonU80swPg==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.28':
-    resolution: {integrity: sha512-qjkoFy/YxO+EExNHsgslX6fyzYZl2qt7OxU4GKcSh4vOiIRGjMlvRDkR/EkA0bbDNWae5Dj9YeG+p6uBoTCwYg==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.29':
+    resolution: {integrity: sha512-c33fOLcRdtvd9cGRW4zBag7ta6tmVBgJV5wUrWCy0ZmgRIPt662UCb4LOEh5clNyklHWXR2lwieDNjIGHFE0Ug==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.28':
-    resolution: {integrity: sha512-6Jh3n4CVYvtJWH4UhPyHvs64YSCTi5jWITAZ1hap8KFwsm+pGdzQPL77cP100cV+eiil/x7FC/3YwmDgpxXd4Q==}
+  '@takazudo/zfb-runtime@0.1.0-next.29':
+    resolution: {integrity: sha512-mUP3qSwkfgQuhwPJyMaux6vp8Ds97JltMXlIkZ+e8t1idQOnO8NY5cbSsbynF6KjYbv4OeDHQPM2O5MUkqj5Cw==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.28
+      '@takazudo/zfb': 0.1.0-next.29
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.28':
-    resolution: {integrity: sha512-TfwCuBlBVLKkKV+ma1xh7IzqsK6AJmHZlG3LfaTDKFCpnbzxapFxdrf3FEQYbojYgREyF0Sza+ssnGdVlXx9JQ==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.29':
+    resolution: {integrity: sha512-M5abT5m5d9zyVOKgEW8TM6UgFJMdswHqSbanPKp7RuU83+by4R6iGR0vvBNESB+OofUMfPPTuh6JAQ4Y90+zDA==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.28':
-    resolution: {integrity: sha512-XSEH/nh0I6fIAFaBuKE/DQ87jPY+E01rVSzrIzTfFkzHmYVQa1BQml+rb+8BY2QgbluyGoB5rNRRfJki51dokw==}
+  '@takazudo/zfb@0.1.0-next.29':
+    resolution: {integrity: sha512-kQcC84gJ+tGvq3ySG07tyzrHut536/wSQU/pwMwWm7USXdxdA0Uhura5ixNGLfpaAM3rAWuPIcQwLsqk96zstw==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
@@ -4594,35 +4594,35 @@ snapshots:
       culori: 4.0.2
       preact: 10.29.2
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.28': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.29': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.28':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.29':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.28':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.29':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.28':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.29':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.28':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.29':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.28(@takazudo/zfb@0.1.0-next.28)':
+  '@takazudo/zfb-runtime@0.1.0-next.29(@takazudo/zfb@0.1.0-next.29)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.28
+      '@takazudo/zfb': 0.1.0-next.29
       hono: 4.12.15
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.28':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.29':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.28':
+  '@takazudo/zfb@0.1.0-next.29':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.28
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.28
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.28
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.28
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.28
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.29
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.29
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.29
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.29
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.29
 
   '@takazudo/zudo-design-token-lint@1.0.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,14 +20,14 @@ importers:
         specifier: 0.2.0-next.2
         version: 0.2.0-next.2(preact@10.29.2)
       '@takazudo/zfb':
-        specifier: 0.1.0-next.29
-        version: 0.1.0-next.29
+        specifier: 0.1.0-next.30
+        version: 0.1.0-next.30
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.29
-        version: 0.1.0-next.29
+        specifier: 0.1.0-next.30
+        version: 0.1.0-next.30
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.29
-        version: 0.1.0-next.29(@takazudo/zfb@0.1.0-next.29)
+        specifier: 0.1.0-next.30
+        version: 0.1.0-next.30(@takazudo/zfb@0.1.0-next.30)
       '@takazudo/zudo-doc':
         specifier: workspace:*
         version: link:packages/zudo-doc
@@ -298,11 +298,11 @@ importers:
         version: 4.0.3
     devDependencies:
       '@takazudo/zfb':
-        specifier: 0.1.0-next.29
-        version: 0.1.0-next.29
+        specifier: 0.1.0-next.30
+        version: 0.1.0-next.30
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.29
-        version: 0.1.0-next.29(@takazudo/zfb@0.1.0-next.29)
+        specifier: 0.1.0-next.30
+        version: 0.1.0-next.30(@takazudo/zfb@0.1.0-next.30)
       '@types/node':
         specifier: ^25.3.5
         version: 25.3.5
@@ -1593,44 +1593,44 @@ packages:
     peerDependencies:
       preact: ^10.29.1
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.29':
-    resolution: {integrity: sha512-I7Bj3JxImNDDhioiwN93kbofe8eRv62Cpec1D+TFkZZOusZH0njlknLi18ASwOEnPIi90WyNgzQ/8W0YKRpwUA==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.30':
+    resolution: {integrity: sha512-yKbQ6fgOMlm1eTwrAXCuTh5ca4vUgO3wSEfjeMwx6vyanBIQAG6u5QjQR6QyNnONJboFhLAe5MhP7S3B8oi4yw==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.29':
-    resolution: {integrity: sha512-VKtcxbjGaNVfg0uVU6pVN5T0DeCc9cIFne7r4qI/+aUBaqO5Am2doRMtnGmO/D01gDqWEikr8G/1CCIdvrFKQA==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.30':
+    resolution: {integrity: sha512-TOKRhLU0yD7KQggTlAAytXJ47ipHV83DxwDU+cd1H3u7ij69GhroAlkQwXJikFm09IASX7oUNdq6Aq4EcnfAlg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.29':
-    resolution: {integrity: sha512-5UxVN7398s84IFQtG6rOnDAzpTaYNNzTTlqO4dcS1EIHGio8LY4DQ6NxQJJcsFAwhphCxeVTjwZm+MLQnH+WJw==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.30':
+    resolution: {integrity: sha512-ei+LtKoLSiLePX5a51NAup+R5uhL40Y9c+KlU4t5dX6FvwmOg0Fu4MDzmbEh5fEelsiCQQ6TgI02XAlyHrTNnQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.29':
-    resolution: {integrity: sha512-xlvKgioK0Abizl+bCAgtEa19rzgtKTnRAkE8acXOcO9SB3eEITpohtxfIbx+faaW+EpMmIWPdcQGXonU80swPg==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.30':
+    resolution: {integrity: sha512-P7VQH8m87uboA6nsf4K9X48PJ86pHPVYI6zS/5eY8y7pPn6Z0H9vXbC8wkx9lwPnPuo+j63VySxtDqEhVRGpvA==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.29':
-    resolution: {integrity: sha512-c33fOLcRdtvd9cGRW4zBag7ta6tmVBgJV5wUrWCy0ZmgRIPt662UCb4LOEh5clNyklHWXR2lwieDNjIGHFE0Ug==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.30':
+    resolution: {integrity: sha512-iyzeJoXaJcwP3hhsjZc5OJ5hRacjiTa2QKj0Vh0OOpJ+YqOkUDVMMI677e+W6FV+qx95qeJ/nYqzErdSptFkGw==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.29':
-    resolution: {integrity: sha512-mUP3qSwkfgQuhwPJyMaux6vp8Ds97JltMXlIkZ+e8t1idQOnO8NY5cbSsbynF6KjYbv4OeDHQPM2O5MUkqj5Cw==}
+  '@takazudo/zfb-runtime@0.1.0-next.30':
+    resolution: {integrity: sha512-43R5WMCoI38YOyJo7lCL87CwmQZlf1rmc8cMstuK+9kEu2ADBAfpNVSqrvfrffQmDIbG+iIq1gzOO987iaBwTQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.29
+      '@takazudo/zfb': 0.1.0-next.30
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.29':
-    resolution: {integrity: sha512-M5abT5m5d9zyVOKgEW8TM6UgFJMdswHqSbanPKp7RuU83+by4R6iGR0vvBNESB+OofUMfPPTuh6JAQ4Y90+zDA==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.30':
+    resolution: {integrity: sha512-dkLPcunw7OVHVg8DezeGzY4waGvv7k72LAgGqT1AAOiFUt4XVUhi+zSVG1DMQ5+CnuAclRQmf8eE9ddR1+tttw==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.29':
-    resolution: {integrity: sha512-kQcC84gJ+tGvq3ySG07tyzrHut536/wSQU/pwMwWm7USXdxdA0Uhura5ixNGLfpaAM3rAWuPIcQwLsqk96zstw==}
+  '@takazudo/zfb@0.1.0-next.30':
+    resolution: {integrity: sha512-+nMRVHG/1ngSKRsq7H+/bdHxBGIAL2izA2iDztr1c/IeqdHHapCWqtZTtnLmgOXrZLgpO+7CdK2vQfxABmPYfA==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
@@ -2419,8 +2419,8 @@ packages:
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
-  hono@4.12.15:
-    resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
+  hono@4.12.23:
+    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
     engines: {node: '>=16.9.0'}
 
   html-validate@10.15.0:
@@ -4594,35 +4594,35 @@ snapshots:
       culori: 4.0.2
       preact: 10.29.2
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.29': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.30': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.29':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.30':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.29':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.30':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.29':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.30':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.29':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.30':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.29(@takazudo/zfb@0.1.0-next.29)':
+  '@takazudo/zfb-runtime@0.1.0-next.30(@takazudo/zfb@0.1.0-next.30)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.29
-      hono: 4.12.15
+      '@takazudo/zfb': 0.1.0-next.30
+      hono: 4.12.23
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.29':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.30':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.29':
+  '@takazudo/zfb@0.1.0-next.30':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.29
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.29
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.29
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.29
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.29
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.30
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.30
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.30
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.30
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.30
 
   '@takazudo/zudo-design-token-lint@1.0.0':
     dependencies:
@@ -5574,7 +5574,7 @@ snapshots:
 
   headers-polyfill@4.0.3: {}
 
-  hono@4.12.15: {}
+  hono@4.12.23: {}
 
   html-validate@10.15.0(vitest@4.1.0(@types/node@25.3.5)(msw@2.12.12(@types/node@25.3.5)(typescript@5.9.3))(vite@7.3.1(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))):
     dependencies:

--- a/src/components/doc-history.tsx
+++ b/src/components/doc-history.tsx
@@ -403,9 +403,18 @@ export function DocHistory({ slug, locale, basePath = "/" }: DocHistoryProps) {
   );
 
   const base = basePath.replace(/\/+$/, "");
+  // Doc-history storage sentinel ("" -> "index"): a root index page has the
+  // canonical route slug "" (→ /docs/), but the per-page JSON is stored/served
+  // under "index" (an empty path segment is unroutable — the server regex
+  // /^\/doc-history\/(.+)\.json$/ rejects ""). The host wrapper already passes
+  // the sentineled slug, but defend the boundary so the component is correct
+  // for any caller. Mirrors `toHistorySlug` in @/utils/slug (inlined here
+  // rather than imported to keep this bundled island free of host-util
+  // coupling — see .template-drift-allowlist). (#1891)
+  const historySlug = slug === "" ? "index" : slug;
   const fetchPath = locale
-    ? `${base}/doc-history/${locale}/${slug}.json`
-    : `${base}/doc-history/${slug}.json`;
+    ? `${base}/doc-history/${locale}/${historySlug}.json`
+    : `${base}/doc-history/${historySlug}.json`;
 
   const fetchHistory = useCallback(async () => {
     if (data) return; // already loaded

--- a/src/utils/slug.ts
+++ b/src/utils/slug.ts
@@ -1,5 +1,48 @@
+// Canonical root-slug rule (zudolab/zudo-doc#1891, closes #1873).
+//
+// A doc collection's bare root `index.mdx` must resolve to the canonical
+// URL `/docs/` — i.e. an EMPTY route slug `""` — NOT `/docs/index/`.
+// Five independent index-stripping sites historically disagreed on what a
+// bare root `index` becomes; this helper is the single source of truth they
+// all route through (the standalone doc-history-server package duplicates the
+// one-liner with a pointer comment back here — it cannot import across the
+// package boundary; see its CLAUDE.md).
+//
+// Rule:
+//   - bare root  "index"      → ""   (URL /docs/)
+//   - nested     "x/index"    → "x"  (URL /docs/x/)
+//   - everything else         → unchanged
+//
+// doc-history storage uses the OPPOSITE convention: the per-page JSON and the
+// build-time meta manifest key the root entry under "index" (an empty path
+// segment is unroutable — the server regex /^\/doc-history\/(.+)\.json$/ and
+// the `<locale>/<slug>.json` composition both reject ""). `toHistorySlug`
+// applies the `"" -> "index"` sentinel so the doc-history client fetch path
+// and the meta-manifest lookup land on the stored key. See `toHistorySlug`.
 export function toRouteSlug(id: string): string {
+  if (id === "index") return "";
   return id.replace(/\/index$/, "");
+}
+
+// Doc-history storage sentinel — the inverse of the bare-root case of
+// `toRouteSlug`. The canonical route slug for a root index is "" (→ /docs/),
+// but doc-history JSON is stored/served under "index" (an empty path segment
+// is unroutable). Apply this to the route slug BEFORE composing the
+// doc-history fetch path and the meta-manifest key so root pages resolve to
+// e.g. /doc-history/index.json and /doc-history/<locale>/index.json.
+// Non-empty slugs pass through unchanged.
+export function toHistorySlug(routeSlug: string): string {
+  return routeSlug === "" ? "index" : routeSlug;
+}
+
+// Convert a canonical route slug into the `params.slug` array zfb's
+// optional-catchall route (`[[...slug]]`) expects. The bare root ("") maps to
+// `[]` (zero segments → /docs/); a naive `"".split("/")` yields `[""]`, which
+// zfb's catchall router REJECTS (empty array element), silently dropping the
+// entire route. Every `.split("/")` at a docs route's paths() site must go
+// through this helper.
+export function toSlugParams(routeSlug: string): string[] {
+  return routeSlug === "" ? [] : routeSlug.split("/");
 }
 
 export function toTitleCase(str: string): string {


### PR DESCRIPTION
## Summary

Two things land together on this branch:

1. **zfb pin bump → `0.1.0-next.30`** across all five pin sources (root `package.json` — `@takazudo/zfb` + `-runtime` + `-adapter-cloudflare`; `create-zudo-doc/src/scaffold.ts` literals; `packages/zudo-doc/package.json` dev exact + peer `^`), verified by `scripts/check-pin-parity.mjs` (9 fields).
2. **Canonical root docs URL `/docs/`** (#1891) — newly unblocked by next.30 and implemented here.

### What next.30 brings (vs next.28)
- next.29: islands code-splitting (dynamic `import()` → self-hashed chunks), dev route-pruning / SSR-reload fixes, symlink-safe outdir wipe.
- next.30: **Next.js-style `[[...slug]]` optional-catchall route syntax** (Takazudo/zudo-front-builder#812) + **zfb-runtime hono floor `^4.7.0` → `^4.12.23`** (Takazudo/zudo-front-builder#813), plus two router hardening fixes (overlapping-sibling rejection #816, per-segment rank sort for dev/prod parity). No consumer-facing breaking change.

### #1891 — canonical `/docs/`
A bare root `index.mdx` now resolves to the canonical zero-segment URL `/docs/` (and `/ja/docs/`), via **one documented rule** in `src/utils/slug.ts` (`toRouteSlug`) that all five index-stripping sites route through:
- `toRouteSlug("index") → ""`; new `toHistorySlug` (`"" → "index"` doc-history storage sentinel) + `toSlugParams` (`"" → []` for the catchall).
- All **four** docs route modules `git mv`'d to `[[...slug]]` (EN, `[locale]`, `v/[version]`, `v/[version]/[locale]`); `.split("/")` → `toSlugParams`; the JA/versioned root derivation switched from `entry.id` (`""` for a root index → would crash a required catchall) to `toRouteSlug(entry.slug)`.
- doc-history `""↔"index"` sentinel on both consumer sides + the visible date block; generator keeps `index` with a pointer comment. Collectors (search-index, llms-txt) canonicalize bare root → `""`. All `create-zudo-doc` templates synced.

## Resolved deferred items
- **#1908** — the 9 hono advisories are cleared: next.30 runtime floor admits the patched line, lockfile re-resolved `hono 4.12.15 → 4.12.23`, `pnpm audit --prod` → **0** (was 9).
- **#1891 / #1905** — zero-segment route now supported upstream (next.30 #812) and implemented downstream here.

## Test Plan
- `check-pin-parity.mjs` — 9 fields at next.30 · `pnpm check` clean · `pnpm check:template-drift` clean · 256 create-zudo-doc tests
- `pnpm audit --prod` → 0 (was 9)
- #1891 probe build (temp EN+JA root index): 254 pages, `dist/docs/index.html` + `dist/ja/docs/index.html` emit, no `dist/docs/index/index.html`, sitemap `/docs/` + `/ja/docs/` once each
- Net-neutral without a root index: 252 pages = base
- Deep-review (codex) on the #1891 diff: no behavioral regressions
- CI: all 10 checks green (incl. E2E full-clone with real git dates — exercises the doc-history date block — and Preview Deploy)

Closes #1891
Closes #1908