### PR TITLE
chore: bump zfb to 0.1.0-next.41

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,9 +78,9 @@
   },
   "dependencies": {
     "@takazudo/zdtp": "0.2.0-next.2",
-    "@takazudo/zfb": "0.1.0-next.40",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.40",
-    "@takazudo/zfb-runtime": "0.1.0-next.40",
+    "@takazudo/zfb": "0.1.0-next.41",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.41",
+    "@takazudo/zfb-runtime": "0.1.0-next.41",
     "@types/hast": "^3.0.4",
     "@takazudo/zudo-doc": "workspace:*",
     "clsx": "^2.1.1",

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -2955,13 +2955,17 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
    * emitted by the generator, so no migration needed. next.39: features +
    * fixes, no breaking changes — npm-dist `"use client"` island scanning,
    * link-resolution fixes for directory-style hrefs, and island-registry
-   * hardening (warns on island marker-name collisions). Now bumped to
-   * 0.1.0-next.40: `zfb dev` lazy rendering on by default (pages render on
-   * first request; `ZFB_DEV_EAGER=1` restores eager mode,
-   * Takazudo/zudo-front-builder#1029) — dev-server-only, no breaking
-   * changes. Generated package.json must pin all three.
+   * hardening (warns on island marker-name collisions). next.40: `zfb dev`
+   * lazy rendering on by default (pages render on first request;
+   * `ZFB_DEV_EAGER=1` restores eager mode, Takazudo/zudo-front-builder#1029)
+   * — dev-server-only, no breaking changes. Now bumped to 0.1.0-next.41:
+   * URL-space fallback in resolve_links for dir-style hrefs written from
+   * non-index pages (Takazudo/zudo-front-builder#1030), and the data-file
+   * skip warning now respects collection include/exclude globs (#1032) — no
+   * consumer-facing breaking change. Generated package.json must pin all
+   * three.
    */
-  it("pins @takazudo/zfb at 0.1.0-next.40", async () => {
+  it("pins @takazudo/zfb at 0.1.0-next.41", async () => {
     const choices: UserChoices = {
       projectName: "test-pin-bump",
       defaultLang: "en",
@@ -2972,10 +2976,10 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
     };
     await scaffold(choices);
     const pkg = await fs.readJson(projectPath("test-pin-bump", "package.json"));
-    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.40");
-    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.40");
+    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.41");
+    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.41");
     expect(pkg.dependencies["@takazudo/zfb-adapter-cloudflare"]).toBe(
-      "0.1.0-next.40",
+      "0.1.0-next.41",
     );
   });
 });

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -342,15 +342,21 @@ function generatePackageJson(choices: UserChoices) {
     // npm-dist `"use client"` island scanning, link-resolution fixes for
     // directory-style hrefs, and island-registry hardening (warns on island
     // marker-name collisions).
-    // next.40 (current pin) flips `zfb dev` to lazy rendering by default —
+    // next.40 flips `zfb dev` to lazy rendering by default —
     // pages render on first request instead of on every file-change tick
     // (Takazudo/zudo-front-builder#1029); `ZFB_DEV_EAGER=1` restores eager
     // mode. Dev-server-only change, no build/config migration needed.
-    "@takazudo/zfb": "0.1.0-next.40",
-    "@takazudo/zfb-runtime": "0.1.0-next.40",
+    // next.41 (current pin) adds a URL-space fallback in resolve_links —
+    // dir-style hrefs written from non-index pages now resolve against the
+    // page's URL directory when the file-space lookup misses
+    // (Takazudo/zudo-front-builder#1030) — and the data-file skip warning
+    // (e.g. for `_category_.json`) now respects the collection's
+    // include/exclude globs (#1032). No consumer-facing breaking change.
+    "@takazudo/zfb": "0.1.0-next.41",
+    "@takazudo/zfb-runtime": "0.1.0-next.41",
     // zfb-adapter-cloudflare — required for any route with `prerender = false`.
     // Pinned in lockstep with @takazudo/zfb.
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.40",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.41",
     // @takazudo/zudo-doc — published from this monorepo via
     // .github/workflows/publish-zudo-doc.yml. The pin here is bumped in
     // lockstep by scripts/release-create-zudo-doc.sh whenever zudo-doc's

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -171,8 +171,8 @@
   ],
   "peerDependencies": {
     "preact": "^10.29.1",
-    "@takazudo/zfb": "^0.1.0-next.40",
-    "@takazudo/zfb-runtime": "^0.1.0-next.40",
+    "@takazudo/zfb": "^0.1.0-next.41",
+    "@takazudo/zfb-runtime": "^0.1.0-next.41",
     "@takazudo/zudo-doc-history-server": "workspace:^",
     "@takazudo/zdtp": "^0.2.0-next.2",
     "shiki": "^4.0.2"
@@ -200,7 +200,7 @@
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
     "vitest": "^4.1.0",
-    "@takazudo/zfb": "0.1.0-next.40",
-    "@takazudo/zfb-runtime": "0.1.0-next.40"
+    "@takazudo/zfb": "0.1.0-next.41",
+    "@takazudo/zfb-runtime": "0.1.0-next.41"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,14 +25,14 @@ importers:
         specifier: 0.2.0-next.2
         version: 0.2.0-next.2(preact@10.29.2)
       '@takazudo/zfb':
-        specifier: 0.1.0-next.40
-        version: 0.1.0-next.40
+        specifier: 0.1.0-next.41
+        version: 0.1.0-next.41
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.40
-        version: 0.1.0-next.40
+        specifier: 0.1.0-next.41
+        version: 0.1.0-next.41
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.40
-        version: 0.1.0-next.40(@takazudo/zfb@0.1.0-next.40)
+        specifier: 0.1.0-next.41
+        version: 0.1.0-next.41(@takazudo/zfb@0.1.0-next.41)
       '@takazudo/zudo-doc':
         specifier: workspace:*
         version: link:packages/zudo-doc
@@ -285,11 +285,11 @@ importers:
         version: 4.0.3
     devDependencies:
       '@takazudo/zfb':
-        specifier: 0.1.0-next.40
-        version: 0.1.0-next.40
+        specifier: 0.1.0-next.41
+        version: 0.1.0-next.41
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.40
-        version: 0.1.0-next.40(@takazudo/zfb@0.1.0-next.40)
+        specifier: 0.1.0-next.41
+        version: 0.1.0-next.41(@takazudo/zfb@0.1.0-next.41)
       '@types/node':
         specifier: ^25.3.5
         version: 25.3.5
@@ -1372,44 +1372,44 @@ packages:
     peerDependencies:
       preact: ^10.29.1
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.40':
-    resolution: {integrity: sha512-lS1LwcwD0f0qoa9GGQTj7AKhnYt3HLxR0XswiwbTDG5J4mwvqN63NoRU1NvqIXfeMv+rnQRr0ECoEglChbfeWQ==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.41':
+    resolution: {integrity: sha512-0GgxEnFn2J7waYxyUR6Hvzll/5wvkt4JK9lIDa74iro4H3fP70XvkvZaoTLpBIK6JDMR0YObM36COC3riZfDDA==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.40':
-    resolution: {integrity: sha512-MK5Ud8BHLd75rcAcyQrxUmerSvrk4phAueTU+F+0+S0294g+3OWxmnpZaiVv1Xn4F4qDaMp9wW5+V+ur3uMQQw==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.41':
+    resolution: {integrity: sha512-uwUVwc6k3FuP9Kzw8JChP7R7wDwCVS3UqEFFcTVLmpeHrDP2h0+48AwDlwzls88knDz621PozjSq/2ojxlhaPA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.40':
-    resolution: {integrity: sha512-qTAP8MoqPu+lG4CdNL5kku8Er3Toe6PQsYRS7YXbW1hQ1LDz3DqMpch2IvzohsHy40ALQzpXpGV894J3tU29uA==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.41':
+    resolution: {integrity: sha512-aswliW7P9bJu/YfaRmILMxFOmw8qiGOl/QboIjMcXzPuqCCtnLpYNZwxnVj4K4C8z90cDs9kCmJrunCCCfEvcQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.40':
-    resolution: {integrity: sha512-3cgSdT7JeldVzMMviYd9wjdkjZVsZaSiDlzPYzYyfhdPUtfhpY99hLZDhrZkbxr5XjRwy2jOsrg62ij70h6Qtg==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.41':
+    resolution: {integrity: sha512-+9yHAnu8oNbYPlvratBLMrhGMn4x//4XB6vNXR0M0NYNq+AsKwOvpmJ4aNAxHq7Ty6OnMu5dH6eUN/KYUIUH4Q==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.40':
-    resolution: {integrity: sha512-PZsfqoyCDpWVos243OLcTyfLWh/1CK9uAjcGHXXANW5hhUSweWLYMyCHd1dnFEor6R2j2OefIIRfMgMsi02Cog==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.41':
+    resolution: {integrity: sha512-ykN9KFdSfzjhElMPFj26wVr/HAzn/0lfUHmXjVkciEt8B22JPz9RJT4gl02MwUKIrJDvDF4r5ZtxD3TF+r28Bw==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.40':
-    resolution: {integrity: sha512-ZnmAdY7/rLn9otIm5g5+F+NDHOGhQVmkmxZmggc+B8O3UrBU9tA37w9FWNT6HJuMTfbUyt3RRtLLa8ul4uEoEg==}
+  '@takazudo/zfb-runtime@0.1.0-next.41':
+    resolution: {integrity: sha512-0/V4srUTz1r05GJgujFJHo2uu/ukVRAHE3k+akOaf6uuCv2gvs9fut1m8nlYX1jqvRdLk6xdQbQIt/m/AOCeAQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.40
+      '@takazudo/zfb': 0.1.0-next.41
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.40':
-    resolution: {integrity: sha512-JTriZ2OwDnnKJhjPFZ93V7gaA1z43OF2WHV4DePcRo9MEJPnZgMhw07HjVzQNNabiJlpSKkvakMZMrLLLrfCmw==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.41':
+    resolution: {integrity: sha512-zBmwAAVCbN9lgNAswL2sAchBQddN2tDfglos96a9yWuJkzfyucqBnKm6TE6Bc8W86oq97+Y2cQUOqjtBDvIw3w==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.40':
-    resolution: {integrity: sha512-X9WXau56QXZhVbTT5tECaFUgV0luh551qD1it2fPD1YlPFzAbh9VEAtwT2THUPa0a7Aexab0b0LPVV6EUnf9Ug==}
+  '@takazudo/zfb@0.1.0-next.41':
+    resolution: {integrity: sha512-bu1MaXEyahQ3jbRK5f51bF7KQY14Kaiota1KKZIs0yoU+OkJ1DP+td5MZw94I4Y70Bs5kjktlpRYw82EDQyh7w==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
@@ -4071,35 +4071,35 @@ snapshots:
       culori: 4.0.2
       preact: 10.29.2
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.40': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.41': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.40':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.41':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.40':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.41':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.40':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.41':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.40':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.41':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.40(@takazudo/zfb@0.1.0-next.40)':
+  '@takazudo/zfb-runtime@0.1.0-next.41(@takazudo/zfb@0.1.0-next.41)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.40
+      '@takazudo/zfb': 0.1.0-next.41
       hono: 4.12.23
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.40':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.41':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.40':
+  '@takazudo/zfb@0.1.0-next.41':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.40
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.40
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.40
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.40
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.40
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.41
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.41
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.41
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.41
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.41
 
   '@takazudo/zudo-design-token-lint@1.0.0':
     dependencies:


### PR DESCRIPTION
## Summary
- Bump the zfb stack from `0.1.0-next.40` to `0.1.0-next.41` across the workspace (`@takazudo/zfb`, `@takazudo/zfb-runtime`, `@takazudo/zfb-adapter-cloudflare`; platform binaries follow via zfb's optionalDependencies; `@takazudo/zdtp` unchanged).
- Update the `create-zudo-doc` generator so newly scaffolded projects pin the new versions.
- next.41 upstream changes: URL-space fallback in `resolve_links` for dir-style hrefs written from non-index pages (Takazudo/zudo-front-builder#1030), and the data-file skip warning (e.g. `_category_.json`) now respects collection include/exclude globs (#1032). No consumer-facing breaking change.

## Changes
- **Dependency updates**
  - Root `package.json`: the three zfb packages → exact `0.1.0-next.41`.
  - `packages/zudo-doc/package.json`: peerDependencies → `^0.1.0-next.41`, devDependencies → exact `0.1.0-next.41` for zfb + zfb-runtime.
  - `pnpm-lock.yaml` refreshed (platform binary resolutions included).
- **Generator alignment**
  - `packages/create-zudo-doc/src/scaffold.ts`: generated projects pin all three zfb packages at `0.1.0-next.41`; extended the in-code release-notes comment chain with the next.41 entry.
- **Test updates**
  - `scaffold.test.ts`: pin-bump test retitled and assertions updated to `0.1.0-next.41`, doc comment extended.

## Test Plan
- [x] `pnpm check:pin-parity` — all pin sources agree on `0.1.0-next.41`
- [x] `create-zudo-doc` unit tests — 304 passed
- [x] `pnpm b4push` automated steps 1–14 — format check, template drift, fixture drift, tags audit, design token lint, typecheck, build, link check, HTML validation, preview smoke (6/6) all green (step 15 is the human-interactive manual smoke prompt, skipped in this non-interactive run)
- [x] CI on this PR — 14/14 checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)