### PR TITLE
fix: inject diff-viewer CSS into scaffolded global.css (docHistory feature)

### DIFF
--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -633,6 +633,43 @@ describe("scaffold — docHistory feature", () => {
     expect(content).toContain("docHistory: true");
   });
 
+  it("injects the diff-viewer CSS into global.css when docHistory is enabled (#2081)", async () => {
+    const choices: UserChoices = {
+      projectName: "test-dh-diff-css",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search", "docHistory"],
+      packageManager: "pnpm",
+    };
+    await scaffold(choices);
+    const css = await fs.readFile(
+      projectPath("test-dh-diff-css", "src/styles/global.css"),
+      "utf-8",
+    );
+    expect(css).toContain(".diff-row {");
+    expect(css).toContain(".diff-line-num {");
+    // Per-line separators ship at the demoted 15% muted mix (#2077)
+    expect(css).toContain("color-mix(in oklch, var(--color-muted) 15%, transparent)");
+  });
+
+  it("does NOT inject the diff-viewer CSS when docHistory is disabled", async () => {
+    const choices: UserChoices = {
+      projectName: "test-dh-no-diff-css",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search"],
+      packageManager: "pnpm",
+    };
+    await scaffold(choices);
+    const css = await fs.readFile(
+      projectPath("test-dh-no-diff-css", "src/styles/global.css"),
+      "utf-8",
+    );
+    expect(css).not.toContain(".diff-row {");
+  });
+
   it("includes @takazudo/zudo-doc-history-server dep when docHistory is enabled (W8A — #1739)", async () => {
     const choices: UserChoices = {
       projectName: "test-dh-history-server-dep",

--- a/packages/create-zudo-doc/src/features/doc-history.ts
+++ b/packages/create-zudo-doc/src/features/doc-history.ts
@@ -9,5 +9,61 @@ import type { FeatureModule } from "../compose.js";
  */
 export const docHistoryFeature: FeatureModule = () => ({
   name: "docHistory",
-  injections: [],
+  injections: [
+    {
+      // Diff-viewer CSS — the DocHistory island's side-by-side diff markup
+      // (.diff-row / .diff-line-*) is styled only here; without this block
+      // scaffolded projects render the diff viewer unstyled (#2081). Values
+      // mirror the showcase src/styles/global.css (per-line separators at
+      // the 15% muted mix, #2077).
+      file: "src/styles/global.css",
+      anchor: "/* @slot:global-css:feature-styles */",
+      content: `/* ========================================
+ * Doc History Diff Viewer (side-by-side)
+ * ======================================== */
+
+.diff-row {
+  border-bottom: 1px solid color-mix(in oklch, var(--color-muted) 15%, transparent);
+}
+
+.diff-line-num {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: var(--text-caption);
+  line-height: 1.5;
+  padding: 0 var(--spacing-hsp-xs);
+  text-align: right;
+  color: var(--color-muted);
+  user-select: none;
+  vertical-align: top;
+  border-right: 1px solid color-mix(in oklch, var(--color-muted) 15%, transparent);
+}
+
+.diff-line-content {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: var(--text-caption);
+  line-height: 1.5;
+  padding: 0 var(--spacing-hsp-sm);
+  white-space: pre-wrap;
+  word-break: break-all;
+  vertical-align: top;
+}
+
+/* Left column right border to separate the two sides */
+.diff-row td:nth-child(2) {
+  border-right: 2px solid var(--color-muted);
+}
+
+.diff-line-added {
+  background-color: color-mix(in oklch, var(--color-success) 15%, transparent);
+}
+
+.diff-line-removed {
+  background-color: color-mix(in oklch, var(--color-danger) 15%, transparent);
+}
+
+.diff-line-empty {
+  background-color: color-mix(in oklch, var(--color-muted) 8%, transparent);
+}`,
+    },
+  ],
 });


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2081

---

## Summary

Scaffolded projects with the docHistory feature enabled rendered the DocHistory diff viewer unstyled: the `.diff-row` / `.diff-line-*` rules live only in the showcase's `global.css` (template-drift-allowlisted) and the docHistory feature module injected no CSS. This injects the diff-viewer block at the `@slot:global-css:feature-styles` anchor, mirroring the showcase values (15% muted per-line separators per #2077).

Tests: scaffold with docHistory on → CSS present; off → absent. 167 scaffold tests green; tsc clean. `dist/` is not committed for this package (built at publish), so no rebuild artifact is needed.

Auto-fix from the ui-generator-polish session (Step 15.5, agent-found #2081). Codex review: no correctness regression found.

Closes #2081

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783875157&installation_id=130359969&pr_number=2083&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2083&signature=95ad89727235543fd53e8237b2a40acd6d7a3f74d254a30451d15a1ea2d6e97d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->