### PR TITLE
fix(sidebar): use onInput for live filter under non-compat Preact builds

### DIFF
--- a/packages/create-zudo-doc/templates/base/src/components/sidebar-tree.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/sidebar-tree.tsx
@@ -288,7 +288,7 @@ export default function SidebarTree({ nodes, currentSlug, rootMenuItems, backToM
             type="text"
             placeholder={filterPlaceholder}
             value={query}
-            onChange={(e) => setQuery(e.currentTarget.value)}
+            onInput={(e) => setQuery(e.currentTarget.value)}
             className="bg-transparent text-small outline-none w-full text-fg placeholder:text-muted"
           />
         </div>

--- a/src/components/sidebar-tree.tsx
+++ b/src/components/sidebar-tree.tsx
@@ -360,7 +360,7 @@ export default function SidebarTree({ nodes, currentSlug, rootMenuItems, backToM
             aria-label="Filter navigation"
             placeholder={filterPlaceholder}
             value={query}
-            onChange={(e) => setQuery(e.currentTarget.value)}
+            onInput={(e) => setQuery(e.currentTarget.value)}
             className="bg-transparent text-small outline-none w-full text-fg placeholder:text-muted"
           />
         </div>


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2135

---

## Summary

The sidebar filter input bound its handler with `onChange`, which under Preact builds **without** `preact/compat` event aliasing (e.g. zfb/esbuild with `jsxImportSource: preact`) maps to the native **`change`** event — firing on **blur**, not per-keystroke. The filter was therefore blur-only on such consumer builds: typing did nothing until the input lost focus.

Switching to `onInput` makes the handler fire on every keystroke regardless of whether `preact/compat` is in play (behavior-equivalent under compat, correct without it), so the filter narrows live across all consumer build setups (Astro/Vite **and** zfb/esbuild).

## Changes

- `src/components/sidebar-tree.tsx` — `onChange` → `onInput` on the filter input (showcase source)
- `packages/create-zudo-doc/templates/base/src/components/sidebar-tree.tsx` — same change in the `create-zudo-doc` base template, keeping the two in parity

## Test Plan

- Existing `e2e/sidebar-filter.spec.ts` drives the input via `fill()` (dispatches `input`) and the fixtures run Preact compat, so the suite stays valid and exercises the live-filter path.
- The fix is the verbatim one-word change suggested in #2135, empirically verified there (typing `commit` narrows 158 → 4 links live, per-keystroke).

## Out of scope

The issue's secondary observation (the `@takazudo/zudo-doc/theme` barrel re-exporting zdtp-typed modules) is an explicitly separate, lower-priority concern and is left tracked in #2135.

Closes #2135

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZkBG7veojMZFxzAqxjacN)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784053024&installation_id=130359969&pr_number=2149&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2149&signature=3364a6d76c879140e2c363d32d7795c9f3e1801ece771308c779f39921907f5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->