### PR TITLE
TOC slug fidelity (#1938) + noUncheckedIndexedAccess & DocsEntry typing (#1926)

### DIFF
--- a/e2e/fixtures/i18n/src/config/settings.ts
+++ b/e2e/fixtures/i18n/src/config/settings.ts
@@ -27,6 +27,8 @@ export const settings = {
   docHistory: false,
   claudeResources: false as { claudeDir: string; projectRoot?: string } | false,
   defaultLocaleOnlyPrefixes: [] as string[],
+  tocMinDepth: 2 as number,
+  tocMaxDepth: 4 as number,
   headerNav: [
     {
       label: "Getting Started",

--- a/e2e/fixtures/sidebar/src/config/settings.ts
+++ b/e2e/fixtures/sidebar/src/config/settings.ts
@@ -24,6 +24,8 @@ export const settings = {
   docHistory: false,
   claudeResources: false as { claudeDir: string; projectRoot?: string } | false,
   defaultLocaleOnlyPrefixes: [] as string[],
+  tocMinDepth: 2 as number,
+  tocMaxDepth: 4 as number,
   headerNav: [
     {
       label: "Getting Started",

--- a/e2e/fixtures/smoke/src/config/settings.ts
+++ b/e2e/fixtures/smoke/src/config/settings.ts
@@ -43,6 +43,8 @@ export const settings = {
   } as HtmlPreviewConfig | undefined,
   claudeResources: false as { claudeDir: string; projectRoot?: string } | false,
   defaultLocaleOnlyPrefixes: [] as string[],
+  tocMinDepth: 2 as number,
+  tocMaxDepth: 4 as number,
   headerNav: [
     {
       label: "Getting Started",

--- a/e2e/fixtures/theme/src/config/settings.ts
+++ b/e2e/fixtures/theme/src/config/settings.ts
@@ -31,6 +31,8 @@ export const settings = {
   docHistory: false,
   claudeResources: false as { claudeDir: string; projectRoot?: string } | false,
   defaultLocaleOnlyPrefixes: [] as string[],
+  tocMinDepth: 2 as number,
+  tocMaxDepth: 4 as number,
   headerNav: [
     {
       label: "Getting Started",

--- a/e2e/fixtures/versioning/src/config/settings.ts
+++ b/e2e/fixtures/versioning/src/config/settings.ts
@@ -35,6 +35,8 @@ export const settings = {
   ] as VersionConfig[] | false,
   claudeResources: false as { claudeDir: string; projectRoot?: string } | false,
   defaultLocaleOnlyPrefixes: [] as string[],
+  tocMinDepth: 2 as number,
+  tocMaxDepth: 4 as number,
   headerNav: [
     {
       label: "Getting Started",

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -734,7 +734,8 @@ describe("scaffold — headerRightItems preset override (sub #440)", () => {
     );
     expect(match).toBeTruthy();
     // Block should be empty (whitespace only) — no fallback entries leaked in.
-    expect(match![1].trim()).toBe("");
+    const matchedBlock = match?.[1] ?? "";
+    expect(matchedBlock.trim()).toBe("");
     // Specifically, the legacy fallback's design-token-panel trigger must not
     // appear even though designTokenPanel is in the features list.
     expect(content).not.toContain('trigger: "design-token-panel"');

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -513,6 +513,24 @@ describe("scaffold — generated settings.ts content", () => {
     );
     expect(content).toContain("designTokenPanel: true");
   });
+
+  it("tocMinDepth and tocMaxDepth default to 2 and 4 in generated settings", async () => {
+    const choices: UserChoices = {
+      projectName: "test-toc-depth-defaults",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search"],
+      packageManager: "pnpm",
+    };
+    await scaffold(choices);
+    const content = await fs.readFile(
+      projectPath("test-toc-depth-defaults", "src/config/settings.ts"),
+      "utf-8",
+    );
+    expect(content).toContain("tocMinDepth: 2");
+    expect(content).toContain("tocMaxDepth: 4");
+  });
 });
 
 describe("scaffold — docHistory feature", () => {

--- a/packages/create-zudo-doc/src/settings-gen.ts
+++ b/packages/create-zudo-doc/src/settings-gen.ts
@@ -156,6 +156,9 @@ export function generateSettingsFile(choices: UserChoices): string {
     lines.push(`  designTokenPanel: false as boolean,`);
   }
 
+  lines.push(`  tocMinDepth: 2 as number,`);
+  lines.push(`  tocMaxDepth: 4 as number,`);
+
   if (choices.features.includes("sidebarResizer")) {
     lines.push(`  sidebarResizer: true as boolean,`);
   } else {

--- a/packages/create-zudo-doc/templates/base/pages/_data.ts
+++ b/packages/create-zudo-doc/templates/base/pages/_data.ts
@@ -13,6 +13,7 @@
 import { getCollection } from "zfb/content";
 import type { CollectionEntry } from "zfb/content";
 import type { DocsEntry } from "@/types/docs-entry";
+import type { DocPageEntry } from "./lib/doc-page-props";
 import { toRouteSlug } from "@/utils/slug";
 
 // ---------------------------------------------------------------------------
@@ -79,7 +80,7 @@ export type ZfbDocsEntry = CollectionEntry<ZfbDocsData> & {
  *   - `collection` — the collection name, for DocsEntry compat
  */
 export function getDocs(collectionName: string): ZfbDocsEntry[] {
-  const entries = getCollection(collectionName) as unknown as CollectionEntry<ZfbDocsData>[];
+  const entries = getCollection<ZfbDocsData>(collectionName);
   return entries.map((e) => ({
     ...e,
     // Astro-compat: strip a trailing `/index` from the entry id so
@@ -123,27 +124,43 @@ export function bridgeEntries<T = ZfbDocsData>(
 }
 
 /**
- * Cast ZfbDocsEntry[] to DocsEntry[] for passing to @/utils/docs utilities.
+ * Typed bridge from a raw zfb collection result to `DocPageEntry[]`.
  *
- * The types are structurally compatible: ZfbDocsEntry has every required field
- * of DocsEntry (id, collection, data, body). The optional `rendered` and
- * `filePath` fields of DocsEntry are absent but not required.
+ * This is the **single, justified** cast at the zfb/DocsEntry boundary.
+ * `CollectionEntry<ZfbDocsData> & { id, collection }` structurally satisfies
+ * `DocPageEntry` because:
+ *   - `id` and `collection` are added by `bridgeEntries`
+ *   - `data` (ZfbDocsData) structurally satisfies `DocsEntry.data` (all
+ *     required/optional fields are present; the index signature is wider)
+ *   - `body`, `slug`, `module_specifier`, `Content` are provided by
+ *     `CollectionEntry<ZfbDocsData>`
+ * The plain `as DocPageEntry[]` (not `as unknown as`) is intentional — it
+ * expresses that this is a well-understood structural subtype relationship,
+ * not an escape from the type system. The zfb type is the source of truth;
+ * DocsEntry/DocPageEntry are local compatibility shapes for @/utils/docs.
  */
-export function asDocsEntries(entries: ZfbDocsEntry[]): DocsEntry[] {
-  return entries as unknown as DocsEntry[];
+export function bridgeDocsEntries(
+  entries: ReadonlyArray<CollectionEntry<ZfbDocsData>>,
+  collectionName: string,
+): DocPageEntry[] {
+  return bridgeEntries(entries, collectionName) as DocPageEntry[];
 }
 
 /**
  * One-shot helper for paths()/render-time pages that just need a
- * `DocsEntry[]` for `@/utils/docs` consumption — wraps `getDocs` and
- * the `asDocsEntries` cast so call sites stay one-line. Use this from
- * any page that previously did
+ * `DocsEntry[]` for `@/utils/docs` consumption — wraps `getDocs` so
+ * call sites stay one-line. Use this from any page that previously did
  * `getCollection("docs") as unknown as DocsEntry[]` — that idiom
  * silently dropped the `id`/`collection` fields the utility helpers
  * read, which threw `Cannot read properties of undefined` at runtime.
+ *
+ * `ZfbDocsEntry` structurally satisfies `DocsEntry`: it carries `id`,
+ * `collection`, `data` (ZfbDocsData satisfies DocsEntry.data field-for-
+ * field), `body`, plus the zfb-specific extras (`slug`, `Content`, etc.)
+ * that DocsEntry does not require.
  */
 export function loadDocs(collectionName: string): DocsEntry[] {
-  return asDocsEntries(getDocs(collectionName));
+  return getDocs(collectionName);
 }
 
 /**

--- a/packages/create-zudo-doc/templates/base/pages/docs/[[...slug]].tsx
+++ b/packages/create-zudo-doc/templates/base/pages/docs/[[...slug]].tsx
@@ -22,7 +22,6 @@
 // Locale: defaultLocale (EN). Non-default locales are handled by
 // pages/[locale]/docs/[[...slug]].tsx.
 
-import type { DocsEntry } from "@/types/docs-entry";
 import { settings } from "@/config/settings";
 import { defaultLocale } from "@/config/i18n";
 import { docsUrl, absoluteUrl } from "@/utils/base";
@@ -83,9 +82,9 @@ export function paths(): Array<{
   const { docs, navDocs, categoryMeta } = resolveNavSource(locale, undefined);
 
   // Nav docs: exclude unlisted (for sidebar/prev-next) but keep for breadcrumbs
-  const tree = buildNavTree(navDocs as unknown as DocsEntry[], locale, categoryMeta);
+  const tree = buildNavTree(navDocs, locale, categoryMeta);
   // Full tree (including unlisted) for accurate breadcrumbs
-  const fullTree = buildNavTree(docs as unknown as DocsEntry[], locale, categoryMeta);
+  const fullTree = buildNavTree(docs, locale, categoryMeta);
 
   const result: Array<{ params: { slug: string[] }; props: DocPageProps }> = [];
 

--- a/packages/create-zudo-doc/templates/base/pages/lib/_extract-headings.ts
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_extract-headings.ts
@@ -8,14 +8,15 @@
 //
 // Algorithm:
 //   1. Walk the body line-by-line looking for ATX-style markdown headings
-//      (`# Text` through `###### Text`, h1–h6).
+//      (`## Text` through `###### Text`, h2–h6).
 //   2. Strip inline markdown markup (links, inline code, bold, italic) from the
 //      heading text to get the plain visible text — matching what the renderer's
 //      `extractText` HAST walker sees after MDX → HTML conversion.
 //   3. Compute a GitHub-compatible slug using the same `GithubSlugger` that
 //      the `rehype-heading-links` plugin uses at render time, advancing the
-//      shared counter for ALL h1–h6 (even those not emitted into the TOC)
-//      so TOC anchor hrefs match the rendered heading IDs in the HTML.
+//      shared counter for ALL h2–h6 (even those not emitted into the TOC)
+//      so TOC anchor hrefs match the rendered heading IDs in the HTML. h1 is
+//      NOT slugged — the renderer never assigns an id to h1 (it's the title).
 //   4. Return only depth 2–4 headings by default (h1 is the page title; h5–h6
 //      are too granular). The window is configurable via `tocMinDepth` /
 //      `tocMaxDepth` in settings (restriction-only: min 2, max 4).
@@ -103,8 +104,9 @@ function resolveDepthWindow(
  *
  * Uses the same slugging algorithm as `rehype-heading-links` so the
  * `href="#slug"` values in the TOC match the rendered heading element IDs.
- * Slugs ALL matched h1–h6 (advancing the shared dedup counter) but only
- * pushes depth 2–4 items into the result (configurable via settings).
+ * Slugs ALL matched h2–h6 (advancing the shared dedup counter) but only
+ * pushes depth 2–4 items into the result (configurable via settings). h1 is
+ * not matched — the renderer does not assign ids to h1.
  *
  * @param body - Raw markdown body string (frontmatter already stripped).
  * @param opts - Optional override for the depth window (used by tests only;
@@ -153,9 +155,12 @@ export function extractHeadings(
     }
     if (codeFenceOpener !== null) continue;
 
-    // Match ATX headings at any depth h1–h6. Allow one or more spaces/tabs
-    // after the hash characters (both are valid per the CommonMark spec).
-    const match = /^(#{1,6})[ \t]+(.+)$/.exec(line.trim());
+    // Match ATX headings at depth h2–h6. The renderer's heading-links plugin
+    // slugs h2–h6 only (h1 is never assigned an id — the frontmatter title is
+    // the page's h1), so matching h1 here would advance the shared dedup counter
+    // out of step with the renderer and break the TOC anchor for a same-text h2.
+    // Allow one or more spaces/tabs after the hashes (both valid per CommonMark).
+    const match = /^(#{2,6})[ \t]+(.+)$/.exec(line.trim());
     if (!match) continue;
 
     const hashes = match[1];

--- a/packages/create-zudo-doc/templates/base/pages/lib/_extract-headings.ts
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_extract-headings.ts
@@ -8,31 +8,37 @@
 //
 // Algorithm:
 //   1. Walk the body line-by-line looking for ATX-style markdown headings
-//      (`## Text`, `### Text`, `#### Text`).
+//      (`# Text` through `###### Text`, h1–h6).
 //   2. Strip inline markdown markup (links, inline code, bold, italic) from the
 //      heading text to get the plain visible text — matching what the renderer's
 //      `extractText` HAST walker sees after MDX → HTML conversion.
 //   3. Compute a GitHub-compatible slug using the same `GithubSlugger` that
-//      the `rehype-heading-links` plugin uses at render time, so the TOC
-//      anchor hrefs match the rendered heading IDs in the HTML.
-//   4. Return only depth 2–4 headings — depth 1 is the page title (rendered
-//      separately as an <h1>); depth 5–6 are too granular for the TOC.
+//      the `rehype-heading-links` plugin uses at render time, advancing the
+//      shared counter for ALL h1–h6 (even those not emitted into the TOC)
+//      so TOC anchor hrefs match the rendered heading IDs in the HTML.
+//   4. Return only depth 2–4 headings by default (h1 is the page title; h5–h6
+//      are too granular). The window is configurable via `tocMinDepth` /
+//      `tocMaxDepth` in settings (restriction-only: min 2, max 4).
 //
 // Caveats:
 //   - This is a regex walk over raw text, not an AST parse. MDX JSX expressions
-//     or code fences that contain `##` on their own line are matched. In
-//     practice this is rare.
-//   - Lines inside code fences (``` … ```) are skipped to avoid treating
-//     literal `## code` examples as real headings. Fence detection uses
-//     `line.trimStart()` to handle indented fences correctly.
+//     that contain `##` on their own line may be matched. In practice this is
+//     rare.
+//   - Lines inside code fences (``` … ``` or ~~~ … ~~~) are skipped to avoid
+//     treating literal `## code` examples as real headings. Fence detection
+//     uses `line.trimStart()` to handle indented fences correctly.
 //   - Reference-style links (`[text][id]`) and image links (`![alt](url)`)
 //     are not stripped — uncommon in headings, treated as plain text.
-//   - h5/h6 headings are slugged by `rehype-heading-links` but not extracted
-//     here. If a doc has h5/h6 text that duplicates an h2–h4, the shared
-//     GithubSlugger dedup counter diverges from the renderer's counter, so
-//     slugs may mismatch for such pages.
+//   - Slugger parity is counter-level (npm `github-slugger` vs zfb Rust) — the
+//     renderer slugs all h2–h6 regardless of `tocMinDepth`/`tocMaxDepth`, so
+//     this extractor must also slug all matched headings (including those outside
+//     the emit window) to keep the shared dedup counter in sync.
+//   - Residual risks: slugger-parity (npm `github-slugger` vs zfb Rust — an
+//     external-binary contract) and text-extraction parity (inline JSX / reference
+//     links not fully stripped).
 
 import GithubSlugger from "github-slugger";
+import { settings } from "../../src/config/settings";
 
 export interface HeadingItem {
   readonly depth: number;
@@ -69,53 +75,105 @@ function stripInlineMarkdown(raw: string): string {
 }
 
 /**
- * Extract depth-2/3/4 headings from a raw MDX/markdown body.
+ * Resolve and clamp the depth window from raw (possibly invalid) inputs.
+ *
+ * Enforces `2 <= min <= max <= 4`. If either value is NaN or the chain breaks,
+ * falls back to the full default window [2, 4].
+ */
+function resolveDepthWindow(
+  rawMin: unknown,
+  rawMax: unknown,
+): { lo: number; hi: number } {
+  const min = Math.trunc(Number(rawMin));
+  const max = Math.trunc(Number(rawMax));
+  if (
+    Number.isFinite(min) &&
+    Number.isFinite(max) &&
+    min >= 2 &&
+    min <= max &&
+    max <= 4
+  ) {
+    return { lo: min, hi: max };
+  }
+  return { lo: 2, hi: 4 };
+}
+
+/**
+ * Extract TOC headings from a raw MDX/markdown body.
  *
  * Uses the same slugging algorithm as `rehype-heading-links` so the
  * `href="#slug"` values in the TOC match the rendered heading element IDs.
+ * Slugs ALL matched h1–h6 (advancing the shared dedup counter) but only
+ * pushes depth 2–4 items into the result (configurable via settings).
  *
  * @param body - Raw markdown body string (frontmatter already stripped).
+ * @param opts - Optional override for the depth window (used by tests only;
+ *   production call sites pass no arguments and read from settings).
  * @returns Array of `{ depth, slug, text }` items in document order.
  */
-export function extractHeadings(body: string): HeadingItem[] {
+export function extractHeadings(
+  body: string,
+  opts?: { tocMinDepth?: number; tocMaxDepth?: number },
+): HeadingItem[] {
+  const { lo, hi } = resolveDepthWindow(
+    opts?.tocMinDepth ?? settings.tocMinDepth,
+    opts?.tocMaxDepth ?? settings.tocMaxDepth,
+  );
+
   const slugger = new GithubSlugger();
   const headings: HeadingItem[] = [];
 
-  // Track the opening fence string (`` ``` `` or ```` ```` ````) so we match the
-  // correct closing fence — Markdown allows longer fences to nest shorter ones.
+  // Track the opening fence character and length so we correctly match the
+  // closing fence. Markdown allows backtick and tilde fences (``` or ~~~),
+  // and longer fences to nest shorter same-character ones.
   let codeFenceOpener: string | null = null;
   for (const line of body.split("\n")) {
-    // Detect code fence open/close. A fence is 3+ backticks optionally followed
-    // by a language specifier. The closing fence must match the opener's length.
+    // Detect code fence open/close. A fence is 3+ backticks OR 3+ tildes,
+    // optionally followed by a language specifier. The closing fence must use
+    // the same character and match or exceed the opener's length.
     // Use trimStart() so indented fences (e.g. inside lists) are also detected.
-    const fenceMatch = /^(`{3,})/.exec(line.trimStart());
+    const trimmed = line.trimStart();
+    const fenceMatch = /^([`~]{3,})/.exec(trimmed);
     if (fenceMatch) {
-      const fence = fenceMatch[1] as string;
+      const fence = fenceMatch[1];
+      if (fence === undefined) continue;
       if (codeFenceOpener === null) {
+        // Opening fence: record character + length.
         codeFenceOpener = fence;
-      } else if (fence.length >= codeFenceOpener.length) {
+      } else if (
+        fence[0] === codeFenceOpener[0] &&
+        fence.length >= codeFenceOpener.length
+      ) {
+        // Closing fence: must match opener's character and be at least as long.
         codeFenceOpener = null;
       }
+      // Whether opening, closing, or a mismatched-character line (content inside
+      // a fence), always skip — do not try to parse as a heading.
       continue;
     }
     if (codeFenceOpener !== null) continue;
 
-    // Match ATX headings at depth 2, 3, or 4. Allow one or more spaces/tabs
+    // Match ATX headings at any depth h1–h6. Allow one or more spaces/tabs
     // after the hash characters (both are valid per the CommonMark spec).
-    const match = /^(#{2,4})[ \t]+(.+)$/.exec(line.trim());
+    const match = /^(#{1,6})[ \t]+(.+)$/.exec(line.trim());
     if (!match) continue;
 
-    const depth = (match[1] as string).length;
-    const raw = (match[2] as string).trim();
+    const hashes = match[1];
+    const rawText = match[2];
+    if (hashes === undefined || rawText === undefined) continue;
+
+    const depth = hashes.length;
     // Strip inline markup to get the plain text the renderer sees, so the slug
     // matches the heading element's rendered id attribute.
-    const text = stripInlineMarkdown(raw);
+    const text = stripInlineMarkdown(rawText.trim());
 
-    headings.push({
-      depth,
-      slug: slugger.slug(text),
-      text,
-    });
+    // Always advance the slugger counter (maintaining parity with the renderer's
+    // shared dedup counter across all h1–h6), but only push within the configured
+    // depth window.
+    const slug = slugger.slug(text);
+    if (depth >= lo && depth <= hi) {
+      headings.push({ depth, slug, text });
+    }
   }
 
   return headings;

--- a/packages/create-zudo-doc/templates/base/pages/lib/_nav-source-cache.ts
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_nav-source-cache.ts
@@ -34,7 +34,7 @@
 // recomputes — matching the old content-keyed cache's change detection.
 
 import { getCollection, getContentSnapshot } from "zfb/content";
-import { bridgeEntries } from "../_data";
+import { bridgeDocsEntries, type ZfbDocsData } from "../_data";
 import type { DocPageEntry } from "./doc-page-props";
 
 // ---------------------------------------------------------------------------
@@ -56,8 +56,8 @@ function snapshotAnchor(name: string): readonly unknown[] | undefined {
 const bridgedByAnchor = new WeakMap<object, DocPageEntry[]>();
 
 function buildBridged(collectionName: string): DocPageEntry[] {
-  const raw = getCollection(collectionName);
-  return (bridgeEntries(raw, collectionName) as unknown as DocPageEntry[]).filter(
+  const raw = getCollection<ZfbDocsData>(collectionName);
+  return bridgeDocsEntries(raw, collectionName).filter(
     (d) => !d.data.draft,
   );
 }

--- a/packages/create-zudo-doc/templates/base/pages/lib/_nav-source-docs.ts
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_nav-source-docs.ts
@@ -67,7 +67,7 @@ export function stableMergeCategoryMeta(
 
 /** `docs.filter(isNavVisible)`, memoized on the stable `docs` identity so the
  *  filtered array also has stable identity for the nav-tree fast-path. */
-export function stableNavDocs(docs: DocsEntry[]): DocsEntry[] {
+export function stableNavDocs<T extends DocsEntry>(docs: T[]): T[] {
   return memoizeDerived([docs], "navVisible", () => docs.filter(isNavVisible));
 }
 
@@ -154,14 +154,14 @@ export function resolveNavSource(
   const localeDocs = stableDocs(`docs-${lang}`);
 
   const merged = memoizeDerived([baseDocs, localeDocs], `merge;${sig}`, () =>
-    mergeLocaleDocs({
-      baseDocs: baseDocs as unknown as DocsEntry[],
-      localeDocs: localeDocs as unknown as DocsEntry[],
+    mergeLocaleDocs<DocPageEntry>({
+      baseDocs,
+      localeDocs,
       applyDefaultLocaleOnlyFilter: options.applyDefaultLocaleOnlyFilter,
       keepUnlisted: options.keepUnlisted,
     }),
   );
-  const docs = merged.docs as unknown as DocPageEntry[];
+  const docs = merged.docs;
 
   const localeDir = settings.locales[lang]?.dir ?? settings.docsDir;
   const categoryMeta = stableMergeCategoryMeta(settings.docsDir, localeDir);
@@ -189,14 +189,14 @@ export function resolveVersionedLocaleSource(
     localeDir ? [baseDocs, localeDocs] : [baseDocs],
     `vmerge;${lang};${sig}`,
     () =>
-      mergeLocaleDocs({
-        baseDocs: baseDocs as unknown as DocsEntry[],
-        localeDocs: localeDocs as unknown as DocsEntry[],
+      mergeLocaleDocs<DocPageEntry>({
+        baseDocs,
+        localeDocs,
         applyDefaultLocaleOnlyFilter: options.applyDefaultLocaleOnlyFilter,
         keepUnlisted: options.keepUnlisted,
       }),
   );
-  const docs = merged.docs as unknown as DocPageEntry[];
+  const docs = merged.docs;
 
   const categoryMeta = localeDir
     ? stableMergeCategoryMeta(versionDocsDir, localeDir)

--- a/packages/create-zudo-doc/templates/base/pages/lib/locale-merge.ts
+++ b/packages/create-zudo-doc/templates/base/pages/lib/locale-merge.ts
@@ -27,12 +27,16 @@ import type { DocsEntry } from "@/types/docs-entry";
 
 /**
  * Options for mergeLocaleDocs.
+ *
+ * The generic parameter `T` allows callers to pass arrays of a DocsEntry
+ * subtype (e.g. `DocPageEntry[]`) and get back results of the same subtype,
+ * eliminating the need for `as unknown as` casts at call sites.
  */
-export interface MergeLocaleDocsOptions {
+export interface MergeLocaleDocsOptions<T extends DocsEntry = DocsEntry> {
   /** Pre-loaded base (EN/default-locale) docs array, already draft-filtered. */
-  baseDocs: DocsEntry[];
+  baseDocs: T[];
   /** Pre-loaded locale-specific docs array, already draft-filtered. */
-  localeDocs: DocsEntry[];
+  localeDocs: T[];
   /**
    * When true, base docs whose path matches a `defaultLocaleOnlyPrefixes`
    * entry are excluded from the merge result. This matches the behavior of the
@@ -75,13 +79,16 @@ export interface MergeLocaleDocsOptions {
  * result on the snapshot-anchored input arrays + option signature (see
  * `pages/lib/_nav-source-cache.ts`), so `mergeLocaleDocs` itself stays a pure,
  * memo-free function (#1902).
+ *
+ * The generic `T` mirrors the parameter on {@link MergeLocaleDocsOptions} so
+ * the returned `docs` array preserves the subtype of the input arrays.
  */
-export interface MergeLocaleDocsResult {
+export interface MergeLocaleDocsResult<T extends DocsEntry = DocsEntry> {
   /**
    * Merged doc array: locale docs first, followed by base docs for slugs not
    * present in the locale collection (and not excluded by filter options).
    */
-  docs: DocsEntry[];
+  docs: T[];
   /**
    * Set of slugs that came from the locale collection.
    * Useful for callers that need to determine whether a page is a fallback
@@ -104,9 +111,9 @@ export interface MergeLocaleDocsResult {
  * **Array identity**: returns a fresh array on each call — see
  * {@link MergeLocaleDocsResult} for caching guidance.
  */
-export function mergeLocaleDocs(
-  options: MergeLocaleDocsOptions,
-): MergeLocaleDocsResult {
+export function mergeLocaleDocs<T extends DocsEntry = DocsEntry>(
+  options: MergeLocaleDocsOptions<T>,
+): MergeLocaleDocsResult<T> {
   const {
     baseDocs,
     localeDocs,

--- a/packages/create-zudo-doc/templates/base/src/config/color-scheme-utils.ts
+++ b/packages/create-zudo-doc/templates/base/src/config/color-scheme-utils.ts
@@ -172,9 +172,11 @@ export function generateLightDarkCssProperties(): string {
 
   const lines = [":root {", "  color-scheme: light dark;"];
   for (let i = 0; i < lightPairs.length; i++) {
-    const prop = lightPairs[i][0];
-    const lightVal = lightPairs[i][1];
-    const darkVal = darkPairs[i][1];
+    const lightPair = lightPairs[i];
+    const darkPair = darkPairs[i];
+    if (!lightPair || !darkPair) continue;
+    const [prop, lightVal] = lightPair;
+    const darkVal = darkPair[1];
     lines.push(`  ${prop}: light-dark(${lightVal}, ${darkVal});`);
   }
   lines.push("}");

--- a/packages/create-zudo-doc/templates/base/src/utils/base.ts
+++ b/packages/create-zudo-doc/templates/base/src/utils/base.ts
@@ -97,7 +97,7 @@ export function navHref(
  */
 function splitVersionPrefix(path: string): { versionPrefix: string; rest: string } {
   const m = path.match(/^(\/v\/[^/]+)(\/.*|$)/);
-  return m ? { versionPrefix: m[1], rest: m[2] || "/" } : { versionPrefix: "", rest: path };
+  return m ? { versionPrefix: m[1] ?? "", rest: m[2] ?? "/" } : { versionPrefix: "", rest: path };
 }
 
 /** Build a locale-switched path from the current page path. */

--- a/packages/create-zudo-doc/templates/base/src/utils/dedent.ts
+++ b/packages/create-zudo-doc/templates/base/src/utils/dedent.ts
@@ -9,7 +9,7 @@ export function dedent(text: string): string {
   let minIndent = Infinity;
   for (const line of lines) {
     if (line.trim().length === 0) continue;
-    const indent = line.match(/^(\s*)/)?.[1].length ?? 0;
+    const indent = line.match(/^(\s*)/)?.[1]?.length ?? 0;
     if (indent < minIndent) minIndent = indent;
   }
 

--- a/packages/create-zudo-doc/templates/base/src/utils/docs.ts
+++ b/packages/create-zudo-doc/templates/base/src/utils/docs.ts
@@ -145,7 +145,7 @@ export function buildNavTree(
       // Multi-segment: walk the tree creating intermediate nodes as needed
       let current = root;
       for (let i = 0; i < parts.length; i++) {
-        const segment = parts[i];
+        const segment = parts[i] ?? "";
         const fullPath = parts.slice(0, i + 1).join("/");
         if (!current.children.has(segment)) {
           current.children.set(segment, {
@@ -240,16 +240,19 @@ export function groupSatelliteNodes(tree: NavNode[], prefixes: string[]): NavNod
     const primaryIdx = result.findIndex((n) => n.slug === prefix);
     if (primaryIdx < 0) continue;
     const primary = result[primaryIdx];
+    if (!primary) continue;
     const satelliteIdxs: number[] = [];
     for (let i = 0; i < result.length; i++) {
-      if (i !== primaryIdx && result[i].slug.startsWith(`${prefix}-`)) {
+      const node = result[i];
+      if (node && i !== primaryIdx && node.slug.startsWith(`${prefix}-`)) {
         satelliteIdxs.push(i);
       }
     }
     if (satelliteIdxs.length === 0) continue;
     const extraChildren: NavNode[] = [];
     for (const idx of satelliteIdxs) {
-      extraChildren.push(result[idx]);
+      const node = result[idx];
+      if (node) extraChildren.push(node);
     }
     result[primaryIdx] = {
       ...primary,

--- a/packages/create-zudo-doc/templates/base/src/utils/smart-break.tsx
+++ b/packages/create-zudo-doc/templates/base/src/utils/smart-break.tsx
@@ -62,7 +62,7 @@ export function smartBreak(text: string): VNode | string {
   const parts = text.split(DELIM_SPLIT);
   const nodes: (string | VNode)[] = [];
   for (let i = 0; i < parts.length; i++) {
-    const part = parts[i];
+    const part = parts[i] ?? "";
     if (part === "") continue;
     nodes.push(part);
     // Captured delimiter groups always land at odd indices.
@@ -97,7 +97,7 @@ export function escapeAndInjectWbr(text: string): string {
   const parts = text.split(DELIM_SPLIT);
   let out = "";
   for (let i = 0; i < parts.length; i++) {
-    const part = parts[i];
+    const part = parts[i] ?? "";
     if (part === "") continue;
     out += htmlEscape(part);
     if (i % 2 === 1) out += "<wbr>";

--- a/packages/create-zudo-doc/templates/features/docTags/files/pages/docs/tags/[tag].tsx
+++ b/packages/create-zudo-doc/templates/features/docTags/files/pages/docs/tags/[tag].tsx
@@ -21,13 +21,12 @@ import { toRouteSlug } from "@/utils/slug";
 import { t, defaultLocale } from "@/config/i18n";
 import { settings } from "@/config/settings";
 import { withBase, docsUrl } from "@/utils/base";
-import type { DocsEntry } from "@/types/docs-entry";
 import { DocLayoutWithDefaults } from "@takazudo/zudo-doc/doclayout";
 import { Breadcrumb } from "@takazudo/zudo-doc/breadcrumb";
 import type { BreadcrumbItem } from "@takazudo/zudo-doc/breadcrumb";
 import { DocCardGrid } from "@takazudo/zudo-doc/nav-indexing";
 import type { JSX } from "preact";
-import { bridgeEntries } from "../../_data";
+import { bridgeDocsEntries, type ZfbDocsData } from "../../_data";
 import { FooterWithDefaults } from "../../lib/_footer-with-defaults";
 import { HeaderWithDefaults } from "../../lib/_header-with-defaults";
 import { HeadWithDefaults } from "../../lib/_head-with-defaults";
@@ -42,7 +41,7 @@ export function paths(): Array<{
   params: { tag: string };
   props: { tagInfo: TagInfo };
 }> {
-  const allDocs = (bridgeEntries(getCollection("docs"), "docs") as unknown as DocsEntry[]);
+  const allDocs = bridgeDocsEntries(getCollection<ZfbDocsData>("docs"), "docs");
   const docs = allDocs.filter((doc) => !doc.data.unlisted && !doc.data.draft);
   const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));
 

--- a/packages/create-zudo-doc/templates/features/docTags/files/pages/docs/tags/index.tsx
+++ b/packages/create-zudo-doc/templates/features/docTags/files/pages/docs/tags/index.tsx
@@ -18,14 +18,13 @@ import { toRouteSlug } from "@/utils/slug";
 import { t, defaultLocale } from "@/config/i18n";
 import { withBase } from "@/utils/base";
 import { settings } from "@/config/settings";
-import type { DocsEntry } from "@/types/docs-entry";
 import { DocLayoutWithDefaults } from "@takazudo/zudo-doc/doclayout";
 import { Breadcrumb } from "@takazudo/zudo-doc/breadcrumb";
 import type { BreadcrumbItem } from "@takazudo/zudo-doc/breadcrumb";
 import { TagNav } from "@takazudo/zudo-doc/nav-indexing";
 import type { TagItem, TagNavLabels } from "@takazudo/zudo-doc/nav-indexing";
 import type { JSX } from "preact";
-import { bridgeEntries } from "../../_data";
+import { bridgeDocsEntries, type ZfbDocsData } from "../../_data";
 import { FooterWithDefaults } from "../../lib/_footer-with-defaults";
 import { HeaderWithDefaults } from "../../lib/_header-with-defaults";
 import { HeadWithDefaults } from "../../lib/_head-with-defaults";
@@ -39,7 +38,7 @@ export default function DocsTagsIndexPage(): JSX.Element {
   const locale = defaultLocale;
   const pageTitle = t("doc.allTags", locale);
 
-  const allDocs = (bridgeEntries(getCollection("docs"), "docs") as unknown as DocsEntry[]);
+  const allDocs = bridgeDocsEntries(getCollection<ZfbDocsData>("docs"), "docs");
   const docs = allDocs.filter((doc) => !doc.data.unlisted && !doc.data.draft);
   const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));
 

--- a/packages/create-zudo-doc/templates/features/i18n/files/pages/[locale]/docs/[[...slug]].tsx
+++ b/packages/create-zudo-doc/templates/features/i18n/files/pages/[locale]/docs/[[...slug]].tsx
@@ -24,7 +24,6 @@
 //   - Locale-first merge: locale docs take priority; base EN docs fill in
 //     pages not translated yet (shown with a fallback notice).
 
-import type { DocsEntry } from "@/types/docs-entry";
 import { settings } from "@/config/settings";
 import { docsUrl, absoluteUrl } from "@/utils/base";
 import {
@@ -114,8 +113,8 @@ export function paths(): Array<{
         .map((d) => d.data.slug ?? d.id),
     );
 
-    const tree = buildNavTree(navDocs as unknown as DocsEntry[], locale, categoryMeta);
-    const fullTree = buildNavTree(allDocs as unknown as DocsEntry[], locale, categoryMeta);
+    const tree = buildNavTree(navDocs, locale, categoryMeta);
+    const fullTree = buildNavTree(allDocs, locale, categoryMeta);
 
     // Regular doc pages
     for (const entry of allDocs) {
@@ -145,7 +144,7 @@ export function paths(): Array<{
         params: { locale, slug: toSlugParams(slug) },
         props: {
           kind: "entry",
-          entry: entry as unknown as DocPageEntry,
+          entry,
           contentDir: entryContentDir,
           isFallback,
           breadcrumbs: buildBreadcrumbs(fullTree, slug, locale),

--- a/packages/create-zudo-doc/templates/features/tagGovernance/files/scripts/tags-audit.ts
+++ b/packages/create-zudo-doc/templates/features/tagGovernance/files/scripts/tags-audit.ts
@@ -287,7 +287,10 @@ export function rewriteAliasesByteStable(
 
   const fmMatch = content.match(/^(---\r?\n)([\s\S]*?)(\r?\n---(?:\r?\n|$))/);
   if (!fmMatch) return { content, changed: false };
-  const [whole, open, fmBody, close] = fmMatch;
+  const whole = fmMatch[0] ?? "";
+  const open = fmMatch[1] ?? "";
+  const fmBody = fmMatch[2] ?? "";
+  const close = fmMatch[3] ?? "";
 
   let changed = false;
   let newBody = fmBody;

--- a/packages/create-zudo-doc/templates/features/versioning/files/pages/v/[version]/[locale]/docs/[[...slug]].tsx
+++ b/packages/create-zudo-doc/templates/features/versioning/files/pages/v/[version]/[locale]/docs/[[...slug]].tsx
@@ -20,7 +20,6 @@
 // Prev/next hrefs are pre-resolved to the versioned locale URL form
 // (e.g. /v/1.0/ja/docs/…) so the component needs no URL computation.
 
-import type { DocsEntry } from "@/types/docs-entry";
 import { settings } from "@/config/settings";
 import type { VersionConfig } from "@/config/settings";
 import { t } from "@/config/i18n";
@@ -119,7 +118,7 @@ export function paths(): Array<{
           .map((d) => d.data.slug ?? toRouteSlug(d.slug)),
       );
 
-      const tree = buildNavTree(navDocs as unknown as DocsEntry[], locale, categoryMeta);
+      const tree = buildNavTree(navDocs, locale, categoryMeta);
 
       // URL closure for THIS (version, locale) — every versioned-locale href
       // (prev/next, breadcrumb crumbs, auto-index cards) is produced by this
@@ -147,7 +146,7 @@ export function paths(): Array<{
           params: { version: version.slug, locale, slug: toSlugParams(slug) },
           props: {
             kind: "entry",
-            entry: entry as unknown as DocPageEntry,
+            entry,
             version,
             contentDir: entryContentDir,
             isFallback,

--- a/packages/create-zudo-doc/templates/features/versioning/files/pages/v/[version]/docs/[[...slug]].tsx
+++ b/packages/create-zudo-doc/templates/features/versioning/files/pages/v/[version]/docs/[[...slug]].tsx
@@ -20,7 +20,6 @@
 // Version banner: if version.banner is set ("unmaintained" | "unreleased"),
 // the DocLayoutWithDefaults version-banner prop drives the banner display.
 
-import type { DocsEntry } from "@/types/docs-entry";
 import { settings } from "@/config/settings";
 import type { VersionConfig } from "@/config/settings";
 import { t } from "@/config/i18n";
@@ -94,7 +93,7 @@ export function paths(): Array<{
     // pages/lib/_nav-source-docs.ts (#1902).
     const { docs: allDocs, navDocs, categoryMeta } = resolveNavSource("en", version.slug);
     // Versioned docs always use EN locale for nav tree
-    const tree = buildNavTree(navDocs as unknown as DocsEntry[], "en", categoryMeta);
+    const tree = buildNavTree(navDocs, "en", categoryMeta);
 
     // URL closure for THIS version — every versioned href (prev/next,
     // breadcrumb crumbs, auto-index cards) is produced by this single

--- a/packages/create-zudo-doc/tsconfig.json
+++ b/packages/create-zudo-doc/tsconfig.json
@@ -6,6 +6,7 @@
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "declaration": true

--- a/packages/doc-history-server/src/__tests__/shared.test.ts
+++ b/packages/doc-history-server/src/__tests__/shared.test.ts
@@ -22,7 +22,9 @@ describe("getContentDirEntries", () => {
 
   it("resolves paths to absolute", () => {
     const result = getContentDirEntries("relative/path", []);
-    const [, dir] = result[0];
+    const first = result[0];
+    if (first === undefined) throw new Error("Expected at least one entry");
+    const [, dir] = first;
     expect(dir).toBe(resolve("relative/path"));
     // Absolute paths start with /
     expect(dir.startsWith("/")).toBe(true);

--- a/packages/doc-history-server/src/args.ts
+++ b/packages/doc-history-server/src/args.ts
@@ -59,11 +59,12 @@ export function resolveContentPath(p: string): string {
 
 /** Safely get the next argument, or exit with an error if missing */
 function requireNextArg(args: string[], index: number, flag: string): string {
-  if (index >= args.length) {
+  const value = args[index];
+  if (value === undefined) {
     console.error(`Missing value for ${flag}`);
     process.exit(1);
   }
-  return args[index];
+  return value;
 }
 
 /** Parse --locale value into { key, dir } — dir is resolved via resolveContentPath */
@@ -106,6 +107,7 @@ export function parseCommonArgs(
 
   for (let i = 0; i < args.length; i++) {
     const flag = args[i];
+    if (flag === undefined) continue;
     const next = () => requireNextArg(args, ++i, flag);
 
     switch (flag) {

--- a/packages/doc-history-server/src/server.ts
+++ b/packages/doc-history-server/src/server.ts
@@ -88,7 +88,7 @@ export function startServer(options: ServerOptions): void {
 
     // Match routes against the pathname only — req.url includes any query
     // string, which would make exact/$-anchored matches reject e.g. ?cachebust=1.
-    const pathname = url.split(/[?#]/, 1)[0];
+    const pathname = url.split(/[?#]/, 1)[0] ?? "";
 
     // Health check
     if (pathname === "/health") {
@@ -100,7 +100,7 @@ export function startServer(options: ServerOptions): void {
     const match = pathname.match(/^\/doc-history\/(.+)\.json$/);
     if (match) {
       try {
-        const requestedSlug = decodeURIComponent(match[1]);
+        const requestedSlug = decodeURIComponent(match[1] ?? "");
         handleDocHistory(requestedSlug, fileIndex, maxEntries, res);
       } catch (err) {
         sendJson(res, 500, {

--- a/packages/doc-history-server/tsconfig.json
+++ b/packages/doc-history-server/tsconfig.json
@@ -6,6 +6,7 @@
     "lib": ["ES2022"],
     "types": ["node"],
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "noEmit": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,

--- a/packages/md-plugins/tsconfig.json
+++ b/packages/md-plugins/tsconfig.json
@@ -6,6 +6,7 @@
     "lib": ["ES2022"],
     "types": ["node"],
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "noEmit": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,

--- a/packages/search-worker/src/__tests__/search.test.ts
+++ b/packages/search-worker/src/__tests__/search.test.ts
@@ -52,8 +52,10 @@ describe("search", () => {
 
     expect(total).toBeGreaterThan(0);
     expect(results.length).toBeGreaterThan(0);
-    expect(results[0].title).toBe("Getting Started");
-    expect(results[0].url).toBe("/docs/getting-started");
+    const firstResult = results[0];
+    if (firstResult === undefined) throw new Error("Expected at least one result");
+    expect(firstResult.title).toBe("Getting Started");
+    expect(firstResult.url).toBe("/docs/getting-started");
   });
 
   it("returns empty results for non-matching query", async () => {
@@ -76,6 +78,7 @@ describe("search", () => {
 
     expect(results.length).toBeGreaterThan(0);
     const result = results[0];
+    if (result === undefined) throw new Error("Expected at least one result");
     expect(result).toHaveProperty("id");
     expect(result).toHaveProperty("title");
     expect(result).toHaveProperty("url");

--- a/packages/search-worker/tsconfig.json
+++ b/packages/search-worker/tsconfig.json
@@ -6,6 +6,7 @@
     "lib": ["ES2022"],
     "types": ["@cloudflare/workers-types"],
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "noEmit": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,

--- a/packages/zudo-doc/src/breadcrumb/__tests__/breadcrumb.test.tsx
+++ b/packages/zudo-doc/src/breadcrumb/__tests__/breadcrumb.test.tsx
@@ -109,7 +109,7 @@ describe("buildBreadcrumbItems", () => {
 
   it("omits href on the final (current page) item", () => {
     const items = buildBreadcrumbItems(tree, "guides/advanced/perf", "/");
-    expect(items[items.length - 1].href).toBeUndefined();
+    expect(items[items.length - 1]?.href).toBeUndefined();
   });
 
   it("returns only the home rung when target is not in the tree", () => {

--- a/packages/zudo-doc/src/breadcrumb/breadcrumb.tsx
+++ b/packages/zudo-doc/src/breadcrumb/breadcrumb.tsx
@@ -26,6 +26,7 @@ export function buildBreadcrumbItems(
   const path = findPath(tree, currentId);
   for (let i = 0; i < path.length; i++) {
     const node = path[i];
+    if (!node) continue;
     const isLast = i === path.length - 1;
     items.push({
       label: node.label,
@@ -55,7 +56,7 @@ function SmartLabel({ label }: SmartLabelProps): VNode | string {
   const nodes: (string | VNode)[] = [];
   for (let i = 0; i < parts.length; i++) {
     const part = parts[i];
-    if (part === "") continue;
+    if (!part) continue;
     nodes.push(part);
     if (i % 2 === 1) nodes.push(<wbr key={`wbr-${i}`} />);
   }

--- a/packages/zudo-doc/src/html-preview-wrapper/dedent.ts
+++ b/packages/zudo-doc/src/html-preview-wrapper/dedent.ts
@@ -12,7 +12,7 @@ export function dedent(text: string): string {
   let minIndent = Infinity;
   for (const line of lines) {
     if (line.trim().length === 0) continue;
-    const indent = line.match(/^(\s*)/)?.[1].length ?? 0;
+    const indent = line.match(/^(\s*)/)?.[1]?.length ?? 0;
     if (indent < minIndent) minIndent = indent;
   }
 

--- a/packages/zudo-doc/src/html-preview-wrapper/preview-base.tsx
+++ b/packages/zudo-doc/src/html-preview-wrapper/preview-base.tsx
@@ -89,7 +89,7 @@ export function PreviewBase({
     return () => clearTimeout(id);
   }, [activeViewport, syncHeight, height]);
 
-  const containerWidth = VIEWPORTS[activeViewport].width;
+  const containerWidth = VIEWPORTS[activeViewport]?.width ?? "100%";
 
   return (
     <div class="border border-muted rounded-lg overflow-hidden my-vsp-md">

--- a/packages/zudo-doc/src/i18n-version/__tests__/language-switcher.test.tsx
+++ b/packages/zudo-doc/src/i18n-version/__tests__/language-switcher.test.tsx
@@ -69,7 +69,7 @@ describe("LanguageSwitcher", () => {
     const noneRendered =
       LanguageSwitcher({ links: [] as LocaleLink[] }) === null;
     const oneRendered =
-      LanguageSwitcher({ links: [enJa[0]] }) === null;
+      LanguageSwitcher({ links: enJa.slice(0, 1) }) === null;
     expect(noneRendered).toBe(true);
     expect(oneRendered).toBe(true);
   });

--- a/packages/zudo-doc/src/integrations/claude-resources/escape-for-mdx.ts
+++ b/packages/zudo-doc/src/integrations/claude-resources/escape-for-mdx.ts
@@ -88,7 +88,7 @@ export function escapeForMdx(content: string): string {
       // Restore inline code placeholders
       escaped = escaped.replace(
         new RegExp(`${inlinePlaceholder}(\\d+)\x00`, "g"),
-        (_, idx: string) => inlineCodes[Number(idx)],
+        (_, idx: string) => inlineCodes[Number(idx)] ?? "",
       );
 
       return escaped;

--- a/packages/zudo-doc/src/integrations/claude-resources/generate.ts
+++ b/packages/zudo-doc/src/integrations/claude-resources/generate.ts
@@ -268,6 +268,7 @@ function getSkillFileTree(
 
   for (let i = 0; i < entries.length; i++) {
     const entry = entries[i];
+    if (!entry) continue;
     const isLast = i === entries.length - 1;
     const prefix = isLast ? "└── " : "├── ";
 
@@ -277,6 +278,7 @@ function getSkillFileTree(
       lines.push(`${prefix}${entry.name}/`);
       for (let j = 0; j < entry.children.length; j++) {
         const child = entry.children[j];
+        if (!child) continue;
         const childIsLast = j === entry.children.length - 1;
         const continuation = isLast ? "    " : "│   ";
         const childPrefix = childIsLast ? "└── " : "├── ";
@@ -292,9 +294,10 @@ function getScriptDescription(filePath: string): string {
   try {
     const topLines = fs.readFileSync(filePath, "utf8").split("\n", 2);
     // Skip shebang, use second line if available
-    const commentLine = topLines[0].startsWith("#!")
-      ? topLines[1] || ""
-      : topLines[0];
+    const firstLine = topLines[0] ?? "";
+    const commentLine = firstLine.startsWith("#!")
+      ? topLines[1] ?? ""
+      : firstLine;
     // Match # comments (shell/python) or // comments (JS/TS)
     const match = commentLine.match(/^(?:#|\/\/)\s*(.+)/);
     return match ? ` — ${match[1]}` : "";
@@ -317,7 +320,7 @@ function getSkillReferences(
       const content = fs.readFileSync(path.join(refsDir, f), "utf8");
       const name = f.replace(/\.md$/, "");
       const h1Match = content.match(/^#\s+(.+)$/m);
-      const title = h1Match ? h1Match[1] : name;
+      const title = h1Match?.[1] ?? name;
       return { name, title, content };
     })
     .sort((a, b) => a.name.localeCompare(b.name));
@@ -449,7 +452,7 @@ ${escapeForMdx(ref.content.trim())}
         "utf8",
       );
       const h1Match = raw.match(/^#\s+(.+)$/m);
-      const title = h1Match ? h1Match[1] : slug;
+      const title = h1Match?.[1] ?? slug;
       fs.writeFileSync(
         path.join(outputDir, `${dir}--script-${slug}.mdx`),
         `---\ntitle: "${escapeTitle(title)}"\nslug: "${subSlug}"\nunlisted: true\ngenerated: true\n---\n\n${escapeForMdx(raw.trim())}\n`,
@@ -464,7 +467,7 @@ ${escapeForMdx(ref.content.trim())}
         "utf8",
       );
       const h1Match = raw.match(/^#\s+(.+)$/m);
-      const title = h1Match ? h1Match[1] : slug;
+      const title = h1Match?.[1] ?? slug;
       fs.writeFileSync(
         path.join(outputDir, `${dir}--asset-${slug}.mdx`),
         `---\ntitle: "${escapeTitle(title)}"\nslug: "${subSlug}"\nunlisted: true\ngenerated: true\n---\n\n${escapeForMdx(raw.trim())}\n`,

--- a/packages/zudo-doc/src/integrations/doc-history/pre-build.ts
+++ b/packages/zudo-doc/src/integrations/doc-history/pre-build.ts
@@ -231,7 +231,7 @@ export async function runDocHistoryMetaStep(
   const meta: DocHistoryMetaManifest = {};
   for (let i = 0; i < jobs.length; i++) {
     const result = results[i];
-    if (result === null) continue; // untracked / not yet committed
+    if (result == null) continue; // untracked / not yet committed
 
     meta[jobs[i]!.composedSlug] = {
       // Author comes from the FIRST (oldest) commit.

--- a/packages/zudo-doc/src/integrations/llms-txt/dev-middleware.ts
+++ b/packages/zudo-doc/src/integrations/llms-txt/dev-middleware.ts
@@ -162,7 +162,7 @@ function matchLlmsRoute(
   url: string,
   localeCodes: Set<string>,
 ): { kind: "llms" | "llms-full"; locale: string | null } | null {
-  const pathname = url.split("?")[0];
+  const pathname = url.split("?")[0] ?? url;
   const m = pathname.match(LLMS_KIND_PATTERN);
   if (!m) return null;
   const prefix = m[1];

--- a/packages/zudo-doc/src/metainfo/__tests__/doc-tags.test.tsx
+++ b/packages/zudo-doc/src/metainfo/__tests__/doc-tags.test.tsx
@@ -91,7 +91,7 @@ describe("DocTags", () => {
 
   it("includes aria-label using the default taggedWithLabel", () => {
     const html = serialize(
-      <DocTags placement="after-title" tags={[sampleTags[0]]} />,
+      <DocTags placement="after-title" tags={sampleTags.slice(0, 1)} />,
     );
     expect(html).toContain('aria-label="Tagged with: typescript"');
   });
@@ -100,7 +100,7 @@ describe("DocTags", () => {
     const html = serialize(
       <DocTags
         placement="after-title"
-        tags={[sampleTags[0]]}
+        tags={sampleTags.slice(0, 1)}
         taggedWithLabel="タグ付き"
       />,
     );

--- a/packages/zudo-doc/src/toc/smart-break.tsx
+++ b/packages/zudo-doc/src/toc/smart-break.tsx
@@ -38,7 +38,7 @@ export function smartBreak(text: string): VNode | string {
   const nodes: (string | VNode)[] = [];
   for (let i = 0; i < parts.length; i++) {
     const part = parts[i];
-    if (part === "") continue;
+    if (!part) continue;
     nodes.push(part);
     if (i % 2 === 1) nodes.push(<wbr key={`wbr-${i}`} />);
   }

--- a/packages/zudo-doc/tsconfig.json
+++ b/packages/zudo-doc/tsconfig.json
@@ -8,6 +8,7 @@
     "target": "ES2022",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "noEmit": true,
     "skipLibCheck": true
   },

--- a/pages/[locale]/docs/[[...slug]].tsx
+++ b/pages/[locale]/docs/[[...slug]].tsx
@@ -24,7 +24,6 @@
 //   - Locale-first merge: locale docs take priority; base EN docs fill in
 //     pages not translated yet (shown with a fallback notice).
 
-import type { DocsEntry } from "@/types/docs-entry";
 import { settings } from "@/config/settings";
 import { docsUrl, absoluteUrl } from "@/utils/base";
 import {
@@ -114,8 +113,8 @@ export function paths(): Array<{
         .map((d) => d.data.slug ?? d.id),
     );
 
-    const tree = buildNavTree(navDocs as unknown as DocsEntry[], locale, categoryMeta);
-    const fullTree = buildNavTree(allDocs as unknown as DocsEntry[], locale, categoryMeta);
+    const tree = buildNavTree(navDocs, locale, categoryMeta);
+    const fullTree = buildNavTree(allDocs, locale, categoryMeta);
 
     // Regular doc pages
     for (const entry of allDocs) {
@@ -145,7 +144,7 @@ export function paths(): Array<{
         params: { locale, slug: toSlugParams(slug) },
         props: {
           kind: "entry",
-          entry: entry as unknown as DocPageEntry,
+          entry,
           contentDir: entryContentDir,
           isFallback,
           breadcrumbs: buildBreadcrumbs(fullTree, slug, locale),

--- a/pages/_data.ts
+++ b/pages/_data.ts
@@ -13,6 +13,7 @@
 import { getCollection } from "zfb/content";
 import type { CollectionEntry } from "zfb/content";
 import type { DocsEntry } from "@/types/docs-entry";
+import type { DocPageEntry } from "./lib/doc-page-props";
 import { toRouteSlug } from "@/utils/slug";
 
 // ---------------------------------------------------------------------------
@@ -79,7 +80,7 @@ export type ZfbDocsEntry = CollectionEntry<ZfbDocsData> & {
  *   - `collection` — the collection name, for DocsEntry compat
  */
 export function getDocs(collectionName: string): ZfbDocsEntry[] {
-  const entries = getCollection(collectionName) as unknown as CollectionEntry<ZfbDocsData>[];
+  const entries = getCollection<ZfbDocsData>(collectionName);
   return entries.map((e) => ({
     ...e,
     // Astro-compat: strip a trailing `/index` from the entry id so
@@ -123,27 +124,43 @@ export function bridgeEntries<T = ZfbDocsData>(
 }
 
 /**
- * Cast ZfbDocsEntry[] to DocsEntry[] for passing to @/utils/docs utilities.
+ * Typed bridge from a raw zfb collection result to `DocPageEntry[]`.
  *
- * The types are structurally compatible: ZfbDocsEntry has every required field
- * of DocsEntry (id, collection, data, body). The optional `rendered` and
- * `filePath` fields of DocsEntry are absent but not required.
+ * This is the **single, justified** cast at the zfb/DocsEntry boundary.
+ * `CollectionEntry<ZfbDocsData> & { id, collection }` structurally satisfies
+ * `DocPageEntry` because:
+ *   - `id` and `collection` are added by `bridgeEntries`
+ *   - `data` (ZfbDocsData) structurally satisfies `DocsEntry.data` (all
+ *     required/optional fields are present; the index signature is wider)
+ *   - `body`, `slug`, `module_specifier`, `Content` are provided by
+ *     `CollectionEntry<ZfbDocsData>`
+ * The plain `as DocPageEntry[]` (not `as unknown as`) is intentional — it
+ * expresses that this is a well-understood structural subtype relationship,
+ * not an escape from the type system. The zfb type is the source of truth;
+ * DocsEntry/DocPageEntry are local compatibility shapes for @/utils/docs.
  */
-export function asDocsEntries(entries: ZfbDocsEntry[]): DocsEntry[] {
-  return entries as unknown as DocsEntry[];
+export function bridgeDocsEntries(
+  entries: ReadonlyArray<CollectionEntry<ZfbDocsData>>,
+  collectionName: string,
+): DocPageEntry[] {
+  return bridgeEntries(entries, collectionName) as DocPageEntry[];
 }
 
 /**
  * One-shot helper for paths()/render-time pages that just need a
- * `DocsEntry[]` for `@/utils/docs` consumption — wraps `getDocs` and
- * the `asDocsEntries` cast so call sites stay one-line. Use this from
- * any page that previously did
+ * `DocsEntry[]` for `@/utils/docs` consumption — wraps `getDocs` so
+ * call sites stay one-line. Use this from any page that previously did
  * `getCollection("docs") as unknown as DocsEntry[]` — that idiom
  * silently dropped the `id`/`collection` fields the utility helpers
  * read, which threw `Cannot read properties of undefined` at runtime.
+ *
+ * `ZfbDocsEntry` structurally satisfies `DocsEntry`: it carries `id`,
+ * `collection`, `data` (ZfbDocsData satisfies DocsEntry.data field-for-
+ * field), `body`, plus the zfb-specific extras (`slug`, `Content`, etc.)
+ * that DocsEntry does not require.
  */
 export function loadDocs(collectionName: string): DocsEntry[] {
-  return asDocsEntries(getDocs(collectionName));
+  return getDocs(collectionName);
 }
 
 /**

--- a/pages/docs/[[...slug]].tsx
+++ b/pages/docs/[[...slug]].tsx
@@ -22,7 +22,6 @@
 // Locale: defaultLocale (EN). Non-default locales are handled by
 // pages/[locale]/docs/[[...slug]].tsx.
 
-import type { DocsEntry } from "@/types/docs-entry";
 import { settings } from "@/config/settings";
 import { defaultLocale } from "@/config/i18n";
 import { docsUrl, absoluteUrl } from "@/utils/base";
@@ -83,9 +82,9 @@ export function paths(): Array<{
   const { docs, navDocs, categoryMeta } = resolveNavSource(locale, undefined);
 
   // Nav docs: exclude unlisted (for sidebar/prev-next) but keep for breadcrumbs
-  const tree = buildNavTree(navDocs as unknown as DocsEntry[], locale, categoryMeta);
+  const tree = buildNavTree(navDocs, locale, categoryMeta);
   // Full tree (including unlisted) for accurate breadcrumbs
-  const fullTree = buildNavTree(docs as unknown as DocsEntry[], locale, categoryMeta);
+  const fullTree = buildNavTree(docs, locale, categoryMeta);
 
   const result: Array<{ params: { slug: string[] }; props: DocPageProps }> = [];
 

--- a/pages/docs/tags/[tag].tsx
+++ b/pages/docs/tags/[tag].tsx
@@ -21,13 +21,12 @@ import { toRouteSlug } from "@/utils/slug";
 import { t, defaultLocale } from "@/config/i18n";
 import { settings } from "@/config/settings";
 import { withBase, docsUrl } from "@/utils/base";
-import type { DocsEntry } from "@/types/docs-entry";
 import { DocLayoutWithDefaults } from "@takazudo/zudo-doc/doclayout";
 import { Breadcrumb } from "@takazudo/zudo-doc/breadcrumb";
 import type { BreadcrumbItem } from "@takazudo/zudo-doc/breadcrumb";
 import { DocCardGrid } from "@takazudo/zudo-doc/nav-indexing";
 import type { JSX } from "preact";
-import { bridgeEntries } from "../../_data";
+import { bridgeDocsEntries, type ZfbDocsData } from "../../_data";
 import { FooterWithDefaults } from "../../lib/_footer-with-defaults";
 import { HeaderWithDefaults } from "../../lib/_header-with-defaults";
 import { HeadWithDefaults } from "../../lib/_head-with-defaults";
@@ -42,7 +41,7 @@ export function paths(): Array<{
   params: { tag: string };
   props: { tagInfo: TagInfo };
 }> {
-  const allDocs = (bridgeEntries(getCollection("docs"), "docs") as unknown as DocsEntry[]);
+  const allDocs = bridgeDocsEntries(getCollection<ZfbDocsData>("docs"), "docs");
   const docs = allDocs.filter((doc) => !doc.data.unlisted && !doc.data.draft);
   const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));
 

--- a/pages/docs/tags/index.tsx
+++ b/pages/docs/tags/index.tsx
@@ -18,14 +18,13 @@ import { toRouteSlug } from "@/utils/slug";
 import { t, defaultLocale } from "@/config/i18n";
 import { withBase } from "@/utils/base";
 import { settings } from "@/config/settings";
-import type { DocsEntry } from "@/types/docs-entry";
 import { DocLayoutWithDefaults } from "@takazudo/zudo-doc/doclayout";
 import { Breadcrumb } from "@takazudo/zudo-doc/breadcrumb";
 import type { BreadcrumbItem } from "@takazudo/zudo-doc/breadcrumb";
 import { TagNav } from "@takazudo/zudo-doc/nav-indexing";
 import type { TagItem, TagNavLabels } from "@takazudo/zudo-doc/nav-indexing";
 import type { JSX } from "preact";
-import { bridgeEntries } from "../../_data";
+import { bridgeDocsEntries, type ZfbDocsData } from "../../_data";
 import { FooterWithDefaults } from "../../lib/_footer-with-defaults";
 import { HeaderWithDefaults } from "../../lib/_header-with-defaults";
 import { HeadWithDefaults } from "../../lib/_head-with-defaults";
@@ -39,7 +38,7 @@ export default function DocsTagsIndexPage(): JSX.Element {
   const locale = defaultLocale;
   const pageTitle = t("doc.allTags", locale);
 
-  const allDocs = (bridgeEntries(getCollection("docs"), "docs") as unknown as DocsEntry[]);
+  const allDocs = bridgeDocsEntries(getCollection<ZfbDocsData>("docs"), "docs");
   const docs = allDocs.filter((doc) => !doc.data.unlisted && !doc.data.draft);
   const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));
 

--- a/pages/lib/_extract-headings.ts
+++ b/pages/lib/_extract-headings.ts
@@ -8,14 +8,15 @@
 //
 // Algorithm:
 //   1. Walk the body line-by-line looking for ATX-style markdown headings
-//      (`# Text` through `###### Text`, h1–h6).
+//      (`## Text` through `###### Text`, h2–h6).
 //   2. Strip inline markdown markup (links, inline code, bold, italic) from the
 //      heading text to get the plain visible text — matching what the renderer's
 //      `extractText` HAST walker sees after MDX → HTML conversion.
 //   3. Compute a GitHub-compatible slug using the same `GithubSlugger` that
 //      the `rehype-heading-links` plugin uses at render time, advancing the
-//      shared counter for ALL h1–h6 (even those not emitted into the TOC)
-//      so TOC anchor hrefs match the rendered heading IDs in the HTML.
+//      shared counter for ALL h2–h6 (even those not emitted into the TOC)
+//      so TOC anchor hrefs match the rendered heading IDs in the HTML. h1 is
+//      NOT slugged — the renderer never assigns an id to h1 (it's the title).
 //   4. Return only depth 2–4 headings by default (h1 is the page title; h5–h6
 //      are too granular). The window is configurable via `tocMinDepth` /
 //      `tocMaxDepth` in settings (restriction-only: min 2, max 4).
@@ -103,8 +104,9 @@ function resolveDepthWindow(
  *
  * Uses the same slugging algorithm as `rehype-heading-links` so the
  * `href="#slug"` values in the TOC match the rendered heading element IDs.
- * Slugs ALL matched h1–h6 (advancing the shared dedup counter) but only
- * pushes depth 2–4 items into the result (configurable via settings).
+ * Slugs ALL matched h2–h6 (advancing the shared dedup counter) but only
+ * pushes depth 2–4 items into the result (configurable via settings). h1 is
+ * not matched — the renderer does not assign ids to h1.
  *
  * @param body - Raw markdown body string (frontmatter already stripped).
  * @param opts - Optional override for the depth window (used by tests only;
@@ -153,9 +155,12 @@ export function extractHeadings(
     }
     if (codeFenceOpener !== null) continue;
 
-    // Match ATX headings at any depth h1–h6. Allow one or more spaces/tabs
-    // after the hash characters (both are valid per the CommonMark spec).
-    const match = /^(#{1,6})[ \t]+(.+)$/.exec(line.trim());
+    // Match ATX headings at depth h2–h6. The renderer's heading-links plugin
+    // slugs h2–h6 only (h1 is never assigned an id — the frontmatter title is
+    // the page's h1), so matching h1 here would advance the shared dedup counter
+    // out of step with the renderer and break the TOC anchor for a same-text h2.
+    // Allow one or more spaces/tabs after the hashes (both valid per CommonMark).
+    const match = /^(#{2,6})[ \t]+(.+)$/.exec(line.trim());
     if (!match) continue;
 
     const hashes = match[1];

--- a/pages/lib/_extract-headings.ts
+++ b/pages/lib/_extract-headings.ts
@@ -8,31 +8,37 @@
 //
 // Algorithm:
 //   1. Walk the body line-by-line looking for ATX-style markdown headings
-//      (`## Text`, `### Text`, `#### Text`).
+//      (`# Text` through `###### Text`, h1–h6).
 //   2. Strip inline markdown markup (links, inline code, bold, italic) from the
 //      heading text to get the plain visible text — matching what the renderer's
 //      `extractText` HAST walker sees after MDX → HTML conversion.
 //   3. Compute a GitHub-compatible slug using the same `GithubSlugger` that
-//      the `rehype-heading-links` plugin uses at render time, so the TOC
-//      anchor hrefs match the rendered heading IDs in the HTML.
-//   4. Return only depth 2–4 headings — depth 1 is the page title (rendered
-//      separately as an <h1>); depth 5–6 are too granular for the TOC.
+//      the `rehype-heading-links` plugin uses at render time, advancing the
+//      shared counter for ALL h1–h6 (even those not emitted into the TOC)
+//      so TOC anchor hrefs match the rendered heading IDs in the HTML.
+//   4. Return only depth 2–4 headings by default (h1 is the page title; h5–h6
+//      are too granular). The window is configurable via `tocMinDepth` /
+//      `tocMaxDepth` in settings (restriction-only: min 2, max 4).
 //
 // Caveats:
 //   - This is a regex walk over raw text, not an AST parse. MDX JSX expressions
-//     or code fences that contain `##` on their own line are matched. In
-//     practice this is rare.
-//   - Lines inside code fences (``` … ```) are skipped to avoid treating
-//     literal `## code` examples as real headings. Fence detection uses
-//     `line.trimStart()` to handle indented fences correctly.
+//     that contain `##` on their own line may be matched. In practice this is
+//     rare.
+//   - Lines inside code fences (``` … ``` or ~~~ … ~~~) are skipped to avoid
+//     treating literal `## code` examples as real headings. Fence detection
+//     uses `line.trimStart()` to handle indented fences correctly.
 //   - Reference-style links (`[text][id]`) and image links (`![alt](url)`)
 //     are not stripped — uncommon in headings, treated as plain text.
-//   - h5/h6 headings are slugged by `rehype-heading-links` but not extracted
-//     here. If a doc has h5/h6 text that duplicates an h2–h4, the shared
-//     GithubSlugger dedup counter diverges from the renderer's counter, so
-//     slugs may mismatch for such pages.
+//   - Slugger parity is counter-level (npm `github-slugger` vs zfb Rust) — the
+//     renderer slugs all h2–h6 regardless of `tocMinDepth`/`tocMaxDepth`, so
+//     this extractor must also slug all matched headings (including those outside
+//     the emit window) to keep the shared dedup counter in sync.
+//   - Residual risks: slugger-parity (npm `github-slugger` vs zfb Rust — an
+//     external-binary contract) and text-extraction parity (inline JSX / reference
+//     links not fully stripped).
 
 import GithubSlugger from "github-slugger";
+import { settings } from "../../src/config/settings";
 
 export interface HeadingItem {
   readonly depth: number;
@@ -69,53 +75,105 @@ function stripInlineMarkdown(raw: string): string {
 }
 
 /**
- * Extract depth-2/3/4 headings from a raw MDX/markdown body.
+ * Resolve and clamp the depth window from raw (possibly invalid) inputs.
+ *
+ * Enforces `2 <= min <= max <= 4`. If either value is NaN or the chain breaks,
+ * falls back to the full default window [2, 4].
+ */
+function resolveDepthWindow(
+  rawMin: unknown,
+  rawMax: unknown,
+): { lo: number; hi: number } {
+  const min = Math.trunc(Number(rawMin));
+  const max = Math.trunc(Number(rawMax));
+  if (
+    Number.isFinite(min) &&
+    Number.isFinite(max) &&
+    min >= 2 &&
+    min <= max &&
+    max <= 4
+  ) {
+    return { lo: min, hi: max };
+  }
+  return { lo: 2, hi: 4 };
+}
+
+/**
+ * Extract TOC headings from a raw MDX/markdown body.
  *
  * Uses the same slugging algorithm as `rehype-heading-links` so the
  * `href="#slug"` values in the TOC match the rendered heading element IDs.
+ * Slugs ALL matched h1–h6 (advancing the shared dedup counter) but only
+ * pushes depth 2–4 items into the result (configurable via settings).
  *
  * @param body - Raw markdown body string (frontmatter already stripped).
+ * @param opts - Optional override for the depth window (used by tests only;
+ *   production call sites pass no arguments and read from settings).
  * @returns Array of `{ depth, slug, text }` items in document order.
  */
-export function extractHeadings(body: string): HeadingItem[] {
+export function extractHeadings(
+  body: string,
+  opts?: { tocMinDepth?: number; tocMaxDepth?: number },
+): HeadingItem[] {
+  const { lo, hi } = resolveDepthWindow(
+    opts?.tocMinDepth ?? settings.tocMinDepth,
+    opts?.tocMaxDepth ?? settings.tocMaxDepth,
+  );
+
   const slugger = new GithubSlugger();
   const headings: HeadingItem[] = [];
 
-  // Track the opening fence string (`` ``` `` or ```` ```` ````) so we match the
-  // correct closing fence — Markdown allows longer fences to nest shorter ones.
+  // Track the opening fence character and length so we correctly match the
+  // closing fence. Markdown allows backtick and tilde fences (``` or ~~~),
+  // and longer fences to nest shorter same-character ones.
   let codeFenceOpener: string | null = null;
   for (const line of body.split("\n")) {
-    // Detect code fence open/close. A fence is 3+ backticks optionally followed
-    // by a language specifier. The closing fence must match the opener's length.
+    // Detect code fence open/close. A fence is 3+ backticks OR 3+ tildes,
+    // optionally followed by a language specifier. The closing fence must use
+    // the same character and match or exceed the opener's length.
     // Use trimStart() so indented fences (e.g. inside lists) are also detected.
-    const fenceMatch = /^(`{3,})/.exec(line.trimStart());
+    const trimmed = line.trimStart();
+    const fenceMatch = /^([`~]{3,})/.exec(trimmed);
     if (fenceMatch) {
-      const fence = fenceMatch[1] as string;
+      const fence = fenceMatch[1];
+      if (fence === undefined) continue;
       if (codeFenceOpener === null) {
+        // Opening fence: record character + length.
         codeFenceOpener = fence;
-      } else if (fence.length >= codeFenceOpener.length) {
+      } else if (
+        fence[0] === codeFenceOpener[0] &&
+        fence.length >= codeFenceOpener.length
+      ) {
+        // Closing fence: must match opener's character and be at least as long.
         codeFenceOpener = null;
       }
+      // Whether opening, closing, or a mismatched-character line (content inside
+      // a fence), always skip — do not try to parse as a heading.
       continue;
     }
     if (codeFenceOpener !== null) continue;
 
-    // Match ATX headings at depth 2, 3, or 4. Allow one or more spaces/tabs
+    // Match ATX headings at any depth h1–h6. Allow one or more spaces/tabs
     // after the hash characters (both are valid per the CommonMark spec).
-    const match = /^(#{2,4})[ \t]+(.+)$/.exec(line.trim());
+    const match = /^(#{1,6})[ \t]+(.+)$/.exec(line.trim());
     if (!match) continue;
 
-    const depth = (match[1] as string).length;
-    const raw = (match[2] as string).trim();
+    const hashes = match[1];
+    const rawText = match[2];
+    if (hashes === undefined || rawText === undefined) continue;
+
+    const depth = hashes.length;
     // Strip inline markup to get the plain text the renderer sees, so the slug
     // matches the heading element's rendered id attribute.
-    const text = stripInlineMarkdown(raw);
+    const text = stripInlineMarkdown(rawText.trim());
 
-    headings.push({
-      depth,
-      slug: slugger.slug(text),
-      text,
-    });
+    // Always advance the slugger counter (maintaining parity with the renderer's
+    // shared dedup counter across all h1–h6), but only push within the configured
+    // depth window.
+    const slug = slugger.slug(text);
+    if (depth >= lo && depth <= hi) {
+      headings.push({ depth, slug, text });
+    }
   }
 
   return headings;

--- a/pages/lib/_nav-source-cache.ts
+++ b/pages/lib/_nav-source-cache.ts
@@ -34,7 +34,7 @@
 // recomputes — matching the old content-keyed cache's change detection.
 
 import { getCollection, getContentSnapshot } from "zfb/content";
-import { bridgeEntries } from "../_data";
+import { bridgeDocsEntries, type ZfbDocsData } from "../_data";
 import type { DocPageEntry } from "./doc-page-props";
 
 // ---------------------------------------------------------------------------
@@ -56,8 +56,8 @@ function snapshotAnchor(name: string): readonly unknown[] | undefined {
 const bridgedByAnchor = new WeakMap<object, DocPageEntry[]>();
 
 function buildBridged(collectionName: string): DocPageEntry[] {
-  const raw = getCollection(collectionName);
-  return (bridgeEntries(raw, collectionName) as unknown as DocPageEntry[]).filter(
+  const raw = getCollection<ZfbDocsData>(collectionName);
+  return bridgeDocsEntries(raw, collectionName).filter(
     (d) => !d.data.draft,
   );
 }

--- a/pages/lib/_nav-source-docs.ts
+++ b/pages/lib/_nav-source-docs.ts
@@ -67,7 +67,7 @@ export function stableMergeCategoryMeta(
 
 /** `docs.filter(isNavVisible)`, memoized on the stable `docs` identity so the
  *  filtered array also has stable identity for the nav-tree fast-path. */
-export function stableNavDocs(docs: DocsEntry[]): DocsEntry[] {
+export function stableNavDocs<T extends DocsEntry>(docs: T[]): T[] {
   return memoizeDerived([docs], "navVisible", () => docs.filter(isNavVisible));
 }
 
@@ -154,14 +154,14 @@ export function resolveNavSource(
   const localeDocs = stableDocs(`docs-${lang}`);
 
   const merged = memoizeDerived([baseDocs, localeDocs], `merge;${sig}`, () =>
-    mergeLocaleDocs({
-      baseDocs: baseDocs as unknown as DocsEntry[],
-      localeDocs: localeDocs as unknown as DocsEntry[],
+    mergeLocaleDocs<DocPageEntry>({
+      baseDocs,
+      localeDocs,
       applyDefaultLocaleOnlyFilter: options.applyDefaultLocaleOnlyFilter,
       keepUnlisted: options.keepUnlisted,
     }),
   );
-  const docs = merged.docs as unknown as DocPageEntry[];
+  const docs = merged.docs;
 
   const localeDir = settings.locales[lang]?.dir ?? settings.docsDir;
   const categoryMeta = stableMergeCategoryMeta(settings.docsDir, localeDir);
@@ -189,14 +189,14 @@ export function resolveVersionedLocaleSource(
     localeDir ? [baseDocs, localeDocs] : [baseDocs],
     `vmerge;${lang};${sig}`,
     () =>
-      mergeLocaleDocs({
-        baseDocs: baseDocs as unknown as DocsEntry[],
-        localeDocs: localeDocs as unknown as DocsEntry[],
+      mergeLocaleDocs<DocPageEntry>({
+        baseDocs,
+        localeDocs,
         applyDefaultLocaleOnlyFilter: options.applyDefaultLocaleOnlyFilter,
         keepUnlisted: options.keepUnlisted,
       }),
   );
-  const docs = merged.docs as unknown as DocPageEntry[];
+  const docs = merged.docs;
 
   const categoryMeta = localeDir
     ? stableMergeCategoryMeta(versionDocsDir, localeDir)

--- a/pages/lib/locale-merge.ts
+++ b/pages/lib/locale-merge.ts
@@ -27,12 +27,16 @@ import type { DocsEntry } from "@/types/docs-entry";
 
 /**
  * Options for mergeLocaleDocs.
+ *
+ * The generic parameter `T` allows callers to pass arrays of a DocsEntry
+ * subtype (e.g. `DocPageEntry[]`) and get back results of the same subtype,
+ * eliminating the need for `as unknown as` casts at call sites.
  */
-export interface MergeLocaleDocsOptions {
+export interface MergeLocaleDocsOptions<T extends DocsEntry = DocsEntry> {
   /** Pre-loaded base (EN/default-locale) docs array, already draft-filtered. */
-  baseDocs: DocsEntry[];
+  baseDocs: T[];
   /** Pre-loaded locale-specific docs array, already draft-filtered. */
-  localeDocs: DocsEntry[];
+  localeDocs: T[];
   /**
    * When true, base docs whose path matches a `defaultLocaleOnlyPrefixes`
    * entry are excluded from the merge result. This matches the behavior of the
@@ -75,13 +79,16 @@ export interface MergeLocaleDocsOptions {
  * result on the snapshot-anchored input arrays + option signature (see
  * `pages/lib/_nav-source-cache.ts`), so `mergeLocaleDocs` itself stays a pure,
  * memo-free function (#1902).
+ *
+ * The generic `T` mirrors the parameter on {@link MergeLocaleDocsOptions} so
+ * the returned `docs` array preserves the subtype of the input arrays.
  */
-export interface MergeLocaleDocsResult {
+export interface MergeLocaleDocsResult<T extends DocsEntry = DocsEntry> {
   /**
    * Merged doc array: locale docs first, followed by base docs for slugs not
    * present in the locale collection (and not excluded by filter options).
    */
-  docs: DocsEntry[];
+  docs: T[];
   /**
    * Set of slugs that came from the locale collection.
    * Useful for callers that need to determine whether a page is a fallback
@@ -104,9 +111,9 @@ export interface MergeLocaleDocsResult {
  * **Array identity**: returns a fresh array on each call — see
  * {@link MergeLocaleDocsResult} for caching guidance.
  */
-export function mergeLocaleDocs(
-  options: MergeLocaleDocsOptions,
-): MergeLocaleDocsResult {
+export function mergeLocaleDocs<T extends DocsEntry = DocsEntry>(
+  options: MergeLocaleDocsOptions<T>,
+): MergeLocaleDocsResult<T> {
   const {
     baseDocs,
     localeDocs,

--- a/pages/v/[version]/[locale]/docs/[[...slug]].tsx
+++ b/pages/v/[version]/[locale]/docs/[[...slug]].tsx
@@ -20,7 +20,6 @@
 // Prev/next hrefs are pre-resolved to the versioned locale URL form
 // (e.g. /v/1.0/ja/docs/…) so the component needs no URL computation.
 
-import type { DocsEntry } from "@/types/docs-entry";
 import { settings } from "@/config/settings";
 import type { VersionConfig } from "@/config/settings";
 import { t } from "@/config/i18n";
@@ -119,7 +118,7 @@ export function paths(): Array<{
           .map((d) => d.data.slug ?? toRouteSlug(d.slug)),
       );
 
-      const tree = buildNavTree(navDocs as unknown as DocsEntry[], locale, categoryMeta);
+      const tree = buildNavTree(navDocs, locale, categoryMeta);
 
       // URL closure for THIS (version, locale) — every versioned-locale href
       // (prev/next, breadcrumb crumbs, auto-index cards) is produced by this
@@ -147,7 +146,7 @@ export function paths(): Array<{
           params: { version: version.slug, locale, slug: toSlugParams(slug) },
           props: {
             kind: "entry",
-            entry: entry as unknown as DocPageEntry,
+            entry,
             version,
             contentDir: entryContentDir,
             isFallback,

--- a/pages/v/[version]/docs/[[...slug]].tsx
+++ b/pages/v/[version]/docs/[[...slug]].tsx
@@ -20,7 +20,6 @@
 // Version banner: if version.banner is set ("unmaintained" | "unreleased"),
 // the DocLayoutWithDefaults version-banner prop drives the banner display.
 
-import type { DocsEntry } from "@/types/docs-entry";
 import { settings } from "@/config/settings";
 import type { VersionConfig } from "@/config/settings";
 import { t } from "@/config/i18n";
@@ -94,7 +93,7 @@ export function paths(): Array<{
     // pages/lib/_nav-source-docs.ts (#1902).
     const { docs: allDocs, navDocs, categoryMeta } = resolveNavSource("en", version.slug);
     // Versioned docs always use EN locale for nav tree
-    const tree = buildNavTree(navDocs as unknown as DocsEntry[], "en", categoryMeta);
+    const tree = buildNavTree(navDocs, "en", categoryMeta);
 
     // URL closure for THIS version — every versioned href (prev/next,
     // breadcrumb crumbs, auto-index cards) is produced by this single

--- a/scripts/__tests__/check-links.test.ts
+++ b/scripts/__tests__/check-links.test.ts
@@ -534,7 +534,7 @@ describe("check-links", () => {
 
       const warnings = await checkMdxLinks([docsDir], tmpDir);
       expect(warnings).toHaveLength(1);
-      expect(warnings[0].href).toBe("/docs/ref");
+      expect(warnings[0]?.href).toBe("/docs/ref");
     });
 
     it("skips non-existent directories", async () => {

--- a/scripts/tags-audit.ts
+++ b/scripts/tags-audit.ts
@@ -287,7 +287,10 @@ export function rewriteAliasesByteStable(
 
   const fmMatch = content.match(/^(---\r?\n)([\s\S]*?)(\r?\n---(?:\r?\n|$))/);
   if (!fmMatch) return { content, changed: false };
-  const [whole, open, fmBody, close] = fmMatch;
+  const whole = fmMatch[0] ?? "";
+  const open = fmMatch[1] ?? "";
+  const fmBody = fmMatch[2] ?? "";
+  const close = fmMatch[3] ?? "";
 
   let changed = false;
   let newBody = fmBody;

--- a/src/__tests__/pages-lib/extract-headings.test.ts
+++ b/src/__tests__/pages-lib/extract-headings.test.ts
@@ -89,3 +89,202 @@ describe("extractHeadings — slug fidelity", () => {
     expect(heading?.text).toBe("Enable fast mode");
   });
 });
+
+describe("extractHeadings — cross-level dedup (h5/h6 counter parity)", () => {
+  it("h5 duplicating an earlier h2 advances the renderer counter — second h2 gets -2 suffix", () => {
+    // The renderer slugs ALL headings (h2–h6), so an h5 with text "Dup" that
+    // follows the first h2 "Dup" advances the shared counter. Without the fix,
+    // extractHeadings only slugged h2–h4 and the second h2 anchor would be
+    // "#dup-1" while the rendered id would be "#dup-2" — a broken TOC link.
+    const body = [
+      "## Dup",    // rendered id: "dup"  / TOC slug: "dup"
+      "##### Dup", // rendered id: "dup-1" (renderer counts it; not in TOC)
+      "## Dup",   // rendered id: "dup-2" / TOC slug must also be "dup-2"
+    ].join("\n");
+    const headings = extractHeadings(body);
+    // Only depth-2 items are pushed; the h5 is invisible to the result.
+    expect(headings).toHaveLength(2);
+    expect(headings[0]?.slug).toBe("dup");
+    // Post-fix: second h2 gets "dup-2" (h5 consumed "dup-1" in the counter).
+    // Pre-fix: would have been "dup-1" (counter didn't advance for the h5).
+    expect(headings[1]?.slug).toBe("dup-2");
+  });
+
+  it("h6 duplicating an earlier h3 advances the renderer counter — second h3 gets -2 suffix", () => {
+    const body = [
+      "### Alpha",   // slug: "alpha"
+      "###### Alpha", // not in TOC, but advances counter to "alpha-1"
+      "### Alpha",   // slug must be "alpha-2", not "alpha-1"
+    ].join("\n");
+    const headings = extractHeadings(body);
+    expect(headings).toHaveLength(2);
+    expect(headings[0]?.slug).toBe("alpha");
+    expect(headings[1]?.slug).toBe("alpha-2");
+  });
+
+  it("multiple h5/h6 dup entries each advance the counter correctly", () => {
+    // Each intermediate h5/h6 with the same text advances the counter by one.
+    const body = [
+      "## Foo",    // slug: "foo"
+      "##### Foo", // not in TOC, counter: "foo-1"
+      "##### Foo", // not in TOC, counter: "foo-2"
+      "## Foo",   // slug must be "foo-3"
+    ].join("\n");
+    const headings = extractHeadings(body);
+    expect(headings).toHaveLength(2);
+    expect(headings[0]?.slug).toBe("foo");
+    expect(headings[1]?.slug).toBe("foo-3");
+  });
+
+  it("h5 with unique text does not affect counter for different h2 text", () => {
+    // Counter is per-text (slug-based), so an h5 with a different slug does
+    // not affect the dedup count for unrelated headings.
+    const body = [
+      "## Setup",       // slug: "setup"
+      "##### Details",  // slug: "details" (different text; does not affect "setup" counter)
+      "## Setup",       // slug must be "setup-1"
+    ].join("\n");
+    const headings = extractHeadings(body);
+    expect(headings).toHaveLength(2);
+    expect(headings[0]?.slug).toBe("setup");
+    expect(headings[1]?.slug).toBe("setup-1");
+  });
+});
+
+describe("extractHeadings — tilde fence (~~~) recognition", () => {
+  it("does not extract headings inside a tilde fence block", () => {
+    const body = [
+      "## Before fence",
+      "",
+      "~~~md",
+      "## Inside tilde fence — not a heading",
+      "~~~",
+      "",
+      "## After fence",
+    ].join("\n");
+    const headings = extractHeadings(body);
+    expect(headings).toHaveLength(2);
+    expect(headings[0]?.text).toBe("Before fence");
+    expect(headings[1]?.text).toBe("After fence");
+  });
+
+  it("backtick fence does not close a tilde fence", () => {
+    // A ``` line inside a ~~~ fence is content, not a fence boundary.
+    const body = [
+      "~~~",
+      "```",            // content — should not close the tilde fence
+      "## Still inside",
+      "```",            // content — still inside
+      "~~~",            // closes the tilde fence
+      "",
+      "## Real heading",
+    ].join("\n");
+    const headings = extractHeadings(body);
+    expect(headings).toHaveLength(1);
+    expect(headings[0]?.text).toBe("Real heading");
+  });
+
+  it("tilde fence does not close a backtick fence", () => {
+    const body = [
+      "```",
+      "~~~",            // content — should not close the backtick fence
+      "## Still inside",
+      "~~~",            // content — still inside
+      "```",            // closes the backtick fence
+      "",
+      "## Real heading",
+    ].join("\n");
+    const headings = extractHeadings(body);
+    expect(headings).toHaveLength(1);
+    expect(headings[0]?.text).toBe("Real heading");
+  });
+});
+
+describe("extractHeadings — configurable depth window (opts override)", () => {
+  it("default depth (no opts) emits h2–h4 only", () => {
+    const body = [
+      "# H1 title",
+      "## H2 section",
+      "### H3 sub",
+      "#### H4 deep",
+      "##### H5 too deep",
+      "###### H6 too deep",
+    ].join("\n");
+    const headings = extractHeadings(body);
+    expect(headings).toHaveLength(3);
+    expect(headings[0]?.depth).toBe(2);
+    expect(headings[1]?.depth).toBe(3);
+    expect(headings[2]?.depth).toBe(4);
+  });
+
+  it("tocMinDepth:3 excludes h2 from result", () => {
+    const body = [
+      "## H2 excluded",
+      "### H3 included",
+      "#### H4 included",
+    ].join("\n");
+    const headings = extractHeadings(body, { tocMinDepth: 3, tocMaxDepth: 4 });
+    expect(headings).toHaveLength(2);
+    expect(headings[0]?.depth).toBe(3);
+    expect(headings[1]?.depth).toBe(4);
+  });
+
+  it("tocMaxDepth:2 emits only h2", () => {
+    const body = [
+      "## H2 included",
+      "### H3 excluded",
+      "#### H4 excluded",
+    ].join("\n");
+    const headings = extractHeadings(body, { tocMinDepth: 2, tocMaxDepth: 2 });
+    expect(headings).toHaveLength(1);
+    expect(headings[0]?.depth).toBe(2);
+  });
+
+  it("window-excluded h2 still advances counter for subsequent same-text h3 in window", () => {
+    // When tocMinDepth:3, h2 headings are not pushed but must still be slugged
+    // so that a subsequent h3 with the same text gets the correct dedup suffix.
+    const body = [
+      "## Concept",   // excluded from result, but slugger consumes "concept"
+      "### Concept",  // included; slug must be "concept-1" (not "concept")
+    ].join("\n");
+    const headings = extractHeadings(body, { tocMinDepth: 3, tocMaxDepth: 4 });
+    expect(headings).toHaveLength(1);
+    expect(headings[0]?.slug).toBe("concept-1");
+  });
+
+  it("invalid tocMinDepth > tocMaxDepth falls back to 2/4", () => {
+    // min > max is invalid — fall back to the full default window.
+    const body = [
+      "## H2",
+      "### H3",
+      "#### H4",
+    ].join("\n");
+    const headings = extractHeadings(body, { tocMinDepth: 4, tocMaxDepth: 2 });
+    // Fallback: 2/4, so all three headings are emitted.
+    expect(headings).toHaveLength(3);
+  });
+
+  it("tocMinDepth below 2 falls back to 2/4", () => {
+    const body = "## H2\n### H3";
+    const headings = extractHeadings(body, { tocMinDepth: 1, tocMaxDepth: 4 });
+    // min:1 < 2 → invalid → fallback 2/4: both headings emitted
+    expect(headings).toHaveLength(2);
+  });
+
+  it("tocMaxDepth above 4 falls back to 2/4", () => {
+    const body = "## H2\n### H3";
+    const headings = extractHeadings(body, { tocMinDepth: 2, tocMaxDepth: 5 });
+    // max:5 > 4 → invalid → fallback 2/4: both headings emitted
+    expect(headings).toHaveLength(2);
+  });
+
+  it("non-integer values are truncated before validation", () => {
+    // 2.9 truncates to 2, 4.9 truncates to 4 — both valid after truncation.
+    const body = "## H2\n### H3\n#### H4";
+    const headings = extractHeadings(body, { tocMinDepth: 2.9, tocMaxDepth: 3.9 });
+    // min:2, max:3 after trunc → valid → emit h2+h3 only
+    expect(headings).toHaveLength(2);
+    expect(headings[0]?.depth).toBe(2);
+    expect(headings[1]?.depth).toBe(3);
+  });
+});

--- a/src/__tests__/pages-lib/extract-headings.test.ts
+++ b/src/__tests__/pages-lib/extract-headings.test.ts
@@ -217,6 +217,16 @@ describe("extractHeadings — configurable depth window (opts override)", () => 
     expect(headings[2]?.depth).toBe(4);
   });
 
+  it("h1 does NOT advance the slugger counter (renderer assigns no id to h1)", () => {
+    // The renderer's heading-links plugin slugs h2–h6 only; an h1 in the body
+    // (rare — the frontmatter title is the page h1) must NOT consume a slug, or
+    // a same-text h2 would diverge from its rendered id. Regression for #1938.
+    const body = ["# Intro", "## Intro"].join("\n");
+    const headings = extractHeadings(body);
+    expect(headings).toHaveLength(1);
+    expect(headings[0]?.slug).toBe("intro");
+  });
+
   it("tocMinDepth:3 excludes h2 from result", () => {
     const body = [
       "## H2 excluded",

--- a/src/components/doc-history.tsx
+++ b/src/components/doc-history.tsx
@@ -66,6 +66,7 @@ function buildSideBySideRows(
   let i = 0;
   while (i < changes.length) {
     const change = changes[i];
+    if (!change) { i++; continue; }
 
     if (!change.added && !change.removed) {
       // Context lines — show on both sides
@@ -76,25 +77,35 @@ function buildSideBySideRows(
         rows.push({ leftLine: line, rightLine: line, leftNum, rightNum, type: "context" });
       }
       i++;
-    } else if (change.removed && i + 1 < changes.length && changes[i + 1].added) {
-      // Paired remove+add — show side by side
-      const removedLines = change.value.replace(/\n$/, "").split("\n");
-      const addedLines = changes[i + 1].value.replace(/\n$/, "").split("\n");
-      const maxLen = Math.max(removedLines.length, addedLines.length);
-      for (let j = 0; j < maxLen; j++) {
-        const left = j < removedLines.length ? removedLines[j] : null;
-        const right = j < addedLines.length ? addedLines[j] : null;
-        if (left !== null) leftNum++;
-        if (right !== null) rightNum++;
-        rows.push({
-          leftLine: left,
-          rightLine: right,
-          leftNum: left !== null ? leftNum : null,
-          rightNum: right !== null ? rightNum : null,
-          type: "changed",
-        });
+    } else if (change.removed && i + 1 < changes.length) {
+      const nextChange = changes[i + 1];
+      if (nextChange?.added) {
+        // Paired remove+add — show side by side
+        const removedLines = change.value.replace(/\n$/, "").split("\n");
+        const addedLines = nextChange.value.replace(/\n$/, "").split("\n");
+        const maxLen = Math.max(removedLines.length, addedLines.length);
+        for (let j = 0; j < maxLen; j++) {
+          const left = j < removedLines.length ? (removedLines[j] ?? null) : null;
+          const right = j < addedLines.length ? (addedLines[j] ?? null) : null;
+          if (left !== null) leftNum++;
+          if (right !== null) rightNum++;
+          rows.push({
+            leftLine: left,
+            rightLine: right,
+            leftNum: left !== null ? leftNum : null,
+            rightNum: right !== null ? rightNum : null,
+            type: "changed",
+          });
+        }
+        i += 2;
+      } else {
+        const lines = change.value.replace(/\n$/, "").split("\n");
+        for (const line of lines) {
+          leftNum++;
+          rows.push({ leftLine: line, rightLine: null, leftNum, rightNum: null, type: "removed" });
+        }
+        i++;
       }
-      i += 2;
     } else if (change.removed) {
       const lines = change.value.replace(/\n$/, "").split("\n");
       for (const line of lines) {
@@ -277,9 +288,12 @@ function RevisionList({
     if (!canCompare) return;
     const idxOlder = Math.max(selectedA, selectedB);
     const idxNewer = Math.min(selectedA, selectedB);
+    const olderEntry = entries[idxOlder];
+    const newerEntry = entries[idxNewer];
+    if (!olderEntry || !newerEntry) return;
     onSelectDiff({
-      older: entries[idxOlder],
-      newer: entries[idxNewer],
+      older: olderEntry,
+      newer: newerEntry,
     });
   }
 

--- a/src/config/color-scheme-utils.ts
+++ b/src/config/color-scheme-utils.ts
@@ -172,9 +172,11 @@ export function generateLightDarkCssProperties(): string {
 
   const lines = [":root {", "  color-scheme: light dark;"];
   for (let i = 0; i < lightPairs.length; i++) {
-    const prop = lightPairs[i][0];
-    const lightVal = lightPairs[i][1];
-    const darkVal = darkPairs[i][1];
+    const lightPair = lightPairs[i];
+    const darkPair = darkPairs[i];
+    if (!lightPair || !darkPair) continue;
+    const [prop, lightVal] = lightPair;
+    const darkVal = darkPair[1];
     lines.push(`  ${prop}: light-dark(${lightVal}, ${darkVal});`);
   }
   lines.push("}");

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -135,6 +135,22 @@ export const settings = {
    * Set to `true` to enable the panel.
    */
   designTokenPanel: true as boolean,
+  /**
+   * Minimum heading depth included in the TOC (restriction-only: 2–4, default 2).
+   *
+   * Raise to 3 or 4 to hide shallower headings from the TOC. Cannot go below 2
+   * (h1 is always the page title) or above `tocMaxDepth`. Invalid values fall
+   * back to the default of 2.
+   */
+  tocMinDepth: 2 as number,
+  /**
+   * Maximum heading depth included in the TOC (restriction-only: 2–4, default 4).
+   *
+   * Lower to 2 or 3 to hide deeper headings from the TOC. Cannot exceed 4
+   * (h5–h6 are never shown) or go below `tocMinDepth`. Invalid values fall
+   * back to the default of 4.
+   */
+  tocMaxDepth: 4 as number,
   sidebarResizer: true as boolean,
   sidebarToggle: true as boolean,
   imageEnlarge: true as boolean,

--- a/src/hooks/use-active-heading.ts
+++ b/src/hooks/use-active-heading.ts
@@ -14,7 +14,9 @@ function getActiveHeadingId(
 
   let firstVisibleIndex = -1;
   for (let i = 0; i < headingIds.length; i++) {
-    const el = elementMap.get(headingIds[i]);
+    const id = headingIds[i];
+    if (id === undefined) continue;
+    const el = elementMap.get(id);
     if (!el) continue;
     const { top } = el.getBoundingClientRect();
     if (top >= SCROLL_MARGIN_TOP) {
@@ -24,29 +26,35 @@ function getActiveHeadingId(
   }
 
   if (firstVisibleIndex === -1) {
-    return headingIds[headingIds.length - 1];
+    return headingIds[headingIds.length - 1] ?? null;
   }
 
   if (firstVisibleIndex === 0) {
-    const el = elementMap.get(headingIds[0]);
-    if (el) {
-      const { top } = el.getBoundingClientRect();
-      if (top < viewportHeight / 2) {
-        return headingIds[0];
+    const firstId = headingIds[0];
+    if (firstId !== undefined) {
+      const el = elementMap.get(firstId);
+      if (el) {
+        const { top } = el.getBoundingClientRect();
+        if (top < viewportHeight / 2) {
+          return firstId;
+        }
       }
     }
     return null;
   }
 
-  const el = elementMap.get(headingIds[firstVisibleIndex]);
-  if (el) {
-    const { top } = el.getBoundingClientRect();
-    if (top < viewportHeight / 2) {
-      return headingIds[firstVisibleIndex];
+  const visibleId = headingIds[firstVisibleIndex];
+  if (visibleId !== undefined) {
+    const el = elementMap.get(visibleId);
+    if (el) {
+      const { top } = el.getBoundingClientRect();
+      if (top < viewportHeight / 2) {
+        return visibleId;
+      }
     }
   }
 
-  return headingIds[firstVisibleIndex - 1];
+  return headingIds[firstVisibleIndex - 1] ?? null;
 }
 
 interface UseActiveHeadingResult {

--- a/src/utils/base.ts
+++ b/src/utils/base.ts
@@ -97,7 +97,7 @@ export function navHref(
  */
 function splitVersionPrefix(path: string): { versionPrefix: string; rest: string } {
   const m = path.match(/^(\/v\/[^/]+)(\/.*|$)/);
-  return m ? { versionPrefix: m[1], rest: m[2] || "/" } : { versionPrefix: "", rest: path };
+  return m ? { versionPrefix: m[1] ?? "", rest: m[2] ?? "/" } : { versionPrefix: "", rest: path };
 }
 
 /** Build a locale-switched path from the current page path. */

--- a/src/utils/dedent.ts
+++ b/src/utils/dedent.ts
@@ -9,7 +9,7 @@ export function dedent(text: string): string {
   let minIndent = Infinity;
   for (const line of lines) {
     if (line.trim().length === 0) continue;
-    const indent = line.match(/^(\s*)/)?.[1].length ?? 0;
+    const indent = line.match(/^(\s*)/)?.[1]?.length ?? 0;
     if (indent < minIndent) minIndent = indent;
   }
 

--- a/src/utils/docs.ts
+++ b/src/utils/docs.ts
@@ -145,7 +145,7 @@ export function buildNavTree(
       // Multi-segment: walk the tree creating intermediate nodes as needed
       let current = root;
       for (let i = 0; i < parts.length; i++) {
-        const segment = parts[i];
+        const segment = parts[i] ?? "";
         const fullPath = parts.slice(0, i + 1).join("/");
         if (!current.children.has(segment)) {
           current.children.set(segment, {
@@ -240,16 +240,19 @@ export function groupSatelliteNodes(tree: NavNode[], prefixes: string[]): NavNod
     const primaryIdx = result.findIndex((n) => n.slug === prefix);
     if (primaryIdx < 0) continue;
     const primary = result[primaryIdx];
+    if (!primary) continue;
     const satelliteIdxs: number[] = [];
     for (let i = 0; i < result.length; i++) {
-      if (i !== primaryIdx && result[i].slug.startsWith(`${prefix}-`)) {
+      const node = result[i];
+      if (node && i !== primaryIdx && node.slug.startsWith(`${prefix}-`)) {
         satelliteIdxs.push(i);
       }
     }
     if (satelliteIdxs.length === 0) continue;
     const extraChildren: NavNode[] = [];
     for (const idx of satelliteIdxs) {
-      extraChildren.push(result[idx]);
+      const node = result[idx];
+      if (node) extraChildren.push(node);
     }
     result[primaryIdx] = {
       ...primary,

--- a/src/utils/render-markdown.ts
+++ b/src/utils/render-markdown.ts
@@ -64,7 +64,7 @@ function renderInline(text: string): string {
     });
 
   // Restore inline code spans
-  return processed.replace(/%%CODE_(\d+)%%/g, (_match, idx) => codeSpans[parseInt(idx, 10)]);
+  return processed.replace(/%%CODE_(\d+)%%/g, (_match, idx) => codeSpans[parseInt(idx, 10)] ?? "");
 }
 
 export function renderMarkdown(src: string): string {
@@ -92,7 +92,7 @@ export function renderMarkdown(src: string): string {
 
       // Code block placeholder
       const cbMatch = trimmed.match(/^%%CODEBLOCK_(\d+)%%$/);
-      if (cbMatch) return codeBlocks[parseInt(cbMatch[1], 10)];
+      if (cbMatch) return codeBlocks[parseInt(cbMatch[1] ?? "0", 10)] ?? "";
 
       // Unordered list (lines starting with - or *)
       if (/^[-*] /m.test(trimmed)) {
@@ -117,8 +117,10 @@ export function renderMarkdown(src: string): string {
       // Heading (# to ###)
       const headingMatch = trimmed.match(/^(#{1,3}) (.+)$/);
       if (headingMatch) {
-        const level = headingMatch[1].length;
-        return `<h${level + 3}>${renderInline(headingMatch[2])}</h${level + 3}>`;
+        const hashes = headingMatch[1] ?? "";
+        const headingText = headingMatch[2] ?? "";
+        const level = hashes.length;
+        return `<h${level + 3}>${renderInline(headingText)}</h${level + 3}>`;
       }
 
       // Regular paragraph — convert single newlines to <br>

--- a/src/utils/smart-break.tsx
+++ b/src/utils/smart-break.tsx
@@ -62,7 +62,7 @@ export function smartBreak(text: string): VNode | string {
   const parts = text.split(DELIM_SPLIT);
   const nodes: (string | VNode)[] = [];
   for (let i = 0; i < parts.length; i++) {
-    const part = parts[i];
+    const part = parts[i] ?? "";
     if (part === "") continue;
     nodes.push(part);
     // Captured delimiter groups always land at odd indices.
@@ -97,7 +97,7 @@ export function escapeAndInjectWbr(text: string): string {
   const parts = text.split(DELIM_SPLIT);
   let out = "";
   for (let i = 0; i < parts.length; i++) {
-    const part = parts[i];
+    const part = parts[i] ?? "";
     if (part === "") continue;
     out += htmlEscape(part);
     if (i % 2 === 1) out += "<wbr>";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
     "noImplicitThis": true,
     "useUnknownInCatchVariables": true,
     "alwaysStrict": true,
+    "noUncheckedIndexedAccess": true,
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"],


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/1939 (epic), https://github.com/zudolab/zudo-doc/issues/1938, https://github.com/zudolab/zudo-doc/issues/1926

---

## Summary

Two hardening topics from epic #1939, implemented across worktrees and merged here.

### #1938 — TOC slug fidelity
- **Floor fix:** `pages/lib/_extract-headings.ts` now advances one shared `github-slugger` counter across **h2–h6** (matching zfb's Rust `HeadingLinks` renderer) while still emitting only the configured h2–h4 window. This fixes the latent bug where an h5/h6 duplicating an earlier h2–h4 made the TOC anchor diverge from the rendered heading id. (h1 is intentionally **not** slugged — the renderer assigns no id to h1; this was a codex-review catch, verified against the built `dist/`.)
- **Restriction-only configurable TOC depth:** new `tocMinDepth`/`tocMaxDepth` settings (clamped `2 ≤ min ≤ max ≤ 4`, default 2/4 preserves current behavior). `extractHeadings` reads them internally; the published `Toc`/`MobileToc` filter is left as a harmless superset (no package change).
- **Hierarchical heading hashes** (the bigger redesign) require an upstream change — filed as **Takazudo/zudo-front-builder#871**; not in this PR.
- Binding gate: a built probe page confirms the TOC href equals the rendered heading `id` on the real renderer.

### #1926 — Type-safety hardening
- **`noUncheckedIndexedAccess` enabled** across every typecheck-gated config (root `tsconfig` + `packages/{zudo-doc,md-plugins,doc-history-server,search-worker,create-zudo-doc}`), with ~83 surfaced errors fixed using real guards (no `!`/`as` band-aids). `pages/` is not typechecked by any gate and is out of scope (documented).
- **DocsEntry sound-typing:** removed the `as unknown as DocsEntry[]` / `DocPageEntry` double-casts via `getCollection<ZfbDocsData>`, a single documented `bridgeDocsEntries` boundary cast, and a generic `mergeLocaleDocs<T>`. Verified with a one-off `tsc` probe over `pages/`.
- All create-zudo-doc template mirrors + the settings generator kept in sync (`check:template-drift` green).

## Sub-issues
- #1940 (B1) standalone-package NUIA · #1941 (B2) zudo-doc NUIA · #1944 (B3) root NUIA · #1942 (B4) DocsEntry typing · #1943 (A-host) TOC slugger + depth

## Verification
Root `pnpm check` + all package typechecks + full `pnpm build` + `check:template-drift` green; extract-headings test suite 22/22 incl. cross-level dedup, h1-parity, and depth-clamp cases; dual dist-probe (h5/h6 dedup + h1) pass on the rendered output.