### PR TITLE
Island wiring fixes: inert drawer, gated body-end islands, layout shims

### DIFF
--- a/.template-drift-allowlist
+++ b/.template-drift-allowlist
@@ -182,3 +182,14 @@ src/components/find-bar.tsx
 src/utils/find-in-page.ts
 src/utils/content-files.ts
 src/utils/git-info.ts
+
+# #2057 — TOC-title resolver for the scanner-visible Toc/MobileToc shims.
+# Deliberate, behaviour-preserving divergence: the HOST resolves
+# @takazudo/zudo-doc as a workspace package and imports the real `getTocTitle`
+# from the /toc barrel (a single re-export line). The TEMPLATE hand-mirrors the
+# lang→title map locally because scaffolded projects install the PUBLISHED
+# @takazudo/zudo-doc (<= 0.2.2), which does not export `getTocTitle` yet.
+# Keep the two in behavioural sync; the template can switch to the import once
+# its pinned @takazudo/zudo-doc dependency moves past 0.2.2. Confined to this
+# tiny helper so the byte-identical _doc-page-shell.tsx stays fully drift-checked.
+pages/lib/_toc-title.ts

--- a/e2e/smoke-mobile-sidebar.spec.ts
+++ b/e2e/smoke-mobile-sidebar.spec.ts
@@ -108,4 +108,45 @@ test.describe("Mobile sidebar", () => {
     // Sidebar should be closed after navigation (via astro:after-swap handler)
     await expect(page.locator('button[aria-label="Open sidebar"]')).toBeVisible({ timeout: 5000 });
   });
+
+  test("closed sidebar panel is inert and unfocusable; opening clears inert", async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto(DOCS_PAGE, { waitUntil: "load" });
+
+    const sidebarPanel = page.locator("header aside");
+    await expect(sidebarPanel).toBeAttached();
+
+    // Closed by default: the panel is only visually hidden via
+    // `-translate-x-full`, so it must be `inert` to keep its links/filter/
+    // buttons out of the tab order and the accessibility tree
+    // (zudolab/zudo-doc#2059). `inert` is present in the SSR markup, so this
+    // holds even before hydration.
+    const closedState = await sidebarPanel.evaluate((el) => ({
+      inertProp: (el as HTMLElement).inert,
+      hasAttr: el.hasAttribute("inert"),
+    }));
+    expect(closedState.inertProp).toBe(true);
+    expect(closedState.hasAttr).toBe(true);
+
+    // A link inside the inert panel cannot take focus (inert blocks focus).
+    const closedLink = sidebarPanel.locator("a").first();
+    if (await closedLink.count()) {
+      const focusedWhileInert = await closedLink.evaluate((el) => {
+        (el as HTMLElement).focus();
+        return document.activeElement === el;
+      });
+      expect(focusedWhileInert).toBe(false);
+    }
+
+    // Opening the drawer clears `inert`, restoring focusability.
+    await page.locator('button[aria-label="Open sidebar"]').click();
+    await expect(page.locator('button[aria-label="Close sidebar"]')).toBeVisible();
+
+    const openState = await sidebarPanel.evaluate((el) => ({
+      inertProp: (el as HTMLElement).inert,
+      hasAttr: el.hasAttribute("inert"),
+    }));
+    expect(openState.inertProp).toBe(false);
+    expect(openState.hasAttr).toBe(false);
+  });
 });

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -146,6 +146,58 @@ describe("scaffold — minimal (no i18n, search only, single dark scheme)", () =
     expect(content).toContain("export default");
   });
 
+  // #2057: scanner-visible Toc/MobileToc shims ship in the base template so
+  // generated projects (which install the PUBLISHED @takazudo/zudo-doc, whose
+  // "use client" island modules zfb's scanner skips under node_modules — zfb#999)
+  // get a local binding the scanner can register. _doc-page-shell.tsx mounts
+  // them via tocOverride/mobileTocOverride.
+  it("ships scanner-visible Toc/MobileToc shims with 'use client' + pinned displayName (#2057)", async () => {
+    const tocPath = projectPath("test-minimal", "src/components/toc.tsx");
+    const mobileTocPath = projectPath(
+      "test-minimal",
+      "src/components/mobile-toc.tsx",
+    );
+    expect(await fs.pathExists(tocPath)).toBe(true);
+    expect(await fs.pathExists(mobileTocPath)).toBe(true);
+
+    const toc = await fs.readFile(tocPath, "utf-8");
+    expect(toc.startsWith('"use client";')).toBe(true);
+    expect(toc).toContain('from "@takazudo/zudo-doc/toc"');
+    expect(toc).toContain('Toc.displayName = "Toc";');
+
+    const mobileToc = await fs.readFile(mobileTocPath, "utf-8");
+    expect(mobileToc.startsWith('"use client";')).toBe(true);
+    expect(mobileToc).toContain('from "@takazudo/zudo-doc/toc"');
+    expect(mobileToc).toContain('MobileToc.displayName = "MobileToc";');
+  });
+
+  // #2057: the doc-page shell mounts the local shims via the override props and
+  // derives the TOC title from the hand-mirrored _toc-title helper (the
+  // published package this scaffold installs does not export getTocTitle yet).
+  it("wires tocOverride/mobileTocOverride in _doc-page-shell with the _toc-title helper (#2057)", async () => {
+    const shellPath = projectPath(
+      "test-minimal",
+      "pages/lib/_doc-page-shell.tsx",
+    );
+    const shell = await fs.readFile(shellPath, "utf-8");
+    expect(shell).toContain('import { Toc } from "@/components/toc";');
+    expect(shell).toContain(
+      'import { MobileToc } from "@/components/mobile-toc";',
+    );
+    expect(shell).toContain('import { getTocTitle } from "./_toc-title";');
+    expect(shell).toContain("tocOverride={tocOverride}");
+    expect(shell).toContain("mobileTocOverride={mobileTocOverride}");
+
+    const tocTitlePath = projectPath(
+      "test-minimal",
+      "pages/lib/_toc-title.ts",
+    );
+    expect(await fs.pathExists(tocTitlePath)).toBe(true);
+    const tocTitle = await fs.readFile(tocTitlePath, "utf-8");
+    expect(tocTitle).toContain("export function getTocTitle");
+    expect(tocTitle).toContain('"目次"');
+  });
+
   it(".gitignore includes standard Node + macOS + Cloudflare entries", async () => {
     const gitignore = await fs.readFile(
       projectPath("test-minimal", ".gitignore"),

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -1193,6 +1193,41 @@ describe("scaffold — tauri feature", () => {
   });
 });
 
+describe("scaffold — body-end-islands feature gating (#2058)", () => {
+  // pages/lib/_body-end-islands.tsx feature-gates the AiChatModal island +
+  // sr-only "AI Assistant" landmark on settings.aiAssistant and the
+  // ImageEnlarge island on settings.imageEnlarge, mirroring the existing
+  // designTokenPanel gating. The conditionals are part of the wholesale-copied
+  // base template, so every scaffold variant carries them regardless of the
+  // flag values — a feature-off consumer (aiAssistant/imageEnlarge false) then
+  // ships neither the dead island marker nor the misleading landmark heading.
+  it("gates AiChatModal/heading on aiAssistant and ImageEnlarge on imageEnlarge", async () => {
+    const choices: UserChoices = {
+      projectName: "test-body-end-gating",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search", "imageEnlarge"],
+      packageManager: "pnpm",
+    };
+    await scaffold(choices);
+
+    const bodyEnd = await fs.readFile(
+      projectPath("test-body-end-gating", "pages/lib/_body-end-islands.tsx"),
+      "utf-8",
+    );
+    // AI assistant gating wraps both the island and the landmark heading.
+    expect(bodyEnd).toContain("settings.aiAssistant ?");
+    expect(bodyEnd).toContain('<h2 class="sr-only">AI Assistant</h2>');
+    // Image-enlarge island gating.
+    expect(bodyEnd).toContain("settings.imageEnlarge");
+    // designTokenPanel gating stays in place and untouched.
+    expect(bodyEnd).toContain("settings.designTokenPanel");
+    // No leftover slot anchors in the generated output.
+    expect(bodyEnd).not.toContain("@slot:");
+  });
+});
+
 describe("scaffold — tauri-dev feature (Mode 2)", () => {
   it("generates src-tauri-dev/ when tauriDev is enabled", async () => {
     const choices: UserChoices = {

--- a/packages/create-zudo-doc/templates/base/pages/404.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/404.tsx
@@ -36,6 +36,11 @@ export default function NotFoundPage(): JSX.Element {
       noindex={true}
       hideSidebar={true}
       hideToc={true}
+      // Empty fragment suppresses DocLayoutWithDefaults' empty-data default
+      // Sidebar island — its marker never hydrates for published-package
+      // consumers (zfb#999) and zfb >= next.38 warns about it; the sidebar is
+      // hidden on this page anyway (zudolab/zudo-doc#2057).
+      sidebarOverride={<></>}
       headerOverride={<HeaderWithDefaults lang={locale} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
       bodyEndComponents={<BodyEndIslands basePath={settings.base ?? "/"} />}

--- a/packages/create-zudo-doc/templates/base/pages/index.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/index.tsx
@@ -65,6 +65,11 @@ export default function IndexPage(): JSX.Element {
       noindex={settings.noindex}
       hideSidebar={true}
       hideToc={true}
+      // Empty fragment suppresses DocLayoutWithDefaults' empty-data default
+      // Sidebar island — its marker never hydrates for published-package
+      // consumers (zfb#999) and zfb >= next.38 warns about it; the sidebar is
+      // hidden on this page anyway (zudolab/zudo-doc#2057).
+      sidebarOverride={<></>}
       headerOverride={<HeaderWithDefaults lang={locale} currentPath={withBase("/")} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
       bodyEndComponents={<BodyEndIslands basePath={settings.base ?? "/"} />}

--- a/packages/create-zudo-doc/templates/base/pages/lib/_body-end-islands.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_body-end-islands.tsx
@@ -109,10 +109,14 @@ export interface BodyEndIslandsProps {
 }
 
 /**
- * The three default body-end islands every doc page mounts: the
- * design-token tweak panel (overlay, fixed-position), the AI chat
- * modal (`<dialog>` overlay), and the image-enlarge dialog (mounted
- * lazily based on viewport scan).
+ * The default body-end islands a doc page may mount: the design-token
+ * tweak panel (overlay, fixed-position), the AI chat modal (`<dialog>`
+ * overlay), and the image-enlarge dialog (mounted lazily based on
+ * viewport scan). Each is feature-gated — the design-token panel on
+ * `settings.designTokenPanel`, the AI chat modal (and its sr-only
+ * landmark heading) on `settings.aiAssistant`, and image-enlarge on
+ * `settings.imageEnlarge` — so a feature-off consumer ships neither the
+ * island marker nor a misleading landmark (zudolab/zudo-doc#2058).
  *
  * Each island is wrapped in `<Island ssrFallback>` so the heavy
  * component is NOT evaluated server-side — they depend on
@@ -120,9 +124,10 @@ export interface BodyEndIslandsProps {
  * fetch, etc. The hydration runtime swaps each placeholder on the
  * client.
  *
- * The `<h2 class="sr-only">AI Assistant</h2>` heading is emitted in
- * the SSG output so screen readers and crawlers can discover the chat
- * section landmark before JS hydration.
+ * When `settings.aiAssistant` is enabled, the
+ * `<h2 class="sr-only">AI Assistant</h2>` heading is emitted in the SSG
+ * output so screen readers and crawlers can discover the chat section
+ * landmark before JS hydration.
  */
 export function BodyEndIslands({
   basePath,
@@ -163,26 +168,52 @@ export function BodyEndIslands({
         )
       : null;
 
-  // Use a visually-hidden paragraph as the AiChatModal SSR fallback so
-  // the body label is present in static HTML for screen readers before
-  // JS hydration. sr-only keeps it invisible to sighted users.
-  const aiChat = Island({
-    ssrFallback: <p class="sr-only">{aiChatBodyLabel}</p>,
-    children: <AiChatModal basePath={basePath} />,
-  }) as unknown as VNode;
+  // Gated on `settings.aiAssistant` (zudolab/zudo-doc#2058): when the AI
+  // assistant feature is off, neither the AiChatModal island marker nor the
+  // sr-only "AI Assistant" landmark heading should reach the SSG output —
+  // otherwise feature-off consumers ship a dead island marker plus a
+  // misleading screen-reader landmark for a section that never hydrates.
+  // Mirrors the `designTokenPanel` gating above.
+  //
+  // KNOWN CAVEAT: zfb's island scanner walks the static `"use client"`
+  // import chain, so gating this JSX removes the SSR marker and heading but
+  // may NOT strip the AiChatModal bundle from the build output. Marker
+  // removal is the agreed first fix (#2058); bundle stripping is out of scope.
+  //
+  // The sr-only <p> fallback keeps the body label in static HTML for screen
+  // readers before JS hydration; sr-only keeps it invisible to sighted users.
+  const aiAssistant = settings.aiAssistant ? (
+    <>
+      {/* Emits the "AI Assistant" heading in the SSG output so screen
+          readers can discover the chat section landmark before JS
+          hydration. */}
+      <h2 class="sr-only">AI Assistant</h2>
+      {
+        Island({
+          ssrFallback: <p class="sr-only">{aiChatBodyLabel}</p>,
+          children: <AiChatModal basePath={basePath} />,
+        }) as unknown as VNode
+      }
+    </>
+  ) : null;
 
-  // Wave 11 (zudolab/zudo-doc#1355): the SSR fallback is the empty,
-  // closed `<dialog class="zd-enlarge-dialog ...">` shell so the dist
-  // HTML carries one dialog from the start. Without this the smoke
-  // "exactly one zd-enlarge-dialog element" assertion sees zero
-  // (skip-ssr placeholders are empty divs) and the no-JS path has no
-  // dialog at all. Hydration replaces this shell with the real
-  // ImageEnlarge component when the page goes idle.
-  const imageEnlarge = Island({
-    when: "idle",
-    ssrFallback: <ImageEnlargeSsrFallback />,
-    children: <ImageEnlarge />,
-  }) as unknown as VNode;
+  // Gated on `settings.imageEnlarge` (zudolab/zudo-doc#2058). Same caveat as
+  // the AI assistant gating: removing this JSX drops the SSR dialog shell and
+  // island marker, but the bundle may persist via the static import scan.
+  //
+  // Wave 11 (zudolab/zudo-doc#1355): the SSR fallback is the empty, closed
+  // `<dialog class="zd-enlarge-dialog ...">` shell so the dist HTML carries
+  // one dialog from the start. Without this the smoke "exactly one
+  // zd-enlarge-dialog element" assertion sees zero (skip-ssr placeholders are
+  // empty divs) and the no-JS path has no dialog at all. Hydration replaces
+  // this shell with the real ImageEnlarge component when the page goes idle.
+  const imageEnlarge = settings.imageEnlarge
+    ? (Island({
+        when: "idle",
+        ssrFallback: <ImageEnlargeSsrFallback />,
+        children: <ImageEnlarge />,
+      }) as unknown as VNode)
+    : null;
 
   return (
     <>
@@ -192,11 +223,7 @@ export function BodyEndIslands({
       <PageLoadingOverlay />
       {clientRouterBootstrap}
       {designTokenPanelBootstrap}
-      {/* Emits the "AI Assistant" heading in the SSG output so screen
-          readers can discover the chat section landmark before JS
-          hydration. */}
-      <h2 class="sr-only">AI Assistant</h2>
-      {aiChat}
+      {aiAssistant}
       {imageEnlarge}
       {/* @slot:body-end-islands:extra-islands */}
     </>

--- a/packages/create-zudo-doc/templates/base/pages/lib/_doc-page-shell.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_doc-page-shell.tsx
@@ -17,9 +17,13 @@
 // keeping the create-zudo-doc template copies byte-identical to the host.
 
 import type { ComponentChildren, JSX, VNode } from "preact";
+import { Island } from "@takazudo/zfb";
 import { settings } from "@/config/settings";
 import type { NavNode } from "@/utils/docs";
 import { DocLayoutWithDefaults } from "@takazudo/zudo-doc/doclayout";
+import { Toc } from "@/components/toc";
+import { MobileToc } from "@/components/mobile-toc";
+import { getTocTitle } from "./_toc-title";
 import { Breadcrumb } from "@takazudo/zudo-doc/breadcrumb";
 import { NavCardGrid } from "@takazudo/zudo-doc/nav-indexing";
 import { HeadWithDefaults } from "./_head-with-defaults";
@@ -145,6 +149,31 @@ export function DocPageShell(props: DocPageShellProps): JSX.Element {
     docHistorySlot,
   } = props;
 
+  // TOC overrides: mount the scanner-visible local Toc/MobileToc shims instead
+  // of DocLayoutWithDefaults' package-internal default islands. zfb's island
+  // scanner skips "use client" modules under node_modules
+  // (Takazudo/zudo-front-builder#999), so the package defaults emit markers
+  // that never hydrate for published-package consumers (zudolab/zudo-doc#2057).
+  // The gating mirrors the package's `shouldRenderDefaultToc` exactly
+  // (`!hideToc && headings.length > 0`) so an undefined override never silently
+  // falls back to the dead package default. Each shim is wrapped in
+  // `<Island when="load">` here (the call site), matching how the package wraps
+  // its own default — the bundle then hydrates the bare nav/panel in place.
+  const tocTitle = getTocTitle(locale);
+  const shouldRenderToc = !hideToc && headings.length > 0;
+  const tocOverride = shouldRenderToc
+    ? (Island({
+        when: "load",
+        children: <Toc headings={headings} title={tocTitle} />,
+      }) as unknown as VNode)
+    : undefined;
+  const mobileTocOverride = shouldRenderToc
+    ? (Island({
+        when: "load",
+        children: <MobileToc headings={headings} title={tocTitle} />,
+      }) as unknown as VNode)
+    : undefined;
+
   return (
     <DocLayoutWithDefaults
       title={composeMetaTitle(title)}
@@ -183,6 +212,8 @@ export function DocPageShell(props: DocPageShellProps): JSX.Element {
           currentPath={currentPath}
         />
       }
+      tocOverride={tocOverride}
+      mobileTocOverride={mobileTocOverride}
       afterSidebar={<SidebarPrepaint />}
       footerOverride={<FooterWithDefaults lang={locale} />}
       bodyEndComponents={<DocBodyEnd />}

--- a/packages/create-zudo-doc/templates/base/pages/lib/_toc-title.ts
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_toc-title.ts
@@ -1,0 +1,22 @@
+// TOC section-label resolver for the scanner-visible Toc/MobileToc shims
+// (zudolab/zudo-doc#2057). Hand-mirrors `getTocTitle`, which the zudo-doc
+// package exports from "@takazudo/zudo-doc/toc" in versions > 0.2.2. The
+// published version this scaffold installs (<= 0.2.2) does not yet export it,
+// so the tiny lang→title map is duplicated here. After bumping the
+// @takazudo/zudo-doc dependency past 0.2.2 you can replace this whole file
+// with: export { getTocTitle } from "@takazudo/zudo-doc/toc";
+const TOC_TITLES: Record<string, string> = {
+  en: "On this page",
+  ja: "目次",
+  de: "Auf dieser Seite",
+};
+
+const DEFAULT_TOC_TITLE = "On this page";
+
+/** Return the TOC section label for the given BCP-47 language tag. */
+export function getTocTitle(lang?: string): string {
+  if (!lang) return DEFAULT_TOC_TITLE;
+  // "en-US" → try "en" first, then "en-US", then the English default.
+  const primary = lang.split("-")[0]!;
+  return TOC_TITLES[primary] ?? TOC_TITLES[lang] ?? DEFAULT_TOC_TITLE;
+}

--- a/packages/create-zudo-doc/templates/base/src/components/mobile-toc.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/mobile-toc.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+// Scanner-visible MobileToc shim — same rationale as `toc.tsx`: zfb's island
+// scanner skips "use client" modules under node_modules
+// (Takazudo/zudo-front-builder#999), so the package-internal default
+// MobileToc island never hydrates for published-package consumers
+// (zudolab/zudo-doc#2057). `pages/lib/_doc-page-shell.tsx` mounts this via
+// `mobileTocOverride`.
+import type { JSX } from "preact";
+import {
+  MobileToc as ZudoDocMobileToc,
+  type MobileTocProps,
+} from "@takazudo/zudo-doc/toc";
+
+export function MobileToc(props: MobileTocProps): JSX.Element {
+  return <ZudoDocMobileToc {...props} />;
+}
+MobileToc.displayName = "MobileToc";
+
+export type { MobileTocProps };
+
+export default MobileToc;

--- a/packages/create-zudo-doc/templates/base/src/components/sidebar-toggle.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/sidebar-toggle.tsx
@@ -131,8 +131,15 @@ export default function SidebarToggle({
         onClick={() => setOpen(false)}
       />
 
-      {/* Sidebar panel - mobile only (desktop sidebar is in doc-layout) */}
+      {/* Sidebar panel - mobile only (desktop sidebar is in doc-layout).
+          `inert` when closed: the panel is only visually hidden via
+          `-translate-x-full`, so without `inert` its links/filter/buttons
+          stay in the tab order and accessibility tree while off-screen
+          (zudolab/zudo-doc#2059). `inert={false}` serialises to no attribute,
+          so the SSR (open=false → `inert`) and initial client render stay
+          byte-stable for hydration. */}
       <aside
+        inert={!open}
         className={`
           fixed top-[3.5rem] left-0 z-40 h-[calc(100vh-3.5rem)] w-[16rem] flex flex-col
           border-r border-muted bg-bg transition-transform duration-200

--- a/packages/create-zudo-doc/templates/base/src/components/toc.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/toc.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+// Scanner-visible Toc shim. zfb's island scanner does not register
+// "use client" modules under node_modules (Takazudo/zudo-front-builder#999),
+// so the package-internal default Toc island that DocLayoutWithDefaults
+// renders emits a marker with no registry entry for published-package
+// consumers — the TOC renders but never hydrates (active-heading highlight
+// stays dead) on every doc page (zudolab/zudo-doc#2057). Same class as the
+// ThemeToggle case fixed upstream in zudolab/zudo-doc#2048. This thin
+// project-source wrapper gives the scanner a local binding to register;
+// `pages/lib/_doc-page-shell.tsx` mounts it via `tocOverride`. Heals
+// natively once zfb#1001 ships and node_modules "use client" modules are
+// scanned again.
+import type { JSX } from "preact";
+import { Toc as ZudoDocToc, type TocProps } from "@takazudo/zudo-doc/toc";
+
+export function Toc(props: TocProps): JSX.Element {
+  return <ZudoDocToc {...props} />;
+}
+Toc.displayName = "Toc";
+
+export type { TocProps };
+
+export default Toc;

--- a/packages/create-zudo-doc/templates/features/docTags/files/pages/lib/_tag-pages.tsx
+++ b/packages/create-zudo-doc/templates/features/docTags/files/pages/lib/_tag-pages.tsx
@@ -131,6 +131,11 @@ export function TagDetailPageView({
       noindex={settings.noindex}
       hideSidebar={true}
       hideToc={true}
+      // Empty fragment suppresses DocLayoutWithDefaults' empty-data default
+      // Sidebar island — its marker never hydrates for published-package
+      // consumers (zfb#999) and zfb >= next.38 warns about it; the sidebar is
+      // hidden on this page anyway (zudolab/zudo-doc#2057).
+      sidebarOverride={<></>}
       // Tag segment URL-encoded — emitted href/path sites only; route params
       // stay raw (e.g. "type:guide" → "type%3Aguide").
       headerOverride={<HeaderWithDefaults lang={locale} currentPath={withBase(`${prefix}/docs/tags/${encodeURIComponent(tag)}`)} />}
@@ -184,6 +189,11 @@ export function TagsIndexPageView({ locale }: { locale: string }): JSX.Element {
       noindex={settings.noindex}
       hideSidebar={true}
       hideToc={true}
+      // Empty fragment suppresses DocLayoutWithDefaults' empty-data default
+      // Sidebar island — its marker never hydrates for published-package
+      // consumers (zfb#999) and zfb >= next.38 warns about it; the sidebar is
+      // hidden on this page anyway (zudolab/zudo-doc#2057).
+      sidebarOverride={<></>}
       headerOverride={<HeaderWithDefaults lang={locale} currentPath={withBase(`${prefix}/docs/tags`)} />}
       breadcrumbOverride={<Breadcrumb items={breadcrumbItems} />}
       footerOverride={<FooterWithDefaults lang={locale} />}

--- a/packages/create-zudo-doc/templates/features/i18n/files/pages/[locale]/index.tsx
+++ b/packages/create-zudo-doc/templates/features/i18n/files/pages/[locale]/index.tsx
@@ -103,6 +103,11 @@ export default function LocaleIndexPage({ params }: PageArgs): JSX.Element {
       noindex={settings.noindex}
       hideSidebar={true}
       hideToc={true}
+      // Empty fragment suppresses DocLayoutWithDefaults' empty-data default
+      // Sidebar island — its marker never hydrates for published-package
+      // consumers (zfb#999) and zfb >= next.38 warns about it; the sidebar is
+      // hidden on this page anyway (zudolab/zudo-doc#2057).
+      sidebarOverride={<></>}
       headerOverride={<HeaderWithDefaults lang={locale as Locale} currentPath={withBase(`/${locale}/`)} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
       bodyEndComponents={<BodyEndIslands basePath={settings.base ?? "/"} />}

--- a/packages/create-zudo-doc/templates/features/versioning/files/pages/lib/_versions-page.tsx
+++ b/packages/create-zudo-doc/templates/features/versioning/files/pages/lib/_versions-page.tsx
@@ -65,6 +65,11 @@ export function VersionsPageView({ locale }: { locale: string }): JSX.Element {
       noindex={settings.noindex}
       hideSidebar={true}
       hideToc={true}
+      // Empty fragment suppresses DocLayoutWithDefaults' empty-data default
+      // Sidebar island — its marker never hydrates for published-package
+      // consumers (zfb#999) and zfb >= next.38 warns about it; the sidebar is
+      // hidden on this page anyway (zudolab/zudo-doc#2057).
+      sidebarOverride={<></>}
       headerOverride={<HeaderWithDefaults lang={locale as Locale} currentPath={withBase(`${prefix}/docs/versions`)} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
       bodyEndComponents={<BodyEndIslands basePath={settings.base ?? "/"} />}

--- a/packages/zudo-doc/src/toc/__tests__/toc-title.test.ts
+++ b/packages/zudo-doc/src/toc/__tests__/toc-title.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { getTocTitle } from "../toc-title.js";
+import { getTocTitle as getTocTitleFromBarrel } from "../index.js";
+
+describe("toc barrel public API", () => {
+  it("re-exports getTocTitle from @takazudo/zudo-doc/toc (zudolab/zudo-doc#2057)", () => {
+    expect(getTocTitleFromBarrel).toBe(getTocTitle);
+    expect(getTocTitleFromBarrel("ja")).toBe("目次");
+  });
+});
 
 describe("getTocTitle", () => {
   it("returns English label for undefined input", () => {

--- a/packages/zudo-doc/src/toc/index.ts
+++ b/packages/zudo-doc/src/toc/index.ts
@@ -5,3 +5,7 @@ export type { MobileTocProps } from "./mobile-toc.js";
 export { useActiveHeading, getActiveHeadingId } from "./use-active-heading.js";
 export type { UseActiveHeadingResult } from "./use-active-heading.js";
 export type { HeadingItem } from "./types.js";
+// Exposed so consumers wiring their own scanner-visible Toc/MobileToc shims
+// (the override pattern from zudolab/zudo-doc#2057) can derive the locale TOC
+// label from the page `lang` without hand-mirroring the lang→title map.
+export { getTocTitle } from "./toc-title.js";

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -36,6 +36,11 @@ export default function NotFoundPage(): JSX.Element {
       noindex={true}
       hideSidebar={true}
       hideToc={true}
+      // Empty fragment suppresses DocLayoutWithDefaults' empty-data default
+      // Sidebar island — its marker never hydrates for published-package
+      // consumers (zfb#999) and zfb >= next.38 warns about it; the sidebar is
+      // hidden on this page anyway (zudolab/zudo-doc#2057).
+      sidebarOverride={<></>}
       headerOverride={<HeaderWithDefaults lang={locale} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
       bodyEndComponents={<BodyEndIslands basePath={settings.base ?? "/"} />}

--- a/pages/[locale]/index.tsx
+++ b/pages/[locale]/index.tsx
@@ -103,6 +103,11 @@ export default function LocaleIndexPage({ params }: PageArgs): JSX.Element {
       noindex={settings.noindex}
       hideSidebar={true}
       hideToc={true}
+      // Empty fragment suppresses DocLayoutWithDefaults' empty-data default
+      // Sidebar island — its marker never hydrates for published-package
+      // consumers (zfb#999) and zfb >= next.38 warns about it; the sidebar is
+      // hidden on this page anyway (zudolab/zudo-doc#2057).
+      sidebarOverride={<></>}
       headerOverride={<HeaderWithDefaults lang={locale as Locale} currentPath={withBase(`/${locale}/`)} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
       bodyEndComponents={<BodyEndIslands basePath={settings.base ?? "/"} />}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -65,6 +65,11 @@ export default function IndexPage(): JSX.Element {
       noindex={settings.noindex}
       hideSidebar={true}
       hideToc={true}
+      // Empty fragment suppresses DocLayoutWithDefaults' empty-data default
+      // Sidebar island — its marker never hydrates for published-package
+      // consumers (zfb#999) and zfb >= next.38 warns about it; the sidebar is
+      // hidden on this page anyway (zudolab/zudo-doc#2057).
+      sidebarOverride={<></>}
       headerOverride={<HeaderWithDefaults lang={locale} currentPath={withBase("/")} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
       bodyEndComponents={<BodyEndIslands basePath={settings.base ?? "/"} />}

--- a/pages/lib/_body-end-islands.tsx
+++ b/pages/lib/_body-end-islands.tsx
@@ -107,10 +107,14 @@ export interface BodyEndIslandsProps {
 }
 
 /**
- * The three default body-end islands every doc page mounts: the
- * design-token tweak panel (overlay, fixed-position), the AI chat
- * modal (`<dialog>` overlay), and the image-enlarge dialog (mounted
- * lazily based on viewport scan).
+ * The default body-end islands a doc page may mount: the design-token
+ * tweak panel (overlay, fixed-position), the AI chat modal (`<dialog>`
+ * overlay), and the image-enlarge dialog (mounted lazily based on
+ * viewport scan). Each is feature-gated — the design-token panel on
+ * `settings.designTokenPanel`, the AI chat modal (and its sr-only
+ * landmark heading) on `settings.aiAssistant`, and image-enlarge on
+ * `settings.imageEnlarge` — so a feature-off consumer ships neither the
+ * island marker nor a misleading landmark (zudolab/zudo-doc#2058).
  *
  * Each island is wrapped in `<Island ssrFallback>` so the heavy
  * component is NOT evaluated server-side — they depend on
@@ -118,9 +122,10 @@ export interface BodyEndIslandsProps {
  * fetch, etc. The hydration runtime swaps each placeholder on the
  * client.
  *
- * The `<h2 class="sr-only">AI Assistant</h2>` heading is emitted in
- * the SSG output so screen readers and crawlers can discover the chat
- * section landmark before JS hydration.
+ * When `settings.aiAssistant` is enabled, the
+ * `<h2 class="sr-only">AI Assistant</h2>` heading is emitted in the SSG
+ * output so screen readers and crawlers can discover the chat section
+ * landmark before JS hydration.
  */
 export function BodyEndIslands({
   basePath,
@@ -161,26 +166,52 @@ export function BodyEndIslands({
         )
       : null;
 
-  // Use a visually-hidden paragraph as the AiChatModal SSR fallback so
-  // the body label is present in static HTML for screen readers before
-  // JS hydration. sr-only keeps it invisible to sighted users.
-  const aiChat = Island({
-    ssrFallback: <p class="sr-only">{aiChatBodyLabel}</p>,
-    children: <AiChatModal basePath={basePath} />,
-  }) as unknown as VNode;
+  // Gated on `settings.aiAssistant` (zudolab/zudo-doc#2058): when the AI
+  // assistant feature is off, neither the AiChatModal island marker nor the
+  // sr-only "AI Assistant" landmark heading should reach the SSG output —
+  // otherwise feature-off consumers ship a dead island marker plus a
+  // misleading screen-reader landmark for a section that never hydrates.
+  // Mirrors the `designTokenPanel` gating above.
+  //
+  // KNOWN CAVEAT: zfb's island scanner walks the static `"use client"`
+  // import chain, so gating this JSX removes the SSR marker and heading but
+  // may NOT strip the AiChatModal bundle from the build output. Marker
+  // removal is the agreed first fix (#2058); bundle stripping is out of scope.
+  //
+  // The sr-only <p> fallback keeps the body label in static HTML for screen
+  // readers before JS hydration; sr-only keeps it invisible to sighted users.
+  const aiAssistant = settings.aiAssistant ? (
+    <>
+      {/* Emits the "AI Assistant" heading in the SSG output so screen
+          readers can discover the chat section landmark before JS
+          hydration. */}
+      <h2 class="sr-only">AI Assistant</h2>
+      {
+        Island({
+          ssrFallback: <p class="sr-only">{aiChatBodyLabel}</p>,
+          children: <AiChatModal basePath={basePath} />,
+        }) as unknown as VNode
+      }
+    </>
+  ) : null;
 
-  // Wave 11 (zudolab/zudo-doc#1355): the SSR fallback is the empty,
-  // closed `<dialog class="zd-enlarge-dialog ...">` shell so the dist
-  // HTML carries one dialog from the start. Without this the smoke
-  // "exactly one zd-enlarge-dialog element" assertion sees zero
-  // (skip-ssr placeholders are empty divs) and the no-JS path has no
-  // dialog at all. Hydration replaces this shell with the real
-  // ImageEnlarge component when the page goes idle.
-  const imageEnlarge = Island({
-    when: "idle",
-    ssrFallback: <ImageEnlargeSsrFallback />,
-    children: <ImageEnlarge />,
-  }) as unknown as VNode;
+  // Gated on `settings.imageEnlarge` (zudolab/zudo-doc#2058). Same caveat as
+  // the AI assistant gating: removing this JSX drops the SSR dialog shell and
+  // island marker, but the bundle may persist via the static import scan.
+  //
+  // Wave 11 (zudolab/zudo-doc#1355): the SSR fallback is the empty, closed
+  // `<dialog class="zd-enlarge-dialog ...">` shell so the dist HTML carries
+  // one dialog from the start. Without this the smoke "exactly one
+  // zd-enlarge-dialog element" assertion sees zero (skip-ssr placeholders are
+  // empty divs) and the no-JS path has no dialog at all. Hydration replaces
+  // this shell with the real ImageEnlarge component when the page goes idle.
+  const imageEnlarge = settings.imageEnlarge
+    ? (Island({
+        when: "idle",
+        ssrFallback: <ImageEnlargeSsrFallback />,
+        children: <ImageEnlarge />,
+      }) as unknown as VNode)
+    : null;
 
   return (
     <>
@@ -190,11 +221,7 @@ export function BodyEndIslands({
       <PageLoadingOverlay />
       {clientRouterBootstrap}
       {designTokenPanelBootstrap}
-      {/* Emits the "AI Assistant" heading in the SSG output so screen
-          readers can discover the chat section landmark before JS
-          hydration. */}
-      <h2 class="sr-only">AI Assistant</h2>
-      {aiChat}
+      {aiAssistant}
       {imageEnlarge}
     </>
   );

--- a/pages/lib/_doc-page-shell.tsx
+++ b/pages/lib/_doc-page-shell.tsx
@@ -17,9 +17,13 @@
 // keeping the create-zudo-doc template copies byte-identical to the host.
 
 import type { ComponentChildren, JSX, VNode } from "preact";
+import { Island } from "@takazudo/zfb";
 import { settings } from "@/config/settings";
 import type { NavNode } from "@/utils/docs";
 import { DocLayoutWithDefaults } from "@takazudo/zudo-doc/doclayout";
+import { Toc } from "@/components/toc";
+import { MobileToc } from "@/components/mobile-toc";
+import { getTocTitle } from "./_toc-title";
 import { Breadcrumb } from "@takazudo/zudo-doc/breadcrumb";
 import { NavCardGrid } from "@takazudo/zudo-doc/nav-indexing";
 import { HeadWithDefaults } from "./_head-with-defaults";
@@ -145,6 +149,31 @@ export function DocPageShell(props: DocPageShellProps): JSX.Element {
     docHistorySlot,
   } = props;
 
+  // TOC overrides: mount the scanner-visible local Toc/MobileToc shims instead
+  // of DocLayoutWithDefaults' package-internal default islands. zfb's island
+  // scanner skips "use client" modules under node_modules
+  // (Takazudo/zudo-front-builder#999), so the package defaults emit markers
+  // that never hydrate for published-package consumers (zudolab/zudo-doc#2057).
+  // The gating mirrors the package's `shouldRenderDefaultToc` exactly
+  // (`!hideToc && headings.length > 0`) so an undefined override never silently
+  // falls back to the dead package default. Each shim is wrapped in
+  // `<Island when="load">` here (the call site), matching how the package wraps
+  // its own default — the bundle then hydrates the bare nav/panel in place.
+  const tocTitle = getTocTitle(locale);
+  const shouldRenderToc = !hideToc && headings.length > 0;
+  const tocOverride = shouldRenderToc
+    ? (Island({
+        when: "load",
+        children: <Toc headings={headings} title={tocTitle} />,
+      }) as unknown as VNode)
+    : undefined;
+  const mobileTocOverride = shouldRenderToc
+    ? (Island({
+        when: "load",
+        children: <MobileToc headings={headings} title={tocTitle} />,
+      }) as unknown as VNode)
+    : undefined;
+
   return (
     <DocLayoutWithDefaults
       title={composeMetaTitle(title)}
@@ -183,6 +212,8 @@ export function DocPageShell(props: DocPageShellProps): JSX.Element {
           currentPath={currentPath}
         />
       }
+      tocOverride={tocOverride}
+      mobileTocOverride={mobileTocOverride}
       afterSidebar={<SidebarPrepaint />}
       footerOverride={<FooterWithDefaults lang={locale} />}
       bodyEndComponents={<DocBodyEnd />}

--- a/pages/lib/_tag-pages.tsx
+++ b/pages/lib/_tag-pages.tsx
@@ -131,6 +131,11 @@ export function TagDetailPageView({
       noindex={settings.noindex}
       hideSidebar={true}
       hideToc={true}
+      // Empty fragment suppresses DocLayoutWithDefaults' empty-data default
+      // Sidebar island — its marker never hydrates for published-package
+      // consumers (zfb#999) and zfb >= next.38 warns about it; the sidebar is
+      // hidden on this page anyway (zudolab/zudo-doc#2057).
+      sidebarOverride={<></>}
       // Tag segment URL-encoded — emitted href/path sites only; route params
       // stay raw (e.g. "type:guide" → "type%3Aguide").
       headerOverride={<HeaderWithDefaults lang={locale} currentPath={withBase(`${prefix}/docs/tags/${encodeURIComponent(tag)}`)} />}
@@ -184,6 +189,11 @@ export function TagsIndexPageView({ locale }: { locale: string }): JSX.Element {
       noindex={settings.noindex}
       hideSidebar={true}
       hideToc={true}
+      // Empty fragment suppresses DocLayoutWithDefaults' empty-data default
+      // Sidebar island — its marker never hydrates for published-package
+      // consumers (zfb#999) and zfb >= next.38 warns about it; the sidebar is
+      // hidden on this page anyway (zudolab/zudo-doc#2057).
+      sidebarOverride={<></>}
       headerOverride={<HeaderWithDefaults lang={locale} currentPath={withBase(`${prefix}/docs/tags`)} />}
       breadcrumbOverride={<Breadcrumb items={breadcrumbItems} />}
       footerOverride={<FooterWithDefaults lang={locale} />}

--- a/pages/lib/_toc-title.ts
+++ b/pages/lib/_toc-title.ts
@@ -1,0 +1,12 @@
+// TOC section-label resolver for the scanner-visible Toc/MobileToc shims
+// (zudolab/zudo-doc#2057). The host resolves @takazudo/zudo-doc as a workspace
+// package, so it imports the real `getTocTitle` straight from the /toc barrel.
+//
+// The create-zudo-doc TEMPLATE counterpart
+// (packages/create-zudo-doc/templates/base/pages/lib/_toc-title.ts) instead
+// hand-mirrors this lang→title map, because scaffolded projects install the
+// PUBLISHED @takazudo/zudo-doc (<= 0.2.2), which does not yet export
+// `getTocTitle`. That deliberate divergence is allowlisted in
+// .template-drift-allowlist; keep the two files behaviourally in sync until
+// the template can switch to this import after the next package release.
+export { getTocTitle } from "@takazudo/zudo-doc/toc";

--- a/pages/lib/_versions-page.tsx
+++ b/pages/lib/_versions-page.tsx
@@ -65,6 +65,11 @@ export function VersionsPageView({ locale }: { locale: string }): JSX.Element {
       noindex={settings.noindex}
       hideSidebar={true}
       hideToc={true}
+      // Empty fragment suppresses DocLayoutWithDefaults' empty-data default
+      // Sidebar island — its marker never hydrates for published-package
+      // consumers (zfb#999) and zfb >= next.38 warns about it; the sidebar is
+      // hidden on this page anyway (zudolab/zudo-doc#2057).
+      sidebarOverride={<></>}
       headerOverride={<HeaderWithDefaults lang={locale as Locale} currentPath={withBase(`${prefix}/docs/versions`)} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
       bodyEndComponents={<BodyEndIslands basePath={settings.base ?? "/"} />}

--- a/src/components/mobile-toc.tsx
+++ b/src/components/mobile-toc.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+// Scanner-visible MobileToc shim — same rationale as `toc.tsx`: zfb's island
+// scanner skips "use client" modules under node_modules
+// (Takazudo/zudo-front-builder#999), so the package-internal default
+// MobileToc island never hydrates for published-package consumers
+// (zudolab/zudo-doc#2057). `pages/lib/_doc-page-shell.tsx` mounts this via
+// `mobileTocOverride`.
+import type { JSX } from "preact";
+import {
+  MobileToc as ZudoDocMobileToc,
+  type MobileTocProps,
+} from "@takazudo/zudo-doc/toc";
+
+export function MobileToc(props: MobileTocProps): JSX.Element {
+  return <ZudoDocMobileToc {...props} />;
+}
+MobileToc.displayName = "MobileToc";
+
+export type { MobileTocProps };
+
+export default MobileToc;

--- a/src/components/sidebar-toggle.tsx
+++ b/src/components/sidebar-toggle.tsx
@@ -131,8 +131,15 @@ export default function SidebarToggle({
         onClick={() => setOpen(false)}
       />
 
-      {/* Sidebar panel - mobile only (desktop sidebar is in doc-layout) */}
+      {/* Sidebar panel - mobile only (desktop sidebar is in doc-layout).
+          `inert` when closed: the panel is only visually hidden via
+          `-translate-x-full`, so without `inert` its links/filter/buttons
+          stay in the tab order and accessibility tree while off-screen
+          (zudolab/zudo-doc#2059). `inert={false}` serialises to no attribute,
+          so the SSR (open=false → `inert`) and initial client render stay
+          byte-stable for hydration. */}
       <aside
+        inert={!open}
         className={`
           fixed top-[3.5rem] left-0 z-40 h-[calc(100vh-3.5rem)] w-[16rem] flex flex-col
           border-r border-muted bg-bg transition-transform duration-200

--- a/src/components/toc.tsx
+++ b/src/components/toc.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+// Scanner-visible Toc shim. zfb's island scanner does not register
+// "use client" modules under node_modules (Takazudo/zudo-front-builder#999),
+// so the package-internal default Toc island that DocLayoutWithDefaults
+// renders emits a marker with no registry entry for published-package
+// consumers — the TOC renders but never hydrates (active-heading highlight
+// stays dead) on every doc page (zudolab/zudo-doc#2057). Same class as the
+// ThemeToggle case fixed upstream in zudolab/zudo-doc#2048. This thin
+// project-source wrapper gives the scanner a local binding to register;
+// `pages/lib/_doc-page-shell.tsx` mounts it via `tocOverride`. Heals
+// natively once zfb#1001 ships and node_modules "use client" modules are
+// scanned again.
+import type { JSX } from "preact";
+import { Toc as ZudoDocToc, type TocProps } from "@takazudo/zudo-doc/toc";
+
+export function Toc(props: TocProps): JSX.Element {
+  return <ZudoDocToc {...props} />;
+}
+Toc.displayName = "Toc";
+
+export type { TocProps };
+
+export default Toc;


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2060

---

## Summary

Batch fix for the 3 most recent island wiring/hydration issues on zfb `0.1.0-next.38` (closes #2059, closes #2058, closes #2057; tracking: #2060):

- **#2059** — the closed SidebarToggle mobile drawer is now `inert`: its SidebarTree links, filter input, and buttons leave the tab order and accessibility tree while the drawer is off-screen.
- **#2058** — `BodyEndIslands` now gates the `AiChatModal` island (+ its sr-only "AI Assistant" landmark heading) on `settings.aiAssistant` and the `ImageEnlarge` island on `settings.imageEnlarge`, mirroring the existing `designTokenPanel` conditional. Feature-off consumers ship neither markers nor a misleading landmark.
- **#2057** — fresh `create-zudo-doc` scaffolds build **warning-free on released zfb next.38**: scanner-visible local `Toc`/`MobileToc` shims (the #2048 wrapper pattern: `"use client"`, pinned `displayName`) re-wrap `@takazudo/zudo-doc/toc` and mount via `DocLayoutWithDefaults` `tocOverride`/`mobileTocOverride` with `shouldRenderDefaultToc`-equivalent gating; every `hideSidebar` call site (index, 404, i18n locale index, tag pages ×2, versions page) gets an empty-fragment `sidebarOverride` so the empty-data `Sidebar` marker disappears. Interim measure until upstream zudo-front-builder#1001 ships in a zfb release.

## Changes

**Host + base template (kept drift-consistent):**
- `src/components/sidebar-toggle.tsx` ⇄ template — `inert={!open}` on the drawer `<aside>` (byte-stable SSR/hydration preserved; SSR renders closed with `inert` present)
- `pages/lib/_body-end-islands.tsx` ⇄ template — feature-flag gating for AiChatModal / sr-only heading / ImageEnlarge
- `src/components/toc.tsx`, `src/components/mobile-toc.tsx` ⇄ template — new scanner-visible shims
- `pages/lib/_doc-page-shell.tsx` ⇄ template — mounts the shims via toc overrides
- `pages/lib/_toc-title.ts` — host re-exports the real `getTocTitle`; the template hand-mirrors the lang→title map (published `zudo-doc@0.2.2` doesn't export it yet) — the one allowlisted host↔template divergence
- `pages/{index,404,[locale]/index}.tsx`, `pages/lib/{_tag-pages,_versions-page}.tsx` ⇄ template + feature overlays — `sidebarOverride={<></>}` on all `hideSidebar` sites

**Package:**
- `packages/zudo-doc/src/toc/index.ts` — export `getTocTitle` from the public `/toc` barrel (+ unit test)

**Tests:**
- `e2e/smoke-mobile-sidebar.spec.ts` — closed drawer is inert/unfocusable, open drawer restores access
- `packages/create-zudo-doc/src/__tests__/scaffold.test.ts` — gating + shim expectations (now 303 tests)

## Test plan / verification done

- Host build (merged base): 269 pages, exit 0, **0 island-marker warnings**; markers/heading/dialog shell present with features ON; drawer `<aside inert>` in SSR HTML
- External-consumer oracle: scaffolded with the new templates against **published** `zfb@0.1.0-next.38` + `zudo-doc@0.2.2` from npm → **0 dead-island warnings** (was 3: Toc/MobileToc/Sidebar); Toc/MobileToc markers registered; 0 Sidebar markers
- Feature-off scaffold builds: `aiAssistant: false` → no AiChatModal marker/heading; `imageEnlarge: false` → no ImageEnlarge marker
- `pnpm check` clean; codex deep review: no findings; CI 14/14 green

## Known caveat

Gating removes SSR markers + landmark, but zfb's static `"use client"` import scan may still emit the island **bundles** for feature-off consumers — agreed first fix for #2058; bundle stripping is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)