### PR TITLE
Fix DiffViewer stale-diff race and switch template _toc-title.ts to package re-export

### DIFF
--- a/.template-drift-allowlist
+++ b/.template-drift-allowlist
@@ -182,14 +182,3 @@ src/components/find-bar.tsx
 src/utils/find-in-page.ts
 src/utils/content-files.ts
 src/utils/git-info.ts
-
-# #2057 — TOC-title resolver for the Toc/MobileToc overrides in _doc-page-shell.
-# Deliberate, behaviour-preserving divergence: the HOST resolves
-# @takazudo/zudo-doc as a workspace package and imports the real `getTocTitle`
-# from the /toc barrel (a single re-export line). The TEMPLATE hand-mirrors the
-# lang→title map locally because scaffolded projects install the PUBLISHED
-# @takazudo/zudo-doc (<= 0.2.2), which does not export `getTocTitle` yet.
-# Keep the two in behavioural sync; the template can switch to the import once
-# its pinned @takazudo/zudo-doc dependency moves past 0.2.2. Confined to this
-# tiny helper so the byte-identical _doc-page-shell.tsx stays fully drift-checked.
-pages/lib/_toc-title.ts

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -163,10 +163,10 @@ describe("scaffold — minimal (no i18n, search only, single dark scheme)", () =
     }
   });
 
-  // #2057: the doc-page shell mounts the package Toc/MobileToc via the override
-  // props and derives the TOC title from the hand-mirrored _toc-title helper
-  // (the published package this scaffold installs does not export getTocTitle
-  // yet).
+  // #2057/#2067: the doc-page shell mounts the package Toc/MobileToc via the
+  // override props and derives the TOC title from the `_toc-title` helper, which
+  // re-exports `getTocTitle` from "@takazudo/zudo-doc/toc" (exported by the
+  // scaffolded package since 0.2.3 — no local hand-mirror anymore).
   it("wires tocOverride/mobileTocOverride in _doc-page-shell with the _toc-title helper (#2057)", async () => {
     const shellPath = projectPath(
       "test-minimal",
@@ -186,8 +186,25 @@ describe("scaffold — minimal (no i18n, search only, single dark scheme)", () =
     );
     expect(await fs.pathExists(tocTitlePath)).toBe(true);
     const tocTitle = await fs.readFile(tocTitlePath, "utf-8");
-    expect(tocTitle).toContain("export function getTocTitle");
-    expect(tocTitle).toContain('"目次"');
+    // Re-export, not a hand-mirrored map — and definitely no stale TOC_TITLES.
+    expect(tocTitle).toContain(
+      'export { getTocTitle } from "@takazudo/zudo-doc/toc";',
+    );
+    expect(tocTitle).not.toContain("TOC_TITLES");
+    expect(tocTitle).not.toContain("export function getTocTitle");
+
+    // The re-export only resolves because the scaffolded @takazudo/zudo-doc
+    // exports ./toc (getTocTitle), which landed in 0.2.3. Guard the pinned
+    // version so dropping below 0.2.3 fails loudly instead of silently
+    // reintroducing the duplicate map (#2067).
+    const pkg = await fs.readJson(projectPath("test-minimal", "package.json"));
+    const zudoDocDep = pkg.dependencies["@takazudo/zudo-doc"] as string;
+    const versionMatch = zudoDocDep.match(/^\^?(\d+)\.(\d+)\.(\d+)/);
+    expect(versionMatch).not.toBeNull();
+    const major = Number(versionMatch![1]);
+    const minor = Number(versionMatch![2]);
+    const patch = Number(versionMatch![3]);
+    expect(major > 0 || minor > 2 || (minor === 2 && patch >= 3)).toBe(true);
   });
 
   it(".gitignore includes standard Node + macOS + Cloudflare entries", async () => {

--- a/packages/create-zudo-doc/templates/base/pages/lib/_toc-title.ts
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_toc-title.ts
@@ -1,22 +1,3 @@
 // TOC section-label resolver for the Toc/MobileToc overrides mounted by
-// `_doc-page-shell.tsx`. Hand-mirrors `getTocTitle`, which the zudo-doc
-// package exports from "@takazudo/zudo-doc/toc" in versions > 0.2.2. The
-// published version this scaffold installs (<= 0.2.2) does not yet export it,
-// so the tiny lang→title map is duplicated here. After bumping the
-// @takazudo/zudo-doc dependency past 0.2.2 you can replace this whole file
-// with: export { getTocTitle } from "@takazudo/zudo-doc/toc";
-const TOC_TITLES: Record<string, string> = {
-  en: "On this page",
-  ja: "目次",
-  de: "Auf dieser Seite",
-};
-
-const DEFAULT_TOC_TITLE = "On this page";
-
-/** Return the TOC section label for the given BCP-47 language tag. */
-export function getTocTitle(lang?: string): string {
-  if (!lang) return DEFAULT_TOC_TITLE;
-  // "en-US" → try "en" first, then "en-US", then the English default.
-  const primary = lang.split("-")[0]!;
-  return TOC_TITLES[primary] ?? TOC_TITLES[lang] ?? DEFAULT_TOC_TITLE;
-}
+// `_doc-page-shell.tsx`, re-exported from the @takazudo/zudo-doc package.
+export { getTocTitle } from "@takazudo/zudo-doc/toc";

--- a/packages/create-zudo-doc/templates/features/docHistory/files/src/components/doc-history.tsx
+++ b/packages/create-zudo-doc/templates/features/docHistory/files/src/components/doc-history.tsx
@@ -610,7 +610,12 @@ export function DocHistory({ slug, locale, basePath = "/" }: DocHistoryProps) {
               {/* Right: diff viewer (on mobile, replaces the sidebar) */}
               {hasDiff && (
                 <div className="flex-1 min-w-0 h-full">
+                  {/* Key on the compared pair forces a fresh mount whenever the
+                      selection changes, so the previous pair's diff rows can
+                      never render under the new header hashes while the lazy
+                      import("diff") recompute is in flight (#2068). */}
                   <DiffViewer
+                    key={`${diffSelection.older.hash}:${diffSelection.newer.hash}`}
                     selection={diffSelection}
                     onBack={handleBackToRevisions}
                     showBackButton={true}

--- a/pages/lib/_toc-title.ts
+++ b/pages/lib/_toc-title.ts
@@ -1,12 +1,3 @@
 // TOC section-label resolver for the Toc/MobileToc overrides mounted by
-// `_doc-page-shell.tsx`. The host resolves @takazudo/zudo-doc as a workspace
-// package, so it imports the real `getTocTitle` straight from the /toc barrel.
-//
-// The create-zudo-doc TEMPLATE counterpart
-// (packages/create-zudo-doc/templates/base/pages/lib/_toc-title.ts) instead
-// hand-mirrors this lang→title map, because scaffolded projects install the
-// PUBLISHED @takazudo/zudo-doc (<= 0.2.2), which does not yet export
-// `getTocTitle`. That deliberate divergence is allowlisted in
-// .template-drift-allowlist; keep the two files behaviourally in sync until
-// the template can switch to this import after the next package release.
+// `_doc-page-shell.tsx`, re-exported from the @takazudo/zudo-doc package.
 export { getTocTitle } from "@takazudo/zudo-doc/toc";

--- a/src/components/doc-history.tsx
+++ b/src/components/doc-history.tsx
@@ -588,7 +588,12 @@ export function DocHistory({ slug, locale, basePath = "/" }: DocHistoryProps) {
               {/* Right: diff viewer (on mobile, replaces the sidebar) */}
               {hasDiff && (
                 <div className="flex-1 min-w-0 h-full">
+                  {/* Key on the compared pair forces a fresh mount whenever the
+                      selection changes, so the previous pair's diff rows can
+                      never render under the new header hashes while the lazy
+                      diff recompute is in flight (#2068). */}
                   <DiffViewer
+                    key={`${diffSelection.older.hash}:${diffSelection.newer.hash}`}
                     selection={diffSelection}
                     onBack={handleBackToRevisions}
                     showBackButton={true}


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2069

---

## Summary

- **#2068**: `DiffViewer` could render the previous Compare pair's diff rows under the new pair's header hashes — the component doesn't remount when the selection changes in the desktop layout, and its `changes` state stayed populated while the lazy `import("diff")` / cached-diff promise resolved. Both render sites now key `<DiffViewer>` by `${older.hash}:${newer.hash}`, so a selection change discards the old instance and state during reconciliation: the fresh mount shows the loading branch and stale rows can never paint under new hashes (stronger than an effect-side `setChanges(null)`, which still allows one stale frame since effects run post-render).
- **#2067**: `create-zudo-doc`'s `templates/base/pages/lib/_toc-title.ts` still hand-mirrored the `getTocTitle` lang→title map with a comment claiming the installed `@takazudo/zudo-doc` (<= 0.2.2) lacks the export — but the 0.2.3 scaffold installs `^0.2.3`, which exports `./toc`. The template is now the same one-liner re-export as the host, the deliberate-divergence allowlist entry is gone, and the drift gate re-engages for this file.

## Changes

### DiffViewer stale-diff fix (#2068)
- `src/components/doc-history.tsx` — key `<DiffViewer>` by the compared hash pair (host implementation keeps its module-level LRU diff cache; the existing `cancelled` cleanup flag now guards unmount races)
- `packages/create-zudo-doc/templates/features/docHistory/files/src/components/doc-history.tsx` — same keyed remount in the feature template (direct `import("diff")` variant)
- `templates/base/src/components/doc-history.tsx` stub verified unaffected; no regression test added deliberately — the repo has no DOM test harness (root vitest is Node-env, `.test.ts` only) and bolting one on was out of scope

### Template _toc-title.ts re-export (#2067)
- `packages/create-zudo-doc/templates/base/pages/lib/_toc-title.ts` — replaced the hand-mirrored `TOC_TITLES` map + stale comment with `export { getTocTitle } from "@takazudo/zudo-doc/toc";`
- `pages/lib/_toc-title.ts` — host comment rewritten; host and template are now byte-identical
- `.template-drift-allowlist` — removed the `pages/lib/_toc-title.ts` entry and its obsolete explanatory block
- `packages/create-zudo-doc/src/__tests__/scaffold.test.ts` — asserts the re-export (and absence of `TOC_TITLES`), and guards the scaffolded `@takazudo/zudo-doc` dependency floor at `>= 0.2.3` so dropping below it fails loudly

## Test Plan

- `pnpm check` (typecheck) — clean in both topic worktrees
- `pnpm check:template-drift` — passes with the allowlist entry removed (files identical)
- `pnpm --filter create-zudo-doc test` — 304 passed
- Review: codex review of the combined diff against `main` — no actionable findings
- Manual repro for #2068 (optional): desktop viewport → doc page with history → Compare pair A → with the diff open, Compare pair B → expect B's hashes + brief spinner then B's diff; never A's rows under B's hashes

Fixes #2068
Fixes #2067
Closes #2069

🤖 Generated with [Claude Code](https://claude.com/claude-code)