### PR TITLE
recent-3-issues: sidebar toggle centering (#2002) + README consumer Tailwind docs (#2001)

### DIFF
--- a/e2e/sidebar-toggle-layout.spec.ts
+++ b/e2e/sidebar-toggle-layout.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * E2E regression for the desktop sidebar-toggle layout (#2002).
+ *
+ * When the sidebar is hidden via the desktop toggle, the content used to
+ * keep the dead left gap where the sidebar was, instead of centering in a
+ * narrower band like the `hide_sidebar: true` frontmatter variant.
+ *
+ * Root cause: global.css already had the
+ * `html[data-sidebar-hidden] .zd-sidebar-content-wrapper { margin-left: 0 }`
+ * override, but `.zd-sidebar-content-wrapper` was never applied to the
+ * content wrapper in doc-layout.tsx, so the override was dormant. The fix
+ * applies that hook class plus a new `.zd-doc-content-band` class and adds a
+ * max-width override so the band narrows to the hide_sidebar width (80rem).
+ *
+ * This is a pure CSS contract: the toggle island's only layout-affecting
+ * action is setting `data-sidebar-hidden` on <html> (see
+ * src/components/desktop-sidebar-toggle.tsx). We set that attribute directly
+ * rather than clicking the toggle button because the `sidebarToggle` feature
+ * is not enabled in this fixture — but the attribute-driven CSS is
+ * feature-independent and is exactly what was broken.
+ */
+
+// A sidebar-fixture doc page that renders the desktop sidebar.
+const DOC_PAGE = "/docs/guides/sub-a/page-1";
+
+// 80rem at the default 16px root font-size — the hide_sidebar content-band width.
+const HIDE_SIDEBAR_BAND_MAX_WIDTH = "1280px";
+
+test.describe("Desktop sidebar toggle layout @local-only", () => {
+  test("hiding the sidebar removes the content gap and narrows the band", async ({
+    page,
+  }) => {
+    // Wide enough that the `lg:` (>=1024px) rules are active and the sidebar
+    // width margin is unambiguously non-zero.
+    await page.setViewportSize({ width: 1600, height: 900 });
+    await page.goto(DOC_PAGE, { waitUntil: "load" });
+
+    const wrapper = page.locator(".zd-sidebar-content-wrapper");
+    const band = page.locator(".zd-doc-content-band");
+    await expect(wrapper).toHaveCount(1);
+    await expect(band).toHaveCount(1);
+
+    // Sidebar shown: the wrapper is pushed right to clear the fixed
+    // #desktop-sidebar, leaving the gap the issue is about.
+    const shownMargin = await wrapper.evaluate(
+      (el) => getComputedStyle(el).marginLeft,
+    );
+    expect(shownMargin).not.toBe("0px");
+    const shownBandMaxWidth = await band.evaluate(
+      (el) => getComputedStyle(el).maxWidth,
+    );
+    expect(shownBandMaxWidth).not.toBe(HIDE_SIDEBAR_BAND_MAX_WIDTH);
+
+    // Simulate the toggle hiding the sidebar.
+    await page.evaluate(() => {
+      document.documentElement.setAttribute("data-sidebar-hidden", "");
+    });
+
+    // No dead gap: the wrapper margin collapses to zero...
+    await expect(wrapper).toHaveCSS("margin-left", "0px");
+    // ...and the band narrows to the hide_sidebar width, which the flex
+    // parent (justify-content: center) then centers.
+    await expect(band).toHaveCSS("max-width", HIDE_SIDEBAR_BAND_MAX_WIDTH);
+  });
+});

--- a/packages/create-zudo-doc/templates/base/src/styles/global.css
+++ b/packages/create-zudo-doc/templates/base/src/styles/global.css
@@ -1002,6 +1002,20 @@ pre[class^="syntect-"] .line .highlighted-word {
   html[data-sidebar-hidden] .zd-sidebar-content-wrapper {
     margin-left: 0;
   }
+
+  /* When hidden via the toggle, narrow the content band to the
+   * hide_sidebar frontmatter width so it centers (the flex parent already
+   * applies justify-content: center) instead of leaving a dead gap where
+   * the sidebar was. 80rem must match the `max-w-[80rem]` hide_sidebar
+   * branch in doc-layout.tsx. These rules are unlayered, so they win over
+   * the Tailwind `max-w-[clamp(...)]` utility (utilities layer). (#2002) */
+  .zd-doc-content-band {
+    transition: max-width 200ms ease-in-out;
+  }
+
+  html[data-sidebar-hidden] .zd-doc-content-band {
+    max-width: 80rem;
+  }
 }
 
 /* Sidebar toggle button — left position uses CSS variable, needs global rule */

--- a/packages/zudo-doc/README.md
+++ b/packages/zudo-doc/README.md
@@ -13,6 +13,23 @@ This package provides the missing-by-design framework concerns:
 - **Head injection** (`./head`) — canonical, og:\*, twitter:\*, robots, preload hints, RSS link, sitemap link, theme-color — byte-equal to today's legacy doc-layout output.
 - **SSR-skip wrappers** (`./ssr-skip`) — `<AiChatModalIsland>`, `<ImageEnlargeIsland>`, `<DesignTokenTweakPanelIsland>`, `<MockInitIsland>` — wrap zfb's `<Island ssrFallback>` with the right fallback markup so doc pages don't have to re-implement the SSR-skip pattern.
 
+## Styling — Tailwind setup for consumers
+
+This package ships **no precompiled CSS** — the component utility classes are inlined in the `dist/` JavaScript, and Tailwind v4 does not scan `node_modules`. Without help, those utilities never make it into your build, so the components render unstyled.
+
+The fix is to import the package's build-generated safelist into your Tailwind CSS entry, right next to your `@import "tailwindcss";`:
+
+```css
+@import "tailwindcss";
+@import "@takazudo/zudo-doc/safelist.css";
+```
+
+`dist/safelist.css` is generated at package build time and contains an `@source inline()` set covering every utility the components use (including arbitrary-value classes like `w-[var(--zd-sidebar-w)]`). It auto-syncs whenever you upgrade the package — no drift, no manual maintenance. Available in `@takazudo/zudo-doc` **>= 0.2.0**.
+
+> **Don't `@source` into `node_modules`.** A glob like `@source "../node_modules/@takazudo/zudo-doc/dist/**"` looks plausible but is unreliable: pnpm surfaces packages via symlinks and Tailwind v4's file scanner does not reliably traverse them, so utilities get intermittently dropped across rebuilds (see zudolab/zudo-doc#1989). Import the package safelist instead.
+
+**Migrating from a pre-0.2.0 workaround?** If you vendored or copied the package `dist/` to get its styles, delete that workaround and replace it with the single `@import "@takazudo/zudo-doc/safelist.css";` line above.
+
 ## Pre-publish dev workflow
 
 Phase A npm publish is deferred (see super-epic comment 2026-04-28). During pre-publish dev, this package references zfb via the local checkout at `$HOME/repos/myoss/zfb`. Use `/refer-another-project zfb` to read zfb's APIs. If a zfb bug is discovered, fix it directly on zfb's `main` and push (zfb is not public yet).

--- a/packages/zudo-doc/src/doclayout/doc-layout.tsx
+++ b/packages/zudo-doc/src/doclayout/doc-layout.tsx
@@ -298,10 +298,22 @@ export function DocLayout(props: DocLayoutProps): JSX.Element {
         )}
         {afterSidebar}
 
-        <div class={showSidebar ? "lg:ml-[var(--zd-sidebar-w)]" : undefined}>
+        {/*
+          Stable hook classes for the attribute-driven sidebar-toggle CSS in
+          global.css. `zd-sidebar-content-wrapper` lets `html[data-sidebar-hidden]`
+          zero the left margin, and `zd-doc-content-band` lets it narrow the
+          content band to the hide_sidebar width (80rem) — so the JS toggle
+          reproduces the `hide_sidebar: true` centered layout purely via CSS.
+          See "Desktop sidebar toggle" in src/styles/global.css. (#2002)
+        */}
+        <div
+          class={`zd-sidebar-content-wrapper${
+            showSidebar ? " lg:ml-[var(--zd-sidebar-w)]" : ""
+          }`}
+        >
           <div class="flex min-h-[calc(100vh-3.5rem)] justify-center">
             <div
-              class={`flex w-full gap-[clamp(1.5rem,3vw,4rem)] ${
+              class={`zd-doc-content-band flex w-full gap-[clamp(1.5rem,3vw,4rem)] ${
                 showSidebar
                   ? "max-w-[clamp(50rem,75vw,90rem)]"
                   : "max-w-[80rem]"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1064,6 +1064,20 @@ pre[class^="syntect-"] .line .highlighted-word {
   html[data-sidebar-hidden] .zd-sidebar-content-wrapper {
     margin-left: 0;
   }
+
+  /* When hidden via the toggle, narrow the content band to the
+   * hide_sidebar frontmatter width so it centers (the flex parent already
+   * applies justify-content: center) instead of leaving a dead gap where
+   * the sidebar was. 80rem must match the `max-w-[80rem]` hide_sidebar
+   * branch in doc-layout.tsx. These rules are unlayered, so they win over
+   * the Tailwind `max-w-[clamp(...)]` utility (utilities layer). (#2002) */
+  .zd-doc-content-band {
+    transition: max-width 200ms ease-in-out;
+  }
+
+  html[data-sidebar-hidden] .zd-doc-content-band {
+    max-width: 80rem;
+  }
 }
 
 /* Sidebar toggle button — left position uses CSS variable, needs global rule */


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2003

---

## Summary

- **#2002 — sidebar toggle now centers the content**: hiding the desktop sidebar via the toggle reproduces the `hide_sidebar: true` frontmatter layout (centered 80rem content band) instead of leaving a dead gap where the sidebar was.
- **#2001 — consumer Tailwind story documented**: `packages/zudo-doc/README.md` gains a "Styling — Tailwind setup for consumers" section covering the `@import "@takazudo/zudo-doc/safelist.css"` setup.
- **#1999** was verified already resolved by the v0.2.0 release (`latest: 0.2.0` ≥ `next`) and closed with evidence — no code change here.

## Changes

### sidebar-toggle-fix (#2002)

- `packages/zudo-doc/src/doclayout/doc-layout.tsx`: applied the (previously dormant) `zd-sidebar-content-wrapper` hook class to the content wrapper and added a new `zd-doc-content-band` hook class to the inner flex band, so the attribute-driven CSS can reach both.
- `src/styles/global.css`: under `html[data-sidebar-hidden]`, the band's max-width now switches to 80rem (matching the `hide_sidebar` branch in doc-layout.tsx) with a synced 200ms transition; the flex parent's `justify-content: center` then centers it. Rules are unlayered so they win over Tailwind utilities without `!important`.
- `packages/create-zudo-doc/templates/base/src/styles/global.css`: same CSS mirrored into the scaffold template (manual-sync, drift-allowlisted file).
- `e2e/sidebar-toggle-layout.spec.ts`: new `@local-only` regression spec asserting margin-left collapses to 0 and band max-width becomes 1280px when `data-sidebar-hidden` is set.

### readme-tailwind-docs (#2001)

- `packages/zudo-doc/README.md`: new consumer-facing section — why no precompiled CSS ships (utilities inlined in dist JS; Tailwind v4 doesn't scan `node_modules`), the safelist import fix with exact snippet and placement, `>= 0.2.0` availability note, the `@source`-into-`node_modules` dead end (pnpm symlinks, #1989), and a migration hint for pre-0.2.0 vendor-dist workarounds.

## Test Plan

- `pnpm check` (tsc) — pass
- `@takazudo/zudo-doc` tsup rebuild — pass
- Template drift + fixture settings drift checks — pass (CI green, 14/14)
- New e2e spec run locally against the sidebar fixture — pass
- Browser verification (1600×900): toggle hides sidebar → wrapper margin 320px→0, band max-width 1200px→1280px, band centered at viewport center, toggle restores wide layout; `hide_sidebar` demo page unchanged

Closes #2002
Closes #2001

🤖 Generated with [Claude Code](https://claude.com/claude-code)