### PR TITLE
Honor prefers-reduced-motion for view-transition cross-fades

### DIFF
--- a/packages/create-zudo-doc/templates/base/src/styles/global.css
+++ b/packages/create-zudo-doc/templates/base/src/styles/global.css
@@ -994,6 +994,27 @@ pre[class^="syntect-"] .line .highlighted-word {
   animation: 300ms ease-out both contentFadeIn;
 }
 
+/* Reduced motion: collapse all view-transition animation to an instant
+ * swap (zudolab/zudo-doc#2086). With every snapshot animation at none the
+ * transition settles immediately — no cross-fade, no translateY slide.
+ * Covers the root cross-fade and the #2072 :only-child entry/exit rules;
+ * the both-sides chrome layers are already animation: none above. Equal
+ * specificity per selector, but later in source order, so these win. */
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(root),
+  ::view-transition-new(root),
+  ::view-transition-old(zfb-header):only-child,
+  ::view-transition-old(zfb-sidebar):only-child,
+  ::view-transition-old(zfb-footer):only-child,
+  ::view-transition-old(zfb-sidebar-toggle):only-child,
+  ::view-transition-new(zfb-header):only-child,
+  ::view-transition-new(zfb-sidebar):only-child,
+  ::view-transition-new(zfb-footer):only-child,
+  ::view-transition-new(zfb-sidebar-toggle):only-child {
+    animation: none;
+  }
+}
+
 /* Version-switcher responsive visibility (moved out of the component to
  * avoid <style>-inside-<div> HTML5 content-model violation; required when
  * the i18nVersion feature ships a <VersionSwitcher> wrapped in

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1320,6 +1320,27 @@ dialog.zd-enlarge-dialog::backdrop {
   animation: 300ms ease-out both contentFadeIn;
 }
 
+/* Reduced motion: collapse all view-transition animation to an instant
+ * swap (zudolab/zudo-doc#2086). With every snapshot animation at none the
+ * transition settles immediately — no cross-fade, no translateY slide.
+ * Covers the root cross-fade and the #2072 :only-child entry/exit rules;
+ * the both-sides chrome layers are already animation: none above. Equal
+ * specificity per selector, but later in source order, so these win. */
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(root),
+  ::view-transition-new(root),
+  ::view-transition-old(zfb-header):only-child,
+  ::view-transition-old(zfb-sidebar):only-child,
+  ::view-transition-old(zfb-footer):only-child,
+  ::view-transition-old(zfb-sidebar-toggle):only-child,
+  ::view-transition-new(zfb-header):only-child,
+  ::view-transition-new(zfb-sidebar):only-child,
+  ::view-transition-new(zfb-footer):only-child,
+  ::view-transition-new(zfb-sidebar-toggle):only-child {
+    animation: none;
+  }
+}
+
 /* Version-switcher responsive visibility (was an inline <style> child of
  * the data-version-switcher <div>; moved to global.css to avoid the
  * <style>-inside-<div> HTML5 content-model violation flagged by


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2086

---

## Summary

Closes #2086 (agent-found during the #2072 workflow). The view-transition root cross-fade and the #2072 `:only-child` chrome entry/exit rules animated unconditionally. Under `prefers-reduced-motion: reduce`, all view-transition snapshot animations are now `none`, collapsing navigations to an instant swap.

## Changes

- `src/styles/global.css` — `@media (prefers-reduced-motion: reduce)` block after the root cross-fade rules.
- `packages/create-zudo-doc/templates/base/src/styles/global.css` — identical mirror (byte-verified).

## Test Plan

- Reviewed: equal-specificity-later-in-source override confirmed; non-reduced-motion path untouched (block only applies under the media condition, so existing e2e VT assertions are unaffected).
- CI (template drift, build, e2e) on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783880185&installation_id=130359969&pr_number=2087&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2087&signature=e3923fb50217e392032318214b76ae758f0b587b643b13029ca674c979a0d309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->