### PR TITLE
fix(create-zudo-doc): real client-router bootstrap + vsp-3xs/shadow-lg theme tokens (#1991, #1990)

### DIFF
--- a/.template-drift-allowlist
+++ b/.template-drift-allowlist
@@ -122,15 +122,23 @@ src/utils/header-right-items.ts
 # in templates/base/src/components/ so the mirrored unconditional pages
 # (templates/base/pages/lib/_body-end-islands.tsx and friends) resolve their
 # @/components/* imports without dragging full feature implementations into
-# every scaffold. The five files below have no feature template to swap them
+# every scaffold. The four files below have no feature template to swap them
 # out — they ship as permanent no-ops in base; a future PR can introduce a
 # feature flag if downstream consumers ask. The other two stubs
 # (doc-history.tsx, image-enlarge.tsx) are already allowlisted above via the
 # Wave-11 / E2-task-2 entries; the imageEnlarge feature now also ships the
 # ImageEnlargeSsrFallback named export to mirror the host shape.
 # Spec-lock §1.5 + Decision 5 — see #1728.
+#
+# client-router-bootstrap.tsx was REMOVED from this list (#1991): the no-op
+# stub silently disabled SPA page transitions in fresh scaffolds (the island
+# marker + <ClientRouter/> SSR meta + view-transition CSS were all present,
+# but the bundle shipped zero client-router code, so every internal link was
+# a full page reload). It now ships the REAL bootstrap, byte-identical to the
+# host src/components/client-router-bootstrap.tsx, so the drift checker
+# enforces parity going forward — same rationale as the W4A
+# desktop-sidebar-toggle de-allowlisting above.
 src/components/ai-chat-modal.tsx
-src/components/client-router-bootstrap.tsx
 src/components/design-token-panel-bootstrap.tsx
 src/components/desktop-sidebar-toggle.tsx
 src/components/preset-generator.tsx

--- a/packages/create-zudo-doc/templates/base/src/components/client-router-bootstrap.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/client-router-bootstrap.tsx
@@ -1,14 +1,64 @@
-// W6A stub — no-op default export.
+"use client";
+
+// Client-side bootstrap for the @takazudo/zfb-runtime ClientRouter.
 //
-// The host installs a tiny client-side router bootstrap that re-runs
-// island lifecycle code across zfb navigations. Generated projects ship
-// the no-op so unconditional page imports (`pages/lib/_body-end-islands`)
-// resolve without dragging the routing bridge into every scaffold.
+// Why this exists (zudolab/zudo-doc#1524, W7A verification):
+// `<ClientRouter />` (mounted in doc-layout.tsx) emits SSR meta tags + CSS
+// for the SPA soft-swap router, but the actual click/form intercept
+// registration runs as a top-of-module side effect inside
+// `@takazudo/zfb-runtime/src/client-router.ts`:
+//
+//   if (typeof document !== "undefined") { init(); }
+//
+// The host's existing `import { ClientRouter } from "@takazudo/zfb-runtime"`
+// in doc-layout.tsx happens during SSR (where typeof document ===
+// "undefined"), so the side effect is silently skipped — the router
+// module never reaches the client bundle and every navigation falls
+// through to a full page load. W7A's Playwright harness confirmed this:
+// pageswap.viewTransition is null, getAnimations() is empty during nav,
+// and the sidebar DOM identity is destroyed on every click.
+//
+// The fix is a minimal "use client" island whose only job is to
+// side-effect-import `@takazudo/zfb-runtime/client-router` so the same
+// guard fires in the browser. The `init()` is idempotent (guarded by an
+// `initialized` flag in router.ts), so even if the import path is
+// reached again later the registration runs exactly once.
+//
+// Bundle cost: the only thing this island ships to the client is the
+// client-router subgraph (router.ts + swap-functions.ts + events.ts +
+// types.ts + cssesc.ts) plus its single dep on `@takazudo/zfb/runtime`'s
+// island manager. The server-only zfb-runtime modules
+// (createPageRouter, snapshot, framework adapter) are not transitively
+// reachable from the client-router barrel and stay out of the bundle.
+//
+// Why not call init() in useEffect instead of a side-effect import:
+// useEffect fires after Preact mounts, which is after the islands
+// runtime fetches and executes the bundle. Module top-level code runs
+// as soon as the bundle is parsed by the browser — earlier than mount,
+// closer to Astro's <script type="module"> emission timing. The first
+// click on a fresh page typically arrives 100ms+ after parse, so this
+// timing is what makes the SPA-router actually intercept.
+
+// Side-effect import — running this file's bundle in the browser
+// triggers the `if (typeof document !== "undefined") { init(); }` guard
+// at the top of `@takazudo/zfb-runtime/src/client-router.ts`.
+import "@takazudo/zfb-runtime/client-router";
+
 import type { JSX } from "preact";
 
+/**
+ * Renders nothing. The island marker exists only so zfb's island scanner
+ * walks page → BodyEndIslands → ClientRouterBootstrap and includes the
+ * client-router barrel in the per-island bundle, where the side-effect
+ * import above can fire on the client.
+ */
 function ClientRouterBootstrap(): JSX.Element | null {
   return null;
 }
+
+// Stable marker name across SSR / scanner / hydration manifest. Required
+// for production minification per the existing pattern in
+// `pages/lib/_body-end-islands.tsx` (zfb PR #150 marker-name alignment).
 ClientRouterBootstrap.displayName = "ClientRouterBootstrap";
 
 export default ClientRouterBootstrap;

--- a/packages/create-zudo-doc/templates/base/src/styles/global.css
+++ b/packages/create-zudo-doc/templates/base/src/styles/global.css
@@ -130,7 +130,8 @@
   --spacing-hsp-xl: 1.5rem;     /* 24px — generous padding */
   --spacing-hsp-2xl: 2rem;      /* 32px — large padding */
 
-  /* Vertical spacing (7 steps) */
+  /* Vertical spacing (8 steps) */
+  --spacing-vsp-3xs: 0.25rem;     /* 4px — hairline gap */
   --spacing-vsp-2xs: 0.4375rem;   /* 7px — tight gap */
   --spacing-vsp-xs: 0.875rem;    /* 14px — small gap */
   --spacing-vsp-sm: 1.25rem;     /* 20px — compact gap */
@@ -149,6 +150,16 @@
 
   /* Image overlay button chrome */
   --spacing-image-overlay-inset: 0.5rem;  /* 8px — overlay button corner inset + internal padding */
+
+  /* ========================================
+   * Elevation — the tight `@import "tailwindcss/utilities"` (no default
+   * @theme) drops Tailwind's default shadow scale, so `shadow-*` utilities
+   * generate nothing. Re-add the one elevation the components use: header
+   * and version-switcher dropdown panels apply `shadow-lg`. Value is
+   * Tailwind v4's default shadow-lg; the black is intentionally
+   * theme-independent (a drop shadow is absence of light, not a themed color).
+   * ======================================== */
+  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
 
   /* ========================================
    * Typography

--- a/packages/create-zudo-doc/templates/features/designTokenPanel/files/src/config/design-tokens-manifest.ts
+++ b/packages/create-zudo-doc/templates/features/designTokenPanel/files/src/config/design-tokens-manifest.ts
@@ -39,6 +39,7 @@ export const SPACING_TOKENS: readonly TokenDef[] = [
   { id: "hsp-2xl", cssVar: "--spacing-hsp-2xl", label: "hsp-2xl", group: "hsp", default: "2rem",     step: 0.025, unit: "rem" },
 
   // --- Vertical spacing ---
+  { id: "vsp-3xs", cssVar: "--spacing-vsp-3xs", label: "vsp-3xs", group: "vsp", default: "0.25rem",   step: 0.025, unit: "rem" },
   { id: "vsp-2xs", cssVar: "--spacing-vsp-2xs", label: "vsp-2xs", group: "vsp", default: "0.4375rem", step: 0.025, unit: "rem" },
   { id: "vsp-xs",  cssVar: "--spacing-vsp-xs",  label: "vsp-xs",  group: "vsp", default: "0.875rem",  step: 0.025, unit: "rem" },
   { id: "vsp-sm",  cssVar: "--spacing-vsp-sm",  label: "vsp-sm",  group: "vsp", default: "1.25rem",   step: 0.025, unit: "rem" },

--- a/src/config/design-tokens-manifest.ts
+++ b/src/config/design-tokens-manifest.ts
@@ -39,6 +39,7 @@ export const SPACING_TOKENS: readonly TokenDef[] = [
   { id: "hsp-2xl", cssVar: "--spacing-hsp-2xl", label: "hsp-2xl", group: "hsp", default: "2rem",     step: 0.025, unit: "rem" },
 
   // --- Vertical spacing ---
+  { id: "vsp-3xs", cssVar: "--spacing-vsp-3xs", label: "vsp-3xs", group: "vsp", default: "0.25rem",   step: 0.025, unit: "rem" },
   { id: "vsp-2xs", cssVar: "--spacing-vsp-2xs", label: "vsp-2xs", group: "vsp", default: "0.4375rem", step: 0.025, unit: "rem" },
   { id: "vsp-xs",  cssVar: "--spacing-vsp-xs",  label: "vsp-xs",  group: "vsp", default: "0.875rem",  step: 0.025, unit: "rem" },
   { id: "vsp-sm",  cssVar: "--spacing-vsp-sm",  label: "vsp-sm",  group: "vsp", default: "1.25rem",   step: 0.025, unit: "rem" },

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -154,7 +154,8 @@
   --spacing-hsp-xl: 1.5rem;     /* 24px — generous padding */
   --spacing-hsp-2xl: 2rem;      /* 32px — large padding */
 
-  /* Vertical spacing (7 steps) */
+  /* Vertical spacing (8 steps) */
+  --spacing-vsp-3xs: 0.25rem;     /* 4px — hairline gap */
   --spacing-vsp-2xs: 0.4375rem;   /* 7px — tight gap */
   --spacing-vsp-xs: 0.875rem;    /* 14px — small gap */
   --spacing-vsp-sm: 1.25rem;     /* 20px — compact gap */
@@ -173,6 +174,16 @@
 
   /* Image overlay button chrome */
   --spacing-image-overlay-inset: 0.5rem;  /* 8px — overlay button corner inset + internal padding */
+
+  /* ========================================
+   * Elevation — the tight `@import "tailwindcss/utilities"` (no default
+   * @theme) drops Tailwind's default shadow scale, so `shadow-*` utilities
+   * generate nothing. Re-add the one elevation the components use: header
+   * and version-switcher dropdown panels apply `shadow-lg`. Value is
+   * Tailwind v4's default shadow-lg; the black is intentionally
+   * theme-independent (a drop shadow is absence of light, not a themed color).
+   * ======================================== */
+  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
 
   /* ========================================
    * Typography


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/1991
    - https://github.com/zudolab/zudo-doc/issues/1990

Closes #1991
Closes #1990

---

## Summary

Fixes two `create-zudo-doc` scaffold-parity bugs where a fresh consumer's output silently no-ops despite every signal saying it works. Bundled (non-overlapping files, same theme: scaffold drift).

- **#1991** — the scaffolded `client-router-bootstrap.tsx` was a no-op stub, so fresh consumers shipped the ClientRouter island marker + `<ClientRouter/>` SSR meta + view-transition CSS but **zero** client-router code in the bundle → every internal link was a full page reload, with no signal transitions were off.
- **#1990** — the base template `@theme` omitted `--spacing-vsp-3xs` and any shadow scale (tight `@import "tailwindcss/utilities"`, no default theme), so `@takazudo/zudo-doc` components' `py-vsp-3xs` / `mt-vsp-3xs` / `pt-vsp-3xs` and `shadow-lg` classes emitted no CSS. The same gap existed in the monorepo dogfood theme.

## Changes

**FIX A — #1991 (client-router bootstrap)**
- `packages/create-zudo-doc/templates/base/src/components/client-router-bootstrap.tsx`: replaced the no-op stub with the real bootstrap — now **byte-identical** to the proven-working host `src/components/client-router-bootstrap.tsx` (`"use client"` + side-effect `import "@takazudo/zfb-runtime/client-router"`, which fires `init()` in the browser and pulls the client-router subgraph into the island bundle). The template already wires the island (`pages/lib/_body-end-islands.tsx`, `when: "load"`); only the stub body was missing.
- `.template-drift-allowlist`: removed the `client-router-bootstrap.tsx` entry (it was allowlisted as a "permanent no-op stub" — exactly how it drifted into a broken default). The drift checker now **enforces template/host parity** going forward, mirroring the W4A `desktop-sidebar-toggle` de-allowlisting.

**FIX B — #1990 (theme tokens)**
- `src/styles/global.css` + `packages/create-zudo-doc/templates/base/src/styles/global.css`: added `--spacing-vsp-3xs: 0.25rem` (4px — a hairline step below the 7px `vsp-2xs`) and `--shadow-lg` (Tailwind v4's default shadow-lg value, restored after the tight utilities import drops it).
- `src/config/design-tokens-manifest.ts` + the mirrored `designTokenPanel` feature template: registered the `vsp-3xs` entry in `SPACING_TOKENS` (caught by codex review — the manifest coverage unit test scans every `--spacing-*` in `global.css`; the template copy is not drift-allowlisted so it must stay byte-identical). `--shadow-lg` needs no manifest entry (the size-coverage test scans only `--radius-*` / `--default-transition-duration`).

## Test Plan
- `pnpm check:template-drift` ✓ (de-allowlisting valid — template bootstrap + manifest byte-identical to host)
- `pnpm check` (tsc) ✓
- `pnpm build` ✓ — dogfood `dist/` CSS now emits `.shadow-lg` (Tailwind's standard shadow), `.py-vsp-3xs` resolving `--spacing-vsp-3xs: 0.25rem`, plus `.mt-vsp-3xs` / `.pt-vsp-3xs`
- `pnpm lint:tokens` ✓ (raw `rgb()` in `--shadow-lg` accepted)
- `pnpm test:unit` (426) + create-zudo-doc package tests (258) ✓ — incl. the design-tokens-manifest coverage test
- **FIX A guarantee**: the template bootstrap now matches the working host bootstrap and drift is enforced — parity guaranteed structurally (not separately verified in a fresh scaffold; it reaches consumers only via the next release, which is tracked by #1985).

## Notes
- Sibling issue **#1985** is intentionally **not** addressed here — it's release-coordination only (run `/l-make-release`), a human-gated npm publish with no code change.