### PR TITLE
Stagger e2e webServer startup to avoid wrangler inspector-port race

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,7 +15,17 @@ export default defineConfig({
     // `setup-fixtures.sh` already ran `zfb build` per fixture; this only
     // launches the static preview server. The fixture's `node_modules`
     // is a symlink back to the repo root, so the binary path is shared.
-    command: `cd e2e/fixtures/${name} && ./node_modules/.bin/zfb preview --port ${BASE_PORT + i}`,
+    //
+    // The `sleep ${i * 3}` stagger works around a workerd inspector-port
+    // race (zudolab/zudo-doc#2084): `zfb preview` hands off to `wrangler
+    // pages dev`, and every wrangler instance probes inspector port 9230.
+    // Booting all five simultaneously makes several instances probe the
+    // same free port and race the bind — losers die with "Address already
+    // in use (127.0.0.1:9230)" and the webServer wait times out. A
+    // staggered start means each later instance sees the port already
+    // held and falls back cleanly (verified manually; wrangler does not
+    // honor WRANGLER_INSPECTOR_PORT to pin distinct ports per instance).
+    command: `sleep ${i * 3} && cd e2e/fixtures/${name} && ./node_modules/.bin/zfb preview --port ${BASE_PORT + i}`,
     url: `http://localhost:${BASE_PORT + i}/`,
     reuseExistingServer: true,
     timeout: 120_000,


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2084

---

## Summary

Closes #2084 (agent-found during the #2072 workflow). Booting all five fixture preview servers simultaneously made several `wrangler pages dev` instances race the bind on workerd inspector port 9230 — losers crashed (followed by an esbuild deadlock dump) and Playwright's webServer wait timed out after 120s. Locally this reproduced on 2 of 3 consecutive runs.

## Changes

- `playwright.config.ts` — `sleep ${i * 3} &&` prefix per webServer command (0/3/6/9/12s). Each later instance then sees inspector port 9230 already held and falls back cleanly instead of racing the bind. `WRANGLER_INSPECTOR_PORT` is not honored by wrangler (verified), so port pinning wasn't an option without upstream zfb work.

## Test Plan

- Two consecutive cold boots of all five servers via `npx playwright test --project smoke` succeeded (previously failed 2 of 3 attempts).
- `reuseExistingServer: true` path unaffected (sleep only runs when Playwright actually spawns the command). Max added wall-clock is 12s, well under the 120s per-server timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783880188&installation_id=130359969&pr_number=2088&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2088&signature=e21ad48a7d6337c65eadf5878e8ab74ffa5196824bbb093020e45fc654908acc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->