### PR TITLE
template-fixes: fix create-zudo-doc template bugs (#2047, #2048, #2049)

### DIFF
--- a/.template-drift-allowlist
+++ b/.template-drift-allowlist
@@ -1,3 +1,8 @@
+# NOTE: entries here exempt files from the whole-file CONTENT check only.
+# "use client" directive parity is checked separately and is NOT exempted by
+# this list — its exemptions live in DIRECTIVE_EXEMPT inside
+# scripts/check-template-drift.sh, keyed by template-relative path.
+
 # Slot-based files — templates use @slot: injection anchors,
 # production has features inlined
 src/styles/global.css

--- a/packages/create-zudo-doc/templates/base/pages/lib/_header-with-defaults.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_header-with-defaults.tsx
@@ -45,11 +45,14 @@ import {
   VersionSwitcher,
   type VersionSwitcherLabels,
 } from "@takazudo/zudo-doc/i18n-version";
-// BARE (non-island-wrapped) ThemeToggle from the dedicated subpath
-// (#2012 E2). The `./theme` barrel exports an Island-wrapped variant;
-// this wrapper composes its own Island below, and the bare subpath
-// avoids nesting an island inside an island.
-import { ThemeToggle } from "@takazudo/zudo-doc/theme-toggle";
+// ThemeToggle via the project-source shim (`@/components/theme-toggle`)
+// rather than the package subpath directly. zfb's island scanner does not
+// register "use client" modules under node_modules (zfb#999), so importing
+// the package component here would emit an island marker with no registry
+// entry and the toggle would never hydrate (zudolab/zudo-doc#2048). The shim
+// re-wraps the bare (non-island-wrapped) package ThemeToggle; this wrapper
+// composes its own Island below, avoiding nesting an island inside an island.
+import { ThemeToggle } from "@/components/theme-toggle";
 import SidebarToggle from "@/components/sidebar-toggle";
 import { settings } from "@/config/settings";
 import { defaultLocale, locales, t, type Locale } from "@/config/i18n";

--- a/packages/create-zudo-doc/templates/base/src/components/ai-chat-modal.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/ai-chat-modal.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 // W6A stub — no-op default export.
 //
 // The host (zudo-doc showcase) ships a full AI-chat modal island here. In

--- a/packages/create-zudo-doc/templates/base/src/components/doc-history.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/doc-history.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 // W6A stub — no-op default + DocHistory named exports.
 //
 // When the docHistory feature is enabled, the feature template

--- a/packages/create-zudo-doc/templates/base/src/components/image-enlarge.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/image-enlarge.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 // W6A stub — no-op default + ImageEnlargeSsrFallback named exports.
 //
 // When the imageEnlarge feature is enabled, the feature template

--- a/packages/create-zudo-doc/templates/base/src/components/sidebar-tree.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/sidebar-tree.tsx
@@ -288,7 +288,7 @@ export default function SidebarTree({ nodes, currentSlug, rootMenuItems, backToM
             type="text"
             placeholder={filterPlaceholder}
             value={query}
-            onChange={(e) => setQuery(e.target.value)}
+            onChange={(e) => setQuery(e.currentTarget.value)}
             className="bg-transparent text-small outline-none w-full text-fg placeholder:text-muted"
           />
         </div>

--- a/packages/create-zudo-doc/templates/base/src/components/theme-toggle.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/theme-toggle.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+// Scanner-visible ThemeToggle shim. zfb's island scanner does not register
+// "use client" modules located under node_modules (Takazudo/zudo-front-builder#999),
+// so importing the package ThemeToggle straight into the server-rendered header
+// emits an island marker with no matching registry entry — the toggle renders
+// but never hydrates, on every page (zudolab/zudo-doc#2048). This thin
+// project-source wrapper gives the scanner a local binding to register; it
+// re-wraps the bare (non-island-wrapped) package component unchanged.
+import type { JSX } from "preact";
+import {
+  ThemeToggle as ZudoDocThemeToggle,
+  type ThemeToggleProps,
+} from "@takazudo/zudo-doc/theme-toggle";
+
+export function ThemeToggle(props: ThemeToggleProps): JSX.Element {
+  return <ZudoDocThemeToggle {...props} />;
+}
+ThemeToggle.displayName = "ThemeToggle";
+
+export type { ThemeToggleProps };
+
+export default ThemeToggle;

--- a/packages/create-zudo-doc/templates/features/docHistory/files/src/components/doc-history.tsx
+++ b/packages/create-zudo-doc/templates/features/docHistory/files/src/components/doc-history.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState, useEffect, useCallback, useMemo, useRef } from "preact/compat";
 import type { Change } from "diff";
 import type { DocHistoryData, DocHistoryEntry } from "@/types/doc-history";

--- a/packages/create-zudo-doc/templates/features/imageEnlarge/files/src/components/image-enlarge.tsx
+++ b/packages/create-zudo-doc/templates/features/imageEnlarge/files/src/components/image-enlarge.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState, useEffect, useRef } from "preact/compat";
 import type { JSX } from "preact";
 

--- a/pages/lib/_header-with-defaults.tsx
+++ b/pages/lib/_header-with-defaults.tsx
@@ -45,11 +45,14 @@ import {
   VersionSwitcher,
   type VersionSwitcherLabels,
 } from "@takazudo/zudo-doc/i18n-version";
-// BARE (non-island-wrapped) ThemeToggle from the dedicated subpath
-// (#2012 E2). The `./theme` barrel exports an Island-wrapped variant;
-// this wrapper composes its own Island below, and the bare subpath
-// avoids nesting an island inside an island.
-import { ThemeToggle } from "@takazudo/zudo-doc/theme-toggle";
+// ThemeToggle via the project-source shim (`@/components/theme-toggle`)
+// rather than the package subpath directly. zfb's island scanner does not
+// register "use client" modules under node_modules (zfb#999), so importing
+// the package component here would emit an island marker with no registry
+// entry and the toggle would never hydrate (zudolab/zudo-doc#2048). The shim
+// re-wraps the bare (non-island-wrapped) package ThemeToggle; this wrapper
+// composes its own Island below, avoiding nesting an island inside an island.
+import { ThemeToggle } from "@/components/theme-toggle";
 import SidebarToggle from "@/components/sidebar-toggle";
 import { settings } from "@/config/settings";
 import { defaultLocale, locales, t, type Locale } from "@/config/i18n";

--- a/scripts/check-template-drift.sh
+++ b/scripts/check-template-drift.sh
@@ -114,7 +114,10 @@ check_directive_parity() {
   local prod_file="$ROOT_DIR/$prod_path"
   # No host counterpart → nothing to compare. The content-drift pass already
   # reports genuinely-missing prod files when they are not allowlisted.
-  [[ -f "$prod_file" ]] || return
+  # "return 0" is load-bearing: a bare "return" after the failed [[ -f ]]
+  # propagates status 1 and set -e aborts the whole scan on the first
+  # template-only file.
+  [[ -f "$prod_file" ]] || return 0
 
   local host_has=0 tmpl_has=0
   has_use_client "$prod_file" && host_has=1

--- a/scripts/check-template-drift.sh
+++ b/scripts/check-template-drift.sh
@@ -31,12 +31,24 @@ fi
 # warnings. See zudolab/zudo-doc#2047.
 #
 # check_directive_parity() therefore enforces directive parity for every
-# template/host pair INDEPENDENTLY of the content allowlist. A few template
-# files are intentional no-op base stubs that legitimately ship WITHOUT the
-# host's directive (permanent stubs with no feature counterpart, not registered
-# as live islands in the generated page tree). They are keyed by their
-# template-relative path so the exemption applies to the base stub ONLY — the
-# real feature-template counterparts (which DO carry the directive) stay checked.
+# template/host pair INDEPENDENTLY of the content allowlist (.template-drift-
+# allowlist entries, keyed by prod path, do NOT exempt a file here; this list
+# is keyed by TEMPLATE-relative path and gates the directive check only).
+#
+# The exempted files are deliberate no-op base stubs whose host counterparts
+# are real "use client" islands. They ship WITHOUT the directive because the
+# stub never emits an island marker in a generated project:
+# - design-token-panel-bootstrap / desktop-sidebar-toggle: the real,
+#   directive-carrying implementations are feature overlays (designTokenPanel /
+#   sidebarToggle) that replace the stub when the feature is enabled; the base
+#   stub serves feature-disabled scaffolds, where it renders nothing. The
+#   overlay copies have different template-relative keys and stay checked.
+# - preset-generator: renders null and is only reachable through the MDX
+#   component map when a doc page uses it; downstream projects replace the
+#   stub to wire a real implementation (see the stub's header comment).
+# Contrast ai-chat-modal: its base copy is Island-wrapped unconditionally in
+# pages/lib/_body-end-islands.tsx, so even as a minimal component it MUST
+# carry the directive — that is why it is NOT exempt (zudolab/zudo-doc#2047).
 declare -A DIRECTIVE_EXEMPT=(
   ["base/src/components/design-token-panel-bootstrap.tsx"]=1
   ["base/src/components/desktop-sidebar-toggle.tsx"]=1
@@ -51,6 +63,10 @@ TEMPLATES_DIR="$ROOT_DIR/packages/create-zudo-doc/templates"
 has_use_client() {
   local first
   first="$(head -1 "$1")"
+  # Tolerate a UTF-8 BOM and CRLF line ending so a byte-level oddity in one
+  # copy cannot silently flip parity into a false result.
+  first="${first#$'\xef\xbb\xbf'}"
+  first="${first%$'\r'}"
   [[ "$first" == '"use client";' || "$first" == "'use client';" \
     || "$first" == '"use client"' || "$first" == "'use client'" ]]
 }
@@ -109,6 +125,21 @@ check_directive_parity() {
     DRIFTED+=("$prod_path (\"use client\" directive)")
   fi
 }
+
+# Guard against exemption rot: every DIRECTIVE_EXEMPT key must still point at
+# an existing template file that still ships WITHOUT the directive. A renamed
+# or deleted stub — or a stub that gained "use client" — leaves a stale entry
+# that would silently exempt a future file of the same name.
+for tmpl_key in "${!DIRECTIVE_EXEMPT[@]}"; do
+  exempt_file="$TEMPLATES_DIR/$tmpl_key"
+  if [[ ! -f "$exempt_file" ]]; then
+    echo "  [STALE EXEMPT] $tmpl_key — no such template file; remove the DIRECTIVE_EXEMPT entry"
+    DRIFTED+=("$tmpl_key (stale DIRECTIVE_EXEMPT entry)")
+  elif has_use_client "$exempt_file"; then
+    echo "  [STALE EXEMPT] $tmpl_key — template now carries \"use client\"; remove the DIRECTIVE_EXEMPT entry"
+    DRIFTED+=("$tmpl_key (obsolete DIRECTIVE_EXEMPT entry)")
+  fi
+done
 
 echo "Checking base template files..."
 

--- a/scripts/check-template-drift.sh
+++ b/scripts/check-template-drift.sh
@@ -20,6 +20,41 @@ if [[ -f "$ALLOWLIST" ]]; then
   done < "$ALLOWLIST"
 fi
 
+# ---------------------------------------------------------------------------
+# "use client" directive-parity exceptions
+# ---------------------------------------------------------------------------
+# The whole-file content check above skips anything in .template-drift-allowlist.
+# Several allowlisted island components legitimately diverge in BODY from their
+# host counterpart (no-op stubs, leaner downstream variants) but must still
+# carry the same "use client" module directive — otherwise generated projects
+# ship dead islands that never hydrate and zfb >= next.38 prints island-marker
+# warnings. See zudolab/zudo-doc#2047.
+#
+# check_directive_parity() therefore enforces directive parity for every
+# template/host pair INDEPENDENTLY of the content allowlist. A few template
+# files are intentional no-op base stubs that legitimately ship WITHOUT the
+# host's directive (permanent stubs with no feature counterpart, not registered
+# as live islands in the generated page tree). They are keyed by their
+# template-relative path so the exemption applies to the base stub ONLY — the
+# real feature-template counterparts (which DO carry the directive) stay checked.
+declare -A DIRECTIVE_EXEMPT=(
+  ["base/src/components/design-token-panel-bootstrap.tsx"]=1
+  ["base/src/components/desktop-sidebar-toggle.tsx"]=1
+  ["base/src/components/preset-generator.tsx"]=1
+)
+
+TEMPLATES_DIR="$ROOT_DIR/packages/create-zudo-doc/templates"
+
+# True when the file's FIRST line is a "use client" module directive. The
+# directive is only valid as the very first statement, so line 1 is checked
+# strictly — a "use client" string buried after comments is not a directive.
+has_use_client() {
+  local first
+  first="$(head -1 "$1")"
+  [[ "$first" == '"use client";' || "$first" == "'use client';" \
+    || "$first" == '"use client"' || "$first" == "'use client'" ]]
+}
+
 DRIFTED=()
 
 check_pair() {
@@ -49,12 +84,39 @@ check_pair() {
   fi
 }
 
+check_directive_parity() {
+  local template_file="$1"
+  local prod_path="$2" # relative to repo root
+  local tmpl_key="${template_file#"$TEMPLATES_DIR/"}"
+
+  # Skip files explicitly exempted from directive parity (intentional no-op
+  # base stubs that legitimately ship without the host's "use client").
+  if [[ -n "${DIRECTIVE_EXEMPT[$tmpl_key]+_}" ]]; then
+    return
+  fi
+
+  local prod_file="$ROOT_DIR/$prod_path"
+  # No host counterpart → nothing to compare. The content-drift pass already
+  # reports genuinely-missing prod files when they are not allowlisted.
+  [[ -f "$prod_file" ]] || return
+
+  local host_has=0 tmpl_has=0
+  has_use_client "$prod_file" && host_has=1
+  has_use_client "$template_file" && tmpl_has=1
+
+  if [[ "$host_has" != "$tmpl_has" ]]; then
+    echo "  [USE-CLIENT DRIFT] $prod_path (host=$host_has template=$tmpl_has) [$tmpl_key]"
+    DRIFTED+=("$prod_path (\"use client\" directive)")
+  fi
+}
+
 echo "Checking base template files..."
 
 BASE_DIR="$ROOT_DIR/packages/create-zudo-doc/templates/base"
 while IFS= read -r -d '' template_file; do
   prod_path="${template_file#"$BASE_DIR/"}"
   check_pair "$template_file" "$prod_path"
+  check_directive_parity "$template_file" "$prod_path"
 done < <(find "$BASE_DIR" -type f -print0 | sort -z)
 
 echo "Checking feature template files..."
@@ -68,6 +130,7 @@ for feature_dir in "$FEATURES_DIR"/*/; do
   while IFS= read -r -d '' template_file; do
     prod_path="${template_file#"$files_dir/"}"
     check_pair "$template_file" "$prod_path"
+    check_directive_parity "$template_file" "$prod_path"
   done < <(find "$files_dir" -type f -print0 | sort -z)
 done
 

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+// Scanner-visible ThemeToggle shim. zfb's island scanner does not register
+// "use client" modules located under node_modules (Takazudo/zudo-front-builder#999),
+// so importing the package ThemeToggle straight into the server-rendered header
+// emits an island marker with no matching registry entry — the toggle renders
+// but never hydrates, on every page (zudolab/zudo-doc#2048). This thin
+// project-source wrapper gives the scanner a local binding to register; it
+// re-wraps the bare (non-island-wrapped) package component unchanged.
+import type { JSX } from "preact";
+import {
+  ThemeToggle as ZudoDocThemeToggle,
+  type ThemeToggleProps,
+} from "@takazudo/zudo-doc/theme-toggle";
+
+export function ThemeToggle(props: ThemeToggleProps): JSX.Element {
+  return <ZudoDocThemeToggle {...props} />;
+}
+ThemeToggle.displayName = "ThemeToggle";
+
+export type { ThemeToggleProps };
+
+export default ThemeToggle;


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2050

---

## Summary

Fixes three bugs in the `create-zudo-doc` scaffold templates that shipped broken code to generated/synced consumer projects, and hardens the template-drift tooling so the worst class (dead islands) can't silently recur.

- **#2047 — dead islands in generated projects.** Five template island components lacked the `"use client"` directive their host counterparts carry (`ai-chat-modal`, `doc-history`, `image-enlarge` in `templates/base` plus the `docHistory`/`imageEnlarge` feature copies). zfb's scanner never registered them, so DocHistory/ImageEnlarge/AiChatModal rendered but never hydrated, and zfb ≥ next.38 printed island-marker warnings on every build. The directives are now added, and `scripts/check-template-drift.sh` gained a `check_directive_parity()` pass that asserts host/template directive parity independently of the content allowlist (with an explicit, staleness-guarded `DIRECTIVE_EXEMPT` list for the three intentional no-op base stubs).
- **#2048 — dead header theme toggle for synced consumers.** The 0.2.1 base template imported `ThemeToggle` from `@takazudo/zudo-doc/theme-toggle` directly; the zfb island scanner does not register `"use client"` modules under `node_modules` (zfb#999), so published-package consumers shipped a toggle that rendered but did nothing. The template now ships a thin scanner-visible shim at `src/components/theme-toggle.tsx` (wrapper shape verified downstream in zudo-css-wisdom#103) and the header imports `@/components/theme-toggle`. The shim is mirrored into the host byte-identically so the drift check protects the pair.
- **#2049 — template fails consumer tsc.** The base template `sidebar-tree.tsx` filter input used `e.target.value` (TS2339 under a scaffold's own tsconfig). Now `e.currentTarget.value`, matching the host's existing fix — no cast needed.

## Verification

- Generated-project end-to-end check (scaffold → install published deps → `zfb check` → `zfb build`): zero island-marker warnings for DocHistory/ImageEnlarge/AiChatModal/ThemeToggle; no TS2339 in `sidebar-tree.tsx`. (Remaining Toc/MobileToc/Sidebar warnings are the known upstream scanner gap zfb#999; a pre-existing no-i18n `zfb check` failure was found and raised as #2053.)
- Host: `pnpm check` clean, create-zudo-doc tests 299/299, full build (267 pages) with zero island warnings.
- Review pass fixed a `set -e` abort in the new drift-check code (bare `return` → `return 0`), corrected the `DIRECTIVE_EXEMPT` rationale comment, added BOM/CRLF tolerance and an exemption staleness guard, and cross-referenced the two exemption systems.
- All 14 CI checks green.

## Topic PRs

Topic branches were merged locally into `base/template-fixes` (no separate PRs — the base branch contained all topic commits before push):

- `template-fixes/sidebar-tree-cast` (#2049) — dd281916
- `template-fixes/use-client-islands` (#2047) — 5217290d
- `template-fixes/theme-toggle-shim` (#2048) — 4cf95525

Closes #2047, closes #2048, closes #2049.

🤖 Generated with [Claude Code](https://claude.com/claude-code)