### PR TITLE
fix(dev): pin dev port 4321 and stop claude-watch symlink feedback loop

### DIFF
--- a/packages/create-zudo-doc/src/zfb-config-gen.ts
+++ b/packages/create-zudo-doc/src/zfb-config-gen.ts
@@ -186,6 +186,9 @@ export function generateZfbConfig(choices: UserChoices): string {
   // --- Export ---
   lines.push(`export default defineConfig({`);
   lines.push(`  framework: "preact",`);
+  lines.push(`  // Pin the dev/preview port — zfb defaults to 3000, but the generated`);
+  lines.push(`  // CLAUDE.md and the Tauri dev wrappers assume 4321.`);
+  lines.push(`  port: 4321,`);
   lines.push(`  tailwind: { enabled: true },`);
   lines.push(`  collections,`);
   lines.push(`  stripMdExt: true,`);

--- a/scripts/dev-claude-watch.mjs
+++ b/scripts/dev-claude-watch.mjs
@@ -100,6 +100,12 @@ const watcher = watch(CLAUDE_DIR, {
   ignoreInitial: true, // preBuild already ran at zfb startup
   persistent: true,
   awaitWriteFinish: false,
+  // The doc-skill (.claude/skills/*/docs/) symlinks INTO src/content/docs —
+  // i.e. into this watcher's own regeneration OUTPUT. Following symlinks made
+  // every regen write re-appear as a .claude change, looping regeneration
+  // forever and starving zfb's content snapshot (#2042). Real .claude sources
+  // are regular files, so not following symlinks loses nothing.
+  followSymlinks: false,
 });
 
 watcher

--- a/zfb.config.ts
+++ b/zfb.config.ts
@@ -378,6 +378,9 @@ const integrationPlugins = [
 
 export default defineConfig({
   framework: "preact",
+  // Pin the dev/preview port — zfb defaults to 3000, but CLAUDE.md, the
+  // EADDRINUSE guidance, and the Tauri Mode-1 devUrl all assume 4321 (#2043).
+  port: 4321,
   tailwind: { enabled: true },
   collections,
   // Keep the md-plugins test fixtures out of the bundler's shadow-tree


### PR DESCRIPTION
Closes #2042
Closes #2043

---

## Summary

Auto-fix PR for two `agent-found` findings raised during the #2041 workflow (`-fix` step):

- **#2043** — `zfb.config.ts` never set `port`, so zfb's default (3000) won while CLAUDE.md, the EADDRINUSE guidance, and the Tauri Mode-1 `devUrl` all assume 4321. Pinned `port: 4321` in the host config and in the `create-zudo-doc` zfb-config generator (the generated CLAUDE.md and both Tauri templates hardcode 4321 for downstream too).
- **#2042** — `dev-claude-watch.mjs` watched `.claude/` with chokidar's default `followSymlinks: true`. The doc-skill (`.claude/skills/*/docs/`) symlinks point INTO the watcher's own regeneration output under `src/content/docs/`, so every regen re-triggered the watcher in an endless loop, starving zfb's content snapshot — `pnpm dev` never became ready. Set `followSymlinks: false`; real `.claude` sources are regular files, so nothing is lost.

## Test Plan

- `pnpm dev`: ready on :4321 in ~70s, nothing on :3000, zero `content snapshot build failed` lines.
- Touching a real `.claude` file triggers exactly one regeneration with no follow-up loop.
- 299 create-zudo-doc tests pass; `pnpm build` of the generator compiles the port line into `dist/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2044"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783747674&installation_id=130359969&pr_number=2044&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2044&signature=2902afc26ece55b53c74fd17c7124584dc316c7b767f2a6fa36be5d89e19d27c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->