### PR TITLE
chore(deps): bump zfb pins to 0.1.0-next.31 across all five pin sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,9 +67,9 @@
   "dependencies": {
     "@shikijs/transformers": "^4.0.1",
     "@takazudo/zdtp": "0.2.0-next.2",
-    "@takazudo/zfb": "0.1.0-next.30",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.30",
-    "@takazudo/zfb-runtime": "0.1.0-next.30",
+    "@takazudo/zfb": "0.1.0-next.31",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.31",
+    "@takazudo/zfb-runtime": "0.1.0-next.31",
     "@types/hast": "^3.0.4",
     "@takazudo/zudo-doc-md-plugins": "workspace:*",
     "@takazudo/zudo-doc": "workspace:*",

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -2723,14 +2723,19 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
    * next.28). next.29 (PR #1910): islands code-splitting
    * (dynamic import() boundaries become self-hashed chunks), dev-server route
    * pruning/SSR-reload fixes, and a symlink-safe outdir wipe at build start.
-   * Now bumped to 0.1.0-next.30 (PR #1910): adds Next.js-style `[[...slug]]`
+   * Bumped to 0.1.0-next.30 (PR #1910): adds Next.js-style `[[...slug]]`
    * optional-catchall route syntax (Takazudo/zudo-front-builder#812) and raises
    * the zfb-runtime hono floor to ^4.12.23, clearing 9 known advisories (#813);
    * plus two router hardening fixes (overlapping-sibling rejection #816,
    * per-segment rank sort for dev/prod parity) — no consumer-facing breaking
-   * change. Generated package.json must pin all three.
+   * change. Now bumped to 0.1.0-next.31: CSS-pipeline and islands-scanner fixes
+   * (authored-CSS path when Tailwind is disabled, reproducible CSS-Modules
+   * scoped names via project-relative paths, dev-mode git-restore detection,
+   * Tailwind temp-file cleanup, near-miss `"use client"` directive scanner) —
+   * no consumer-facing breaking change. Generated package.json must pin all
+   * three.
    */
-  it("pins @takazudo/zfb at 0.1.0-next.30", async () => {
+  it("pins @takazudo/zfb at 0.1.0-next.31", async () => {
     const choices: UserChoices = {
       projectName: "test-pin-bump",
       defaultLang: "en",
@@ -2741,10 +2746,10 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
     };
     await scaffold(choices);
     const pkg = await fs.readJson(projectPath("test-pin-bump", "package.json"));
-    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.30");
-    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.30");
+    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.31");
+    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.31");
     expect(pkg.dependencies["@takazudo/zfb-adapter-cloudflare"]).toBe(
-      "0.1.0-next.30",
+      "0.1.0-next.31",
     );
   });
 });

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -322,11 +322,16 @@ function generatePackageJson(choices: UserChoices) {
     // hono floor to ^4.12.23, clearing 9 advisories (#813); also two router
     // hardening fixes (overlapping-sibling rejection #816, per-segment rank
     // sort for dev/prod parity). No consumer-facing breaking change.
-    "@takazudo/zfb": "0.1.0-next.30",
-    "@takazudo/zfb-runtime": "0.1.0-next.30",
+    // Bumped to next.31 — CSS-pipeline and islands-scanner fixes (no
+    // consumer-facing breaking change): authored-CSS path when Tailwind is
+    // disabled, reproducible CSS-Modules scoped names (project-relative paths),
+    // dev-mode git-restore detection, Tailwind temp-file cleanup, and a
+    // near-miss `"use client"` directive scanner.
+    "@takazudo/zfb": "0.1.0-next.31",
+    "@takazudo/zfb-runtime": "0.1.0-next.31",
     // zfb-adapter-cloudflare — required for any route with `prerender = false`.
     // Pinned in lockstep with @takazudo/zfb.
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.30",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.31",
     // @takazudo/zudo-doc — published from this monorepo via
     // .github/workflows/publish-zudo-doc.yml. The pin here is bumped in
     // lockstep by scripts/release-create-zudo-doc.sh whenever zudo-doc's

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -165,8 +165,8 @@
   ],
   "peerDependencies": {
     "preact": "^10.29.1",
-    "@takazudo/zfb": "^0.1.0-next.30",
-    "@takazudo/zfb-runtime": "^0.1.0-next.30",
+    "@takazudo/zfb": "^0.1.0-next.31",
+    "@takazudo/zfb-runtime": "^0.1.0-next.31",
     "@takazudo/zudo-doc-history-server": "workspace:^",
     "@takazudo/zdtp": "^0.2.0-next.2"
   },
@@ -189,7 +189,7 @@
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
     "vitest": "^3.0.0",
-    "@takazudo/zfb": "0.1.0-next.30",
-    "@takazudo/zfb-runtime": "0.1.0-next.30"
+    "@takazudo/zfb": "0.1.0-next.31",
+    "@takazudo/zfb-runtime": "0.1.0-next.31"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,14 +20,14 @@ importers:
         specifier: 0.2.0-next.2
         version: 0.2.0-next.2(preact@10.29.2)
       '@takazudo/zfb':
-        specifier: 0.1.0-next.30
-        version: 0.1.0-next.30
+        specifier: 0.1.0-next.31
+        version: 0.1.0-next.31
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.30
-        version: 0.1.0-next.30
+        specifier: 0.1.0-next.31
+        version: 0.1.0-next.31
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.30
-        version: 0.1.0-next.30(@takazudo/zfb@0.1.0-next.30)
+        specifier: 0.1.0-next.31
+        version: 0.1.0-next.31(@takazudo/zfb@0.1.0-next.31)
       '@takazudo/zudo-doc':
         specifier: workspace:*
         version: link:packages/zudo-doc
@@ -298,11 +298,11 @@ importers:
         version: 4.0.3
     devDependencies:
       '@takazudo/zfb':
-        specifier: 0.1.0-next.30
-        version: 0.1.0-next.30
+        specifier: 0.1.0-next.31
+        version: 0.1.0-next.31
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.30
-        version: 0.1.0-next.30(@takazudo/zfb@0.1.0-next.30)
+        specifier: 0.1.0-next.31
+        version: 0.1.0-next.31(@takazudo/zfb@0.1.0-next.31)
       '@types/node':
         specifier: ^25.3.5
         version: 25.3.5
@@ -1593,44 +1593,44 @@ packages:
     peerDependencies:
       preact: ^10.29.1
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.30':
-    resolution: {integrity: sha512-yKbQ6fgOMlm1eTwrAXCuTh5ca4vUgO3wSEfjeMwx6vyanBIQAG6u5QjQR6QyNnONJboFhLAe5MhP7S3B8oi4yw==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.31':
+    resolution: {integrity: sha512-pNmr3P8OU8kw7cS5rfYDrZiy9emhGOx3HNpSpC23TopwxPlhWBmfwqCndhe76G0CiGH6UNEPNgRQ7mKntrqglQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.30':
-    resolution: {integrity: sha512-TOKRhLU0yD7KQggTlAAytXJ47ipHV83DxwDU+cd1H3u7ij69GhroAlkQwXJikFm09IASX7oUNdq6Aq4EcnfAlg==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.31':
+    resolution: {integrity: sha512-Pt6iXcy302mi4F3GiOXgk1s728jvzyV/ZBHSb1fdaAYocpnmjT1w2UIxiL7U8qAEmLyEypbL4gAkXfxgG7WGrA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.30':
-    resolution: {integrity: sha512-ei+LtKoLSiLePX5a51NAup+R5uhL40Y9c+KlU4t5dX6FvwmOg0Fu4MDzmbEh5fEelsiCQQ6TgI02XAlyHrTNnQ==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.31':
+    resolution: {integrity: sha512-BJltKp/sRhEUOIEjXlBw3OxXzu34ky5uNeuu2lEeed9Qy0N5AGUMZwarrNI5D/4RHzbqv2Xwj7or5AqrnJa2Gg==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.30':
-    resolution: {integrity: sha512-P7VQH8m87uboA6nsf4K9X48PJ86pHPVYI6zS/5eY8y7pPn6Z0H9vXbC8wkx9lwPnPuo+j63VySxtDqEhVRGpvA==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.31':
+    resolution: {integrity: sha512-q5t0w6vnfb+oA/J/HYKsKaad6BrfqHd+sFOsq8nkkqIUP2c0Yl7md3hhyGMqeKVSwj8jQlXddcdsK5nZiaoRgA==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.30':
-    resolution: {integrity: sha512-iyzeJoXaJcwP3hhsjZc5OJ5hRacjiTa2QKj0Vh0OOpJ+YqOkUDVMMI677e+W6FV+qx95qeJ/nYqzErdSptFkGw==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.31':
+    resolution: {integrity: sha512-zKRg2oIMBXzP7JheXRnzgZPtXKymgvQP+EtxC/Zm6t/8mpv2WoCGyvlel3dRhk+rChU2AgpGIvzh+Ne/npJF+w==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.30':
-    resolution: {integrity: sha512-43R5WMCoI38YOyJo7lCL87CwmQZlf1rmc8cMstuK+9kEu2ADBAfpNVSqrvfrffQmDIbG+iIq1gzOO987iaBwTQ==}
+  '@takazudo/zfb-runtime@0.1.0-next.31':
+    resolution: {integrity: sha512-om6vpF8/EHuAtt4tQh1Iw1M8Ik1UIIIt7sQ06FyERJ9FzHLHKFkrUYh4VUlI+mmOydNm2hpsSzkDv0LJwDjoww==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.30
+      '@takazudo/zfb': 0.1.0-next.31
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.30':
-    resolution: {integrity: sha512-dkLPcunw7OVHVg8DezeGzY4waGvv7k72LAgGqT1AAOiFUt4XVUhi+zSVG1DMQ5+CnuAclRQmf8eE9ddR1+tttw==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.31':
+    resolution: {integrity: sha512-h1iqf0QQWI+2PnVqDA1qPWSpq5ffFEFecSLzpmEkKSZc9BqWJf1v6kt5sFgAevvPP6vZHdwpjHSLAp1yZDgung==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.30':
-    resolution: {integrity: sha512-+nMRVHG/1ngSKRsq7H+/bdHxBGIAL2izA2iDztr1c/IeqdHHapCWqtZTtnLmgOXrZLgpO+7CdK2vQfxABmPYfA==}
+  '@takazudo/zfb@0.1.0-next.31':
+    resolution: {integrity: sha512-ozdkn50w4UplGmvdWBG16xs6e82xxeLlgWmD+mdooRVjZ8amdDQxlY09uVqI/iS5n/6BzCpJ+KVcyqYfHuuKLQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
@@ -4594,35 +4594,35 @@ snapshots:
       culori: 4.0.2
       preact: 10.29.2
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.30': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.31': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.30':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.31':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.30':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.31':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.30':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.31':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.30':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.31':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.30(@takazudo/zfb@0.1.0-next.30)':
+  '@takazudo/zfb-runtime@0.1.0-next.31(@takazudo/zfb@0.1.0-next.31)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.30
+      '@takazudo/zfb': 0.1.0-next.31
       hono: 4.12.23
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.30':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.31':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.30':
+  '@takazudo/zfb@0.1.0-next.31':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.30
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.30
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.30
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.30
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.30
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.31
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.31
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.31
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.31
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.31
 
   '@takazudo/zudo-design-token-lint@1.0.0':
     dependencies:


### PR DESCRIPTION
## Summary

Bumps the zfb engine pins from `0.1.0-next.30` → `0.1.0-next.31` across the **five pin sources** that `scripts/check-pin-parity.mjs` enforces in lockstep. `next.31` is a CSS-pipeline / islands-scanner fix release with **no consumer-facing breaking change** (per the upstream changelog), so this is a mechanical dependency bump.

### What next.31 brings (upstream)
- `AuthoredCssEngine` path preserves authored global CSS + CSS Modules when `tailwind: { enabled: false }` (strips unresolvable `@import "tailwindcss"`).
- CSS-Modules scoped names now derive from **project-relative** module paths (forward-slash normalized) → identical sources hash identically across checkouts.
- `zfb dev` detects git-restored files (`git checkout` / `stash pop` / branch switch) instead of serving stale renders.
- Orphaned `zfb-tailwind-entry-*.css` temp files cleaned up before each Tailwind run.
- Islands scanner gains `ScanMeta.near_miss_candidates` (AST detection of malformed `"use client"` directives); empty-islands warning demoted to an info note unless real near-misses exist.

## Changes
- **Root `package.json`** — `@takazudo/zfb`, `-runtime`, `-adapter-cloudflare` → `0.1.0-next.31`
- **`packages/create-zudo-doc/src/scaffold.ts`** — generated-project pins → `next.31` (+ appended the `next.31` line to the running pin-lineage comment)
- **`packages/create-zudo-doc/src/__tests__/scaffold.test.ts`** — pin assertions + test name + lineage comment → `next.31`
- **`packages/zudo-doc/package.json`** — peerDeps `^0.1.0-next.31`, devDeps `0.1.0-next.31`
- **`pnpm-lock.yaml`** — regenerated (0 `next.30` entries remain)

## Test Plan
- `pnpm check:pin-parity` — green across all 9 fields (3 external + 2 internal + 4 workspace)
- `pnpm --filter create-zudo-doc test` — **256 generator tests pass**
- `pnpm b4push` — all 12 automated steps pass (format, template-drift, tags audit, token lint, typecheck, **build 254 pages**, link check, HTML validation, preview smoke 6/6); only the interactive manual-smoke step is N/A in an agent context
- On-disk verification: `node_modules/@takazudo/zfb*` all report `0.1.0-next.31`
- `/codex-review` — clean (pins consistent across all sources, no actionable findings)