### PR TITLE
fix(deps): bump zfb to 0.1.0-next.35 — fixes bare in-content #anchor resolution (#1948)

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,9 +67,9 @@
   "dependencies": {
     "@shikijs/transformers": "^4.0.1",
     "@takazudo/zdtp": "0.2.0-next.2",
-    "@takazudo/zfb": "0.1.0-next.34",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.34",
-    "@takazudo/zfb-runtime": "0.1.0-next.34",
+    "@takazudo/zfb": "0.1.0-next.35",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.35",
+    "@takazudo/zfb-runtime": "0.1.0-next.35",
     "@types/hast": "^3.0.4",
     "@takazudo/zudo-doc-md-plugins": "workspace:*",
     "@takazudo/zudo-doc": "workspace:*",

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -2774,11 +2774,13 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
    * opt-in hierarchical heading-ID strategy
    * (Takazudo/zudo-front-builder#871) — `markdown.features.headingIds.strategy`,
    * which the generated config + TOC builder consume via
-   * `settings.headingIdStrategy`. Now bumped to 0.1.0-next.34: a routine
-   * bin-wrapper signal-handling release (no consumer-facing change).
-   * Generated package.json must pin all three.
+   * `settings.headingIdStrategy`. next.34 was a routine bin-wrapper
+   * signal-handling release. Now bumped to 0.1.0-next.35: fixes resolve_links
+   * rewriting bare same-page `[text](#anchor)` / `[text](?query)` links to
+   * `/<parent-dir>/#anchor` (zudolab/zudo-doc#1948, upstream
+   * Takazudo/zudo-front-builder#875). Generated package.json must pin all three.
    */
-  it("pins @takazudo/zfb at 0.1.0-next.34", async () => {
+  it("pins @takazudo/zfb at 0.1.0-next.35", async () => {
     const choices: UserChoices = {
       projectName: "test-pin-bump",
       defaultLang: "en",
@@ -2789,10 +2791,10 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
     };
     await scaffold(choices);
     const pkg = await fs.readJson(projectPath("test-pin-bump", "package.json"));
-    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.34");
-    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.34");
+    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.35");
+    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.35");
     expect(pkg.dependencies["@takazudo/zfb-adapter-cloudflare"]).toBe(
-      "0.1.0-next.34",
+      "0.1.0-next.35",
     );
   });
 });

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -330,12 +330,14 @@ function generatePackageJson(choices: UserChoices) {
     // next.33 added the opt-in hierarchical heading-ID strategy
     // (Takazudo/zudo-front-builder#871): `markdown.features.headingIds.strategy`.
     // The generated config + TOC builder use it via settings.headingIdStrategy.
-    // next.34 is a routine bin-wrapper signal-handling bump (no feature change).
-    "@takazudo/zfb": "0.1.0-next.34",
-    "@takazudo/zfb-runtime": "0.1.0-next.34",
+    // next.35 fixes resolve_links rewriting bare same-page `[text](#anchor)` /
+    // `[text](?query)` links to `/<parent-dir>/#anchor` (zudolab/zudo-doc#1948,
+    // upstream Takazudo/zudo-front-builder#875).
+    "@takazudo/zfb": "0.1.0-next.35",
+    "@takazudo/zfb-runtime": "0.1.0-next.35",
     // zfb-adapter-cloudflare — required for any route with `prerender = false`.
     // Pinned in lockstep with @takazudo/zfb.
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.34",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.35",
     // @takazudo/zudo-doc — published from this monorepo via
     // .github/workflows/publish-zudo-doc.yml. The pin here is bumped in
     // lockstep by scripts/release-create-zudo-doc.sh whenever zudo-doc's

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -165,8 +165,8 @@
   ],
   "peerDependencies": {
     "preact": "^10.29.1",
-    "@takazudo/zfb": "^0.1.0-next.34",
-    "@takazudo/zfb-runtime": "^0.1.0-next.34",
+    "@takazudo/zfb": "^0.1.0-next.35",
+    "@takazudo/zfb-runtime": "^0.1.0-next.35",
     "@takazudo/zudo-doc-history-server": "workspace:^",
     "@takazudo/zdtp": "^0.2.0-next.2"
   },
@@ -189,7 +189,7 @@
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
     "vitest": "^3.0.0",
-    "@takazudo/zfb": "0.1.0-next.34",
-    "@takazudo/zfb-runtime": "0.1.0-next.34"
+    "@takazudo/zfb": "0.1.0-next.35",
+    "@takazudo/zfb-runtime": "0.1.0-next.35"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,14 +20,14 @@ importers:
         specifier: 0.2.0-next.2
         version: 0.2.0-next.2(preact@10.29.2)
       '@takazudo/zfb':
-        specifier: 0.1.0-next.34
-        version: 0.1.0-next.34
+        specifier: 0.1.0-next.35
+        version: 0.1.0-next.35
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.34
-        version: 0.1.0-next.34
+        specifier: 0.1.0-next.35
+        version: 0.1.0-next.35
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.34
-        version: 0.1.0-next.34(@takazudo/zfb@0.1.0-next.34)
+        specifier: 0.1.0-next.35
+        version: 0.1.0-next.35(@takazudo/zfb@0.1.0-next.35)
       '@takazudo/zudo-doc':
         specifier: workspace:*
         version: link:packages/zudo-doc
@@ -295,11 +295,11 @@ importers:
         version: 4.0.3
     devDependencies:
       '@takazudo/zfb':
-        specifier: 0.1.0-next.34
-        version: 0.1.0-next.34
+        specifier: 0.1.0-next.35
+        version: 0.1.0-next.35
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.34
-        version: 0.1.0-next.34(@takazudo/zfb@0.1.0-next.34)
+        specifier: 0.1.0-next.35
+        version: 0.1.0-next.35(@takazudo/zfb@0.1.0-next.35)
       '@types/node':
         specifier: ^25.3.5
         version: 25.3.5
@@ -1590,44 +1590,44 @@ packages:
     peerDependencies:
       preact: ^10.29.1
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.34':
-    resolution: {integrity: sha512-xiccrTOHtxXiunnujlrPIzJsGoHbj2SXFZKhtMJAta2wHxb4/GtT8aTE1JYHtg56szP5yKxXjYHFejdMG3onjQ==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.35':
+    resolution: {integrity: sha512-7Tl63UQ50aHnXoO+h5x7m1hGSCte7Fzj7mlTl8RbxsvHyLl1RPgV0vp2h1WGmwQMOmGjYkvLkJZmo4SbhnayVg==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.34':
-    resolution: {integrity: sha512-K8lV4OHe12RLEjJfCwdEv/43YM4XqaDGrI0g1LrDGTN4yX1crAq0AgFxQbdP+Q+hD/GNYSzyUiUAhA6inLQ+sg==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.35':
+    resolution: {integrity: sha512-zITxJqQx83JXJb3vCTkGx6IFHUUYvZWomitVY7wLPvn+A3GbVthhcnIDo9lsIOpAdZzyMBQbxl7fsOgL5lPseA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.34':
-    resolution: {integrity: sha512-CXQJMQwEaP+1F1lrP8FhwEAMjkwTnfd+TUA/QpO0ORQmsP41CxVwaBaSLjAc3NCa0rbKAhiW5HNsD8GyJkVH1A==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.35':
+    resolution: {integrity: sha512-v9/5AvcH4ehWd5gwojJTDJTo2dCf5JI2AIcJlUYIKZVJkLw4XMxhtzp8ZagfA5yzvfkqCfiBs7RM7ed+d9DKzQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.34':
-    resolution: {integrity: sha512-MaMAzz5b8unwgkPJkpAg8mcNaCQ2bWUgPZjNRNgh2H22WDyjIXv9fAoYkPrCQdUEDiytIlG6U4ydsP0GJUAF1A==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.35':
+    resolution: {integrity: sha512-cjiTbQd0uon8Q44jXGv2RWviwgkd8UU4yAjn7p+zOQBBLoNHIq55tDqjKmV47NCLmuChVTVubOlmYczFjU+bOg==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.34':
-    resolution: {integrity: sha512-09vgc1i++RlZsjrS1krPChiNlFTR+Xnv3LVQb7JEuzPoF23pj0OtS1GJLI1DCu+OC6Mer8DdzoxLQG7aRDx2iw==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.35':
+    resolution: {integrity: sha512-0ZpKY+vUmziaQfJThF0aA4Phl+EW5fxk1DBDt/TRs4X/J8Fv3G3sOj+2ljEI7t5iIkJoVjeeNxZKTL9sGAn8Dw==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.34':
-    resolution: {integrity: sha512-XdZRW+MhBWw805QIyW0zEGkGieeeXV1rlolV8kcTILfAhd6Zn6x0+kCLrnPbRovbfuzwnJ6J2olmIqn+FbGSbg==}
+  '@takazudo/zfb-runtime@0.1.0-next.35':
+    resolution: {integrity: sha512-PA5Ti3UB2/izMLyFRXspD+ffrSCXMcG0OlHE4B9D8HpljvvdFyt0FI8u95L+kOlJFeSHG9bPw14c30cNLf0+Xw==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.34
+      '@takazudo/zfb': 0.1.0-next.35
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.34':
-    resolution: {integrity: sha512-FRam+byoFWxQkyoqxlNFidafTFPZMMbaKbCHObOMv5K27J2hymnptak2ezLDlDOnSAnOME9E3Wcdz9GUV/QiGA==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.35':
+    resolution: {integrity: sha512-0wjK34hsd8KZDVNIA0Cr071aaTYYoKzPkcbXwaHvHJGNW0YB2y+ARY67cUdKLj5A9jc2mXdSNr1Zt4Y1OE3pZQ==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.34':
-    resolution: {integrity: sha512-adPEFEIhQbk1gwJoTkN1Pn3tDw2ClRB87DahDYCnsUAux4SpBWr2uhOv/HclcMCPe2Vm91Z6Kroj4EVIlYFZPw==}
+  '@takazudo/zfb@0.1.0-next.35':
+    resolution: {integrity: sha512-WREfJQmNHpiOH8O2wW7uN8EyQr3xdFyyERKhPaAG6idLLTo2lOcy5VTHZUXnllQ1sSUf8Cv4iLGQz2J5lybZzQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
@@ -4591,35 +4591,35 @@ snapshots:
       culori: 4.0.2
       preact: 10.29.2
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.34': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.35': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.34':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.35':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.34':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.35':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.34':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.35':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.34':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.35':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.34(@takazudo/zfb@0.1.0-next.34)':
+  '@takazudo/zfb-runtime@0.1.0-next.35(@takazudo/zfb@0.1.0-next.35)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.34
+      '@takazudo/zfb': 0.1.0-next.35
       hono: 4.12.23
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.34':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.35':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.34':
+  '@takazudo/zfb@0.1.0-next.35':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.34
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.34
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.34
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.34
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.34
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.35
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.35
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.35
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.35
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.35
 
   '@takazudo/zudo-design-token-lint@1.0.0':
     dependencies:


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/1948

---

## Summary

Bumps the pinned zfb packages `0.1.0-next.34 → 0.1.0-next.35`. **next.35 fixes #1948** — zfb's `resolveMarkdownLinks` (`resolve_links.rs`) no longer rewrites bare same-page `[text](#anchor)` / `[text](?query)` links to the wrong `/<parent-dir>/#anchor` form (upstream Takazudo/zudo-front-builder#875: an early return now lets bare `#fragment` / `?query` links pass through untouched).

Closes #1948.

## Verification (fresh build on `zfb 0.1.0-next.35`)

All five affected in-content **prose** links now resolve same-page, and the broken parent-dir form is gone everywhere (confirmed by an adversarial 10-agent / 2-lens sweep + direct grep):

| Page | Fragment | broken `/parent/#…` | same-page `#…` |
|---|---|---|---|
| docs/guides/doc-history | per-page-visibility | 0 | 4 |
| docs/guides/tags | naming-conventions | 0 | 4 |
| docs/reference/search-worker | when-to-use-each | 0 | 4 |
| docs-ja/guides/doc-history | ページごとの表示制御 | 0 | 4 |
| docs-ja/reference/search-worker | 使い分けガイド | 0 | 4 |

## Changes
- `package.json`: three zfb pins `next.34 → next.35`
- `packages/create-zudo-doc/src/scaffold.ts`: generator pins `next.34 → next.35`
- `packages/zudo-doc/package.json`: dev/peer zfb pins `next.34 → next.35`
- `packages/create-zudo-doc/src/__tests__/scaffold.test.ts`: pin-bump assertion `next.34 → next.35`
- `pnpm-lock.yaml`: regenerated (zfb refs only)

## Test Plan
- `pnpm build` — ✅ 259 pages on `zfb 0.1.0-next.35`
- `pnpm check` — ✅ typecheck + 3 collections
- `pnpm check:pin-parity` — ✅ root ↔ scaffold ↔ workspace lockstep
- `pnpm check:template-drift` — ✅ no drift
- generator unit tests — ✅ 258 passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/1951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783403410&installation_id=130359969&pr_number=1951&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F1951&signature=e7921e2f4c44d3bcad5392302a7597b2167ac0a40f71ab26823491fcb5ea3013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->