### PR TITLE
fix(create-zudo-doc): generated projects pass zfb check out of the box

### DIFF
--- a/packages/create-zudo-doc/src/settings-gen.ts
+++ b/packages/create-zudo-doc/src/settings-gen.ts
@@ -91,7 +91,10 @@ export function generateSettingsFile(choices: UserChoices): string {
     );
     lines.push(`  } satisfies Record<string, LocaleConfig>,`);
   } else {
-    lines.push(`  locales: {} satisfies Record<string, LocaleConfig>,`);
+    // `as`, not `satisfies`: satisfies keeps the inferred type at literal {},
+    // so Object.entries(settings.locales) in the generated zfb.config.ts
+    // yields unknown values and `zfb check` fails with TS18046 (#2053).
+    lines.push(`  locales: {} as Record<string, LocaleConfig>,`);
   }
 
   // mermaid is controlled by the markdown.features block in zfb.config.ts

--- a/packages/create-zudo-doc/templates/base/zfb-shim.d.ts
+++ b/packages/create-zudo-doc/templates/base/zfb-shim.d.ts
@@ -1,0 +1,167 @@
+// Local type shim for the bare `zfb/config` specifier.
+//
+// `@takazudo/zfb` is consumed as a published npm package (version pinned
+// in the root `package.json`). The package exposes its real config types
+// under the *scoped* subpath `@takazudo/zfb/config` → `dist/config.d.ts`.
+// But `zfb.config.ts` imports from the *bare* specifier `zfb/config`,
+// which zfb's build tool aliases to a runtime-only stub at parse time
+// (`zfb-config-stub.mjs` — `defineConfig` is identity, carrying no types).
+// No real file backs `zfb/config` in `node_modules`, so this ambient
+// declaration is what supplies the `ZfbConfig` type to `zfb.config.ts`.
+//
+// IMPORTANT — this block is the source of truth for the type `zfb check`
+// (plain `tsc --noEmit`) binds against the config. An ambient `declare
+// module` wins over node resolution AND over tsconfig `paths`, so it must
+// be kept in sync BY HAND with the published `@takazudo/zfb/config`
+// (`dist/config.d.ts`). When it lags the engine, valid config fields fail
+// `pnpm check` with TS2353 (see Takazudo/zudo-front-builder#678 +
+// zudolab/zudo-doc#1834 — `bundle` was missing here, blocking next.22's
+// `bundle.exclude`).
+
+declare module "zfb/config" {
+  /** JSX framework runtime. */
+  export type Framework = "preact" | "react";
+
+  /** A content collection registered with the zfb engine. */
+  export interface CollectionDef {
+    /** Identifier used at the call site (e.g. `"docs"`). */
+    name: string;
+    /** Directory (relative to the project root) holding the entries. */
+    path: string;
+    /**
+     * Optional schema. Reserved for v1.1 — accepted but not enforced
+     * today. Authored as zod and converted to JSON Schema via
+     * `z.toJSONSchema()` at the boundary.
+     */
+    schema?: Record<string, unknown>;
+  }
+
+  /** Tailwind options; absent = defaults. */
+  export interface TailwindConfig {
+    enabled?: boolean;
+  }
+
+  /** User-supplied plugin configuration entry. */
+  export interface PluginConfig {
+    name: string;
+    options?: Record<string, unknown>;
+  }
+
+  /**
+   * Bundler options. Mirrors `BundleConfig` in crates/zfb/src/config.rs
+   * and the published `@takazudo/zfb/config` (`dist/config.d.ts`). Added
+   * in next.22 (`bundle.exclude`, #664) and extended in next.23
+   * (`mainFields` / `external`, #676).
+   */
+  export interface BundleConfig {
+    /**
+     * Project-relative, gitignore-style globs for source files the bundler
+     * must NOT pull into the esbuild graph (e.g. test fixtures or
+     * `*.stories.tsx`). Matched files are skipped from the shadow-tree walk
+     * and dropped from any eager `import.meta.glob(...)` expansion.
+     */
+    exclude?: string[];
+    /**
+     * Explicit esbuild `main-fields` for the `--platform=neutral` page/SSR
+     * pass (empty by default under `neutral`), letting CJS-`main`-only deps
+     * resolve. Mirrors `BundleConfig::main_fields`.
+     */
+    mainFields?: string[];
+    /**
+     * Bare specifiers to mark external in the `--platform=neutral` pass so
+     * esbuild leaves them unbundled. Mirrors `BundleConfig::external`.
+     */
+    external?: string[];
+  }
+
+  /** Mirrors the Rust `Config` struct one-for-one. */
+  export interface ZfbConfig {
+    outDir?: string;
+    publicDir?: string;
+    host?: string;
+    port?: number;
+    framework?: Framework;
+    collections?: CollectionDef[];
+    tailwind?: TailwindConfig;
+    /**
+     * Bundler options. `bundle.exclude` keeps project-relative globs out of
+     * the esbuild graph — used here to skip `packages/md-plugins/__fixtures__/**`
+     * so the MDX link resolver no longer walks the test fixtures (silences
+     * ~15 pre-existing broken-link warnings). Mirrors `Config::bundle`.
+     */
+    bundle?: BundleConfig;
+    plugins?: PluginConfig[];
+    adapter?: string;
+    /**
+     * Strip `.md` / `.mdx` from in-page `<a href>` paths and append a
+     * trailing `/` so author-written `[label](other.mdx)` references
+     * resolve to the rendered route URL. Mirrors Config::strip_md_ext
+     * in crates/zfb/src/config.rs (zudolab/zfb#131).
+     */
+    stripMdExt?: boolean;
+    /**
+     * Site base path. Prefixed onto stable HTML asset URLs (CSS / JS
+     * `<link>` and `<script>` tags). Normalised to start AND end with
+     * `/`; `undefined` / `""` / `"/"` all behave identically (no
+     * prefix). Mirrors Config::base in crates/zfb/src/config.rs
+     * (Takazudo/zudo-front-builder#154).
+     */
+    base?: string;
+    /**
+     * Configures the syntect-based syntax highlighter shipped with zfb.
+     * Mirrors `code_highlight` in crates/zfb/src/config.rs (Takazudo/zudo-front-builder#188 / sub #194; landed in commit 339e30f).
+     * When omitted, the engine falls back to the hardcoded default theme `base16-ocean.dark`.
+     */
+    codeHighlight?: {
+      theme?: string;
+      themesDir?: string;
+    };
+    /**
+     * Markdown link resolver (port of `remarkResolveMarkdownLinks`).
+     * Mirrors `Config::resolve_markdown_links` in crates/zfb/src/config.rs
+     * (Takazudo/zudo-front-builder PR #234 / zudolab/zudo-doc#1577).
+     * When `enabled: true`, the build appends `ResolveLinksPlugin` to the
+     * mdast pipeline so author-written `[label](./other.mdx)` links are
+     * rewritten to the corresponding rendered route URL — bypassing the
+     * file→directory transformation that breaks relative paths in dist
+     * HTML when `foo.mdx` becomes `foo/index.html`.
+     */
+    resolveMarkdownLinks?: {
+      enabled?: boolean;
+      docsDir?: string;
+      dirs?: Array<{ dir: string; routePrefix: string }>;
+      onBrokenLinks?: "warn" | "error" | "ignore";
+    };
+    /**
+     * Whether the basePath rewriter should append a trailing `/` to
+     * extensionless absolute hrefs. Mirrors `Config::trailing_slash` in
+     * crates/zfb/src/config.rs (Takazudo/zudo-front-builder PR #234 /
+     * zudolab/zudo-doc#1579). Off by default — preserves byte-for-byte
+     * parity with the pre-`trailingSlash` build for projects that
+     * haven't opted in.
+     */
+    trailingSlash?: boolean;
+    /**
+     * Markdown / MDX pipeline options. Mirrors `Config::markdown` →
+     * `MarkdownConfig` in crates/zfb/src/config.rs. zfb next.12 moved the
+     * former-Core features under `markdown.features` and next.13 ships the
+     * rest as opt-in; zudo-doc uses `markdown.features` to opt back into the
+     * former-Core four plus the additional opt-in features (#1804). Each
+     * `features` value is per-feature: `true` for boolean-shorthand features,
+     * or an options object for object-typed features.
+     */
+    markdown?: {
+      gfm?: boolean | Record<string, boolean>;
+      toc?: Record<string, unknown>;
+      externalLinks?: Record<string, unknown>;
+      cjkFriendly?: boolean;
+      features?: Record<string, boolean | Record<string, unknown>>;
+    };
+  }
+
+  /**
+   * Identity helper: returns the supplied config as-is, but typed
+   * against `ZfbConfig`. Use as the default export of `zfb.config.ts`.
+   */
+  export function defineConfig(config: ZfbConfig): ZfbConfig;
+}


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2053

---

## Summary

Auto-fix for #2053, raised during the template-fixes workflow (PR #2051). Generated projects failed `zfb check` out of the box, in two layers:

- **TS18046 (non-i18n scaffolds):** `settings-gen.ts` emitted `locales: {} satisfies Record<string, LocaleConfig>` — `satisfies` keeps the inferred type at literal `{}`, so `Object.entries(settings.locales)` in the generated `zfb.config.ts` yields `unknown` values. Now emits `{} as Record<string, LocaleConfig>`.
- **TS2307 (ALL scaffolds):** the bare `zfb/config` specifier has no backing file in `node_modules`; the host supplies its types via the ambient `zfb-shim.d.ts`, which the template never shipped. The shim is now in `templates/base/` byte-identical to the host's, which also puts it under template-drift protection going forward.

## Verification

- Fresh scaffold (docHistory + imageEnlarge, no i18n) → `pnpm install` → `zfb check` → **no errors** (was: 2× TS18046 + TS2307).
- create-zudo-doc unit tests 299/299.
- Light review (opus): no actionable findings.

Closes #2053.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783771110&installation_id=130359969&pr_number=2054&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2054&signature=161d8f562f3460c9f68b0efd7b49244cfe16b2546a1da009804dbb753bf82aaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->