### PR TITLE
Triage Batch: resolve recent open issues #2115 / #2116 / #2117

### DIFF
--- a/.claude/skills/l-make-release/SKILL.md
+++ b/.claude/skills/l-make-release/SKILL.md
@@ -400,6 +400,13 @@ Clean versions (no `-`) publish under `latest`; prereleases (any tag containing 
 `latest` to the newest build and a tagless `npm install` / `pnpm dlx` always gets
 it. `-next` is reserved for opt-in previews and the `1.0.0-beta` run-up.
 
+**`next` is removed on stable graduation.** Each publish workflow runs an extra
+step after a clean `X.Y.Z` publish that removes the `next` dist-tag
+(`npm dist-tag rm <pkg> next`). This prevents `@next` from silently resolving to a
+stale prerelease once the line graduates. The step is idempotent and non-fatal.
+See RELEASE.md — "One-time manual cleanup" — for the manual runbook that clears
+the currently-stale `next` tag (frozen at `0.2.0-next.9` as of #2121).
+
 ## Files involved (pin sources)
 
 The release script writes to ALL of these in one pass:

--- a/.github/workflows/exam.yml
+++ b/.github/workflows/exam.yml
@@ -69,7 +69,7 @@ jobs:
       # (it treats the suffix as a reporter MODULE name → MODULE_NOT_FOUND); the
       # env var is the supported way to redirect the json reporter's file output.
       - name: Run CI-safe E2E suite
-        run: pnpm test:e2e:ci -- --reporter=list,json
+        run: pnpm test:e2e:ci:json
         env:
           PLAYWRIGHT_JSON_OUTPUT_NAME: playwright-report/ci-results.json
 

--- a/.github/workflows/publish-create-zudo-doc.yml
+++ b/.github/workflows/publish-create-zudo-doc.yml
@@ -208,3 +208,22 @@ jobs:
           echo "Publishing create-zudo-doc@$VERSION with --tag $DIST_TAG..."
           npm publish --access public --provenance --tag "$DIST_TAG"
           echo "Published: https://www.npmjs.com/package/create-zudo-doc/v/$VERSION"
+
+      # ── Remove stale `next` dist-tag on stable graduation ─────────────────
+      # When a clean X.Y.Z version graduates the prerelease line, the `next`
+      # dist-tag is left dangling at the old prerelease. Remove it so
+      # `npm install create-zudo-doc@next` returns a clear "tag not found"
+      # rather than silently resolving to a stale build.
+      # Only runs for clean versions (no `-`); prerelease publishes still set
+      # `next` normally via the Compute dist-tag step above.
+      # Non-fatal: tolerates "tag does not exist" so a re-run or a first-ever
+      # stable publish (where `next` was never set) does not fail the workflow.
+      - name: Remove stale npm next dist-tag (stable graduation only)
+        if: ${{ inputs.dry_run != true && !contains(env.VERSION, '-') }}
+        shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          echo "Stable version $VERSION — removing stale 'next' dist-tag if present..."
+          npm dist-tag rm create-zudo-doc next || true
+          echo "Done (tag may not have existed — that is fine)."

--- a/.github/workflows/publish-zudo-doc-history-server.yml
+++ b/.github/workflows/publish-zudo-doc-history-server.yml
@@ -202,3 +202,22 @@ jobs:
             --no-git-checks \
             --tag "$DIST_TAG"
           echo "Published: https://www.npmjs.com/package/@takazudo/zudo-doc-history-server/v/$VERSION"
+
+      # ── Remove stale `next` dist-tag on stable graduation ─────────────────
+      # When a clean X.Y.Z version graduates the prerelease line, the `next`
+      # dist-tag is left dangling at the old prerelease. Remove it so
+      # `npm install @takazudo/zudo-doc-history-server@next` returns a clear
+      # "tag not found" rather than silently resolving to a stale build.
+      # Only runs for clean versions (no `-`); prerelease publishes still set
+      # `next` normally via the Compute dist-tag step above.
+      # Non-fatal: tolerates "tag does not exist" so a re-run or a first-ever
+      # stable publish (where `next` was never set) does not fail the workflow.
+      - name: Remove stale npm next dist-tag (stable graduation only)
+        if: ${{ inputs.dry_run != true && !contains(env.VERSION, '-') }}
+        shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          echo "Stable version $VERSION — removing stale 'next' dist-tag if present..."
+          npm dist-tag rm @takazudo/zudo-doc-history-server next || true
+          echo "Done (tag may not have existed — that is fine)."

--- a/.github/workflows/publish-zudo-doc.yml
+++ b/.github/workflows/publish-zudo-doc.yml
@@ -250,3 +250,22 @@ jobs:
             --no-git-checks \
             --tag "$DIST_TAG"
           echo "Published: https://www.npmjs.com/package/@takazudo/zudo-doc/v/$VERSION"
+
+      # ── Remove stale `next` dist-tag on stable graduation ─────────────────
+      # When a clean X.Y.Z version graduates the prerelease line, the `next`
+      # dist-tag is left dangling at the old prerelease. Remove it so
+      # `npm install @takazudo/zudo-doc@next` returns a clear "tag not found"
+      # rather than silently resolving to a stale build.
+      # Only runs for clean versions (no `-`); prerelease publishes still set
+      # `next` normally via the Compute dist-tag step above.
+      # Non-fatal: tolerates "tag does not exist" so a re-run or a first-ever
+      # stable publish (where `next` was never set) does not fail the workflow.
+      - name: Remove stale npm next dist-tag (stable graduation only)
+        if: ${{ inputs.dry_run != true && !contains(env.VERSION, '-') }}
+        shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          echo "Stable version $VERSION — removing stale 'next' dist-tag if present..."
+          npm dist-tag rm @takazudo/zudo-doc next || true
+          echo "Done (tag may not have existed — that is fine)."

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -42,6 +42,13 @@ resumes automatically.
 The CI publish workflow computes the dist-tag from the version string: any
 version containing `-` gets `--tag next`; a clean `X.Y.Z` gets `--tag latest`.
 
+**`next` is removed on stable graduation.** When a clean `X.Y.Z` publish
+graduates the prerelease line, each publish workflow runs an extra step that
+removes the `next` dist-tag (`npm dist-tag rm <pkg> next`). This prevents
+`npm install <pkg>@next` from silently resolving to a stale prerelease. The
+step is idempotent and non-fatal — if `next` does not exist (e.g. the first
+stable release ever), the step logs a notice and succeeds anyway.
+
 ---
 
 ## How `latest` stays current (Scheme B)
@@ -159,3 +166,23 @@ node scripts/release-bootstrap-latest.mjs 0.2.0-next.9
 It is idempotent: re-running with the same version is a no-op. The **preferred**
 fix, though, is simply to ship a clean version (e.g. `0.2.0`), which supersedes the
 stranded tag through the normal publish path.
+
+---
+
+## One-time manual cleanup: remove stale `next` dist-tag (#2121)
+
+As of the first stable `0.2.x` graduation, the `next` dist-tag on all three
+packages is frozen at `0.2.0-next.9` — a stale prerelease from before Scheme B
+was adopted. The publish workflows now automatically remove `next` on each future
+stable graduation (see the dist-tag table note above), but the **currently-stale
+tag must be cleared once by a maintainer**:
+
+```sh
+npm dist-tag rm @takazudo/zudo-doc next
+npm dist-tag rm @takazudo/zudo-doc-history-server next
+npm dist-tag rm create-zudo-doc next
+```
+
+Run these from any machine with an npm Automation token (`npm login` or
+`NPM_TOKEN` set). Each command is idempotent — safe to re-run if the tag has
+already been removed.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test:packages": "pnpm -r --filter './packages/*' run test",
     "test:e2e": "bash e2e/setup-fixtures.sh && playwright test",
     "test:e2e:ci": "bash e2e/setup-fixtures.sh && playwright test --grep-invert \"@flaky|@local-only\"",
+    "test:e2e:ci:json": "bash e2e/setup-fixtures.sh && playwright test --grep-invert \"@flaky|@local-only\" --reporter=list,json",
     "check:links": "node scripts/check-links.js",
     "check:html": "html-validate \"dist/**/*.html\"",
     "smoke:preview": "node scripts/smoke-preview.mjs",

--- a/packages/create-zudo-doc/src/__tests__/preset-swap.slow.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/preset-swap.slow.test.ts
@@ -67,6 +67,53 @@ function runOrThrow(
   }
 }
 
+/**
+ * Resilient `pnpm install` for the network-dependent install step.
+ *
+ * This test resolves the scaffolded project's deps against the public npm
+ * registry. The generated `package.json` pins ranges (e.g. `@types/node`
+ * `^22.0.0`), so a fresh patch release can land in the range that is not yet
+ * in the local pnpm store — pnpm then has to fetch it, and that fetch can
+ * transiently fail (registry hiccup, network blip). This is exactly the
+ * nightly-exam failure tracked in zudolab/zudo-doc#2123: a one-off
+ * `--prefer-offline` install of `@types/node@22.19.21`'s transitive
+ * `undici-types` failed to download, even though the version range itself is
+ * healthy and installs fine on a warm store.
+ *
+ * Strategy: try `--prefer-offline` first (fast once the store is warm). If it
+ * fails, retry without `--prefer-offline` so the retry does a full online
+ * resolution and cannot be tripped by a cold/stale offline cache, with a
+ * short backoff between attempts. Only after the final attempt fails do we
+ * surface the captured diagnostics. This keeps a transient registry flake
+ * from re-filing the nightly issue without masking a genuine resolution bug
+ * (a real bad pin fails every attempt and still throws).
+ */
+function installScaffoldedDeps(cwd: string): void {
+  const attempts = [
+    "pnpm install --prefer-offline --ignore-workspace",
+    "pnpm install --ignore-workspace",
+    "pnpm install --ignore-workspace",
+  ];
+  let lastErr: unknown;
+  for (const [i, cmd] of attempts.entries()) {
+    try {
+      runOrThrow(cmd, cwd);
+      return;
+    } catch (err) {
+      lastErr = err;
+      if (i < attempts.length - 1) {
+        // Synchronous backoff (~3s, ~6s) between retries. The surrounding
+        // execSync is already blocking, so a blocking sleep here is fine and
+        // avoids turning beforeAll async-racy. Atomics.wait is the standard
+        // no-busy-loop synchronous sleep idiom.
+        const waitMs = 3000 * (i + 1);
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, waitMs);
+      }
+    }
+  }
+  throw lastErr;
+}
+
 let tempDir: string;
 let projectDir: string;
 let originalCwd: string;
@@ -139,10 +186,13 @@ beforeAll(async () => {
 
   // 5. Install + build. We use pnpm because that is the package manager the
   //    scaffolder defaults to and the dev environment guarantees.
-  //    `--prefer-offline` keeps repeated local runs fast once the store is
-  //    warm. We capture stdout/stderr and surface them on failure so
-  //    diagnosing a broken scaffold/build does not require re-running.
-  runOrThrow("pnpm install --prefer-offline --ignore-workspace", projectDir);
+  //    `installScaffoldedDeps` tries `--prefer-offline` first (fast on a warm
+  //    store) and retries online on failure, so a transient registry flake on
+  //    a freshly-released patch version does not fail the slow tier
+  //    (zudolab/zudo-doc#2123). We capture stdout/stderr and surface them on
+  //    the final failure so diagnosing a broken scaffold/build does not
+  //    require re-running.
+  installScaffoldedDeps(projectDir);
   runOrThrow("pnpm build", projectDir, { SKIP_DOC_HISTORY: "1" });
 }, 5 * 60 * 1000);
 

--- a/packages/zudo-doc/src/integrations/claude-resources/__tests__/generate.test.ts
+++ b/packages/zudo-doc/src/integrations/claude-resources/__tests__/generate.test.ts
@@ -532,4 +532,36 @@ describe("generateClaudeResourcesDocs", () => {
       ).toThrow(/reserved name "index"/);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // projectRoot default scope regression test
+  // ---------------------------------------------------------------------------
+
+  describe("projectRoot default scope", () => {
+    it("walks claudeDir (not its parent) when projectRoot is omitted", () => {
+      // The fixture already writes tmpDir/CLAUDE.md (outside claudeDir).
+      // With the old bug (projectRoot = path.dirname(claudeDir) = tmpDir), the
+      // walk starts at tmpDir and picks up tmpDir/CLAUDE.md. With the fix
+      // (projectRoot = claudeDir), the walk starts inside claudeDir and does NOT
+      // reach tmpDir/CLAUDE.md (parent dirs are never walked upward).
+      //
+      // To distinguish, we write a CLAUDE.md inside claudeDir with unique content
+      // and verify the generated page body matches IT, not the outside one.
+      fs.writeFileSync(
+        path.join(claudeDir, "CLAUDE.md"),
+        "# Claude dir unique content xyz123",
+      );
+
+      // Call with NO projectRoot.
+      generateClaudeResourcesDocs({ claudeDir, docsDir });
+
+      // The generated root.mdx body must contain the inside-claudeDir content.
+      const claudeMdDir = path.join(docsDir, "claude-md");
+      const rootMdx = fs.readFileSync(path.join(claudeMdDir, "root.mdx"), "utf8");
+      expect(rootMdx).toContain("xyz123");
+
+      // And must NOT contain the outside content (from tmpDir/CLAUDE.md).
+      expect(rootMdx).not.toContain("Project instructions");
+    });
+  });
 });

--- a/packages/zudo-doc/src/integrations/claude-resources/generate.ts
+++ b/packages/zudo-doc/src/integrations/claude-resources/generate.ts
@@ -164,7 +164,7 @@ function findClaudeMdFiles(dir: string, excludeDirs: string[]): string[] {
 function generateClaudemdDocs(
   config: ClaudeResourcesConfig,
 ): ClaudeMdItem[] {
-  const projectRoot = config.projectRoot ?? path.dirname(config.claudeDir);
+  const projectRoot = config.projectRoot ?? config.claudeDir;
   const outputDir = path.join(config.docsDir, "claude-md");
 
   cleanDir(outputDir);

--- a/scripts/file-exam-issue.sh
+++ b/scripts/file-exam-issue.sh
@@ -71,13 +71,24 @@ echo "Label ready."
 FAILING_SPECS=""
 if [[ -n "$REPORT_PATH" && -f "$REPORT_PATH" ]]; then
   echo "Parsing failing specs from $REPORT_PATH..."
-  # Extract test titles from failed tests using jq
+  # Extract test titles from failed tests using node (no jq dependency required).
   # Playwright JSON report structure: { suites: [ { suites: [ { specs: [ { ok, title } ] } ] } ] }
-  FAILING_SPECS=$(jq -r '
-    [ .. | objects | select(has("ok") and has("title") and (.ok == false)) | .title ]
-    | unique
-    | .[]
-  ' "$REPORT_PATH" 2>/dev/null || true)
+  FAILING_SPECS=$(node --eval "
+    const fs = require('fs');
+    const report = JSON.parse(fs.readFileSync(process.argv[1], 'utf8'));
+    const titles = new Set();
+    function walk(obj) {
+      if (obj && typeof obj === 'object') {
+        if (Array.isArray(obj)) { obj.forEach(walk); }
+        else {
+          if ('ok' in obj && 'title' in obj && obj.ok === false) titles.add(obj.title);
+          for (const v of Object.values(obj)) walk(v);
+        }
+      }
+    }
+    walk(report);
+    if (titles.size) process.stdout.write([...titles].join('\n') + '\n');
+  " -- "$REPORT_PATH" 2>/dev/null || true)
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2119

---

## Summary

Resolves epic #2119 — the three most recent open issues (#2115, #2116, #2117), implemented as four parallel sub-issues merged into `base/triage-batch`.

## Changes

### #2120 — Bound claude-resources CLAUDE.md walk to `claudeDir` (fixes #2115)
- `generate.ts:167`: `projectRoot` now defaults to `config.claudeDir` (not `path.dirname(config.claudeDir)`), so a direct `generateClaudeResourcesDocs({ claudeDir: ~/.claude })` call no longer walks all of `$HOME`. `runClaudeResourcesPreStep` (`index.ts:85`, `process.cwd()` default) is untouched.
- Regression test added (asserts an out-of-`claudeDir` `CLAUDE.md` is excluded and an in-`claudeDir` one is included).

### #2121 — Remove stale npm `next` dist-tag on stable graduation (fixes #2116)
- All three publish workflows now remove the `next` dist-tag after a successful **stable** (clean-version) publish, guarded to skip prereleases and tolerant of a missing tag (`|| true`, non-fatal).
- `RELEASE.md` + `l-make-release` SKILL document the behavior and the **one-time manual cleanup** (`npm dist-tag rm <pkg> next` for the three packages). No registry mutation is performed by this PR.

### #2122 — Fix Nightly Exam Full E2E "No tests found" + `jq`/127 (fixes #2117 part A)
- Added `test:e2e:ci:json` (reporter inline, before any `--`); `exam.yml` calls it instead of `pnpm test:e2e:ci -- --reporter=list,json` (the trailing `--` made Playwright treat the reporter as a positional test-path filter → "No tests found").
- `scripts/file-exam-issue.sh` parses the report with `node` instead of `jq` (the missing `jq` caused exit 127); the missing/empty `--report` path is non-fatal.

### #2123 — create-zudo-doc slow-test `pnpm install` resilience (fixes #2117 part B)
- Root cause: transient registry flake under `--prefer-offline` (reproduction passed 4/4; pin `@types/node: ^22.0.0` is healthy).
- `preset-swap.slow.test.ts` now installs via `installScaffoldedDeps()` — tries `--prefer-offline`, then retries online without it (backoff). A genuine bad pin still fails all attempts, so real bugs aren't masked.

## Validation
- All 15 PR CI checks green.
- `/deep-review` (codex backend): no actionable regressions.
- Workflow-only changes (#2121, #2122) validate behaviorally on the next real release / Nightly Exam (they don't run on PR CI).
