### PR TITLE
chore: bump @takazudo/zfb family 0.1.0-next.43 → next.44

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,9 +80,9 @@
   },
   "dependencies": {
     "@takazudo/zdtp": "0.2.0-next.2",
-    "@takazudo/zfb": "0.1.0-next.43",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.43",
-    "@takazudo/zfb-runtime": "0.1.0-next.43",
+    "@takazudo/zfb": "0.1.0-next.44",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.44",
+    "@takazudo/zfb-runtime": "0.1.0-next.44",
     "@types/hast": "^3.0.4",
     "@takazudo/zudo-doc": "workspace:*",
     "clsx": "^2.1.1",

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -3069,12 +3069,13 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
    * resolve_links for dir-style hrefs written from non-index pages
    * (Takazudo/zudo-front-builder#1030), and the data-file skip warning now
    * respects collection include/exclude globs (#1032). Now bumped to
-   * 0.1.0-next.43: next.42/next.43 are release-tooling + formatter-glob fixes
-   * only (npm-publish idempotency, gitignored-artifact excludes) — no
-   * consumer-facing breaking change. Generated package.json must pin all
+   * 0.1.0-next.44: next.42/next.43 were release-tooling + formatter-glob fixes;
+   * next.44 is embed-as-library enhancements only (ServerBuilder::with_page_cache,
+   * opt-in ExternalInvalidationHook, TS-config-loader path canonicalization) —
+   * no consumer-facing breaking change. Generated package.json must pin all
    * three.
    */
-  it("pins @takazudo/zfb at 0.1.0-next.43", async () => {
+  it("pins @takazudo/zfb at 0.1.0-next.44", async () => {
     const choices: UserChoices = {
       projectName: "test-pin-bump",
       defaultLang: "en",
@@ -3085,10 +3086,10 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
     };
     await scaffold(choices);
     const pkg = await fs.readJson(projectPath("test-pin-bump", "package.json"));
-    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.43");
-    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.43");
+    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.44");
+    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.44");
     expect(pkg.dependencies["@takazudo/zfb-adapter-cloudflare"]).toBe(
-      "0.1.0-next.43",
+      "0.1.0-next.44",
     );
   });
 });

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -346,7 +346,7 @@ function generatePackageJson(choices: UserChoices) {
     // pages render on first request instead of on every file-change tick
     // (Takazudo/zudo-front-builder#1029); `ZFB_DEV_EAGER=1` restores eager
     // mode. Dev-server-only change, no build/config migration needed.
-    // next.41 (current pin) adds a URL-space fallback in resolve_links —
+    // next.41 adds a URL-space fallback in resolve_links —
     // dir-style hrefs written from non-index pages now resolve against the
     // page's URL directory when the file-space lookup misses
     // (Takazudo/zudo-front-builder#1030) — and the data-file skip warning
@@ -354,11 +354,15 @@ function generatePackageJson(choices: UserChoices) {
     // include/exclude globs (#1032). No consumer-facing breaking change.
     // next.42/next.43: release-tooling + formatter-glob fixes only (npm-publish
     // idempotency, gitignored-artifact excludes). No consumer-facing change.
-    "@takazudo/zfb": "0.1.0-next.43",
-    "@takazudo/zfb-runtime": "0.1.0-next.43",
+    // next.44 (current pin): embed-as-library enhancements only — ServerBuilder
+    // ::with_page_cache for live content, an opt-in ExternalInvalidationHook to
+    // narrow extraWatchPaths rebuilds, and TS-config-loader path canonicalization
+    // (Takazudo/zudo-front-builder#1036–#1043). No consumer-facing / CLI change.
+    "@takazudo/zfb": "0.1.0-next.44",
+    "@takazudo/zfb-runtime": "0.1.0-next.44",
     // zfb-adapter-cloudflare — required for any route with `prerender = false`.
     // Pinned in lockstep with @takazudo/zfb.
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.43",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.44",
     // @takazudo/zudo-doc — published from this monorepo via
     // .github/workflows/publish-zudo-doc.yml. The pin here is bumped in
     // lockstep by scripts/release-create-zudo-doc.sh whenever zudo-doc's

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -171,8 +171,8 @@
   ],
   "peerDependencies": {
     "preact": "^10.29.1",
-    "@takazudo/zfb": "^0.1.0-next.43",
-    "@takazudo/zfb-runtime": "^0.1.0-next.43",
+    "@takazudo/zfb": "^0.1.0-next.44",
+    "@takazudo/zfb-runtime": "^0.1.0-next.44",
     "@takazudo/zudo-doc-history-server": "workspace:^",
     "@takazudo/zdtp": "^0.2.0-next.2",
     "shiki": "^4.0.2"
@@ -200,7 +200,7 @@
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
     "vitest": "^4.1.0",
-    "@takazudo/zfb": "0.1.0-next.43",
-    "@takazudo/zfb-runtime": "0.1.0-next.43"
+    "@takazudo/zfb": "0.1.0-next.44",
+    "@takazudo/zfb-runtime": "0.1.0-next.44"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,14 +25,14 @@ importers:
         specifier: 0.2.0-next.2
         version: 0.2.0-next.2(preact@10.29.2)
       '@takazudo/zfb':
-        specifier: 0.1.0-next.43
-        version: 0.1.0-next.43
+        specifier: 0.1.0-next.44
+        version: 0.1.0-next.44
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.43
-        version: 0.1.0-next.43
+        specifier: 0.1.0-next.44
+        version: 0.1.0-next.44
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.43
-        version: 0.1.0-next.43(@takazudo/zfb@0.1.0-next.43)
+        specifier: 0.1.0-next.44
+        version: 0.1.0-next.44(@takazudo/zfb@0.1.0-next.44)
       '@takazudo/zudo-doc':
         specifier: workspace:*
         version: link:packages/zudo-doc
@@ -285,11 +285,11 @@ importers:
         version: 4.0.3
     devDependencies:
       '@takazudo/zfb':
-        specifier: 0.1.0-next.43
-        version: 0.1.0-next.43
+        specifier: 0.1.0-next.44
+        version: 0.1.0-next.44
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.43
-        version: 0.1.0-next.43(@takazudo/zfb@0.1.0-next.43)
+        specifier: 0.1.0-next.44
+        version: 0.1.0-next.44(@takazudo/zfb@0.1.0-next.44)
       '@types/node':
         specifier: ^25.3.5
         version: 25.3.5
@@ -1372,44 +1372,44 @@ packages:
     peerDependencies:
       preact: ^10.29.1
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.43':
-    resolution: {integrity: sha512-2mOI2fRqGBcFqRvop/yjWNgY6LFI/3/SVssJT9jzsS52ojvrZ/rX06jsnhcF/gLMIXqlsh3lEJh37sAFjI3qbA==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.44':
+    resolution: {integrity: sha512-qH85aARkLElWD04aMKY0laEGii/h6n6zWfAwIAYvP6ZJzfp8OiY2J66FFXG2KelcVmem6RM0heNbTXsCEWPTQQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.43':
-    resolution: {integrity: sha512-FUFEg0n1QVurgE9S1D7lJKI/d/th8zj8e7rB+oL8uUBjbmakw+m/M0Gx2p/EapwDVDFqNJo1kQPRGoXMeQ9gTQ==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.44':
+    resolution: {integrity: sha512-T0LiNS/zvDKRipn5vyam4MvcNWtDXDTn/Ldjt8uTw6xlabxOLlqbMxidR00U5hF1RMVGjzpqEwHK3Rwtf1aU6Q==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.43':
-    resolution: {integrity: sha512-s/w0VYcG76dy2jLWcDAx/bHjoR1CROlutTqqgH0UYtjbouGJwMZU9MULxuDsFDzh/YdwJ5Kv23AcxEfsg16iGQ==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.44':
+    resolution: {integrity: sha512-ccl3j/Ks8JQIr67df0aOG51UBXPYlcADymmuxzrhVKs8f14LsG17ZyTMDQVN+mrRCwq69TXdmmsKCqX0UouYaw==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.43':
-    resolution: {integrity: sha512-XicsRVvYlkSvBaw4iD3eIXfUecfguzce4fLdW8tXm+SVGfu2tZ0mTbgRRHmUVBtF/okbvHadEl6UtSrgIYj95A==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.44':
+    resolution: {integrity: sha512-YlX73IIse50JxdollPVn5vs6pKdKLLlTxJu6D/U8rZmx0HIhx+/z27zywy3vfIuK11bxkGMRxJNT41uHJ6eJuA==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.43':
-    resolution: {integrity: sha512-4szqWGy87nc/S3bV9PX/4IySv8xFqUnaRCteiqRwZbErGRLk3mMAXoWQJfEQWepYmBhyCpAcDHn0d6sW4b15YA==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.44':
+    resolution: {integrity: sha512-WRzAHKBAx9e+SS0x95uaLewgViUhmaH+Q4NgiVjEVMSj6pAc6/6RIhwehRjyN+MnnrVmJHyb6f+oawP//cnCjw==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.43':
-    resolution: {integrity: sha512-7h9Xm+Q8M6GxYOHXSNBey0kpr4VHOnEOiER6E/28jN2R9uHojHQTOk96s6yBtuFblsEEViTLK1uOP0Du2Ooh1Q==}
+  '@takazudo/zfb-runtime@0.1.0-next.44':
+    resolution: {integrity: sha512-sZX9wdAIM54X5LjwuSDFw4VG6VoyQ8GZbiKVyl9O//F7ZyFuuVVF2d3MZCS5J6PxRG/fOm0F6su8atkCZJngTg==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.43
+      '@takazudo/zfb': 0.1.0-next.44
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.43':
-    resolution: {integrity: sha512-51cmAmhI/RaAIVz6asZUpne4ZBppsGR0cbj6Itu0Juv6BUy10x9WRCeHT6SSWiZNh6TiYlyOxiQLtLzGA11U/g==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.44':
+    resolution: {integrity: sha512-pZHPxZpFFmBvtZPo75kCQtly9DYtc2/gA6hgXkxhTlhAFlDmOe3IfaYiWDnGBMN0Gv8K/IcbakO0oRsaaEzp4Q==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.43':
-    resolution: {integrity: sha512-5weWigclI6XPRToLNyzEYuUN33mPby6N4wZFnJLqBHSmHeENNFh88miWBw11rZK/PNwJSLkt8D34ENx8ViQtLQ==}
+  '@takazudo/zfb@0.1.0-next.44':
+    resolution: {integrity: sha512-RZ4LyXjCAhZJzuw/NGyNfxXb57QExVwZeY0ngoR2GBssGNLxCDgWG8LRuXaDWAef6ZF0x0FQYwsY8VIDr1t3xQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
@@ -4071,35 +4071,35 @@ snapshots:
       culori: 4.0.2
       preact: 10.29.2
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.43': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.44': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.43':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.44':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.43':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.44':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.43':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.44':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.43':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.44':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.43(@takazudo/zfb@0.1.0-next.43)':
+  '@takazudo/zfb-runtime@0.1.0-next.44(@takazudo/zfb@0.1.0-next.44)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.43
+      '@takazudo/zfb': 0.1.0-next.44
       hono: 4.12.23
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.43':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.44':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.43':
+  '@takazudo/zfb@0.1.0-next.44':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.43
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.43
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.43
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.43
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.43
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.44
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.44
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.44
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.44
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.44
 
   '@takazudo/zudo-design-token-lint@1.0.0':
     dependencies:


### PR DESCRIPTION
## Summary

Bump the `@takazudo/zfb` family (`zfb`, `zfb-runtime`, `zfb-adapter-cloudflare`) from `0.1.0-next.43` to the latest `@next` tag, **`0.1.0-next.44`**, keeping all pin-parity sites in lockstep.

`next.44` is a low-risk bump for a CLI consumer like zudo-doc:

- The TS SDK surface is **byte-identical** to next.43 (verified via tarball diff — no `exports`/`dependencies` changes, no files added/removed).
- **No breaking changes.** The one breaking change in the recent series (`linkValidation.allowExternal` removal) landed earlier and was already handled — our config never emitted it.
- The new work in next.44 is embed-as-library / opt-in territory zudo-doc doesn't use: `ServerBuilder::with_page_cache`, an opt-in `ExternalInvalidationHook`, and TS-config-loader path canonicalization (upstream Takazudo/zudo-front-builder#1036–#1043).

## Changes

- **`package.json`** — bump the three zfb deps to `0.1.0-next.44`.
- **`packages/zudo-doc/package.json`** — `devDependencies` (exact) and `peerDependencies` (`^`) for `zfb` / `zfb-runtime` bumped in lockstep.
- **`packages/create-zudo-doc/src/scaffold.ts`** — generated downstream pins bumped to next.44; version-history comment extended with the next.44 note and the stale `(current pin)` marker moved off next.41.
- **`packages/create-zudo-doc/src/__tests__/scaffold.test.ts`** — pin assertions + `it()` title + history comment updated to next.44.
- **`pnpm-lock.yaml`** — regenerated (`pnpm install`); zfb entries incl. platform binaries now next.44.

`@takazudo/zdtp` was left untouched — it is already at its `@next` (`0.2.0-next.2`), and the request was scoped to the zfb family.

## Test Plan

- `pnpm check:pin-parity` — ✅ 3 external + 2 internal + 4 workspace-package fields verified in lockstep at next.44.
- `pnpm b4push` — ✅ all 16 automated steps pass (typecheck, build 274 pages, link check, HTML validation, preview smoke, generator tests incl. the pin assertions). Step 17 is the human-only interactive smoke (not runnable headless).
- Codex review — clean, no findings (independently re-ran pin-parity, exit 0).