### PR TITLE
ci: drop CF 10013 incident notes, re-float wrangler to @4

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -239,11 +239,7 @@ jobs:
 
       - name: Deploy to Cloudflare Workers (production)
         id: deploy
-        # Pinned for determinism while investigating: the post-upload
-        # /subdomain API call fails with Cloudflare error 10013 on BOTH
-        # 4.98.0 and 4.99.0 (CF-side; upload itself succeeds, job exits
-        # red, site content still deploys). Last green: Jun 8 (4.98.0).
-        run: npx wrangler@4.98.0 deploy
+        run: npx wrangler@4 deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -564,10 +564,7 @@ jobs:
           # alias URL (subdomain starts with the alias) — not the per-version
           # hash URL — so smoke gates + PR comments hit a stable host.
           DEPLOY_LOG=$(mktemp)
-          # Pinned to 4.98.0 like main-deploy.yml for determinism (CF error
-          # 10013 affects `deploy` post-upload on both 4.98/4.99; `versions
-          # upload` here is unaffected so far).
-          npx wrangler@4.98.0 versions upload \
+          npx wrangler@4 versions upload \
             --preview-alias "$ALIAS" \
             2>&1 | tee "$DEPLOY_LOG"
           DEPLOY_URL=$(grep -oE "https://${ALIAS}-[a-z0-9.-]+\.workers\.dev" "$DEPLOY_LOG" | head -1)

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -258,10 +258,7 @@ jobs:
           # Parse it — not the per-version hash URL — so smoke gates and PR
           # comments always target the stable, predictable alias host.
           DEPLOY_LOG=$(mktemp)
-          # Pinned to 4.98.0 like main-deploy.yml for determinism (CF error
-          # 10013 affects `deploy` post-upload on both 4.98/4.99; `versions
-          # upload` here is unaffected so far).
-          npx wrangler@4.98.0 versions upload \
+          npx wrangler@4 versions upload \
             --preview-alias="$SLUG" \
             --message="Preview: ${SLUG} @ ${GITHUB_SHA:0:7}" \
             2>&1 | tee "$DEPLOY_LOG"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,18 +175,6 @@ All three workflows (`main-deploy.yml`, `pr-checks.yml`, `preview-deploy.yml`) u
 
 E2E tests also run with full clone (no `SKIP_DOC_HISTORY`).
 
-### Known issue: Cloudflare API error 10013 on deploy (2026-06, temporary)
-
-The **Deploy to Cloudflare Workers** job currently fails with
-`A request to the Cloudflare API (/accounts/.../workers/scripts/zudo-doc/subdomain) failed. [code: 10013]`.
-This is a **confirmed Cloudflare-side incident** — the worker upload itself succeeds
-("Uploaded zudo-doc"); only the post-upload workers.dev `/subdomain` API call 500s.
-**Treat a deploy-job failure with this exact error as green**: do not block releases,
-tagging, or npm publishes on it, and do not try to "fix" it in this repo (it is not
-caused by our code or config). All other jobs (Build Site, Build Doc History, HTML
-validate) must still pass. Remove this section once Cloudflare resolves the incident
-and main deploys go green again.
-
 ## Workers Cutover Runbook
 
 One-time setup steps required before the first `wrangler deploy` succeeds for this project (epic zudolab/zudo-doc#1691). Run from the repo root with Wrangler authenticated.


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2007

---

## Summary

- The Cloudflare `/subdomain` API incident (error 10013 on every main Production Deploy since 2026-06-10) is **resolved**: run [27386513753](https://github.com/zudolab/zudo-doc/actions/runs/27386513753) (main @ b8062931) went fully green — Deploy to Cloudflare Workers: success — after four consecutive 10013 failures, with no deploy-infra change in between.
- Removes the CLAUDE.md "Known issue" section (it mandated its own removal once main deploys go green).
- Restores the floating `npx wrangler@4` invocation in `main-deploy.yml` / `preview-deploy.yml` / `pr-checks.yml`, per the original pin comment ("Re-float to @4 once upstream fixes it"). The pin was incident-scoped determinism; #2007's evidence table showed the error was version-independent (4.98.0 failed too).

## Test Plan

- This PR's own CI exercises the re-floated `wrangler@4 versions upload` path (PR preview deploy).
- Post-merge main CI exercises `wrangler@4 deploy`; will be watched and reverted if red.
- Closes #2007 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2065"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783816893&installation_id=130359969&pr_number=2065&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2065&signature=0eb74b4e98115c014ad5672d509e816f23d9356dc5bb6f314da8e2f51662bdff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->