### PR TITLE
agent-found fixes: doc-history CWD bug (#1907) + versioned nav locales (#1909)

### DIFF
--- a/packages/create-zudo-doc/templates/base/pages/lib/_nav-source-docs.ts
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_nav-source-docs.ts
@@ -117,12 +117,25 @@ export function resolveNavSource(
 ): NavSourceDocs {
   const sig = optionSig(options);
 
-  // --- Versioned (always EN base for the version; locale variant handled by
-  //     the versioned-locale route directly via resolveVersionedLocaleSource).
+  // --- Versioned. For a non-default locale the version IS configured for,
+  //     delegate to resolveVersionedLocaleSource so every nav surface uses the
+  //     SAME version-scoped locale-first merge the page body / route
+  //     enumeration use (#1909) — keeping nav labels and locale-only version
+  //     pages in sync. Otherwise (default locale, or the version not configured
+  //     for this locale) fall back to the version's EN base collection.
   if (currentVersion) {
-    const collectionName = `docs-v-${currentVersion}`;
     const versionConfig = settings.versions?.find((v) => v.slug === currentVersion);
-    const docs = stableDocs(collectionName);
+    const localeDir = versionConfig?.locales?.[lang]?.dir;
+    if (lang !== defaultLocale && localeDir) {
+      return resolveVersionedLocaleSource(
+        currentVersion,
+        versionConfig?.docsDir ?? settings.docsDir,
+        lang,
+        localeDir,
+        options,
+      );
+    }
+    const docs = stableDocs(`docs-v-${currentVersion}`);
     const categoryMeta = loadCategoryMeta(versionConfig?.docsDir ?? settings.docsDir);
     const navDocs = stableNavDocs(docs);
     return { docs, navDocs, categoryMeta, localeSlugSet: EMPTY_SLUG_SET as Set<string> };

--- a/packages/doc-history-server/src/__tests__/git-history.test.ts
+++ b/packages/doc-history-server/src/__tests__/git-history.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock node:child_process so we can observe the options (especially `cwd`)
+// passed to every git invocation without touching a real repo. This locks in
+// the #1907 fix: under `pnpm --filter`, process.cwd() is the package dir, so
+// all git commands must run with cwd = repo root or repo-relative pathspecs
+// match nothing (0 entries).
+const FAKE_REPO_ROOT = "/fake/repo/root";
+
+const execFileSyncMock = vi.fn();
+
+vi.mock("node:child_process", () => ({
+  execFileSync: (...args: unknown[]) => execFileSyncMock(...args),
+}));
+
+// Default behaviour: `rev-parse --show-toplevel` returns the fake root; any
+// other git command returns an empty string (so getDocHistory early-returns
+// with no entries — we only care about the cwd here).
+function installDefaultGit(): void {
+  execFileSyncMock.mockImplementation(
+    (_cmd: string, gitArgs: string[]) => {
+      if (gitArgs[0] === "rev-parse") return `${FAKE_REPO_ROOT}\n`;
+      return "";
+    },
+  );
+}
+
+beforeEach(() => {
+  vi.resetModules(); // reset the module-level repoRootCache between cases
+  execFileSyncMock.mockReset();
+  installDefaultGit();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** All recorded git invocations except the `rev-parse --show-toplevel` probe. */
+function gitCalls(): Array<{ args: string[]; opts: Record<string, unknown> }> {
+  return execFileSyncMock.mock.calls
+    .map((call) => ({
+      args: call[1] as string[],
+      opts: (call[2] ?? {}) as Record<string, unknown>,
+    }))
+    .filter((c) => c.args[0] !== "rev-parse");
+}
+
+describe("git-history cwd handling (#1907)", () => {
+  it("getDocHistory runs git with cwd = repo root regardless of process.cwd()", async () => {
+    const { getDocHistory } = await import("../git-history.js");
+    getDocHistory("/some/abs/path/src/content/docs/page.mdx", "page");
+
+    const calls = gitCalls();
+    expect(calls.length).toBeGreaterThan(0);
+    for (const c of calls) {
+      expect(c.opts["cwd"]).toBe(FAKE_REPO_ROOT);
+    }
+  });
+
+  it("getFileCommits runs git with cwd = repo root", async () => {
+    const { getFileCommits } = await import("../git-history.js");
+    getFileCommits("/some/abs/path/page.mdx");
+
+    const calls = gitCalls();
+    expect(calls.length).toBeGreaterThan(0);
+    for (const c of calls) {
+      expect(c.opts["cwd"]).toBe(FAKE_REPO_ROOT);
+    }
+  });
+
+  it("getFirstCommit runs git with cwd = repo root", async () => {
+    const { getFirstCommit } = await import("../git-history.js");
+    getFirstCommit("/some/abs/path/page.mdx");
+
+    const calls = gitCalls();
+    expect(calls.length).toBeGreaterThan(0);
+    for (const c of calls) {
+      expect(c.opts["cwd"]).toBe(FAKE_REPO_ROOT);
+    }
+  });
+
+  it("getCommitInfo runs git with cwd = repo root", async () => {
+    const { getCommitInfo } = await import("../git-history.js");
+    getCommitInfo("deadbeef", "/some/abs/path/page.mdx");
+
+    const calls = gitCalls();
+    expect(calls.length).toBeGreaterThan(0);
+    for (const c of calls) {
+      expect(c.opts["cwd"]).toBe(FAKE_REPO_ROOT);
+    }
+  });
+
+  it("getFileCommitsMeta runs git with cwd = repo root", async () => {
+    const { getFileCommitsMeta } = await import("../git-history.js");
+    getFileCommitsMeta("/some/abs/path/page.mdx");
+
+    const calls = gitCalls();
+    expect(calls.length).toBeGreaterThan(0);
+    for (const c of calls) {
+      expect(c.opts["cwd"]).toBe(FAKE_REPO_ROOT);
+    }
+  });
+
+  it("getFileAtCommit runs every git command (including the rename fallbacks) with cwd = repo root", async () => {
+    // Force the happy-path `git show` to fail so the rename-fallback chain
+    // (which fires extra git commands) is exercised too.
+    execFileSyncMock.mockImplementation(
+      (_cmd: string, gitArgs: string[]) => {
+        if (gitArgs[0] === "rev-parse") return `${FAKE_REPO_ROOT}\n`;
+        if (gitArgs[0] === "show") throw new Error("missing object");
+        return ""; // log fallbacks return empty -> no further show calls
+      },
+    );
+
+    const { getFileAtCommit } = await import("../git-history.js");
+    getFileAtCommit("deadbeef", "/some/abs/path/page.mdx");
+
+    const calls = gitCalls();
+    // At minimum: the failing `show` + the two rename-detection `log` calls.
+    expect(calls.length).toBeGreaterThanOrEqual(3);
+    for (const c of calls) {
+      expect(c.opts["cwd"]).toBe(FAKE_REPO_ROOT);
+    }
+  });
+
+  it("the cat-file --batch content fetch also runs with cwd = repo root", async () => {
+    // Drive getDocHistory down the batched-content path by returning a real
+    // metadata block from `git log` so it proceeds to cat-file --batch.
+    execFileSyncMock.mockImplementation(
+      (_cmd: string, gitArgs: string[]) => {
+        if (gitArgs[0] === "rev-parse") return `${FAKE_REPO_ROOT}\n`;
+        if (gitArgs[0] === "log") {
+          // metadata format: %H%n%aI%n%aN%n%s%n  (record + blank-line separator)
+          return "abc123\n2024-01-01T00:00:00Z\nAuthor\nmsg\n";
+        }
+        if (gitArgs[0] === "cat-file") {
+          // header + body for one blob, then EOF
+          return Buffer.from("abc123 blob 5\nhello\n");
+        }
+        return "";
+      },
+    );
+
+    const { getDocHistory } = await import("../git-history.js");
+    getDocHistory("/some/abs/path/page.mdx", "page");
+
+    const catFile = gitCalls().filter((c) => c.args[0] === "cat-file");
+    expect(catFile.length).toBeGreaterThan(0);
+    for (const c of catFile) {
+      expect(c.opts["cwd"]).toBe(FAKE_REPO_ROOT);
+    }
+  });
+});

--- a/packages/doc-history-server/src/git-history.ts
+++ b/packages/doc-history-server/src/git-history.ts
@@ -14,10 +14,23 @@ let repoRootCache: string | null = null;
 
 function getRepoRoot(): string {
   if (repoRootCache) return repoRootCache;
+  // `rev-parse --show-toplevel` walks up from process.cwd(), so it works from
+  // any CWD (no explicit cwd needed here).
   repoRootCache = execFileSync("git", ["rev-parse", "--show-toplevel"], {
     encoding: "utf-8",
   }).trim();
   return repoRootCache;
+}
+
+/**
+ * Shared git options pinned to the repo root. Every git command MUST run with
+ * cwd = repo root: under `pnpm --filter <pkg>`, process.cwd() is the package
+ * dir (packages/doc-history-server/), so the repo-relative pathspecs we build
+ * via toRepoRelative() would match nothing and every file would yield 0
+ * entries (#1907). Running from the repo root happened to work by accident.
+ */
+function gitOpts(): typeof QUIET & { cwd: string } {
+  return { ...QUIET, cwd: getRepoRoot() };
 }
 
 /** Convert an absolute path to a repo-relative path for git commands */
@@ -46,7 +59,7 @@ export function getFileCommits(
         "--",
         filePath,
       ],
-      QUIET,
+      gitOpts(),
     ).trim();
     return output ? [...new Set(output.split("\n"))] : [];
   } catch {
@@ -81,7 +94,7 @@ export function getFirstCommit(filePath: string): string | null {
         "--",
         filePath,
       ],
-      QUIET,
+      gitOpts(),
     ).trim();
     if (!output) return null;
     // git log can emit additional follow-related lines on some platforms;
@@ -105,7 +118,7 @@ export function getCommitInfo(
     const output = execFileSync(
       "git",
       ["log", "-1", "--format=%H%n%aI%n%aN%n%s", hash, "--", filePath],
-      QUIET,
+      gitOpts(),
     ).trim();
     const lines = output.split("\n");
     return {
@@ -129,7 +142,7 @@ export function getFileAtCommit(hash: string, filePath: string): string {
   const relPath = isAbsolute ? toRepoRelative(filePath) : filePath;
 
   try {
-    return execFileSync("git", ["show", `${hash}:${relPath}`], QUIET);
+    return execFileSync("git", ["show", `${hash}:${relPath}`], gitOpts());
   } catch {
     // File may have been renamed — find the old path at this commit
     try {
@@ -146,10 +159,10 @@ export function getFileAtCommit(hash: string, filePath: string): string {
           "--",
           relPath,
         ],
-        QUIET,
+        gitOpts(),
       ).trim();
       if (oldPath) {
-        return execFileSync("git", ["show", `${hash}:${oldPath}`], QUIET);
+        return execFileSync("git", ["show", `${hash}:${oldPath}`], gitOpts());
       }
     } catch {
       // ignore
@@ -168,7 +181,7 @@ export function getFileAtCommit(hash: string, filePath: string): string {
           "--",
           relPath,
         ],
-        QUIET,
+        gitOpts(),
       ).trim();
       const lines = followOutput.split("\n").filter(Boolean);
       // Lines alternate: hash, filename, hash, filename...
@@ -177,7 +190,7 @@ export function getFileAtCommit(hash: string, filePath: string): string {
           return execFileSync(
             "git",
             ["show", `${hash}:${lines[i + 1]}`],
-            QUIET,
+            gitOpts(),
           );
         }
       }
@@ -242,7 +255,7 @@ function buildHashToPathMap(
         "--",
         relPath,
       ],
-      QUIET,
+      gitOpts(),
     ).trim();
     if (!output) return new Map();
 
@@ -309,7 +322,8 @@ function batchFetchContents(
       ["cat-file", "--batch"],
       // encoding must be omitted (or "buffer") to get a raw Buffer so that
       // byte offsets from the <size> field stay accurate across UTF-8 content.
-      { stdio: ["pipe", "pipe", "pipe"], input: inputBuf },
+      // cwd = repo root for the same reason as gitOpts() (see #1907 above).
+      { stdio: ["pipe", "pipe", "pipe"], input: inputBuf, cwd: getRepoRoot() },
     ) as unknown as Buffer;
 
     const result = new Map<string, string>();
@@ -377,7 +391,7 @@ export function getDocHistory(
         "--",
         relPath,
       ],
-      QUIET,
+      gitOpts(),
     ).trim();
     if (logOutput) {
       metaRecords = parseCommitLog(logOutput);
@@ -435,7 +449,7 @@ export function getFileCommitsMeta(
         "--",
         relPath,
       ],
-      QUIET,
+      gitOpts(),
     ).trim();
     if (!output) return [];
     return parseCommitLog(output);

--- a/pages/lib/_nav-source-docs.ts
+++ b/pages/lib/_nav-source-docs.ts
@@ -117,12 +117,25 @@ export function resolveNavSource(
 ): NavSourceDocs {
   const sig = optionSig(options);
 
-  // --- Versioned (always EN base for the version; locale variant handled by
-  //     the versioned-locale route directly via resolveVersionedLocaleSource).
+  // --- Versioned. For a non-default locale the version IS configured for,
+  //     delegate to resolveVersionedLocaleSource so every nav surface uses the
+  //     SAME version-scoped locale-first merge the page body / route
+  //     enumeration use (#1909) — keeping nav labels and locale-only version
+  //     pages in sync. Otherwise (default locale, or the version not configured
+  //     for this locale) fall back to the version's EN base collection.
   if (currentVersion) {
-    const collectionName = `docs-v-${currentVersion}`;
     const versionConfig = settings.versions?.find((v) => v.slug === currentVersion);
-    const docs = stableDocs(collectionName);
+    const localeDir = versionConfig?.locales?.[lang]?.dir;
+    if (lang !== defaultLocale && localeDir) {
+      return resolveVersionedLocaleSource(
+        currentVersion,
+        versionConfig?.docsDir ?? settings.docsDir,
+        lang,
+        localeDir,
+        options,
+      );
+    }
+    const docs = stableDocs(`docs-v-${currentVersion}`);
     const categoryMeta = loadCategoryMeta(versionConfig?.docsDir ?? settings.docsDir);
     const navDocs = stableNavDocs(docs);
     return { docs, navDocs, categoryMeta, localeSlugSet: EMPTY_SLUG_SET as Set<string> };

--- a/src/__tests__/pages-lib/nav-source-versioned-locale.test.ts
+++ b/src/__tests__/pages-lib/nav-source-versioned-locale.test.ts
@@ -1,0 +1,166 @@
+/**
+ * nav-source-versioned-locale.test.ts
+ *
+ * Regression coverage for #1909: the versioned branch of `resolveNavSource`
+ * used to ALWAYS return the base EN collection `docs-v-${version}` and base
+ * category meta, ignoring `lang`. So on a versioned-locale page the header /
+ * mobile / desktop nav showed untranslated labels and missed locale-only
+ * version pages, while the body (built via `resolveVersionedLocaleSource`) was
+ * localized.
+ *
+ * The fix delegates the versioned + non-default-locale case (when the version
+ * is configured for that locale) to the SAME `resolveVersionedLocaleSource`
+ * the page body / route enumeration use, so every nav surface agrees with the
+ * body. This test asserts:
+ *   (a) locale-first merge with base EN fallback for a configured version-locale
+ *   (b) referential stability (memoization) across repeated identical calls
+ *   (c) base-fallback behavior preserved when the version has NO locale config
+ *
+ * zfb/content (getCollection / getContentSnapshot) is a build-time runtime
+ * module unavailable in Node, so it is mocked. `settings.versions` is mutated
+ * per-test (and restored) rather than mocking the whole settings module — i18n
+ * and the merge helpers read many other settings fields, so the real object is
+ * kept intact and only `versions` is swapped.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// zfb/content mock
+//
+// getContentSnapshot returns a stable snapshot whose per-collection arrays are
+// DISTINCT references. `stableDocs` (pages/lib/_nav-source-cache.ts) keys its
+// bridged-array WeakMap on `getContentSnapshot().collections[name]` as the
+// anchor object; with a snapshot installed it memoizes, giving the referential
+// stability this test asserts. Distinct anchor arrays per collection are
+// required — a shared array would collide in the WeakMap and make base + locale
+// resolve to the same bridged array.
+// ---------------------------------------------------------------------------
+
+const SNAPSHOT = {
+  collections: {
+    "docs-v-1.0": [{}],
+    "docs-v-1.0-ja": [{}],
+  } as Record<string, readonly unknown[]>,
+};
+
+vi.mock("zfb/content", () => ({
+  getCollection: vi.fn((_name: string) => []),
+  getContentSnapshot: vi.fn(() => SNAPSHOT),
+}));
+
+import { getCollection } from "zfb/content";
+const mockGetCollection = getCollection as ReturnType<typeof vi.fn>;
+
+import { settings } from "@/config/settings";
+import type { VersionConfig } from "@/config/settings";
+import { resolveNavSource } from "../../../pages/lib/_nav-source-docs";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type EntryData = { title?: string; slug?: string; unlisted?: boolean; draft?: boolean };
+
+/** Build a minimal collection entry. slug is the zfb raw slug (pre-bridge). */
+function makeEntry(slug: string, data: EntryData = {}) {
+  return { slug, data: { title: slug, ...data } };
+}
+
+const VERSION_WITH_JA: VersionConfig = {
+  slug: "1.0",
+  label: "1.0.0",
+  docsDir: "src/content/docs-v1",
+  locales: { ja: { dir: "src/content/docs-v1-ja" } },
+};
+
+const VERSION_NO_LOCALES: VersionConfig = {
+  slug: "1.0",
+  label: "1.0.0",
+  docsDir: "src/content/docs-v1",
+};
+
+let savedVersions: typeof settings.versions;
+
+beforeEach(() => {
+  savedVersions = settings.versions;
+  mockGetCollection.mockReset();
+  mockGetCollection.mockImplementation((name: string) => {
+    if (name === "docs-v-1.0-ja") {
+      return [makeEntry("intro", { title: "JA intro" })];
+    }
+    if (name === "docs-v-1.0") {
+      return [makeEntry("intro", { title: "EN intro" }), makeEntry("guide", { title: "EN guide" })];
+    }
+    return [];
+  });
+});
+
+afterEach(() => {
+  settings.versions = savedVersions;
+});
+
+// ---------------------------------------------------------------------------
+// (a) Versioned non-default locale, version configured for that locale:
+//     locale-first merge with base EN fallback.
+// ---------------------------------------------------------------------------
+
+describe("resolveNavSource — versioned + non-default locale (configured)", () => {
+  it("merges the version-locale collection over the version's EN base", () => {
+    settings.versions = [VERSION_WITH_JA];
+
+    const { docs, localeSlugSet } = resolveNavSource("ja", "1.0", {
+      applyDefaultLocaleOnlyFilter: true,
+      keepUnlisted: true,
+    });
+
+    const slugs = docs.map((d) => d.data.slug ?? d.id);
+    // "intro" comes from the JA collection; "guide" falls back to EN base.
+    expect(slugs).toContain("intro");
+    expect(slugs).toContain("guide");
+    // No duplicate "intro" — locale wins over base for the shared slug.
+    expect(slugs.filter((s) => s === "intro").length).toBe(1);
+    // localeSlugSet tracks which slugs came from the locale collection.
+    expect(localeSlugSet.has("intro")).toBe(true);
+    expect(localeSlugSet.has("guide")).toBe(false);
+  });
+
+  it("returns identity-stable docs / navDocs / categoryMeta across calls", () => {
+    settings.versions = [VERSION_WITH_JA];
+
+    const opts = { applyDefaultLocaleOnlyFilter: true, keepUnlisted: true };
+    const first = resolveNavSource("ja", "1.0", opts);
+    const second = resolveNavSource("ja", "1.0", opts);
+
+    // Memoization (#1902 / #1909): repeated calls with identical logical inputs
+    // must return the SAME instances so buildNavTree's identity fast-path holds.
+    expect(second.docs).toBe(first.docs);
+    expect(second.navDocs).toBe(first.navDocs);
+    expect(second.categoryMeta).toBe(first.categoryMeta);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (b) Versioned non-default locale, version NOT configured for that locale:
+//     existing base-fallback behavior preserved (the regression an
+//     unconditional delegate would cause — case 3).
+// ---------------------------------------------------------------------------
+
+describe("resolveNavSource — versioned + non-default locale (not configured)", () => {
+  it("falls back to the version's EN base collection (no locale merge)", () => {
+    settings.versions = [VERSION_NO_LOCALES];
+
+    const { docs, localeSlugSet } = resolveNavSource("ja", "1.0", {
+      applyDefaultLocaleOnlyFilter: true,
+      keepUnlisted: true,
+    });
+
+    const slugs = docs.map((d) => d.data.slug ?? d.id);
+    // Raw EN base — both EN entries, with their EN titles, no JA override.
+    expect(slugs).toContain("intro");
+    expect(slugs).toContain("guide");
+    expect(docs.find((d) => (d.data.slug ?? d.id) === "intro")?.data.title).toBe("EN intro");
+    // Base single-collection case carries an empty localeSlugSet.
+    expect(localeSlugSet.size).toBe(0);
+  });
+});


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/1907
    - https://github.com/zudolab/zudo-doc/issues/1909

---

## Summary

Two independent `agent-found` bug fixes from the Epic #1884 S19 backlog sweep, developed as parallel topics and merged into this base branch.

### #1907 — doc-history CLI returned 0 entries via `pnpm --filter` (CWD-relative git pathspec bug)

`packages/doc-history-server/src/git-history.ts` built repo-relative git pathspecs (via `toRepoRelative()`) but ran every `git` command **without a `cwd`**, so they executed in `process.cwd()`. Under `pnpm --filter <pkg>` (the form CI's `build-history` job uses), CWD is the package dir, so `git log -- <repo-relative-path>` matched nothing → 0 entries.

**Fix:** added a `gitOpts()` helper that pins `cwd: getRepoRoot()` and applied it to all 12 git invocations (`log --follow`, `log --reverse`, `log -1`, `git show`, rename-detection fallbacks, `cat-file --batch`, metadata log). A new unit test (`src/__tests__/git-history.test.ts`) asserts every git call receives the repo root as cwd.

**Verified:** from the package dir, pre-fix = 0 entries, post-fix = 415 entries — matching a repo-root run exactly. Package vitest suite green (30 tests, 7 new); `pnpm check` green.

> Note: this bug caused the `build-history` CI job to silently emit empty per-page history JSON (it still exits 0). The *visible* Created/Updated/Author block is unaffected (it comes from `build-site`'s preBuild, which runs from the repo root). Expect the **history dropdown to start populating** after this lands — intended effect, not a regression.

### #1909 — versioned nav source ignored per-version locales

`resolveNavSource` (in `pages/lib/_nav-source-docs.ts`) always returned the base EN `docs-v-${version}` collection for versioned routes, ignoring `lang`. On a versioned-locale page the body/breadcrumbs were localized but header/sidebar nav showed untranslated labels and missed locale-only version pages.

**Fix:** for a non-default locale the version is configured for (`versionConfig?.locales?.[lang]?.dir`), delegate to the existing `resolveVersionedLocaleSource` — the same resolver the page body and route enumeration use — so nav and body agree *structurally* (same function, same memo key) rather than via a hand-copied parallel that could drift. Otherwise the base EN behavior is preserved. The `create-zudo-doc` template counterpart was synced identically; `#1902` identity-stable memoization is preserved. New unit test covers locale-first merge, base fallback, and referential identity.

**Verified:** `pnpm check` green, `pnpm check:template-drift` green, new unit test green (red against the old behavior).

## Review

`/deep-review` → `/codex-review` (codex backend). One [P1] finding — "rebuild the committed dist" — was investigated and is a **false positive**: `dist/` is gitignored and untracked (no committed artifact), and both CI deploy workflows run `generate` = `tsx src/cli.ts` (source), so the source fix runs directly in CI; npm publishes rebuild dist via tsup. No dist commit is needed (and would violate the repo's gitignore design).

## Topics
- `agent-found-fixes/dochistory-cwd` — #1907 (commit b38a85af)
- `agent-found-fixes/versioned-nav-locales` — #1909 (commit 7cf6057d)