### PR TITLE
review-loop(main): fail-loud doc-history CI + 2 safe hardening fixes

### DIFF
--- a/packages/create-zudo-doc/templates/base/pages/lib/_nav-source-cache.ts
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_nav-source-cache.ts
@@ -136,8 +136,9 @@ export function memoizeDerived<T>(
     derivedMemo.set(primary, sub);
   }
   const key = `${inputs.map((a) => idOf(a)).join("/")}::${optionSig}`;
-  const hit = sub.get(key);
-  if (hit !== undefined) return hit as T;
+  // Use has(): a legitimately-`undefined` computed result must still register
+  // as a cache hit, otherwise it recomputes every call.
+  if (sub.has(key)) return sub.get(key) as T;
   const computed = compute();
   sub.set(key, computed);
   return computed;

--- a/packages/doc-history-server/src/cli.ts
+++ b/packages/doc-history-server/src/cli.ts
@@ -44,7 +44,7 @@ async function generate(options: {
   locales: Array<{ key: string; dir: string }>;
   outDir: string;
   maxEntries: number;
-}): Promise<void> {
+}): Promise<number> {
   const { contentDir, locales, outDir, maxEntries } = options;
   const startTime = performance.now();
 
@@ -94,6 +94,8 @@ async function generate(options: {
   console.log(
     `\nGenerated ${totalFiles} history files in ${elapsed}s${errorCount ? ` (${errorCount} errors)` : ""}`,
   );
+
+  return errorCount;
 }
 
 const options = parseCliArgs(process.argv.slice(2));
@@ -101,4 +103,21 @@ console.log(`doc-history-server: content-dir resolved to ${options.contentDir}`)
 for (const locale of options.locales) {
   console.log(`doc-history-server: locale ${locale.key} resolved to ${locale.dir}`);
 }
-generate(options);
+generate(options)
+  .then((errorCount) => {
+    // Fail loud, not silent: a partial git failure must not ship incomplete
+    // doc-history JSON behind a green CI (same fail-loud intent as args.ts /
+    // #1907 / #1913).
+    if (errorCount > 0) {
+      console.error(
+        `doc-history-server: ${errorCount} file(s) failed to generate — exiting non-zero so CI does not ship incomplete doc-history.`,
+      );
+      process.exit(1);
+    }
+  })
+  .catch((err) => {
+    console.error(
+      `doc-history-server: generation failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exit(1);
+  });

--- a/pages/api/ai-chat.tsx
+++ b/pages/api/ai-chat.tsx
@@ -233,9 +233,7 @@ function fireAuditLog(
   kv: MinimalKV,
   entry: AuditLogEntry,
 ): void {
-  const key = `audit:${entry.timestamp.slice(0, 10)}:${Date.now()}:${Math.random()
-    .toString(36)
-    .slice(2, 8)}`;
+  const key = `audit:${entry.timestamp.slice(0, 10)}:${Date.now()}:${crypto.randomUUID()}`;
   waitUntil(
     kv
       .put(key, JSON.stringify(entry), { expirationTtl: 7 * 24 * 60 * 60 })

--- a/pages/lib/_nav-source-cache.ts
+++ b/pages/lib/_nav-source-cache.ts
@@ -136,8 +136,9 @@ export function memoizeDerived<T>(
     derivedMemo.set(primary, sub);
   }
   const key = `${inputs.map((a) => idOf(a)).join("/")}::${optionSig}`;
-  const hit = sub.get(key);
-  if (hit !== undefined) return hit as T;
+  // Use has(): a legitimately-`undefined` computed result must still register
+  // as a cache hit, otherwise it recomputes every call.
+  if (sub.has(key)) return sub.get(key) as T;
   const computed = compute();
   sub.set(key, computed);
   return computed;


### PR DESCRIPTION
Automated `/review-loop 2` (full-project Review-PR mode) against `main`. Two rounds of Opus reviewers + codex (standard & adversarial).

## Fixes committed here (Round 1 — clearly-harmful + safely-contained)

- **`doc-history-server/src/cli.ts` — fail loud on partial git-history failure (genuine bug).** The CI `generate` command caught per-file git failures into `errorCount` but always exited 0, and the top-level `generate(options)` call was unawaited with no `.catch` — a partial git failure shipped incomplete doc-history JSON behind a green CI. Now returns the error count, exits non-zero when any file fails, and surfaces top-level rejections with exit 1. Matches the established fail-loud policy (#1907/#1913). CI runs `tsx src/cli.ts` directly (dist is gitignored), so the source fix is effective with no rebuild.
- **`nav-source-cache.ts` `memoizeDerived` — `hit !== undefined` → `sub.has(key)`** so a legitimately-`undefined` computed result registers as a cache hit instead of recomputing each call. Behavior-identical today (computes return arrays). Applied to both the repo file and its `create-zudo-doc` template (verified no template drift).
- **`ai-chat.tsx` audit-log key — `Math.random()` → `crypto.randomUUID()`** to avoid silent same-millisecond key overwrites.

Verified: root `zfb check`, doc-history-server typecheck, template-drift, and the 31 doc-history-server tests all pass.

## Round 2 = verification pass (no new fixes)

Round 1 already took the clearly-harmful-and-safe items, so Round 2 adversarially verified the remaining bug-claims before filing them. Outcomes:

- A reviewer's `nav-scope.ts` "hardening" was a **false positive** — the bare `startsWith` is intentional prefix grouping (`claude` / `claude-agents` / `claude-md` / `claude-skills` all map to `categoryMatch: "claude"`). Not changed.
- Confirmed the find-* island cluster is **dead code**, so a perf finding against `find-bar.tsx` is moot (folded into the dead-code issue).
- Confirmed versioned-docs (`/v/`) issues are live, the `DocMetainfoArea` route drift is real, and `pre-build.ts` git serialization is real.

## Deferred (needs-consideration) → filed as `agent-found` issues

#1923 dead-code sweep · #1916 versioned-docs correctness · #1917 route-file dedup · #1918 rate-limiter/CORS dedup · #1919 single-source lists · #1920 doc-history build perf · #1921 ai-chat prompt-caching · #1922 hardening batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
