### PR TITLE
ci: bump actions/cache v4.3.0 → v5.0.5 (Node 24 runtime)

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -105,7 +105,7 @@ jobs:
         run: pnpm build
 
       - name: Cache site build output
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: dist/
           key: dist-${{ github.run_id }}
@@ -138,7 +138,7 @@ jobs:
         run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Restore dist cache (built by build-site)
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: dist/
           key: dist-${{ github.run_id }}
@@ -184,7 +184,7 @@ jobs:
             --out-dir ../../doc-history-out
 
       - name: Cache doc history output
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: doc-history-out/
           key: doc-history-${{ github.run_id }}
@@ -203,14 +203,14 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Restore site build cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: dist/
           key: dist-${{ github.run_id }}
           fail-on-cache-miss: true
 
       - name: Restore doc history cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: doc-history-out/
           key: doc-history-${{ github.run_id }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -399,7 +399,7 @@ jobs:
         run: pnpm run check:links -- --strict-broken --strict-absolute --allowlist=.check-links-allowlist
 
       - name: Cache site build output
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: dist/
           key: dist-${{ github.run_id }}
@@ -432,7 +432,7 @@ jobs:
         run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Restore dist cache (built by build-site)
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: dist/
           key: dist-${{ github.run_id }}
@@ -479,7 +479,7 @@ jobs:
             --out-dir ../../doc-history-out
 
       - name: Cache doc history output
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: doc-history-out/
           key: doc-history-${{ github.run_id }}
@@ -549,14 +549,14 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Restore site build cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: dist/
           key: dist-${{ github.run_id }}
           fail-on-cache-miss: true
 
       - name: Restore doc history cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: doc-history-out/
           key: doc-history-${{ github.run_id }}

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -95,7 +95,7 @@ jobs:
         run: pnpm build
 
       - name: Cache site build output
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: dist/
           key: dist-${{ github.run_id }}
@@ -128,7 +128,7 @@ jobs:
         run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Restore dist cache (built by build-site)
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: dist/
           key: dist-${{ github.run_id }}
@@ -174,7 +174,7 @@ jobs:
             --out-dir ../../doc-history-out
 
       - name: Cache doc history output
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: doc-history-out/
           key: doc-history-${{ github.run_id }}
@@ -196,14 +196,14 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Restore site build cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: dist/
           key: dist-${{ github.run_id }}
           fail-on-cache-miss: true
 
       - name: Restore doc history cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: doc-history-out/
           key: doc-history-${{ github.run_id }}


### PR DESCRIPTION
Closes #2113.

## Summary
`actions/cache@v4.3.0` (SHA `0057852…`) runs on Node.js 20, which GitHub deprecated. From **2026-06-16** the runner force-migrates Node-20 actions to Node 24, and **2026-09-16** removes Node 20 entirely. `actions/cache@v5.0.5` (SHA `27d5ce7…`) declares `using: node24`.

The `save`/`restore` sub-action inputs are unchanged across v4→v5, so this is a pure runtime bump. PR CI exercises the same `actions/cache/save` + `restore` pattern, so a green run validates the bumped action on the runner.

## Changes
Updated all 15 `save`/`restore` pins in lockstep across the three workflows that use `actions/cache`:

- `.github/workflows/main-deploy.yml` (5)
- `.github/workflows/preview-deploy.yml` (5)
- `.github/workflows/pr-checks.yml` (5)

The publish-* and exam workflows don't use `actions/cache`.

## Test Plan
- `/codex-review` on the diff — no issues
- PR CI (this run) exercises `actions/cache@v5.0.5` save/restore on the runner — green = validated

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783957720&installation_id=130359969&pr_number=2114&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2114&signature=5ae6c8ab543ae51d2173db21f426cf1d4902133dd687094793b4b9c7a395a2de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->