### PR TITLE
fix(create-zudo-doc): wire tauri FindInPageInit island into generated body-end islands

### DIFF
--- a/.template-drift-allowlist
+++ b/.template-drift-allowlist
@@ -153,6 +153,14 @@ src/components/preset-generator.tsx
 # injection too (unlikely — host does not use the compose framework).
 pages/_mdx-components.ts
 
+# #2052 — pages/lib/_body-end-islands.tsx template carries @slot: injection
+# anchors (imports / display-names / extra-islands) so the tauri feature can
+# inject the FindInPageInit island mount. The host has no find-in-page wiring
+# (its counterparts were deleted in S1 #1928), so the anchors exist only in
+# the template — same anchor-carrying-template precedent as
+# pages/_mdx-components.ts above. These will never be byte-identical.
+pages/lib/_body-end-islands.tsx
+
 # W8A (#1739) entries for src/components/content/heading-h3.tsx and
 # src/hooks/use-active-heading.ts were REMOVED in #2012 (S3 package-boundary
 # cleanup): heading-h3 is de-duplicated into @takazudo/zudo-doc/content and

--- a/packages/create-zudo-doc/CLAUDE.md
+++ b/packages/create-zudo-doc/CLAUDE.md
@@ -40,11 +40,13 @@ This replaces the old "copy everything then strip" approach. Features are added,
 
 ### Injection Anchors
 
-The only file shipped with anchors in `templates/base/` today is:
+The files shipped with anchors in `templates/base/` today are:
 
 - `src/styles/global.css` — 2 anchors (`@slot:global-css:theme-tokens`, `@slot:global-css:feature-styles`)
+- `pages/_mdx-components.ts` — anchors consumed by the imageEnlarge feature
+- `pages/lib/_body-end-islands.tsx` — anchors consumed by the tauri feature
 
-Only `src/styles/global.css` carries injection anchors. Feature-specific files are copied wholesale from `templates/features/<name>/files/`; no anchor injection into doc-layout/header is required post-zfb-cutover. The `ANCHOR_FILES` list in `src/compose.ts` is the source of truth for which files are anchor-cleaned after composition.
+The `ANCHOR_FILES` list in `src/compose.ts` is the source of truth for which files are anchor-cleaned after composition. Feature-specific files are copied wholesale from `templates/features/<name>/files/`; no anchor injection into doc-layout/header is required post-zfb-cutover.
 
 `src/compose.ts` `ANCHOR_LINE_RE` accepts JSX-comment (`{/* @slot:… */}`), block-comment, line-comment, HTML-comment, and shell-comment forms so anchors work across `.tsx`, `.ts`, and `.css`.
 

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -1125,6 +1125,72 @@ describe("scaffold — tauri feature", () => {
     );
     expect(pkg.scripts["dev:tauri"]).toBeUndefined();
   });
+
+  it("wires the FindInPageInit island into pages/lib/_body-end-islands.tsx when tauri is enabled", async () => {
+    const choices: UserChoices = {
+      projectName: "test-tauri-find-in-page",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search", "tauri"],
+      packageManager: "pnpm",
+    };
+    await scaffold(choices);
+
+    const bodyEnd = await fs.readFile(
+      projectPath(
+        "test-tauri-find-in-page",
+        "pages/lib/_body-end-islands.tsx",
+      ),
+      "utf-8",
+    );
+    // The three injections: import, displayName, Island mount. Without them
+    // the component files are orphaned and zfb's island scanner never
+    // registers FindInPageInit (#2052).
+    expect(bodyEnd).toContain(
+      'import FindInPageInit from "@/components/find-in-page-init";',
+    );
+    expect(bodyEnd).toContain('displayName = "FindInPageInit"');
+    expect(bodyEnd).toContain("<FindInPageInit />");
+    // Keybind interceptor must hydrate at load, not idle.
+    expect(bodyEnd).toMatch(/when: "load",\s*\n\s*children: <FindInPageInit \/>/);
+    // No leftover slot anchors in the generated output.
+    expect(bodyEnd).not.toContain("@slot:");
+
+    // The island entry module must carry the "use client" directive so it
+    // is bundled as a live island.
+    const initComponent = await fs.readFile(
+      projectPath(
+        "test-tauri-find-in-page",
+        "src/components/find-in-page-init.tsx",
+      ),
+      "utf-8",
+    );
+    expect(initComponent.split("\n")[0]).toBe('"use client";');
+  });
+
+  it("does NOT reference FindInPageInit in pages/lib/_body-end-islands.tsx when tauri is disabled", async () => {
+    const choices: UserChoices = {
+      projectName: "test-no-tauri-find-in-page",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search"],
+      packageManager: "pnpm",
+    };
+    await scaffold(choices);
+
+    const bodyEnd = await fs.readFile(
+      projectPath(
+        "test-no-tauri-find-in-page",
+        "pages/lib/_body-end-islands.tsx",
+      ),
+      "utf-8",
+    );
+    expect(bodyEnd).not.toContain("FindInPageInit");
+    // No leftover slot anchors in the generated output.
+    expect(bodyEnd).not.toContain("@slot:");
+  });
 });
 
 describe("scaffold — tauri-dev feature (Mode 2)", () => {

--- a/packages/create-zudo-doc/src/compose.ts
+++ b/packages/create-zudo-doc/src/compose.ts
@@ -243,11 +243,14 @@ export function validateDependencies(
  * - `pages/_mdx-components.ts` — image-enlarge.ts injects the
  *   EnlargeableParagraph p-override (ENLARGE_SVG, EnlargeableParagraph def,
  *   `p:` map entry) when imageEnlarge is enabled.
- *
- * The .tsx anchor form is still supported in `ANCHOR_LINE_RE` for forward
- * compatibility.
+ * - `pages/lib/_body-end-islands.tsx` — tauri.ts injects the FindInPageInit
+ *   island (import, displayName, Island mount) when tauri is enabled.
  */
-export const ANCHOR_FILES = ["src/styles/global.css", "pages/_mdx-components.ts"];
+export const ANCHOR_FILES = [
+  "src/styles/global.css",
+  "pages/_mdx-components.ts",
+  "pages/lib/_body-end-islands.tsx",
+];
 
 /**
  * Main composition entry point. Orchestrates the full feature composition

--- a/packages/create-zudo-doc/src/features/tauri.ts
+++ b/packages/create-zudo-doc/src/features/tauri.ts
@@ -5,15 +5,58 @@ import type { FeatureModule } from "../compose.js";
 /**
  * Tauri feature.
  *
- * W7A (#1736): post-cutover, the FindInPage island is mounted by the
- * pages/lib body-end wrapper. The find-match highlight CSS is unconditional
- * in `templates/base/src/styles/global.css` (matches host). Only the
- * postProcess hooks (Cargo.toml / tauri.conf.json / .gitignore patches)
- * remain feature-scoped.
+ * #2052: the FindInPageInit island (Cmd/Ctrl+F find bar for the Tauri
+ * WebView, where the browser-native find UI is unavailable) is wired into
+ * `pages/lib/_body-end-islands.tsx` via the three injections below — import,
+ * displayName, and Island mount. zfb's island scanner only registers
+ * components reachable through static import chains (page → wrapper →
+ * component), so without this injection the feature-copied component files
+ * are orphaned dead code that never hydrates. The find-match highlight CSS
+ * is unconditional in `templates/base/src/styles/global.css` (matches host);
+ * the component runtime-gates itself (renders null unless
+ * `window.__TAURI_INTERNALS__` exists), so no settings field is needed.
  */
 export const tauriFeature: FeatureModule = (choices) => ({
   name: "tauri",
-  injections: [],
+  injections: [
+    // 1. Import the island entry. Inserted AFTER the
+    //    `// @slot:body-end-islands:imports` anchor.
+    {
+      file: "pages/lib/_body-end-islands.tsx",
+      anchor: "// @slot:body-end-islands:imports",
+      position: "after",
+      content: `import FindInPageInit from "@/components/find-in-page-init";`,
+    },
+    // 2. Stable island marker name (same belt-and-braces guard as the
+    //    sibling islands in the file). Inserted AFTER the
+    //    `// @slot:body-end-islands:display-names` anchor.
+    {
+      file: "pages/lib/_body-end-islands.tsx",
+      anchor: "// @slot:body-end-islands:display-names",
+      position: "after",
+      content: `(FindInPageInit as { displayName?: string }).displayName = "FindInPageInit";`,
+    },
+    // 3. Island mount. Inserted AFTER the
+    //    `{/* @slot:body-end-islands:extra-islands */}` anchor.
+    //    when="load" (not "idle"): the island's job is to intercept
+    //    Cmd/Ctrl+F via a keydown listener, so it must hydrate as soon as
+    //    the islands runtime mounts — same rationale as the
+    //    clientRouterBootstrap click intercept above it. Deferring to idle
+    //    would leave a post-load window where Cmd+F does nothing, which is
+    //    the very bug this injection fixes.
+    {
+      file: "pages/lib/_body-end-islands.tsx",
+      anchor: "{/* @slot:body-end-islands:extra-islands */}",
+      position: "after",
+      content: `      {/* Tauri-only find-in-page (Cmd/Ctrl+F) bar. Renders null outside
+          a Tauri WebView, so the island is inert in plain browser builds
+          of the same scaffold. */}
+      {Island({
+        when: "load",
+        children: <FindInPageInit />,
+      }) as unknown as VNode}`,
+    },
+  ],
   postProcess: async (targetDir) => {
     // Patch Cargo.toml package name
     const cargoPath = path.join(targetDir, "src-tauri/Cargo.toml");

--- a/packages/create-zudo-doc/templates/base/pages/lib/_body-end-islands.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_body-end-islands.tsx
@@ -37,6 +37,7 @@ import ClientRouterBootstrap from "@/components/client-router-bootstrap";
 import DesignTokenPanelBootstrap from "@/components/design-token-panel-bootstrap";
 import ImageEnlarge, { ImageEnlargeSsrFallback } from "@/components/image-enlarge";
 import { PageLoadingOverlay } from "@takazudo/zudo-doc/page-loading";
+// @slot:body-end-islands:imports
 
 // Set explicit `displayName` on each default-exported island so zfb's
 // `captureComponentName` produces a stable marker even after the SSR
@@ -51,6 +52,7 @@ import { PageLoadingOverlay } from "@takazudo/zudo-doc/page-loading";
 (DesignTokenPanelBootstrap as { displayName?: string }).displayName =
   "DesignTokenPanelBootstrap";
 (ImageEnlarge as { displayName?: string }).displayName = "ImageEnlarge";
+// @slot:body-end-islands:display-names
 
 /**
  * Default sr-only label rendered as the AiChatModal SSR fallback. This
@@ -196,6 +198,7 @@ export function BodyEndIslands({
       <h2 class="sr-only">AI Assistant</h2>
       {aiChat}
       {imageEnlarge}
+      {/* @slot:body-end-islands:extra-islands */}
     </>
   );
 }

--- a/packages/create-zudo-doc/templates/features/tauri/files/src/components/find-in-page-init.tsx
+++ b/packages/create-zudo-doc/templates/features/tauri/files/src/components/find-in-page-init.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState, useEffect, useRef } from "preact/compat";
 import { FindBar } from "./find-bar";
 import { createFindInPage } from "@/utils/find-in-page";

--- a/packages/create-zudo-doc/templates/features/tauri/files/src/components/find-in-page-init.tsx
+++ b/packages/create-zudo-doc/templates/features/tauri/files/src/components/find-in-page-init.tsx
@@ -32,14 +32,18 @@ export default function FindInPageInit() {
     return () => document.removeEventListener("keydown", handler);
   }, [isTauri]);
 
-  // Clear search on zfb page navigation
+  // Clear search on zfb page navigation. zfb navigates via SPA body swap and
+  // fires "zfb:before-preparation" on document before nav — it never fires the
+  // native "pagehide" (full-unload) event. The literal is inlined because
+  // downstream scaffolds do not depend on @takazudo/zudo-doc as a runtime dep
+  // (same reason as the designTokenPanel bootstrap).
   useEffect(() => {
     const handler = () => {
       findInPageRef.current.stop();
       setVisible(false);
     };
-    document.addEventListener("pagehide", handler);
-    return () => document.removeEventListener("pagehide", handler);
+    document.addEventListener("zfb:before-preparation", handler);
+    return () => document.removeEventListener("zfb:before-preparation", handler);
   }, []);
 
   if (!isTauri) return null;


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2052

---

## Summary

The `tauri` feature of create-zudo-doc shipped a find-in-page island (`find-in-page-init.tsx`, `find-bar.tsx`, `find-in-page.ts`) that no generated page imported. zfb's island scanner only registers components reachable through static import chains (page → wrapper → component), so the components shipped as orphaned dead code and Cmd/Ctrl+F did nothing in generated Tauri desktop apps (#2052).

This PR wires `FindInPageInit` into the generated `pages/lib/_body-end-islands.tsx` via the compose framework's anchor-injection system — the same precedent as the imageEnlarge feature's `pages/_mdx-components.ts` injections (S2 #1825).

## Changes

- **`templates/base/pages/lib/_body-end-islands.tsx`** — three new `@slot:body-end-islands:*` anchors (`imports` / `display-names` / `extra-islands`)
- **`src/features/tauri.ts`** — three injections: component import, `displayName` assignment (stable island marker), and the `Island` mount. `when: "load"` (not `idle`): a keybind interceptor must hydrate as soon as the islands runtime mounts — same rationale as `clientRouterBootstrap`; deferring to idle would leave a post-load window where Cmd+F is dead. Stale W7A doc comment (which claimed the island was already mounted) replaced
- **`src/compose.ts`** — `pages/lib/_body-end-islands.tsx` registered in `ANCHOR_FILES` so unused anchors are cleaned when tauri is off
- **`templates/features/tauri/files/src/components/find-in-page-init.tsx`** — `"use client"` added (it is now a live island entry); review fix: the nav-cleanup effect now listens on `zfb:before-preparation` instead of `pagehide`, which zfb's SPA body-swap navigation never fires (the stale find-bar/highlight state would otherwise persist across in-app navigation)
- **`.template-drift-allowlist`** — anchor-carrying template allowlisted (host has no find-in-page wiring; counterparts deleted in S1 #1928)
- **`packages/create-zudo-doc/CLAUDE.md`** — stale "only global.css carries anchors" claim corrected to list all three anchor files
- **`src/__tests__/scaffold.test.ts`** — tauri ON: import + displayName + `when: "load"` mount present, no leftover anchors, `"use client"` first line; tauri OFF: no `FindInPageInit` reference, no leftover anchors

## Test Plan

- [x] `pnpm test` in `packages/create-zudo-doc` — 301/301 pass (2 new tests)
- [x] `pnpm check` — clean
- [x] Template drift check — clean (CI `Template Drift Check` job green)
- [x] Real tauri-ON scaffold to a temp dir — generated `_body-end-islands.tsx` composes correctly (import line 41, displayName line 57, `when: "load"` mount in JSX, anchors cleaned)
- [ ] Full CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)