### PR TITLE
fix(doc-history): adopt clean content-dir form in CI + fail-loud path resolution (#1913)

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -179,8 +179,8 @@ jobs:
       - name: Generate doc history
         run: |
           pnpm --filter @takazudo/zudo-doc-history-server generate \
-            --content-dir ../../src/content/docs \
-            --locale ja:../../src/content/docs-ja \
+            --content-dir src/content/docs \
+            --locale ja:src/content/docs-ja \
             --out-dir ../../doc-history-out
 
       - name: Cache doc history output

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -316,8 +316,8 @@ jobs:
       - name: Generate doc history
         run: |
           pnpm --filter @takazudo/zudo-doc-history-server generate \
-            --content-dir ../../src/content/docs \
-            --locale ja:../../src/content/docs-ja \
+            --content-dir src/content/docs \
+            --locale ja:src/content/docs-ja \
             --out-dir ../../doc-history-out
 
       - name: Cache doc history output

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -169,8 +169,8 @@ jobs:
       - name: Generate doc history
         run: |
           pnpm --filter @takazudo/zudo-doc-history-server generate \
-            --content-dir ../../src/content/docs \
-            --locale ja:../../src/content/docs-ja \
+            --content-dir src/content/docs \
+            --locale ja:src/content/docs-ja \
             --out-dir ../../doc-history-out
 
       - name: Cache doc history output

--- a/packages/doc-history-server/CLAUDE.md
+++ b/packages/doc-history-server/CLAUDE.md
@@ -54,7 +54,7 @@ Root `pnpm dev` runs both the zfb dev server and this server via `run-p`.
 - **Synchronous git** — `execFileSync` is acceptable for dev server (same as original integration). CI uses the CLI which is inherently sequential
 - **Repo-relative paths** — API responses use relative file paths to avoid leaking absolute server paths
 - **`--follow` for renames** — tracks file history across renames with multiple fallback strategies
-- **pnpm --filter paths** — when run via `pnpm --filter`, CWD is the package dir, so content paths need `../../` prefix for repo-relative resolution in CI
+- **pnpm --filter paths** — when run via `pnpm --filter`, `process.cwd()` is the package dir, but pnpm sets `INIT_CWD` to where pnpm was invoked (the repo root). `resolveContentPath` resolves relative `--content-dir` / `--locale` paths against `INIT_CWD`, so pass the clean repo-root-relative form (`src/content/docs`, `ja:src/content/docs-ja`) with NO `../../` prefix — the same form `dev:history` and CI's `build-history` use. A path that resolves to a non-existent directory is a hard error (exit 1), not a silent zero-entry run (#1907 / #1913). `--out-dir` is the exception: it is stored verbatim (not resolved via `INIT_CWD`), so CI keeps `../../doc-history-out` to write the artifact at the repo root.
 
 ## CLI Arguments
 

--- a/packages/doc-history-server/src/__tests__/args.test.ts
+++ b/packages/doc-history-server/src/__tests__/args.test.ts
@@ -1,4 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// resolveContentPath (args.ts) now requires resolved content/locale paths to
+// exist (fail-loud, #1913). These are ARGUMENT-PARSING tests, not filesystem
+// tests, so mock existsSync to decouple them from the real content dirs / CWD.
+// Individual tests flip it to false to exercise the fail-loud branch.
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return { ...actual, existsSync: vi.fn(() => true) };
+});
+
+import { existsSync } from "node:fs";
 import { parseCliArgs, parseServerArgs } from "../args.js";
 
 beforeEach(() => {
@@ -6,6 +17,8 @@ beforeEach(() => {
     throw new Error(`process.exit(${code})`);
   });
   vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.mocked(existsSync).mockReturnValue(true); // default: resolved paths exist
 });
 
 afterEach(() => {
@@ -130,6 +143,18 @@ describe("parseCliArgs", () => {
     ).toThrow("process.exit(1)");
     expect(console.error).toHaveBeenCalledWith(
       "Unknown option: --unknown-flag",
+    );
+  });
+
+  it("exits with error when --content-dir does not resolve to an existing directory", () => {
+    // Fail-loud guard (#1913): a content path that resolves to a missing dir
+    // must hard-error instead of silently producing zero history entries.
+    vi.mocked(existsSync).mockReturnValue(false);
+    expect(() =>
+      parseCliArgs(["--content-dir", "does/not/exist", "--out-dir", "dist"]),
+    ).toThrow("process.exit(1)");
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("did not resolve to an existing directory"),
     );
   });
 });

--- a/packages/doc-history-server/src/args.ts
+++ b/packages/doc-history-server/src/args.ts
@@ -9,21 +9,33 @@ export interface LocaleEntry {
 }
 
 /**
- * Resolve a potentially-relative content path.
+ * Resolve a relative content/locale path to an absolute, existing directory.
  *
  * When invoked via `pnpm --filter <pkg>`, process.cwd() is the package
- * directory, not the repo root. INIT_CWD is set by pnpm to the directory
- * where pnpm was originally invoked — typically the repo root — so relative
- * paths like "src/content/docs" resolve correctly without requiring "../../"
- * prefixes in the root package.json scripts.
+ * directory, not the repo root. pnpm sets INIT_CWD to the directory where pnpm
+ * was originally invoked — typically the repo root — so the canonical clean
+ * form "src/content/docs" resolves correctly via INIT_CWD without any "../../"
+ * prefix. CI (`build-history`) and `dev:history` both pass this clean form.
  *
  * Resolution order:
  *   1. Absolute path → use as-is
  *   2. Relative + INIT_CWD set + resolves to an existing directory → use that
- *   3. Relative + fallback to process.cwd()
+ *   3. Relative → fall back to process.cwd()
+ *
+ * The resolved path MUST be an existing directory. A non-existent path is a
+ * HARD error (exit 1), not a silent fallthrough: scanning a missing dir yields
+ * zero history entries while the process still exits 0, hiding a misconfigured
+ * `--content-dir` behind a green CI run (the silent-empty-history class behind
+ * #1907 / #1913). Failing loud turns that into a visible CI failure.
  */
 export function resolveContentPath(p: string): string {
-  if (isAbsolute(p)) return p;
+  if (isAbsolute(p)) {
+    if (!existsSync(p)) {
+      console.error(`doc-history-server: content path "${p}" does not exist`);
+      process.exit(1);
+    }
+    return p;
+  }
   const initCwd = process.env["INIT_CWD"];
   if (initCwd) {
     const candidate = resolve(initCwd, p);
@@ -33,7 +45,16 @@ export function resolveContentPath(p: string): string {
       `doc-history-server: INIT_CWD candidate "${candidate}" does not exist; falling back to process.cwd()`,
     );
   }
-  return resolve(p);
+  const fallback = resolve(p);
+  if (!existsSync(fallback)) {
+    console.error(
+      `doc-history-server: content path "${p}" did not resolve to an existing directory ` +
+        `(tried INIT_CWD=${initCwd ? `"${initCwd}"` : "(unset)"}, cwd="${process.cwd()}"). ` +
+        `Pass a repo-root-relative path (pnpm sets INIT_CWD) or an absolute path.`,
+    );
+    process.exit(1);
+  }
+  return fallback;
 }
 
 /** Safely get the next argument, or exit with an error if missing */


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/1913

---

## Summary

Resolves #1913. CI's `build-history` passed `../../src/content/docs`, which only resolved via `resolveContentPath`'s `process.cwd()` fallback and logged a spurious `INIT_CWD candidate ... does not exist; falling back to process.cwd()` warning on every run — contradicting `args.ts`'s INIT_CWD design (and `dev:history`, which already uses the clean form).

Adopts the clean form everywhere **and** adds a fail-loud safety net so the silent-empty-history failure class (same class as #1907) cannot recur.

## Changes

- **CI** (`main-deploy.yml`, `preview-deploy.yml`): `build-history` now passes the clean repo-root-relative form `--content-dir src/content/docs --locale ja:src/content/docs-ja` — `INIT_CWD` (set by pnpm to the repo root) resolves it, no warning. `--out-dir ../../doc-history-out` is unchanged (it's stored verbatim, not resolved via `resolveContentPath`).
- **`args.ts` `resolveContentPath`**: now **fails loud** (`console.error` + `exit 1`) when a content/locale path doesn't resolve to an existing directory — both the absolute-path branch and the `process.cwd()` fallback. Previously a missing dir silently produced zero history entries while exiting 0 (green CI hiding a broken `build-history`). Docstring updated.
- **`args.test.ts`**: mock `existsSync` so argument-parsing tests are CWD-independent; new test asserts a non-existent `--content-dir` hard-errors.
- **`doc-history-server/CLAUDE.md`**: the "pnpm --filter paths" note now documents the clean form + INIT_CWD + the fail-loud behavior (the old `../../`-required claim is removed).

## Verification

- Clean form from repo root → **217 files / 808 entries**, no INIT_CWD warning.
- Bogus `--content-dir` → **exit 1** with "did not resolve to an existing directory".
- Package vitest: **31 passed** (args 12, incl. the new fail-loud test). `pnpm check` + package `typecheck` green. Codex review: no actionable regressions.