### PR TITLE
chore: bump zfb to 0.1.0-next.40

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,9 +78,9 @@
   },
   "dependencies": {
     "@takazudo/zdtp": "0.2.0-next.2",
-    "@takazudo/zfb": "0.1.0-next.39",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.39",
-    "@takazudo/zfb-runtime": "0.1.0-next.39",
+    "@takazudo/zfb": "0.1.0-next.40",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.40",
+    "@takazudo/zfb-runtime": "0.1.0-next.40",
     "@types/hast": "^3.0.4",
     "@takazudo/zudo-doc": "workspace:*",
     "clsx": "^2.1.1",

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -2935,13 +2935,16 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
    * (`.client.*` + `clientScript()`), the `when="media"` island strategy,
    * exported VNode types, and stricter cross-file anchor validation; upstream
    * BREAKING: removed the no-op `linkValidation.allowExternal` knob — never
-   * emitted by the generator, so no migration needed. Now bumped to
-   * 0.1.0-next.39: features + fixes, no breaking changes — npm-dist
-   * `"use client"` island scanning, link-resolution fixes for directory-style
-   * hrefs, and island-registry hardening (warns on island marker-name
-   * collisions). Generated package.json must pin all three.
+   * emitted by the generator, so no migration needed. next.39: features +
+   * fixes, no breaking changes — npm-dist `"use client"` island scanning,
+   * link-resolution fixes for directory-style hrefs, and island-registry
+   * hardening (warns on island marker-name collisions). Now bumped to
+   * 0.1.0-next.40: `zfb dev` lazy rendering on by default (pages render on
+   * first request; `ZFB_DEV_EAGER=1` restores eager mode,
+   * Takazudo/zudo-front-builder#1029) — dev-server-only, no breaking
+   * changes. Generated package.json must pin all three.
    */
-  it("pins @takazudo/zfb at 0.1.0-next.39", async () => {
+  it("pins @takazudo/zfb at 0.1.0-next.40", async () => {
     const choices: UserChoices = {
       projectName: "test-pin-bump",
       defaultLang: "en",
@@ -2952,10 +2955,10 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
     };
     await scaffold(choices);
     const pkg = await fs.readJson(projectPath("test-pin-bump", "package.json"));
-    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.39");
-    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.39");
+    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.40");
+    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.40");
     expect(pkg.dependencies["@takazudo/zfb-adapter-cloudflare"]).toBe(
-      "0.1.0-next.39",
+      "0.1.0-next.40",
     );
   });
 });

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -338,15 +338,19 @@ function generatePackageJson(choices: UserChoices) {
     // cross-file anchor validation. BREAKING upstream: the no-op
     // `linkValidation.allowExternal` knob was removed — neither the host nor
     // the generated config ever emitted it, so no migration is needed here.
-    // next.39 (current pin) is features + fixes, no breaking changes:
+    // next.39 is features + fixes, no breaking changes:
     // npm-dist `"use client"` island scanning, link-resolution fixes for
     // directory-style hrefs, and island-registry hardening (warns on island
     // marker-name collisions).
-    "@takazudo/zfb": "0.1.0-next.39",
-    "@takazudo/zfb-runtime": "0.1.0-next.39",
+    // next.40 (current pin) flips `zfb dev` to lazy rendering by default —
+    // pages render on first request instead of on every file-change tick
+    // (Takazudo/zudo-front-builder#1029); `ZFB_DEV_EAGER=1` restores eager
+    // mode. Dev-server-only change, no build/config migration needed.
+    "@takazudo/zfb": "0.1.0-next.40",
+    "@takazudo/zfb-runtime": "0.1.0-next.40",
     // zfb-adapter-cloudflare — required for any route with `prerender = false`.
     // Pinned in lockstep with @takazudo/zfb.
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.39",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.40",
     // @takazudo/zudo-doc — published from this monorepo via
     // .github/workflows/publish-zudo-doc.yml. The pin here is bumped in
     // lockstep by scripts/release-create-zudo-doc.sh whenever zudo-doc's

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -171,8 +171,8 @@
   ],
   "peerDependencies": {
     "preact": "^10.29.1",
-    "@takazudo/zfb": "^0.1.0-next.39",
-    "@takazudo/zfb-runtime": "^0.1.0-next.39",
+    "@takazudo/zfb": "^0.1.0-next.40",
+    "@takazudo/zfb-runtime": "^0.1.0-next.40",
     "@takazudo/zudo-doc-history-server": "workspace:^",
     "@takazudo/zdtp": "^0.2.0-next.2",
     "shiki": "^4.0.2"
@@ -200,7 +200,7 @@
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
     "vitest": "^4.1.0",
-    "@takazudo/zfb": "0.1.0-next.39",
-    "@takazudo/zfb-runtime": "0.1.0-next.39"
+    "@takazudo/zfb": "0.1.0-next.40",
+    "@takazudo/zfb-runtime": "0.1.0-next.40"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,14 +25,14 @@ importers:
         specifier: 0.2.0-next.2
         version: 0.2.0-next.2(preact@10.29.2)
       '@takazudo/zfb':
-        specifier: 0.1.0-next.39
-        version: 0.1.0-next.39
+        specifier: 0.1.0-next.40
+        version: 0.1.0-next.40
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.39
-        version: 0.1.0-next.39
+        specifier: 0.1.0-next.40
+        version: 0.1.0-next.40
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.39
-        version: 0.1.0-next.39(@takazudo/zfb@0.1.0-next.39)
+        specifier: 0.1.0-next.40
+        version: 0.1.0-next.40(@takazudo/zfb@0.1.0-next.40)
       '@takazudo/zudo-doc':
         specifier: workspace:*
         version: link:packages/zudo-doc
@@ -285,11 +285,11 @@ importers:
         version: 4.0.3
     devDependencies:
       '@takazudo/zfb':
-        specifier: 0.1.0-next.39
-        version: 0.1.0-next.39
+        specifier: 0.1.0-next.40
+        version: 0.1.0-next.40
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.39
-        version: 0.1.0-next.39(@takazudo/zfb@0.1.0-next.39)
+        specifier: 0.1.0-next.40
+        version: 0.1.0-next.40(@takazudo/zfb@0.1.0-next.40)
       '@types/node':
         specifier: ^25.3.5
         version: 25.3.5
@@ -1372,44 +1372,44 @@ packages:
     peerDependencies:
       preact: ^10.29.1
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.39':
-    resolution: {integrity: sha512-zv1IuxKxh1uSIXcPFrTwwzt3ZbHXOeeOSQTyobgyeVesDGKzigm+r0ieWJPg+Lw5Yk0XQzh1CwjIdN2H2bJEqA==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.40':
+    resolution: {integrity: sha512-lS1LwcwD0f0qoa9GGQTj7AKhnYt3HLxR0XswiwbTDG5J4mwvqN63NoRU1NvqIXfeMv+rnQRr0ECoEglChbfeWQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.39':
-    resolution: {integrity: sha512-8fy8irSbY0l60c9NI/wZds4mAqLQvtiK5pfNq9kQ59rFlWutOcPCc4njr3j73CWUK+kz27NfN8HKrvTZmjOt/A==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.40':
+    resolution: {integrity: sha512-MK5Ud8BHLd75rcAcyQrxUmerSvrk4phAueTU+F+0+S0294g+3OWxmnpZaiVv1Xn4F4qDaMp9wW5+V+ur3uMQQw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.39':
-    resolution: {integrity: sha512-WBa+HFUxLvyeiZ+v/5RuZ6dJS0NRVJihQuA5tTffnnO6LnuMwchCEDDjwJ3g/LbFbGINQ8jsGmgsrEu1MR6Lfw==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.40':
+    resolution: {integrity: sha512-qTAP8MoqPu+lG4CdNL5kku8Er3Toe6PQsYRS7YXbW1hQ1LDz3DqMpch2IvzohsHy40ALQzpXpGV894J3tU29uA==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.39':
-    resolution: {integrity: sha512-PX5SMhAtTu27xUvw6+E1yXfZ5L531TTlZDOzEHfUTwupyiv/0HMeFaCI5ggEw0NTgnUP/l1FNsFOXzftFQJzIg==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.40':
+    resolution: {integrity: sha512-3cgSdT7JeldVzMMviYd9wjdkjZVsZaSiDlzPYzYyfhdPUtfhpY99hLZDhrZkbxr5XjRwy2jOsrg62ij70h6Qtg==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.39':
-    resolution: {integrity: sha512-j968df4FqUNbY9Ly3k7kmBR6+Joel5Z4uoUxsWSkAvsFDZ2h+RDphh3km+p1fjiV5Q54q07LxwpaadgVsbQUsQ==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.40':
+    resolution: {integrity: sha512-PZsfqoyCDpWVos243OLcTyfLWh/1CK9uAjcGHXXANW5hhUSweWLYMyCHd1dnFEor6R2j2OefIIRfMgMsi02Cog==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.39':
-    resolution: {integrity: sha512-ZbNFOk8Bbxm2hznUvtsCFUsgCxLLU4uqvrgmrxcYAl8jPSmW+yfaBvjJK1UIdbLBDLf0ov77eoW8ccXHdcdFoQ==}
+  '@takazudo/zfb-runtime@0.1.0-next.40':
+    resolution: {integrity: sha512-ZnmAdY7/rLn9otIm5g5+F+NDHOGhQVmkmxZmggc+B8O3UrBU9tA37w9FWNT6HJuMTfbUyt3RRtLLa8ul4uEoEg==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.39
+      '@takazudo/zfb': 0.1.0-next.40
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.39':
-    resolution: {integrity: sha512-KK8MYyEOuoyv7zSf0zkG4WmcQBvTgkWAV/9dplRv+CMVYJMno7O81IS4vTGeFaD/2BshsrohoJjn+cJIORnGSg==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.40':
+    resolution: {integrity: sha512-JTriZ2OwDnnKJhjPFZ93V7gaA1z43OF2WHV4DePcRo9MEJPnZgMhw07HjVzQNNabiJlpSKkvakMZMrLLLrfCmw==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.39':
-    resolution: {integrity: sha512-noSj3fDyobeN40EbZi3WCAL7SzsVRhKSN38NwYY6rjir8YUwKl5SPTDLcpIxI+K0oIoiQ5Tz/Mxt4jVdoXnpsw==}
+  '@takazudo/zfb@0.1.0-next.40':
+    resolution: {integrity: sha512-X9WXau56QXZhVbTT5tECaFUgV0luh551qD1it2fPD1YlPFzAbh9VEAtwT2THUPa0a7Aexab0b0LPVV6EUnf9Ug==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
@@ -4071,35 +4071,35 @@ snapshots:
       culori: 4.0.2
       preact: 10.29.2
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.39': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.40': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.39':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.40':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.39':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.40':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.39':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.40':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.39':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.40':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.39(@takazudo/zfb@0.1.0-next.39)':
+  '@takazudo/zfb-runtime@0.1.0-next.40(@takazudo/zfb@0.1.0-next.40)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.39
+      '@takazudo/zfb': 0.1.0-next.40
       hono: 4.12.23
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.39':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.40':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.39':
+  '@takazudo/zfb@0.1.0-next.40':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.39
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.39
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.39
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.39
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.39
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.40
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.40
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.40
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.40
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.40
 
   '@takazudo/zudo-design-token-lint@1.0.0':
     dependencies:


### PR DESCRIPTION
## Summary
- Bump the @takazudo/zfb package family (`@takazudo/zfb`, `@takazudo/zfb-runtime`, `@takazudo/zfb-adapter-cloudflare`) from `0.1.0-next.39` to the latest `@next` dist-tag, `0.1.0-next.40`
- next.40's headline change is the lazy dev-render flip (Takazudo/zudo-front-builder#1029): `zfb dev` renders pages on first request instead of on every file-change tick; `ZFB_DEV_EAGER=1` restores eager mode. Dev-server-only — no build or config migration needed

## Changes
- `package.json` — root pins for all three zfb packages → `0.1.0-next.40`
- `pnpm-lock.yaml` — lockfile refresh (previous installed state was next.38 despite the next.39 pin; now consistent at next.40)
- `packages/create-zudo-doc/src/scaffold.ts` — generated-project pins → `0.1.0-next.40`, plus a changelog comment entry for next.40 following the existing convention
- `packages/create-zudo-doc/src/__tests__/scaffold.test.ts` — pin assertions + doc comment updated to next.40
- `packages/zudo-doc/package.json` — devDependencies (exact) and peerDependencies (caret) → next.40, keeping `check:pin-parity` green

## Test Plan
- [x] `pnpm install`
- [x] `pnpm check:pin-parity` — all pin sources in lockstep
- [x] `pnpm check` — tsc clean
- [x] create-zudo-doc unit tests — 304 passed
- [x] `pnpm build` — 269 pages built
- [x] `zfb dev` lazy-render smoke test — boot, render-on-request (200s), edit → stale → re-render, revert → re-render
- [x] Codex review — no actionable findings
- [ ] CI green

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2066"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783849945&installation_id=130359969&pr_number=2066&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2066&signature=cf04cf8f24924ffbea498d089e319d27528e7c3ad4a6a2ff08f116946734ab6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->