### PR TITLE
Cross-fade lone chrome snapshots on cross-type page transitions

### DIFF
--- a/.claude/skills/l-lessons-zfb-migration-parity/SKILL.md
+++ b/.claude/skills/l-lessons-zfb-migration-parity/SKILL.md
@@ -647,6 +647,8 @@ Persist in zfb is a **two-part contract** that must be explicitly implemented an
 **Part 2 — Visual extraction (host CSS layer):**
 CSS attribute selectors that map `[data-zfb-transition-persist^="<prefix>"]` to `view-transition-name: <name>` on the matching elements. Plus `animation: none` on the named pseudos — `::view-transition-old(<name>)`, `::view-transition-new(<name>)`, and `::view-transition-group(<name>)` (see below) — so the named elements are held static while the rest of the page crossfades.
 
+> **Amendment (#2072):** "held static" holds only when the chrome element exists on BOTH pages of a navigation — when it exists on one side only, `:only-child`-scoped rules cross-fade the lone snapshot in sync with the root content fade instead of holding it static.
+
 The W7A correction added Part 1 and missed Part 2. The W8 epic (this epic, #1556) adds Part 2 and the visual assertions V1–V8b in T3 to lock both halves in.
 
 The full correct CSS shape for each persisted chrome region is:
@@ -667,7 +669,7 @@ The full correct CSS shape for each persisted chrome region is:
 
 When `::view-transition-old(<name>)` and `::view-transition-new(<name>)` are both `animation: none`, there is still a third UA-generated pseudo-element: `::view-transition-group(<name>)`. This pseudo animates the bounding-box geometry of the named element between its captured position in the old snapshot and its captured position in the new snapshot. If the element's size or position changes between pages (e.g. sidebar width differs across locales, or header height changes on pages with different nav states), the UA will produce a geometry-morph animation on the group even when old/new are frozen.
 
-For the "named chrome element never visually animates" contract to be robust, all three pseudos must be neutralised. The original W8 plan (before Codex and gcoc reviews during planning) only neutralised old/new. Codex's planning review explicitly flagged the group pseudo as a missing neutralisation — surfacing a would-be silent regression before the CSS was written. The final T2 implementation neutralises all three pseudos.
+For the "named chrome element never visually animates" contract to be robust, all three pseudos must be neutralised (with the #2072 amendment above: this "never animates" guarantee applies to chrome present on both sides of a navigation, not to a lone one-sided snapshot). The original W8 plan (before Codex and gcoc reviews during planning) only neutralised old/new. Codex's planning review explicitly flagged the group pseudo as a missing neutralisation — surfacing a would-be silent regression before the CSS was written. The final T2 implementation neutralises all three pseudos.
 
 The lesson: when writing `animation: none` rules for a named VT element, enumerate `::view-transition-old(<name>)`, `::view-transition-new(<name>)`, AND `::view-transition-group(<name>)` as a unit. Missing any one of the three leaves a door open for geometry-morph animations on geometry changes.
 

--- a/e2e/smoke-visual-vt-chrome-persist.spec.ts
+++ b/e2e/smoke-visual-vt-chrome-persist.spec.ts
@@ -410,8 +410,18 @@ async function installKeyframeCountHook(
 async function readKeyframeCount(
   page: import("@playwright/test").Page,
 ): Promise<number | null> {
-  // Allow the 50ms setTimeout to fire and settle.
-  await page.waitForTimeout(200);
+  // Allow vt.ready + rAF to fire and record the count. Poll rather than wait a
+  // fixed window so a loaded CI runner pushing vt.ready + rAF past a fixed
+  // delay doesn't cause a spurious null read; the not-null assertion in the
+  // caller remains the failure reporter.
+  await page
+    .waitForFunction(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      () => (document as any).__keyframeCount__ !== null,
+      undefined,
+      { timeout: 5000 },
+    )
+    .catch(() => null); // fall through — the not-null assertion reports the failure
   return page.evaluate(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     () => (document as any).__keyframeCount__ as number | null,

--- a/e2e/smoke-visual-vt-chrome-persist.spec.ts
+++ b/e2e/smoke-visual-vt-chrome-persist.spec.ts
@@ -11,6 +11,9 @@
  *   3. On the same transition, document.getAnimations() total count >= 1 (regression
  *      sanity: content cross-fade still runs — named-chrome suppression has not
  *      eliminated all view-transition activity).
+ *   4. On cross-type navigation (sidebar page ↔ no-sidebar top page), the lone
+ *      chrome snapshot cross-fades with the content via the :only-child
+ *      entry/exit rules instead of freezing (#2072).
  *
  * Sibling spec files cover DOM-node identity and sidebar assertions:
  *   - smoke-vt-chrome-persist.spec.ts   (DOM identity, sidebar highlight/scroll)
@@ -307,5 +310,175 @@ test.describe("VT Chrome Static: getAnimations() during same-locale + same-secti
       totalCount,
       `Total animation count should be >= 1 at 50ms into transition (root content cross-fade should still be running); got ${totalCount}. Named-chrome suppression may have accidentally eliminated all view-transition activity.`,
     ).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 4 + Test 5: entry/exit cross-fade on cross-type navigation (#2072)
+//
+// When a chrome element exists on only ONE side of a navigation (docs page
+// with sidebar → top page without, or the reverse), its named view-transition
+// group holds a single snapshot. The unconditional `animation: none` rules
+// used to freeze that lone snapshot at full opacity for the whole transition,
+// after which it vanished abruptly. The :only-child rules in global.css now
+// cross-fade the lone snapshot in sync with the root content fade.
+//
+// Assertion strategy: count CSSAnimations by animationName instead of
+// pseudoElement string — headless Chromium does not reliably expose
+// pseudoElement on view-transition Animation objects (see the V6 note in
+// Test 3). The contentFadeOut/contentFadeIn keyframes are referenced ONLY by
+// the view-transition rules in global.css, so per-name counts are exact:
+//   same-section nav: 1 contentFadeOut (root old), 1 contentFadeIn (root new)
+//   exit nav (sidebar → none): >= 2 contentFadeOut (root old + lone zfb-sidebar old)
+//   entry nav (none → sidebar): >= 2 contentFadeIn (root new + lone zfb-sidebar new)
+// ---------------------------------------------------------------------------
+
+// Helper: JS-click the first anchor matching a CSS selector and wait for the
+// zfb:after-swap event. Selector-based variant of spaClick for links whose
+// exact href shape (trailing slash, base prefix) we don't want to hardcode.
+async function spaClickSelector(
+  page: import("@playwright/test").Page,
+  selector: string,
+): Promise<boolean> {
+  const swapFired = await page.evaluate((sel: string) => {
+    return new Promise<boolean>((resolve) => {
+      let tid: ReturnType<typeof setTimeout> | null = null;
+      document.addEventListener(
+        "zfb:after-swap",
+        () => {
+          if (tid !== null) clearTimeout(tid);
+          resolve(true);
+        },
+        { once: true },
+      );
+      const anchor = document.querySelector<HTMLElement>(sel);
+      if (anchor) {
+        tid = setTimeout(() => resolve(false), 8000);
+        anchor.click();
+      } else {
+        resolve(false);
+      }
+    });
+  }, selector);
+  await page.waitForLoadState("networkidle").catch(() => null);
+  await page.waitForTimeout(200);
+  return swapFired;
+}
+
+// Helper: install a startViewTransition hook that samples getAnimations()
+// right after the transition's `ready` promise resolves and records how many
+// CSSAnimations run the given keyframe name. Unlike Tests 2/3's fixed 50ms
+// window, `ready` is used here because the swap callback for a heavy
+// destination (e.g. the guides page with the full sidebar tree) can exceed
+// 50ms — a fixed-delay sample would land before the pseudo-element
+// animations exist and read 0. `ready` resolves exactly when the pseudo
+// tree is built and its animations have started.
+async function installKeyframeCountHook(
+  page: import("@playwright/test").Page,
+  keyframeName: string,
+): Promise<void> {
+  await page.evaluate((name: string) => {
+    const origSVT = document.startViewTransition?.bind(document);
+    if (!origSVT) return;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (document as any).__keyframeCount__ = null;
+    document.startViewTransition = (cb) => {
+      const vt = origSVT(cb);
+      vt.ready
+        .then(() => {
+          // One rAF so the freshly-started animations are observable.
+          requestAnimationFrame(() => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (document as any).__keyframeCount__ = document
+              .getAnimations()
+              .filter(
+                (a) => (a as CSSAnimation).animationName === name,
+              ).length;
+          });
+        })
+        .catch(() => {
+          // Transition was skipped — record a distinct sentinel so the
+          // assertion fails with a recognizable value instead of null.
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (document as any).__keyframeCount__ = -1;
+        });
+      return vt;
+    };
+  }, keyframeName);
+}
+
+async function readKeyframeCount(
+  page: import("@playwright/test").Page,
+): Promise<number | null> {
+  // Allow the 50ms setTimeout to fire and settle.
+  await page.waitForTimeout(200);
+  return page.evaluate(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    () => (document as any).__keyframeCount__ as number | null,
+  );
+}
+
+test.describe("VT chrome entry/exit cross-fade on cross-type nav (#2072)", () => {
+  test("exit: lone zfb-sidebar old snapshot fades out when navigating to a page without sidebar", async ({
+    page,
+  }) => {
+    await page.goto(GUIDES_INDEX, { waitUntil: "domcontentloaded" });
+    await waitForSidebarHydration(page);
+
+    // The header logo links to the top page (withBase("/")), which renders
+    // with hideSidebar=true and no sidebar persist key.
+    const logoFound = await page.evaluate(
+      () => !!document.querySelector('header a[href="/"]'),
+    );
+    expect(
+      logoFound,
+      `Expected the header logo link to "/" on ${GUIDES_INDEX}`,
+    ).toBe(true);
+
+    await installKeyframeCountHook(page, "contentFadeOut");
+
+    const swapFired = await spaClickSelector(page, 'header a[href="/"]');
+    expect(swapFired, "zfb:after-swap did not fire within 8 s").toBe(true);
+
+    const count = await readKeyframeCount(page);
+    expect(
+      count,
+      "startViewTransition hook was not active — animation snapshot not captured",
+    ).not.toBeNull();
+    expect(
+      count,
+      `Expected >= 2 contentFadeOut animations during sidebar→no-sidebar nav (root old + lone zfb-sidebar old via :only-child); got ${count}. The lone sidebar snapshot may be frozen again (#2072 regression).`,
+    ).toBeGreaterThanOrEqual(2);
+  });
+
+  test("entry: lone zfb-sidebar new snapshot fades in when navigating from a page without sidebar", async ({
+    page,
+  }) => {
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    // Any internal link into the guides section works — the destination
+    // renders the desktop sidebar with a persist key.
+    const linkFound = await page.evaluate(
+      () => !!document.querySelector('a[href^="/docs/guides"]'),
+    );
+    expect(
+      linkFound,
+      'Expected a link matching a[href^="/docs/guides"] on the top page',
+    ).toBe(true);
+
+    await installKeyframeCountHook(page, "contentFadeIn");
+
+    const swapFired = await spaClickSelector(page, 'a[href^="/docs/guides"]');
+    expect(swapFired, "zfb:after-swap did not fire within 8 s").toBe(true);
+
+    const count = await readKeyframeCount(page);
+    expect(
+      count,
+      "startViewTransition hook was not active — animation snapshot not captured",
+    ).not.toBeNull();
+    expect(
+      count,
+      `Expected >= 2 contentFadeIn animations during no-sidebar→sidebar nav (root new + lone zfb-sidebar new via :only-child); got ${count}. The entering sidebar may be popping in without the cross-fade (#2072 regression).`,
+    ).toBeGreaterThanOrEqual(2);
   });
 });

--- a/packages/create-zudo-doc/templates/base/src/styles/global.css
+++ b/packages/create-zudo-doc/templates/base/src/styles/global.css
@@ -938,7 +938,17 @@ pre[class^="syntect-"] .line .highlighted-word {
  * article, TOC, etc.). The twelve ::view-transition-{old,new,group}(<name>)
  * rules disable animation for all four chrome layers. The group pseudo must be
  * neutralised too — even when old/new are static the group container can still
- * produce a geometry-morph animation when snapshot size/position differs. */
+ * produce a geometry-morph animation when snapshot size/position differs.
+ *
+ * Entry/exit cross-fade (zudolab/zudo-doc#2072): animation: none is only
+ * correct when the chrome element exists on BOTH pages of a navigation.
+ * When it exists on one side only (docs page with sidebar → top page
+ * without), the named group holds a single snapshot — frozen at full
+ * opacity for the whole transition, then dropped abruptly at finish. The
+ * :only-child rules below detect that one-sided case and cross-fade the
+ * lone snapshot in sync with the root content fade (spec-standard
+ * entry/exit pattern; :only-child outranks the animation: none rules via
+ * the extra pseudo-class specificity). */
 
 /* Chrome extraction — assign view-transition-name from data-zfb-transition-persist */
 [data-zfb-transition-persist^="header-"]               { view-transition-name: zfb-header; }
@@ -959,6 +969,22 @@ pre[class^="syntect-"] .line .highlighted-word {
 ::view-transition-old(zfb-sidebar-toggle),
 ::view-transition-new(zfb-sidebar-toggle),
 ::view-transition-group(zfb-sidebar-toggle) { animation: none; }
+
+/* Entry/exit: chrome element present on one side only (#2072).
+ * Exit — lone old snapshot fades out with the content cross-fade. */
+::view-transition-old(zfb-header):only-child,
+::view-transition-old(zfb-sidebar):only-child,
+::view-transition-old(zfb-footer):only-child,
+::view-transition-old(zfb-sidebar-toggle):only-child {
+  animation: 150ms ease-in both contentFadeOut;
+}
+/* Entry — lone new snapshot fades in with the content cross-fade. */
+::view-transition-new(zfb-header):only-child,
+::view-transition-new(zfb-sidebar):only-child,
+::view-transition-new(zfb-footer):only-child,
+::view-transition-new(zfb-sidebar-toggle):only-child {
+  animation: 300ms ease-out both contentFadeIn;
+}
 
 /* Root cross-fade rules — animate only the non-chrome snapshot */
 ::view-transition-old(root) {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1264,7 +1264,17 @@ dialog.zd-enlarge-dialog::backdrop {
  * article, TOC, etc.). The twelve ::view-transition-{old,new,group}(<name>)
  * rules disable animation for all four chrome layers. The group pseudo must be
  * neutralised too — even when old/new are static the group container can still
- * produce a geometry-morph animation when snapshot size/position differs. */
+ * produce a geometry-morph animation when snapshot size/position differs.
+ *
+ * Entry/exit cross-fade (zudolab/zudo-doc#2072): animation: none is only
+ * correct when the chrome element exists on BOTH pages of a navigation.
+ * When it exists on one side only (docs page with sidebar → top page
+ * without), the named group holds a single snapshot — frozen at full
+ * opacity for the whole transition, then dropped abruptly at finish. The
+ * :only-child rules below detect that one-sided case and cross-fade the
+ * lone snapshot in sync with the root content fade (spec-standard
+ * entry/exit pattern; :only-child outranks the animation: none rules via
+ * the extra pseudo-class specificity). */
 
 /* Chrome extraction — assign view-transition-name from data-zfb-transition-persist */
 [data-zfb-transition-persist^="header-"]               { view-transition-name: zfb-header; }
@@ -1285,6 +1295,22 @@ dialog.zd-enlarge-dialog::backdrop {
 ::view-transition-old(zfb-sidebar-toggle),
 ::view-transition-new(zfb-sidebar-toggle),
 ::view-transition-group(zfb-sidebar-toggle) { animation: none; }
+
+/* Entry/exit: chrome element present on one side only (#2072).
+ * Exit — lone old snapshot fades out with the content cross-fade. */
+::view-transition-old(zfb-header):only-child,
+::view-transition-old(zfb-sidebar):only-child,
+::view-transition-old(zfb-footer):only-child,
+::view-transition-old(zfb-sidebar-toggle):only-child {
+  animation: 150ms ease-in both contentFadeOut;
+}
+/* Entry — lone new snapshot fades in with the content cross-fade. */
+::view-transition-new(zfb-header):only-child,
+::view-transition-new(zfb-sidebar):only-child,
+::view-transition-new(zfb-footer):only-child,
+::view-transition-new(zfb-sidebar-toggle):only-child {
+  animation: 300ms ease-out both contentFadeIn;
+}
 
 /* Root cross-fade rules — animate only the non-chrome snapshot */
 ::view-transition-old(root) {


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2072

---

## Summary

- Fixes #2072: navigating between a page with a sidebar and one without (e.g. a docs page → the top page) left the old sidebar frozen on screen for the whole view transition, then dropped it abruptly at transition end.
- Root cause: the Strategy B+ chrome-extraction rules (#1558) set `animation: none` unconditionally on the `zfb-header` / `zfb-sidebar` / `zfb-footer` / `zfb-sidebar-toggle` view-transition pseudos. That is correct only when the element exists on **both** pages; with a one-sided snapshot the freeze-then-pop is the result.
- Fix: `:only-child`-scoped entry/exit rules (the spec-standard pattern for one-sided snapshots) — a lone **old** snapshot now fades out in sync with the root content cross-fade (150ms ease-in), a lone **new** snapshot fades in (300ms ease-out). Both-sides navigations keep the static-persist behavior unchanged.

## Changes

- `src/styles/global.css` — added the `:only-child` entry/exit rules for all four chrome layers after the `animation: none` block, plus an explanatory comment amendment.
- `packages/create-zudo-doc/templates/base/src/styles/global.css` — identical mirror (byte-identical block; `global.css` is drift-allowlisted so the sync is manual by design).
- `e2e/smoke-visual-vt-chrome-persist.spec.ts` — two new permanent regression tests (Test 4 exit: guides → top page; Test 5 entry: top page → guides). They hook `document.startViewTransition`, sample `document.getAnimations()` after `ViewTransition.ready` (+1 rAF, polled via `waitForFunction`), and count CSSAnimations by keyframe name (`contentFadeOut` / `contentFadeIn`) — name-based because headless Chromium does not reliably expose `pseudoElement` strings; the keyframes are referenced only by the view-transition rules, so counts are exact.
- `.claude/skills/l-lessons-zfb-migration-parity/SKILL.md` — amended the "named chrome never visually animates" lesson passages with the #2072 one-sided exception (the published `.mdx` mirror is generated from this file at build time).

## Review

Two parallel reviewers found no high-priority issues; three polish findings (stale comment, flake-hardening poll, lesson-doc amendment) were fixed via #2085. Unrelated findings raised separately: #2084 (e2e webServer wrangler inspector-port race), #2086 (view transitions ignore `prefers-reduced-motion`, pre-existing).

## Test Plan

- `npx playwright test e2e/smoke-visual-vt-chrome-persist.spec.ts --project smoke` — 5/5 pass (3 pre-existing static-persist assertions + the 2 new entry/exit tests).
- `pnpm check` (tsc) passes.
- Manual repro: from `/docs/reference/` (or any docs page) click the logo to the top page — the sidebar now fades out with the content instead of freezing and popping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)