### PR TITLE
chore(deps): bump @takazudo/zfb family to 0.1.0-next.43

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,9 +80,9 @@
   },
   "dependencies": {
     "@takazudo/zdtp": "0.2.0-next.2",
-    "@takazudo/zfb": "0.1.0-next.41",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.41",
-    "@takazudo/zfb-runtime": "0.1.0-next.41",
+    "@takazudo/zfb": "0.1.0-next.43",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.43",
+    "@takazudo/zfb-runtime": "0.1.0-next.43",
     "@types/hast": "^3.0.4",
     "@takazudo/zudo-doc": "workspace:*",
     "clsx": "^2.1.1",

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -3065,14 +3065,16 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
    * hardening (warns on island marker-name collisions). next.40: `zfb dev`
    * lazy rendering on by default (pages render on first request;
    * `ZFB_DEV_EAGER=1` restores eager mode, Takazudo/zudo-front-builder#1029)
-   * — dev-server-only, no breaking changes. Now bumped to 0.1.0-next.41:
-   * URL-space fallback in resolve_links for dir-style hrefs written from
-   * non-index pages (Takazudo/zudo-front-builder#1030), and the data-file
-   * skip warning now respects collection include/exclude globs (#1032) — no
+   * — dev-server-only, no breaking changes. next.41: URL-space fallback in
+   * resolve_links for dir-style hrefs written from non-index pages
+   * (Takazudo/zudo-front-builder#1030), and the data-file skip warning now
+   * respects collection include/exclude globs (#1032). Now bumped to
+   * 0.1.0-next.43: next.42/next.43 are release-tooling + formatter-glob fixes
+   * only (npm-publish idempotency, gitignored-artifact excludes) — no
    * consumer-facing breaking change. Generated package.json must pin all
    * three.
    */
-  it("pins @takazudo/zfb at 0.1.0-next.41", async () => {
+  it("pins @takazudo/zfb at 0.1.0-next.43", async () => {
     const choices: UserChoices = {
       projectName: "test-pin-bump",
       defaultLang: "en",
@@ -3083,10 +3085,10 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
     };
     await scaffold(choices);
     const pkg = await fs.readJson(projectPath("test-pin-bump", "package.json"));
-    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.41");
-    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.41");
+    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.43");
+    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.43");
     expect(pkg.dependencies["@takazudo/zfb-adapter-cloudflare"]).toBe(
-      "0.1.0-next.41",
+      "0.1.0-next.43",
     );
   });
 });

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -352,11 +352,13 @@ function generatePackageJson(choices: UserChoices) {
     // (Takazudo/zudo-front-builder#1030) — and the data-file skip warning
     // (e.g. for `_category_.json`) now respects the collection's
     // include/exclude globs (#1032). No consumer-facing breaking change.
-    "@takazudo/zfb": "0.1.0-next.41",
-    "@takazudo/zfb-runtime": "0.1.0-next.41",
+    // next.42/next.43: release-tooling + formatter-glob fixes only (npm-publish
+    // idempotency, gitignored-artifact excludes). No consumer-facing change.
+    "@takazudo/zfb": "0.1.0-next.43",
+    "@takazudo/zfb-runtime": "0.1.0-next.43",
     // zfb-adapter-cloudflare — required for any route with `prerender = false`.
     // Pinned in lockstep with @takazudo/zfb.
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.41",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.43",
     // @takazudo/zudo-doc — published from this monorepo via
     // .github/workflows/publish-zudo-doc.yml. The pin here is bumped in
     // lockstep by scripts/release-create-zudo-doc.sh whenever zudo-doc's

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -171,8 +171,8 @@
   ],
   "peerDependencies": {
     "preact": "^10.29.1",
-    "@takazudo/zfb": "^0.1.0-next.41",
-    "@takazudo/zfb-runtime": "^0.1.0-next.41",
+    "@takazudo/zfb": "^0.1.0-next.43",
+    "@takazudo/zfb-runtime": "^0.1.0-next.43",
     "@takazudo/zudo-doc-history-server": "workspace:^",
     "@takazudo/zdtp": "^0.2.0-next.2",
     "shiki": "^4.0.2"
@@ -200,7 +200,7 @@
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
     "vitest": "^4.1.0",
-    "@takazudo/zfb": "0.1.0-next.41",
-    "@takazudo/zfb-runtime": "0.1.0-next.41"
+    "@takazudo/zfb": "0.1.0-next.43",
+    "@takazudo/zfb-runtime": "0.1.0-next.43"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,14 +25,14 @@ importers:
         specifier: 0.2.0-next.2
         version: 0.2.0-next.2(preact@10.29.2)
       '@takazudo/zfb':
-        specifier: 0.1.0-next.41
-        version: 0.1.0-next.41
+        specifier: 0.1.0-next.43
+        version: 0.1.0-next.43
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.41
-        version: 0.1.0-next.41
+        specifier: 0.1.0-next.43
+        version: 0.1.0-next.43
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.41
-        version: 0.1.0-next.41(@takazudo/zfb@0.1.0-next.41)
+        specifier: 0.1.0-next.43
+        version: 0.1.0-next.43(@takazudo/zfb@0.1.0-next.43)
       '@takazudo/zudo-doc':
         specifier: workspace:*
         version: link:packages/zudo-doc
@@ -285,11 +285,11 @@ importers:
         version: 4.0.3
     devDependencies:
       '@takazudo/zfb':
-        specifier: 0.1.0-next.41
-        version: 0.1.0-next.41
+        specifier: 0.1.0-next.43
+        version: 0.1.0-next.43
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.41
-        version: 0.1.0-next.41(@takazudo/zfb@0.1.0-next.41)
+        specifier: 0.1.0-next.43
+        version: 0.1.0-next.43(@takazudo/zfb@0.1.0-next.43)
       '@types/node':
         specifier: ^25.3.5
         version: 25.3.5
@@ -1372,44 +1372,44 @@ packages:
     peerDependencies:
       preact: ^10.29.1
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.41':
-    resolution: {integrity: sha512-0GgxEnFn2J7waYxyUR6Hvzll/5wvkt4JK9lIDa74iro4H3fP70XvkvZaoTLpBIK6JDMR0YObM36COC3riZfDDA==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.43':
+    resolution: {integrity: sha512-2mOI2fRqGBcFqRvop/yjWNgY6LFI/3/SVssJT9jzsS52ojvrZ/rX06jsnhcF/gLMIXqlsh3lEJh37sAFjI3qbA==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.41':
-    resolution: {integrity: sha512-uwUVwc6k3FuP9Kzw8JChP7R7wDwCVS3UqEFFcTVLmpeHrDP2h0+48AwDlwzls88knDz621PozjSq/2ojxlhaPA==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.43':
+    resolution: {integrity: sha512-FUFEg0n1QVurgE9S1D7lJKI/d/th8zj8e7rB+oL8uUBjbmakw+m/M0Gx2p/EapwDVDFqNJo1kQPRGoXMeQ9gTQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.41':
-    resolution: {integrity: sha512-aswliW7P9bJu/YfaRmILMxFOmw8qiGOl/QboIjMcXzPuqCCtnLpYNZwxnVj4K4C8z90cDs9kCmJrunCCCfEvcQ==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.43':
+    resolution: {integrity: sha512-s/w0VYcG76dy2jLWcDAx/bHjoR1CROlutTqqgH0UYtjbouGJwMZU9MULxuDsFDzh/YdwJ5Kv23AcxEfsg16iGQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.41':
-    resolution: {integrity: sha512-+9yHAnu8oNbYPlvratBLMrhGMn4x//4XB6vNXR0M0NYNq+AsKwOvpmJ4aNAxHq7Ty6OnMu5dH6eUN/KYUIUH4Q==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.43':
+    resolution: {integrity: sha512-XicsRVvYlkSvBaw4iD3eIXfUecfguzce4fLdW8tXm+SVGfu2tZ0mTbgRRHmUVBtF/okbvHadEl6UtSrgIYj95A==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.41':
-    resolution: {integrity: sha512-ykN9KFdSfzjhElMPFj26wVr/HAzn/0lfUHmXjVkciEt8B22JPz9RJT4gl02MwUKIrJDvDF4r5ZtxD3TF+r28Bw==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.43':
+    resolution: {integrity: sha512-4szqWGy87nc/S3bV9PX/4IySv8xFqUnaRCteiqRwZbErGRLk3mMAXoWQJfEQWepYmBhyCpAcDHn0d6sW4b15YA==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.41':
-    resolution: {integrity: sha512-0/V4srUTz1r05GJgujFJHo2uu/ukVRAHE3k+akOaf6uuCv2gvs9fut1m8nlYX1jqvRdLk6xdQbQIt/m/AOCeAQ==}
+  '@takazudo/zfb-runtime@0.1.0-next.43':
+    resolution: {integrity: sha512-7h9Xm+Q8M6GxYOHXSNBey0kpr4VHOnEOiER6E/28jN2R9uHojHQTOk96s6yBtuFblsEEViTLK1uOP0Du2Ooh1Q==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.41
+      '@takazudo/zfb': 0.1.0-next.43
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.41':
-    resolution: {integrity: sha512-zBmwAAVCbN9lgNAswL2sAchBQddN2tDfglos96a9yWuJkzfyucqBnKm6TE6Bc8W86oq97+Y2cQUOqjtBDvIw3w==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.43':
+    resolution: {integrity: sha512-51cmAmhI/RaAIVz6asZUpne4ZBppsGR0cbj6Itu0Juv6BUy10x9WRCeHT6SSWiZNh6TiYlyOxiQLtLzGA11U/g==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.41':
-    resolution: {integrity: sha512-bu1MaXEyahQ3jbRK5f51bF7KQY14Kaiota1KKZIs0yoU+OkJ1DP+td5MZw94I4Y70Bs5kjktlpRYw82EDQyh7w==}
+  '@takazudo/zfb@0.1.0-next.43':
+    resolution: {integrity: sha512-5weWigclI6XPRToLNyzEYuUN33mPby6N4wZFnJLqBHSmHeENNFh88miWBw11rZK/PNwJSLkt8D34ENx8ViQtLQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
@@ -4071,35 +4071,35 @@ snapshots:
       culori: 4.0.2
       preact: 10.29.2
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.41': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.43': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.41':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.43':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.41':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.43':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.41':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.43':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.41':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.43':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.41(@takazudo/zfb@0.1.0-next.41)':
+  '@takazudo/zfb-runtime@0.1.0-next.43(@takazudo/zfb@0.1.0-next.43)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.41
+      '@takazudo/zfb': 0.1.0-next.43
       hono: 4.12.23
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.41':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.43':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.41':
+  '@takazudo/zfb@0.1.0-next.43':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.41
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.41
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.41
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.41
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.41
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.43
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.43
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.43
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.43
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.43
 
   '@takazudo/zudo-design-token-lint@1.0.0':
     dependencies:


### PR DESCRIPTION
## Summary
Bump the lockstep `@takazudo/zfb` packages from `0.1.0-next.41` to the latest `@next` (`0.1.0-next.43`):

- `@takazudo/zfb`
- `@takazudo/zfb-runtime`
- `@takazudo/zfb-adapter-cloudflare`

`.42`/`.43` are **non-breaking** per the upstream changelog — bug fixes only (npm-publish idempotency, formatter glob excludes for generated/gitignored dirs). No consumer-facing API or behaviour changes. `@takazudo/zdtp` is a separate package and is intentionally left unchanged.

## Changes
Updated the version in all five lockstep pin sources guarded by `scripts/check-pin-parity.mjs`, plus the scaffold pin test:

- `package.json` — root `dependencies` (3 zfb packages)
- `pnpm-lock.yaml` — regenerated via `pnpm install`
- `packages/zudo-doc/package.json` — `devDependencies` (exact) + `peerDependencies` (`^`) for `zfb` and `zfb-runtime`
- `packages/create-zudo-doc/src/scaffold.ts` — literal pins emitted into generated downstream `package.json`
- `packages/create-zudo-doc/src/__tests__/scaffold.test.ts` — pin assertions + narrative comment updated to `.43`

## Test Plan
All green locally against `.43`:

- `node scripts/check-pin-parity.mjs` — pin parity verified (3 external + 2 internal + 4 workspace-package fields)
- `pnpm check` — typecheck clean
- `pnpm build` — 272 pages built, Cloudflare adapter `_worker.js` written
- `pnpm test:unit` — 521 passed
- `pnpm test` (packages) — search-worker 43, md-plugins 80, create-zudo-doc 326, zudo-doc 529 — all passed
- `/codex-review` — no issues