### PR TITLE
docs(zudo-doc): replace stale pre-publish dev-workflow README section

### DIFF
--- a/packages/zudo-doc/README.md
+++ b/packages/zudo-doc/README.md
@@ -30,6 +30,8 @@ The fix is to import the package's build-generated safelist into your Tailwind C
 
 **Migrating from a pre-0.2.0 workaround?** If you vendored or copied the package `dist/` to get its styles, delete that workaround and replace it with the single `@import "@takazudo/zudo-doc/safelist.css";` line above.
 
-## Pre-publish dev workflow
+## Dev workflow (in this repo)
 
-Phase A npm publish is deferred (see super-epic comment 2026-04-28). During pre-publish dev, this package references zfb via the local checkout at `$HOME/repos/myoss/zfb`. Use `/refer-another-project zfb` to read zfb's APIs. If a zfb bug is discovered, fix it directly on zfb's `main` and push (zfb is not public yet).
+This package is published to npm as `@takazudo/zudo-doc` (since `0.2.0`, `latest` tracks the current line). Inside this repo the host site consumes it as a workspace package through its compiled `dist/` — `pnpm dev` at the repo root runs `tsup --watch` so edits under `src/` rebuild automatically; for a one-off rebuild use `pnpm --filter @takazudo/zudo-doc build`.
+
+zfb itself comes from npm (versions pinned in the root `package.json`). To develop against a local zfb checkout, use the temporary `pnpm.overrides` link escape hatch documented in the root `CLAUDE.md` — do not commit the override.


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2005

---

## Summary

Auto-fix from the `/x-wt-teams` recent-3-issues session (Step 15.5). The "Pre-publish dev workflow" section in `packages/zudo-doc/README.md` still described the deferred-publish era (local zfb checkout at `$HOME/repos/myoss/zfb`, "zfb is not public yet") — but the package is published (`latest: 0.2.0`) and zfb is consumed from npm with versions pinned in the root `package.json`.

Rewritten as "Dev workflow (in this repo)": workspace consumption through compiled `dist/`, `tsup --watch` via `pnpm dev`, one-off rebuild command, and the `pnpm.overrides` escape hatch for local zfb development.

Closes #2005

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2006"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783694708&installation_id=130359969&pr_number=2006&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2006&signature=cb1c66a9c3030ada07e00a80e67b43bec4ba3240e6329154b89f93cfbf3d1176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->