### PR TITLE
UI & Generator Polish: pager spacing fix, preset defaults, diff separators, choosable meta tags

### DIFF
--- a/e2e/fixtures/i18n/src/config/settings.ts
+++ b/e2e/fixtures/i18n/src/config/settings.ts
@@ -2,6 +2,7 @@ import type {
   HeaderNavItem,
   ColorModeConfig,
   LocaleConfig,
+  MetaTagsConfig,
 } from "./settings-types";
 
 export const settings = {
@@ -20,6 +21,13 @@ export const settings = {
   noindex: true as boolean,
   editUrl: false as string | false,
   siteUrl: "" as string,
+  metaTags: {
+    description: true,
+    keywords: false,
+    ogImage: false,
+    ogSiteName: true,
+    twitterCard: false,
+  } satisfies MetaTagsConfig as MetaTagsConfig,
   sitemap: false,
   docMetainfo: false,
   docTags: false,

--- a/e2e/fixtures/sidebar/src/config/settings.ts
+++ b/e2e/fixtures/sidebar/src/config/settings.ts
@@ -2,6 +2,7 @@ import type {
   HeaderNavItem,
   ColorModeConfig,
   LocaleConfig,
+  MetaTagsConfig,
 } from "./settings-types";
 
 export const settings = {
@@ -17,6 +18,13 @@ export const settings = {
   noindex: true as boolean,
   editUrl: false as string | false,
   siteUrl: "" as string,
+  metaTags: {
+    description: true,
+    keywords: false,
+    ogImage: false,
+    ogSiteName: true,
+    twitterCard: false,
+  } satisfies MetaTagsConfig as MetaTagsConfig,
   sitemap: false,
   docMetainfo: false,
   docTags: false,

--- a/e2e/fixtures/smoke/src/config/settings.ts
+++ b/e2e/fixtures/smoke/src/config/settings.ts
@@ -6,6 +6,7 @@ import type {
   LocaleConfig,
   FrontmatterPreviewConfig,
   BodyFootUtilAreaConfig,
+  MetaTagsConfig,
 } from "./settings-types";
 
 export const settings = {
@@ -22,6 +23,13 @@ export const settings = {
   editUrl: "https://github.com/example/repo/edit/main" as string | false,
   githubUrl: "https://github.com/example/repo" as string | false,
   siteUrl: "" as string,
+  metaTags: {
+    description: true,
+    keywords: false,
+    ogImage: false,
+    ogSiteName: true,
+    twitterCard: false,
+  } satisfies MetaTagsConfig as MetaTagsConfig,
   sitemap: false,
   docMetainfo: false,
   docTags: false,

--- a/e2e/fixtures/theme/src/config/settings.ts
+++ b/e2e/fixtures/theme/src/config/settings.ts
@@ -3,6 +3,7 @@ import type {
   HeaderRightItem,
   ColorModeConfig,
   LocaleConfig,
+  MetaTagsConfig,
 } from "./settings-types";
 
 export const settings = {
@@ -23,6 +24,13 @@ export const settings = {
   noindex: true as boolean,
   editUrl: false as string | false,
   siteUrl: "" as string,
+  metaTags: {
+    description: true,
+    keywords: false,
+    ogImage: false,
+    ogSiteName: true,
+    twitterCard: false,
+  } satisfies MetaTagsConfig as MetaTagsConfig,
   sitemap: false,
   docMetainfo: false,
   docTags: false,

--- a/e2e/fixtures/versioning/src/config/settings.ts
+++ b/e2e/fixtures/versioning/src/config/settings.ts
@@ -4,6 +4,7 @@ import type {
   ColorModeConfig,
   LocaleConfig,
   VersionConfig,
+  MetaTagsConfig,
 } from "./settings-types";
 
 export const settings = {
@@ -19,6 +20,13 @@ export const settings = {
   noindex: true as boolean,
   editUrl: false as string | false,
   siteUrl: "" as string,
+  metaTags: {
+    description: true,
+    keywords: false,
+    ogImage: false,
+    ogSiteName: true,
+    twitterCard: false,
+  } satisfies MetaTagsConfig as MetaTagsConfig,
   sitemap: false,
   docMetainfo: false,
   docTags: false,

--- a/packages/create-zudo-doc/src/__tests__/preset.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/preset.test.ts
@@ -212,3 +212,110 @@ describe("validatePreset — projectName (F4 #2013)", () => {
     expect(validatePreset({ projectName: null })).toMatch(/must be a string/);
   });
 });
+
+describe("validatePreset — metaTags (S5 #2079)", () => {
+  it("accepts absent metaTags", () => {
+    expect(validatePreset({})).toBeNull();
+  });
+
+  it("accepts a minimal valid metaTags object", () => {
+    expect(validatePreset({ metaTags: { description: true } })).toBeNull();
+  });
+
+  it("accepts a full valid metaTags object", () => {
+    expect(
+      validatePreset({
+        metaTags: {
+          description: true,
+          keywords: "docs, guide",
+          ogImage: "/img/ogp.png",
+          ogSiteName: true,
+          twitterCard: "summary_large_image",
+          twitterSite: "@brand",
+          twitterCreator: "@author",
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("accepts metaTags with false values", () => {
+    expect(
+      validatePreset({
+        metaTags: { keywords: false, ogImage: false, twitterCard: false },
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects metaTags as a non-object", () => {
+    expect(validatePreset({ metaTags: "yes" })).toMatch(/"metaTags" must be an object/);
+  });
+
+  it("rejects metaTags.description as non-boolean", () => {
+    expect(validatePreset({ metaTags: { description: "yes" } })).toMatch(
+      /"metaTags.description" must be a boolean/,
+    );
+  });
+
+  it("rejects metaTags.keywords as a non-string/non-false value", () => {
+    expect(validatePreset({ metaTags: { keywords: 42 } })).toMatch(
+      /"metaTags.keywords" must be a string or false/,
+    );
+  });
+
+  it("rejects metaTags.ogImage as a non-string/non-false value", () => {
+    expect(validatePreset({ metaTags: { ogImage: 42 } })).toMatch(
+      /"metaTags.ogImage" must be a string or false/,
+    );
+  });
+
+  it("rejects metaTags.ogSiteName as non-boolean", () => {
+    expect(validatePreset({ metaTags: { ogSiteName: "yes" } })).toMatch(
+      /"metaTags.ogSiteName" must be a boolean/,
+    );
+  });
+
+  it("rejects metaTags.twitterCard with an invalid enum value", () => {
+    expect(validatePreset({ metaTags: { twitterCard: "player" } })).toMatch(
+      /"metaTags.twitterCard" must be "summary", "summary_large_image", or false/,
+    );
+  });
+
+  it("rejects metaTags.twitterSite as non-string", () => {
+    expect(validatePreset({ metaTags: { twitterSite: 42 } })).toMatch(
+      /"metaTags.twitterSite" must be a string/,
+    );
+  });
+
+  it("rejects metaTags.twitterCreator as non-string", () => {
+    expect(validatePreset({ metaTags: { twitterCreator: 42 } })).toMatch(
+      /"metaTags.twitterCreator" must be a string/,
+    );
+  });
+});
+
+describe("presetToChoices — metaTags (S5 #2079)", () => {
+  it("forwards metaTags when present", () => {
+    const mt = { description: false, twitterCard: "summary" as const };
+    const choices = presetToChoices({ metaTags: mt });
+    expect(choices.metaTags).toEqual(mt);
+  });
+
+  it("leaves metaTags undefined when omitted", () => {
+    const choices = presetToChoices({});
+    expect(choices.metaTags).toBeUndefined();
+  });
+
+  it("forwards a full metaTags config", () => {
+    const mt = {
+      description: true,
+      keywords: "a, b",
+      ogImage: "/img/og.png",
+      ogSiteName: false,
+      twitterCard: "summary_large_image" as const,
+      twitterSite: "@x",
+      twitterCreator: "@y",
+    };
+    const choices = presetToChoices({ metaTags: mt });
+    expect(choices.metaTags).toEqual(mt);
+  });
+});

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -963,6 +963,76 @@ describe("scaffold — footer features", () => {
     expect(content).toContain("copyright:");
   });
 
+  // S4 (#2078): metaTags block is emitted unconditionally with scaffold defaults
+  // so scaffolded projects are type-correct against the updated
+  // _head-with-defaults.tsx template. Choice-driven values (ogImage path,
+  // twitterCard type) come in S5.
+  it("emits metaTags block unconditionally with scaffold defaults (S4 #2078)", async () => {
+    const choices: UserChoices = {
+      projectName: "test-meta-tags-defaults",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search"],
+      packageManager: "pnpm",
+    };
+    await scaffold(choices);
+    const content = await fs.readFile(
+      projectPath("test-meta-tags-defaults", "src/config/settings.ts"),
+      "utf-8",
+    );
+    expect(content).toContain("metaTags: {");
+    expect(content).toContain("description: true,");
+    expect(content).toContain("keywords: false,");
+    expect(content).toContain("ogImage: false,");
+    expect(content).toContain("ogSiteName: true,");
+    expect(content).toContain("twitterCard: false,");
+    expect(content).toContain("MetaTagsConfig");
+  });
+
+  // S4 (#2078): fresh-scaffold head assertion — with scaffold defaults
+  // (ogImage: false, twitterCard: false, keywords: false), the generated
+  // _head-with-defaults.tsx must gate those tags via settings.metaTags.
+  // This test confirms the generated template emits og:title + description
+  // + og:site_name and does NOT unconditionally emit og:image / twitter:* /
+  // keywords. We assert this by inspecting the template source directly
+  // (a full scaffold render is not feasible in unit tests — pnpm build is
+  // run by the manager after merge per task spec).
+  it("_head-with-defaults.tsx template gates og:image/twitter:card/keywords via settings.metaTags (S4 #2078)", async () => {
+    const choices: UserChoices = {
+      projectName: "test-head-template-gates",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search"],
+      packageManager: "pnpm",
+    };
+    await scaffold(choices);
+    const headSrc = await fs.readFile(
+      projectPath(
+        "test-head-template-gates",
+        "pages/lib/_head-with-defaults.tsx",
+      ),
+      "utf-8",
+    );
+    // og:title is always emitted — DocHead contract (OgTags always emits og:title)
+    expect(headSrc).toContain("composeMetaTitle(title)");
+    // description is gated on metaTags.description
+    expect(headSrc).toContain("metaTags.description");
+    // og:site_name is gated on metaTags.ogSiteName
+    expect(headSrc).toContain("metaTags.ogSiteName");
+    // og:image and twitter:image are gated on metaTags.ogImage
+    expect(headSrc).toContain("metaTags.ogImage");
+    // twitterCard block is gated on metaTags.twitterCard
+    expect(headSrc).toContain("metaTags.twitterCard");
+    // keywords are gated on metaTags.keywords
+    expect(headSrc).toContain("metaTags.keywords");
+    // No hardcoded og:image path (must come from metaTags.ogImage)
+    expect(headSrc).not.toContain('"/img/ogp.png"');
+    // No unconditional TwitterCard emission
+    expect(headSrc).not.toContain('card="summary_large_image"');
+  });
+
 });
 
 

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -3245,3 +3245,80 @@ describe("scaffold — programmatic API rejects invalid project names (F4 #2013)
     ).rejects.toThrow(/Invalid projectName/);
   });
 });
+
+describe("scaffold — metaTags preset override (S5 #2079)", () => {
+  it("emits S4 defaults when metaTags is absent from choices", async () => {
+    const choices: UserChoices = {
+      projectName: "test-metatags-default",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search"],
+      packageManager: "pnpm",
+    };
+    await scaffold(choices);
+    const content = await fs.readFile(
+      projectPath("test-metatags-default", "src/config/settings.ts"),
+      "utf-8",
+    );
+    expect(content).toContain("metaTags: {");
+    expect(content).toContain("description: true");
+    expect(content).toContain("keywords: false");
+    expect(content).toContain("ogImage: false");
+    expect(content).toContain("ogSiteName: true");
+    expect(content).toContain("twitterCard: false");
+  });
+
+  it("emits chosen values when ogImage is enabled in the preset", async () => {
+    const choices: UserChoices = {
+      projectName: "test-metatags-ogimage",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search"],
+      packageManager: "pnpm",
+      metaTags: {
+        description: true,
+        keywords: false,
+        ogImage: "/img/ogp.png",
+        ogSiteName: true,
+        twitterCard: false,
+      },
+    };
+    await scaffold(choices);
+    const content = await fs.readFile(
+      projectPath("test-metatags-ogimage", "src/config/settings.ts"),
+      "utf-8",
+    );
+    expect(content).toContain("metaTags: {");
+    expect(content).toContain('ogImage: "/img/ogp.png"');
+  });
+
+  it("emits twitterCard and handles when full twitter config is set", async () => {
+    const choices: UserChoices = {
+      projectName: "test-metatags-twitter",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search"],
+      packageManager: "pnpm",
+      metaTags: {
+        description: true,
+        keywords: false,
+        ogImage: false,
+        ogSiteName: true,
+        twitterCard: "summary_large_image",
+        twitterSite: "@brand",
+        twitterCreator: "@author",
+      },
+    };
+    await scaffold(choices);
+    const content = await fs.readFile(
+      projectPath("test-metatags-twitter", "src/config/settings.ts"),
+      "utf-8",
+    );
+    expect(content).toContain('"summary_large_image"');
+    expect(content).toContain('"@brand"');
+    expect(content).toContain('"@author"');
+  });
+});

--- a/packages/create-zudo-doc/src/constants.ts
+++ b/packages/create-zudo-doc/src/constants.ts
@@ -240,7 +240,7 @@ export const FEATURES: Feature[] = [
     value: "tagGovernance",
     label: "Tag governance",
     hint: "Vocabulary-aware tag audit + suggest scripts",
-    default: true,
+    default: false,
     cliFlag: "tag-governance",
   },
   {

--- a/packages/create-zudo-doc/src/preset.ts
+++ b/packages/create-zudo-doc/src/preset.ts
@@ -48,6 +48,16 @@ const VALID_HEADER_RIGHT_TRIGGERS = new Set<PresetHeaderRightTriggerName>([
   "ai-chat",
 ]);
 
+export interface PresetMetaTagsConfig {
+  description?: boolean;
+  keywords?: string | false;
+  ogImage?: string | false;
+  ogSiteName?: boolean;
+  twitterCard?: "summary" | "summary_large_image" | false;
+  twitterSite?: string;
+  twitterCreator?: string;
+}
+
 export interface PresetJson {
   projectName?: string;
   defaultLang?: string;
@@ -62,6 +72,7 @@ export interface PresetJson {
   cjkFriendly?: boolean;
   packageManager?: "pnpm" | "npm" | "yarn" | "bun";
   headerRightItems?: PresetHeaderRightItem[];
+  metaTags?: PresetMetaTagsConfig;
 }
 
 export function loadPreset(pathOrStdin: string): PartialChoices {
@@ -167,6 +178,38 @@ export function validatePreset(json: unknown): string | null {
       }
     }
   }
+  if (p.metaTags !== undefined) {
+    if (typeof p.metaTags !== "object" || p.metaTags === null || Array.isArray(p.metaTags)) {
+      return `"metaTags" must be an object in preset`;
+    }
+    const mt = p.metaTags as PresetMetaTagsConfig;
+    if (mt.description !== undefined && typeof mt.description !== "boolean") {
+      return `"metaTags.description" must be a boolean`;
+    }
+    if (mt.keywords !== undefined && mt.keywords !== false && typeof mt.keywords !== "string") {
+      return `"metaTags.keywords" must be a string or false`;
+    }
+    if (mt.ogImage !== undefined && mt.ogImage !== false && typeof mt.ogImage !== "string") {
+      return `"metaTags.ogImage" must be a string or false`;
+    }
+    if (mt.ogSiteName !== undefined && typeof mt.ogSiteName !== "boolean") {
+      return `"metaTags.ogSiteName" must be a boolean`;
+    }
+    if (
+      mt.twitterCard !== undefined &&
+      mt.twitterCard !== false &&
+      mt.twitterCard !== "summary" &&
+      mt.twitterCard !== "summary_large_image"
+    ) {
+      return `"metaTags.twitterCard" must be "summary", "summary_large_image", or false`;
+    }
+    if (mt.twitterSite !== undefined && typeof mt.twitterSite !== "string") {
+      return `"metaTags.twitterSite" must be a string`;
+    }
+    if (mt.twitterCreator !== undefined && typeof mt.twitterCreator !== "string") {
+      return `"metaTags.twitterCreator" must be a string`;
+    }
+  }
   // Cross-field validation
   if (p.colorSchemeMode === "single" && (p.lightScheme || p.darkScheme)) {
     return `lightScheme/darkScheme are only valid with colorSchemeMode "light-dark"`;
@@ -197,6 +240,9 @@ export function presetToChoices(json: PresetJson): PartialChoices {
   if (json.cjkFriendly !== undefined) choices.cjkFriendly = json.cjkFriendly;
   if (json.headerRightItems !== undefined) {
     choices.headerRightItems = json.headerRightItems;
+  }
+  if (json.metaTags !== undefined) {
+    choices.metaTags = json.metaTags;
   }
 
   if (json.features) {

--- a/packages/create-zudo-doc/src/prompts.ts
+++ b/packages/create-zudo-doc/src/prompts.ts
@@ -1,6 +1,6 @@
 import * as p from "@clack/prompts";
 import { LIGHT_DARK_PAIRINGS, SINGLE_SCHEMES, FEATURES, SUPPORTED_LANGS } from "./constants.js";
-import type { PresetHeaderRightItem } from "./preset.js";
+import type { PresetHeaderRightItem, PresetMetaTagsConfig } from "./preset.js";
 import { validateProjectName } from "./utils.js";
 
 export interface UserChoices {
@@ -33,6 +33,9 @@ export interface UserChoices {
   // or CLI args. When omitted, settings-gen.ts emits the existing hardcoded
   // fallback.
   headerRightItems?: PresetHeaderRightItem[];
+  // Meta tags config. Preset-only — no interactive prompt.
+  // When omitted, settings-gen.ts emits the S4 scaffold defaults.
+  metaTags?: PresetMetaTagsConfig;
 }
 
 export interface PartialChoices {
@@ -52,6 +55,8 @@ export interface PartialChoices {
   cjkFriendly?: boolean;
   packageManager?: "pnpm" | "npm" | "yarn" | "bun";
   headerRightItems?: PresetHeaderRightItem[];
+  // Meta tags config. Preset-only — no interactive prompt.
+  metaTags?: PresetMetaTagsConfig;
 }
 
 export async function runPrompts(
@@ -293,5 +298,6 @@ export async function runPrompts(
     cjkFriendly: prefilled.cjkFriendly,
     packageManager,
     headerRightItems: prefilled.headerRightItems,
+    metaTags: prefilled.metaTags,
   };
 }

--- a/packages/create-zudo-doc/src/settings-gen.ts
+++ b/packages/create-zudo-doc/src/settings-gen.ts
@@ -80,11 +80,34 @@ export function generateSettingsFile(choices: UserChoices): string {
   }
   lines.push(`  siteUrl: "" as string,`);
   lines.push(`  metaTags: {`);
-  lines.push(`    description: true,`);
-  lines.push(`    keywords: false,`);
-  lines.push(`    ogImage: false,`);
-  lines.push(`    ogSiteName: true,`);
-  lines.push(`    twitterCard: false,`);
+  if (choices.metaTags) {
+    const mt = choices.metaTags;
+    lines.push(`    description: ${mt.description !== undefined ? mt.description : true},`);
+    lines.push(
+      `    keywords: ${mt.keywords !== undefined ? JSON.stringify(mt.keywords) : false},`,
+    );
+    lines.push(
+      `    ogImage: ${mt.ogImage !== undefined ? JSON.stringify(mt.ogImage) : false},`,
+    );
+    lines.push(`    ogSiteName: ${mt.ogSiteName !== undefined ? mt.ogSiteName : true},`);
+    if (mt.twitterCard) {
+      lines.push(`    twitterCard: ${JSON.stringify(mt.twitterCard)},`);
+      if (mt.twitterSite) {
+        lines.push(`    twitterSite: ${JSON.stringify(mt.twitterSite)},`);
+      }
+      if (mt.twitterCreator) {
+        lines.push(`    twitterCreator: ${JSON.stringify(mt.twitterCreator)},`);
+      }
+    } else {
+      lines.push(`    twitterCard: false,`);
+    }
+  } else {
+    lines.push(`    description: true,`);
+    lines.push(`    keywords: false,`);
+    lines.push(`    ogImage: false,`);
+    lines.push(`    ogSiteName: true,`);
+    lines.push(`    twitterCard: false,`);
+  }
   lines.push(`  } satisfies MetaTagsConfig as MetaTagsConfig,`);
   lines.push(`  docsDir: "src/content/docs",`);
   lines.push(

--- a/packages/create-zudo-doc/src/settings-gen.ts
+++ b/packages/create-zudo-doc/src/settings-gen.ts
@@ -19,6 +19,7 @@ export function generateSettingsFile(choices: UserChoices): string {
   lines.push(`  TagPlacement,`);
   lines.push(`  TagGovernanceMode,`);
   lines.push(`  TagVocabularyEntry,`);
+  lines.push(`  MetaTagsConfig,`);
   lines.push(`} from "./settings-types";`);
   lines.push(`import type {`);
   lines.push(`  HeaderNavItem,`);
@@ -32,6 +33,7 @@ export function generateSettingsFile(choices: UserChoices): string {
   lines.push(`  BodyFootUtilAreaConfig,`);
   lines.push(`  TagPlacement,`);
   lines.push(`  TagGovernanceMode,`);
+  lines.push(`  MetaTagsConfig,`);
   lines.push(`} from "./settings-types";`);
   lines.push(``);
 
@@ -77,6 +79,13 @@ export function generateSettingsFile(choices: UserChoices): string {
     lines.push(`  githubUrl: false as string | false,`);
   }
   lines.push(`  siteUrl: "" as string,`);
+  lines.push(`  metaTags: {`);
+  lines.push(`    description: true,`);
+  lines.push(`    keywords: false,`);
+  lines.push(`    ogImage: false,`);
+  lines.push(`    ogSiteName: true,`);
+  lines.push(`    twitterCard: false,`);
+  lines.push(`  } satisfies MetaTagsConfig as MetaTagsConfig,`);
   lines.push(`  docsDir: "src/content/docs",`);
   lines.push(
     `  defaultLocale: ${JSON.stringify(choices.defaultLang ?? "en")} as const,`,

--- a/packages/create-zudo-doc/templates/base/pages/lib/_doc-page-shell.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_doc-page-shell.tsx
@@ -176,7 +176,9 @@ export function DocPageShell(props: DocPageShellProps): JSX.Element {
   return (
     <DocLayoutWithDefaults
       title={composeMetaTitle(title)}
-      description={description}
+      // Plain <meta name="description"> is emitted by DocLayout from this prop —
+      // gate it here alongside the og:description gate inside HeadWithDefaults (#2078)
+      description={settings.metaTags.description ? description : undefined}
       head={<HeadWithDefaults title={title} description={description} canonical={canonical} />}
       lang={locale}
       noindex={settings.noindex}

--- a/packages/create-zudo-doc/templates/base/pages/lib/_doc-pager.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_doc-pager.tsx
@@ -40,8 +40,9 @@ interface DocPagerProps {
  * per #1535).
  */
 export function DocPager({ prev, next, locale }: DocPagerProps): JSX.Element {
+  // --flow-space override: mt-vsp-2xl alone is dead here — the .zd-content flow rule wins the cascade (see #2075)
   return (
-    <nav class="mt-vsp-2xl grid grid-cols-2 gap-hsp-xl">
+    <nav class="mt-vsp-2xl [--flow-space:var(--spacing-vsp-2xl)] grid grid-cols-2 gap-hsp-xl">
       {prev ? (
         <a
           href={prev.href}

--- a/packages/create-zudo-doc/templates/base/pages/lib/_head-with-defaults.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_head-with-defaults.tsx
@@ -63,6 +63,10 @@ export interface HeadWithDefaultsProps {
  * (the legacy Astro layout produced both shapes; the zfb host has to
  * compose them itself).
  *
+ * og:title is always emitted — it is the unconditional DocHead contract
+ * (OgTags always emits og:title regardless of settings). All other tags
+ * are gated by settings.metaTags.
+ *
  * Pure SSR — no state, no client-only imports. Intended for use as:
  *   head={<HeadWithDefaults title={title} description={description} canonical={canonical} />}
  * on every DocLayoutWithDefaults call site in the host pages.
@@ -72,6 +76,8 @@ export function HeadWithDefaults({
   description,
   canonical,
 }: HeadWithDefaultsProps): JSX.Element {
+  const { metaTags } = settings;
+
   // og:image / twitter:image must be absolute URLs — crawlers silently drop
   // relative og:image values. absoluteUrl joins siteUrl (no trailing slash) +
   // the base-prefixed asset path, and returns undefined when siteUrl is empty
@@ -80,7 +86,10 @@ export function HeadWithDefaults({
   // TwitterCard already gate their image emission on the prop being defined;
   // the og:image:* companion tags below are gated explicitly because they
   // would dangle without the parent og:image.
-  const ogImageUrl = absoluteUrl(withBase("/img/ogp.png"));
+  const ogImageUrl =
+    metaTags.ogImage !== false
+      ? absoluteUrl(withBase(metaTags.ogImage))
+      : undefined;
 
   // Resolve the palette CSS body once per page render (the v2 component
   // is pure SSR — no caching needed).
@@ -93,12 +102,15 @@ export function HeadWithDefaults({
     <>
       <OgTags
         title={composeMetaTitle(title)}
-        description={description}
+        description={metaTags.description ? description : undefined}
         ogType="website"
         ogUrl={canonical}
         ogImage={ogImageUrl}
-        ogSiteName={settings.siteName}
+        ogSiteName={metaTags.ogSiteName ? settings.siteName : undefined}
       />
+      {metaTags.keywords !== false && metaTags.keywords.length > 0 && (
+        <meta name="keywords" content={metaTags.keywords} />
+      )}
       {/* og:image:width / og:image:height / og:image:alt — not in OgTags API;
           emitted here directly to avoid expanding the shared HeadProps surface.
           Standard 1200×630 social preview dimensions. Gated on ogImageUrl so
@@ -110,7 +122,14 @@ export function HeadWithDefaults({
           <meta property="og:image:alt" content={composeMetaTitle(title)} />
         </>
       )}
-      <TwitterCard card="summary_large_image" image={ogImageUrl} />
+      {metaTags.twitterCard !== false && (
+        <TwitterCard
+          card={metaTags.twitterCard}
+          image={ogImageUrl}
+          site={metaTags.twitterSite}
+          creator={metaTags.twitterCreator}
+        />
+      )}
       <ColorSchemeProvider cssText={cssText} colorMode={colorMode} />
       {/* Pre-paint inline script: restore persisted sidebar width to
           --zd-sidebar-w on :root before first paint, so a reload after

--- a/packages/create-zudo-doc/templates/base/src/config/settings-types.ts
+++ b/packages/create-zudo-doc/templates/base/src/config/settings-types.ts
@@ -160,3 +160,20 @@ export interface VersionConfig {
   /** Banner text shown on versioned pages (e.g., "unmaintained", "unreleased") */
   banner?: "unmaintained" | "unreleased" | false;
 }
+
+export interface MetaTagsConfig {
+  /** Emit <meta name="description">. Default true. */
+  description: boolean;
+  /** Emit <meta name="keywords"> with a comma-separated string. false = omit. Default false. */
+  keywords: string | false;
+  /** og:image (and twitter:image) path. false = omit. Default false. Showcase: '/img/ogp.png'. */
+  ogImage: string | false;
+  /** Emit og:site_name. Default true (preserves current og:site_name). */
+  ogSiteName: boolean;
+  /** TwitterCard type. false = omit entire twitter:card block. Default false. Showcase: 'summary_large_image'. */
+  twitterCard: "summary" | "summary_large_image" | false;
+  /** twitter:site handle (e.g. '@yourbrand'). Optional. */
+  twitterSite?: string;
+  /** twitter:creator handle. Optional. */
+  twitterCreator?: string;
+}

--- a/pages/lib/_doc-page-shell.tsx
+++ b/pages/lib/_doc-page-shell.tsx
@@ -176,7 +176,9 @@ export function DocPageShell(props: DocPageShellProps): JSX.Element {
   return (
     <DocLayoutWithDefaults
       title={composeMetaTitle(title)}
-      description={description}
+      // Plain <meta name="description"> is emitted by DocLayout from this prop —
+      // gate it here alongside the og:description gate inside HeadWithDefaults (#2078)
+      description={settings.metaTags.description ? description : undefined}
       head={<HeadWithDefaults title={title} description={description} canonical={canonical} />}
       lang={locale}
       noindex={settings.noindex}

--- a/pages/lib/_doc-pager.tsx
+++ b/pages/lib/_doc-pager.tsx
@@ -40,8 +40,9 @@ interface DocPagerProps {
  * per #1535).
  */
 export function DocPager({ prev, next, locale }: DocPagerProps): JSX.Element {
+  // --flow-space override: mt-vsp-2xl alone is dead here — the .zd-content flow rule wins the cascade (see #2075)
   return (
-    <nav class="mt-vsp-2xl grid grid-cols-2 gap-hsp-xl">
+    <nav class="mt-vsp-2xl [--flow-space:var(--spacing-vsp-2xl)] grid grid-cols-2 gap-hsp-xl">
       {prev ? (
         <a
           href={prev.href}

--- a/pages/lib/_head-with-defaults.tsx
+++ b/pages/lib/_head-with-defaults.tsx
@@ -63,6 +63,10 @@ export interface HeadWithDefaultsProps {
  * (the legacy Astro layout produced both shapes; the zfb host has to
  * compose them itself).
  *
+ * og:title is always emitted — it is the unconditional DocHead contract
+ * (OgTags always emits og:title regardless of settings). All other tags
+ * are gated by settings.metaTags.
+ *
  * Pure SSR — no state, no client-only imports. Intended for use as:
  *   head={<HeadWithDefaults title={title} description={description} canonical={canonical} />}
  * on every DocLayoutWithDefaults call site in the host pages.
@@ -72,6 +76,8 @@ export function HeadWithDefaults({
   description,
   canonical,
 }: HeadWithDefaultsProps): JSX.Element {
+  const { metaTags } = settings;
+
   // og:image / twitter:image must be absolute URLs — crawlers silently drop
   // relative og:image values. absoluteUrl joins siteUrl (no trailing slash) +
   // the base-prefixed asset path, and returns undefined when siteUrl is empty
@@ -80,7 +86,10 @@ export function HeadWithDefaults({
   // TwitterCard already gate their image emission on the prop being defined;
   // the og:image:* companion tags below are gated explicitly because they
   // would dangle without the parent og:image.
-  const ogImageUrl = absoluteUrl(withBase("/img/ogp.png"));
+  const ogImageUrl =
+    metaTags.ogImage !== false
+      ? absoluteUrl(withBase(metaTags.ogImage))
+      : undefined;
 
   // Resolve the palette CSS body once per page render (the v2 component
   // is pure SSR — no caching needed).
@@ -93,12 +102,15 @@ export function HeadWithDefaults({
     <>
       <OgTags
         title={composeMetaTitle(title)}
-        description={description}
+        description={metaTags.description ? description : undefined}
         ogType="website"
         ogUrl={canonical}
         ogImage={ogImageUrl}
-        ogSiteName={settings.siteName}
+        ogSiteName={metaTags.ogSiteName ? settings.siteName : undefined}
       />
+      {metaTags.keywords !== false && metaTags.keywords.length > 0 && (
+        <meta name="keywords" content={metaTags.keywords} />
+      )}
       {/* og:image:width / og:image:height / og:image:alt — not in OgTags API;
           emitted here directly to avoid expanding the shared HeadProps surface.
           Standard 1200×630 social preview dimensions. Gated on ogImageUrl so
@@ -110,7 +122,14 @@ export function HeadWithDefaults({
           <meta property="og:image:alt" content={composeMetaTitle(title)} />
         </>
       )}
-      <TwitterCard card="summary_large_image" image={ogImageUrl} />
+      {metaTags.twitterCard !== false && (
+        <TwitterCard
+          card={metaTags.twitterCard}
+          image={ogImageUrl}
+          site={metaTags.twitterSite}
+          creator={metaTags.twitterCreator}
+        />
+      )}
       <ColorSchemeProvider cssText={cssText} colorMode={colorMode} />
       {/* Pre-paint inline script: restore persisted sidebar width to
           --zd-sidebar-w on :root before first paint, so a reload after

--- a/src/__tests__/preset-generator-logic.test.ts
+++ b/src/__tests__/preset-generator-logic.test.ts
@@ -5,9 +5,15 @@ import {
   buildCliCommand,
   DEFAULT_HEADER_RIGHT_ITEMS,
   INITIAL_HEADER_RIGHT_ITEMS,
+  DEFAULT_META_TAGS,
   type FormState,
   type HeaderRightItemSpec,
+  type MetaTagsFormState,
 } from "../lib/preset-generator-logic";
+
+function makeMetaState(overrides: Partial<MetaTagsFormState> = {}): MetaTagsFormState {
+  return { ...DEFAULT_META_TAGS, ...overrides };
+}
 
 function makeState(overrides: Partial<FormState> = {}): FormState {
   return {
@@ -284,5 +290,104 @@ describe("default generator state — regression: matches target JSON", () => {
         { type: "component", component: "language-switcher" },
       ],
     });
+  });
+});
+
+describe("buildJson — metaTags (S5 #2079)", () => {
+  it("omits metaTags key when all values equal defaults (S2 regression guard)", () => {
+    const json = buildJson(makeState({ metaTags: makeMetaState() }));
+    expect(json).not.toHaveProperty("metaTags");
+  });
+
+  it("also omits metaTags when state.metaTags is absent (makeState backward compat)", () => {
+    const json = buildJson(makeState());
+    expect(json).not.toHaveProperty("metaTags");
+  });
+
+  it("emits metaTags when description is turned off", () => {
+    const json = buildJson(makeState({ metaTags: makeMetaState({ description: false }) }));
+    expect(json).toHaveProperty("metaTags");
+    expect((json.metaTags as Record<string, unknown>).description).toBe(false);
+  });
+
+  it("emits metaTags with keywords string when keywordsEnabled is true", () => {
+    const json = buildJson(makeState({
+      metaTags: makeMetaState({ keywordsEnabled: true, keywords: "docs, guide" }),
+    }));
+    expect(json).toHaveProperty("metaTags");
+    const mt = json.metaTags as Record<string, unknown>;
+    expect(mt.keywords).toBe("docs, guide");
+  });
+
+  it("emits keywords: false when keywordsEnabled is false (default)", () => {
+    const json = buildJson(makeState({ metaTags: makeMetaState({ description: false }) }));
+    const mt = json.metaTags as Record<string, unknown>;
+    expect(mt.keywords).toBe(false);
+  });
+
+  it("emits metaTags with ogImage path when ogImageEnabled is true", () => {
+    const json = buildJson(makeState({
+      metaTags: makeMetaState({ ogImageEnabled: true, ogImage: "/img/custom.png" }),
+    }));
+    expect(json).toHaveProperty("metaTags");
+    const mt = json.metaTags as Record<string, unknown>;
+    expect(mt.ogImage).toBe("/img/custom.png");
+  });
+
+  it("emits ogImage with default path when ogImageEnabled is true and path is empty", () => {
+    const json = buildJson(makeState({
+      metaTags: makeMetaState({ ogImageEnabled: true, ogImage: "" }),
+    }));
+    const mt = json.metaTags as Record<string, unknown>;
+    expect(mt.ogImage).toBe("/img/ogp.png");
+  });
+
+  it("emits metaTags when ogSiteName is turned off", () => {
+    const json = buildJson(makeState({ metaTags: makeMetaState({ ogSiteName: false }) }));
+    expect(json).toHaveProperty("metaTags");
+    const mt = json.metaTags as Record<string, unknown>;
+    expect(mt.ogSiteName).toBe(false);
+  });
+
+  it("emits metaTags with twitterCard when twitterCardEnabled is true", () => {
+    const json = buildJson(makeState({
+      metaTags: makeMetaState({ twitterCardEnabled: true, twitterCard: "summary_large_image" }),
+    }));
+    expect(json).toHaveProperty("metaTags");
+    const mt = json.metaTags as Record<string, unknown>;
+    expect(mt.twitterCard).toBe("summary_large_image");
+  });
+
+  it("emits twitterCard: false when twitterCardEnabled is false", () => {
+    const json = buildJson(makeState({ metaTags: makeMetaState({ description: false }) }));
+    const mt = json.metaTags as Record<string, unknown>;
+    expect(mt.twitterCard).toBe(false);
+  });
+
+  it("emits twitterSite and twitterCreator when set and twitterCardEnabled", () => {
+    const json = buildJson(makeState({
+      metaTags: makeMetaState({
+        twitterCardEnabled: true,
+        twitterCard: "summary",
+        twitterSite: "@brand",
+        twitterCreator: "@author",
+      }),
+    }));
+    const mt = json.metaTags as Record<string, unknown>;
+    expect(mt.twitterSite).toBe("@brand");
+    expect(mt.twitterCreator).toBe("@author");
+  });
+
+  it("omits twitterSite and twitterCreator when twitterCardEnabled is false", () => {
+    const json = buildJson(makeState({
+      metaTags: makeMetaState({
+        description: false,
+        twitterSite: "@brand",
+        twitterCreator: "@author",
+      }),
+    }));
+    const mt = json.metaTags as Record<string, unknown>;
+    expect(mt.twitterSite).toBeUndefined();
+    expect(mt.twitterCreator).toBeUndefined();
   });
 });

--- a/src/__tests__/preset-generator-logic.test.ts
+++ b/src/__tests__/preset-generator-logic.test.ts
@@ -4,6 +4,7 @@ import {
   buildJson,
   buildCliCommand,
   DEFAULT_HEADER_RIGHT_ITEMS,
+  INITIAL_HEADER_RIGHT_ITEMS,
   type FormState,
   type HeaderRightItemSpec,
 } from "../lib/preset-generator-logic";
@@ -245,5 +246,43 @@ describe("buildJson — headerRightItems mapping", () => {
   it("emits headerRightItems even when it equals the default (always present)", () => {
     const json = buildJson(makeState());
     expect(json).toHaveProperty("headerRightItems");
+  });
+});
+
+describe("default generator state — regression: matches target JSON", () => {
+  it("buildJson() with initial state deep-equals the target JSON exactly", () => {
+    const initialState: FormState = {
+      projectName: "my-docs",
+      defaultLang: "en",
+      colorSchemeMode: "light-dark",
+      singleScheme: "Default Dark",
+      lightScheme: "Default Light",
+      darkScheme: "Default Dark",
+      defaultMode: "dark",
+      respectPrefersColorScheme: true,
+      features: FEATURES.filter((f) => f.default).map((f) => f.value),
+      cjkFriendly: true,
+      packageManager: "pnpm",
+      headerRightItems: [...INITIAL_HEADER_RIGHT_ITEMS],
+    };
+
+    expect(buildJson(initialState)).toEqual({
+      projectName: "my-docs",
+      defaultLang: "en",
+      colorSchemeMode: "light-dark",
+      lightScheme: "Default Light",
+      darkScheme: "Default Dark",
+      defaultMode: "dark",
+      respectPrefersColorScheme: true,
+      features: ["search", "sidebarFilter", "imageEnlarge"],
+      cjkFriendly: true,
+      packageManager: "pnpm",
+      headerRightItems: [
+        { type: "component", component: "github-link" },
+        { type: "component", component: "theme-toggle" },
+        { type: "component", component: "search" },
+        { type: "component", component: "language-switcher" },
+      ],
+    });
   });
 });

--- a/src/__tests__/preset-generator-roundtrip.test.ts
+++ b/src/__tests__/preset-generator-roundtrip.test.ts
@@ -89,7 +89,7 @@ function verifyRoundtrip(state: FormState) {
 }
 
 describe("roundtrip: buildCliCommand → parseArgs", () => {
-  it("default state (search + sidebarFilter on)", () => {
+  it("default state (search + sidebarFilter + imageEnlarge on)", () => {
     verifyRoundtrip(makeState());
   });
 

--- a/src/components/preset-generator.tsx
+++ b/src/components/preset-generator.tsx
@@ -8,6 +8,7 @@ import {
   buildCliCommand,
   DEFAULT_HEADER_RIGHT_ITEMS,
   INITIAL_HEADER_RIGHT_ITEMS,
+  DEFAULT_META_TAGS,
   SINGLE_SCHEMES,
   LIGHT_SCHEMES,
   SUPPORTED_LANGS,
@@ -210,6 +211,7 @@ export default function PresetGenerator() {
     cjkFriendly: true,
     packageManager: "pnpm",
     headerRightItems: [...INITIAL_HEADER_RIGHT_ITEMS],
+    metaTags: { ...DEFAULT_META_TAGS },
   });
 
   const [modalState, setModalState] = useState<FormState | null>(null);
@@ -556,6 +558,179 @@ export default function PresetGenerator() {
             Reset to default
           </button>
         </div>
+      </section>
+
+      {/* Meta tags */}
+      <section>
+        <SectionHeading>Meta tags</SectionHeading>
+        <p className="mb-vsp-xs text-caption text-muted">
+          Configure which meta tags are emitted in the document head.
+          og:title is always emitted (DocHead contract) and is not listed here.
+        </p>
+        <ul className="flex flex-col gap-y-vsp-xs">
+          {/* description */}
+          <li className={`text-small ${state.metaTags.description ? "text-fg" : "text-muted"}`}>
+            <label className="flex items-center gap-x-hsp-xs">
+              <input
+                type="checkbox"
+                checked={state.metaTags.description}
+                onChange={(e) =>
+                  setState((prev) => ({
+                    ...prev,
+                    metaTags: { ...prev.metaTags, description: (e.target as HTMLInputElement).checked },
+                  }))
+                }
+                className="accent-accent"
+              />
+              SEO description meta
+            </label>
+          </li>
+          {/* keywords */}
+          <li className={`text-small ${state.metaTags.keywordsEnabled ? "text-fg" : "text-muted"}`}>
+            <label className="flex items-center gap-x-hsp-xs">
+              <input
+                type="checkbox"
+                checked={state.metaTags.keywordsEnabled}
+                onChange={(e) =>
+                  setState((prev) => ({
+                    ...prev,
+                    metaTags: { ...prev.metaTags, keywordsEnabled: (e.target as HTMLInputElement).checked },
+                  }))
+                }
+                className="accent-accent"
+              />
+              Keywords (comma-separated)
+            </label>
+            {state.metaTags.keywordsEnabled && (
+              <input
+                type="text"
+                value={state.metaTags.keywords}
+                placeholder="docs, guide, reference"
+                aria-label="Keywords (comma-separated)"
+                onChange={(e) =>
+                  setState((prev) => ({
+                    ...prev,
+                    metaTags: { ...prev.metaTags, keywords: (e.target as HTMLInputElement).value },
+                  }))
+                }
+                className={`mt-vsp-2xs ${inputClass}`}
+              />
+            )}
+          </li>
+          {/* og:image */}
+          <li className={`text-small ${state.metaTags.ogImageEnabled ? "text-fg" : "text-muted"}`}>
+            <label className="flex items-center gap-x-hsp-xs">
+              <input
+                type="checkbox"
+                checked={state.metaTags.ogImageEnabled}
+                onChange={(e) =>
+                  setState((prev) => ({
+                    ...prev,
+                    metaTags: { ...prev.metaTags, ogImageEnabled: (e.target as HTMLInputElement).checked },
+                  }))
+                }
+                className="accent-accent"
+              />
+              OGP image (og:image)
+            </label>
+            {state.metaTags.ogImageEnabled && (
+              <input
+                type="text"
+                value={state.metaTags.ogImage}
+                placeholder="/img/ogp.png"
+                aria-label="OGP image path"
+                onChange={(e) =>
+                  setState((prev) => ({
+                    ...prev,
+                    metaTags: { ...prev.metaTags, ogImage: (e.target as HTMLInputElement).value },
+                  }))
+                }
+                className={`mt-vsp-2xs ${inputClass}`}
+              />
+            )}
+          </li>
+          {/* og:site_name */}
+          <li className={`text-small ${state.metaTags.ogSiteName ? "text-fg" : "text-muted"}`}>
+            <label className="flex items-center gap-x-hsp-xs">
+              <input
+                type="checkbox"
+                checked={state.metaTags.ogSiteName}
+                onChange={(e) =>
+                  setState((prev) => ({
+                    ...prev,
+                    metaTags: { ...prev.metaTags, ogSiteName: (e.target as HTMLInputElement).checked },
+                  }))
+                }
+                className="accent-accent"
+              />
+              og:site_name
+            </label>
+          </li>
+          {/* Twitter card */}
+          <li className={`text-small ${state.metaTags.twitterCardEnabled ? "text-fg" : "text-muted"}`}>
+            <label className="flex items-center gap-x-hsp-xs">
+              <input
+                type="checkbox"
+                checked={state.metaTags.twitterCardEnabled}
+                onChange={(e) =>
+                  setState((prev) => ({
+                    ...prev,
+                    metaTags: { ...prev.metaTags, twitterCardEnabled: (e.target as HTMLInputElement).checked },
+                  }))
+                }
+                className="accent-accent"
+              />
+              Twitter card
+            </label>
+            {state.metaTags.twitterCardEnabled && (
+              <div className="mt-vsp-2xs flex flex-col gap-y-vsp-2xs">
+                <select
+                  value={state.metaTags.twitterCard}
+                  aria-label="Twitter card type"
+                  onChange={(e) =>
+                    setState((prev) => ({
+                      ...prev,
+                      metaTags: {
+                        ...prev.metaTags,
+                        twitterCard: (e.target as HTMLSelectElement).value as "summary" | "summary_large_image",
+                      },
+                    }))
+                  }
+                  className={inputClass}
+                >
+                  <option value="summary">summary</option>
+                  <option value="summary_large_image">summary_large_image</option>
+                </select>
+                <input
+                  type="text"
+                  value={state.metaTags.twitterSite}
+                  placeholder="@yourbrand (optional)"
+                  aria-label="twitter:site handle"
+                  onChange={(e) =>
+                    setState((prev) => ({
+                      ...prev,
+                      metaTags: { ...prev.metaTags, twitterSite: (e.target as HTMLInputElement).value },
+                    }))
+                  }
+                  className={inputClass}
+                />
+                <input
+                  type="text"
+                  value={state.metaTags.twitterCreator}
+                  placeholder="@author (optional)"
+                  aria-label="twitter:creator handle"
+                  onChange={(e) =>
+                    setState((prev) => ({
+                      ...prev,
+                      metaTags: { ...prev.metaTags, twitterCreator: (e.target as HTMLInputElement).value },
+                    }))
+                  }
+                  className={inputClass}
+                />
+              </div>
+            )}
+          </li>
+        </ul>
       </section>
 
       {/* CJK Friendly */}

--- a/src/components/preset-generator.tsx
+++ b/src/components/preset-generator.tsx
@@ -7,6 +7,7 @@ import {
   buildJson,
   buildCliCommand,
   DEFAULT_HEADER_RIGHT_ITEMS,
+  INITIAL_HEADER_RIGHT_ITEMS,
   SINGLE_SCHEMES,
   LIGHT_SCHEMES,
   SUPPORTED_LANGS,
@@ -208,7 +209,7 @@ export default function PresetGenerator() {
     features: FEATURES.filter((f) => f.default).map((f) => f.value),
     cjkFriendly: true,
     packageManager: "pnpm",
-    headerRightItems: [...DEFAULT_HEADER_RIGHT_ITEMS],
+    headerRightItems: [...INITIAL_HEADER_RIGHT_ITEMS],
   });
 
   const [modalState, setModalState] = useState<FormState | null>(null);
@@ -271,7 +272,7 @@ export default function PresetGenerator() {
   const resetHeaderRightItems = useCallback(() => {
     setState((prev) => ({
       ...prev,
-      headerRightItems: [...DEFAULT_HEADER_RIGHT_ITEMS],
+      headerRightItems: [...INITIAL_HEADER_RIGHT_ITEMS],
     }));
   }, []);
 

--- a/src/config/settings-types.ts
+++ b/src/config/settings-types.ts
@@ -160,3 +160,20 @@ export interface VersionConfig {
   /** Banner text shown on versioned pages (e.g., "unmaintained", "unreleased") */
   banner?: "unmaintained" | "unreleased" | false;
 }
+
+export interface MetaTagsConfig {
+  /** Emit <meta name="description">. Default true. */
+  description: boolean;
+  /** Emit <meta name="keywords"> with a comma-separated string. false = omit. Default false. */
+  keywords: string | false;
+  /** og:image (and twitter:image) path. false = omit. Default false. Showcase: '/img/ogp.png'. */
+  ogImage: string | false;
+  /** Emit og:site_name. Default true (preserves current og:site_name). */
+  ogSiteName: boolean;
+  /** TwitterCard type. false = omit entire twitter:card block. Default false. Showcase: 'summary_large_image'. */
+  twitterCard: "summary" | "summary_large_image" | false;
+  /** twitter:site handle (e.g. '@yourbrand'). Optional. */
+  twitterSite?: string;
+  /** twitter:creator handle. Optional. */
+  twitterCreator?: string;
+}

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -12,6 +12,7 @@ export type {
   TagPlacement,
   TagGovernanceMode,
   TagVocabularyEntry,
+  MetaTagsConfig,
 } from "./settings-types";
 import type {
   HeaderNavItem,
@@ -25,6 +26,7 @@ import type {
   BodyFootUtilAreaConfig,
   TagPlacement,
   TagGovernanceMode,
+  MetaTagsConfig,
 } from "./settings-types";
 
 export const settings = {
@@ -49,6 +51,13 @@ export const settings = {
   editUrl: false as string | false,
   githubUrl: "https://github.com/zudolab/zudo-doc" as string | false,
   siteUrl: "https://zudo-doc.takazudomodular.com" as string, // canonical prod host; sitemap/canonical links use this regardless of deploy URL
+  metaTags: {
+    description: true,
+    keywords: false,
+    ogImage: "/img/ogp.png",
+    ogSiteName: true,
+    twitterCard: "summary_large_image",
+  } satisfies MetaTagsConfig as MetaTagsConfig,
   sitemap: true,
   docMetainfo: true,
   docTags: true,

--- a/src/content/docs-ja/getting-started/setup-preset-generator.mdx
+++ b/src/content/docs-ja/getting-started/setup-preset-generator.mdx
@@ -14,6 +14,18 @@ sidebar_position: 2.5
 
 2 種類のアイテム — `link`(任意の外部リンク)と `html`(生 HTML)— は、意図的に UI に出していません。これらを使う場合はスキャフォールド後に `settings.ts` を直接編集してください。discriminated union のスキーマと使用例は [ヘッダー右側アイテム](../guides/header-right-items.mdx) を参照してください。
 
+## メタタグ
+
+「Meta tags」セクションは `settings.metaTags` — 各ページの `<head>` に出力されるメタタグを設定します。設定できる項目は以下のとおりです。
+
+- **SEO description meta** — `<meta name="description">` を出力します。デフォルトでオン。
+- **Keywords** — カンマ区切りのキーワードリストを持つ `<meta name="keywords">` を出力します。デフォルトでオフ。有効にするとテキスト入力欄が表示されます。
+- **OGP image (og:image)** — `og:image`（と `twitter:image`）を出力します。デフォルトでオフ。有効にするとパス入力欄（デフォルト `/img/ogp.png`）が表示されます。
+- **og:site_name** — `og:site_name` を出力します。デフォルトでオン。
+- **Twitter card** — `twitter:card` ブロックを出力します。デフォルトでオフ。有効にするとカードタイプ選択（`summary` / `summary_large_image`）とオプションの `twitter:site` / `twitter:creator` ハンドル入力欄が表示されます。
+
+`og:title` は常に出力され、ここには表示されません — DocHead の契約であり、この設定では無効化できません。
+
 ## 新しく追加された機能
 
 Features セクションには、いくつか押さえておきたい新項目があります。

--- a/src/content/docs-ja/getting-started/setup-preset-generator.mdx
+++ b/src/content/docs-ja/getting-started/setup-preset-generator.mdx
@@ -19,7 +19,7 @@ sidebar_position: 2.5
 Features セクションには、いくつか押さえておきたい新項目があります。
 
 - **Image enlarge** — コンテンツ画像のクリック拡大。デフォルトで有効。
-- **Tag governance** — タグの語彙ルール監査。デフォルトで有効。詳細は [タグガバナンス](../guides/tag-governance.mdx)。
+- **Tag governance** — タグの語彙ルール監査。詳細は [タグガバナンス](../guides/tag-governance.mdx)。
 - **Body foot util area** — 記事本文の末尾にタグリストやフィードバックリンクなどのユーティリティを差し込めるスロット。詳細は [Body foot util area](../guides/body-foot-util-area.mdx)。
 - **Footer taglist** — サイトフッターにグローバルタグクラウドを表示します。詳細は [Footer taglist](../guides/footer-taglist.mdx)。
 - **Design Token Panel** — 旧称「Color tweak panel」を改称。設定キーは `designTokenPanel`。

--- a/src/content/docs/getting-started/setup-preset-generator.mdx
+++ b/src/content/docs/getting-started/setup-preset-generator.mdx
@@ -14,6 +14,18 @@ The "Header right items" section configures `settings.headerRightItems` — the 
 
 Two item kinds — `link` (custom external link) and `html` (raw HTML) — are intentionally not exposed in the UI. Add those by editing `settings.ts` directly after scaffolding. See [Header Right Items](../guides/header-right-items.mdx) for the full discriminated-union schema and examples.
 
+## Meta tags
+
+The "Meta tags" section configures `settings.metaTags` — which meta tags are emitted in each page's `<head>`. The available options are:
+
+- **SEO description meta** — emit `<meta name="description">`. On by default.
+- **Keywords** — emit `<meta name="keywords">` with a comma-separated list you provide. Off by default; enabling it reveals a text input.
+- **OGP image (og:image)** — emit `og:image` (and `twitter:image`). Off by default; enabling it reveals a path input defaulting to `/img/ogp.png`.
+- **og:site_name** — emit `og:site_name`. On by default.
+- **Twitter card** — emit the `twitter:card` block. Off by default; enabling it reveals a card-type selector (`summary` / `summary_large_image`) and optional `twitter:site` / `twitter:creator` handle inputs.
+
+`og:title` is always emitted and is not listed here — it is a DocHead contract that cannot be disabled via this setting.
+
 ## Newly available features
 
 The Features section now includes a few additions worth calling out:

--- a/src/content/docs/getting-started/setup-preset-generator.mdx
+++ b/src/content/docs/getting-started/setup-preset-generator.mdx
@@ -19,7 +19,7 @@ Two item kinds — `link` (custom external link) and `html` (raw HTML) — are i
 The Features section now includes a few additions worth calling out:
 
 - **Image enlarge** — click-to-zoom for content images. Enabled by default.
-- **Tag governance** — vocabulary-rule audit for tags. Enabled by default. See [Tag governance](../guides/tag-governance.mdx).
+- **Tag governance** — vocabulary-rule audit for tags. See [Tag governance](../guides/tag-governance.mdx).
 - **Body foot util area** — slot at the bottom of the article body for util widgets like a tag list or feedback link. See [Body foot util area](../guides/body-foot-util-area.mdx).
 - **Footer taglist** — render the global tag cloud in the site footer. See [Footer taglist](../guides/footer-taglist.mdx).
 - **Design Token Panel** — renamed from "Color tweak panel". The setting key is `designTokenPanel`.

--- a/src/lib/preset-generator-logic.ts
+++ b/src/lib/preset-generator-logic.ts
@@ -126,6 +126,13 @@ export const DEFAULT_HEADER_RIGHT_ITEMS: readonly HeaderRightItemSpec[] = [
   { kind: "component", name: "language-switcher" },
 ];
 
+export const INITIAL_HEADER_RIGHT_ITEMS: readonly HeaderRightItemSpec[] = [
+  { kind: "component", name: "github-link" },
+  { kind: "component", name: "theme-toggle" },
+  { kind: "component", name: "search" },
+  { kind: "component", name: "language-switcher" },
+];
+
 /**
  * Map a UI-internal {@link HeaderRightItemSpec} to the canonical
  * `HeaderRightItem` shape consumed by `settings.ts`.
@@ -157,7 +164,7 @@ export const FEATURES = [
   { value: "imageEnlarge", label: "Image enlarge", cliFlag: "image-enlarge", default: true },
   { value: "footerCopyright", label: "Footer copyright", cliFlag: "footer-copyright", default: false },
   { value: "changelog", label: "Changelog", cliFlag: "changelog", default: false },
-  { value: "tagGovernance", label: "Tag governance", cliFlag: "tag-governance", default: true },
+  { value: "tagGovernance", label: "Tag governance", cliFlag: "tag-governance", default: false },
   { value: "docTags", label: "Doc tags pages", cliFlag: "doc-tags", default: false },
   { value: "footerTaglist", label: "Footer taglist", cliFlag: "footer-taglist", default: false },
 ] as const;

--- a/src/lib/preset-generator-logic.ts
+++ b/src/lib/preset-generator-logic.ts
@@ -171,6 +171,34 @@ export const FEATURES = [
 
 export type ColorSchemeMode = "single" | "light-dark";
 
+/** Mirrors MetaTagsConfig from src/config/settings-types.ts for preset-generator form state. */
+export interface MetaTagsFormState {
+  description: boolean;
+  keywordsEnabled: boolean;
+  keywords: string;
+  ogImageEnabled: boolean;
+  ogImage: string;
+  ogSiteName: boolean;
+  twitterCardEnabled: boolean;
+  twitterCard: "summary" | "summary_large_image";
+  twitterSite: string;
+  twitterCreator: string;
+}
+
+/** Defaults that mirror S4 scaffold defaults exactly. */
+export const DEFAULT_META_TAGS: MetaTagsFormState = {
+  description: true,
+  keywordsEnabled: false,
+  keywords: "",
+  ogImageEnabled: false,
+  ogImage: "/img/ogp.png",
+  ogSiteName: true,
+  twitterCardEnabled: false,
+  twitterCard: "summary",
+  twitterSite: "",
+  twitterCreator: "",
+};
+
 export interface FormState {
   projectName: string;
   defaultLang: string;
@@ -184,6 +212,7 @@ export interface FormState {
   cjkFriendly: boolean;
   packageManager: string;
   headerRightItems: HeaderRightItemSpec[];
+  metaTags: MetaTagsFormState;
 }
 
 export function buildJson(state: FormState): Record<string, unknown> {
@@ -208,6 +237,41 @@ export function buildJson(state: FormState): Record<string, unknown> {
   // Always emit the canonical {type, trigger|component} shape (not the internal
   // kind/name shape) — self-documents the preset for users who copy-paste.
   base.headerRightItems = state.headerRightItems.map(specToHeaderRightItem);
+
+  // Omit metaTags entirely when every value equals the S4 scaffold defaults —
+  // keeps the default JSON clean (S2 regression test asserts no metaTags key).
+  // state.metaTags may be absent in tests using makeState() without it.
+  const mt = state.metaTags ?? DEFAULT_META_TAGS;
+  const d = DEFAULT_META_TAGS;
+  const isDefault =
+    mt.description === d.description &&
+    mt.keywordsEnabled === d.keywordsEnabled &&
+    mt.keywords === d.keywords &&
+    mt.ogImageEnabled === d.ogImageEnabled &&
+    mt.ogImage === d.ogImage &&
+    mt.ogSiteName === d.ogSiteName &&
+    mt.twitterCardEnabled === d.twitterCardEnabled &&
+    mt.twitterCard === d.twitterCard &&
+    mt.twitterSite === d.twitterSite &&
+    mt.twitterCreator === d.twitterCreator;
+
+  if (!isDefault) {
+    const metaTagsJson: Record<string, unknown> = {
+      description: mt.description,
+      keywords: mt.keywordsEnabled ? mt.keywords || "" : false,
+      ogImage: mt.ogImageEnabled ? mt.ogImage || "/img/ogp.png" : false,
+      ogSiteName: mt.ogSiteName,
+      twitterCard: mt.twitterCardEnabled ? mt.twitterCard : false,
+    };
+    if (mt.twitterCardEnabled && mt.twitterSite) {
+      metaTagsJson.twitterSite = mt.twitterSite;
+    }
+    if (mt.twitterCardEnabled && mt.twitterCreator) {
+      metaTagsJson.twitterCreator = mt.twitterCreator;
+    }
+    base.metaTags = metaTagsJson;
+  }
+
   return base;
 }
 
@@ -241,11 +305,11 @@ export function buildCliCommand(state: FormState): string {
   parts.push(`--pm ${pm}`);
   parts.push("--yes");
 
-  // Trailing comment: headerRightItems is an array of discriminated unions
-  // that does not fit the --flag CLI model. Surfaced as a shell comment line
-  // so users know to use a JSON preset (--preset) for header-right ordering.
+  // Trailing comments: array/object configs that don't fit the --flag CLI model.
+  // Surfaced as shell comment lines so users know to use a JSON preset (--preset).
   const trailingNote =
-    "\n# headerRightItems: use a JSON preset (--preset) — array configs are not expressible as CLI flags";
+    "\n# headerRightItems: use a JSON preset (--preset) — array configs are not expressible as CLI flags" +
+    "\n# metaTags: use a JSON preset (--preset) — object config is not expressible as CLI flags";
 
   return parts.join(" ") + trailingNote;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -895,7 +895,7 @@ pre[class^="syntect-"] .line .highlighted-word {
  * ======================================== */
 
 .diff-row {
-  border-bottom: 1px solid color-mix(in oklch, var(--color-muted) 30%, transparent);
+  border-bottom: 1px solid color-mix(in oklch, var(--color-muted) 15%, transparent);
 }
 
 .diff-line-num {
@@ -907,7 +907,7 @@ pre[class^="syntect-"] .line .highlighted-word {
   color: var(--color-muted);
   user-select: none;
   vertical-align: top;
-  border-right: 1px solid color-mix(in oklch, var(--color-muted) 30%, transparent);
+  border-right: 1px solid color-mix(in oklch, var(--color-muted) 15%, transparent);
 }
 
 .diff-line-content {


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2074

---

## Summary

Four improvements from epic #2074 (planned via /big-plan, implemented via /x-wt-teams):

1. **Pager upper spacing (#2075)** — the prev/next pager's `mt-vsp-2xl` was silently dead (utilities are imported unlayered at the top of `global.css`; the later `.zd-content` flow rule won the cascade), rendering 24px instead of 56px. Added a `[--flow-space:var(--spacing-vsp-2xl)]` override on the nav so the flow rule itself yields the intended gap. Template counterpart synced byte-identically. Verified: computed `margin-top` is now 56px on the built preview. The structural cascade question is tracked separately in #2082.
2. **Preset generator defaults (#2076)** — the untouched generator output now equals the canonical target JSON: `tagGovernance` dropped from default features (flipped in both `preset-generator-logic.ts` and CLI `constants.ts`, pair-enforced by the features-sync test), and the initial `headerRightItems` is the 4-item set (github-link, theme-toggle, search, language-switcher) via a new `INITIAL_HEADER_RIGHT_ITEMS`. The 7-item palette stays addable; Reset restores the 4-item default. A regression test pins the default `buildJson()` output to the target JSON verbatim.
3. **Diff viewer separators (#2077)** — per-line separators (`.diff-row` border-bottom, `.diff-line-num` border-right) demoted from 30% to 15% muted mix; structural dividers untouched. Verified: computed alpha 0.15 on the built preview. Pre-existing scaffold CSS gap tracked in #2081.
4. **Choosable meta tags (#2078 + #2079)** — new `metaTags` settings object (`MetaTagsConfig`): per-tag gating for description, keywords, og:image (+companions), og:site_name, and twitter card in `_head-with-defaults.tsx` (host + template, byte-synced); plain `<meta name="description">` gated at the doc-page shell. og:title stays always-emitted (DocHead contract). The preset generator gains a "Meta tags" section (defaults mirror scaffold defaults; `buildJson` omits `metaTags` when all-default so the target JSON stays exact), and the CLI plumbs `metaTags` through preset validation → choices → settings-gen. All five e2e fixture settings synced. Showcase head output verified tag-for-tag identical to the pre-refactor deployed site; fresh scaffolds default to the minimal set (description + og:site_name only).

## Verification

- 296 root unit tests + 324 create-zudo-doc tests green on the merged base; tsc + template-drift + fixture-drift clean
- Built-preview computed-style checks: pager margin-top 56px ✓, separator alpha 0.15 ✓, center divider full-strength ✓
- Built dist head vs deployed pre-refactor head: identical effective tags ✓
- Codex deep review: one P1 raised and resolved as false positive (fixture `settings-types.ts` is gitignored and auto-synced from the root copy by `e2e/setup-fixtures.sh`)

## Topic PRs

Topic branches were merged locally into the base (s1-pager `ec663543`, s2-preset-defaults `46635753`, s3-diff-separators `f29eb4cd`, s4-metatags-engine `f5d292b9`+`9f1be44c`, s5-metatags-area `5b556792`) — no standalone topic PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)