### PR TITLE
CI Guard Parity: mirror b4push guard gates into CI + add guard-manifest meta-check

### DIFF
--- a/.b4push-ci-parity-allowlist
+++ b/.b4push-ci-parity-allowlist
@@ -1,0 +1,25 @@
+# .b4push-ci-parity-allowlist
+#
+# Each entry is an intentional CI exemption — a pnpm script that appears in
+# the run-b4push.sh guard region but is NOT required to have its own CI job.
+#
+# Convention (enforced by review, not tooling):
+#   - SEED ONCE: entries are added when the check is introduced, for scripts
+#     whose absence from CI is genuinely intentional.
+#   - NEW GUARDS: when a new pnpm script is added to the run-b4push.sh guard
+#     region, the parity check fires. To resolve: either (a) add a CI job and
+#     an entry in REQUIRED_CI_GUARDS, OR (b) add the script name here with a
+#     "# reason:" comment explaining why CI enforcement is not needed.
+#   - NO SILENT EXTENSIONS: every new allowlist entry needs a # reason: comment.
+#
+# Format: one entry per line — exact pnpm script name (no "pnpm " prefix).
+# Comments: lines starting with # are ignored. Blank lines are ignored.
+# Exact-match only (no globs, no wildcards).
+#
+
+# ── format:check:mdx ──────────────────────────────────────────────────────────
+# reason: enforced by lefthook pre-commit hook on every commit, so staged files
+#         are always checked before they reach CI. A dedicated CI job would be
+#         redundant overhead given the hook fires reliably on every developer's
+#         machine (auto-installed by pnpm install via the prepare lifecycle script).
+format:check:mdx

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -8,6 +8,7 @@
 #   Template Drift Check     — pure-shell, no install; scripts/check-template-drift.sh
 #   Pin Parity Check         — pure-Node, no install; scripts/check-pin-parity.mjs
 #   Fixture Settings Drift   — pure-Node, no install; scripts/check-fixture-settings-drift.mjs
+#   B4push/CI Parity Check   — pure-Node, no install; scripts/check-b4push-ci-parity.mjs
 #   Lint Gates               — pnpm install; pnpm tags:audit --ci + pnpm lint:tokens
 #   Type Check               — pnpm install; pnpm check (zfb check → tsc --noEmit)
 #   Package Unit Tests       — pnpm install; pnpm test:packages (all 5 package suites)
@@ -99,6 +100,23 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Check fixture settings drift
         run: node scripts/check-fixture-settings-drift.mjs
+
+  # ---------------------------------------------------------------------------
+  # Job 0.65: B4push/CI parity check (guard manifest meta-check)
+  # ---------------------------------------------------------------------------
+  # Verifies that every lightweight guard gate in scripts/run-b4push.sh also
+  # has a corresponding job in this workflow. Closes the silent-drift gap where
+  # a b4push guard could be added without a matching CI job (#1967).
+  # Pure-Node script — uses preinstalled Node 22 on the runner image, no pnpm.
+  check-b4push-ci-parity:
+    name: B4push/CI Parity Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - name: Check b4push/CI parity
+        run: node scripts/check-b4push-ci-parity.mjs
 
   # ---------------------------------------------------------------------------
   # Job 0.7: Lint gates (tags audit + design token lint)

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,16 +2,21 @@
 #
 # Triggered on PRs targeting `main` or any `base/**` branch (epic-PRs in
 # the zfb migration parity super-epic stack into base/zfb-migration-parity
-# so each child epic-PR also needs CI gating). The pipeline mirrors the
-# local `pnpm b4push` script:
-#   0. Template drift check (no install needed — pure shell)
-#   1. Type checking (`zfb check` → tsc --noEmit)
-#   2. Build the zfb docs site (full clone — needed for SSG meta dates)
-#   3. HTML validate the built dist/
-#   4. Build doc history JSONs (full clone, standalone server package)
-#   5. E2E & smoke tests (Playwright)
-#   6. Merge build outputs and deploy a preview to Cloudflare Workers static assets
-#   7. Post the preview URL as a PR comment
+# so each child epic-PR also needs CI gating).
+#
+# CI jobs (in approximate execution order):
+#   Template Drift Check     — pure-shell, no install; scripts/check-template-drift.sh
+#   Pin Parity Check         — pure-Node, no install; scripts/check-pin-parity.mjs
+#   Fixture Settings Drift   — pure-Node, no install; scripts/check-fixture-settings-drift.mjs
+#   Lint Gates               — pnpm install; pnpm tags:audit --ci + pnpm lint:tokens
+#   Type Check               — pnpm install; pnpm check (zfb check → tsc --noEmit)
+#   Package Unit Tests       — pnpm install; pnpm test:packages (all 5 package suites)
+#   Root Unit Tests          — pnpm install; pnpm test:unit (src/**/__tests__, scripts/__tests__)
+#   Build Site               — full clone, pnpm install; pnpm build + check:links
+#   HTML validate            — needs build-site; pnpm check:html
+#   Build Doc History        — full clone, pnpm install; doc-history-server generate
+#   E2E Tests                — pnpm install (Playwright container); pnpm test:e2e:ci
+#   Preview Deploy           — needs build-site + build-history; wrangler deploy + smoke gates
 #
 # zfb and zdtp are consumed directly from npm (see package.json):
 #   - @takazudo/zfb + @takazudo/zfb-runtime + @takazudo/zfb-adapter-cloudflare
@@ -75,6 +80,60 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Check pin parity
         run: node scripts/check-pin-parity.mjs
+
+  # ---------------------------------------------------------------------------
+  # Job 0.6: Fixture settings drift check (lightweight, no pnpm install needed)
+  # ---------------------------------------------------------------------------
+  # Verifies that every top-level key in src/config/settings.ts (canonical)
+  # is either present in each of the five e2e fixture settings.ts files or
+  # explicitly listed in .fixture-settings-drift-allowlist.
+  # Closes the headingIdStrategy gap (#1946): that drift reached main because
+  # this check existed only in pnpm b4push, not CI.
+  # Pure-Node script — uses preinstalled Node 22 on the runner image, no pnpm.
+  check-fixture-settings-drift:
+    name: Fixture Settings Drift Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - name: Check fixture settings drift
+        run: node scripts/check-fixture-settings-drift.mjs
+
+  # ---------------------------------------------------------------------------
+  # Job 0.7: Lint gates (tags audit + design token lint)
+  # ---------------------------------------------------------------------------
+  # Runs pnpm tags:audit --ci (tsx scripts/tags-audit.ts) and pnpm lint:tokens
+  # (design-token-lint bin from @takazudo/zudo-design-token-lint). Both require
+  # the installed node_modules, so a pnpm install is needed. Combined into one
+  # job (single install, two run steps) to avoid a redundant install.
+  lint-gates:
+    name: Lint Gates
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
+        with:
+          dest: ~/setup-pnpm-${{ github.job }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tags audit
+        run: pnpm tags:audit --ci
+
+      - name: Run design token lint
+        run: pnpm lint:tokens
 
   # ---------------------------------------------------------------------------
   # Job 1: Type checking

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,8 @@ When adding or removing a feature from zudo-doc, update the `create-zudo-doc` ge
 7. **`packages/create-zudo-doc/src/__tests__/scaffold.test.ts`** — Update tests
 8. Run `/l-update-generator` to verify no drift remains
 
+**e2e fixture sync**: Adding a field to `src/config/settings.ts` also requires mirroring it into all five `e2e/fixtures/*/src/config/settings.ts` files — or adding an allowlist entry in `.fixture-settings-drift-allowlist` with a `# reason:` comment. This is now enforced in CI by the `Fixture Settings Drift Check` job.
+
 **Important**: This checklist also applies to incremental improvements (CSS token migrations, icon sizing, spacing changes, etc.) — not just new features. If you change a file that has a template counterpart, update the template too. Run `pnpm check:template-drift` to verify (note: allowlisted files such as `src/styles/global.css`, plugin re-exports, and other slot-based files listed in `.template-drift-allowlist` are excluded from automated checks and need manual review).
 
 ## Tauri (two modes)

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "check:template-drift": "bash scripts/check-template-drift.sh",
     "check:fixture-settings-drift": "node scripts/check-fixture-settings-drift.mjs",
     "check:pin-parity": "node scripts/check-pin-parity.mjs",
+    "check:b4push-ci-parity": "node scripts/check-b4push-ci-parity.mjs",
     "// ── Tags ────────────────────────────────────────": "",
     "tags:audit": "tsx scripts/tags-audit.ts",
     "tags:suggest": "tsx scripts/tags-suggest.ts",

--- a/scripts/check-b4push-ci-parity.mjs
+++ b/scripts/check-b4push-ci-parity.mjs
@@ -136,15 +136,29 @@ function extractB4pushGuardRegion(src) {
   return tokens;
 }
 
+/**
+ * Strip YAML comment lines so ciNeedle substring checks only match
+ * actual step definitions (run:, name:, etc.), not comment text.
+ * Lines where the first non-whitespace character is '#' are removed.
+ */
+function stripYamlComments(src) {
+  return src
+    .split("\n")
+    .filter((line) => !/^\s*#/.test(line))
+    .join("\n");
+}
+
 function main() {
-  const workflowSrc = readFileSync(WORKFLOW_PATH, "utf8");
+  const workflowSrc = stripYamlComments(readFileSync(WORKFLOW_PATH, "utf8"));
   const b4pushSrc = readFileSync(B4PUSH_PATH, "utf8");
   const allowlist = readAllowlist();
 
   const errors = [];
 
   // ── Direction 1: manifest → CI ────────────────────────────────────────────
-  // Assert each required guard's ciNeedle appears somewhere in the workflow YAML.
+  // Assert each required guard's ciNeedle appears in a non-comment workflow line.
+  // Comments are stripped first so a guard removed from CI but still mentioned
+  // in a header comment does NOT produce a false "present" result.
   for (const guard of REQUIRED_CI_GUARDS) {
     if (!workflowSrc.includes(guard.ciNeedle)) {
       errors.push(

--- a/scripts/check-b4push-ci-parity.mjs
+++ b/scripts/check-b4push-ci-parity.mjs
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+// scripts/check-b4push-ci-parity.mjs
+//
+// Guard-manifest meta-check: ensures that every lightweight guard gate in
+// scripts/run-b4push.sh also has a corresponding job in CI (pr-checks.yml).
+//
+// MAINTENANCE CONTRACT
+// ====================
+// Adding a guard gate to scripts/run-b4push.sh means:
+//   1. Add its b4push pnpm script name to REQUIRED_CI_GUARDS (b4pushScript).
+//   2. Add a CI job (or step) running it, named with its ciNeedle string.
+//   3. This script will then confirm both are wired.
+//
+// If a guard is intentionally CI-exempt (e.g. enforced by a pre-commit hook
+// instead), add its b4push pnpm script name to .b4push-ci-parity-allowlist
+// with a "# reason:" comment.
+//
+// Usage: node scripts/check-b4push-ci-parity.mjs
+// Exit 0 = parity OK. Exit 1 = missing guard(s) detected.
+//
+// Wired into:
+//   - scripts/run-b4push.sh (guard step — inside marker region)
+//   - .github/workflows/pr-checks.yml (own lightweight pure-Node job)
+
+import { readFileSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+
+// ── Required CI guards manifest ────────────────────────────────────────────
+//
+// Each entry carries TWO string forms:
+//   ciNeedle     — substring searched in .github/workflows/pr-checks.yml
+//                  (matches the `run:` line or script reference as it appears
+//                  in YAML: file paths, hyphenated names, pnpm script tokens).
+//   b4pushScript — exact pnpm script name as `pnpm <b4pushScript>` in the
+//                  run-b4push.sh guard region (colon-delimited pnpm names).
+//                  Set to null when the b4push step is a raw bash invocation
+//                  (e.g. `bash scripts/...`) so the region parser never emits
+//                  a token for it — a no-op miss, never a false alarm.
+//
+// Having separate forms is intentional: the YAML references hyphenated script
+// paths while b4push invokes colon-delimited pnpm scripts. A single string
+// would fail to match one direction on the clean tree.
+
+const REQUIRED_CI_GUARDS = [
+  {
+    // Template drift: bash scripts/check-template-drift.sh in b4push; same in CI
+    ciNeedle: "check-template-drift",
+    b4pushScript: null, // raw bash invocation — not a pnpm script token
+    comment: "Template drift check (scripts/check-template-drift.sh)",
+  },
+  {
+    // Pin parity: node scripts/check-pin-parity.mjs (CI) / pnpm check:pin-parity (b4push)
+    ciNeedle: "check-pin-parity.mjs",
+    b4pushScript: "check:pin-parity",
+    comment: "Pin parity check (W4A #1732)",
+  },
+  {
+    // Fixture settings drift: node scripts/check-fixture-settings-drift.mjs (CI) / pnpm check:fixture-settings-drift (b4push)
+    ciNeedle: "check-fixture-settings-drift.mjs",
+    b4pushScript: "check:fixture-settings-drift",
+    comment: "Fixture settings drift check (#1946)",
+  },
+  {
+    // Tags audit: pnpm tags:audit --ci (both CI and b4push)
+    ciNeedle: "tags:audit",
+    b4pushScript: "tags:audit",
+    comment: "Tags audit (tsx scripts/tags-audit.ts)",
+  },
+  {
+    // Design token lint: pnpm lint:tokens (both CI and b4push)
+    ciNeedle: "lint:tokens",
+    b4pushScript: "lint:tokens",
+    comment: "Design token lint",
+  },
+  {
+    // This parity check itself — must also appear in CI
+    ciNeedle: "check-b4push-ci-parity.mjs",
+    b4pushScript: "check:b4push-ci-parity",
+    comment: "B4push/CI parity meta-check (this script, #1967)",
+  },
+];
+
+const ALLOWLIST_PATH = resolve(ROOT, ".b4push-ci-parity-allowlist");
+const WORKFLOW_PATH = resolve(ROOT, ".github/workflows/pr-checks.yml");
+const B4PUSH_PATH = resolve(ROOT, "scripts/run-b4push.sh");
+
+// Open/close marker comments that delimit the lightweight guard region in
+// scripts/run-b4push.sh. Only pnpm invocations inside this region are
+// extracted — heavy steps (build, typecheck, e2e) are outside.
+const REGION_OPEN_MARKER = "b4push-ci-parity:guards";
+const REGION_CLOSE_MARKER = "b4push-ci-parity:guards";
+
+/** Read and parse the allowlist file. Returns a Set of allowed b4push script names. */
+function readAllowlist() {
+  if (!existsSync(ALLOWLIST_PATH)) return new Set();
+  return new Set(
+    readFileSync(ALLOWLIST_PATH, "utf8")
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && !line.startsWith("#")),
+  );
+}
+
+/**
+ * Extract pnpm script tokens from the delimited guard region in run-b4push.sh.
+ * Returns an array of pnpm script names (strings after `pnpm ` / `pnpm run `).
+ * Ignores lines outside the markers; never throws on parse failure (returns []).
+ */
+function extractB4pushGuardRegion(src) {
+  const lines = src.split("\n");
+  let inRegion = false;
+  const tokens = [];
+
+  for (const line of lines) {
+    if (!inRegion) {
+      if (line.includes(`>>> ${REGION_OPEN_MARKER}`)) {
+        inRegion = true;
+      }
+      continue;
+    }
+    if (line.includes(`<<< ${REGION_CLOSE_MARKER}`)) {
+      break;
+    }
+    // Match: pnpm <script> or pnpm run <script>
+    // Stop at first whitespace, ), ;, or end-of-line after the script name.
+    const m = line.match(/\bpnpm(?:\s+run)?\s+([A-Za-z0-9:_-]+)/);
+    if (m) {
+      tokens.push(m[1]);
+    }
+  }
+
+  return tokens;
+}
+
+function main() {
+  const workflowSrc = readFileSync(WORKFLOW_PATH, "utf8");
+  const b4pushSrc = readFileSync(B4PUSH_PATH, "utf8");
+  const allowlist = readAllowlist();
+
+  const errors = [];
+
+  // ── Direction 1: manifest → CI ────────────────────────────────────────────
+  // Assert each required guard's ciNeedle appears somewhere in the workflow YAML.
+  for (const guard of REQUIRED_CI_GUARDS) {
+    if (!workflowSrc.includes(guard.ciNeedle)) {
+      errors.push(
+        `[manifest→CI] Guard "${guard.comment}" must run in CI but is absent from pr-checks.yml\n` +
+          `  Missing string: "${guard.ciNeedle}"\n` +
+          `  Fix: add a job or step referencing "${guard.ciNeedle}" to .github/workflows/pr-checks.yml,\n` +
+          `       or add "${guard.b4pushScript ?? guard.ciNeedle}" to .b4push-ci-parity-allowlist if CI-exempt.`,
+      );
+    }
+  }
+
+  // ── Direction 2: b4push region → manifest ────────────────────────────────
+  // Extract pnpm tokens from the marker region and assert each is tracked.
+  const knownB4pushScripts = new Set(
+    REQUIRED_CI_GUARDS.map((g) => g.b4pushScript).filter(Boolean),
+  );
+  const regionTokens = extractB4pushGuardRegion(b4pushSrc);
+
+  if (regionTokens.length === 0) {
+    // No markers found or region is empty — warn but do not error.
+    // The manifest→CI check is the load-bearing path; region parse is a helper.
+    console.warn(
+      `WARN: no pnpm tokens found in the ${REGION_OPEN_MARKER} region of run-b4push.sh.\n` +
+        `  Check that the markers "# >>> ${REGION_OPEN_MARKER}" and "# <<< ${REGION_CLOSE_MARKER}" are present.`,
+    );
+  }
+
+  for (const token of regionTokens) {
+    if (!knownB4pushScripts.has(token) && !allowlist.has(token)) {
+      errors.push(
+        `[b4push→manifest] pnpm ${token} is in the run-b4push.sh guard region but is not in REQUIRED_CI_GUARDS or .b4push-ci-parity-allowlist.\n` +
+          `  Fix: add an entry for "${token}" to REQUIRED_CI_GUARDS in scripts/check-b4push-ci-parity.mjs\n` +
+          `       (with a matching CI job), or add "${token}" to .b4push-ci-parity-allowlist if CI-exempt.`,
+      );
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error("");
+    console.error(
+      "B4push/CI parity check FAILED — guard gate(s) not tracked in manifest or absent from CI:",
+    );
+    console.error("");
+    for (const err of errors) {
+      console.error(err);
+      console.error("");
+    }
+    console.error(
+      "MAINTENANCE CONTRACT: adding a guard gate to scripts/run-b4push.sh means adding it to",
+    );
+    console.error(
+      "  REQUIRED_CI_GUARDS in scripts/check-b4push-ci-parity.mjs AND to .github/workflows/pr-checks.yml.",
+    );
+    return 1;
+  }
+
+  console.log(
+    `OK — b4push/CI parity verified. ${REQUIRED_CI_GUARDS.length} required guards all present in CI.`,
+  );
+  if (regionTokens.length > 0) {
+    console.log(
+      `     Region cross-check: ${regionTokens.length} pnpm token(s) in run-b4push.sh guard region all tracked.`,
+    );
+  }
+  return 0;
+}
+
+process.exit(main());

--- a/scripts/run-b4push.sh
+++ b/scripts/run-b4push.sh
@@ -10,13 +10,14 @@ set -euo pipefail
 #   4. Fixture settings drift check
 #   5. Tags audit (--ci)
 #   6. Design token lint
-#   7. Type checking (zfb check + workspace package typechecks)
-#   8. Root unit tests (test:unit)
-#   9. Build (zfb build)
-#  10. Link check
-#  11. HTML validation (html-validate dist/**/*.html)
-#  12. Automated preview smoke (blocking)
-#  13. Manual interactive smoke (operator-driven)
+#   7. B4push/CI parity check (guard manifest meta-check — #1967)
+#   8. Type checking (zfb check + workspace package typechecks)
+#   9. Root unit tests (test:unit)
+#  10. Build (zfb build)
+#  11. Link check
+#  12. HTML validation (html-validate dist/**/*.html)
+#  13. Automated preview smoke (blocking)
+#  14. Manual interactive smoke (operator-driven)
 #
 # CI parity (Playwright E2E + GitHub Actions) is intentionally parked
 # to E9b until the post-cutover migration window closes.
@@ -28,7 +29,7 @@ set -euo pipefail
 
 START_TIME=$(date +%s)
 FAILURES=()
-TOTAL_STEPS=13
+TOTAL_STEPS=14
 CURRENT_STEP=0
 
 step() {
@@ -45,9 +46,14 @@ skip() { echo "⏭  $1 (skipped)"; }
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
+# >>> b4push-ci-parity:guards
+# Steps 1–7 are lightweight guard gates. They are delimited by the markers
+# above/below so check-b4push-ci-parity.mjs can cross-check them against the
+# REQUIRED_CI_GUARDS manifest without brittle full-file parsing.
+
 # ── Step 1: Format check (mdx only) ───────────────────
 step "Format check (mdx)"
-if (cd "$ROOT_DIR" && pnpm run format:check); then
+if (cd "$ROOT_DIR" && pnpm format:check:mdx); then
   pass "Format check passed"
 else
   fail "Format check"
@@ -96,7 +102,19 @@ else
   fail "Design token lint"
 fi
 
-# ── Step 7: Type checking ─────────────────────────────
+# ── Step 7: B4push/CI parity check ───────────────────
+# Pure-Node check — verifies every lightweight guard gate in this file also
+# has a corresponding CI job. See scripts/check-b4push-ci-parity.mjs.
+step "B4push/CI parity check (check:b4push-ci-parity)"
+if (cd "$ROOT_DIR" && pnpm check:b4push-ci-parity); then
+  pass "B4push/CI parity check passed"
+else
+  fail "B4push/CI parity check"
+fi
+
+# <<< b4push-ci-parity:guards
+
+# ── Step 8: Type checking ─────────────────────────────
 # Prefer `zfb check` (the post-cutover entry point). If it fails to
 # start (e.g. binary not yet built), fall back to `tsc --noEmit` so the
 # typecheck still gates pushes.
@@ -119,7 +137,7 @@ else
   fail "Package typechecks"
 fi
 
-# ── Step 8: Root unit tests ───────────────────────────
+# ── Step 9: Root unit tests ───────────────────────────
 # Root `test:unit` (vitest) guards src/**/__tests__ and scripts/__tests__,
 # which previously ran in no local gate and no CI workflow (#1856). Runs
 # before the expensive site build for fast logic-level feedback.
@@ -136,7 +154,7 @@ else
   fail "Root unit tests"
 fi
 
-# ── Step 9: Build ─────────────────────────────────────
+# ── Step 10: Build ────────────────────────────────────
 step "Build (zfb build)"
 if (cd "$ROOT_DIR" && pnpm build); then
   pass "Build passed"
@@ -144,7 +162,7 @@ else
   fail "Build"
 fi
 
-# ── Step 10: Link check ───────────────────────────────
+# ── Step 11: Link check ───────────────────────────────
 #
 # Strict on broken links + absolute MDX-source warnings (real 404s
 # / sub-path bypass). Trailing-slash warnings stay warn-only — they
@@ -164,7 +182,7 @@ else
   fail "Link check"
 fi
 
-# ── Step 11: HTML validation ──────────────────────────
+# ── Step 12: HTML validation ──────────────────────────
 step "HTML validation (html-validate)"
 if [[ "${B4PUSH_SKIP_HTML_VALIDATE:-}" == "1" ]]; then
   skip "HTML validation (B4PUSH_SKIP_HTML_VALIDATE=1)"
@@ -176,7 +194,7 @@ else
   fi
 fi
 
-# ── Step 12: Automated preview smoke (blocking) ──────
+# ── Step 13: Automated preview smoke (blocking) ──────
 step "Preview smoke (automated)"
 if [[ "${B4PUSH_SKIP_PREVIEW_SMOKE:-}" == "1" ]]; then
   skip "Preview smoke (B4PUSH_SKIP_PREVIEW_SMOKE=1)"
@@ -188,7 +206,7 @@ else
   fi
 fi
 
-# ── Step 13: Manual interactive smoke ────────────────
+# ── Step 14: Manual interactive smoke ────────────────
 step "Manual interactive smoke"
 if [[ "${B4PUSH_SKIP_MANUAL_SMOKE:-}" == "1" ]]; then
   skip "Manual smoke (B4PUSH_SKIP_MANUAL_SMOKE=1)"


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/1965

---

## Summary

Closes the gap that let the `headingIdStrategy` fixture-settings drift reach `main` (caught only at release time by `pnpm b4push`): three b4push guard gates ran locally but **not** in CI, the actual merge gate. This PR mirrors them into CI and adds a meta-check so b4push↔CI parity can't silently drift again.

Epic #1965 · sub-issues #1966 (S1) + #1967 (S2).

### S1 — mirror missing guard gates into CI (#1966)
- New pure-Node **Fixture Settings Drift Check** job (mirrors the `check-pin-parity` job; no install) running `node scripts/check-fixture-settings-drift.mjs` — this is the gate that catches a setting added to `src/config/settings.ts` without a matching e2e fixture key.
- New install-based **Lint Gates** job running `pnpm tags:audit --ci` + `pnpm lint:tokens`.
- Rewrote the `pr-checks.yml` header comment to list every CI job explicitly (dropped the false "mirrors b4push" claim).
- Documented the e2e-fixtures sync point + CI enforcement in the CLAUDE.md Feature Change Checklist.

### S2 — guard-manifest meta-check (#1967)
- New pure-Node `scripts/check-b4push-ci-parity.mjs` with an explicit `REQUIRED_CI_GUARDS` manifest asserting each guard appears in `pr-checks.yml` (strips YAML comments to avoid header-comment false-passes), plus a bounded marker-region cross-check over `run-b4push.sh` so a guard added to b4push but not tracked fails the check.
- New `.b4push-ci-parity-allowlist` (seeded with `format:check:mdx`, lefthook-enforced).
- Wired into both `run-b4push.sh` (new guard step) and `pr-checks.yml` (new pure-Node job).

## Validation
All three new gates run green on this PR itself (the live proof): Fixture Settings Drift Check, Lint Gates, B4push/CI Parity Check. Full CI green (13 checks).

## ⚠️ Manual follow-up (post-merge, repo settings)
The new check contexts (`Fixture Settings Drift Check`, `Lint Gates`, `B4push/CI Parity Check`) run but do **not block merge** until added to the `main` / `base/**` required-status-checks ruleset. Add them after merge or the gates stay advisory. Tracked in epic #1965.