### PR TITLE
fix(e2e): generate smoke doc-history JSON against the fixture repo (real #2106 root cause: INIT_CWD)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -110,12 +110,20 @@ environment-dependence → `@local-only`. Each now **requires a tracking issue**
 
 A local burn-in (`--repeat-each=N`) proves *determinism* but not *CI-capability* — it
 runs on a dev machine, not in the CI container. During the refactor it cleared 26
-previously-`@local-only` tests as genuinely stable AND CI-safe (untagged), but the
-4 `smoke-doc-history` revision-data tests passed locally yet fail in CI because the
-doc-history git-history JSON is only generated in a real local git/build environment
-(see zudolab/zudo-doc#2106). CI is the gate that caught that environmental dependence —
-the layered design working as intended. Those 4 are the only current `@local-only`
-tests; the `@flaky` set is empty (the healthy state for non-determinism).
+previously-`@local-only` tests as genuinely stable AND CI-safe (untagged), and 4
+`smoke-doc-history` revision-data tests were quarantined `@local-only` because they
+passed locally yet rendered 0 entries in CI: the smoke fixture's doc-history JSON came
+back empty in the Playwright container. CI was the gate that caught that
+environment-dependence — the layered design working as intended. The cause was later
+root-caused and fixed (zudolab/zudo-doc#2106): under `pnpm test:e2e:ci`, pnpm sets
+`INIT_CWD=<repo-root>`, so the smoke fixture's `doc-history-generate` resolved its
+relative `--content-dir src/content/docs` against the **outer** repo instead of the
+fixture, walking paths outside the nested smoke `.git` → 0 entries. `setup-fixtures.sh`
+now pins `INIT_CWD` to the fixture dir for the smoke build, so the two-commit history
+generates correctly and those 4 tests are **un-quarantined**. (An earlier
+`safe.directory` attempt addressed a different, *simulated* mechanism — dubious
+ownership via `GIT_TEST_ASSUME_DIFFERENT_OWNER=1` — and was disproven by CI.) Both the
+`@local-only` and `@flaky` sets are now empty (the healthy state).
 
 ### How to tag a test as @flaky
 

--- a/e2e/setup-fixtures.sh
+++ b/e2e/setup-fixtures.sh
@@ -508,7 +508,22 @@ for fixture in "${FIXTURES[@]}"; do
     # GEN_DOC_HISTORY=1: the doc-history postBuild per-page JSON is opt-in for
     # local builds (#1986), so the smoke fixture must request it explicitly —
     # its doc-history specs read those JSON manifests from dist/.
-    (cd "$REPO_ROOT/e2e/fixtures/$fixture" && GEN_DOC_HISTORY=1 "$REPO_ROOT/node_modules/.bin/zfb" build 2>&1) || {
+    #
+    # INIT_CWD pin (#2106 — the real CI empty-data root cause): the postBuild
+    # spawns `doc-history-generate` with a RELATIVE `--content-dir src/content/docs`,
+    # which @takazudo/zudo-doc-history-server's resolveContentPath() resolves
+    # against INIT_CWD (the pnpm --filter dev:history / CI build-history contract).
+    # Under `pnpm test:e2e:ci`, pnpm sets INIT_CWD=<repo-root>, so the generate
+    # scans the OUTER repo's src/content/docs (136 files) instead of THIS fixture's
+    # (12). The git walk roots at the nested smoke .git (cwd), so the outer paths
+    # become ../../../src/content/docs/... — outside the nested repo — and
+    # `git log --follow` returns 0 entries, shipping an empty getting-started.json.
+    # The smoke fixture build's true project root IS the fixture dir, so pin
+    # INIT_CWD to it: content-dir then resolves to the fixture's own content and
+    # the two-commit history is generated correctly. (The previously-attempted
+    # safe.directory fix targeted a different, simulated mechanism and was
+    # disproven by CI; this is the confirmed cause.)
+    (cd "$REPO_ROOT/e2e/fixtures/$fixture" && INIT_CWD="$REPO_ROOT/e2e/fixtures/$fixture" GEN_DOC_HISTORY=1 "$REPO_ROOT/node_modules/.bin/zfb" build 2>&1) || {
       echo "  FAILED: $fixture build failed" >&2
       exit 1
     }

--- a/e2e/smoke-doc-history.spec.ts
+++ b/e2e/smoke-doc-history.spec.ts
@@ -33,8 +33,12 @@ test.describe("Doc History: revision panel and diff", () => {
     await expect(panel).toHaveAttribute("open", "", { timeout: 5000 });
   });
 
-  // quarantined (env-dependent, CI-incapable): https://github.com/zudolab/zudo-doc/issues/2106
-  test("revision list shows 2+ entries after data loads @local-only", async ({ page }) => {
+  // un-quarantined #2106: the CI empty-data gap was the smoke fixture's
+  // doc-history generate resolving its relative --content-dir against
+  // INIT_CWD=<repo-root> (set by pnpm) instead of the fixture dir, scanning the
+  // outer repo and walking paths outside the nested smoke .git → 0 entries.
+  // setup-fixtures.sh now pins INIT_CWD to the fixture dir for the smoke build.
+  test("revision list shows 2+ entries after data loads", async ({ page }) => {
     await page.goto(PAGE, { waitUntil: "load" });
 
     const triggerBtn = page.locator('[aria-label="View document history"]');
@@ -50,8 +54,8 @@ test.describe("Doc History: revision panel and diff", () => {
     await expect(entryButtons).toHaveCount(2, { timeout: 10_000 });
   });
 
-  // quarantined (env-dependent, CI-incapable): https://github.com/zudolab/zudo-doc/issues/2106
-  test("A/B selection buttons are present for each revision @local-only", async ({
+  // un-quarantined #2106 (INIT_CWD pin in setup-fixtures.sh)
+  test("A/B selection buttons are present for each revision", async ({
     page,
   }) => {
     await page.goto(PAGE, { waitUntil: "load" });
@@ -77,8 +81,8 @@ test.describe("Doc History: revision panel and diff", () => {
     await expect(bButtons).toHaveCount(2);
   });
 
-  // quarantined (env-dependent, CI-incapable): https://github.com/zudolab/zudo-doc/issues/2106
-  test("Compare button is present @local-only", async ({ page }) => {
+  // un-quarantined #2106 (INIT_CWD pin in setup-fixtures.sh)
+  test("Compare button is present", async ({ page }) => {
     await page.goto(PAGE, { waitUntil: "load" });
 
     const triggerBtn = page.locator('[aria-label="View document history"]');
@@ -96,8 +100,8 @@ test.describe("Doc History: revision panel and diff", () => {
     await expect(compareBtn).toBeVisible();
   });
 
-  // quarantined (env-dependent, CI-incapable): https://github.com/zudolab/zudo-doc/issues/2106
-  test("clicking Compare shows diff viewer with a table @local-only", async ({ page }) => {
+  // un-quarantined #2106 (INIT_CWD pin in setup-fixtures.sh)
+  test("clicking Compare shows diff viewer with a table", async ({ page }) => {
     await page.goto(PAGE, { waitUntil: "load" });
 
     const triggerBtn = page.locator('[aria-label="View document history"]');


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2106

---

## Summary

Fixes the real root cause of the CI empty doc-history data gap (#2106). The previously-attempted dubious-ownership / `safe.directory` fix was disproven by CI and reverted; this replaces it with the confirmed cause.

**Root cause (reproduced locally, no container needed):** `pnpm test:e2e:ci` sets `INIT_CWD=<repo-root>`. The smoke fixture build's doc-history postBuild spawns `doc-history-generate` with a relative `--content-dir src/content/docs`, which `@takazudo/zudo-doc-history-server`'s `resolveContentPath` resolves against `INIT_CWD` → the **outer** repo's content dir (136 files), not the fixture's (12 files). The git walk roots at the nested smoke repo (cwd), so the outer paths resolve to `../../../src/content/docs/...` which escape it → `git log --follow` returns nothing → `getting-started.json` ships with **0 entries**. The 4 revision-data specs then see 0 entries (`toHaveCount(2) → 0`).

This is why the dubious-ownership theory failed: a different mechanism produced the same 0-entry symptom. Locally it "passed" only when a prior non-pnpm `bash setup-fixtures.sh` (INIT_CWD unset) left a fresh 2-entry `dist/` preserved by the freshness marker; CI always rebuilds from a gitignored-empty `dist/` → always 0.

## Changes

- **`e2e/setup-fixtures.sh`** — pin `INIT_CWD` to the fixture dir for the smoke `GEN_DOC_HISTORY=1 zfb build` (its true project root), so the generate CLI resolves `--content-dir` against the fixture's own content. Documented inline with the root cause.
- **`e2e/smoke-doc-history.spec.ts`** — drop `@local-only` from the 4 revision-data tests (now CI-capable).
- **`TESTING.md`** — update the burn-in/quarantine narrative; both `@local-only` and `@flaky` sets are now empty.

## Test Plan

- Local (CI-faithful — `pnpm` sets `INIT_CWD=<repo-root>`, forced rebuild): `getting-started.json` 0 → **2 entries**.
- `npx playwright test e2e/smoke-doc-history.spec.ts --project smoke` → **7/7 passed** (incl. the 4 un-quarantined).
- Full smoke suite → 159/159 passed.
- **CI E2E Tests job (real Playwright container, `--user 1001`) → PASSED** — the decisive confirmation the prior fix never got.

Closes #2106