### PR TITLE
docs: fill verified coverage gaps (settings, schemes, locale behavior, markdown-feature options)

### DIFF
--- a/src/content/docs-ja/claude/index.mdx
+++ b/src/content/docs-ja/claude/index.mdx
@@ -5,6 +5,13 @@ hide_sidebar: true
 hide_toc: true
 ---
 
+{/* The EN /docs/claude/ index (docs/claude/index.mdx) does NOT exist as a static
+    source file — it is generated at build time by the claude-resources integration
+    (packages/zudo-doc/src/integrations/claude-resources/generate.ts,
+    generateOverviewIndex). That function calls cleanDir + writeFileSync on every
+    preBuild, so a hand-authored docs/claude/index.mdx would be silently clobbered.
+    This JA stub is intentionally locale-only; the link below resolves post-build. */}
+
 This section is only available in English (the default locale).
 
 [View the Claude category in English](/docs/claude/)

--- a/src/content/docs-ja/guides/configuration.mdx
+++ b/src/content/docs-ja/guides/configuration.mdx
@@ -159,6 +159,18 @@ docsDir: "docs",  // プロジェクトルートの./docs/にコンテンツを�
 
 これはDocusaurusの`docs.path`オプションに似ています — zudo-docをドキュメントがプロジェクトルートレベルにある大規模プロジェクトのドキュメントツールとして使用する場合に便利です。
 
+### defaultLocale
+
+デフォルト（プレフィックスなし）ロケールのBCP 47コード。zfbのi18nルーターがルートの`/docs/...`ルートをマッピングするために使用します。
+
+型：`string`
+
+デフォルト：`"en"`
+
+```ts
+defaultLocale: "en",
+```
+
 ### locales
 
 追加ロケール設定のマップ。各キーはロケールコードで、値は`label`（言語切り替えの表示名）と`dir`（コンテンツディレクトリパス）を持つオブジェクトです。
@@ -177,6 +189,23 @@ locales: {
 - zfbコンテンツコレクション（`docs-{code}`）を作成
 - zfbのi18nルーティングにロケールを登録
 - 言語切り替えに追加
+
+### defaultLocaleOnlyPrefixes
+
+デフォルトロケールにのみ存在するURLプレフィックスの配列。これらのプレフィックス下のページは翻訳されず、どのロケールプレフィックス下にもミラーを持つべきではありません。該当ページでは言語切り替えがそれらを省略します。
+
+型：`string[]`
+
+デフォルト：`[]`
+
+```ts
+defaultLocaleOnlyPrefixes: [
+  "/docs/claude-md/",
+  "/docs/claude-skills/",
+],
+```
+
+オーサリングワークフローの詳細については[デフォルトロケール専用プレフィックス](./i18n.mdx#default-locale-only-prefixes)を参照してください。
 
 ### versions
 
@@ -230,6 +259,33 @@ versions: false,
 サイトの完全なベースURL（例：`"https://example.com"`）。サイトマップでの絶対URL生成に必要です。
 
 デフォルト：`""`
+
+### metaTags
+
+出力される`<meta>`タグを細かく制御します。個々のサブフィールドを`false`に設定するとそのタグが省略されます。
+
+型：`MetaTagsConfig`
+
+| プロパティ | 型 | 説明 |
+|----------|------|-------------|
+| `description` | `boolean` | `<meta name="description">`を出力。デフォルト `true` |
+| `keywords` | `string \| false` | この値で`<meta name="keywords">`を出力。`false` = 省略。デフォルト `false` |
+| `ogImage` | `string \| false` | `og:image`（および`twitter:image`）のパス。`false` = 省略。デフォルト `false` |
+| `ogSiteName` | `boolean` | `og:site_name`を出力。デフォルト `true` |
+| `twitterCard` | `"summary" \| "summary_large_image" \| false` | Twitter Cardの種類。`false` = ブロック全体を省略。デフォルト `false` |
+| `twitterSite` | `string`（オプション） | `twitter:site`ハンドル（例：`"@yourbrand"`） |
+| `twitterCreator` | `string`（オプション） | `twitter:creator`ハンドル |
+
+```ts
+metaTags: {
+  description: true,
+  keywords: false,
+  ogImage: "/img/ogp.png",
+  ogSiteName: true,
+  twitterCard: "summary_large_image",
+  twitterSite: "@yourbrand",
+},
+```
 
 ### noindex
 
@@ -335,6 +391,22 @@ tagPlacement: "before-pager",
 ```
 
 `docTags` が `false` の場合、またはページにタグが付いていない場合は効果がありません。
+
+### tagGovernance
+
+タグボキャブラリーが有効な場合に適用される強制レベル。詳細なリファレンスは[タグガバナンス](./tag-governance.mdx)を参照してください。
+
+型：`"off" | "warn" | "strict"`
+
+デフォルト：`"warn"`
+
+### tagVocabulary
+
+`tag-vocabulary.ts`を実行時に参照するかどうか（エイリアス解決、非推奨フィルタリング、グループ化フッター）。`false`に設定すると`tagGovernance`に関わらずファイルを完全に無視します。詳細は[タグガバナンス](./tag-governance.mdx)を参照してください。
+
+型：`boolean`
+
+デフォルト：`true`
 
 ### frontmatterPreview
 
@@ -463,6 +535,28 @@ sidebarResizer: true,
 使用方法の詳細、キーボードショートカット、技術情報については[ドキュメント履歴ガイド](./doc-history.mdx)を参照してください。
 
 </Tip>
+
+### bodyFootUtilArea
+
+各ドキュメントページのボディ末尾のユーティリティアクションエリアに表示する項目を制御します。エリアを完全に非表示にするには`false`を設定します。
+
+型：`BodyFootUtilAreaConfig | false`
+
+デフォルト：`false`
+
+| プロパティ | 型 | 説明 |
+|----------|------|-------------|
+| `docHistory` | `boolean`（オプション） | **History**ボタンを表示（`docHistory: true`が必要） |
+| `viewSourceLink` | `boolean`（オプション） | ソースファイルへのリンクを表示（`editUrl`が必要） |
+
+```ts
+bodyFootUtilArea: {
+  docHistory: true,
+  viewSourceLink: true,
+},
+// またはエリアを非表示:
+bodyFootUtilArea: false,
+```
 
 ### tocMinDepth
 
@@ -631,6 +725,33 @@ headerNav: [
   { label: "Guides", labelKey: "nav.guides", path: "/docs/guides", categoryMatch: "guides" },
   { label: "Reference", labelKey: "nav.reference", path: "/docs/reference", categoryMatch: "reference" },
   { label: "Claude", labelKey: "nav.claude", path: "/docs/claude", categoryMatch: "claude" },
+],
+```
+
+### headerRightItems
+
+サイトヘッダーの右側にレンダリングされる項目を順番に制御します。各項目は`type`フィールドによる直和型です。
+
+型：`HeaderRightItem[]`
+
+| `type` | 追加フィールド | 説明 |
+|--------|-------------------|-------------|
+| `"component"` | `component` — `"theme-toggle"`, `"language-switcher"`, `"version-switcher"`, `"github-link"`, `"search"` のいずれか | 組み込みヘッダーコンポーネントをレンダリング |
+| `"trigger"` | `trigger` — `"design-token-panel"`, `"ai-chat"` のいずれか | パネルを開くボタンをレンダリング（対応する機能の有効化が必要） |
+| `"link"` | `href`（string）、`label?`（string）、`ariaLabel?`（string）、`icon?`（`"github"`） | カスタムリンクをレンダリング |
+| `"html"` | `html`（string） | 生のHTMLをレンダリング |
+
+```ts
+headerRightItems: [
+  { type: "component", component: "version-switcher" },
+  { type: "trigger", trigger: "design-token-panel" },
+  { type: "trigger", trigger: "ai-chat" },
+  { type: "component", component: "github-link" },
+  { type: "component", component: "theme-toggle" },
+  { type: "component", component: "search" },
+  { type: "component", component: "language-switcher" },
+  // カスタム外部リンク:
+  { type: "link", href: "https://example.com", label: "Blog", ariaLabel: "Blog" },
 ],
 ```
 

--- a/src/content/docs-ja/guides/i18n.mdx
+++ b/src/content/docs-ja/guides/i18n.mdx
@@ -105,3 +105,73 @@ zudo-docは組み込みUI文字列に翻訳キーシステムを使用してい�
 ステップ1が最も重要です — `settings.ts`にロケールを追加すると、コンテンツコレクションの作成とi18nルーティングの登録が自動的に行われます。ロケールごとのページルートファイルを作成する必要はありません。`pages/[locale]/docs/[[...slug]].tsx` のパラメーター化されたルートがすべてのロケールを自動的に処理します。
 
 </Tip>
+
+## defaultLocale
+
+`defaultLocale`はURLプレフィックスなしで配信されるロケールを指定します。デフォルトは`"en"`で、zfbのデフォルトロケールルーティングに使用するキーと一致している必要があります：
+
+```ts
+export const settings = {
+  // ...
+  defaultLocale: "en" as const,
+  locales: {
+    ja: { label: "JA", dir: "src/content/docs-ja" },
+  },
+};
+```
+
+`zfb.config.ts`で設定された`prefixDefaultLocale: false`により、デフォルトロケールはパスに言語コードを含まない`/docs/...`で配信され、他のすべてのロケールはキーをプレフィックスとして使用します（日本語の場合は`/ja/docs/...`）。`defaultLocale`を変更する場合は、`zfb.config.ts`内の対応するルーティングとコレクションの設定も更新する必要があります。
+
+## Default-locale-only prefixes
+
+一部のコンテンツはデフォルトロケールでのみ提供されるよう意図的に設計されています。これらのルートは**デフォルトロケール専用プレフィックス**と呼ばれ、`src/config/settings.ts`の`defaultLocaleOnlyPrefixes`設定で管理されます：
+
+```ts
+export const settings = {
+  // ...
+  defaultLocaleOnlyPrefixes: [
+    "/docs/claude-md/",
+    "/docs/claude-skills/",
+    "/docs/claude-agents/",
+    "/docs/claude-commands/",
+  ] as string[],
+};
+```
+
+### 意味するところ
+
+これらのプレフィックスのいずれかで始まるURLを持つページは、**デフォルトロケール（英語）のみ**に存在します。言語切り替えはこれらのページに対して別ロケールへのリンクを表示しません。また、`docs-ja/`配下にこれらのページの日本語ミラーファイルを作成すべきではありません。
+
+### 現在のエントリ
+
+上記の4つのプレフィックスは、プロジェクトの`.claude/`ディレクトリにあるClaude設定ファイル（`CLAUDE.md`、スキル、エージェント、コマンド）を表示する自動生成ページ（Claudeリソースセクション）をカバーしています。ソース素材（Claude設定ファイル）は翻訳されていないため、これらは英語専用となっています。
+
+<Note>
+
+トップレベルの`/docs/claude/`インデックスページはこのリストに含まれて**いません** — `docs-ja/claude/index.mdx`にバイリンガルのスタブが存在します。デフォルトロケール専用なのは、より深い4つのプレフィックス（`claude-md/`、`claude-skills/`、`claude-agents/`、`claude-commands/`）のみです。
+
+</Note>
+
+### ルーターによる適用方法
+
+`pages/[locale]/docs/[[...slug]].tsx`のページルートは、`paths()`エクスポート内で各スラッグを`defaultLocaleOnlyPrefixes`と照合します。再構築されたURLがプレフィックスと一致する場合、そのパスはデフォルト以外のロケールのパスリストから除外されるため、`/ja/docs/claude-md/...`のようなルートは生成されません。
+
+### 独自プレフィックスの追加
+
+英語専用にしたいセクション（例：自動生成されたAPIリファレンスページ）がある場合は、配列にURLプレフィックスを追加します：
+
+```ts
+defaultLocaleOnlyPrefixes: [
+  "/docs/claude-md/",
+  "/docs/claude-skills/",
+  "/docs/claude-agents/",
+  "/docs/claude-commands/",
+  "/docs/api-reference/", // 追加するプレフィックス
+] as string[],
+```
+
+プレフィックスが以下の条件を満たしていることを確認してください：
+
+- `/docs/`（またはコンテンツディレクトリに対応するパス）で始まる
+- 末尾にスラッシュがある
+- バイリンガルで保持したいプレフィックスと重複しない

--- a/src/content/docs-ja/markdown-features/admonitions-preset.mdx
+++ b/src/content/docs-ja/markdown-features/admonitions-preset.mdx
@@ -115,6 +115,7 @@ export default defineConfig({
 ## メモ
 
 - `:::details` タイプはレガシーな `:::details title="Click me"` 属性形式も受け付けます。
-- `:::caution` はこのプロジェクトが登録するボキャブラリの一部です。`:::warning` が `<Warning>` を出力するのと同様に、`<Caution>`（`data-admonition="caution"`）を出力します。
+- `:::caution` はこのプロジェクトが登録するボキャブラリの一部です。`:::warning` が `<Warning>` を出力するのと同様に、`<Caution>`（`data-admonition="caution"`）を出力します。また `caution` は [GitHub Alerts](./github-alerts.mdx) の `> [!CAUTION]` からも使用できるため、両方のパスで利用可能です。
+- `important` は `directives` マップに含まれておらず、`:::important` としては使用できません。[GitHub Alerts](./github-alerts.mdx) の `> [!IMPORTANT]` を通じてのみ利用でき、`<Important>` コンポーネント（`data-admonition="important"`）にマッピングされます。
 - ディレクティブを追加・上書きするには、`zfb.config.ts` の `directives` マップに名前 → タイトルのペアを追加します。
 - [GitHub Alerts](./github-alerts.mdx) は `> [!NOTE]` 形式のブロック引用から同じアドモニションマークアップを出力します。両機能はクリーンに共存します。

--- a/src/content/docs-ja/markdown-features/code-tabs.mdx
+++ b/src/content/docs-ja/markdown-features/code-tabs.mdx
@@ -85,8 +85,41 @@ export const greeting = "hello";
 
 フレームワークは `<CodeGroup>` を同梱していません — zudo-doc は `pages/_mdx-components.ts` で独自の実装を登録し、`tabs` 配列と `<pre data-lang>` の子要素を既存の `<Tabs>` / `<TabItem>` UI にマッピングします。各 `<pre>` 内のコードは生のテキストです（Rust パイプラインは `:::code-group` フェンス内でシンタックスハイライトを実行しません）。
 
+## `name` によるタブの同期
+
+オプションの `name` 属性を使うと、同じページ内で同じ名前を持つすべての `:::code-group` ブロックが連動します。一方のグループでタブをクリックすると、同じ名前を持つほかのグループも — 対応するラベルのタブが存在する場合に — 自動的に切り替わります。
+
+````md
+:::code-group{name="package-manager"}
+
+```sh title="npm"
+npm install my-lib
+```
+
+```sh title="pnpm"
+pnpm add my-lib
+```
+
+:::
+
+:::code-group{name="package-manager"}
+
+```sh title="npm"
+npm run dev
+```
+
+```sh title="pnpm"
+pnpm dev
+```
+
+:::
+````
+
+選択したタブは `localStorage` の `tabs-group-{name}` というキーにも保存されます。次回のページ読み込み時、同じ名前を持つすべてのグループが保存済みのタブを復元します（保存されたラベルがグループに存在しない場合はデフォルトのタブにフォールバックします）。
+
+内部的には、`name` は zfb によって `<CodeGroup>` コンポーネントへの prop として転送され、`<CodeGroup>` はそれを下層の `<Tabs>` コンポーネントの `groupId` として渡します。`TabsInit` スクリプトはレンダリングされた DOM の `data-group-id` を読み取り、クリック時に同じ `groupId` を持つすべてのコンテナを同期しながら、`localStorage` への読み書きによってページをまたいだ永続化を行います。
+
 ## 補足
 
-- ディレクティブのオプション属性 `name`（`:::code-group{name="install"}`）は、ナビゲーションをまたいでアクティブなタブを保持するためにコンシューマーコンポーネントが利用できます。
 - 空の `:::code-group` コンテナ（フェンスなし）は、プレーンテキストのまま変更されません。
 - ネストした `:::code-group` ディレクティブはサポートされていません。

--- a/src/content/docs-ja/markdown-features/directives-registry.mdx
+++ b/src/content/docs-ja/markdown-features/directives-registry.mdx
@@ -93,9 +93,41 @@ Directives Registry は、markdown における `:::name`（および `::name` /
 
 ## カスタムディレクティブ
 
-プロジェクト側のコンポーネントは、`_mdx-components.ts` の設定を通じて追加のディレクティブ名を登録できます。Rust コードを書く必要はありません。コンポーネントオーバーライドの連携方法については [Components](../components/index.mdx) セクションを参照してください。
+カスタムディレクティブの登録には 2 つのステップが必要です。`zfb.config.ts` でディレクティブ名とコンポーネント名のマッピングを定義し、`pages/_mdx-components.ts` でコンポーネントの実装を提供します。
+
+**ステップ 1 — `zfb.config.ts` にディレクティブ名 → コンポーネント名のマッピングを追加する:**
+
+```ts title="zfb.config.ts"
+export default defineConfig({
+  markdown: {
+    features: {
+      directives: {
+        // 既存のエントリ...
+        callout: "Callout", // :::callout → <Callout>
+      },
+    },
+  },
+});
+```
+
+値（`"Callout"`）は、コンパイル済みの MDX 出力で zfb が出力する JSX タグ名です。コンポーネントマップに登録するキーと一致している必要があります。
+
+**ステップ 2 — `pages/_mdx-components.ts` でコンポーネント名を実装にバインドする:**
+
+```ts title="pages/_mdx-components.ts"
+import { Callout } from "@/components/content/callout";
+
+export function createMdxComponents(lang) {
+  return {
+    // 既存のエントリ...
+    Callout,
+  };
+}
+```
+
+作者が `:::callout` と書くと、zfb はコンパイル済みの MDX に `<Callout>` を出力します。`<entry.Content components={createMdxComponents(lang)} />` の呼び出しが、このマップを通じて `Callout` をコンポーネントに解決します。Rust コードは不要です。
 
 ## 補足
 
-- アドモニションディレクティブ（`note`、`tip`、`info`、`warning`、`danger`、`caution`、`details`）は、このプロジェクトが `directives` マップで登録している[アドモニションレシピ](./admonitions-preset.mdx)が提供します。Core レジストリ自体ではありません。レジストリはエンジンであり、`directives` マップがコンポーネントマッピングを提供します。
+- アドモニションディレクティブ（`note`、`tip`、`info`、`warning`、`danger`、`caution`、`details`）は、このプロジェクトが `directives` マップで登録している[アドモニションレシピ](./admonitions-preset.mdx)が提供します。Core レジストリ自体ではありません。レジストリはエンジンであり、`zfb.config.ts` の `directives` マップがディレクティブ名 → コンポーネント名のバインディングを、`pages/_mdx-components.ts` がコンポーネント名 → 実装のバインディングを提供します。
 - `important` と `caution` コンポーネントが登録されていることを確認しない限り、`> [!IMPORTANT]` や `> [!CAUTION]` の GitHub アラート構文は使用しないでください。それぞれ `data-admonition="important"` / `data-admonition="caution"` にマッピングされ、コンポーネントが存在しない場合は 500 エラーになります。

--- a/src/content/docs-ja/markdown-features/resolve-links.mdx
+++ b/src/content/docs-ja/markdown-features/resolve-links.mdx
@@ -29,6 +29,53 @@ mdast フェーズでの書き換えプロセスは以下のとおりです。
 
 ターゲットファイルがソースマップに存在しない場合、zfb は診断警告を出力します。デフォルトでは壊れたリンクによってビルドは失敗しません。警告をエラーにエスカレートするには、オプトインの [Link Validation](./link-validation.mdx) 機能を有効にしてください。
 
+## 上級: 複数ディレクトリ、ロケール、バージョン
+
+Resolve Links は各コンテンツディレクトリをルートプレフィックスにマッピングします。zfb はディレクトリごとに 1 つのエントリを登録し、リライターが各ソースツリーに対応する URL プレフィックスを特定できるようにします。
+
+デフォルトのシングルロケール構成では、1 つのディレクトリが登録されます。
+
+```ts
+resolveMarkdownLinks: {
+  enabled: true,
+  dirs: [
+    { dir: settings.docsDir, routePrefix: "/docs/" },
+  ],
+}
+```
+
+ロケールが設定されている場合、各ロケールのコンテンツディレクトリにはロケールプレフィックス付きのルートエントリが追加されます。
+
+```ts
+resolveMarkdownLinks: {
+  enabled: true,
+  dirs: [
+    { dir: settings.docsDir, routePrefix: "/docs/" },
+    // ロケールごと: 各ロケールディレクトリを /<code>/docs/ にマッピング
+    { dir: settings.locales.ja.dir, routePrefix: "/ja/docs/" },
+  ],
+}
+```
+
+日本語ソースファイル内の相対リンク（例: `[page](./other.mdx)`）が `/docs/...` ではなく `/ja/docs/...` に解決されるのはこのためです。リライターはファイルのソースディレクトリを正しいプレフィックスに照合します。
+
+バージョン管理されたコレクションも有効な場合、同じパターンが各バージョンの英語ディレクトリおよびそのロケールごとのミラーにも適用されます。
+
+```ts
+resolveMarkdownLinks: {
+  enabled: true,
+  dirs: [
+    { dir: settings.docsDir, routePrefix: "/docs/" },
+    { dir: settings.locales.ja.dir, routePrefix: "/ja/docs/" },
+    // バージョン管理: バージョンごとに英語ディレクトリ + ロケールディレクトリ
+    { dir: version.docsDir, routePrefix: "/v/1.0/docs/" },
+    { dir: version.locales.ja.dir, routePrefix: "/v/1.0/ja/docs/" },
+  ],
+}
+```
+
+このプロジェクトの実際の `zfb.config.ts` では、`dirs` 配列が `settings.locales` および `settings.versions` から動的に構築されます。そのため、新しいロケールやバージョンを追加しても `dirs` を手動で編集する必要はありません。
+
 ## 補足
 
 - このプラグインは hast 処理の前、mdast フェーズで動作します。

--- a/src/content/docs-ja/reference/create-zudo-doc.mdx
+++ b/src/content/docs-ja/reference/create-zudo-doc.mdx
@@ -37,6 +37,82 @@ create-zudo-doc [project-name] [options]
 | `--default-mode <mode>` | `light` または `dark`（light-dark モード） | `dark` |
 | `--[no-]respect-system-preference` | OS のカラースキーム設定を尊重 | `true` |
 
+## 利用可能なカラースキーム
+
+### シングルモードのスキーム（`--color-scheme-mode single`）
+
+`--scheme <name>` で指定します。デフォルトは `Dracula` です。
+
+**ダークスキーム:**
+
+| 名前 |
+|------|
+| Default Dark |
+| Dracula |
+| Catppuccin Mocha |
+| GitHub Dark |
+| Nord |
+| TokyoNight |
+| Gruvbox Dark |
+| Atom One Dark |
+| Rose Pine |
+| Solarized Dark |
+| Material Ocean |
+| Monokai Pro |
+| Everforest Dark |
+| Kanagawa Wave |
+| Night Owl |
+| Ayu Dark |
+| VS Code Dark+ |
+| Doom One |
+| Challenger Deep |
+| Catppuccin Frappe |
+| Catppuccin Macchiato |
+| Gruvbox Dark Hard |
+| Rose Pine Moon |
+| GitHub Dark Dimmed |
+| Ayu Mirage |
+| Material Darker |
+| Material Dark |
+| Monokai Remastered |
+| Monokai Vivid |
+| Monokai Soda |
+| Solarized Dark Higher Contrast |
+| Gruvbox Material Dark |
+| Kanagawa Dragon |
+
+**ライトスキーム:**
+
+| 名前 |
+|------|
+| Default Light |
+| GitHub Light |
+| Catppuccin Latte |
+| Solarized Light |
+| Rose Pine Dawn |
+| Atom One Light |
+| Everforest Light |
+| Gruvbox Light |
+| Ayu Light |
+
+### ライト/ダークペアリング（`--color-scheme-mode light-dark`）
+
+`--light-scheme` と `--dark-scheme` で指定します。デフォルトはライトが `Default Light`、ダークが `Default Dark` です。
+
+| ペアリング名 | ライトスキーム | ダークスキーム |
+|-------------|--------------|---------------|
+| Default | Default Light | Default Dark |
+| GitHub | GitHub Light | GitHub Dark |
+| Catppuccin | Catppuccin Latte | Catppuccin Mocha |
+| Solarized | Solarized Light | Solarized Dark |
+| Rosé Pine | Rose Pine Dawn | Rose Pine |
+| Atom One | Atom One Light | Atom One Dark |
+| Everforest | Everforest Light | Everforest Dark |
+| Gruvbox | Gruvbox Light | Gruvbox Dark |
+| Ayu | Ayu Light | Ayu Dark |
+
+ペアリング名は対話式ウィザードおよびセットアッププリセットジェネレーターで表示されます。CLI フラグを直接使用する場合は、ライトとダーク各スキームの名前を個別に指定してください。
+
 ### 機能
 
 | フラグ | 説明 | デフォルト |

--- a/src/content/docs/guides/configuration.mdx
+++ b/src/content/docs/guides/configuration.mdx
@@ -159,6 +159,18 @@ docsDir: "docs",  // content in ./docs/ at project root
 
 This is similar to Docusaurus' `docs.path` option — useful when using zudo-doc as a documentation tool for a larger project where docs live at the project root level.
 
+### defaultLocale
+
+The BCP 47 code for the default (prefix-less) locale. Used by zfb's i18n router to map the root `/docs/...` routes.
+
+Type: `string`
+
+Default: `"en"`
+
+```ts
+defaultLocale: "en",
+```
+
 ### locales
 
 A map of additional locale configurations. Each key is a locale code, and the value is an object with `label` (display name for the language switcher) and `dir` (content directory path).
@@ -177,6 +189,23 @@ For each locale entry, zudo-doc automatically:
 - Creates a zfb content collection (`docs-{code}`)
 - Registers the locale in zfb's i18n routing
 - Adds it to the language switcher
+
+### defaultLocaleOnlyPrefixes
+
+An array of URL prefixes that exist only in the default locale. Pages under these prefixes are not translated and should have no mirror under any locale prefix. The language switcher omits them when on an affected page.
+
+Type: `string[]`
+
+Default: `[]`
+
+```ts
+defaultLocaleOnlyPrefixes: [
+  "/docs/claude-md/",
+  "/docs/claude-skills/",
+],
+```
+
+See [Default-locale-only prefixes](./i18n.mdx#default-locale-only-prefixes) for the full authoring workflow.
 
 ### versions
 
@@ -230,6 +259,33 @@ Default: `""`
 The full base URL of your site (e.g., `"https://example.com"`). Required for generating absolute URLs in the sitemap.
 
 Default: `""`
+
+### metaTags
+
+Fine-grained control over which `<meta>` tags are emitted. Set individual sub-fields to `false` to omit a tag entirely.
+
+Type: `MetaTagsConfig`
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `description` | `boolean` | Emit `<meta name="description">`. Default `true` |
+| `keywords` | `string \| false` | Emit `<meta name="keywords">` with this value. `false` = omit. Default `false` |
+| `ogImage` | `string \| false` | Path for `og:image` (and `twitter:image`). `false` = omit. Default `false` |
+| `ogSiteName` | `boolean` | Emit `og:site_name`. Default `true` |
+| `twitterCard` | `"summary" \| "summary_large_image" \| false` | Twitter Card type. `false` = omit entire block. Default `false` |
+| `twitterSite` | `string` (optional) | `twitter:site` handle (e.g. `"@yourbrand"`) |
+| `twitterCreator` | `string` (optional) | `twitter:creator` handle |
+
+```ts
+metaTags: {
+  description: true,
+  keywords: false,
+  ogImage: "/img/ogp.png",
+  ogSiteName: true,
+  twitterCard: "summary_large_image",
+  twitterSite: "@yourbrand",
+},
+```
 
 ### noindex
 
@@ -335,6 +391,22 @@ tagPlacement: "before-pager",
 ```
 
 Has no effect when `docTags` is `false` or when a page carries no tags.
+
+### tagGovernance
+
+Enforcement level applied when the tag vocabulary is active. See [Tag governance](./tag-governance.mdx) for the full reference.
+
+Type: `"off" | "warn" | "strict"`
+
+Default: `"warn"`
+
+### tagVocabulary
+
+Whether `tag-vocabulary.ts` is consulted at runtime (alias resolution, deprecation filtering, grouped footer). Set to `false` to ignore the file entirely regardless of `tagGovernance`. See [Tag governance](./tag-governance.mdx) for details.
+
+Type: `boolean`
+
+Default: `true`
 
 ### frontmatterPreview
 
@@ -463,6 +535,28 @@ Default: `false` (set to `true` to enable)
 See the [Document History guide](./doc-history.mdx) for usage details, keyboard shortcuts, and technical information.
 
 </Tip>
+
+### bodyFootUtilArea
+
+Controls which utility items appear in the bottom-of-body action area on every doc page. Set to `false` to hide the area entirely.
+
+Type: `BodyFootUtilAreaConfig | false`
+
+Default: `false`
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `docHistory` | `boolean` (optional) | Show the **History** button (requires `docHistory: true`) |
+| `viewSourceLink` | `boolean` (optional) | Show a link to the raw source file (requires `editUrl`) |
+
+```ts
+bodyFootUtilArea: {
+  docHistory: true,
+  viewSourceLink: true,
+},
+// or hide entirely:
+bodyFootUtilArea: false,
+```
 
 ### tocMinDepth
 
@@ -631,6 +725,33 @@ headerNav: [
   { label: "Guides", labelKey: "nav.guides", path: "/docs/guides", categoryMatch: "guides" },
   { label: "Reference", labelKey: "nav.reference", path: "/docs/reference", categoryMatch: "reference" },
   { label: "Claude", labelKey: "nav.claude", path: "/docs/claude", categoryMatch: "claude" },
+],
+```
+
+### headerRightItems
+
+Controls the items rendered in the right side of the site header, in order. Each item is a discriminated union on the `type` field.
+
+Type: `HeaderRightItem[]`
+
+| `type` | Additional fields | Description |
+|--------|-------------------|-------------|
+| `"component"` | `component` — one of `"theme-toggle"`, `"language-switcher"`, `"version-switcher"`, `"github-link"`, `"search"` | Renders a built-in header component |
+| `"trigger"` | `trigger` — one of `"design-token-panel"`, `"ai-chat"` | Renders a button that opens a panel (requires the matching feature to be enabled) |
+| `"link"` | `href` (string), `label?` (string), `ariaLabel?` (string), `icon?` (`"github"`) | Renders a custom link |
+| `"html"` | `html` (string) | Renders raw HTML |
+
+```ts
+headerRightItems: [
+  { type: "component", component: "version-switcher" },
+  { type: "trigger", trigger: "design-token-panel" },
+  { type: "trigger", trigger: "ai-chat" },
+  { type: "component", component: "github-link" },
+  { type: "component", component: "theme-toggle" },
+  { type: "component", component: "search" },
+  { type: "component", component: "language-switcher" },
+  // custom external link:
+  { type: "link", href: "https://example.com", label: "Blog", ariaLabel: "Blog" },
 ],
 ```
 

--- a/src/content/docs/guides/i18n.mdx
+++ b/src/content/docs/guides/i18n.mdx
@@ -105,3 +105,73 @@ To add a new language (e.g., Korean):
 Step 1 is the key step — adding the locale to `settings.ts` automatically creates the content collection and registers the i18n routing. No per-locale page route file is needed; the parameterized route at `pages/[locale]/docs/[[...slug]].tsx` handles every locale automatically.
 
 </Tip>
+
+## defaultLocale
+
+`defaultLocale` identifies which locale is served without a URL prefix. It defaults to `"en"` and must match one of the keys that zfb uses for its default-locale routing:
+
+```ts
+export const settings = {
+  // ...
+  defaultLocale: "en" as const,
+  locales: {
+    ja: { label: "JA", dir: "src/content/docs-ja" },
+  },
+};
+```
+
+With `prefixDefaultLocale: false` (configured in `zfb.config.ts`), the default locale is served at `/docs/...` with no language code in the path, while every other locale uses its key as a prefix — `/ja/docs/...` for Japanese. Changing `defaultLocale` requires updating the corresponding routing and collection wiring in `zfb.config.ts`.
+
+## Default-locale-only prefixes
+
+Some content is intentionally only available in the default locale. These routes are called **default-locale-only prefixes** and are controlled by the `defaultLocaleOnlyPrefixes` setting in `src/config/settings.ts`:
+
+```ts
+export const settings = {
+  // ...
+  defaultLocaleOnlyPrefixes: [
+    "/docs/claude-md/",
+    "/docs/claude-skills/",
+    "/docs/claude-agents/",
+    "/docs/claude-commands/",
+  ] as string[],
+};
+```
+
+### What it means
+
+Any page whose URL starts with one of these prefixes exists **only** in the default locale (English). The language switcher suppresses the alternate-locale link for those pages, and no Japanese mirror file should be created under `docs-ja/` for them.
+
+### Current entries
+
+The four prefixes above cover the Claude-resource sections — the auto-generated pages that surface `CLAUDE.md`, skills, agents, and commands from the project's `.claude/` directory. These are English-only because the source material (Claude config files) is not translated.
+
+<Note>
+
+The top-level `/docs/claude/` index page is **not** in this list — it has a bilingual stub at `docs-ja/claude/index.mdx`. Only the four deeper prefixes (`claude-md/`, `claude-skills/`, `claude-agents/`, `claude-commands/`) are default-locale-only.
+
+</Note>
+
+### How the router enforces this
+
+The page route at `pages/[locale]/docs/[[...slug]].tsx` checks each slug against `defaultLocaleOnlyPrefixes` in its `paths()` export. If the reconstructed URL matches a prefix, that path is omitted from the non-default-locale path list, so no `/ja/docs/claude-md/...` route is ever generated.
+
+### Adding your own prefix
+
+If you have a section that should remain English-only (for example, auto-generated API reference pages), add its URL prefix to the array:
+
+```ts
+defaultLocaleOnlyPrefixes: [
+  "/docs/claude-md/",
+  "/docs/claude-skills/",
+  "/docs/claude-agents/",
+  "/docs/claude-commands/",
+  "/docs/api-reference/", // your new prefix
+] as string[],
+```
+
+Make sure the prefix:
+
+- Starts with `/docs/` (or the equivalent path for your content directory)
+- Ends with a trailing slash
+- Does not overlap with a prefix you want to keep bilingual

--- a/src/content/docs/markdown-features/admonitions-preset.mdx
+++ b/src/content/docs/markdown-features/admonitions-preset.mdx
@@ -115,6 +115,7 @@ The type class (`admonition-note`, `admonition-tip`, `admonition-warning`, `admo
 ## Notes
 
 - The `:::details` type also accepts the legacy `:::details title="Click me"` attribute form.
-- `:::caution` is part of the vocabulary this project registers; it emits `<Caution>` (`data-admonition="caution"`), mirroring how `:::warning` emits `<Warning>`.
+- `:::caution` is part of the vocabulary this project registers; it emits `<Caution>` (`data-admonition="caution"`), mirroring how `:::warning` emits `<Warning>`. `caution` is also reachable via [GitHub Alerts](./github-alerts.mdx) as `> [!CAUTION]`, so it is available through both paths.
+- `important` is **not** in the `directives` map and cannot be used as `:::important`. It is only available via [GitHub Alerts](./github-alerts.mdx) as `> [!IMPORTANT]`, which maps to the `<Important>` component (`data-admonition="important"`).
 - To add or override directives, extend the `directives` map in `zfb.config.ts` with additional name → title pairs.
 - [GitHub Alerts](./github-alerts.mdx) emits the same admonition markup from `> [!NOTE]`-style blockquotes; the two features coexist cleanly.

--- a/src/content/docs/markdown-features/code-tabs.mdx
+++ b/src/content/docs/markdown-features/code-tabs.mdx
@@ -85,8 +85,41 @@ The `:::code-group` directive produces a `<CodeGroup>` JSX element with a `tabs`
 
 The framework does not ship `<CodeGroup>` — zudo-doc registers its own implementation in `pages/_mdx-components.ts`, mapping the `tabs` array and `<pre data-lang>` children onto the existing `<Tabs>` / `<TabItem>` UI. The code inside each `<pre>` is raw text (the Rust pipeline does not run syntax highlighting inside `:::code-group` fences).
 
+## Syncing tabs with `name`
+
+The optional `name` attribute links all `:::code-group` blocks on the page that share the same name. When a user clicks a tab in one group, every other group with the same name switches to the matching tab automatically — if a tab with that label exists.
+
+````md
+:::code-group{name="package-manager"}
+
+```sh title="npm"
+npm install my-lib
+```
+
+```sh title="pnpm"
+pnpm add my-lib
+```
+
+:::
+
+:::code-group{name="package-manager"}
+
+```sh title="npm"
+npm run dev
+```
+
+```sh title="pnpm"
+pnpm dev
+```
+
+:::
+````
+
+The chosen tab is also written to `localStorage` under the key `tabs-group-{name}`. On the next page load, every group with that name restores the stored tab (falling back to the default tab if the stored label is not present in the group).
+
+Internally, `name` is forwarded by zfb as a prop to the `<CodeGroup>` component, which passes it as `groupId` to the underlying `<Tabs>` component. The `TabsInit` script reads `data-group-id` from the rendered DOM, syncs all same-`groupId` containers on click, and reads/writes `localStorage` for cross-visit persistence.
+
 ## Notes
 
-- An optional `name` attribute on the directive (`:::code-group{name="install"}`) can be used by the consumer component to persist the active tab across navigation.
 - Empty `:::code-group` containers (no fences) are left unchanged as plain text.
 - Nested `:::code-group` directives are not supported.

--- a/src/content/docs/markdown-features/directives-registry.mdx
+++ b/src/content/docs/markdown-features/directives-registry.mdx
@@ -93,9 +93,41 @@ The `data-admonition` attribute carries the variant name. The type-specific clas
 
 ## Custom directives
 
-Project-side components can register additional directive names through the `_mdx-components.ts` configuration, without writing any Rust code. See the [Components](../components/index.mdx) section for how component overrides are wired.
+Registering a custom directive requires two steps: mapping the directive name in `zfb.config.ts`, and providing the component implementation in `pages/_mdx-components.ts`.
+
+**Step 1 — Add the directive name → component name mapping in `zfb.config.ts`:**
+
+```ts title="zfb.config.ts"
+export default defineConfig({
+  markdown: {
+    features: {
+      directives: {
+        // existing entries...
+        callout: "Callout", // :::callout → <Callout>
+      },
+    },
+  },
+});
+```
+
+The value (`"Callout"`) is the JSX tag name zfb emits in the compiled MDX output. It must match the key you register in the components map.
+
+**Step 2 — Bind the component name to its implementation in `pages/_mdx-components.ts`:**
+
+```ts title="pages/_mdx-components.ts"
+import { Callout } from "@/components/content/callout";
+
+export function createMdxComponents(lang) {
+  return {
+    // existing entries...
+    Callout,
+  };
+}
+```
+
+When an author writes `:::callout`, zfb emits `<Callout>` in the compiled MDX. The `<entry.Content components={createMdxComponents(lang)} />` call resolves `Callout` to your component via this map. No Rust code is needed.
 
 ## Notes
 
-- The admonition directives (`note`, `tip`, `info`, `warning`, `danger`, `caution`, `details`) are provided by the [admonitions recipe](./admonitions-preset.mdx) this project registers via the `directives` map — not by the Core registry itself. The registry is the engine; the `directives` map supplies the component mappings.
+- The admonition directives (`note`, `tip`, `info`, `warning`, `danger`, `caution`, `details`) are provided by the [admonitions recipe](./admonitions-preset.mdx) this project registers via the `directives` map — not by the Core registry itself. The registry is the engine; the `directives` map in `zfb.config.ts` supplies the directive-name → component-name bindings, and `pages/_mdx-components.ts` supplies the component-name → implementation bindings.
 - Do not use `> [!IMPORTANT]` or `> [!CAUTION]` GitHub-alert syntax unless you have verified that `important` and `caution` components are registered. These map to `data-admonition="important"` / `data-admonition="caution"` respectively and will 500 if no component handles them.

--- a/src/content/docs/markdown-features/resolve-links.mdx
+++ b/src/content/docs/markdown-features/resolve-links.mdx
@@ -29,6 +29,53 @@ Outputs a link pointing to `/docs/markdown-features/resolve-links`, not the raw 
 
 When the target file does not exist in the source map, zfb emits a diagnostic warning. The build does not fail on broken links by default. To escalate warnings to errors, enable the opt-in [Link Validation](./link-validation.mdx) feature.
 
+## Advanced: multiple directories, locales, and versions
+
+Resolve Links maps each content directory to a route prefix. zfb registers one entry per directory so the rewriter knows which URL prefix corresponds to each source tree.
+
+The default single-locale setup registers one directory:
+
+```ts
+resolveMarkdownLinks: {
+  enabled: true,
+  dirs: [
+    { dir: settings.docsDir, routePrefix: "/docs/" },
+  ],
+}
+```
+
+When locales are configured, each locale's content directory gets its own entry with a locale-prefixed route:
+
+```ts
+resolveMarkdownLinks: {
+  enabled: true,
+  dirs: [
+    { dir: settings.docsDir, routePrefix: "/docs/" },
+    // Per-locale: each locale dir maps to /<code>/docs/
+    { dir: settings.locales.ja.dir, routePrefix: "/ja/docs/" },
+  ],
+}
+```
+
+This is why a relative link such as `[page](./other.mdx)` inside a Japanese source file resolves to `/ja/docs/...` rather than `/docs/...` — the rewriter matches the file's source directory to the correct prefix.
+
+When versioned collections are also enabled, the same pattern extends to each version's EN directory and its per-locale mirrors:
+
+```ts
+resolveMarkdownLinks: {
+  enabled: true,
+  dirs: [
+    { dir: settings.docsDir, routePrefix: "/docs/" },
+    { dir: settings.locales.ja.dir, routePrefix: "/ja/docs/" },
+    // Versioned: EN dir + per-locale dirs for each version
+    { dir: version.docsDir, routePrefix: "/v/1.0/docs/" },
+    { dir: version.locales.ja.dir, routePrefix: "/v/1.0/ja/docs/" },
+  ],
+}
+```
+
+The actual `zfb.config.ts` in this project builds the `dirs` array dynamically from `settings.locales` and `settings.versions`, so entries are added automatically as new locales or versions are registered — no manual `dirs` edits are needed when you add a locale or a version.
+
 ## Notes
 
 - The plugin operates during the mdast phase, before hast processing.

--- a/src/content/docs/reference/create-zudo-doc.mdx
+++ b/src/content/docs/reference/create-zudo-doc.mdx
@@ -37,6 +37,82 @@ You can also use the [Setup Preset Generator](../getting-started/setup-preset-ge
 | `--default-mode <mode>` | `light` or `dark` (light-dark mode) | `dark` |
 | `--[no-]respect-system-preference` | Respect OS color scheme preference | `true` |
 
+## Available Color Schemes
+
+### Single-mode schemes (`--color-scheme-mode single`)
+
+Used with `--scheme <name>`. The default is `Dracula`.
+
+**Dark schemes:**
+
+| Name |
+|------|
+| Default Dark |
+| Dracula |
+| Catppuccin Mocha |
+| GitHub Dark |
+| Nord |
+| TokyoNight |
+| Gruvbox Dark |
+| Atom One Dark |
+| Rose Pine |
+| Solarized Dark |
+| Material Ocean |
+| Monokai Pro |
+| Everforest Dark |
+| Kanagawa Wave |
+| Night Owl |
+| Ayu Dark |
+| VS Code Dark+ |
+| Doom One |
+| Challenger Deep |
+| Catppuccin Frappe |
+| Catppuccin Macchiato |
+| Gruvbox Dark Hard |
+| Rose Pine Moon |
+| GitHub Dark Dimmed |
+| Ayu Mirage |
+| Material Darker |
+| Material Dark |
+| Monokai Remastered |
+| Monokai Vivid |
+| Monokai Soda |
+| Solarized Dark Higher Contrast |
+| Gruvbox Material Dark |
+| Kanagawa Dragon |
+
+**Light schemes:**
+
+| Name |
+|------|
+| Default Light |
+| GitHub Light |
+| Catppuccin Latte |
+| Solarized Light |
+| Rose Pine Dawn |
+| Atom One Light |
+| Everforest Light |
+| Gruvbox Light |
+| Ayu Light |
+
+### Light-dark pairings (`--color-scheme-mode light-dark`)
+
+Used with `--light-scheme` and `--dark-scheme`. The defaults are `Default Light` (light) and `Default Dark` (dark).
+
+| Pairing label | Light scheme | Dark scheme |
+|---------------|-------------|------------|
+| Default | Default Light | Default Dark |
+| GitHub | GitHub Light | GitHub Dark |
+| Catppuccin | Catppuccin Latte | Catppuccin Mocha |
+| Solarized | Solarized Light | Solarized Dark |
+| Rosé Pine | Rose Pine Dawn | Rose Pine |
+| Atom One | Atom One Light | Atom One Dark |
+| Everforest | Everforest Light | Everforest Dark |
+| Gruvbox | Gruvbox Light | Gruvbox Dark |
+| Ayu | Ayu Light | Ayu Dark |
+
+The pairing label is used in the interactive wizard and the Setup Preset Generator. When using CLI flags directly, specify the individual light and dark scheme names.
+
 ### Features
 
 | Flag | Description | Default |


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2125 (epic)

---

## Summary

Documents verified missing information in the showcase docs, found by diffing the implementation surface against current doc coverage and **manually verifying each finding against code** (discarding false positives). Closes the epic #2125 and its sub-issues #2126–#2133.

All changes are **bilingual** (EN `src/content/docs/` + JA `src/content/docs-ja/`).

## Changes

| Sub | Page(s) | What |
|---|---|---|
| #2126 | `guides/configuration.mdx` | Added `defaultLocale`, `defaultLocaleOnlyPrefixes`, `metaTags` (+ sub-fields), `bodyFootUtilArea`, `headerRightItems`, and `tagGovernance`/`tagVocabulary` cross-links |
| #2127 | `guides/i18n.mdx` | Deep-dive on `defaultLocale` + `defaultLocaleOnlyPrefixes` (heading `Default-locale-only prefixes`) |
| #2128 | `reference/create-zudo-doc.mdx` | Enumerated available color schemes (single + light-dark pairings) from `constants.ts` |
| #2129 | `docs-ja/claude/index.mdx` | Clarified `/docs/claude/` is build-generated by the claude-resources plugin (no static EN file authored — it would be clobbered) |
| #2130 | `markdown-features/code-tabs.mdx`, `directives-registry.mdx` | `:::code-group{name}` → `groupId`/localStorage persistence; custom-directive registration via the `directives` map (+ corrected a misleading note) |
| #2131 | `markdown-features/admonitions-preset.mdx` | `important` variant via GitHub Alerts; `caution` dual path |
| #2132 | `markdown-features/resolve-links.mdx` | Advanced `dirs[]`/`routePrefix` for locales and versions (framed as always-on) |

## Validation (#2133 confirm)

- `pnpm check` (typecheck) — clean
- `pnpm build` — 275 pages built
- `pnpm check:links` — no broken links
- Verified the #2126→#2127 cross-link anchor (`i18n/#default-locale-only-prefixes`) resolves in the built output
- Verified the generated `/docs/claude/` page exists post-build (JA stub link resolves)
- EN/JA trees still mirror

## Out of scope (verified false positives, intentionally NOT changed)

- "JA staleness" re-translations — JA pages end at the same logical point as EN; shorter only because Japanese prose is more compact.
- ~30 per-package-export reference pages — low value; several suggested pages already exist.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UQ7VcK2k9MgyPvFzngmBsg)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783989020&installation_id=130359969&pr_number=2134&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2134&signature=1f3d5ff300a0a8487f281fbd1a1572770f085b789a7b4884328e3be659e1be39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->