### PR TITLE
chore(deps): bump zfb 0.1.0-next.33 → next.34

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,9 +67,9 @@
   "dependencies": {
     "@shikijs/transformers": "^4.0.1",
     "@takazudo/zdtp": "0.2.0-next.2",
-    "@takazudo/zfb": "0.1.0-next.33",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.33",
-    "@takazudo/zfb-runtime": "0.1.0-next.33",
+    "@takazudo/zfb": "0.1.0-next.34",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.34",
+    "@takazudo/zfb-runtime": "0.1.0-next.34",
     "@types/hast": "^3.0.4",
     "@takazudo/zudo-doc-md-plugins": "workspace:*",
     "@takazudo/zudo-doc": "workspace:*",

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -2770,13 +2770,15 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
    * (authored-CSS path when Tailwind is disabled, reproducible CSS-Modules
    * scoped names via project-relative paths, dev-mode git-restore detection,
    * Tailwind temp-file cleanup, near-miss `"use client"` directive scanner) —
-   * no consumer-facing breaking change. Now bumped to 0.1.0-next.33: adds the
+   * no consumer-facing breaking change. Bumped to 0.1.0-next.33: adds the
    * opt-in hierarchical heading-ID strategy
    * (Takazudo/zudo-front-builder#871) — `markdown.features.headingIds.strategy`,
    * which the generated config + TOC builder consume via
-   * `settings.headingIdStrategy`. Generated package.json must pin all three.
+   * `settings.headingIdStrategy`. Now bumped to 0.1.0-next.34: a routine
+   * bin-wrapper signal-handling release (no consumer-facing change).
+   * Generated package.json must pin all three.
    */
-  it("pins @takazudo/zfb at 0.1.0-next.33", async () => {
+  it("pins @takazudo/zfb at 0.1.0-next.34", async () => {
     const choices: UserChoices = {
       projectName: "test-pin-bump",
       defaultLang: "en",
@@ -2787,10 +2789,10 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
     };
     await scaffold(choices);
     const pkg = await fs.readJson(projectPath("test-pin-bump", "package.json"));
-    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.33");
-    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.33");
+    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.34");
+    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.34");
     expect(pkg.dependencies["@takazudo/zfb-adapter-cloudflare"]).toBe(
-      "0.1.0-next.33",
+      "0.1.0-next.34",
     );
   });
 });

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -327,14 +327,15 @@ function generatePackageJson(choices: UserChoices) {
     // disabled, reproducible CSS-Modules scoped names (project-relative paths),
     // dev-mode git-restore detection, Tailwind temp-file cleanup, and a
     // near-miss `"use client"` directive scanner.
-    // Bumped to next.33 — adds the opt-in hierarchical heading-ID strategy
+    // next.33 added the opt-in hierarchical heading-ID strategy
     // (Takazudo/zudo-front-builder#871): `markdown.features.headingIds.strategy`.
     // The generated config + TOC builder use it via settings.headingIdStrategy.
-    "@takazudo/zfb": "0.1.0-next.33",
-    "@takazudo/zfb-runtime": "0.1.0-next.33",
+    // next.34 is a routine bin-wrapper signal-handling bump (no feature change).
+    "@takazudo/zfb": "0.1.0-next.34",
+    "@takazudo/zfb-runtime": "0.1.0-next.34",
     // zfb-adapter-cloudflare — required for any route with `prerender = false`.
     // Pinned in lockstep with @takazudo/zfb.
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.33",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.34",
     // @takazudo/zudo-doc — published from this monorepo via
     // .github/workflows/publish-zudo-doc.yml. The pin here is bumped in
     // lockstep by scripts/release-create-zudo-doc.sh whenever zudo-doc's

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -165,8 +165,8 @@
   ],
   "peerDependencies": {
     "preact": "^10.29.1",
-    "@takazudo/zfb": "^0.1.0-next.33",
-    "@takazudo/zfb-runtime": "^0.1.0-next.33",
+    "@takazudo/zfb": "^0.1.0-next.34",
+    "@takazudo/zfb-runtime": "^0.1.0-next.34",
     "@takazudo/zudo-doc-history-server": "workspace:^",
     "@takazudo/zdtp": "^0.2.0-next.2"
   },
@@ -189,7 +189,7 @@
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
     "vitest": "^3.0.0",
-    "@takazudo/zfb": "0.1.0-next.33",
-    "@takazudo/zfb-runtime": "0.1.0-next.33"
+    "@takazudo/zfb": "0.1.0-next.34",
+    "@takazudo/zfb-runtime": "0.1.0-next.34"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,11 +295,11 @@ importers:
         version: 4.0.3
     devDependencies:
       '@takazudo/zfb':
-        specifier: 0.1.0-next.33
-        version: 0.1.0-next.33
+        specifier: 0.1.0-next.34
+        version: 0.1.0-next.34
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.33
-        version: 0.1.0-next.33(@takazudo/zfb@0.1.0-next.33)
+        specifier: 0.1.0-next.34
+        version: 0.1.0-next.34(@takazudo/zfb@0.1.0-next.34)
       '@types/node':
         specifier: ^25.3.5
         version: 25.3.5
@@ -1595,19 +1595,9 @@ packages:
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.33':
-    resolution: {integrity: sha512-c9vGnK6YfRDndYzgFCYjfDc927G16JCnG22WwXvdeeYQkqq1ZNk9YNbc4QzpJ1xrICzMqbhI3ltv0TlodN7IEQ==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@takazudo/zfb-darwin-arm64@0.1.0-next.34':
     resolution: {integrity: sha512-K8lV4OHe12RLEjJfCwdEv/43YM4XqaDGrI0g1LrDGTN4yX1crAq0AgFxQbdP+Q+hD/GNYSzyUiUAhA6inLQ+sg==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@takazudo/zfb-darwin-x64@0.1.0-next.33':
-    resolution: {integrity: sha512-UOp3BPFmvxucd4FGjqfzCXEFTtwCb5LgXGHF4mtBuasqQTudZAhUy11wPD4Ovsnnz0TRNmFwMHp/eS+sPxNpzg==}
-    cpu: [x64]
     os: [darwin]
 
   '@takazudo/zfb-darwin-x64@0.1.0-next.34':
@@ -1615,19 +1605,9 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.33':
-    resolution: {integrity: sha512-whtw8tCpw23Vus7tHm53njR++z5njYNeblD2/S+yG4oZUsjXDlLOJ+UVi+u4BZ02DyNQBdpj9Xyje4l9EmjoqA==}
-    cpu: [arm64]
-    os: [linux]
-
   '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.34':
     resolution: {integrity: sha512-MaMAzz5b8unwgkPJkpAg8mcNaCQ2bWUgPZjNRNgh2H22WDyjIXv9fAoYkPrCQdUEDiytIlG6U4ydsP0GJUAF1A==}
     cpu: [arm64]
-    os: [linux]
-
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.33':
-    resolution: {integrity: sha512-weg55qg7Vk8cTVrKEVxzryYK36ZFSMI4yCc7VVUq8RYbNdTEegk10UCvFhghiXpdG6C/FiKw8kvI6AdCo1K2sA==}
-    cpu: [x64]
     os: [linux]
 
   '@takazudo/zfb-linux-x64-gnu@0.1.0-next.34':
@@ -1635,32 +1615,16 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.33':
-    resolution: {integrity: sha512-EQbhM0zIHAe0YxEkRSbZbisjN77l3Ljta6CQx5jAPqdnf7FeI6F54DfvnhAmfhaXFZODcptW8f7o10i+Qjfn+A==}
-    engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
-    peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.33
-
   '@takazudo/zfb-runtime@0.1.0-next.34':
     resolution: {integrity: sha512-XdZRW+MhBWw805QIyW0zEGkGieeeXV1rlolV8kcTILfAhd6Zn6x0+kCLrnPbRovbfuzwnJ6J2olmIqn+FbGSbg==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
       '@takazudo/zfb': 0.1.0-next.34
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.33':
-    resolution: {integrity: sha512-S5WIEwgzyGMyeN4SX8YtZWwE3crWYD2G3lnwn1+xQt57hQPu0LUuaAy7u0LgSLwqaF93jdEu6l7Ii2C3CsMf7w==}
-    cpu: [x64]
-    os: [win32]
-
   '@takazudo/zfb-win32-x64-msvc@0.1.0-next.34':
     resolution: {integrity: sha512-FRam+byoFWxQkyoqxlNFidafTFPZMMbaKbCHObOMv5K27J2hymnptak2ezLDlDOnSAnOME9E3Wcdz9GUV/QiGA==}
     cpu: [x64]
     os: [win32]
-
-  '@takazudo/zfb@0.1.0-next.33':
-    resolution: {integrity: sha512-OkyEovxGuPKfq5dWnv2dZEOrX6Fiq+5PCELOTRoZmxjCN2MQSVU/xoB4Stb5dLsvs5sgI2zLDyRdcm0aVQRe1w==}
-    engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
-    hasBin: true
 
   '@takazudo/zfb@0.1.0-next.34':
     resolution: {integrity: sha512-adPEFEIhQbk1gwJoTkN1Pn3tDw2ClRB87DahDYCnsUAux4SpBWr2uhOv/HclcMCPe2Vm91Z6Kroj4EVIlYFZPw==}
@@ -4629,53 +4593,25 @@ snapshots:
 
   '@takazudo/zfb-adapter-cloudflare@0.1.0-next.34': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.33':
-    optional: true
-
   '@takazudo/zfb-darwin-arm64@0.1.0-next.34':
-    optional: true
-
-  '@takazudo/zfb-darwin-x64@0.1.0-next.33':
     optional: true
 
   '@takazudo/zfb-darwin-x64@0.1.0-next.34':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.33':
-    optional: true
-
   '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.34':
-    optional: true
-
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.33':
     optional: true
 
   '@takazudo/zfb-linux-x64-gnu@0.1.0-next.34':
     optional: true
-
-  '@takazudo/zfb-runtime@0.1.0-next.33(@takazudo/zfb@0.1.0-next.33)':
-    dependencies:
-      '@takazudo/zfb': 0.1.0-next.33
-      hono: 4.12.23
 
   '@takazudo/zfb-runtime@0.1.0-next.34(@takazudo/zfb@0.1.0-next.34)':
     dependencies:
       '@takazudo/zfb': 0.1.0-next.34
       hono: 4.12.23
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.33':
-    optional: true
-
   '@takazudo/zfb-win32-x64-msvc@0.1.0-next.34':
     optional: true
-
-  '@takazudo/zfb@0.1.0-next.33':
-    optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.33
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.33
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.33
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.33
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.33
 
   '@takazudo/zfb@0.1.0-next.34':
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,14 +20,14 @@ importers:
         specifier: 0.2.0-next.2
         version: 0.2.0-next.2(preact@10.29.2)
       '@takazudo/zfb':
-        specifier: 0.1.0-next.33
-        version: 0.1.0-next.33
+        specifier: 0.1.0-next.34
+        version: 0.1.0-next.34
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.33
-        version: 0.1.0-next.33
+        specifier: 0.1.0-next.34
+        version: 0.1.0-next.34
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.33
-        version: 0.1.0-next.33(@takazudo/zfb@0.1.0-next.33)
+        specifier: 0.1.0-next.34
+        version: 0.1.0-next.34(@takazudo/zfb@0.1.0-next.34)
       '@takazudo/zudo-doc':
         specifier: workspace:*
         version: link:packages/zudo-doc
@@ -1590,8 +1590,8 @@ packages:
     peerDependencies:
       preact: ^10.29.1
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.33':
-    resolution: {integrity: sha512-O9v6iCaBgRaVfKSS/xR0MH35pAI9z+FPOPzG57ITXJjYIJYQqXpSHCyrVX80WN6q/FnP9qpE0akF5QPntYJiZw==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.34':
+    resolution: {integrity: sha512-xiccrTOHtxXiunnujlrPIzJsGoHbj2SXFZKhtMJAta2wHxb4/GtT8aTE1JYHtg56szP5yKxXjYHFejdMG3onjQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
@@ -1600,8 +1600,18 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.34':
+    resolution: {integrity: sha512-K8lV4OHe12RLEjJfCwdEv/43YM4XqaDGrI0g1LrDGTN4yX1crAq0AgFxQbdP+Q+hD/GNYSzyUiUAhA6inLQ+sg==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@takazudo/zfb-darwin-x64@0.1.0-next.33':
     resolution: {integrity: sha512-UOp3BPFmvxucd4FGjqfzCXEFTtwCb5LgXGHF4mtBuasqQTudZAhUy11wPD4Ovsnnz0TRNmFwMHp/eS+sPxNpzg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@takazudo/zfb-darwin-x64@0.1.0-next.34':
+    resolution: {integrity: sha512-CXQJMQwEaP+1F1lrP8FhwEAMjkwTnfd+TUA/QpO0ORQmsP41CxVwaBaSLjAc3NCa0rbKAhiW5HNsD8GyJkVH1A==}
     cpu: [x64]
     os: [darwin]
 
@@ -1610,8 +1620,18 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.34':
+    resolution: {integrity: sha512-MaMAzz5b8unwgkPJkpAg8mcNaCQ2bWUgPZjNRNgh2H22WDyjIXv9fAoYkPrCQdUEDiytIlG6U4ydsP0GJUAF1A==}
+    cpu: [arm64]
+    os: [linux]
+
   '@takazudo/zfb-linux-x64-gnu@0.1.0-next.33':
     resolution: {integrity: sha512-weg55qg7Vk8cTVrKEVxzryYK36ZFSMI4yCc7VVUq8RYbNdTEegk10UCvFhghiXpdG6C/FiKw8kvI6AdCo1K2sA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.34':
+    resolution: {integrity: sha512-09vgc1i++RlZsjrS1krPChiNlFTR+Xnv3LVQb7JEuzPoF23pj0OtS1GJLI1DCu+OC6Mer8DdzoxLQG7aRDx2iw==}
     cpu: [x64]
     os: [linux]
 
@@ -1621,13 +1641,29 @@ packages:
     peerDependencies:
       '@takazudo/zfb': 0.1.0-next.33
 
+  '@takazudo/zfb-runtime@0.1.0-next.34':
+    resolution: {integrity: sha512-XdZRW+MhBWw805QIyW0zEGkGieeeXV1rlolV8kcTILfAhd6Zn6x0+kCLrnPbRovbfuzwnJ6J2olmIqn+FbGSbg==}
+    engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
+    peerDependencies:
+      '@takazudo/zfb': 0.1.0-next.34
+
   '@takazudo/zfb-win32-x64-msvc@0.1.0-next.33':
     resolution: {integrity: sha512-S5WIEwgzyGMyeN4SX8YtZWwE3crWYD2G3lnwn1+xQt57hQPu0LUuaAy7u0LgSLwqaF93jdEu6l7Ii2C3CsMf7w==}
     cpu: [x64]
     os: [win32]
 
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.34':
+    resolution: {integrity: sha512-FRam+byoFWxQkyoqxlNFidafTFPZMMbaKbCHObOMv5K27J2hymnptak2ezLDlDOnSAnOME9E3Wcdz9GUV/QiGA==}
+    cpu: [x64]
+    os: [win32]
+
   '@takazudo/zfb@0.1.0-next.33':
     resolution: {integrity: sha512-OkyEovxGuPKfq5dWnv2dZEOrX6Fiq+5PCELOTRoZmxjCN2MQSVU/xoB4Stb5dLsvs5sgI2zLDyRdcm0aVQRe1w==}
+    engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
+    hasBin: true
+
+  '@takazudo/zfb@0.1.0-next.34':
+    resolution: {integrity: sha512-adPEFEIhQbk1gwJoTkN1Pn3tDw2ClRB87DahDYCnsUAux4SpBWr2uhOv/HclcMCPe2Vm91Z6Kroj4EVIlYFZPw==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
@@ -4591,18 +4627,30 @@ snapshots:
       culori: 4.0.2
       preact: 10.29.2
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.33': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.34': {}
 
   '@takazudo/zfb-darwin-arm64@0.1.0-next.33':
+    optional: true
+
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.34':
     optional: true
 
   '@takazudo/zfb-darwin-x64@0.1.0-next.33':
     optional: true
 
+  '@takazudo/zfb-darwin-x64@0.1.0-next.34':
+    optional: true
+
   '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.33':
     optional: true
 
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.34':
+    optional: true
+
   '@takazudo/zfb-linux-x64-gnu@0.1.0-next.33':
+    optional: true
+
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.34':
     optional: true
 
   '@takazudo/zfb-runtime@0.1.0-next.33(@takazudo/zfb@0.1.0-next.33)':
@@ -4610,7 +4658,15 @@ snapshots:
       '@takazudo/zfb': 0.1.0-next.33
       hono: 4.12.23
 
+  '@takazudo/zfb-runtime@0.1.0-next.34(@takazudo/zfb@0.1.0-next.34)':
+    dependencies:
+      '@takazudo/zfb': 0.1.0-next.34
+      hono: 4.12.23
+
   '@takazudo/zfb-win32-x64-msvc@0.1.0-next.33':
+    optional: true
+
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.34':
     optional: true
 
   '@takazudo/zfb@0.1.0-next.33':
@@ -4620,6 +4676,14 @@ snapshots:
       '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.33
       '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.33
       '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.33
+
+  '@takazudo/zfb@0.1.0-next.34':
+    optionalDependencies:
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.34
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.34
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.34
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.34
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.34
 
   '@takazudo/zudo-design-token-lint@1.0.0':
     dependencies:


### PR DESCRIPTION
## Summary

Routine bump of the pinned zfb packages from `0.1.0-next.33` to `0.1.0-next.34`:

- `@takazudo/zfb`
- `@takazudo/zfb-runtime`
- `@takazudo/zfb-adapter-cloudflare`

`next.34` is a small bin-wrapper signal-handling release. The matching platform binaries (`zfb-*` optionalDependencies) move to `next.34` automatically via the lockfile. Pins are aligned in lockstep across root, the `create-zudo-doc` generator, and the `@takazudo/zudo-doc` package to satisfy the pin-parity gate.

## Not a fix for #1948

This bump was originally attempted as a fix for #1948 (bare in-content `#anchor` links rewritten to `/<parent-dir>/#anchor`). **It does not fix it** — verified empirically (the broken prose links persist after a fresh build on `zfb 0.1.0-next.34`) and via changelog (`next.34` touches nothing in `resolve_links`). `next.34` is the current latest, so there is no newer version to try. #1948 stays open, blocked on an upstream `resolve_links.rs` change. Kept this PR as routine dependency hygiene only.

## Changes
- `package.json`: three zfb pins `next.33 → next.34`
- `packages/create-zudo-doc/src/scaffold.ts`: generator pins `next.33 → next.34`
- `packages/zudo-doc/package.json`: dev/peer zfb pins `next.33 → next.34`
- `packages/create-zudo-doc/src/__tests__/scaffold.test.ts`: pin-bump assertion `next.33 → next.34`
- `pnpm-lock.yaml`: regenerated (zfb refs only)

## Test Plan
- `pnpm build` — ✅ 259 pages built on `zfb 0.1.0-next.34`
- `pnpm check` — ✅ typecheck + 3 collections, no errors
- `pnpm check:pin-parity` — ✅ root ↔ scaffold ↔ workspace in lockstep
- `pnpm check:template-drift` — ✅ no drift
- generator unit tests — ✅ 258 passed