### PR TITLE
Consumer Parity Fixes: OGP completeness, scaffold drift re-sync, Tailwind @source, _category_.json frontmatter migration, i18n doc-history fallback

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -8,6 +8,7 @@
 #   Template Drift Check     — pure-shell, no install; scripts/check-template-drift.sh
 #   Pin Parity Check         — pure-Node, no install; scripts/check-pin-parity.mjs
 #   Fixture Settings Drift   — pure-Node, no install; scripts/check-fixture-settings-drift.mjs
+#   Package Safelist Check   — pure-Node, no install; scripts/check-package-safelist.mjs
 #   B4push/CI Parity Check   — pure-Node, no install; scripts/check-b4push-ci-parity.mjs
 #   Lint Gates               — pnpm install; pnpm tags:audit --ci + pnpm lint:tokens
 #   Type Check               — pnpm install; pnpm check (zfb check → tsc --noEmit)
@@ -100,6 +101,27 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Check fixture settings drift
         run: node scripts/check-fixture-settings-drift.mjs
+
+  # ---------------------------------------------------------------------------
+  # Job 0.63: Package safelist drift check (#1982)
+  # ---------------------------------------------------------------------------
+  # Verifies that the @source inline() safelist in the scaffold template
+  # (packages/create-zudo-doc/templates/base/src/styles/global.css) covers
+  # every responsive-variant + arbitrary-value utility class used in
+  # packages/zudo-doc/src/**/*.tsx. Closes the silent-drift gap from #1971:
+  # a new bracket/responsive utility in the package reaches the host repo
+  # (which @source's the package source directly) but silently misses
+  # consumers (which rely solely on the template safelist).
+  # Pure-Node script — uses preinstalled Node 22 on the runner image, no pnpm.
+  check-package-safelist:
+    name: Package Safelist Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - name: Check package safelist drift
+        run: node scripts/check-package-safelist.mjs
 
   # ---------------------------------------------------------------------------
   # Job 0.65: B4push/CI parity check (guard manifest meta-check)

--- a/.template-drift-allowlist
+++ b/.template-drift-allowlist
@@ -42,19 +42,13 @@ src/config/tag-vocabulary.ts
 # These will be reconciled via /l-update-generator post super-epic merge
 # (Phase D follow-up). Allowlisting here keeps PR-checks green on epic-PRs.
 #
-# Wave 11 (#1355 / PR #1356) reshaped sidebar-toggle.tsx (always-render
-# hamburger/X icons with hidden-class toggling, AFTER_NAVIGATE_EVENT instead
-# of DOMContentLoaded, explicit aria-expanded) and sidebar-tree.tsx
-# (URL-derived currentSlug lazy-init via deriveActiveSlugFromUrl) to fix
-# host-side island state-defaults exposed by Wave 10's hydration unblock.
-# Template counterparts under packages/create-zudo-doc/templates/ are
-# intentionally NOT synced in PR #1356 — the post-super-epic
-# /l-update-generator pass is the single reconciliation point. theme-toggle
-# drift predates Wave 11.
+# i18n.ts: host ships showcase-specific keys (search, nav.markdownFeatures,
+# doc.history) that the template omits; template ships a leaner baseline.
+# sidebar-tree.tsx: intentional divergence — template uses literal preact/compat
+# imports (W8A preact/compat note in the W8A block below) and the URL-derived
+# currentSlug lazy-init is needed only in the host's island setup.
 src/config/i18n.ts
-src/components/sidebar-toggle.tsx
 src/components/sidebar-tree.tsx
-src/components/theme-toggle.tsx
 
 # Phase B-11-2 — new TS path alias `#doc-history-meta` -> .zfb/doc-history-meta.json
 # enables the host wrapper to import the build-time manifest without dragging

--- a/e2e/smoke-seo.spec.ts
+++ b/e2e/smoke-seo.spec.ts
@@ -27,4 +27,16 @@ test.describe("SEO: meta tags render correctly", () => {
       'content="A page for testing code blocks, tabs, details, and mermaid diagrams."',
     );
   });
+
+  test("og:type meta tag is present with value website", () => {
+    const html = readDistFile("docs/guides/page-1/index.html");
+    expect(html).toMatch(/<meta property="og:type" content="website"\s*\/?>/);
+  });
+
+  test("og:site_name meta tag is present with correct site name", () => {
+    const html = readDistFile("docs/guides/page-1/index.html");
+    expect(html).toMatch(
+      /<meta property="og:site_name" content="Smoke Test"\s*\/?>/,
+    );
+  });
 });

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "check:fixture-settings-drift": "node scripts/check-fixture-settings-drift.mjs",
     "check:pin-parity": "node scripts/check-pin-parity.mjs",
     "check:b4push-ci-parity": "node scripts/check-b4push-ci-parity.mjs",
+    "check:package-safelist": "node scripts/check-package-safelist.mjs",
     "// ── Tags ────────────────────────────────────────": "",
     "tags:audit": "tsx scripts/tags-audit.ts",
     "tags:suggest": "tsx scripts/tags-suggest.ts",

--- a/packages/create-zudo-doc/src/__tests__/zfb-config-gen.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/zfb-config-gen.test.ts
@@ -106,6 +106,11 @@ describe("generateZfbConfig", () => {
     expect(result).toContain("sidebar_position: z.number().optional()");
     expect(result).toContain("draft: z.boolean().optional()");
     expect(result).toContain("slug: z.string().optional()");
+    // Category-metadata-via-frontmatter fields (mirrors the host docsSchema).
+    expect(result).toContain("category_no_page: z.boolean().optional()");
+    expect(result).toContain(
+      'category_sort_order: z.enum(["asc", "desc"]).optional()',
+    );
   });
 
   it("emits .passthrough() to preserve unknown frontmatter keys", () => {

--- a/packages/create-zudo-doc/src/zfb-config-gen.ts
+++ b/packages/create-zudo-doc/src/zfb-config-gen.ts
@@ -90,6 +90,8 @@ export function generateZfbConfig(choices: UserChoices): string {
   lines.push(`    standalone: z.boolean().optional(),`);
   lines.push(`    slug: z.string().optional(),`);
   lines.push(`    generated: z.boolean().optional(),`);
+  lines.push(`    category_no_page: z.boolean().optional(),`);
+  lines.push(`    category_sort_order: z.enum(["asc", "desc"]).optional(),`);
   lines.push(`  })`);
   lines.push(`  .passthrough();`);
   lines.push(``);

--- a/packages/create-zudo-doc/templates/base/pages/docs/[[...slug]].tsx
+++ b/packages/create-zudo-doc/templates/base/pages/docs/[[...slug]].tsx
@@ -90,6 +90,11 @@ export function paths(): Array<{
 
   // Regular doc pages
   for (const entry of docs) {
+    // A `category_no_page` index.mdx carries category metadata only — keep it
+    // in the nav tree (built above, used for breadcrumbs) but emit NO route for
+    // it. zfb's walker retains every .mdx as a collection entry, so without
+    // this explicit skip the metadata file would silently add a route.
+    if (entry.data.category_no_page === true) continue;
     const slug = entry.data.slug ?? toRouteSlug(entry.slug);
     const navSection = getNavSectionForSlug(slug);
     const subtree = getNavSubtree(tree, navSection);

--- a/packages/create-zudo-doc/templates/base/pages/index.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/index.tsx
@@ -46,8 +46,10 @@ export default function IndexPage(): JSX.Element {
   const categoryOrder = getCategoryOrder();
   const groupedTree = groupSatelliteNodes(tree, categoryOrder);
 
+  // Drop category_no_page index files so the count matches the number of tag
+  // pages actually built (the tag routes exclude them too).
   const tagCount = collectTags(
-    navDocs,
+    navDocs.filter((d) => !d.data.category_no_page),
     (id, data) => data.slug ?? toRouteSlug(id),
   ).size;
 

--- a/packages/create-zudo-doc/templates/base/pages/lib/_doc-history-area.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_doc-history-area.tsx
@@ -67,6 +67,17 @@ interface DocHistoryAreaProps {
    * view-source GitHub URL. Omit to suppress the view-source link.
    */
   contentDir?: string;
+  /**
+   * True when this locale page falls back to the base EN collection
+   * (i.e. the slug has no translation for the active locale). When true,
+   * the history data-path derivations use defaultLocale so the island
+   * fetches the correct bare-slug JSON and the SSR manifest lookup hits
+   * the bare key — both of which only exist for EN-origin files.
+   * Display labels (t() calls) still use the active locale so JA users
+   * see JA labels on fallback pages. Omit (or false) for translated pages
+   * and all other call sites (EN route, tag pages) — behavior unchanged.
+   */
+  isFallback?: boolean;
 }
 
 /**
@@ -93,6 +104,7 @@ export function DocHistoryArea({
   locale,
   entrySlug,
   contentDir,
+  isFallback,
 }: DocHistoryAreaProps): VNode | null {
   if (!settings.docHistory) return null;
 
@@ -106,11 +118,18 @@ export function DocHistoryArea({
   // collectContentFiles walk in packages/doc-history-server. (#1891)
   const historySlug = toHistorySlug(slug);
 
+  // On EN-fallback locale pages the history data exists only at the bare
+  // (non-locale-prefixed) path — the prebuild/server writes locale-prefixed
+  // keys/paths only for files physically present in the locale collection.
+  // Use defaultLocale for data lookups when isFallback is true; keep locale
+  // for all display label calls (t()) so JA users see JA labels.
+  const effectiveHistoryLocale = isFallback ? defaultLocale : locale;
+
   // Look up the build-time manifest entry for this page. The composedSlug
   // matches the key written by the prebuild step: bare slug for the default
   // locale, "<localeKey>/<slug>" for non-default locales.
   const composedSlug =
-    locale === defaultLocale ? historySlug : `${locale}/${historySlug}`;
+    effectiveHistoryLocale === defaultLocale ? historySlug : `${effectiveHistoryLocale}/${historySlug}`;
   type MetaEntry = { author: string; createdDate: string; updatedDate: string };
   const meta = (docHistoryMeta as Record<string, MetaEntry>)[composedSlug];
 
@@ -120,7 +139,8 @@ export function DocHistoryArea({
   const historyLabel = t("doc.history", locale);
 
   // Real-component props — locale omitted for the default locale.
-  const docHistoryLocale = locale === defaultLocale ? undefined : locale;
+  // Use effectiveHistoryLocale so fallback pages fetch the bare (non-ja/) path.
+  const docHistoryLocale = effectiveHistoryLocale === defaultLocale ? undefined : effectiveHistoryLocale;
   const docHistoryBasePath = settings.base ?? "/";
 
   // Build the SSR fallback with only the sr-only metadata block so the

--- a/packages/create-zudo-doc/templates/base/pages/lib/_footer-with-defaults.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_footer-with-defaults.tsx
@@ -124,17 +124,15 @@ export function FooterWithDefaults({
       // pages ([tag].tsx / tags/index.tsx) and enumerateTagsRoutes, which all
       // now filter. Without this, the footer would link to /{locale}/docs/tags/
       // pages that are never built for tags living only on default-locale-only
-      // prefix pages. category_no_page is dropped for the same reason.
+      // prefix pages. category_no_page is dropped for the same reason — AFTER
+      // the merge, so a locale override carrying the flag first wins the merge
+      // (pre-merge filtering would let the unflagged base doc resurface).
       const result = mergeLocaleDocs({
-        baseDocs: loadDocs("docs").filter(
-          (d) => !d.data.draft && !d.data.category_no_page,
-        ),
-        localeDocs: loadDocs(`docs-${lang}`).filter(
-          (d) => !d.data.draft && !d.data.category_no_page,
-        ),
+        baseDocs: loadDocs("docs").filter((d) => !d.data.draft),
+        localeDocs: loadDocs(`docs-${lang}`).filter((d) => !d.data.draft),
         applyDefaultLocaleOnlyFilter: true,
       });
-      docs = result.docs;
+      docs = result.docs.filter((d) => !d.data.category_no_page);
     }
 
     const tagMap = collectTags(

--- a/packages/create-zudo-doc/templates/base/pages/lib/_footer-with-defaults.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_footer-with-defaults.tsx
@@ -113,17 +113,25 @@ export function FooterWithDefaults({
     // Load docs synchronously (zfb ADR-004 — synchronous content snapshot).
     let docs: DocsEntry[];
     if (lang === defaultLocale) {
-      docs = loadDocs("docs").filter((d) => !d.data.draft && !d.data.unlisted);
+      // category_no_page index files build no route — drop them so the footer
+      // taglist matches the tag-route pages (which all now filter too).
+      docs = loadDocs("docs").filter(
+        (d) => !d.data.draft && !d.data.unlisted && !d.data.category_no_page,
+      );
     } else {
       // Apply the default-locale-only filter so the footer taglist only counts
       // tags that have a locale-routable tag page — matching the tag-route
       // pages ([tag].tsx / tags/index.tsx) and enumerateTagsRoutes, which all
       // now filter. Without this, the footer would link to /{locale}/docs/tags/
       // pages that are never built for tags living only on default-locale-only
-      // prefix pages.
+      // prefix pages. category_no_page is dropped for the same reason.
       const result = mergeLocaleDocs({
-        baseDocs: loadDocs("docs").filter((d) => !d.data.draft),
-        localeDocs: loadDocs(`docs-${lang}`).filter((d) => !d.data.draft),
+        baseDocs: loadDocs("docs").filter(
+          (d) => !d.data.draft && !d.data.category_no_page,
+        ),
+        localeDocs: loadDocs(`docs-${lang}`).filter(
+          (d) => !d.data.draft && !d.data.category_no_page,
+        ),
         applyDefaultLocaleOnlyFilter: true,
       });
       docs = result.docs;

--- a/packages/create-zudo-doc/templates/base/pages/lib/_head-with-defaults.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_head-with-defaults.tsx
@@ -97,7 +97,10 @@ export function HeadWithDefaults({
       <OgTags
         title={composeMetaTitle(title)}
         description={description}
+        ogType="website"
+        ogUrl={canonical}
         ogImage={ogImageUrl}
+        ogSiteName={settings.siteName}
       />
       {/* og:image:width / og:image:height / og:image:alt — not in OgTags API;
           emitted here directly to avoid expanding the shared HeadProps surface.

--- a/packages/create-zudo-doc/templates/base/pages/lib/route-enumerators.ts
+++ b/packages/create-zudo-doc/templates/base/pages/lib/route-enumerators.ts
@@ -107,7 +107,9 @@ export function enumerateTagsRoutes(locale: string): string[] {
   // Filter unlisted + draft + category_no_page — mirrors the tag [tag].tsx
   // pages so the sitemap lists exactly the tag pages that get built (a
   // category_no_page index has no route, so a tag it carries must not coin a
-  // tag page that links back to it).
+  // tag page that links back to it). The category_no_page drop happens AFTER
+  // the locale merge so a locale override carrying the flag first wins the
+  // merge — pre-merge filtering would let the unflagged base doc resurface.
   let docs: DocsEntry[];
   if (locale === defaultLocale) {
     docs = loadDocs("docs").filter(
@@ -115,15 +117,11 @@ export function enumerateTagsRoutes(locale: string): string[] {
     );
   } else {
     const result = mergeLocaleDocs({
-      baseDocs: loadDocs("docs").filter(
-        (d) => !d.data.draft && !d.data.category_no_page,
-      ),
-      localeDocs: loadDocs(`docs-${locale}`).filter(
-        (d) => !d.data.draft && !d.data.category_no_page,
-      ),
+      baseDocs: loadDocs("docs").filter((d) => !d.data.draft),
+      localeDocs: loadDocs(`docs-${locale}`).filter((d) => !d.data.draft),
       applyDefaultLocaleOnlyFilter: true,
     });
-    docs = result.docs;
+    docs = result.docs.filter((d) => !d.data.category_no_page);
   }
 
   const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));

--- a/packages/create-zudo-doc/templates/base/pages/lib/route-enumerators.ts
+++ b/packages/create-zudo-doc/templates/base/pages/lib/route-enumerators.ts
@@ -104,14 +104,23 @@ export function enumerateTagsRoutes(locale: string): string[] {
   urls.push(withBase(tagsBase));
 
   // Collect tags from the same merged doc set the tag pages use.
-  // Filter unlisted + draft — mirrors the tag [tag].tsx pages which do the same.
+  // Filter unlisted + draft + category_no_page — mirrors the tag [tag].tsx
+  // pages so the sitemap lists exactly the tag pages that get built (a
+  // category_no_page index has no route, so a tag it carries must not coin a
+  // tag page that links back to it).
   let docs: DocsEntry[];
   if (locale === defaultLocale) {
-    docs = loadDocs("docs").filter((d) => !d.data.unlisted && !d.data.draft);
+    docs = loadDocs("docs").filter(
+      (d) => !d.data.unlisted && !d.data.draft && !d.data.category_no_page,
+    );
   } else {
     const result = mergeLocaleDocs({
-      baseDocs: loadDocs("docs").filter((d) => !d.data.draft),
-      localeDocs: loadDocs(`docs-${locale}`).filter((d) => !d.data.draft),
+      baseDocs: loadDocs("docs").filter(
+        (d) => !d.data.draft && !d.data.category_no_page,
+      ),
+      localeDocs: loadDocs(`docs-${locale}`).filter(
+        (d) => !d.data.draft && !d.data.category_no_page,
+      ),
       applyDefaultLocaleOnlyFilter: true,
     });
     docs = result.docs;

--- a/packages/create-zudo-doc/templates/base/pages/lib/route-enumerators.ts
+++ b/packages/create-zudo-doc/templates/base/pages/lib/route-enumerators.ts
@@ -60,6 +60,10 @@ export function enumerateDocsRoutes(locale: string): string[] {
   const tree = buildNavTree(navDocs, locale as Locale, categoryMeta);
 
   for (const doc of allDocs) {
+    // A `category_no_page` index.mdx is metadata-only — no route, so no sitemap
+    // URL. Same exclusion the doc-route paths() apply (zfb retains every .mdx
+    // as a collection entry, so the skip must be explicit).
+    if (doc.data.category_no_page === true) continue;
     // Canonical route slug via the one shared rule (@/utils/slug). `doc.id` is
     // already `toRouteSlug(doc.slug)` (bridged through stripIndexSuffix in
     // pages/_data.ts), so a bare root index.mdx is "" here → `/docs/` — the
@@ -157,6 +161,8 @@ export function enumerateVersionedRoutes(
     const tree = buildNavTree(navDocs, "en", categoryMeta);
 
     for (const doc of allDocs) {
+      // category_no_page index.mdx → no route, no sitemap URL (see paths()).
+      if (doc.data.category_no_page === true) continue;
       const slug = doc.data.slug ?? toRouteSlug(doc.id);
       urls.push(versionedDocsUrl(slug, version.slug));
     }
@@ -178,6 +184,8 @@ export function enumerateVersionedRoutes(
     const tree = buildNavTree(navDocs, locale as Locale, categoryMeta);
 
     for (const doc of allDocs) {
+      // category_no_page index.mdx → no route, no sitemap URL (see paths()).
+      if (doc.data.category_no_page === true) continue;
       const slug = doc.data.slug ?? toRouteSlug(doc.id);
       urls.push(versionedDocsUrl(slug, version.slug, locale as string));
     }

--- a/packages/create-zudo-doc/templates/base/src/components/sidebar-toggle.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/sidebar-toggle.tsx
@@ -1,11 +1,55 @@
-import { useState, useEffect } from "preact/compat";
-import type { ComponentChildren } from "preact";
+"use client";
+
+// Use preact hook entrypoints directly — the "react" → "preact/compat" alias
+// lets us consume React-typed components in this Preact app (configured
+// project-wide). Same pattern as src/components/sidebar-tree.tsx and
+// packages/zudo-doc/src/theme/theme-toggle.tsx. Type references via
+// the global React namespace still resolve via @types/react.
+import { useState, useEffect } from "preact/hooks";
+import clsx from "clsx";
+// After zudolab/zudo-doc#1335 (E2 task 2 half B) the host components
+// pull lifecycle event names from the v2 transitions module rather
+// than hard-coding `astro:*` literals.
+import { AFTER_NAVIGATE_EVENT } from "@takazudo/zudo-doc/transitions";
+import SidebarTree from "@/components/sidebar-tree";
+import type { NavNode } from "@/utils/docs";
+import type { LocaleLink } from "@/types/locale";
+// Types-only subpath (`./sidebar/types`) sidesteps the JSX type-graph
+// pulled in by `./sidebar`'s runtime barrel.
+import type { SidebarRootMenuItem } from "@takazudo/zudo-doc/sidebar/types";
+
+// Mobile drawer hosts the SidebarTree directly (rather than receiving it as
+// JSX children) so the tree's data props ride across the SSR → hydrate
+// boundary inside the Island marker's `data-props` attribute. zfb's
+// `Island()` only serialises a child component's *own* props (excluding
+// `children`); when SidebarTree was passed as `children`, its data was
+// dropped during hydration and Preact wiped the SSR-rendered tree DOM.
+// Mirroring the desktop `<Sidebar treeComponent={SidebarTree} ...>` shape
+// keeps the data attached to the wrapping island. zudolab/zudo-doc#1355
+// wave 13.5.
 
 interface SidebarToggleProps {
-  children: ComponentChildren;
+  nodes: NavNode[];
+  currentSlug?: string;
+  rootMenuItems?: SidebarRootMenuItem[];
+  backToMenuLabel?: string;
+  localeLinks?: LocaleLink[];
+  themeDefaultMode?: "light" | "dark";
 }
 
-export default function SidebarToggle({ children }: SidebarToggleProps) {
+export default function SidebarToggle({
+  nodes,
+  currentSlug,
+  rootMenuItems,
+  backToMenuLabel,
+  localeLinks,
+  themeDefaultMode,
+}: SidebarToggleProps) {
+  // Initial state must match SSR (`open=false`) so the hydration DOM
+  // matches the SSG output byte-for-byte. The backdrop and toggle-icon
+  // are rendered unconditionally below so the hydration tree has the
+  // same shape regardless of `open`, preventing Preact from re-mounting
+  // the subtree (which can drop click handlers on the hamburger button).
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
@@ -24,61 +68,68 @@ export default function SidebarToggle({ children }: SidebarToggleProps) {
     function handleSwap() {
       setOpen(false);
     }
-    // zfb's `<ViewTransitions />` does a real page load on every
-    // navigation, so `DOMContentLoaded` is the post-navigate signal.
-    document.addEventListener("DOMContentLoaded", handleSwap);
-    return () => document.removeEventListener("DOMContentLoaded", handleSwap);
+    document.addEventListener(AFTER_NAVIGATE_EVENT, handleSwap);
+    return () => document.removeEventListener(AFTER_NAVIGATE_EVENT, handleSwap);
   }, []);
 
   return (
     <>
-      {/* Hamburger button - visible only on mobile */}
+      {/* Hamburger button - visible only on mobile.
+          Both icons are always rendered so the SSR output has the same
+          DOM shape as the post-hydration tree. The closed-state icon is
+          hidden via `hidden` when open=true, and vice versa, so Preact's
+          hydration walk sees byte-stable markup and keeps the click
+          handler attached. */}
       <button
         type="button"
         onClick={() => setOpen(!open)}
         className="lg:hidden px-hsp-sm py-vsp-xs -ml-hsp-sm mr-hsp-sm text-muted hover:text-fg"
         aria-label={open ? "Close sidebar" : "Open sidebar"}
+        aria-expanded={open}
       >
-        {open ? (
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            className="h-icon-lg w-icon-lg"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={2}
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M6 18L18 6M6 6l12 12"
-            />
-          </svg>
-        ) : (
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            className="h-icon-lg w-icon-lg"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={2}
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M4 6h16M4 12h16M4 18h16"
-            />
-          </svg>
-        )}
+        {/* X icon — visible only when open */}
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className={clsx("h-icon-lg w-icon-lg", !open && "hidden")}
+          aria-hidden="true"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M6 18L18 6M6 6l12 12"
+          />
+        </svg>
+        {/* Hamburger icon — visible only when closed */}
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className={clsx("h-icon-lg w-icon-lg", open && "hidden")}
+          aria-hidden="true"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M4 6h16M4 12h16M4 18h16"
+          />
+        </svg>
       </button>
 
-      {/* Backdrop overlay - mobile only */}
-      {open && (
-        <div
-          className="fixed inset-0 z-30 bg-overlay/30 lg:hidden"
-          onClick={() => setOpen(false)}
-        />
-      )}
+      {/* Backdrop overlay - mobile only.
+          Rendered unconditionally; CSS `hidden` toggles visibility so
+          the SSR DOM tree matches the hydrated tree (no subtree
+          mount/unmount across the hydration boundary). */}
+      <div
+        className={clsx("fixed inset-0 z-30 bg-overlay/30 lg:hidden", !open && "hidden")}
+        aria-hidden={!open}
+        onClick={() => setOpen(false)}
+      />
 
       {/* Sidebar panel - mobile only (desktop sidebar is in doc-layout) */}
       <aside
@@ -90,7 +141,14 @@ export default function SidebarToggle({ children }: SidebarToggleProps) {
         `}
       >
         <div className="flex-1 overflow-y-auto">
-          {children}
+          <SidebarTree
+            nodes={nodes}
+            currentSlug={currentSlug}
+            rootMenuItems={rootMenuItems}
+            backToMenuLabel={backToMenuLabel}
+            localeLinks={localeLinks}
+            themeDefaultMode={themeDefaultMode}
+          />
         </div>
       </aside>
     </>

--- a/packages/create-zudo-doc/templates/base/src/components/theme-toggle.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/theme-toggle.tsx
@@ -1,4 +1,9 @@
-import { useState, useEffect } from "preact/compat";
+"use client";
+
+// Use preact hook entrypoints directly — the "react" → "preact/compat" alias
+// lets us consume React-typed components in this Preact app (configured
+// project-wide). Same pattern as packages/zudo-doc/src/theme/theme-toggle.tsx.
+import { useState, useEffect } from "preact/hooks";
 
 const STORAGE_KEY = "zudo-doc-theme";
 
@@ -91,3 +96,12 @@ export default function ThemeToggle({ defaultMode = "dark" }: ThemeToggleProps) 
     </button>
   );
 }
+// Pin the island marker name to "ThemeToggle" regardless of esbuild's
+// identifier deduplication. Both this host component and the v2 package's
+// ThemeToggleInner share the plain name "ThemeToggle"; when both land in the
+// same SSR bundle esbuild renames one to "ThemeToggle2", making
+// captureComponentName() emit "ThemeToggle2" — a name that has no entry in
+// the island manifest. Setting displayName explicitly ensures Island() reads
+// the attribute-level name (displayName is preferred over .name) and emits
+// the correct data-zfb-island="ThemeToggle" marker. zudolab/zudo-doc#1446.
+ThemeToggle.displayName = "ThemeToggle";

--- a/packages/create-zudo-doc/templates/base/src/config/frontmatter-preview-defaults.ts
+++ b/packages/create-zudo-doc/templates/base/src/config/frontmatter-preview-defaults.ts
@@ -21,4 +21,6 @@ export const DEFAULT_FRONTMATTER_IGNORE_KEYS: string[] = [
   "standalone",
   "slug",
   "generated",
+  "category_no_page",
+  "category_sort_order",
 ];

--- a/packages/create-zudo-doc/templates/base/src/styles/global.css
+++ b/packages/create-zudo-doc/templates/base/src/styles/global.css
@@ -27,6 +27,48 @@
 @source "pages/**/*.{tsx,ts,jsx,js}";
 
 /* ========================================
+ * @takazudo/zudo-doc package sources
+ *
+ * Primary fix for zudolab/zudo-doc#1971: consumers scaffolded via
+ * create-zudo-doc were missing `lg:block` and bracket utilities (e.g.
+ * `w-[var(--zd-sidebar-w)]`, `h-[calc(100vh-3.5rem)]`) that are used
+ * by @takazudo/zudo-doc's layout components. The host repo works only
+ * because its src/styles/global.css also @source's the monorepo path
+ * `packages/zudo-doc/src/**` — a path consumers don't have.
+ *
+ * Fix (1): @source the package dist. The package ships non-minified
+ * ESM (tsup bundle:false), so class strings like `"hidden lg:block
+ * fixed top-[3.5rem] …"` survive verbatim in dist JS. Path depth:
+ * src/styles/ is two directories below the consumer project root.
+ *
+ * Fix (2): @source inline() safelist. Tailwind v4's scanner is
+ * INTERMITTENTLY unreliable for arbitrary-value candidates extracted
+ * from node_modules JS (observed across rebuilds in real consumers).
+ * Requires Tailwind v4.1+; the scaffold pins ^4.2.0 so this is safe.
+ * Inventory re-derived from packages/zudo-doc/src/**\/*.tsx (excluding
+ * __tests__) — do NOT prune without re-running the derivation grep.
+ * ======================================== */
+
+@source "../../node_modules/@takazudo/zudo-doc/dist/**/*.{js,mjs}";
+
+@source inline("
+  lg:block lg:flex lg:ml-[var(--zd-sidebar-w)] lg:px-hsp-2xl lg:py-vsp-2xl
+  lg:pt-vsp-2xl lg:grid-cols-[repeat(auto-fit,minmax(12rem,1fr))]
+  xl:hidden xl:flex sm:grid-cols-2 sm:justify-between sm:items-center sm:flex-row
+  top-[3.5rem] w-[var(--zd-sidebar-w)] h-[calc(100vh-3.5rem)]
+  min-h-[calc(100vh-3.5rem)] gap-[clamp(1.5rem,3vw,4rem)]
+  max-w-[clamp(50rem,75vw,90rem)] max-w-[80rem] max-w-[46rem]
+  min-w-[8rem] min-w-[10rem] max-h-[80vh]
+  h-[3.5rem] h-[0.875rem] w-[0.875rem] h-[0.5rem] w-[0.5rem]
+  h-[1.575rem] w-[1.575rem] w-[280px] w-[16px] h-[1lh]
+  pl-[1.25rem] border-l-[3px] border-b-[5px] border-t-[2px] border-t-[3px]
+  transition-[background,color,border-color]
+  shadow-[0_1px_3px_color-mix(in_srgb,var(--color-fg)_8%,transparent)]
+  hover:bg-[color-mix(in_srgb,var(--color-surface)_80%,var(--color-fg)_20%)]
+  bg-[#fff]
+");
+
+/* ========================================
  * Design Token System
  *
  * Tight token strategy: import preflight + utilities only (no default theme).

--- a/packages/create-zudo-doc/templates/base/src/styles/global.css
+++ b/packages/create-zudo-doc/templates/base/src/styles/global.css
@@ -51,22 +51,7 @@
 
 @source "../../node_modules/@takazudo/zudo-doc/dist/**/*.{js,mjs}";
 
-@source inline("
-  lg:block lg:flex lg:ml-[var(--zd-sidebar-w)] lg:px-hsp-2xl lg:py-vsp-2xl
-  lg:pt-vsp-2xl lg:grid-cols-[repeat(auto-fit,minmax(12rem,1fr))]
-  xl:hidden xl:flex sm:grid-cols-2 sm:justify-between sm:items-center sm:flex-row
-  top-[3.5rem] w-[var(--zd-sidebar-w)] h-[calc(100vh-3.5rem)]
-  min-h-[calc(100vh-3.5rem)] gap-[clamp(1.5rem,3vw,4rem)]
-  max-w-[clamp(50rem,75vw,90rem)] max-w-[80rem] max-w-[46rem]
-  min-w-[8rem] min-w-[10rem] max-h-[80vh]
-  h-[3.5rem] h-[0.875rem] w-[0.875rem] h-[0.5rem] w-[0.5rem]
-  h-[1.575rem] w-[1.575rem] w-[280px] w-[16px] h-[1lh]
-  pl-[1.25rem] border-l-[3px] border-b-[5px] border-t-[2px] border-t-[3px]
-  transition-[background,color,border-color]
-  shadow-[0_1px_3px_color-mix(in_srgb,var(--color-fg)_8%,transparent)]
-  hover:bg-[color-mix(in_srgb,var(--color-surface)_80%,var(--color-fg)_20%)]
-  bg-[#fff]
-");
+@source inline("lg:block lg:flex lg:ml-[var(--zd-sidebar-w)] lg:px-hsp-2xl lg:py-vsp-2xl lg:pt-vsp-2xl lg:grid-cols-[repeat(auto-fit,minmax(12rem,1fr))] xl:hidden xl:flex sm:grid-cols-2 sm:justify-between sm:items-center sm:flex-row top-[3.5rem] w-[var(--zd-sidebar-w)] h-[calc(100vh-3.5rem)] min-h-[calc(100vh-3.5rem)] gap-[clamp(1.5rem,3vw,4rem)] max-w-[clamp(50rem,75vw,90rem)] max-w-[80rem] max-w-[46rem] min-w-[8rem] min-w-[10rem] max-h-[80vh] h-[3.5rem] h-[0.875rem] w-[0.875rem] h-[0.5rem] w-[0.5rem] h-[1.575rem] w-[1.575rem] w-[280px] w-[16px] h-[1lh] pl-[1.25rem] border-l-[3px] border-b-[5px] border-t-[2px] border-t-[3px] transition-[background,color,border-color] shadow-[0_1px_3px_color-mix(in_srgb,var(--color-fg)_8%,transparent)] hover:bg-[color-mix(in_srgb,var(--color-surface)_80%,var(--color-fg)_20%)] bg-[#fff]");
 
 /* ========================================
  * Design Token System

--- a/packages/create-zudo-doc/templates/base/src/types/docs-entry.ts
+++ b/packages/create-zudo-doc/templates/base/src/types/docs-entry.ts
@@ -33,6 +33,13 @@ export interface DocsEntry {
     standalone?: boolean;
     slug?: string;
     generated?: boolean;
+    /** Category metadata on a directory's index.mdx (frontmatter form of
+     *  `_category_.json` `noPage`): non-linked sidebar header + excluded from
+     *  routes/sitemap/search. Frontmatter wins over the sidecar. */
+    category_no_page?: boolean;
+    /** Frontmatter form of `_category_.json` `sortOrder` — child sort
+     *  direction. Frontmatter wins over the sidecar. */
+    category_sort_order?: "asc" | "desc";
   };
   rendered?: RenderedContent;
   filePath?: string;

--- a/packages/create-zudo-doc/templates/base/src/utils/docs.ts
+++ b/packages/create-zudo-doc/templates/base/src/utils/docs.ts
@@ -70,8 +70,17 @@ function navTreeCacheKey(
     : "_";
   return `${lang}:${metaKey}:${docs
     .map((d) => {
-      const { sidebar_position, sidebar_label, title, description, unlisted, standalone, slug } =
-        d.data;
+      const {
+        sidebar_position,
+        sidebar_label,
+        title,
+        description,
+        unlisted,
+        standalone,
+        slug,
+        category_no_page,
+        category_sort_order,
+      } = d.data;
       return JSON.stringify([
         d.id,
         sidebar_position,
@@ -81,6 +90,8 @@ function navTreeCacheKey(
         unlisted,
         standalone,
         slug,
+        category_no_page,
+        category_sort_order,
       ]);
     })
     .sort()
@@ -197,7 +208,9 @@ function toNavNodes(
   for (const child of parent.children.values()) {
     const doc = child.doc;
     const meta = categoryMeta?.get(child.fullPath);
-    const sortOrder = meta?.sortOrder ?? "asc";
+    // Frontmatter wins over the `_category_.json` sidecar when both exist.
+    const noPage = doc?.data.category_no_page ?? meta?.noPage;
+    const sortOrder = doc?.data.category_sort_order ?? meta?.sortOrder ?? "asc";
     const children = toNavNodes(child, lang, categoryMeta, sortOrder);
 
     nodes.push({
@@ -206,12 +219,16 @@ function toNavNodes(
         doc?.data.sidebar_label ?? doc?.data.title ?? meta?.label ?? toTitleCase(child.segment),
       description: doc?.data.description ?? meta?.description,
       position: doc?.data.sidebar_position ?? meta?.position ?? 999,
-      href: meta?.noPage
+      href: noPage
         ? undefined
         : doc || children.length > 0
           ? docsUrl(child.fullPath, lang)
           : undefined,
-      hasPage: !!doc,
+      // A `category_no_page` index.mdx is metadata-only — force hasPage false so
+      // it matches a `_category_.json` noPage category (no backing file): a
+      // non-linked header that flattenTree drops from prev/next. Otherwise the
+      // route-excluded slug would surface as a 404 pagination target.
+      hasPage: !!doc && noPage !== true,
       children,
       sortOrder,
     });

--- a/packages/create-zudo-doc/templates/features/claudeResources/files/src/integrations/claude-resources/__tests__/generate.test.ts
+++ b/packages/create-zudo-doc/templates/features/claudeResources/files/src/integrations/claude-resources/__tests__/generate.test.ts
@@ -462,4 +462,74 @@ describe("generateClaudeResourcesDocs", () => {
       ).not.toThrow();
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Reserved "index" slug guard tests
+  // ---------------------------------------------------------------------------
+
+  describe("reserved index slug guard", () => {
+    it("throws when a CLAUDE.md directory maps to the reserved index slug", () => {
+      // index/CLAUDE.md → slug "index" — reserved for category index.mdx
+      fs.mkdirSync(path.join(tmpDir, "index"), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, "index", "CLAUDE.md"),
+        "# index dir instructions",
+      );
+
+      expect(() =>
+        generateClaudeResourcesDocs({
+          claudeDir,
+          projectRoot: tmpDir,
+          docsDir,
+        }),
+      ).toThrow(/reserved slug "index"/);
+    });
+
+    it("throws when a command file is named index.md", () => {
+      fs.writeFileSync(
+        path.join(claudeDir, "commands", "index.md"),
+        '---\ndescription: "Index command"\n---\n\nIndex body.',
+      );
+
+      expect(() =>
+        generateClaudeResourcesDocs({
+          claudeDir,
+          projectRoot: tmpDir,
+          docsDir,
+        }),
+      ).toThrow(/reserved name "index"/);
+    });
+
+    it("throws when a skill directory is named index", () => {
+      const indexSkillDir = path.join(claudeDir, "skills", "index");
+      fs.mkdirSync(indexSkillDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(indexSkillDir, "SKILL.md"),
+        '---\nname: index\ndescription: "Index skill"\n---\n\nIndex skill body.',
+      );
+
+      expect(() =>
+        generateClaudeResourcesDocs({
+          claudeDir,
+          projectRoot: tmpDir,
+          docsDir,
+        }),
+      ).toThrow(/reserved name "index"/);
+    });
+
+    it("throws when an agent file is named index.md", () => {
+      fs.writeFileSync(
+        path.join(claudeDir, "agents", "index.md"),
+        '---\nname: index-agent\ndescription: "Index agent"\nmodel: sonnet\n---\n\nIndex agent body.',
+      );
+
+      expect(() =>
+        generateClaudeResourcesDocs({
+          claudeDir,
+          projectRoot: tmpDir,
+          docsDir,
+        }),
+      ).toThrow(/reserved name "index"/);
+    });
+  });
 });

--- a/packages/create-zudo-doc/templates/features/claudeResources/files/src/integrations/claude-resources/__tests__/generate.test.ts
+++ b/packages/create-zudo-doc/templates/features/claudeResources/files/src/integrations/claude-resources/__tests__/generate.test.ts
@@ -91,7 +91,7 @@ describe("generateClaudeResourcesDocs", () => {
       expect(fs.existsSync(path.join(docsDir, "claude-agents"))).toBe(true);
     });
 
-    it("generates _category_.json with noPage for sub-categories", () => {
+    it("generates index.mdx with category_no_page for sub-categories", () => {
       generateClaudeResourcesDocs({
         claudeDir,
         projectRoot: tmpDir,
@@ -100,14 +100,14 @@ describe("generateClaudeResourcesDocs", () => {
 
       const dirs = ["claude-md", "claude-commands", "claude-skills", "claude-agents"];
       for (const dir of dirs) {
-        const catPath = path.join(docsDir, dir, "_category_.json");
-        expect(fs.existsSync(catPath)).toBe(true);
+        const indexPath = path.join(docsDir, dir, "index.mdx");
+        expect(fs.existsSync(indexPath)).toBe(true);
 
-        const cat = JSON.parse(fs.readFileSync(catPath, "utf8"));
-        expect(cat).toHaveProperty("label");
-        expect(cat).toHaveProperty("position");
-        expect(cat).toHaveProperty("description");
-        expect(cat.noPage).toBe(true);
+        const parsed = matter(fs.readFileSync(indexPath, "utf8"));
+        expect(parsed.data).toHaveProperty("title");
+        expect(parsed.data).toHaveProperty("sidebar_position");
+        expect(parsed.data).toHaveProperty("description");
+        expect(parsed.data.category_no_page).toBe(true);
       }
     });
 
@@ -332,7 +332,7 @@ describe("generateClaudeResourcesDocs", () => {
   // ---------------------------------------------------------------------------
 
   describe("category metadata", () => {
-    it("_category_.json positions are ordered correctly", () => {
+    it("index.mdx sidebar_position values are ordered correctly", () => {
       generateClaudeResourcesDocs({
         claudeDir,
         projectRoot: tmpDir,
@@ -340,16 +340,36 @@ describe("generateClaudeResourcesDocs", () => {
       });
 
       const readPos = (dir: string) => {
-        const cat = JSON.parse(
-          fs.readFileSync(path.join(docsDir, dir, "_category_.json"), "utf8"),
+        const parsed = matter(
+          fs.readFileSync(path.join(docsDir, dir, "index.mdx"), "utf8"),
         );
-        return cat.position;
+        return parsed.data.sidebar_position;
       };
 
       expect(readPos("claude-md")).toBe(900);
       expect(readPos("claude-commands")).toBe(901);
       expect(readPos("claude-skills")).toBe(902);
       expect(readPos("claude-agents")).toBe(903);
+    });
+
+    it("index.mdx has correct label as title for each sub-category", () => {
+      generateClaudeResourcesDocs({
+        claudeDir,
+        projectRoot: tmpDir,
+        docsDir,
+      });
+
+      const readTitle = (dir: string) => {
+        const parsed = matter(
+          fs.readFileSync(path.join(docsDir, dir, "index.mdx"), "utf8"),
+        );
+        return parsed.data.title;
+      };
+
+      expect(readTitle("claude-md")).toBe("CLAUDE.md");
+      expect(readTitle("claude-commands")).toBe("Commands");
+      expect(readTitle("claude-skills")).toBe("Skills");
+      expect(readTitle("claude-agents")).toBe("Agents");
     });
   });
 
@@ -371,6 +391,75 @@ describe("generateClaudeResourcesDocs", () => {
         skills: 1,
         agents: 1,
       });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Slug collision detection tests
+  // ---------------------------------------------------------------------------
+
+  describe("slug collision detection", () => {
+    it("throws when two CLAUDE.md paths produce the same slug", () => {
+      // foo/bar/CLAUDE.md → slug "foo--bar"
+      // foo--bar/CLAUDE.md → slug "foo--bar"  (collision)
+      fs.mkdirSync(path.join(tmpDir, "foo", "bar"), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, "foo", "bar", "CLAUDE.md"),
+        "# foo/bar instructions",
+      );
+      fs.mkdirSync(path.join(tmpDir, "foo--bar"), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, "foo--bar", "CLAUDE.md"),
+        "# foo--bar instructions",
+      );
+
+      expect(() =>
+        generateClaudeResourcesDocs({
+          claudeDir,
+          projectRoot: tmpDir,
+          docsDir,
+        }),
+      ).toThrow(/slug collision/);
+    });
+
+    it("names both colliding source paths in the error", () => {
+      fs.mkdirSync(path.join(tmpDir, "foo", "bar"), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, "foo", "bar", "CLAUDE.md"),
+        "# foo/bar instructions",
+      );
+      fs.mkdirSync(path.join(tmpDir, "foo--bar"), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, "foo--bar", "CLAUDE.md"),
+        "# foo--bar instructions",
+      );
+
+      let caughtMessage = "";
+      try {
+        generateClaudeResourcesDocs({
+          claudeDir,
+          projectRoot: tmpDir,
+          docsDir,
+        });
+      } catch (e) {
+        caughtMessage = (e as Error).message;
+      }
+
+      expect(caughtMessage).toContain("foo--bar");
+      // Both source paths must appear in the message
+      expect(caughtMessage).toMatch(/foo.bar.CLAUDE\.md/);
+      expect(caughtMessage).toMatch(/foo--bar.CLAUDE\.md/);
+    });
+
+    it("does not throw for a clean tree (no collisions)", () => {
+      // The default fixture has only root/CLAUDE.md — no collision
+      expect(() =>
+        generateClaudeResourcesDocs({
+          claudeDir,
+          projectRoot: tmpDir,
+          docsDir,
+        }),
+      ).not.toThrow();
     });
   });
 });

--- a/packages/create-zudo-doc/templates/features/claudeResources/files/src/integrations/claude-resources/generate.ts
+++ b/packages/create-zudo-doc/templates/features/claudeResources/files/src/integrations/claude-resources/generate.ts
@@ -76,19 +76,21 @@ function listFiles(dir: string): string[] {
     .sort();
 }
 
-function writeCategoryMeta(
+function writeCategoryIndex(
   outputDir: string,
   label: string,
   position: number,
   description: string,
-  noPage = true,
 ) {
-  const meta: Record<string, unknown> = { label, position, description };
-  if (noPage) meta.noPage = true;
-  fs.writeFileSync(
-    path.join(outputDir, "_category_.json"),
-    JSON.stringify(meta, null, 2) + "\n",
-  );
+  const mdx = `---
+title: "${escapeTitle(label)}"
+description: "${escapeTitle(description)}"
+sidebar_position: ${position}
+category_no_page: true
+generated: true
+---
+`;
+  fs.writeFileSync(path.join(outputDir, "index.mdx"), mdx);
 }
 
 // ---------------------------------------------------------------------------
@@ -197,7 +199,7 @@ ${escapeForMdx(content.trim())}
     fs.writeFileSync(path.join(outputDir, `${item.slug}.mdx`), mdx);
   });
 
-  writeCategoryMeta(outputDir, "CLAUDE.md", 900, "Project-specific instructions");
+  writeCategoryIndex(outputDir, "CLAUDE.md", 900, "Project-specific instructions");
   return items;
 }
 
@@ -243,7 +245,7 @@ ${escapeForMdx(parsed.content.trim())}
 
   items.sort((a, b) => a.name.localeCompare(b.name));
 
-  writeCategoryMeta(outputDir, "Commands", 901, "Custom slash commands");
+  writeCategoryIndex(outputDir, "Commands", 901, "Custom slash commands");
   return items;
 }
 
@@ -474,7 +476,7 @@ ${escapeForMdx(ref.content.trim())}
 
   items.sort((a, b) => a.name.localeCompare(b.name));
 
-  writeCategoryMeta(outputDir, "Skills", 902, "Skill packages");
+  writeCategoryIndex(outputDir, "Skills", 902, "Skill packages");
   return items;
 }
 
@@ -525,7 +527,7 @@ ${escapeForMdx(parsed.content.trim())}
 
   items.sort((a, b) => a.name.localeCompare(b.name));
 
-  writeCategoryMeta(outputDir, "Agents", 903, "Custom subagents");
+  writeCategoryIndex(outputDir, "Agents", 903, "Custom subagents");
   return items;
 }
 

--- a/packages/create-zudo-doc/templates/features/claudeResources/files/src/integrations/claude-resources/generate.ts
+++ b/packages/create-zudo-doc/templates/features/claudeResources/files/src/integrations/claude-resources/generate.ts
@@ -176,6 +176,11 @@ function generateClaudemdDocs(
 
   const emittedSlugs = new Map<string, string>();
   items.forEach((item, index) => {
+    if (item.slug === "index") {
+      throw new Error(
+        `claude-resources: "${item.relPath}" maps to the reserved slug "index", which is used for the category metadata file. Rename the directory to resolve the conflict.`,
+      );
+    }
     const previous = emittedSlugs.get(item.slug);
     if (previous !== undefined) {
       throw new Error(
@@ -227,6 +232,11 @@ function generateCommandsDocs(config: ClaudeResourcesConfig): CommandItem[] {
     if (!parsed) continue;
 
     const name = file.replace(/\.md$/, "");
+    if (name === "index") {
+      throw new Error(
+        `claude-resources: ".claude/commands/index.md" uses the reserved name "index", which is used for the category metadata file. Rename the command file to resolve the conflict.`,
+      );
+    }
     const description = (parsed.data.description as string) || "";
 
     items.push({ name, description });
@@ -347,6 +357,11 @@ function generateSkillsDocs(config: ClaudeResourcesConfig): SkillItem[] {
   const items: SkillItem[] = [];
 
   for (const dir of dirs) {
+    if (dir === "index") {
+      throw new Error(
+        `claude-resources: skill directory ".claude/skills/index/" uses the reserved name "index", which is used for the category metadata file. Rename the skill directory to resolve the conflict.`,
+      );
+    }
     const content = fs.readFileSync(
       path.join(skillsDir, dir, "SKILL.md"),
       "utf8",
@@ -507,6 +522,11 @@ function generateAgentsDocs(config: ClaudeResourcesConfig): AgentItem[] {
     const description = (parsed.data.description as string) || "";
     const model = (parsed.data.model as string) || "";
     const fileSlug = file.replace(/\.md$/, "");
+    if (fileSlug === "index") {
+      throw new Error(
+        `claude-resources: ".claude/agents/index.md" uses the reserved name "index", which is used for the category metadata file. Rename the agent file to resolve the conflict.`,
+      );
+    }
 
     items.push({ name, file: fileSlug, description, model });
 

--- a/packages/create-zudo-doc/templates/features/docTags/files/pages/[locale]/docs/tags/[tag].tsx
+++ b/packages/create-zudo-doc/templates/features/docTags/files/pages/[locale]/docs/tags/[tag].tsx
@@ -48,17 +48,17 @@ export function paths(): Array<{
   }> = [];
 
   for (const locale of Object.keys(settings.locales)) {
-    // category_no_page index files build no route — drop them so a tag they
-    // carry doesn't surface a card linking to a non-existent locale doc page.
-    const { docs } = mergeLocaleDocs({
-      baseDocs: loadDocs("docs").filter(
-        (d) => !d.data.draft && !d.data.category_no_page,
-      ),
-      localeDocs: loadDocs(`docs-${locale}`).filter(
-        (d) => !d.data.draft && !d.data.category_no_page,
-      ),
+    const { docs: mergedDocs } = mergeLocaleDocs({
+      baseDocs: loadDocs("docs").filter((d) => !d.data.draft),
+      localeDocs: loadDocs(`docs-${locale}`).filter((d) => !d.data.draft),
       applyDefaultLocaleOnlyFilter: true,
     });
+    // category_no_page index files build no route — drop them AFTER the merge
+    // so a locale override carrying the flag first wins the merge (suppressing
+    // the base doc); pre-merge filtering would drop it from localeSlugSet and
+    // the unflagged base doc would resurface as a card linking to a locale
+    // route the docs route never builds.
+    const docs = mergedDocs.filter((d) => !d.data.category_no_page);
     const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));
 
     for (const [tag, tagInfo] of tagMap.entries()) {

--- a/packages/create-zudo-doc/templates/features/docTags/files/pages/[locale]/docs/tags/[tag].tsx
+++ b/packages/create-zudo-doc/templates/features/docTags/files/pages/[locale]/docs/tags/[tag].tsx
@@ -48,9 +48,15 @@ export function paths(): Array<{
   }> = [];
 
   for (const locale of Object.keys(settings.locales)) {
+    // category_no_page index files build no route — drop them so a tag they
+    // carry doesn't surface a card linking to a non-existent locale doc page.
     const { docs } = mergeLocaleDocs({
-      baseDocs: loadDocs("docs").filter((d) => !d.data.draft),
-      localeDocs: loadDocs(`docs-${locale}`).filter((d) => !d.data.draft),
+      baseDocs: loadDocs("docs").filter(
+        (d) => !d.data.draft && !d.data.category_no_page,
+      ),
+      localeDocs: loadDocs(`docs-${locale}`).filter(
+        (d) => !d.data.draft && !d.data.category_no_page,
+      ),
       applyDefaultLocaleOnlyFilter: true,
     });
     const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));

--- a/packages/create-zudo-doc/templates/features/docTags/files/pages/[locale]/docs/tags/index.tsx
+++ b/packages/create-zudo-doc/templates/features/docTags/files/pages/[locale]/docs/tags/index.tsx
@@ -53,17 +53,17 @@ export default function LocaleTagsIndexPage({
   const { locale } = params;
   const pageTitle = t("doc.allTags", locale);
 
-  // category_no_page index files build no route — drop them so a tag they
-  // carry doesn't surface a card linking to a non-existent locale doc page.
-  const { docs } = mergeLocaleDocs({
-    baseDocs: loadDocs("docs").filter(
-      (d) => !d.data.draft && !d.data.category_no_page,
-    ),
-    localeDocs: loadDocs(`docs-${locale}`).filter(
-      (d) => !d.data.draft && !d.data.category_no_page,
-    ),
+  const { docs: mergedDocs } = mergeLocaleDocs({
+    baseDocs: loadDocs("docs").filter((d) => !d.data.draft),
+    localeDocs: loadDocs(`docs-${locale}`).filter((d) => !d.data.draft),
     applyDefaultLocaleOnlyFilter: true,
   });
+  // category_no_page index files build no route — drop them AFTER the merge
+  // so a locale override carrying the flag first wins the merge (suppressing
+  // the base doc); pre-merge filtering would drop it from localeSlugSet and
+  // the unflagged base doc would resurface as a card linking to a locale
+  // route the docs route never builds.
+  const docs = mergedDocs.filter((d) => !d.data.category_no_page);
   const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));
 
   const labels: TagNavLabels = {

--- a/packages/create-zudo-doc/templates/features/docTags/files/pages/[locale]/docs/tags/index.tsx
+++ b/packages/create-zudo-doc/templates/features/docTags/files/pages/[locale]/docs/tags/index.tsx
@@ -53,9 +53,15 @@ export default function LocaleTagsIndexPage({
   const { locale } = params;
   const pageTitle = t("doc.allTags", locale);
 
+  // category_no_page index files build no route — drop them so a tag they
+  // carry doesn't surface a card linking to a non-existent locale doc page.
   const { docs } = mergeLocaleDocs({
-    baseDocs: loadDocs("docs").filter((d) => !d.data.draft),
-    localeDocs: loadDocs(`docs-${locale}`).filter((d) => !d.data.draft),
+    baseDocs: loadDocs("docs").filter(
+      (d) => !d.data.draft && !d.data.category_no_page,
+    ),
+    localeDocs: loadDocs(`docs-${locale}`).filter(
+      (d) => !d.data.draft && !d.data.category_no_page,
+    ),
     applyDefaultLocaleOnlyFilter: true,
   });
   const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));

--- a/packages/create-zudo-doc/templates/features/docTags/files/pages/docs/tags/[tag].tsx
+++ b/packages/create-zudo-doc/templates/features/docTags/files/pages/docs/tags/[tag].tsx
@@ -42,7 +42,12 @@ export function paths(): Array<{
   props: { tagInfo: TagInfo };
 }> {
   const allDocs = bridgeDocsEntries(getCollection<ZfbDocsData>("docs"), "docs");
-  const docs = allDocs.filter((doc) => !doc.data.unlisted && !doc.data.draft);
+  // category_no_page index.mdx builds no route — drop it so a tag it carries
+  // doesn't render a DocCard linking to a non-existent /docs/<cat>/ page.
+  const docs = allDocs.filter(
+    (doc) =>
+      !doc.data.unlisted && !doc.data.draft && !doc.data.category_no_page,
+  );
   const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));
 
   return [...tagMap.entries()].map(([tag, tagInfo]) => ({

--- a/packages/create-zudo-doc/templates/features/docTags/files/pages/docs/tags/index.tsx
+++ b/packages/create-zudo-doc/templates/features/docTags/files/pages/docs/tags/index.tsx
@@ -39,7 +39,12 @@ export default function DocsTagsIndexPage(): JSX.Element {
   const pageTitle = t("doc.allTags", locale);
 
   const allDocs = bridgeDocsEntries(getCollection<ZfbDocsData>("docs"), "docs");
-  const docs = allDocs.filter((doc) => !doc.data.unlisted && !doc.data.draft);
+  // category_no_page index.mdx builds no route — drop it so a tag it carries
+  // doesn't inflate the tag list with a card linking to a non-existent page.
+  const docs = allDocs.filter(
+    (doc) =>
+      !doc.data.unlisted && !doc.data.draft && !doc.data.category_no_page,
+  );
   const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));
 
   const labels: TagNavLabels = {

--- a/packages/create-zudo-doc/templates/features/i18n/files/pages/[locale]/docs/[[...slug]].tsx
+++ b/packages/create-zudo-doc/templates/features/i18n/files/pages/[locale]/docs/[[...slug]].tsx
@@ -259,6 +259,7 @@ export default function LocaleDocsPage(props: PageArgs): JSX.Element {
             locale={locale}
             entrySlug={props.entry.slug}
             contentDir={contentDir}
+            isFallback={isFallback}
           />
         ) : null
       }

--- a/packages/create-zudo-doc/templates/features/i18n/files/pages/[locale]/docs/[[...slug]].tsx
+++ b/packages/create-zudo-doc/templates/features/i18n/files/pages/[locale]/docs/[[...slug]].tsx
@@ -118,6 +118,10 @@ export function paths(): Array<{
 
     // Regular doc pages
     for (const entry of allDocs) {
+      // A `category_no_page` index.mdx is metadata-only — kept in the nav tree
+      // for breadcrumbs but emits no route (zfb retains every .mdx as a
+      // collection entry, so the skip must be explicit).
+      if (entry.data.category_no_page === true) continue;
       // Canonical route slug via the one shared rule (@/utils/slug). `entry.id`
       // is already `toRouteSlug(entry.slug)` (bridgeEntries → stripIndexSuffix →
       // toRouteSlug), so this is identical to the previous `entry.id` form for

--- a/packages/create-zudo-doc/templates/features/i18n/files/pages/[locale]/index.tsx
+++ b/packages/create-zudo-doc/templates/features/i18n/files/pages/[locale]/index.tsx
@@ -84,8 +84,10 @@ export default function LocaleIndexPage({ params }: PageArgs): JSX.Element {
   const categoryOrder = getCategoryOrder();
   const groupedTree = groupSatelliteNodes(tree, categoryOrder);
 
+  // Drop category_no_page index files so the count matches the number of tag
+  // pages actually built (the tag routes exclude them too).
   const tagCount = collectTags(
-    navDocs,
+    navDocs.filter((d) => !d.data.category_no_page),
     (id, data) => data.slug ?? toRouteSlug(id),
   ).size;
 

--- a/packages/create-zudo-doc/templates/features/versioning/files/pages/v/[version]/[locale]/docs/[[...slug]].tsx
+++ b/packages/create-zudo-doc/templates/features/versioning/files/pages/v/[version]/[locale]/docs/[[...slug]].tsx
@@ -128,6 +128,10 @@ export function paths(): Array<{
 
       // Regular doc pages
       for (const entry of allDocs) {
+        // A `category_no_page` index.mdx is metadata-only — kept in the nav
+        // tree for breadcrumbs but emits no route (zfb retains every .mdx as a
+        // collection entry, so the skip must be explicit).
+        if (entry.data.category_no_page === true) continue;
         const slug = entry.data.slug ?? toRouteSlug(entry.slug);
         const isFallback = fallbackSlugs.has(slug);
         const entryContentDir = isFallback ? version.docsDir : (localeDir ?? version.docsDir);

--- a/packages/create-zudo-doc/templates/features/versioning/files/pages/v/[version]/docs/[[...slug]].tsx
+++ b/packages/create-zudo-doc/templates/features/versioning/files/pages/v/[version]/docs/[[...slug]].tsx
@@ -106,6 +106,10 @@ export function paths(): Array<{
 
     // Regular doc pages
     for (const entry of allDocs) {
+      // A `category_no_page` index.mdx is metadata-only — kept in the nav tree
+      // for breadcrumbs but emits no route (zfb retains every .mdx as a
+      // collection entry, so the skip must be explicit).
+      if (entry.data.category_no_page === true) continue;
       const slug = entry.data.slug ?? toRouteSlug(entry.slug);
       const navSection = getNavSectionForSlug(slug);
       const subtree = getNavSubtree(tree, navSection);

--- a/packages/zudo-doc/src/integrations/claude-resources/__tests__/generate.test.ts
+++ b/packages/zudo-doc/src/integrations/claude-resources/__tests__/generate.test.ts
@@ -462,4 +462,74 @@ describe("generateClaudeResourcesDocs", () => {
       ).not.toThrow();
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Reserved "index" slug guard tests
+  // ---------------------------------------------------------------------------
+
+  describe("reserved index slug guard", () => {
+    it("throws when a CLAUDE.md directory maps to the reserved index slug", () => {
+      // index/CLAUDE.md → slug "index" — reserved for category index.mdx
+      fs.mkdirSync(path.join(tmpDir, "index"), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, "index", "CLAUDE.md"),
+        "# index dir instructions",
+      );
+
+      expect(() =>
+        generateClaudeResourcesDocs({
+          claudeDir,
+          projectRoot: tmpDir,
+          docsDir,
+        }),
+      ).toThrow(/reserved slug "index"/);
+    });
+
+    it("throws when a command file is named index.md", () => {
+      fs.writeFileSync(
+        path.join(claudeDir, "commands", "index.md"),
+        '---\ndescription: "Index command"\n---\n\nIndex body.',
+      );
+
+      expect(() =>
+        generateClaudeResourcesDocs({
+          claudeDir,
+          projectRoot: tmpDir,
+          docsDir,
+        }),
+      ).toThrow(/reserved name "index"/);
+    });
+
+    it("throws when a skill directory is named index", () => {
+      const indexSkillDir = path.join(claudeDir, "skills", "index");
+      fs.mkdirSync(indexSkillDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(indexSkillDir, "SKILL.md"),
+        '---\nname: index\ndescription: "Index skill"\n---\n\nIndex skill body.',
+      );
+
+      expect(() =>
+        generateClaudeResourcesDocs({
+          claudeDir,
+          projectRoot: tmpDir,
+          docsDir,
+        }),
+      ).toThrow(/reserved name "index"/);
+    });
+
+    it("throws when an agent file is named index.md", () => {
+      fs.writeFileSync(
+        path.join(claudeDir, "agents", "index.md"),
+        '---\nname: index-agent\ndescription: "Index agent"\nmodel: sonnet\n---\n\nIndex agent body.',
+      );
+
+      expect(() =>
+        generateClaudeResourcesDocs({
+          claudeDir,
+          projectRoot: tmpDir,
+          docsDir,
+        }),
+      ).toThrow(/reserved name "index"/);
+    });
+  });
 });

--- a/packages/zudo-doc/src/integrations/claude-resources/__tests__/generate.test.ts
+++ b/packages/zudo-doc/src/integrations/claude-resources/__tests__/generate.test.ts
@@ -91,7 +91,7 @@ describe("generateClaudeResourcesDocs", () => {
       expect(fs.existsSync(path.join(docsDir, "claude-agents"))).toBe(true);
     });
 
-    it("generates _category_.json with noPage for sub-categories", () => {
+    it("generates index.mdx with category_no_page for sub-categories", () => {
       generateClaudeResourcesDocs({
         claudeDir,
         projectRoot: tmpDir,
@@ -100,14 +100,14 @@ describe("generateClaudeResourcesDocs", () => {
 
       const dirs = ["claude-md", "claude-commands", "claude-skills", "claude-agents"];
       for (const dir of dirs) {
-        const catPath = path.join(docsDir, dir, "_category_.json");
-        expect(fs.existsSync(catPath)).toBe(true);
+        const indexPath = path.join(docsDir, dir, "index.mdx");
+        expect(fs.existsSync(indexPath)).toBe(true);
 
-        const cat = JSON.parse(fs.readFileSync(catPath, "utf8"));
-        expect(cat).toHaveProperty("label");
-        expect(cat).toHaveProperty("position");
-        expect(cat).toHaveProperty("description");
-        expect(cat.noPage).toBe(true);
+        const parsed = matter(fs.readFileSync(indexPath, "utf8"));
+        expect(parsed.data).toHaveProperty("title");
+        expect(parsed.data).toHaveProperty("sidebar_position");
+        expect(parsed.data).toHaveProperty("description");
+        expect(parsed.data.category_no_page).toBe(true);
       }
     });
 
@@ -332,7 +332,7 @@ describe("generateClaudeResourcesDocs", () => {
   // ---------------------------------------------------------------------------
 
   describe("category metadata", () => {
-    it("_category_.json positions are ordered correctly", () => {
+    it("index.mdx sidebar_position values are ordered correctly", () => {
       generateClaudeResourcesDocs({
         claudeDir,
         projectRoot: tmpDir,
@@ -340,16 +340,36 @@ describe("generateClaudeResourcesDocs", () => {
       });
 
       const readPos = (dir: string) => {
-        const cat = JSON.parse(
-          fs.readFileSync(path.join(docsDir, dir, "_category_.json"), "utf8"),
+        const parsed = matter(
+          fs.readFileSync(path.join(docsDir, dir, "index.mdx"), "utf8"),
         );
-        return cat.position;
+        return parsed.data.sidebar_position;
       };
 
       expect(readPos("claude-md")).toBe(900);
       expect(readPos("claude-commands")).toBe(901);
       expect(readPos("claude-skills")).toBe(902);
       expect(readPos("claude-agents")).toBe(903);
+    });
+
+    it("index.mdx has correct label as title for each sub-category", () => {
+      generateClaudeResourcesDocs({
+        claudeDir,
+        projectRoot: tmpDir,
+        docsDir,
+      });
+
+      const readTitle = (dir: string) => {
+        const parsed = matter(
+          fs.readFileSync(path.join(docsDir, dir, "index.mdx"), "utf8"),
+        );
+        return parsed.data.title;
+      };
+
+      expect(readTitle("claude-md")).toBe("CLAUDE.md");
+      expect(readTitle("claude-commands")).toBe("Commands");
+      expect(readTitle("claude-skills")).toBe("Skills");
+      expect(readTitle("claude-agents")).toBe("Agents");
     });
   });
 

--- a/packages/zudo-doc/src/integrations/claude-resources/generate.ts
+++ b/packages/zudo-doc/src/integrations/claude-resources/generate.ts
@@ -76,19 +76,21 @@ function listFiles(dir: string): string[] {
     .sort();
 }
 
-function writeCategoryMeta(
+function writeCategoryIndex(
   outputDir: string,
   label: string,
   position: number,
   description: string,
-  noPage = true,
 ) {
-  const meta: Record<string, unknown> = { label, position, description };
-  if (noPage) meta.noPage = true;
-  fs.writeFileSync(
-    path.join(outputDir, "_category_.json"),
-    JSON.stringify(meta, null, 2) + "\n",
-  );
+  const mdx = `---
+title: "${escapeTitle(label)}"
+description: "${escapeTitle(description)}"
+sidebar_position: ${position}
+category_no_page: true
+generated: true
+---
+`;
+  fs.writeFileSync(path.join(outputDir, "index.mdx"), mdx);
 }
 
 // ---------------------------------------------------------------------------
@@ -197,7 +199,7 @@ ${escapeForMdx(content.trim())}
     fs.writeFileSync(path.join(outputDir, `${item.slug}.mdx`), mdx);
   });
 
-  writeCategoryMeta(outputDir, "CLAUDE.md", 900, "Project-specific instructions");
+  writeCategoryIndex(outputDir, "CLAUDE.md", 900, "Project-specific instructions");
   return items;
 }
 
@@ -243,7 +245,7 @@ ${escapeForMdx(parsed.content.trim())}
 
   items.sort((a, b) => a.name.localeCompare(b.name));
 
-  writeCategoryMeta(outputDir, "Commands", 901, "Custom slash commands");
+  writeCategoryIndex(outputDir, "Commands", 901, "Custom slash commands");
   return items;
 }
 
@@ -477,7 +479,7 @@ ${escapeForMdx(ref.content.trim())}
 
   items.sort((a, b) => a.name.localeCompare(b.name));
 
-  writeCategoryMeta(outputDir, "Skills", 902, "Skill packages");
+  writeCategoryIndex(outputDir, "Skills", 902, "Skill packages");
   return items;
 }
 
@@ -528,7 +530,7 @@ ${escapeForMdx(parsed.content.trim())}
 
   items.sort((a, b) => a.name.localeCompare(b.name));
 
-  writeCategoryMeta(outputDir, "Agents", 903, "Custom subagents");
+  writeCategoryIndex(outputDir, "Agents", 903, "Custom subagents");
   return items;
 }
 

--- a/packages/zudo-doc/src/integrations/claude-resources/generate.ts
+++ b/packages/zudo-doc/src/integrations/claude-resources/generate.ts
@@ -176,6 +176,11 @@ function generateClaudemdDocs(
 
   const emittedSlugs = new Map<string, string>();
   items.forEach((item, index) => {
+    if (item.slug === "index") {
+      throw new Error(
+        `claude-resources: "${item.relPath}" maps to the reserved slug "index", which is used for the category metadata file. Rename the directory to resolve the conflict.`,
+      );
+    }
     const previous = emittedSlugs.get(item.slug);
     if (previous !== undefined) {
       throw new Error(
@@ -227,6 +232,11 @@ function generateCommandsDocs(config: ClaudeResourcesConfig): CommandItem[] {
     if (!parsed) continue;
 
     const name = file.replace(/\.md$/, "");
+    if (name === "index") {
+      throw new Error(
+        `claude-resources: ".claude/commands/index.md" uses the reserved name "index", which is used for the category metadata file. Rename the command file to resolve the conflict.`,
+      );
+    }
     const description = (parsed.data.description as string) || "";
 
     items.push({ name, description });
@@ -350,6 +360,11 @@ function generateSkillsDocs(config: ClaudeResourcesConfig): SkillItem[] {
   const items: SkillItem[] = [];
 
   for (const dir of dirs) {
+    if (dir === "index") {
+      throw new Error(
+        `claude-resources: skill directory ".claude/skills/index/" uses the reserved name "index", which is used for the category metadata file. Rename the skill directory to resolve the conflict.`,
+      );
+    }
     const content = fs.readFileSync(
       path.join(skillsDir, dir, "SKILL.md"),
       "utf8",
@@ -510,6 +525,11 @@ function generateAgentsDocs(config: ClaudeResourcesConfig): AgentItem[] {
     const description = (parsed.data.description as string) || "";
     const model = (parsed.data.model as string) || "";
     const fileSlug = file.replace(/\.md$/, "");
+    if (fileSlug === "index") {
+      throw new Error(
+        `claude-resources: ".claude/agents/index.md" uses the reserved name "index", which is used for the category metadata file. Rename the agent file to resolve the conflict.`,
+      );
+    }
 
     items.push({ name, file: fileSlug, description, model });
 

--- a/packages/zudo-doc/src/integrations/llms-txt/__tests__/is-excluded.test.ts
+++ b/packages/zudo-doc/src/integrations/llms-txt/__tests__/is-excluded.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { isExcluded } from "../load.js";
+import type { LlmsTxtFrontmatter } from "../types.js";
+
+describe("llms-txt isExcluded", () => {
+  it("includes a normal page", () => {
+    expect(isExcluded({ title: "Intro" })).toBe(false);
+  });
+
+  it("excludes draft / unlisted / search_exclude pages", () => {
+    expect(isExcluded({ draft: true })).toBe(true);
+    expect(isExcluded({ unlisted: true })).toBe(true);
+    expect(isExcluded({ search_exclude: true })).toBe(true);
+  });
+
+  it("excludes a category_no_page metadata-only index (no built route to link to)", () => {
+    const data: LlmsTxtFrontmatter = { title: "Guides", category_no_page: true };
+    expect(isExcluded(data)).toBe(true);
+  });
+
+  it("does NOT exclude a category index that omits category_no_page", () => {
+    expect(isExcluded({ title: "Guides", category_no_page: false })).toBe(false);
+  });
+});

--- a/packages/zudo-doc/src/integrations/llms-txt/load.ts
+++ b/packages/zudo-doc/src/integrations/llms-txt/load.ts
@@ -88,9 +88,16 @@ export function slugToUrl(
   return path;
 }
 
-/** Whether a given doc should be excluded from the llms.txt index. */
+/** Whether a given doc should be excluded from the llms.txt index.
+ *  `category_no_page` index files are metadata-only with no built route, so
+ *  they are excluded alongside search_exclude / draft / unlisted. */
 export function isExcluded(data: LlmsTxtFrontmatter): boolean {
-  return Boolean(data.search_exclude || data.draft || data.unlisted);
+  return Boolean(
+    data.search_exclude ||
+      data.draft ||
+      data.unlisted ||
+      data.category_no_page,
+  );
 }
 
 /**

--- a/packages/zudo-doc/src/integrations/llms-txt/types.ts
+++ b/packages/zudo-doc/src/integrations/llms-txt/types.ts
@@ -23,6 +23,12 @@ export interface LlmsTxtFrontmatter {
    * Mirrors the `search_exclude` flag used by the existing project.
    */
   search_exclude?: boolean;
+  /**
+   * A `category_no_page` index.mdx carries category metadata only and builds
+   * no route — so it must NOT appear in llms.txt (the link would 404). Mirrors
+   * the route/sitemap/search exclusion in the host project.
+   */
+  category_no_page?: boolean;
   [key: string]: unknown;
 }
 

--- a/packages/zudo-doc/src/integrations/search-index/__tests__/is-excluded.test.ts
+++ b/packages/zudo-doc/src/integrations/search-index/__tests__/is-excluded.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { isExcluded, type DocFrontmatter } from "../content-files.js";
+
+describe("search-index isExcluded", () => {
+  it("includes a normal page", () => {
+    expect(isExcluded({ title: "Intro" })).toBe(false);
+  });
+
+  it("excludes draft / unlisted / search_exclude pages", () => {
+    expect(isExcluded({ draft: true })).toBe(true);
+    expect(isExcluded({ unlisted: true })).toBe(true);
+    expect(isExcluded({ search_exclude: true })).toBe(true);
+  });
+
+  it("excludes a category_no_page metadata-only index (no built route to link to)", () => {
+    const data: DocFrontmatter = { title: "Guides", category_no_page: true };
+    expect(isExcluded(data)).toBe(true);
+  });
+
+  it("does NOT exclude a category index that omits category_no_page", () => {
+    expect(isExcluded({ title: "Guides", category_no_page: false })).toBe(false);
+  });
+});

--- a/packages/zudo-doc/src/integrations/search-index/content-files.ts
+++ b/packages/zudo-doc/src/integrations/search-index/content-files.ts
@@ -106,6 +106,12 @@ export interface DocFrontmatter {
   draft?: boolean;
   unlisted?: boolean;
   search_exclude?: boolean;
+  /**
+   * A `category_no_page` index.mdx carries category metadata only and builds
+   * no route — so its slug must NOT enter the search index (the result link
+   * would 404). Mirrors the route/sitemap exclusion in the host project.
+   */
+  category_no_page?: boolean;
   [key: string]: unknown;
 }
 
@@ -121,7 +127,16 @@ export function parseMarkdownFile(
   }
 }
 
-/** A page is excluded from indexing when explicitly opted out, drafted, or unlisted. */
+/**
+ * A page is excluded from indexing when explicitly opted out, drafted,
+ * unlisted, or a `category_no_page` metadata-only category index (no built
+ * route to link to).
+ */
 export function isExcluded(data: DocFrontmatter): boolean {
-  return !!(data.search_exclude || data.draft || data.unlisted);
+  return !!(
+    data.search_exclude ||
+    data.draft ||
+    data.unlisted ||
+    data.category_no_page
+  );
 }

--- a/packages/zudo-doc/src/sidebar-tree/__tests__/build-tree.test.ts
+++ b/packages/zudo-doc/src/sidebar-tree/__tests__/build-tree.test.ts
@@ -188,6 +188,100 @@ describe("buildSidebarTree", () => {
     expect(guides.href).toBeUndefined();
   });
 
+  it("treats a category_no_page index.mdx like a _category_.json noPage category", () => {
+    // The index.mdx exists (carries label/position) but is metadata-only:
+    // non-linked header, NOT a backing page.
+    const tree = buildSidebarTree(
+      [
+        entry("guides/index", {
+          title: "Guides",
+          sidebar_label: "Guides",
+          sidebar_position: 3,
+          category_no_page: true,
+        }),
+        entry("guides/intro", { title: "Intro" }),
+      ],
+      "en",
+    );
+    const guides = tree.find((n) => n.id === "guides")!;
+    // (a) non-linked header with correct label/position
+    expect(guides.type).toBe("category");
+    expect(guides.label).toBe("Guides");
+    expect(guides.sidebar_position).toBe(3);
+    expect(guides.href).toBeUndefined();
+    // hasPage false so it matches the no-index noPage case exactly.
+    expect(guides.hasPage).toBe(false);
+  });
+
+  it("excludes a category_no_page node from flattenSidebarTree (no prev/next 404 target)", () => {
+    const tree = buildSidebarTree(
+      [
+        entry("guides/index", {
+          title: "Guides",
+          category_no_page: true,
+        }),
+        entry("guides/intro", { title: "Intro", sidebar_position: 1 }),
+        entry("guides/advanced", { title: "Advanced", sidebar_position: 2 }),
+      ],
+      "en",
+    );
+    const flatIds = flattenSidebarTree(tree).map((n) => n.id);
+    expect(flatIds).not.toContain("guides");
+    expect(flatIds).toEqual(["guides/intro", "guides/advanced"]);
+  });
+
+  it("frontmatter category_no_page wins over a _category_.json without noPage", () => {
+    const meta = new Map<string, CategoryMeta>([
+      ["guides", { label: "Sidecar Label" }],
+    ]);
+    const tree = buildSidebarTree(
+      [
+        entry("guides/index", { title: "Guides", category_no_page: true }),
+        entry("guides/intro", { title: "Intro" }),
+      ],
+      "en",
+      { categoryMeta: meta },
+    );
+    const guides = tree.find((n) => n.id === "guides")!;
+    // Frontmatter index.mdx label wins; noPage from frontmatter suppresses href.
+    expect(guides.href).toBeUndefined();
+    expect(guides.hasPage).toBe(false);
+  });
+
+  it("respects category_sort_order=desc from index.mdx frontmatter", () => {
+    const tree = buildSidebarTree(
+      [
+        entry("log/index", { title: "Changelog", category_sort_order: "desc" }),
+        entry("log/2025-01", { title: "2025-01", sidebar_position: 1 }),
+        entry("log/2025-02", { title: "2025-02", sidebar_position: 2 }),
+      ],
+      "en",
+    );
+    const log = tree.find((n) => n.id === "log")!;
+    expect(log.children.map((c) => c.id)).toEqual([
+      "log/2025-02",
+      "log/2025-01",
+    ]);
+    expect(log.sortOrder).toBe("desc");
+  });
+
+  it("frontmatter category_sort_order wins over a _category_.json sortOrder", () => {
+    const meta = new Map<string, CategoryMeta>([
+      ["log", { sortOrder: "asc" }],
+    ]);
+    const tree = buildSidebarTree(
+      [
+        entry("log/index", { title: "Changelog", category_sort_order: "desc" }),
+        entry("log/a", { title: "A", sidebar_position: 1 }),
+        entry("log/b", { title: "B", sidebar_position: 2 }),
+      ],
+      "en",
+      { categoryMeta: meta },
+    );
+    const log = tree.find((n) => n.id === "log")!;
+    expect(log.children.map((c) => c.id)).toEqual(["log/b", "log/a"]);
+  });
+
   it("uses the default href builder when none is supplied", () => {
     const tree = buildSidebarTree([entry("intro", { title: "Intro" })], "en");
     expect(tree[0]!.href).toBe("/en/docs/intro/");

--- a/packages/zudo-doc/src/sidebar-tree/build-tree.ts
+++ b/packages/zudo-doc/src/sidebar-tree/build-tree.ts
@@ -139,7 +139,9 @@ function toSidebarNodes<T extends SidebarFrontmatter>(
   for (const child of parent.children.values()) {
     const doc = child.doc;
     const meta = categoryMeta?.get(child.fullPath);
-    const sortOrder = meta?.sortOrder ?? "asc";
+    // Frontmatter wins over the `_category_.json` sidecar when both exist.
+    const noPage = doc?.data.category_no_page ?? meta?.noPage;
+    const sortOrder = doc?.data.category_sort_order ?? meta?.sortOrder ?? "asc";
     const children = toSidebarNodes(
       child,
       locale,
@@ -148,7 +150,13 @@ function toSidebarNodes<T extends SidebarFrontmatter>(
       sortOrder,
     );
 
-    const hasPage = !!doc;
+    // A `category_no_page` index.mdx carries metadata only — it must behave
+    // exactly like a `_category_.json` `noPage` category, which has no backing
+    // file at all (doc undefined → hasPage false). Forcing hasPage false here
+    // keeps the node a non-linked category header AND drops it from
+    // flattenSidebarTree (prev/next), so the excluded route never appears as a
+    // pagination target.
+    const hasPage = !!doc && noPage !== true;
     const isCategory = !hasPage && children.length > 0;
 
     const label =
@@ -162,11 +170,14 @@ function toSidebarNodes<T extends SidebarFrontmatter>(
     // 999 mirrors the legacy fallback so tied entries sort alphabetically.
     const position = positionRaw ?? 999;
 
-    const href = meta?.noPage
+    const href = noPage
       ? undefined
       : doc || children.length > 0
         ? buildHref(child.fullPath, locale)
         : undefined;
+
+    const hasSortOrder =
+      doc?.data.category_sort_order !== undefined || meta?.sortOrder !== undefined;
 
     nodes.push({
       type: isCategory ? "category" : "doc",
@@ -176,7 +187,7 @@ function toSidebarNodes<T extends SidebarFrontmatter>(
       ...(positionRaw !== undefined ? { sidebar_position: positionRaw } : {}),
       ...(href !== undefined ? { href } : {}),
       hasPage,
-      ...(meta?.sortOrder ? { sortOrder } : {}),
+      ...(hasSortOrder ? { sortOrder } : {}),
       children,
     });
 

--- a/packages/zudo-doc/src/sidebar-tree/types.ts
+++ b/packages/zudo-doc/src/sidebar-tree/types.ts
@@ -28,6 +28,20 @@ export interface SidebarFrontmatter {
    * the slug from the entry's id (stripping a trailing `/index`).
    */
   slug?: string;
+  /**
+   * Category metadata carried on a directory's `index.mdx` frontmatter — the
+   * frontmatter equivalent of `_category_.json`'s `noPage`. When `true`, this
+   * index file exists only to label/position the category: it renders as a
+   * non-linked sidebar header and is excluded from routes, the sitemap, and
+   * the search index. Frontmatter wins over the sidecar when both are present.
+   */
+  category_no_page?: boolean;
+  /**
+   * Frontmatter equivalent of `_category_.json`'s `sortOrder`. Controls the
+   * sort direction of this category's children. Frontmatter wins over the
+   * sidecar when both are present.
+   */
+  category_sort_order?: "asc" | "desc";
 }
 
 /**

--- a/pages/[locale]/docs/[[...slug]].tsx
+++ b/pages/[locale]/docs/[[...slug]].tsx
@@ -259,6 +259,7 @@ export default function LocaleDocsPage(props: PageArgs): JSX.Element {
             locale={locale}
             entrySlug={props.entry.slug}
             contentDir={contentDir}
+            isFallback={isFallback}
           />
         ) : null
       }

--- a/pages/[locale]/docs/[[...slug]].tsx
+++ b/pages/[locale]/docs/[[...slug]].tsx
@@ -118,6 +118,10 @@ export function paths(): Array<{
 
     // Regular doc pages
     for (const entry of allDocs) {
+      // A `category_no_page` index.mdx is metadata-only — kept in the nav tree
+      // for breadcrumbs but emits no route (zfb retains every .mdx as a
+      // collection entry, so the skip must be explicit).
+      if (entry.data.category_no_page === true) continue;
       // Canonical route slug via the one shared rule (@/utils/slug). `entry.id`
       // is already `toRouteSlug(entry.slug)` (bridgeEntries → stripIndexSuffix →
       // toRouteSlug), so this is identical to the previous `entry.id` form for

--- a/pages/[locale]/docs/tags/[tag].tsx
+++ b/pages/[locale]/docs/tags/[tag].tsx
@@ -48,17 +48,17 @@ export function paths(): Array<{
   }> = [];
 
   for (const locale of Object.keys(settings.locales)) {
-    // category_no_page index files build no route — drop them so a tag they
-    // carry doesn't surface a card linking to a non-existent locale doc page.
-    const { docs } = mergeLocaleDocs({
-      baseDocs: loadDocs("docs").filter(
-        (d) => !d.data.draft && !d.data.category_no_page,
-      ),
-      localeDocs: loadDocs(`docs-${locale}`).filter(
-        (d) => !d.data.draft && !d.data.category_no_page,
-      ),
+    const { docs: mergedDocs } = mergeLocaleDocs({
+      baseDocs: loadDocs("docs").filter((d) => !d.data.draft),
+      localeDocs: loadDocs(`docs-${locale}`).filter((d) => !d.data.draft),
       applyDefaultLocaleOnlyFilter: true,
     });
+    // category_no_page index files build no route — drop them AFTER the merge
+    // so a locale override carrying the flag first wins the merge (suppressing
+    // the base doc); pre-merge filtering would drop it from localeSlugSet and
+    // the unflagged base doc would resurface as a card linking to a locale
+    // route the docs route never builds.
+    const docs = mergedDocs.filter((d) => !d.data.category_no_page);
     const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));
 
     for (const [tag, tagInfo] of tagMap.entries()) {

--- a/pages/[locale]/docs/tags/[tag].tsx
+++ b/pages/[locale]/docs/tags/[tag].tsx
@@ -48,9 +48,15 @@ export function paths(): Array<{
   }> = [];
 
   for (const locale of Object.keys(settings.locales)) {
+    // category_no_page index files build no route — drop them so a tag they
+    // carry doesn't surface a card linking to a non-existent locale doc page.
     const { docs } = mergeLocaleDocs({
-      baseDocs: loadDocs("docs").filter((d) => !d.data.draft),
-      localeDocs: loadDocs(`docs-${locale}`).filter((d) => !d.data.draft),
+      baseDocs: loadDocs("docs").filter(
+        (d) => !d.data.draft && !d.data.category_no_page,
+      ),
+      localeDocs: loadDocs(`docs-${locale}`).filter(
+        (d) => !d.data.draft && !d.data.category_no_page,
+      ),
       applyDefaultLocaleOnlyFilter: true,
     });
     const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));

--- a/pages/[locale]/docs/tags/index.tsx
+++ b/pages/[locale]/docs/tags/index.tsx
@@ -53,17 +53,17 @@ export default function LocaleTagsIndexPage({
   const { locale } = params;
   const pageTitle = t("doc.allTags", locale);
 
-  // category_no_page index files build no route — drop them so a tag they
-  // carry doesn't surface a card linking to a non-existent locale doc page.
-  const { docs } = mergeLocaleDocs({
-    baseDocs: loadDocs("docs").filter(
-      (d) => !d.data.draft && !d.data.category_no_page,
-    ),
-    localeDocs: loadDocs(`docs-${locale}`).filter(
-      (d) => !d.data.draft && !d.data.category_no_page,
-    ),
+  const { docs: mergedDocs } = mergeLocaleDocs({
+    baseDocs: loadDocs("docs").filter((d) => !d.data.draft),
+    localeDocs: loadDocs(`docs-${locale}`).filter((d) => !d.data.draft),
     applyDefaultLocaleOnlyFilter: true,
   });
+  // category_no_page index files build no route — drop them AFTER the merge
+  // so a locale override carrying the flag first wins the merge (suppressing
+  // the base doc); pre-merge filtering would drop it from localeSlugSet and
+  // the unflagged base doc would resurface as a card linking to a locale
+  // route the docs route never builds.
+  const docs = mergedDocs.filter((d) => !d.data.category_no_page);
   const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));
 
   const labels: TagNavLabels = {

--- a/pages/[locale]/docs/tags/index.tsx
+++ b/pages/[locale]/docs/tags/index.tsx
@@ -53,9 +53,15 @@ export default function LocaleTagsIndexPage({
   const { locale } = params;
   const pageTitle = t("doc.allTags", locale);
 
+  // category_no_page index files build no route — drop them so a tag they
+  // carry doesn't surface a card linking to a non-existent locale doc page.
   const { docs } = mergeLocaleDocs({
-    baseDocs: loadDocs("docs").filter((d) => !d.data.draft),
-    localeDocs: loadDocs(`docs-${locale}`).filter((d) => !d.data.draft),
+    baseDocs: loadDocs("docs").filter(
+      (d) => !d.data.draft && !d.data.category_no_page,
+    ),
+    localeDocs: loadDocs(`docs-${locale}`).filter(
+      (d) => !d.data.draft && !d.data.category_no_page,
+    ),
     applyDefaultLocaleOnlyFilter: true,
   });
   const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));

--- a/pages/[locale]/index.tsx
+++ b/pages/[locale]/index.tsx
@@ -84,8 +84,10 @@ export default function LocaleIndexPage({ params }: PageArgs): JSX.Element {
   const categoryOrder = getCategoryOrder();
   const groupedTree = groupSatelliteNodes(tree, categoryOrder);
 
+  // Drop category_no_page index files so the count matches the number of tag
+  // pages actually built (the tag routes exclude them too).
   const tagCount = collectTags(
-    navDocs,
+    navDocs.filter((d) => !d.data.category_no_page),
     (id, data) => data.slug ?? toRouteSlug(id),
   ).size;
 

--- a/pages/docs/[[...slug]].tsx
+++ b/pages/docs/[[...slug]].tsx
@@ -90,6 +90,11 @@ export function paths(): Array<{
 
   // Regular doc pages
   for (const entry of docs) {
+    // A `category_no_page` index.mdx carries category metadata only — keep it
+    // in the nav tree (built above, used for breadcrumbs) but emit NO route for
+    // it. zfb's walker retains every .mdx as a collection entry, so without
+    // this explicit skip the metadata file would silently add a route.
+    if (entry.data.category_no_page === true) continue;
     const slug = entry.data.slug ?? toRouteSlug(entry.slug);
     const navSection = getNavSectionForSlug(slug);
     const subtree = getNavSubtree(tree, navSection);

--- a/pages/docs/tags/[tag].tsx
+++ b/pages/docs/tags/[tag].tsx
@@ -42,7 +42,12 @@ export function paths(): Array<{
   props: { tagInfo: TagInfo };
 }> {
   const allDocs = bridgeDocsEntries(getCollection<ZfbDocsData>("docs"), "docs");
-  const docs = allDocs.filter((doc) => !doc.data.unlisted && !doc.data.draft);
+  // category_no_page index.mdx builds no route — drop it so a tag it carries
+  // doesn't render a DocCard linking to a non-existent /docs/<cat>/ page.
+  const docs = allDocs.filter(
+    (doc) =>
+      !doc.data.unlisted && !doc.data.draft && !doc.data.category_no_page,
+  );
   const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));
 
   return [...tagMap.entries()].map(([tag, tagInfo]) => ({

--- a/pages/docs/tags/index.tsx
+++ b/pages/docs/tags/index.tsx
@@ -39,7 +39,12 @@ export default function DocsTagsIndexPage(): JSX.Element {
   const pageTitle = t("doc.allTags", locale);
 
   const allDocs = bridgeDocsEntries(getCollection<ZfbDocsData>("docs"), "docs");
-  const docs = allDocs.filter((doc) => !doc.data.unlisted && !doc.data.draft);
+  // category_no_page index.mdx builds no route — drop it so a tag it carries
+  // doesn't inflate the tag list with a card linking to a non-existent page.
+  const docs = allDocs.filter(
+    (doc) =>
+      !doc.data.unlisted && !doc.data.draft && !doc.data.category_no_page,
+  );
   const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));
 
   const labels: TagNavLabels = {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -46,8 +46,10 @@ export default function IndexPage(): JSX.Element {
   const categoryOrder = getCategoryOrder();
   const groupedTree = groupSatelliteNodes(tree, categoryOrder);
 
+  // Drop category_no_page index files so the count matches the number of tag
+  // pages actually built (the tag routes exclude them too).
   const tagCount = collectTags(
-    navDocs,
+    navDocs.filter((d) => !d.data.category_no_page),
     (id, data) => data.slug ?? toRouteSlug(id),
   ).size;
 

--- a/pages/lib/_doc-history-area.tsx
+++ b/pages/lib/_doc-history-area.tsx
@@ -67,6 +67,17 @@ interface DocHistoryAreaProps {
    * view-source GitHub URL. Omit to suppress the view-source link.
    */
   contentDir?: string;
+  /**
+   * True when this locale page falls back to the base EN collection
+   * (i.e. the slug has no translation for the active locale). When true,
+   * the history data-path derivations use defaultLocale so the island
+   * fetches the correct bare-slug JSON and the SSR manifest lookup hits
+   * the bare key — both of which only exist for EN-origin files.
+   * Display labels (t() calls) still use the active locale so JA users
+   * see JA labels on fallback pages. Omit (or false) for translated pages
+   * and all other call sites (EN route, tag pages) — behavior unchanged.
+   */
+  isFallback?: boolean;
 }
 
 /**
@@ -93,6 +104,7 @@ export function DocHistoryArea({
   locale,
   entrySlug,
   contentDir,
+  isFallback,
 }: DocHistoryAreaProps): VNode | null {
   if (!settings.docHistory) return null;
 
@@ -106,11 +118,18 @@ export function DocHistoryArea({
   // collectContentFiles walk in packages/doc-history-server. (#1891)
   const historySlug = toHistorySlug(slug);
 
+  // On EN-fallback locale pages the history data exists only at the bare
+  // (non-locale-prefixed) path — the prebuild/server writes locale-prefixed
+  // keys/paths only for files physically present in the locale collection.
+  // Use defaultLocale for data lookups when isFallback is true; keep locale
+  // for all display label calls (t()) so JA users see JA labels.
+  const effectiveHistoryLocale = isFallback ? defaultLocale : locale;
+
   // Look up the build-time manifest entry for this page. The composedSlug
   // matches the key written by the prebuild step: bare slug for the default
   // locale, "<localeKey>/<slug>" for non-default locales.
   const composedSlug =
-    locale === defaultLocale ? historySlug : `${locale}/${historySlug}`;
+    effectiveHistoryLocale === defaultLocale ? historySlug : `${effectiveHistoryLocale}/${historySlug}`;
   type MetaEntry = { author: string; createdDate: string; updatedDate: string };
   const meta = (docHistoryMeta as Record<string, MetaEntry>)[composedSlug];
 
@@ -120,7 +139,8 @@ export function DocHistoryArea({
   const historyLabel = t("doc.history", locale);
 
   // Real-component props — locale omitted for the default locale.
-  const docHistoryLocale = locale === defaultLocale ? undefined : locale;
+  // Use effectiveHistoryLocale so fallback pages fetch the bare (non-ja/) path.
+  const docHistoryLocale = effectiveHistoryLocale === defaultLocale ? undefined : effectiveHistoryLocale;
   const docHistoryBasePath = settings.base ?? "/";
 
   // Build the SSR fallback with only the sr-only metadata block so the

--- a/pages/lib/_footer-with-defaults.tsx
+++ b/pages/lib/_footer-with-defaults.tsx
@@ -124,17 +124,15 @@ export function FooterWithDefaults({
       // pages ([tag].tsx / tags/index.tsx) and enumerateTagsRoutes, which all
       // now filter. Without this, the footer would link to /{locale}/docs/tags/
       // pages that are never built for tags living only on default-locale-only
-      // prefix pages. category_no_page is dropped for the same reason.
+      // prefix pages. category_no_page is dropped for the same reason — AFTER
+      // the merge, so a locale override carrying the flag first wins the merge
+      // (pre-merge filtering would let the unflagged base doc resurface).
       const result = mergeLocaleDocs({
-        baseDocs: loadDocs("docs").filter(
-          (d) => !d.data.draft && !d.data.category_no_page,
-        ),
-        localeDocs: loadDocs(`docs-${lang}`).filter(
-          (d) => !d.data.draft && !d.data.category_no_page,
-        ),
+        baseDocs: loadDocs("docs").filter((d) => !d.data.draft),
+        localeDocs: loadDocs(`docs-${lang}`).filter((d) => !d.data.draft),
         applyDefaultLocaleOnlyFilter: true,
       });
-      docs = result.docs;
+      docs = result.docs.filter((d) => !d.data.category_no_page);
     }
 
     const tagMap = collectTags(

--- a/pages/lib/_footer-with-defaults.tsx
+++ b/pages/lib/_footer-with-defaults.tsx
@@ -113,17 +113,25 @@ export function FooterWithDefaults({
     // Load docs synchronously (zfb ADR-004 — synchronous content snapshot).
     let docs: DocsEntry[];
     if (lang === defaultLocale) {
-      docs = loadDocs("docs").filter((d) => !d.data.draft && !d.data.unlisted);
+      // category_no_page index files build no route — drop them so the footer
+      // taglist matches the tag-route pages (which all now filter too).
+      docs = loadDocs("docs").filter(
+        (d) => !d.data.draft && !d.data.unlisted && !d.data.category_no_page,
+      );
     } else {
       // Apply the default-locale-only filter so the footer taglist only counts
       // tags that have a locale-routable tag page — matching the tag-route
       // pages ([tag].tsx / tags/index.tsx) and enumerateTagsRoutes, which all
       // now filter. Without this, the footer would link to /{locale}/docs/tags/
       // pages that are never built for tags living only on default-locale-only
-      // prefix pages.
+      // prefix pages. category_no_page is dropped for the same reason.
       const result = mergeLocaleDocs({
-        baseDocs: loadDocs("docs").filter((d) => !d.data.draft),
-        localeDocs: loadDocs(`docs-${lang}`).filter((d) => !d.data.draft),
+        baseDocs: loadDocs("docs").filter(
+          (d) => !d.data.draft && !d.data.category_no_page,
+        ),
+        localeDocs: loadDocs(`docs-${lang}`).filter(
+          (d) => !d.data.draft && !d.data.category_no_page,
+        ),
         applyDefaultLocaleOnlyFilter: true,
       });
       docs = result.docs;

--- a/pages/lib/_head-with-defaults.tsx
+++ b/pages/lib/_head-with-defaults.tsx
@@ -97,7 +97,10 @@ export function HeadWithDefaults({
       <OgTags
         title={composeMetaTitle(title)}
         description={description}
+        ogType="website"
+        ogUrl={canonical}
         ogImage={ogImageUrl}
+        ogSiteName={settings.siteName}
       />
       {/* og:image:width / og:image:height / og:image:alt — not in OgTags API;
           emitted here directly to avoid expanding the shared HeadProps surface.

--- a/pages/lib/route-enumerators.ts
+++ b/pages/lib/route-enumerators.ts
@@ -107,7 +107,9 @@ export function enumerateTagsRoutes(locale: string): string[] {
   // Filter unlisted + draft + category_no_page — mirrors the tag [tag].tsx
   // pages so the sitemap lists exactly the tag pages that get built (a
   // category_no_page index has no route, so a tag it carries must not coin a
-  // tag page that links back to it).
+  // tag page that links back to it). The category_no_page drop happens AFTER
+  // the locale merge so a locale override carrying the flag first wins the
+  // merge — pre-merge filtering would let the unflagged base doc resurface.
   let docs: DocsEntry[];
   if (locale === defaultLocale) {
     docs = loadDocs("docs").filter(
@@ -115,15 +117,11 @@ export function enumerateTagsRoutes(locale: string): string[] {
     );
   } else {
     const result = mergeLocaleDocs({
-      baseDocs: loadDocs("docs").filter(
-        (d) => !d.data.draft && !d.data.category_no_page,
-      ),
-      localeDocs: loadDocs(`docs-${locale}`).filter(
-        (d) => !d.data.draft && !d.data.category_no_page,
-      ),
+      baseDocs: loadDocs("docs").filter((d) => !d.data.draft),
+      localeDocs: loadDocs(`docs-${locale}`).filter((d) => !d.data.draft),
       applyDefaultLocaleOnlyFilter: true,
     });
-    docs = result.docs;
+    docs = result.docs.filter((d) => !d.data.category_no_page);
   }
 
   const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));

--- a/pages/lib/route-enumerators.ts
+++ b/pages/lib/route-enumerators.ts
@@ -104,14 +104,23 @@ export function enumerateTagsRoutes(locale: string): string[] {
   urls.push(withBase(tagsBase));
 
   // Collect tags from the same merged doc set the tag pages use.
-  // Filter unlisted + draft — mirrors the tag [tag].tsx pages which do the same.
+  // Filter unlisted + draft + category_no_page — mirrors the tag [tag].tsx
+  // pages so the sitemap lists exactly the tag pages that get built (a
+  // category_no_page index has no route, so a tag it carries must not coin a
+  // tag page that links back to it).
   let docs: DocsEntry[];
   if (locale === defaultLocale) {
-    docs = loadDocs("docs").filter((d) => !d.data.unlisted && !d.data.draft);
+    docs = loadDocs("docs").filter(
+      (d) => !d.data.unlisted && !d.data.draft && !d.data.category_no_page,
+    );
   } else {
     const result = mergeLocaleDocs({
-      baseDocs: loadDocs("docs").filter((d) => !d.data.draft),
-      localeDocs: loadDocs(`docs-${locale}`).filter((d) => !d.data.draft),
+      baseDocs: loadDocs("docs").filter(
+        (d) => !d.data.draft && !d.data.category_no_page,
+      ),
+      localeDocs: loadDocs(`docs-${locale}`).filter(
+        (d) => !d.data.draft && !d.data.category_no_page,
+      ),
       applyDefaultLocaleOnlyFilter: true,
     });
     docs = result.docs;

--- a/pages/lib/route-enumerators.ts
+++ b/pages/lib/route-enumerators.ts
@@ -60,6 +60,10 @@ export function enumerateDocsRoutes(locale: string): string[] {
   const tree = buildNavTree(navDocs, locale as Locale, categoryMeta);
 
   for (const doc of allDocs) {
+    // A `category_no_page` index.mdx is metadata-only — no route, so no sitemap
+    // URL. Same exclusion the doc-route paths() apply (zfb retains every .mdx
+    // as a collection entry, so the skip must be explicit).
+    if (doc.data.category_no_page === true) continue;
     // Canonical route slug via the one shared rule (@/utils/slug). `doc.id` is
     // already `toRouteSlug(doc.slug)` (bridged through stripIndexSuffix in
     // pages/_data.ts), so a bare root index.mdx is "" here → `/docs/` — the
@@ -157,6 +161,8 @@ export function enumerateVersionedRoutes(
     const tree = buildNavTree(navDocs, "en", categoryMeta);
 
     for (const doc of allDocs) {
+      // category_no_page index.mdx → no route, no sitemap URL (see paths()).
+      if (doc.data.category_no_page === true) continue;
       const slug = doc.data.slug ?? toRouteSlug(doc.id);
       urls.push(versionedDocsUrl(slug, version.slug));
     }
@@ -178,6 +184,8 @@ export function enumerateVersionedRoutes(
     const tree = buildNavTree(navDocs, locale as Locale, categoryMeta);
 
     for (const doc of allDocs) {
+      // category_no_page index.mdx → no route, no sitemap URL (see paths()).
+      if (doc.data.category_no_page === true) continue;
       const slug = doc.data.slug ?? toRouteSlug(doc.id);
       urls.push(versionedDocsUrl(slug, version.slug, locale as string));
     }

--- a/pages/v/[version]/[locale]/docs/[[...slug]].tsx
+++ b/pages/v/[version]/[locale]/docs/[[...slug]].tsx
@@ -128,6 +128,10 @@ export function paths(): Array<{
 
       // Regular doc pages
       for (const entry of allDocs) {
+        // A `category_no_page` index.mdx is metadata-only — kept in the nav
+        // tree for breadcrumbs but emits no route (zfb retains every .mdx as a
+        // collection entry, so the skip must be explicit).
+        if (entry.data.category_no_page === true) continue;
         const slug = entry.data.slug ?? toRouteSlug(entry.slug);
         const isFallback = fallbackSlugs.has(slug);
         const entryContentDir = isFallback ? version.docsDir : (localeDir ?? version.docsDir);

--- a/pages/v/[version]/docs/[[...slug]].tsx
+++ b/pages/v/[version]/docs/[[...slug]].tsx
@@ -106,6 +106,10 @@ export function paths(): Array<{
 
     // Regular doc pages
     for (const entry of allDocs) {
+      // A `category_no_page` index.mdx is metadata-only — kept in the nav tree
+      // for breadcrumbs but emits no route (zfb retains every .mdx as a
+      // collection entry, so the skip must be explicit).
+      if (entry.data.category_no_page === true) continue;
       const slug = entry.data.slug ?? toRouteSlug(entry.slug);
       const navSection = getNavSectionForSlug(slug);
       const subtree = getNavSubtree(tree, navSection);

--- a/scripts/check-b4push-ci-parity.mjs
+++ b/scripts/check-b4push-ci-parity.mjs
@@ -77,6 +77,12 @@ const REQUIRED_CI_GUARDS = [
     comment: "Design token lint",
   },
   {
+    // Package safelist: node scripts/check-package-safelist.mjs (CI) / pnpm check:package-safelist (b4push)
+    ciNeedle: "check-package-safelist.mjs",
+    b4pushScript: "check:package-safelist",
+    comment: "Package safelist drift check (#1982)",
+  },
+  {
     // This parity check itself — must also appear in CI
     ciNeedle: "check-b4push-ci-parity.mjs",
     b4pushScript: "check:b4push-ci-parity",

--- a/scripts/check-package-safelist.mjs
+++ b/scripts/check-package-safelist.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+// scripts/check-package-safelist.mjs
+//
+// Guard check: ensures the @source inline() safelist in
+// packages/create-zudo-doc/templates/base/src/styles/global.css
+// covers every responsive-variant + arbitrary-value utility class
+// found in packages/zudo-doc/src/**/*.tsx (excluding __tests__).
+//
+// Background (#1971, #1982): consumers scaffolded via create-zudo-doc
+// lack the monorepo's src/styles/global.css @source for
+// packages/zudo-doc/src/**. The template global.css compensates via
+// an @source inline() safelist. This check closes the silent-drift gap
+// where a new bracket or responsive utility added to the package would
+// never reach consumers (the scan passes at build time in the host repo
+// because its own @source covers the package source directly, masking
+// the consumer-side gap).
+//
+// Usage: node scripts/check-package-safelist.mjs
+// Exit 0 = safelist covers all source utilities. Exit 1 = drift detected.
+//
+// Wired into:
+//   - scripts/run-b4push.sh (guard step — inside marker region)
+//   - .github/workflows/pr-checks.yml (pure-Node CI job)
+
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve, join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+
+const PKG_SRC_DIR = resolve(ROOT, "packages/zudo-doc/src");
+const TEMPLATE_CSS = resolve(
+  ROOT,
+  "packages/create-zudo-doc/templates/base/src/styles/global.css",
+);
+
+// ── File discovery ─────────────────────────────────────────────────────────
+
+/** Recursively collect .tsx files, skipping __tests__ directories. */
+function findTsxFiles(dir) {
+  const results = [];
+  const entries = readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (entry.name === "__tests__") continue;
+      results.push(...findTsxFiles(join(dir, entry.name)));
+    } else if (entry.name.endsWith(".tsx")) {
+      results.push(join(dir, entry.name));
+    }
+  }
+  return results;
+}
+
+// ── Class extraction ───────────────────────────────────────────────────────
+//
+// Strategy: direct token scan over raw source text, using a regex that
+// matches the TARGET class shapes only:
+//
+//   A) Responsive variants — start with sm:|md:|lg:|xl:|2xl:
+//      (may have an arbitrary-value suffix)
+//
+//   B) Bracket utilities — match pattern: property-name-[value]
+//      where "-[" is the canonical Tailwind arbitrary-value separator.
+//      The value must not contain quotes or whitespace (filters out TS
+//      type expressions like IntrinsicElements["a"] and pairs[i]).
+//
+// This direct approach avoids the fragility of string-literal parsing:
+//   - No risk of apostrophes in JSDoc comments being mis-parsed as
+//     single-quoted string starts (a real issue in this codebase).
+//   - No risk of nested template literals consuming inner double-quoted
+//     strings (e.g. `...${condition ? "max-w-[80rem]" : "..."}...`).
+//   - No need to enumerate known Tailwind property names — the shape
+//     criterion (property-name-[...]) is self-contained.
+//
+// The leading-character anchor (whitespace, quote, brace, comma, etc.)
+// ensures we start at a class-token boundary and do not capture tokens
+// mid-way (e.g., grabbing "lg" from inside a longer identifier).
+
+// Matches a complete responsive-or-bracket utility class token, preceded
+// by a token boundary (beginning of line, whitespace, or JSX structural
+// characters). Group 1 is the full class token.
+const TARGET_RE =
+  /(?:^|[\s"'`{,;(])((?:(?:sm|md|lg|xl|2xl):)[a-zA-Z0-9_/[\](),.*%:#-]+|(?:(?:hover:|focus(?:-visible|-within)?:)?)[a-zA-Z][a-zA-Z0-9_/-]*-\[[^\]"'`\s]+\])/g;
+
+/** True when a captured token contains no HTML/JSX structural characters. */
+function isValidToken(token) {
+  return !/[><"'`]/.test(token);
+}
+
+/**
+ * Scan a source file and return the set of Tailwind utility classes that
+ * match the responsive-variant or arbitrary-value shapes.
+ */
+function extractClasses(src) {
+  const classes = new Set();
+  TARGET_RE.lastIndex = 0;
+  let m;
+  while ((m = TARGET_RE.exec(src)) !== null) {
+    const cls = m[1];
+    if (cls && isValidToken(cls)) {
+      classes.add(cls);
+    }
+  }
+  return classes;
+}
+
+// ── Safelist parser ────────────────────────────────────────────────────────
+
+/**
+ * Parse the @source inline("…") block from the template global.css.
+ * Returns a Set of class tokens.
+ */
+function parseSafelist(cssSrc) {
+  const match = cssSrc.match(/@source\s+inline\s*\(\s*"([\s\S]*?)"\s*\)/);
+  if (!match) {
+    throw new Error(
+      'Could not locate @source inline("…") in template global.css.\n' +
+        "Expected a single @source inline() block in:\n" +
+        TEMPLATE_CSS,
+    );
+  }
+  return new Set(match[1].trim().split(/\s+/).filter(Boolean));
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────
+
+function main() {
+  const files = findTsxFiles(PKG_SRC_DIR);
+  if (files.length === 0) {
+    console.error(`ERROR: no .tsx files found under ${PKG_SRC_DIR}`);
+    return 1;
+  }
+
+  // Collect all target classes from source files
+  const sourceClasses = new Set();
+  for (const file of files) {
+    const src = readFileSync(file, "utf8");
+    for (const cls of extractClasses(src)) {
+      sourceClasses.add(cls);
+    }
+  }
+
+  // Parse safelist
+  const templateCss = readFileSync(TEMPLATE_CSS, "utf8");
+  const safelist = parseSafelist(templateCss);
+
+  // Direction: source → safelist (critical — missing = drift that hurts consumers)
+  const missingFromSafelist = [...sourceClasses]
+    .filter((c) => !safelist.has(c))
+    .sort();
+
+  // Direction: safelist → source (informational only — warn but don't fail.
+  // Safelist entries not found in source are safe to keep: the dist/ @source
+  // directive also scans compiled JS and may cover classes the source scanner
+  // misses in complex template expressions.)
+  const notInSource = [...safelist].filter((c) => !sourceClasses.has(c)).sort();
+
+  if (missingFromSafelist.length === 0) {
+    console.log(
+      `OK — package safelist check passed. ${sourceClasses.size} source utilities all present in safelist.`,
+    );
+    if (notInSource.length > 0) {
+      console.log(
+        `\nNote: ${notInSource.length} safelist entr${notInSource.length === 1 ? "y" : "ies"} not found in source scan (covered by dist/ @source — safe to keep):`,
+      );
+      for (const c of notInSource) {
+        console.log(`  ${c}`);
+      }
+    }
+    return 0;
+  }
+
+  console.error("");
+  console.error(
+    "Package safelist check FAILED — the following utilities exist in",
+  );
+  console.error(
+    `packages/zudo-doc/src/**/*.tsx but are MISSING from the @source inline()\n` +
+      `safelist in packages/create-zudo-doc/templates/base/src/styles/global.css:`,
+  );
+  console.error("");
+  for (const c of missingFromSafelist) {
+    console.error(`  ${c}`);
+  }
+  console.error("");
+  console.error(
+    "Remediation — add the missing entries to the @source inline() block:",
+  );
+  console.error(
+    `  File: packages/create-zudo-doc/templates/base/src/styles/global.css`,
+  );
+  console.error(
+    `  Locate the @source inline("…") block and append the following tokens:`,
+  );
+  console.error("");
+  console.error("  " + missingFromSafelist.join(" "));
+  console.error("");
+  console.error(
+    "Re-run `pnpm check:package-safelist` after updating to verify.",
+  );
+  return 1;
+}
+
+process.exit(main());

--- a/scripts/run-b4push.sh
+++ b/scripts/run-b4push.sh
@@ -10,26 +10,27 @@ set -euo pipefail
 #   4. Fixture settings drift check
 #   5. Tags audit (--ci)
 #   6. Design token lint
-#   7. B4push/CI parity check (guard manifest meta-check — #1967)
-#   8. Type checking (zfb check + workspace package typechecks)
-#   9. Root unit tests (test:unit)
-#  10. Build (zfb build)
-#  11. Link check
-#  12. HTML validation (html-validate dist/**/*.html)
-#  13. Automated preview smoke (blocking)
-#  14. Manual interactive smoke (operator-driven)
+#   7. Package safelist check (#1982)
+#   8. B4push/CI parity check (guard manifest meta-check — #1967)
+#   9. Type checking (zfb check + workspace package typechecks)
+#  10. Root unit tests (test:unit)
+#  11. Build (zfb build)
+#  12. Link check
+#  13. HTML validation (html-validate dist/**/*.html)
+#  14. Automated preview smoke (blocking)
+#  15. Manual interactive smoke (operator-driven)
 #
 # CI parity (Playwright E2E + GitHub Actions) is intentionally parked
 # to E9b until the post-cutover migration window closes.
 #
 # Env overrides for non-interactive use:
-#   B4PUSH_SKIP_HTML_VALIDATE=1  — skip HTML validation (step 10)
+#   B4PUSH_SKIP_HTML_VALIDATE=1  — skip HTML validation (step 13)
 #   B4PUSH_SKIP_PREVIEW_SMOKE=1  — skip the automated preview smoke
 #   B4PUSH_SKIP_MANUAL_SMOKE=1   — skip the manual interactive smoke
 
 START_TIME=$(date +%s)
 FAILURES=()
-TOTAL_STEPS=14
+TOTAL_STEPS=15
 CURRENT_STEP=0
 
 step() {
@@ -102,7 +103,21 @@ else
   fail "Design token lint"
 fi
 
-# ── Step 7: B4push/CI parity check ───────────────────
+# ── Step 7: Package safelist check ───────────────────
+# Pure-Node check — verifies the @source inline() safelist in the scaffold
+# template covers every responsive-variant + arbitrary-value utility class
+# used in packages/zudo-doc/src/**/*.tsx. Closes the silent-drift gap from
+# #1971/#1982: a new bracket/responsive utility in the package would reach
+# the host repo (which @source's the package source directly) but silently
+# miss consumers (which rely solely on the template safelist).
+step "Package safelist check (check:package-safelist)"
+if (cd "$ROOT_DIR" && pnpm check:package-safelist); then
+  pass "Package safelist check passed"
+else
+  fail "Package safelist check"
+fi
+
+# ── Step 8: B4push/CI parity check ───────────────────
 # Pure-Node check — verifies every lightweight guard gate in this file also
 # has a corresponding CI job. See scripts/check-b4push-ci-parity.mjs.
 step "B4push/CI parity check (check:b4push-ci-parity)"
@@ -114,7 +129,7 @@ fi
 
 # <<< b4push-ci-parity:guards
 
-# ── Step 8: Type checking ─────────────────────────────
+# ── Step 9: Type checking ─────────────────────────────
 # Prefer `zfb check` (the post-cutover entry point). If it fails to
 # start (e.g. binary not yet built), fall back to `tsc --noEmit` so the
 # typecheck still gates pushes.
@@ -137,7 +152,7 @@ else
   fail "Package typechecks"
 fi
 
-# ── Step 9: Root unit tests ───────────────────────────
+# ── Step 10: Root unit tests ───────────────────────────
 # Root `test:unit` (vitest) guards src/**/__tests__ and scripts/__tests__,
 # which previously ran in no local gate and no CI workflow (#1856). Runs
 # before the expensive site build for fast logic-level feedback.
@@ -154,7 +169,7 @@ else
   fail "Root unit tests"
 fi
 
-# ── Step 10: Build ────────────────────────────────────
+# ── Step 11: Build ────────────────────────────────────
 step "Build (zfb build)"
 if (cd "$ROOT_DIR" && pnpm build); then
   pass "Build passed"
@@ -162,7 +177,7 @@ else
   fail "Build"
 fi
 
-# ── Step 11: Link check ───────────────────────────────
+# ── Step 12: Link check ───────────────────────────────
 #
 # Strict on broken links + absolute MDX-source warnings (real 404s
 # / sub-path bypass). Trailing-slash warnings stay warn-only — they
@@ -182,7 +197,7 @@ else
   fail "Link check"
 fi
 
-# ── Step 12: HTML validation ──────────────────────────
+# ── Step 13: HTML validation ──────────────────────────
 step "HTML validation (html-validate)"
 if [[ "${B4PUSH_SKIP_HTML_VALIDATE:-}" == "1" ]]; then
   skip "HTML validation (B4PUSH_SKIP_HTML_VALIDATE=1)"
@@ -194,7 +209,7 @@ else
   fi
 fi
 
-# ── Step 13: Automated preview smoke (blocking) ──────
+# ── Step 14: Automated preview smoke (blocking) ──────
 step "Preview smoke (automated)"
 if [[ "${B4PUSH_SKIP_PREVIEW_SMOKE:-}" == "1" ]]; then
   skip "Preview smoke (B4PUSH_SKIP_PREVIEW_SMOKE=1)"
@@ -206,7 +221,7 @@ else
   fi
 fi
 
-# ── Step 14: Manual interactive smoke ────────────────
+# ── Step 15: Manual interactive smoke ────────────────
 step "Manual interactive smoke"
 if [[ "${B4PUSH_SKIP_MANUAL_SMOKE:-}" == "1" ]]; then
   skip "Manual smoke (B4PUSH_SKIP_MANUAL_SMOKE=1)"

--- a/src/__tests__/pages-lib/nav-tree-category-frontmatter.test.ts
+++ b/src/__tests__/pages-lib/nav-tree-category-frontmatter.test.ts
@@ -1,0 +1,116 @@
+/**
+ * nav-tree-category-frontmatter.test.ts
+ *
+ * Coverage for the category-metadata-via-frontmatter capability on the HOST's
+ * own `buildNavTree` (src/utils/docs.ts), parallel to the framework builder
+ * tests in packages/zudo-doc/src/sidebar-tree/__tests__/build-tree.test.ts.
+ *
+ * Asserts the frontmatter-first fallback chains (category_no_page,
+ * category_sort_order) and — the subtle correctness point — that a
+ * `category_no_page` index.mdx behaves exactly like a `_category_.json` noPage
+ * category: hasPage false, no href, and DROPPED from flattenTree so it can
+ * never surface as a prev/next pagination target for a route that was excluded.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildNavTree,
+  flattenTree,
+  findNode,
+  type CategoryMeta,
+} from "@/utils/docs";
+import type { DocsEntry } from "@/types/docs-entry";
+
+function entry(id: string, data: Partial<DocsEntry["data"]> = {}): DocsEntry {
+  return {
+    id,
+    collection: "docs",
+    data: { title: data.title ?? id, ...data },
+  };
+}
+
+describe("buildNavTree — category frontmatter", () => {
+  it("treats a category_no_page index.mdx like a _category_.json noPage category", () => {
+    const tree = buildNavTree([
+      entry("guides/index", {
+        title: "Guides",
+        sidebar_label: "Guides",
+        sidebar_position: 3,
+        category_no_page: true,
+      }),
+      entry("guides/intro", { title: "Intro" }),
+    ]);
+    const guides = findNode(tree, "guides")!;
+    expect(guides.label).toBe("Guides");
+    expect(guides.position).toBe(3);
+    expect(guides.href).toBeUndefined();
+    expect(guides.hasPage).toBe(false);
+  });
+
+  it("drops a category_no_page node from flattenTree (no prev/next 404 target)", () => {
+    const tree = buildNavTree([
+      entry("guides/index", { title: "Guides", category_no_page: true }),
+      entry("guides/intro", { title: "Intro", sidebar_position: 1 }),
+      entry("guides/advanced", { title: "Advanced", sidebar_position: 2 }),
+    ]);
+    const flatSlugs = flattenTree(tree).map((n) => n.slug);
+    expect(flatSlugs).not.toContain("guides");
+    expect(flatSlugs).toEqual(["guides/intro", "guides/advanced"]);
+  });
+
+  it("frontmatter category_no_page wins over a sidecar without noPage", () => {
+    const meta = new Map<string, CategoryMeta>([
+      ["guides", { label: "Sidecar Label" }],
+    ]);
+    const tree = buildNavTree(
+      [
+        entry("guides/index", { title: "Guides", category_no_page: true }),
+        entry("guides/intro", { title: "Intro" }),
+      ],
+      "en",
+      meta,
+    );
+    const guides = findNode(tree, "guides")!;
+    expect(guides.href).toBeUndefined();
+    expect(guides.hasPage).toBe(false);
+  });
+
+  it("respects category_sort_order=desc from index.mdx frontmatter", () => {
+    const tree = buildNavTree([
+      entry("log/index", { title: "Changelog", category_sort_order: "desc" }),
+      entry("log/2025-01", { title: "2025-01", sidebar_position: 1 }),
+      entry("log/2025-02", { title: "2025-02", sidebar_position: 2 }),
+    ]);
+    const log = findNode(tree, "log")!;
+    expect(log.children.map((c) => c.slug)).toEqual([
+      "log/2025-02",
+      "log/2025-01",
+    ]);
+  });
+
+  it("frontmatter category_sort_order wins over a _category_.json sortOrder", () => {
+    const meta = new Map<string, CategoryMeta>([["log", { sortOrder: "asc" }]]);
+    const tree = buildNavTree(
+      [
+        entry("log/index", { title: "Changelog", category_sort_order: "desc" }),
+        entry("log/a", { title: "A", sidebar_position: 1 }),
+        entry("log/b", { title: "B", sidebar_position: 2 }),
+      ],
+      "en",
+      meta,
+    );
+    const log = findNode(tree, "log")!;
+    expect(log.children.map((c) => c.slug)).toEqual(["log/b", "log/a"]);
+  });
+
+  it("a normal category index (no category_no_page) is unaffected", () => {
+    const tree = buildNavTree([
+      entry("guides/index", { title: "Guides", sidebar_position: 1 }),
+      entry("guides/intro", { title: "Intro" }),
+    ]);
+    const guides = findNode(tree, "guides")!;
+    expect(guides.hasPage).toBe(true);
+    expect(guides.href).toBeDefined();
+    expect(flattenTree(tree).map((n) => n.slug)).toContain("guides");
+  });
+});

--- a/src/__tests__/pages-lib/tag-exclusion-category-frontmatter.test.ts
+++ b/src/__tests__/pages-lib/tag-exclusion-category-frontmatter.test.ts
@@ -1,0 +1,72 @@
+/**
+ * tag-exclusion-category-frontmatter.test.ts
+ *
+ * A `category_no_page` index.mdx builds NO doc route, so a tag it carries must
+ * not reach the tag pages / tag-route enumerator — otherwise the tag listing
+ * renders a DocCard (or sitemap URL) linking to a non-existent /docs/<cat>/
+ * page (the same dead-link class the route/sitemap/search exclusion fixes).
+ *
+ * The exclusion lives in each enumerator's `.filter(...)` BEFORE collectTags
+ * (pages/docs/tags/*, pages/[locale]/docs/tags/*, route-enumerators
+ * enumerateTagsRoutes, the footer taglist). This test asserts the shared
+ * predicate so the filter the pages apply provably drops a noPage doc's tag.
+ */
+
+import { describe, it, expect } from "vitest";
+import { collectTags } from "@/utils/tags";
+import type { DocsEntry } from "@/types/docs-entry";
+
+function entry(id: string, data: Partial<DocsEntry["data"]> = {}): DocsEntry {
+  return {
+    id,
+    collection: "docs",
+    data: { title: data.title ?? id, ...data },
+  };
+}
+
+/** The predicate every tag enumerator applies before collectTags. */
+const tagVisible = (d: DocsEntry): boolean =>
+  !d.data.unlisted && !d.data.draft && !d.data.category_no_page;
+
+const slugFn = (id: string, data: { slug?: string }): string =>
+  data.slug ?? id;
+
+describe("tag enumeration excludes category_no_page docs", () => {
+  it("drops a tag that lives ONLY on a category_no_page index (no dead tag page)", () => {
+    const docs = [
+      entry("guides/index", {
+        category_no_page: true,
+        tags: ["pageless-only"],
+      }),
+      entry("guides/intro", { tags: ["real-tag"] }),
+    ];
+    const tagMap = collectTags(docs.filter(tagVisible), slugFn);
+    // The tag carried only by the pageless category is gone.
+    expect(tagMap.has("pageless-only")).toBe(false);
+    // A tag on a real page is unaffected.
+    expect(tagMap.has("real-tag")).toBe(true);
+  });
+
+  it("a tag shared by a real page survives even if a noPage index also carries it", () => {
+    const docs = [
+      entry("guides/index", { category_no_page: true, tags: ["shared"] }),
+      entry("guides/intro", { tags: ["shared"] }),
+    ];
+    const tagMap = collectTags(docs.filter(tagVisible), slugFn);
+    const shared = tagMap.get("shared");
+    expect(shared).toBeDefined();
+    // Count reflects only the real page — the pageless index is excluded.
+    expect(shared!.count).toBe(1);
+    expect(shared!.docs.map((d) => d.slug)).toEqual(["guides/intro"]);
+  });
+
+  it("a normal category index (no category_no_page) keeps contributing tags", () => {
+    const docs = [
+      entry("guides/index", { tags: ["kept"] }),
+      entry("guides/intro", { tags: ["other"] }),
+    ];
+    const tagMap = collectTags(docs.filter(tagVisible), slugFn);
+    expect(tagMap.has("kept")).toBe(true);
+    expect(tagMap.has("other")).toBe(true);
+  });
+});

--- a/src/config/frontmatter-preview-defaults.ts
+++ b/src/config/frontmatter-preview-defaults.ts
@@ -21,4 +21,6 @@ export const DEFAULT_FRONTMATTER_IGNORE_KEYS: string[] = [
   "standalone",
   "slug",
   "generated",
+  "category_no_page",
+  "category_sort_order",
 ];

--- a/src/content/CLAUDE.md
+++ b/src/content/CLAUDE.md
@@ -59,8 +59,8 @@ Use relative file paths with `.mdx` extension:
 Navigation is filesystem-driven. Directory structure becomes sidebar navigation.
 
 - Pages ordered by `sidebar_position` (ascending)
-- Category index pages (`index.mdx`) control category position
-- `_category_.json` for category-level metadata (label, position, noPage)
+- Category index pages (`index.mdx`) control category position via `sidebar_position`; add `sidebar_label` for a custom sidebar name; add `category_sort_order: "desc"` for newest-first ordering; add `category_no_page: true` to create a non-linked category header (no route/sitemap/search entry)
+- `_category_.json` still works but triggers a zfb build warning; prefer `index.mdx` frontmatter
 - Header nav defined in `src/config/settings.ts` via `headerNav` with `categoryMatch`
 
 ## Content Creation Workflow

--- a/src/content/docs-ja/changelog/_category_.json
+++ b/src/content/docs-ja/changelog/_category_.json
@@ -1,5 +1,0 @@
-{
-  "label": "変更履歴",
-  "position": 10,
-  "sortOrder": "desc"
-}

--- a/src/content/docs-ja/changelog/index.mdx
+++ b/src/content/docs-ja/changelog/index.mdx
@@ -1,7 +1,9 @@
 ---
 title: 変更履歴
 description: zudo-docのリリースノートとバージョン履歴。
+sidebar_label: 変更履歴
 sidebar_position: 10
+category_sort_order: desc
 ---
 
 zudo-docの各リリースにおける変更、改善、修正を追跡します。

--- a/src/content/docs-ja/components/category-nav.mdx
+++ b/src/content/docs-ja/components/category-nav.mdx
@@ -57,7 +57,7 @@ Welcome to the Getting Started section. Choose a topic below to begin.
 <CategoryNav categories={["claude-md", "claude-skills", "claude-agents"]} />
 ```
 
-各スラッグは対応するナビゲーションノードに解決され、カードとして表示されます。ツリー内で見つからないスラッグは、エラーにならず単に無視されます。`index.mdx`を持たないカテゴリ（`noPage: true`）の場合、カードのリンク先は自動生成されるカテゴリインデックスのURLになります。
+各スラッグは対応するナビゲーションノードに解決され、カードとして表示されます。ツリー内で見つからないスラッグは、エラーにならず単に無視されます。no-pageカテゴリ（`index.mdx` の `category_no_page: true`、またはレガシーの `_category_.json` の `noPage: true`）の場合、カードのリンク先は自動生成されるカテゴリインデックスのURLになります。
 
 ## 特徴
 

--- a/src/content/docs-ja/concepts/_category_.json
+++ b/src/content/docs-ja/concepts/_category_.json
@@ -1,5 +1,0 @@
-{
-  "label": "コンセプト",
-  "position": 8,
-  "description": "zfb移行のアーキテクチャとデザインのコンセプト"
-}

--- a/src/content/docs-ja/concepts/index.mdx
+++ b/src/content/docs-ja/concepts/index.mdx
@@ -1,0 +1,6 @@
+---
+title: コンセプト
+sidebar_label: コンセプト
+sidebar_position: 8
+category_no_page: true
+---

--- a/src/content/docs-ja/concepts/index.mdx
+++ b/src/content/docs-ja/concepts/index.mdx
@@ -1,6 +1,10 @@
 ---
 title: コンセプト
+description: zfb移行のアーキテクチャとデザインのコンセプト。
 sidebar_label: コンセプト
 sidebar_position: 8
-category_no_page: true
 ---
+
+zfb移行のアーキテクチャとデザインのコンセプト。
+
+<CategoryNav category="concepts" />

--- a/src/content/docs-ja/develop/_category_.json
+++ b/src/content/docs-ja/develop/_category_.json
@@ -1,5 +1,0 @@
-{
-  "label": "開発",
-  "position": 11,
-  "description": "zudo-doc自体の開発メモ"
-}

--- a/src/content/docs-ja/develop/index.mdx
+++ b/src/content/docs-ja/develop/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: 開発
 description: zudo-doc自体の開発メモ。
+sidebar_label: 開発
 sidebar_position: 1
 ---
 

--- a/src/content/docs-ja/guides/changelog.mdx
+++ b/src/content/docs-ja/guides/changelog.mdx
@@ -13,25 +13,24 @@ zudo-docには、リリースノートとバージョン履歴を追跡するた
 ```
 src/content/docs/
 └── changelog/
-    ├── _category_.json    # 降順ソート付きカテゴリ設定
-    ├── index.mdx          # カテゴリインデックスページ
+    ├── index.mdx          # カテゴリインデックスページ（降順ソートを設定）
     ├── 0.2.0.mdx          # 新しいエントリ (sidebar_position: 2)
     └── 0.1.0.mdx          # 古いエントリ (sidebar_position: 1)
 ```
 
 ## カテゴリ設定
 
-`_category_.json`ファイルで降順ソートを設定し、新しいエントリがサイドバーの先頭に表示されるようにします：
+`index.mdx` の `category_sort_order` フロントマターで降順ソートを設定し、新しいエントリがサイドバーの先頭に表示されるようにします：
 
-```json title="_category_.json"
-{
-  "label": "Changelog",
-  "position": 10,
-  "sortOrder": "desc"
-}
+```mdx title="changelog/index.mdx"
+---
+title: Changelog
+sidebar_position: 10
+category_sort_order: "desc"
+---
 ```
 
-`sortOrder: "desc"`を設定すると、`sidebar_position`の値が大きいエントリが先に表示されます。これにより、新しいバージョンが自然に先頭にソートされます。
+`category_sort_order: "desc"`を設定すると、`sidebar_position`の値が大きいエントリが先に表示されます。これにより、新しいバージョンが自然に先頭にソートされます。
 
 ## 新しいエントリの追加
 
@@ -62,7 +61,7 @@ sidebar_position: 2
 
 <Tip>
 
-新しいバージョンごとに`sidebar_position`の値を増やしてください。カテゴリ設定の`sortOrder: "desc"`と組み合わせることで、最新のエントリが常にサイドバーの先頭に表示されます。
+新しいバージョンごとに`sidebar_position`の値を増やしてください。カテゴリの`index.mdx`の`category_sort_order: "desc"`と組み合わせることで、最新のエントリが常にサイドバーの先頭に表示されます。
 
 </Tip>
 
@@ -148,4 +147,4 @@ headerNav: [
 
 ## i18n
 
-翻訳されたリリースノートを提供するために、変更履歴エントリを日本語コンテンツディレクトリ（`src/content/docs-ja/changelog/`）にミラーしてください。`_category_.json`とディレクトリ構造は英語版と一致させる必要があります。
+翻訳されたリリースノートを提供するために、変更履歴エントリを日本語コンテンツディレクトリ（`src/content/docs-ja/changelog/`）にミラーしてください。`index.mdx`とディレクトリ構造は英語版と一致させる必要があります。

--- a/src/content/docs-ja/guides/sidebar.mdx
+++ b/src/content/docs-ja/guides/sidebar.mdx
@@ -99,18 +99,18 @@ src/content/docs/
 
 ## ネストカテゴリ（サブグループ）
 
-カテゴリディレクトリ内にサブディレクトリを作成すると、サイドバーにネストされた折りたたみグループが生成されます。各サブディレクトリには `_category_.json` ファイルが必要です：
+カテゴリディレクトリ内にサブディレクトリを作成すると、サイドバーにネストされた折りたたみグループが生成されます。各サブディレクトリには `category_no_page: true` を含む `index.mdx` ファイルが必要です：
 
 ```
 src/content/docs/
   methodology/
     index.mdx
     architecture/
-      _category_.json       → { "label": "Architecture", "position": 1, "noPage": true }
+      index.mdx             → title: Architecture, sidebar_position: 1, category_no_page: true
       bem-strategy.mdx
       component-first.mdx
     design-systems/
-      _category_.json       → { "label": "Design Systems", "position": 2, "noPage": true }
+      index.mdx             → title: Design Systems, sidebar_position: 2, category_no_page: true
       tight-token.mdx
       two-tier-size.mdx
 ```
@@ -176,17 +176,23 @@ Methodology            (depth 0, リーフリンク)
 
 ## ソート順（昇順・降順）
 
-デフォルトでは、カテゴリ内のアイテムは昇順（`sidebar_position`が小さい順、次にアルファベット順）でソートされます。`_category_.json`を使用してカテゴリごとに降順に変更できます：
+デフォルトでは、カテゴリ内のアイテムは昇順（`sidebar_position`が小さい順、次にアルファベット順）でソートされます。カテゴリの `index.mdx` の `category_sort_order` フロントマターフィールドを使用してカテゴリごとに降順に変更できます：
 
-```json title="_category_.json"
-{
-  "label": "Changelog",
-  "position": 10,
-  "sortOrder": "desc"
-}
+```mdx title="changelog/index.mdx"
+---
+title: Changelog
+sidebar_position: 10
+category_sort_order: "desc"
+---
 ```
 
-`sortOrder`が`"desc"`の場合、アイテムは逆順でソートされます — positionが大きい順、次に逆アルファベット順。これは日付ベースのコンテンツ（変更履歴、リリースノート）で、最新のアイテムを上部に表示したい場合に便利です。
+`category_sort_order`が`"desc"`の場合、アイテムは逆順でソートされます — positionが大きい順、次に逆アルファベット順。これは日付ベースのコンテンツ（変更履歴、リリースノート）で、最新のアイテムを上部に表示したい場合に便利です。
+
+<Note>
+
+`_category_.json` は引き続き動作しますが、zfb のビルド警告が発生します。新しいカテゴリには `index.mdx` のフロントマターを使用してください。
+
+</Note>
 
 `src/config/sidebars.ts`でも手動サイドバー設定で`sortOrder`を設定できます：
 
@@ -213,4 +219,4 @@ Methodology            (depth 0, リーフリンク)
 - カテゴリインデックスページには`sidebar_position: 0`を使用する
 - 各カテゴリ内のページには連番（1, 2, 3...）を使用する
 - 後でページを挿入する予定がある場合は番号に間隔を空ける（例：10, 20, 30）
-- 最新順のカテゴリには`_category_.json`で`sortOrder: "desc"`を使用する
+- 最新順のカテゴリには`index.mdx`で`category_sort_order: "desc"`を使用する

--- a/src/content/docs-ja/markdown-features/_category_.json
+++ b/src/content/docs-ja/markdown-features/_category_.json
@@ -1,5 +1,0 @@
-{
-  "label": "Markdown 機能",
-  "position": 4,
-  "description": "zfb が提供する組み込みおよびオプトイン Markdown パイプライン機能"
-}

--- a/src/content/docs-ja/markdown-features/index.mdx
+++ b/src/content/docs-ja/markdown-features/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Markdown 機能
 description: zfb が提供する組み込みおよびオプトイン Markdown パイプライン機能。
+sidebar_label: Markdown 機能
 sidebar_position: 1
 ---
 

--- a/src/content/docs/changelog/_category_.json
+++ b/src/content/docs/changelog/_category_.json
@@ -1,5 +1,0 @@
-{
-  "label": "Changelog",
-  "position": 10,
-  "sortOrder": "desc"
-}

--- a/src/content/docs/changelog/index.mdx
+++ b/src/content/docs/changelog/index.mdx
@@ -1,7 +1,9 @@
 ---
 title: Changelog
 description: Release notes and version history for zudo-doc.
+sidebar_label: Changelog
 sidebar_position: 10
+category_sort_order: desc
 ---
 
 Track the changes, improvements, and fixes in each release of zudo-doc.

--- a/src/content/docs/components/category-nav.mdx
+++ b/src/content/docs/components/category-nav.mdx
@@ -57,7 +57,7 @@ By default `CategoryNav` infers a single parent and lists its immediate children
 <CategoryNav categories={["claude-md", "claude-skills", "claude-agents"]} />
 ```
 
-Each slug is resolved to its nav node and rendered as a card; slugs not found in the tree are silently skipped. For categories with no `index.mdx` (`noPage: true`), the card links to the auto-generated category index URL.
+Each slug is resolved to its nav node and rendered as a card; slugs not found in the tree are silently skipped. For no-page categories (`category_no_page: true` in `index.mdx`, or `noPage: true` in a legacy `_category_.json`), the card links to the auto-generated category index URL.
 
 ## Features
 

--- a/src/content/docs/concepts/_category_.json
+++ b/src/content/docs/concepts/_category_.json
@@ -1,5 +1,0 @@
-{
-  "label": "Concepts",
-  "position": 8,
-  "description": "Architecture and design concepts for the zfb migration"
-}

--- a/src/content/docs/concepts/index.mdx
+++ b/src/content/docs/concepts/index.mdx
@@ -1,6 +1,10 @@
 ---
 title: Concepts
+description: Architecture and design concepts for the zfb migration.
 sidebar_label: Concepts
 sidebar_position: 8
-category_no_page: true
 ---
+
+Architecture and design concepts for the zfb migration.
+
+<CategoryNav category="concepts" />

--- a/src/content/docs/concepts/index.mdx
+++ b/src/content/docs/concepts/index.mdx
@@ -1,0 +1,6 @@
+---
+title: Concepts
+sidebar_label: Concepts
+sidebar_position: 8
+category_no_page: true
+---

--- a/src/content/docs/develop/_category_.json
+++ b/src/content/docs/develop/_category_.json
@@ -1,5 +1,0 @@
-{
-  "label": "Develop",
-  "position": 11,
-  "description": "Development notes for zudo-doc itself"
-}

--- a/src/content/docs/develop/index.mdx
+++ b/src/content/docs/develop/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Develop
 description: Development notes for zudo-doc itself.
+sidebar_label: Develop
 sidebar_position: 1
 ---
 

--- a/src/content/docs/guides/changelog.mdx
+++ b/src/content/docs/guides/changelog.mdx
@@ -13,25 +13,24 @@ Changelog entries live in a dedicated content directory:
 ```
 src/content/docs/
 └── changelog/
-    ├── _category_.json    # Category config with desc sort
-    ├── index.mdx          # Category index page
+    ├── index.mdx          # Category index page (sets desc sort order)
     ├── 0.2.0.mdx          # Newer entry (sidebar_position: 2)
     └── 0.1.0.mdx          # Older entry (sidebar_position: 1)
 ```
 
 ## Category Configuration
 
-The `_category_.json` file configures descending sort order so newer entries appear first in the sidebar:
+The `index.mdx` file configures descending sort order so newer entries appear first in the sidebar:
 
-```json title="_category_.json"
-{
-  "label": "Changelog",
-  "position": 10,
-  "sortOrder": "desc"
-}
+```mdx title="changelog/index.mdx"
+---
+title: Changelog
+sidebar_position: 10
+category_sort_order: "desc"
+---
 ```
 
-With `sortOrder: "desc"`, entries with higher `sidebar_position` values appear first. This means newer versions naturally sort to the top.
+With `category_sort_order: "desc"`, entries with higher `sidebar_position` values appear first. This means newer versions naturally sort to the top.
 
 ## Adding a New Entry
 
@@ -62,7 +61,7 @@ Summary of changes in this release.
 
 <Tip>
 
-Use incrementing `sidebar_position` values for each new version. Combined with `sortOrder: "desc"` in the category config, this ensures the newest entry always appears at the top of the sidebar.
+Use incrementing `sidebar_position` values for each new version. Combined with `category_sort_order: "desc"` in the category's `index.mdx`, this ensures the newest entry always appears at the top of the sidebar.
 
 </Tip>
 
@@ -148,4 +147,4 @@ headerNav: [
 
 ## i18n
 
-Mirror changelog entries in the Japanese content directory (`src/content/docs-ja/changelog/`) to provide translated release notes. The `_category_.json` and directory structure should match the English version.
+Mirror changelog entries in the Japanese content directory (`src/content/docs-ja/changelog/`) to provide translated release notes. The `index.mdx` and directory structure should match the English version.

--- a/src/content/docs/guides/sidebar.mdx
+++ b/src/content/docs/guides/sidebar.mdx
@@ -99,18 +99,18 @@ src/content/docs/
 
 ## Nested Categories (Sub-Groups)
 
-Subdirectories within a category directory create nested collapsible groups in the sidebar. Each sub-directory needs a `_category_.json` file to set its label and position:
+Subdirectories within a category directory create nested collapsible groups in the sidebar. Each sub-directory needs an `index.mdx` file with `category_no_page: true` to set its label and position without creating a route:
 
 ```
 src/content/docs/
   methodology/
     index.mdx
     architecture/
-      _category_.json       → { "label": "Architecture", "position": 1, "noPage": true }
+      index.mdx             → title: Architecture, sidebar_position: 1, category_no_page: true
       bem-strategy.mdx
       component-first.mdx
     design-systems/
-      _category_.json       → { "label": "Design Systems", "position": 2, "noPage": true }
+      index.mdx             → title: Design Systems, sidebar_position: 2, category_no_page: true
       tight-token.mdx
       two-tier-size.mdx
 ```
@@ -176,17 +176,23 @@ This pattern is recommended when categories have sub-groups. The explicit config
 
 ## Sort Order (Ascending / Descending)
 
-By default, items within a category are sorted in ascending order (lowest `sidebar_position` first, then alphabetical). You can reverse this to descending order per category using `_category_.json`:
+By default, items within a category are sorted in ascending order (lowest `sidebar_position` first, then alphabetical). You can reverse this to descending order per category using the `category_sort_order` frontmatter field on the category's `index.mdx`:
 
-```json title="_category_.json"
-{
-  "label": "Changelog",
-  "position": 10,
-  "sortOrder": "desc"
-}
+```mdx title="changelog/index.mdx"
+---
+title: Changelog
+sidebar_position: 10
+category_sort_order: "desc"
+---
 ```
 
-When `sortOrder` is `"desc"`, items are sorted in reverse — highest position first, then reverse alphabetical. This is useful for date-based content (changelogs, release notes) where the newest items should appear at the top.
+When `category_sort_order` is `"desc"`, items are sorted in reverse — highest position first, then reverse alphabetical. This is useful for date-based content (changelogs, release notes) where the newest items should appear at the top.
+
+<Note>
+
+`_category_.json` still works but triggers a zfb build warning. Prefer frontmatter on `index.mdx` for new categories.
+
+</Note>
 
 You can also set `sortOrder` in `src/config/sidebars.ts` for manual sidebar configurations:
 
@@ -213,4 +219,4 @@ For changelog-style categories, combine `sortOrder: "desc"` with date-prefixed f
 - Use `sidebar_position: 0` on category index pages
 - Use sequential numbers (1, 2, 3...) for pages within each category
 - Leave gaps between numbers (e.g., 10, 20, 30) if you expect to insert pages later
-- Use `sortOrder: "desc"` in `_category_.json` for newest-first categories
+- Use `category_sort_order: "desc"` in `index.mdx` for newest-first categories

--- a/src/content/docs/markdown-features/_category_.json
+++ b/src/content/docs/markdown-features/_category_.json
@@ -1,5 +1,0 @@
-{
-  "label": "Markdown Features",
-  "position": 4,
-  "description": "Built-in and opt-in markdown pipeline features provided by zfb"
-}

--- a/src/content/docs/markdown-features/index.mdx
+++ b/src/content/docs/markdown-features/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Markdown Features
 description: Built-in and opt-in markdown pipeline features provided by zfb.
+sidebar_label: Markdown Features
 sidebar_position: 1
 ---
 

--- a/src/types/docs-entry.ts
+++ b/src/types/docs-entry.ts
@@ -33,6 +33,13 @@ export interface DocsEntry {
     standalone?: boolean;
     slug?: string;
     generated?: boolean;
+    /** Category metadata on a directory's index.mdx (frontmatter form of
+     *  `_category_.json` `noPage`): non-linked sidebar header + excluded from
+     *  routes/sitemap/search. Frontmatter wins over the sidecar. */
+    category_no_page?: boolean;
+    /** Frontmatter form of `_category_.json` `sortOrder` — child sort
+     *  direction. Frontmatter wins over the sidecar. */
+    category_sort_order?: "asc" | "desc";
   };
   rendered?: RenderedContent;
   filePath?: string;

--- a/src/utils/docs.ts
+++ b/src/utils/docs.ts
@@ -70,8 +70,17 @@ function navTreeCacheKey(
     : "_";
   return `${lang}:${metaKey}:${docs
     .map((d) => {
-      const { sidebar_position, sidebar_label, title, description, unlisted, standalone, slug } =
-        d.data;
+      const {
+        sidebar_position,
+        sidebar_label,
+        title,
+        description,
+        unlisted,
+        standalone,
+        slug,
+        category_no_page,
+        category_sort_order,
+      } = d.data;
       return JSON.stringify([
         d.id,
         sidebar_position,
@@ -81,6 +90,8 @@ function navTreeCacheKey(
         unlisted,
         standalone,
         slug,
+        category_no_page,
+        category_sort_order,
       ]);
     })
     .sort()
@@ -197,7 +208,9 @@ function toNavNodes(
   for (const child of parent.children.values()) {
     const doc = child.doc;
     const meta = categoryMeta?.get(child.fullPath);
-    const sortOrder = meta?.sortOrder ?? "asc";
+    // Frontmatter wins over the `_category_.json` sidecar when both exist.
+    const noPage = doc?.data.category_no_page ?? meta?.noPage;
+    const sortOrder = doc?.data.category_sort_order ?? meta?.sortOrder ?? "asc";
     const children = toNavNodes(child, lang, categoryMeta, sortOrder);
 
     nodes.push({
@@ -206,12 +219,16 @@ function toNavNodes(
         doc?.data.sidebar_label ?? doc?.data.title ?? meta?.label ?? toTitleCase(child.segment),
       description: doc?.data.description ?? meta?.description,
       position: doc?.data.sidebar_position ?? meta?.position ?? 999,
-      href: meta?.noPage
+      href: noPage
         ? undefined
         : doc || children.length > 0
           ? docsUrl(child.fullPath, lang)
           : undefined,
-      hasPage: !!doc,
+      // A `category_no_page` index.mdx is metadata-only — force hasPage false so
+      // it matches a `_category_.json` noPage category (no backing file): a
+      // non-linked header that flattenTree drops from prev/next. Otherwise the
+      // route-excluded slug would surface as a 404 pagination target.
+      hasPage: !!doc && noPage !== true,
       children,
       sortOrder,
     });

--- a/zfb.config.ts
+++ b/zfb.config.ts
@@ -215,6 +215,13 @@ const docsSchema = z
     standalone: z.boolean().optional(),
     slug: z.string().optional(),
     generated: z.boolean().optional(),
+    // Category metadata expressed as a directory index.mdx's frontmatter — the
+    // frontmatter form of `_category_.json`. `category_no_page` makes the index
+    // a non-linked sidebar header excluded from routes/sitemap/search;
+    // `category_sort_order` sets the child sort direction. Frontmatter wins
+    // over the sidecar.
+    category_no_page: z.boolean().optional(),
+    category_sort_order: z.enum(["asc", "desc"]).optional(),
   })
   .passthrough();
 


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/1974

---

## Summary

Fixes the five consumer-facing parity bugs found during real downstream migrations (epic #1974), in one accumulated base branch:

1. **OGP completeness** (#1975 / closes #1973-via-epic) — `HeadWithDefaults` now passes `ogType="website"`, `ogSiteName={settings.siteName}`, `ogUrl={canonical}` to the already-capable `OgTags`; e2e assertions added for og:type/og:site_name. og:url auto-suppresses where no canonical exists (fixtures, 404, tags).
2. **Scaffold component drift** (#1976) — `sidebar-toggle.tsx` (data-props version; fixes empty mobile drawer) and `theme-toggle.tsx` (`"use client"` + displayName pin; fixes dead toggle) re-synced verbatim into the scaffold templates; their `.template-drift-allowlist` exemptions removed so the drift check now enforces sync.
3. **Tailwind @source gap** (#1977 + #1982) — scaffold `global.css` gains `@source` over the package's node_modules dist plus a single-line `@source inline()` bracket-utility safelist (Tailwind v4 scanner is intermittent on arbitrary values from node_modules JS); a new `check:package-safelist` guard (wired into b4push AND pr-checks, parity-checked) prevents silent safelist rot.
4. **`_category_.json` engine warning** (#1978 + #1980 + #1981) — category metadata moves to index.mdx frontmatter: new `category_no_page` / `category_sort_order` fields readable by BOTH nav builders (package `build-tree` + host/template `docs.ts`), with explicit exclusion of metadata-only entries from routes/sitemap/search/llms.txt/tags (zfb retains `unlisted` docs in routes, so the exclusion is explicit); the claude-resources generator emits index.mdx instead of `_category_.json` (cleanDir handles residuals; slug-collision guards added); all 8 hand-authored `_category_.json` files migrated (concepts gets a real CategoryNav landing page preserving its existing route); docs updated EN+JA. `_category_.json` reading stays for downstream back-compat.
5. **i18n doc-history fallback** (#1979) — EN-fallback pages under /{locale}/ now resolve history data via `effectiveHistoryLocale` (optional `isFallback` prop), so the Revision History island fetches the bare-slug JSON that actually exists and the sr-only meta block populates; labels stay in the display locale.

Post-review fix (codex P2): `category_no_page` filtering in locale tag/footer/sitemap enumerators moved AFTER `mergeLocaleDocs` so locale-specific no-page overrides win the merge instead of resurfacing the unflagged base doc as a dead link.

## Verification

- Wave-3 confirm sub-issue (#1983): scaffolded consumer built 3×, CSS contains `lg:block` + bracket utilities every time; mobile drawer renders SidebarTree; theme-toggle marker correct; repo build emits ZERO `unsupported data-file extension` warnings; OGP tags verified in dist; sitemap surface neutral (concepts preserved, no new category routes).
- Manager independently re-ran the scaffold-CSS grep and the warning-free build on persisted state (epic verification pin).
- Pre-existing finding (NOT this PR): local `pnpm build` doc-history postBuild exceeds zfb's 120s hook budget on this machine — also fails on main; tracked in #1986.
- Release-lag note: consumers keep seeing the `_category_.json` warning until the next `@takazudo/zudo-doc` release ships the new generator — tracked in #1985.

## Topic branches

All 9 topic branches were merged locally into this base and deleted (commits preserved in the merge history).