### PR TITLE
Adopt zcss semantic z-index token system + fix search-dialog overlay (epic #2148)

### DIFF
--- a/.design-token-lint.json
+++ b/.design-token-lint.json
@@ -4,6 +4,7 @@
     "m-{n}", "mx-{n}", "my-{n}", "mt-{n}", "mr-{n}", "mb-{n}", "ml-{n}",
     "gap-{n}", "gap-x-{n}", "gap-y-{n}", "space-x-{n}", "space-y-{n}",
     "inset-{n}", "top-{n}", "right-{n}", "bottom-{n}", "left-{n}",
+    "z-{n}",
     "bg-{color}-{shade}", "text-{color}-{shade}", "border-{color}-{shade}",
     "ring-{color}-{shade}", "outline-{color}-{shade}", "divide-{color}-{shade}",
     "from-{color}-{shade}", "via-{color}-{shade}", "to-{color}-{shade}",

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -178,6 +178,26 @@ jobs:
         run: node scripts/check-e2e-spec-naming.mjs
 
   # ---------------------------------------------------------------------------
+  # Job 0.68: Z-index codegen drift check (#2148)
+  # ---------------------------------------------------------------------------
+  # Re-runs the z-index @theme codegen into a buffer and fails if
+  # src/styles/global.css has drifted from src/config/z-index-tokens.ts (the
+  # single source of truth). Also the structural guard for CSS-file raw
+  # z-index: every z-index now flows through the generated @theme block, so a
+  # hand-edited block (or a stale commit after editing the tokens file) turns
+  # the PR red here.
+  # Pure-Node script — uses preinstalled Node 22 on the runner image, no pnpm.
+  check-z-index:
+    name: Z-Index Codegen Drift Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - name: Check z-index codegen drift
+        run: node scripts/gen-z-index.mjs --check
+
+  # ---------------------------------------------------------------------------
   # Job 0.7: Lint gates (tags audit + design token lint)
   # ---------------------------------------------------------------------------
   # Runs pnpm tags:audit --ci (tsx scripts/tags-audit.ts) and pnpm lint:tokens

--- a/_temp-resource/2148-zindex-tokens/PLAN.md
+++ b/_temp-resource/2148-zindex-tokens/PLAN.md
@@ -151,3 +151,68 @@ path with documented purpose. Values are deliberately gapped but otherwise arbit
 - `pnpm check:template-drift` + `pnpm check:fixture-settings-drift` pass (template mirrored).
 - `pnpm b4push` green; the search-dialog E2E passes in CI.
 - No raw `z-index:` integer or numeric `z-{n}` utility remains outside the escape hatch.
+
+## Review addenda (incorporated from Step-5 plan review)
+
+These corrections are authoritative and override anything above that conflicts. The
+wave structure is unchanged; only scope details tightened.
+
+**A1 (foundation):**
+
+- **b4push ⇄ CI parity (do NOT skip a touch-point).** `check:z-index` must be wired in
+  THREE places or `pnpm check:b4push-ci-parity` fails:
+  1. `scripts/run-b4push.sh` — add the step **inside** the
+     `# >>> b4push-ci-parity:guards` / `# <<< b4push-ci-parity:guards` marker region
+     (a step added after the close marker escapes the scan), and bump `TOTAL_STEPS`.
+  2. `scripts/check-b4push-ci-parity.mjs` — add a `REQUIRED_CI_GUARDS` entry with its
+     `ciNeedle` + `b4pushScript`.
+  3. `.github/workflows/pr-checks.yml` — add the matching CI job/step.
+- **Tailwind v4 namespace (confirmed):** the `z` utility reads the `--z-index` theme key,
+  so `@theme { --z-index-toolbar: 20 }` generates `.z-toolbar { z-index: 20 }`. The
+  `--z-index-*` namespace is independent of the existing `--color-*: initial` reset at
+  `global.css:96` — do NOT add a `--z-index-*: initial` reset; it isn't needed.
+
+**A2 (migration) — additions/corrections:**
+
+- **MISSED usage — add it:** `src/styles/global.css:696` `.code-buttons { z-index: 1 }`
+  → `var(--z-index-local-1)`. `.code-block-wrapper` (its stacking parent) already has
+  `position: relative` at ~666. (Plus the template mirror `templates/base/src/styles/global.css:699`.)
+- Drop the `~` from line numbers — these exact lines are accurate now: global.css 696,
+  1166, 1175, 1180, 1215, 1228, 1233, 1398.
+- **Deliberate behavioral change (call out, don't "fix"):** desktop sidebar drops 30→`z-sidebar`(10)
+  and mobile drawer backdrop goes 30→`z-modal-backdrop`(50). Previously backdrop and desktop
+  sidebar shared z=30 (paint-order dependent); now the backdrop is definitively above the
+  sidebar (50 > 10). This is intended and harmless.
+- `header.tsx:422` dropdown is a child of the sticky header's stacking context, so its
+  own z-index is inoperative (it escapes visually via `top-full`, not z-order). Migrate to
+  `z-dropdown` for consistency anyway; do not try to "make it work" — no behavior change.
+- `find-bar.tsx` is **template-only** (Tauri feature); there is no host-side counterpart —
+  the template edit is the whole story for that file.
+- **Definition of done additions:** after migrating `packages/zudo-doc/src/**`, run
+  `pnpm build` (or the package's `tsup` build) so `gen-safelist.mjs` regenerates
+  `packages/zudo-doc/dist/safelist.css`; verify it now contains the new semantic `z-*`
+  classes (and no stale `z-10/z-30/z-50` from removed code), and that
+  `pnpm check:package-safelist` passes. (`gen-safelist.test.ts` tests the extractor logic,
+  not the literal class set — it stays green; don't be thrown by its `z-50` fixtures.)
+- Confirm no third-party CSS (zdtp panel, Mermaid) sets a z-index above the new `modal`(60)
+  that would be newly exposed by lowering `page-loading-overlay` 9999→`modal`(60).
+
+**B (search dialog) — scope clarification:**
+
+- The `<dialog>` currently has **no** explicit z-index and relies on native `showModal()`
+  top-layer promotion. The real fix is **close-on-result-click** under `zfb:after-swap`.
+  The `z-modal` + `::backdrop` `--z-index-modal-backdrop` hardening is **defense-in-depth**
+  for the SPA-swap window where the dialog can momentarily lose top-layer promotion and
+  flash behind the header — it is intentionally redundant in the normal case, not a no-op.
+  State this in the issue so the implementer doesn't "simplify" it away.
+
+**A3 (lint) — scope decision (pick this one):**
+
+- The current `@takazudo/zudo-design-token-lint` config only scans `*.{tsx,jsx}`
+  (`patterns` field). A3's PRIMARY pass is therefore the **Tailwind class** prohibition:
+  add the numeric `z-{n}` utilities to `prohibited`, with `z-auto` allowed and the
+  documented escape-hatch comment. **CSS-file raw `z-index:` integers are NOT linted by
+  this tool** — they are instead guarded structurally by `check:z-index` (the codegen
+  drift check) since every CSS z-index now flows through the generated `@theme` block.
+  Do not attempt to extend the linter to `.css` files; rely on `check:z-index` for that
+  surface and say so in the issue.

--- a/_temp-resource/2148-zindex-tokens/PLAN.md
+++ b/_temp-resource/2148-zindex-tokens/PLAN.md
@@ -1,0 +1,153 @@
+# zudo-doc z-index token adoption — implementation plan
+
+Source strategy: `./zcss-z-index-strategy.mdx` (copied from `zudolab/zudo-css-wisdom`
+`src/content/docs/methodology/design-systems/z-index-strategy.mdx`). Read it first —
+this plan applies that strategy to zudo-doc. Epic: zudolab/zudo-doc#2148.
+
+## What the strategy prescribes (summary)
+
+1. **Semantic, single-namespace tokens** — names describe roles, never magnitudes
+   (`--z-modal`, not `--z-60`). One flat ordered list.
+2. **Codegen from a TypeScript source of truth** — a `z-index-tokens.ts` file is the
+   single source; a `gen:z-index` script rewrites a `GENERATED:Z_INDEX` marker block in
+   CSS; a `check:z-index` script re-runs codegen to a temp buffer and diffs (non-zero on
+   drift) for pre-push/CI.
+3. **Lint rule forbidding raw z-index integers** — block magic numbers; allow
+   `var(...)`, `auto/inherit/initial`, and an escape-hatch comment.
+4. **`--z-local-1/2/3`** for child promotion *inside* a parent stacking context
+   (`isolation: isolate` etc.) — anonymous reusable helpers, not global tiers.
+5. Anti-patterns to avoid: numeric token names (`--z-50`), `--z-emergency: 99999`,
+   per-context namespaces, hand-editing the generated block.
+
+## zudo-doc-specific wrinkle: Tailwind v4
+
+zudo-doc styles via **Tailwind v4 utility classes** (`z-50`, `z-30`, ...), not raw
+`z-index:` in component CSS. So the token system must wire through Tailwind's `@theme`
+z-index namespace so that semantic utilities (`z-toolbar`, `z-modal`, ...) are generated.
+
+- Tailwind v4 reads `@theme { --z-index-<name>: <n>; }` and generates a `z-<name>` utility.
+- Raw CSS (e.g. the `<dialog>` rules, pseudo-elements in `global.css`) references the same
+  var: `z-index: var(--z-index-<name>);`.
+- The codegen therefore rewrites a `@theme`-scoped `GENERATED:Z_INDEX` marker block inside
+  `src/styles/global.css`. The TS source stays the single source of truth; the styleguide
+  (if/when added) imports it directly.
+- **Verify** the generated utilities actually resolve (a quick build + grep of `dist/`
+  for the class) — the exact `@theme` encoding (`--z-index-*` namespace) is the one detail
+  the generic strategy doc does not cover.
+
+## Tier list (the single source of truth contents)
+
+Single namespace. Canonical names from the strategy where they apply, plus two
+zudo-doc-specific tiers (`sidebar`, `drag`) added via the strategy's "add a new tier"
+path with documented purpose. Values are deliberately gapped but otherwise arbitrary
+(renaming/reordering is cheap — that's the whole point).
+
+| token (`--z-index-*` / utility `z-*`) | value | kind | purpose / who uses it |
+|---|---|---|---|
+| `content`          | 0  | global | default in-flow content (implicit baseline) |
+| `local-1`          | 1  | local  | child promotion inside an isolated parent |
+| `local-2`          | 2  | local  | child promotion inside an isolated parent |
+| `local-3`          | 3  | local  | child promotion inside an isolated parent |
+| `sidebar`          | 10 | global | persistent layout chrome: desktop sidebar, TOC, sidebar-toggle handle, resizer handle |
+| `toolbar`          | 20 | global | sticky top header (strategy's "toolbar/header" tier; sits above sidebar chrome) |
+| `dropdown`         | 30 | global | header menus, version/language switchers |
+| `popover`          | 40 | global | reserved — inline popovers (canonical scale; not yet used) |
+| `modal-backdrop`   | 50 | global | mobile drawer backdrop, `<dialog>` `::backdrop` |
+| `modal`            | 60 | global | mobile sidebar drawer panel, search `<dialog>` |
+| `toast`            | 70 | global | reserved — transient notifications (canonical scale; not yet used) |
+| `tooltip`          | 80 | global | reserved — highest steady UI layer (canonical scale; not yet used) |
+| `drag`             | 90 | global | transient drag affordance: sidebar-resizer ghost line (replaces the `z-9999` anti-pattern) |
+
+> Rationale notes to embed as comments in `z-index-tokens.ts`:
+> - `sidebar` and `drag` are zudo-doc additions — the strategy's overlay-centric scale has
+>   no persistent-sidebar/TOC tier nor a drag-affordance tier. Header is given a tier
+>   ABOVE sidebar to preserve the existing header-wins ordering (they don't overlap
+>   spatially, but keep the historical relationship explicit).
+> - `popover`/`toast`/`tooltip` are reserved canonical tiers kept for completeness and so
+>   downstream `create-zudo-doc` users inherit the full scale.
+
+## Migration mapping (current → token)
+
+### Host app `src/`
+
+- `components/sidebar-tree.tsx:508` `z-10` (tree connector line) → `z-local-1`
+- `components/site-tree-nav.tsx:121` `z-10` (dashed connector line) → `z-local-1`
+- `components/sidebar-toggle.tsx:129` `z-30` (mobile drawer backdrop) → `z-modal-backdrop`
+- `components/sidebar-toggle.tsx:144` `z-40` (mobile drawer panel) → `z-modal`
+- `components/desktop-sidebar-toggle.tsx:105` `z-40` (floating toggle handle) → `z-sidebar`
+- `styles/global.css` raw `z-index: 1 / 0` at lines ~696, 1166, 1175, 1180, 1215, 1228,
+  1233 (component pseudo-elements / local layering) → `var(--z-index-local-1)` /
+  `var(--z-index-local-2)` — inspect each; these are local promotions inside their own
+  components, so `local-N`. Keep relative order within each component.
+- `styles/global.css:1398` `.page-loading-overlay { z-index: 9999 }` → `var(--z-index-modal)`
+  (it is a full-screen blocking overlay = modal tier; NOT `drag`).
+
+### Package `packages/zudo-doc/src/`
+
+- `header/header.tsx:258` `z-50` (sticky header) → `z-toolbar`
+- `header/header.tsx:327` `z-10` (header dropdown menu) → `z-dropdown`
+- `header/header.tsx:422` `z-50` (header hover dropdown) → `z-dropdown`
+- `i18n-version/version-switcher.tsx:216` `z-10` (switcher menu) → `z-dropdown`
+- `doclayout/doc-layout.tsx:282` `z-30` (desktop sidebar) → `z-sidebar`
+- `doclayout/doc-layout-with-defaults.tsx:367` `z-50` (sticky header variant) → `z-toolbar`
+- `toc/toc.tsx:76` `z-10` (sticky TOC) → `z-sidebar`
+- `sidebar-resizer/index.ts:126` `zIndex:"10"` (handle) → `var(--z-index-sidebar)`
+- `sidebar-resizer/index.ts:212` `zIndex:"9999"` (drag ghost) → `var(--z-index-drag)`
+- `sidebar-resizer/sidebar-resizer-init.tsx:85` `zIndex:"10"` (handle) → `var(--z-index-sidebar)`
+- `sidebar-resizer/sidebar-resizer-init.tsx:120` `zIndex:"9999"` (drag ghost) → `var(--z-index-drag)`
+
+> Inline `Object.assign(el.style, { zIndex: ... })` cases read the CSS var via
+> `getComputedStyle`/`var()` — simplest is to set `zIndex: "var(--z-index-sidebar)"` if the
+> element is in the document (custom props cascade to it), or read the resolved value once.
+> The agent verifies the resizer still layers correctly (handle below ghost during drag).
+
+### Search dialog (handled in sub-issue B, not A2)
+
+- `pages/lib/_search-widget.tsx` / `_search-widget-script.ts`: dialog gets `z-modal`,
+  its `::backdrop` gets `--z-index-modal-backdrop`, plus the close-on-result-click fix.
+
+### Template mirrors (create-zudo-doc) — keep in lock-step
+
+- `packages/create-zudo-doc/templates/base/src/components/{sidebar-tree,sidebar-toggle,site-tree-nav,desktop-sidebar-toggle}.tsx`
+- `packages/create-zudo-doc/templates/base/src/styles/global.css`
+- `packages/create-zudo-doc/templates/features/sidebarToggle/files/src/components/desktop-sidebar-toggle.tsx`
+- `packages/create-zudo-doc/templates/features/tauri/files/src/components/find-bar.tsx` (`z-50` → `z-toolbar`)
+- The token file, codegen scripts, `package.json` scripts, and `.design-token-lint.json`
+  must be mirrored into the template too (Feature Change Checklist + `check:template-drift`).
+
+## Sub-issue breakdown (4 issues, 3 waves)
+
+**Wave 1 — foundation**
+
+- **A1: token source of truth + codegen + drift check + `@theme` block.**
+  Create `z-index-tokens.ts`, `scripts/gen-z-index.mjs` (+ `--check` mode or a sibling
+  `check-z-index`), add `gen:z-index` / `check:z-index` to `package.json`, insert the
+  `GENERATED:Z_INDEX` `@theme` marker block in `src/styles/global.css`, wire `check:z-index`
+  into `b4push` and the `b4push-ci-parity` guard (+ CI), and mirror all of it into the
+  `create-zudo-doc` template. No behavior change yet (tokens defined, nothing migrated).
+
+**Wave 2 — migration + dialog (parallel; both depend on A1)**
+
+- **A2: migrate every existing z-index usage onto tokens** per the mapping table above
+  (host + package + template mirrors). Excludes the search dialog. Verify visual stacking
+  unchanged (header > sidebar > content; dropdowns above header; mobile drawer above all
+  chrome; resizer ghost on top during drag).
+- **B: search dialog fix** (the original task) — close-on-result-click under
+  `zfb:after-swap`, harden the `<dialog>` with `z-modal` + `::backdrop`
+  `--z-index-modal-backdrop`, template mirror, and an E2E spec (spec-naming-guard
+  compliant). Disjoint files from A2, so runs in parallel.
+
+**Wave 3 — enforcement (depends on A2 + B)**
+
+- **A3: add the raw-z-index lint pass** — extend `.design-token-lint.json` `prohibited`
+  with the numeric Tailwind `z-{n}` utilities (and document the escape hatch); run
+  `pnpm lint:tokens` → must be clean (proves A2 + B migrated everything). Mirror the config
+  into the template. Update the b4push token-lint note if needed.
+
+## Definition of done
+
+- `pnpm gen:z-index` regenerates the block idempotently; `pnpm check:z-index` is clean.
+- `pnpm lint:tokens` rejects new `z-{n}` and passes on the migrated tree.
+- `pnpm check:template-drift` + `pnpm check:fixture-settings-drift` pass (template mirrored).
+- `pnpm b4push` green; the search-dialog E2E passes in CI.
+- No raw `z-index:` integer or numeric `z-{n}` utility remains outside the escape hatch.

--- a/_temp-resource/2148-zindex-tokens/zcss-z-index-strategy.mdx
+++ b/_temp-resource/2148-zindex-tokens/zcss-z-index-strategy.mdx
@@ -1,0 +1,602 @@
+---
+title: Z-Index Strategy
+sidebar_position: 5
+description: Semantic z-index tokens, single-source-of-truth codegen, global vs local tiers, and a forbid-raw-z-index lint rule.
+---
+
+import CssPreview from '@/components/CssPreview';
+
+## The Problem
+
+A site grows past five overlay types — modal, drawer, popover, toolbar, tooltip — and z-index becomes a hand-rolled lottery. Every new overlay nudges a value up: `10`, `20`, `99`, `100`, `9999`. Within a year the codebase contains `z-index: 1`, `z-index: 21`, `z-index: 100`, `z-index: 99999`, and a comment that reads `/* must be above modal */` with no way to verify the claim.
+
+The standard symptoms:
+
+- **Magic numbers everywhere.** A grep for `z-index:` returns dozens of unique integers with no shared scale.
+- **The `99999` reflex.** When a layer renders behind another, the fix is "make my number bigger" — no investigation of the actual stacking context.
+- **Renumbering paralysis.** Adding a new tier between `100` (modal) and `200` (toast) means picking `150` and praying nothing in the codebase already uses it.
+- **Tailwind's `z-10` / `z-20` / `z-30` scale.** This was a workaround for the renumbering pain — leave gaps so you can squeeze new layers between old ones. It traded one numeric scale for another and demanded that every developer memorise which class corresponds to which overlay role.
+
+The renumbering pain and the memorisation tax both dissolve in the AI-era refactor: a model can rename `--z-200` → `--z-toast` across hundreds of files in seconds. The cost that drove numeric scales no longer exists.
+
+## The Solution
+
+Define z-index tiers as **semantic, single-namespace tokens** generated from a single TypeScript source of truth.
+
+```css
+:root {
+  /* Generated from z-index-tokens.ts — do not hand-edit */
+  --z-content:           0;
+  --z-toolbar:          10;
+  --z-dropdown:         20;
+  --z-popover:          30;
+  --z-popover-portaled: 40;
+  --z-modal-backdrop:   50;
+  --z-modal:            60;
+  --z-toast:            70;
+  --z-tooltip:          80;
+}
+```
+
+Every component CSS file uses the named token, never a raw integer:
+
+```css
+.modal {
+  position: fixed;
+  z-index: var(--z-modal);
+}
+
+.toast {
+  position: fixed;
+  z-index: var(--z-toast);
+}
+```
+
+Three properties make this work:
+
+1. **Semantic names** — `--z-modal` tells you what layer it is. `--z-200` does not.
+2. **Single namespace** — one flat list of tiers, not split by feature or context. (Z-index is fundamentally one ordering problem, unlike density tokens which split per design context.)
+3. **Codegen from a TS source of truth** — the CSS block, the styleguide table, and any TypeScript constants all derive from one file. Drift is structurally impossible.
+
+<CssPreview
+  client:load
+  title="Semantic Tier Tokens vs Magic Numbers"
+  height={340}
+  html={`    <div class="ztk-demo">
+      <div class="ztk-demo__col">
+        <div class="ztk-demo__heading">Magic numbers (anti-pattern)</div>
+        <pre class="ztk-demo__code ztk-demo__code--bad"><code>{".modal       { z-index: 9999; }\\n.toast       { z-index: 100; }\\n.tooltip     { z-index: 21; }\\n.dropdown    { z-index: 50; }\\n.toolbar     { z-index: 5; }"}</code></pre>
+        <div class="ztk-demo__verdict ztk-demo__verdict--bad">No shared scale. No way to know what \`100\` means without reading it.</div>
+      </div>
+      <div class="ztk-demo__col">
+        <div class="ztk-demo__heading">Semantic tokens</div>
+        <pre class="ztk-demo__code ztk-demo__code--good"><code>{".modal    { z-index: var(--z-modal); }\\n.toast    { z-index: var(--z-toast); }\\n.tooltip  { z-index: var(--z-tooltip); }\\n.dropdown { z-index: var(--z-dropdown); }\\n.toolbar  { z-index: var(--z-toolbar); }"}</code></pre>
+        <div class="ztk-demo__verdict ztk-demo__verdict--good">Each line states intent. Tier order lives in one generated file.</div>
+      </div>
+    </div>`}
+  css={`    .ztk-demo {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 12px;
+      padding: 1rem;
+      font-family: system-ui, sans-serif;
+      color: hsl(222 47% 11%);
+    }
+    .ztk-demo__col {
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+    }
+    .ztk-demo__heading {
+      font-size: 0.75rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: hsl(215 16% 47%);
+    }
+    .ztk-demo__code {
+      background: hsl(222 47% 11%);
+      color: hsl(210 20% 85%);
+      padding: 0.55rem 0.7rem;
+      border-radius: 6px;
+      margin: 0;
+      font-size: 0.75rem;
+      font-family: ui-monospace, monospace;
+      line-height: 1.55;
+      overflow-x: auto;
+    }
+    .ztk-demo__code--bad {
+      border-left: 3px solid hsl(0 60% 50%);
+    }
+    .ztk-demo__code--good {
+      border-left: 3px solid hsl(142 50% 40%);
+    }
+    .ztk-demo__verdict {
+      font-size: 0.75rem;
+      padding: 0.4rem 0.6rem;
+      border-radius: 6px;
+      line-height: 1.4;
+    }
+    .ztk-demo__verdict--bad {
+      color: hsl(0 60% 30%);
+      background: hsl(0 80% 95%);
+      border-left: 3px solid hsl(0 60% 50%);
+    }
+    .ztk-demo__verdict--good {
+      color: hsl(142 50% 25%);
+      background: hsl(142 50% 93%);
+      border-left: 3px solid hsl(142 50% 40%);
+    }`}
+>
+      <div class="ztk-demo__col">
+        <div class="ztk-demo__heading">Magic numbers (anti-pattern)</div>
+        <pre class="ztk-demo__code ztk-demo__code--bad"><code>{".modal       { z-index: 9999; }\\n.toast       { z-index: 100; }\\n.tooltip     { z-index: 21; }\\n.dropdown    { z-index: 50; }\\n.toolbar     { z-index: 5; }"}</code></pre>
+        <div class="ztk-demo__verdict ztk-demo__verdict--bad">No shared scale. No way to know what \`100\` means without reading it.</div>
+      </div>
+      <div class="ztk-demo__col">
+        <div class="ztk-demo__heading">Semantic tokens</div>
+        <pre class="ztk-demo__code ztk-demo__code--good"><code>{".modal    { z-index: var(--z-modal); }\\n.toast    { z-index: var(--z-toast); }\\n.tooltip  { z-index: var(--z-tooltip); }\\n.dropdown { z-index: var(--z-dropdown); }\\n.toolbar  { z-index: var(--z-toolbar); }"}</code></pre>
+        <div class="ztk-demo__verdict ztk-demo__verdict--good">Each line states intent. Tier order lives in one generated file.</div>
+      </div>
+    </div>`}
+  css={`    .ztk-demo {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 12px;
+      padding: 1rem;
+      font-family: system-ui, sans-serif;
+      color: hsl(222 47% 11%);
+    }
+    .ztk-demo__col {
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+    }
+    .ztk-demo__heading {
+      font-size: 0.75rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: hsl(215 16% 47%);
+    }
+    .ztk-demo__code {
+      background: hsl(222 47% 11%);
+      color: hsl(210 20% 85%);
+      padding: 0.55rem 0.7rem;
+      border-radius: 6px;
+      margin: 0;
+      font-size: 0.75rem;
+      font-family: ui-monospace, monospace;
+      line-height: 1.55;
+      overflow-x: auto;
+    }
+    .ztk-demo__code--bad {
+      border-left: 3px solid hsl(0 60% 50%);
+    }
+    .ztk-demo__code--good {
+      border-left: 3px solid hsl(142 50% 40%);
+    }
+    .ztk-demo__verdict {
+      font-size: 0.75rem;
+      padding: 0.4rem 0.6rem;
+      border-radius: 6px;
+      line-height: 1.4;
+    }
+    .ztk-demo__verdict--bad {
+      color: hsl(0 60% 30%);
+      background: hsl(0 80% 95%);
+      border-left: 3px solid hsl(0 60% 50%);
+    }
+    .ztk-demo__verdict--good {
+      color: hsl(142 50% 25%);
+      background: hsl(142 50% 93%);
+      border-left: 3px solid hsl(142 50% 40%);
+    }`}
+>
+      <div class="ztk-demo__col">
+        <div class="ztk-demo__heading">Magic numbers (anti-pattern)</div>
+        <pre class="ztk-demo__code ztk-demo__code--bad"><code>{".modal       { z-index: 9999; }\\n.toast       { z-index: 100; }\\n.tooltip     { z-index: 21; }\\n.dropdown    { z-index: 50; }\\n.toolbar     { z-index: 5; }"}</code></pre>
+        <div class="ztk-demo__verdict ztk-demo__verdict--bad">No shared scale. No way to know what \`100\` means without reading it.</div>
+      </div>
+      <div class="ztk-demo__col">
+        <div class="ztk-demo__heading">Semantic tokens</div>
+        <pre class="ztk-demo__code ztk-demo__code--good"><code>{".modal    { z-index: var(--z-modal); }\\n.toast    { z-index: var(--z-toast); }\\n.tooltip  { z-index: var(--z-tooltip); }\\n.dropdown { z-index: var(--z-dropdown); }\\n.toolbar  { z-index: var(--z-toolbar); }"}</code></pre>
+        <div class="ztk-demo__verdict ztk-demo__verdict--good">Each line states intent. Tier order lives in one generated file.</div>
+      </div>
+    </div>`}
+  css={`    .ztk-demo {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 12px;
+      padding: 1rem;
+      font-family: system-ui, sans-serif;
+      color: hsl(222 47% 11%);
+    }
+    .ztk-demo__col {
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+    }
+    .ztk-demo__heading {
+      font-size: 0.75rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: hsl(215 16% 47%);
+    }
+    .ztk-demo__code {
+      background: hsl(222 47% 11%);
+      color: hsl(210 20% 85%);
+      padding: 0.55rem 0.7rem;
+      border-radius: 6px;
+      margin: 0;
+      font-size: 0.75rem;
+      font-family: ui-monospace, monospace;
+      line-height: 1.55;
+      overflow-x: auto;
+    }
+    .ztk-demo__code--bad {
+      border-left: 3px solid hsl(0 60% 50%);
+    }
+    .ztk-demo__code--good {
+      border-left: 3px solid hsl(142 50% 40%);
+    }
+    .ztk-demo__verdict {
+      font-size: 0.75rem;
+      padding: 0.4rem 0.6rem;
+      border-radius: 6px;
+      line-height: 1.4;
+    }
+    .ztk-demo__verdict--bad {
+      color: hsl(0 60% 30%);
+      background: hsl(0 80% 95%);
+      border-left: 3px solid hsl(0 60% 50%);
+    }
+    .ztk-demo__verdict--good {
+      color: hsl(142 50% 25%);
+      background: hsl(142 50% 93%);
+      border-left: 3px solid hsl(142 50% 40%);
+    }`}
+>
+</CssPreview>
+
+## Why not Tailwind-numeric?
+
+Tailwind's default `z-0` / `z-10` / `z-20` / `z-30` / `z-40` / `z-50` scale exists for one reason: in pre-AI CSS work, renumbering tokens across a codebase was painful. Leaving gaps (`10`, `20`, `30`...) let you squeeze new tiers between old ones without touching existing code.
+
+| Era cost | Pre-AI (manual refactor) | AI-era refactor |
+| --- | --- | --- |
+| Renaming `--z-200` → `--z-toast` across 300 files | Hours of find-and-replace, easy to break | Seconds, structural rename |
+| Inserting a tier between two existing values | Painful — may force renumbering downstream | Trivial — regenerate the scale, AI updates references |
+| Memorising "what does `z-30` mean in our app?" | Required onboarding doc | Eliminated — names are self-describing |
+
+Both costs that drove numeric scales — refactor pain and memorisation tax — collapse once a model can confidently rename across the whole codebase. Semantic names win on every other axis: readability, grepability, code review, onboarding.
+
+:::tip[Migration path]
+If a project is already on Tailwind-numeric (`z-10`/`z-20`/...), migrate by mapping each numeric utility to a semantic token, then doing a single AI-assisted rename pass. Do not migrate one component at a time — half-migrated codebases are harder to reason about than either pure state.
+:::
+
+## Single-namespace vs multi-namespace
+
+For density tokens (spacing, font sizes), splitting into multiple namespaces — `--spacing-myweb-*` and `--spacing-myadmin-*` — is the right call. Article pages and admin dashboards genuinely need different scales. See [Multi Namespace Token Strategy](./multi-namespace-token-strategy.mdx).
+
+Z-index does **not** follow that rule. There is exactly one viewport, one stacking universe, and one ordering question: "is this above or below that?". A modal in the article context still needs to render above a tooltip in the admin context if both happen to be on screen during a flow.
+
+| Token category | Namespace | Reason |
+| --- | --- | --- |
+| Spacing, font sizes | Multi | Different design contexts have different density |
+| Colors, font families | Single (shared) | Brand identity is global |
+| **Z-index** | **Single (global)** | **One ordering universe per app** |
+
+Keep z-index in a single namespace. Resist the urge to define `--z-myweb-modal` separate from `--z-myadmin-modal` — they would always need to be kept in sync, which is exactly what a single token already does.
+
+## Source of truth: TS → codegen → CSS
+
+Define tiers in TypeScript. Generate the CSS block. Have the styleguide read the TS file directly.
+
+```ts
+// src/styles/z-index-tokens.ts
+export type ZIndexTier = {
+  name: string;       // CSS var name without --z- prefix
+  value: number;      // numeric z-index
+  purpose: string;    // human-readable role
+  kind: "global" | "local";
+};
+
+export const Z_INDEX_TIERS: ZIndexTier[] = [
+  { name: "content",          value:  0, purpose: "Default in-flow content",         kind: "global" },
+  { name: "toolbar",          value: 10, purpose: "Sticky toolbars and headers",     kind: "global" },
+  { name: "dropdown",         value: 20, purpose: "In-flow dropdown menus",          kind: "global" },
+  { name: "popover",          value: 30, purpose: "Inline popovers (not portaled)",  kind: "global" },
+  { name: "popover-portaled", value: 40, purpose: "Popovers rendered via portal",    kind: "global" },
+  { name: "modal-backdrop",   value: 50, purpose: "Modal/drawer backdrop",           kind: "global" },
+  { name: "modal",            value: 60, purpose: "Modal/drawer foreground",         kind: "global" },
+  { name: "toast",            value: 70, purpose: "Transient notifications",         kind: "global" },
+  { name: "tooltip",          value: 80, purpose: "Tooltips (highest UI layer)",     kind: "global" },
+  { name: "local-1",          value:  1, purpose: "Child promotion within parent",   kind: "local"  },
+  { name: "local-2",          value:  2, purpose: "Child promotion within parent",   kind: "local"  },
+  { name: "local-3",          value:  3, purpose: "Child promotion within parent",   kind: "local"  },
+];
+```
+
+The codegen rewrites a marker block inside the main CSS file:
+
+```css
+/* GENERATED:Z_INDEX_BEGIN — do not hand-edit; run `pnpm gen:z-index` */
+:root {
+  --z-content:           0;
+  --z-toolbar:          10;
+  --z-dropdown:         20;
+  --z-popover:          30;
+  --z-popover-portaled: 40;
+  --z-modal-backdrop:   50;
+  --z-modal:            60;
+  --z-toast:            70;
+  --z-tooltip:          80;
+  --z-local-1:           1;
+  --z-local-2:           2;
+  --z-local-3:           3;
+}
+/* GENERATED:Z_INDEX_END */
+```
+
+Wire two scripts:
+
+| Script | Purpose | When to run |
+| --- | --- | --- |
+| `pnpm gen:z-index` | Rewrites the `GENERATED:Z_INDEX_*` marker block in `App.css` from `Z_INDEX_TIERS` | After editing `z-index-tokens.ts` |
+| `pnpm check:z-index` | Re-runs codegen to a temp file and diffs against the committed CSS — non-zero exit on drift | Pre-push hook, CI |
+
+The styleguide page imports `Z_INDEX_TIERS` directly from the TS file and renders a table. The table can never go stale because there is no second copy of the data.
+
+:::note[Why a marker block, not a separate CSS file]
+Putting the generated CSS inside `App.css` between markers means the rest of `App.css` stays hand-written. A separate `tokens-z-index.css` would also work, but markers keep the file count down and make it obvious to a reader of `App.css` that this block is generated.
+:::
+
+## Global vs local tokens
+
+Once the global tier list is in place, a recurring pattern emerges in components: `z-index: 1` on a child to lift it above siblings within a stacking-context-creating parent. These values are **not** independent tiers in the global ordering — they only matter relative to the parent.
+
+For these cases, define a small reserved family: `--z-local-1`, `--z-local-2`, `--z-local-3`.
+
+```css
+.card {
+  position: relative;
+  isolation: isolate;        /* parent creates a stacking context */
+}
+
+.card__background {
+  position: absolute;
+  inset: 0;
+  z-index: var(--z-local-1); /* sits above default flow but inside .card */
+}
+
+.card__content {
+  position: relative;
+  z-index: var(--z-local-2); /* sits above .card__background */
+}
+```
+
+The rule for using `--z-local-N`:
+
+> Use `--z-local-N` **only** when (a) the parent creates a stacking context and (b) the child is being promoted above its siblings, not stacked against other components.
+
+If the child needs to render above unrelated UI (e.g. a popover that must sit above the page toolbar), it is not local — it is a global tier and belongs in the named scale.
+
+<CssPreview
+  client:load
+  title="Local Promotion Inside a Stacking Context"
+  height={300}
+  html={`    <div class="zlocal-demo">
+      <div class="zlocal-demo__card">
+        <div class="zlocal-demo__bg"></div>
+        <div class="zlocal-demo__body">
+          <div class="zlocal-demo__title">Card Title</div>
+          <div class="zlocal-demo__text">Background uses --z-local-1, content uses --z-local-2. Both stay inside the card's stacking context.</div>
+        </div>
+      </div>
+      <div class="zlocal-demo__caption">The card's isolation: isolate seals the local layers — they cannot interfere with global tiers.</div>
+    </div>`}
+  css={`    .zlocal-demo {
+      padding: 1rem;
+      font-family: system-ui, sans-serif;
+      color: hsl(222 47% 11%);
+      display: flex;
+      flex-direction: column;
+      gap: 0.6rem;
+      font-size: 0.85rem;
+    }
+    .zlocal-demo__card {
+      position: relative;
+      isolation: isolate;
+      border-radius: 12px;
+      overflow: hidden;
+      min-height: 140px;
+      box-shadow: 0 4px 16px hsl(222 47% 11% / 0.12);
+      --z-local-1: 1;
+      --z-local-2: 2;
+    }
+    .zlocal-demo__bg {
+      position: absolute;
+      inset: 0;
+      z-index: var(--z-local-1);
+      background: linear-gradient(135deg, hsl(220 80% 50%), hsl(260 70% 45%));
+    }
+    .zlocal-demo__body {
+      position: relative;
+      z-index: var(--z-local-2);
+      color: hsl(0 0% 100%);
+      padding: 1rem 1.25rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+    }
+    .zlocal-demo__title {
+      font-size: 1rem;
+      font-weight: 700;
+    }
+    .zlocal-demo__text {
+      font-size: 0.8rem;
+      line-height: 1.5;
+    }
+    .zlocal-demo__caption {
+      font-size: 0.75rem;
+      color: hsl(215 16% 47%);
+      font-style: italic;
+    }`} />
+
+:::note[--z-local-N is reusable]
+The same `--z-local-1` token applies to every isolated parent. There is no need for `--z-card-bg` or `--z-modal-content` local tokens — local tiers are anonymous helpers, not semantic per-component values.
+:::
+
+<CssPreview
+  client:load
+  title="Sibling-Ordered Global Overlays"
+  height={320}
+  html={`    <div class="zsib-demo">
+      <div class="zsib-demo__content">Page content (no z-index)</div>
+      <div class="zsib-demo__toolbar">Toolbar — var(--z-toolbar)</div>
+      <div class="zsib-demo__modal">Modal — var(--z-modal)</div>
+      <div class="zsib-demo__tooltip">Tooltip — var(--z-tooltip)</div>
+    </div>`}
+  css={`    .zsib-demo {
+      position: relative;
+      height: 280px;
+      padding: 1rem;
+      font-family: system-ui, sans-serif;
+      font-size: 0.8rem;
+      background: hsl(210 20% 96%);
+      border-radius: 8px;
+      overflow: hidden;
+      --z-toolbar: 10;
+      --z-modal: 60;
+      --z-tooltip: 80;
+    }
+    .zsib-demo__content {
+      position: absolute;
+      inset: 1rem;
+      padding: 0.6rem;
+      background: hsl(0 0% 100%);
+      border: 1px solid hsl(214 32% 88%);
+      color: hsl(215 16% 35%);
+      border-radius: 6px;
+    }
+    .zsib-demo__toolbar {
+      position: absolute;
+      top: 1rem;
+      left: 1rem;
+      right: 1rem;
+      z-index: var(--z-toolbar);
+      padding: 0.5rem 0.75rem;
+      background: hsl(220 80% 50%);
+      color: hsl(0 0% 100%);
+      border-radius: 6px;
+      font-weight: 600;
+    }
+    .zsib-demo__modal {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      z-index: var(--z-modal);
+      padding: 1rem 1.5rem;
+      background: hsl(280 60% 45%);
+      color: hsl(0 0% 100%);
+      border-radius: 8px;
+      font-weight: 700;
+      box-shadow: 0 8px 24px hsl(222 47% 11% / 0.25);
+    }
+    .zsib-demo__tooltip {
+      position: absolute;
+      bottom: 1rem;
+      right: 1rem;
+      z-index: var(--z-tooltip);
+      padding: 0.4rem 0.6rem;
+      background: hsl(0 0% 10%);
+      color: hsl(0 0% 100%);
+      border-radius: 4px;
+      font-size: 0.75rem;
+    }`} />
+
+## Lint enforcement
+
+A token system that is not enforced is a token system that decays. Add a lint rule that forbids raw `z-index: <integer>` in component CSS.
+
+| Allowed | Forbidden |
+| --- | --- |
+| `z-index: var(--z-modal);` | `z-index: 100;` |
+| `z-index: calc(var(--z-modal) + 1);` | `z-index: 999;` |
+| `z-index: auto;` / `inherit;` / `initial;` | `z-index: 9999;` |
+| Raw integer with `/* design-token-lint-ignore */` escape hatch | Bare raw integer with no escape comment |
+
+The escape hatch matters. Some legitimate cases (a one-off third-party widget integration, an experimental layer) need a raw integer with a code comment explaining why — block by default, but do not block forever.
+
+For the full multi-pass linter pattern (raw color literals, zone-aware semantic tokens, and the matching enforcement rules for other token families), see [Design Token Lint](../architecture/design-token-lint.mdx). Pass 3 covers the raw-z-index rule documented above.
+
+:::info[Pre-push wiring]
+Add both `pnpm check:z-index` (codegen drift) and the lint rule (raw `z-index:` integers) to a pre-push hook. The drift check catches stale generated CSS; the lint check catches new violations. Together they prevent the system from rotting between PRs.
+:::
+
+## Decision tree: where does my new overlay belong?
+
+```
+Is the new layer a stacking promotion *inside* a parent that has its own
+stacking context (isolation: isolate, position+z-index, transform, etc.)?
+│
+├── YES → use --z-local-1 / --z-local-2 / --z-local-3
+│         (No global tier needed. The parent's stacking context contains it.)
+│
+└── NO  → it is a global UI layer
+          │
+          ├── Does it already match a tier? (modal, toast, tooltip, popover, ...)
+          │   │
+          │   ├── YES → use that tier's token
+          │   │
+          │   └── NO  → add a new tier to z-index-tokens.ts, run pnpm gen:z-index,
+          │              then use the new token. Update the styleguide automatically.
+          │
+          └── If you find yourself adding more than 1-2 tiers per quarter, the tier
+              list is probably too granular — review whether existing tiers cover it.
+```
+
+### Portal vs inline decision
+
+A popover anchored to a button can render either inline (in the button's DOM subtree) or portaled (appended to `<body>`). The choice changes which token applies.
+
+| Situation | Render mode | Token |
+| --- | --- | --- |
+| Anchor element has no stacking-context ancestor between it and `<html>` | Inline | `--z-popover` |
+| Anchor element is inside a stacking context (modal, isolated card, transform parent) and the popover must escape | Portaled to `<body>` | `--z-popover-portaled` |
+| Popover must always sit above a modal | Portaled | `--z-popover-portaled` (placed above `--z-modal` in the scale) |
+
+Walk up the DOM from the anchor to the root; if any ancestor creates a stacking context, the inline popover will be trapped inside it. See [Stacking Context](../../layout/positioning/stacking-context.mdx) for the full list of properties that create one.
+
+## Common AI Mistakes
+
+- **Defining a numeric scale (`--z-50`, `--z-100`, `--z-200`).** This recreates the Tailwind-numeric problem with custom property syntax. Names should describe roles, not magnitudes.
+- **Hardcoding `z-index: 100` "because bigger".** The fix to a layering bug is almost never a higher number — it is understanding which stacking context the element lives in. See [Stacking Context](../../layout/positioning/stacking-context.mdx).
+- **Using `--z-local-N` outside a stacking context.** Without an isolated parent, `--z-local-1` participates in the root stacking context and competes against global tiers. Either add `isolation: isolate` to the parent, or use a global tier.
+- **Defining `--z-emergency: 99999`.** The "emergency" tier is the bug, not the fix. If a layer needs to escape its parent, fix the stacking context. If a real new tier is needed, add it to the named scale at the right position.
+- **Splitting z-index into per-context namespaces (`--z-myweb-modal`, `--z-myadmin-modal`).** The viewport is one ordering universe. Multi-namespace makes sense for density tokens but not for z-index.
+- **Hand-editing the generated CSS marker block.** Edit `z-index-tokens.ts` and re-run `pnpm gen:z-index`. Hand edits are wiped on next codegen and cause `pnpm check:z-index` to fail in CI.
+- **Skipping the lint rule.** Without enforcement, raw `z-index: 100` reappears within a sprint and the system slowly returns to magic-number chaos.
+
+## When to Use
+
+### Good fit
+
+- **Projects with 5+ overlay types** — once modal, drawer, popover, tooltip, toast, and a sticky toolbar coexist, ad-hoc numbers stop scaling
+- **Multi-team codebases** — a shared semantic scale prevents one team's `z-index: 100` from colliding with another team's `z-index: 200`
+- **Projects with a styleguide / design system page** — the generated table becomes the canonical reference for designers and developers
+
+### Not needed
+
+- **Prototypes and single-overlay sites** — a marketing landing page with one mobile menu does not need a tier system
+- **Static content sites** — blog and documentation sites with no overlays beyond the menu can use `z-index: 1` and stop there
+- **One-off internal tools** — if the entire app has three z-index values total, the tier system is overhead
+
+## References
+
+- [Stacking Context](../../layout/positioning/stacking-context.mdx) — what creates a stacking context and how to debug layering bugs
+- [Multi Namespace Token Strategy](./multi-namespace-token-strategy.mdx) — companion strategy for density tokens (spacing, font sizes); contrast with z-index's single-namespace rule
+- [pgen worked example (zudo-pattern-gen #940)](https://github.com/zudolab/zudo-pattern-gen/issues/940) — concrete migration from magic numbers to the tier-token system

--- a/e2e/smoke-search-dialog-close.spec.ts
+++ b/e2e/smoke-search-dialog-close.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures";
 
 /**
  * Regression spec for epic #2148 — the two linked search-dialog defects:
@@ -24,7 +24,10 @@ import { test, expect } from "@playwright/test";
 const DOCS_PAGE = "/docs/getting-started";
 
 test.describe("Search dialog closes on result click (#2148)", () => {
-  test("clicking a result closes the dialog AND navigates", async ({ page }) => {
+  test("clicking a result closes the dialog AND navigates", async ({
+    page,
+    assertNoConsoleErrors,
+  }) => {
     await page.goto(DOCS_PAGE, { waitUntil: "domcontentloaded" });
 
     const startUrl = page.url();
@@ -51,6 +54,11 @@ test.describe("Search dialog closes on result click (#2148)", () => {
     // (a) Dialog is closed. Assert via both the visibility locator and the
     // native <dialog>.open property (showModal/close drives `open`).
     await expect(dialog).not.toBeVisible({ timeout: 5000 });
+    // The <dialog> element itself must still exist after the SPA swap (the
+    // header persists across same-locale swaps via data-zfb-transition-persist).
+    // Assert presence first so a missing element gives a clear diagnostic rather
+    // than an opaque `expect(null).toBe(false)`.
+    await expect(dialog).toHaveCount(1);
     const dialogOpen = await page.evaluate(() => {
       const d = document.querySelector<HTMLDialogElement>("[data-search-dialog]");
       return d ? d.open : null;
@@ -68,5 +76,8 @@ test.describe("Search dialog closes on result click (#2148)", () => {
 
     // The dialog stays closed after the swap settles (no flash / re-open).
     await expect(dialog).not.toBeVisible();
+
+    // No errors thrown during close + SPA swap (e.g. inside closeDialog()).
+    assertNoConsoleErrors();
   });
 });

--- a/e2e/smoke-search-dialog-close.spec.ts
+++ b/e2e/smoke-search-dialog-close.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Regression spec for epic #2148 — the two linked search-dialog defects:
+ *
+ *   1. Clicking a search result did NOT close the <dialog>. Result links are
+ *      plain <a> created in renderResult(); nothing closed the dialog, so under
+ *      zfb Strategy-B SPA navigation (`zfb:after-swap`) the page body swapped
+ *      while the open <dialog> lingered.
+ *   2. Overlay z-index flash: an open native showModal() dialog can lose its
+ *      top-layer promotion during the SPA swap and fall back to z-index:auto,
+ *      flashing behind the header/sidebar.
+ *
+ * The fix wires a delegated click handler on the results container that calls
+ * closeDialog() on any result-link activation (WITHOUT preventDefault, so SPA
+ * navigation still proceeds), plus an `zfb:after-swap` backstop that closes the
+ * dialog if it is somehow still open after a body swap.
+ *
+ * This spec asserts BOTH outcomes after a result click:
+ *   (a) the dialog is closed, and
+ *   (b) navigation actually occurred (URL changed to the result page).
+ */
+
+const DOCS_PAGE = "/docs/getting-started";
+
+test.describe("Search dialog closes on result click (#2148)", () => {
+  test("clicking a result closes the dialog AND navigates", async ({ page }) => {
+    await page.goto(DOCS_PAGE, { waitUntil: "domcontentloaded" });
+
+    const startUrl = page.url();
+
+    // Open search and type a query that yields results.
+    await page.keyboard.press("Control+k");
+    const dialog = page.locator("[data-search-dialog]");
+    await expect(dialog).toBeVisible();
+
+    const input = page.locator("[data-search-input]");
+    await expect(input).toBeFocused({ timeout: 3000 });
+    await input.fill("Guides");
+
+    // Wait for at least one result link (index loads async).
+    const firstResultLink = page.locator("[data-search-results] article a").first();
+    await expect(firstResultLink).toBeVisible({ timeout: 10000 });
+
+    const href = await firstResultLink.getAttribute("href");
+    expect(href, "result link should have a real href").toBeTruthy();
+
+    // Click the result — must NOT preventDefault, so navigation proceeds.
+    await firstResultLink.click();
+
+    // (a) Dialog is closed. Assert via both the visibility locator and the
+    // native <dialog>.open property (showModal/close drives `open`).
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+    const dialogOpen = await page.evaluate(() => {
+      const d = document.querySelector<HTMLDialogElement>("[data-search-dialog]");
+      return d ? d.open : null;
+    });
+    expect(dialogOpen, "native <dialog>.open should be false after result click").toBe(false);
+
+    // (b) Navigation occurred — URL changed to the result page.
+    await page.waitForURL(
+      new RegExp(href!.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+      { timeout: 5000 },
+    );
+    expect(page.url(), "URL should have changed away from the starting page").not.toBe(
+      startUrl,
+    );
+
+    // The dialog stays closed after the swap settles (no flash / re-open).
+    await expect(dialog).not.toBeVisible();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "setup:zudo-doc-wisdom": "bash scripts/setup-zudo-doc-wisdom.sh",
     "// ── Linting ─────────────────────────────────────": "",
     "lint:tokens": "design-token-lint",
+    "gen:z-index": "node scripts/gen-z-index.mjs",
+    "check:z-index": "node scripts/gen-z-index.mjs --check",
     "check:template-drift": "bash scripts/check-template-drift.sh",
     "check:fixture-settings-drift": "node scripts/check-fixture-settings-drift.mjs",
     "check:pin-parity": "node scripts/check-pin-parity.mjs",

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -1686,6 +1686,16 @@ describe("scaffold — plugin copying and settings", () => {
     );
   });
 
+  it("includes z-index codegen scripts (#2148)", async () => {
+    const pkg = await fs.readJson(
+      projectPath("test-minimal", "package.json"),
+    );
+    expect(pkg.scripts["gen:z-index"]).toBe("node scripts/gen-z-index.mjs");
+    expect(pkg.scripts["check:z-index"]).toBe(
+      "node scripts/gen-z-index.mjs --check",
+    );
+  });
+
   it("does not emit check:pages (host-only gate — template stubs not type-clean, #2018)", async () => {
     const pkg = await fs.readJson(
       projectPath("test-minimal", "package.json"),

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -470,6 +470,12 @@ function generatePackageJson(choices: UserChoices) {
     // the pages/lib call sites, so emitting the script would fail on a fresh
     // scaffold. Revisit once the template stubs carry typed props.
     "check:html": "html-validate \"dist/**/*.html\"",
+    // Z-index token codegen (#2148): regenerate the GENERATED:Z_INDEX @theme
+    // block in src/styles/global.css from src/config/z-index-tokens.ts, and a
+    // drift check for pre-push/CI. Both ship in base — the z-index token system
+    // is part of every scaffold.
+    "gen:z-index": "node scripts/gen-z-index.mjs",
+    "check:z-index": "node scripts/gen-z-index.mjs --check",
   };
 
   if (choices.features.includes("tagGovernance")) {

--- a/packages/create-zudo-doc/templates/base/pages/lib/_search-widget-script.ts
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_search-widget-script.ts
@@ -135,6 +135,10 @@ export const SEARCH_WIDGET_SCRIPT = /* javascript */ `(function () {
       this._shortcut = "";
       this._resultCountTemplate = "";
       this._keydownHandler = null;
+      // Delegated click handler on the results container: closing the dialog
+      // when a result link is activated (epic #2148). Held so disconnectedCallback
+      // can detach it on body swap.
+      this._resultsClickHandler = null;
       this._observer = null;
       this._sentinel = null;
       this._isLoadingBatch = false;
@@ -191,6 +195,24 @@ export const SEARCH_WIDGET_SCRIPT = /* javascript */ `(function () {
         this._input.addEventListener("input", function() { self.handleInput(); });
       }
 
+      // Close-on-result-click (epic #2148): result links are created dynamically
+      // in renderResult(), so use one delegated listener on the results container
+      // instead of per-link handlers. We do NOT preventDefault — the link's own
+      // navigation (zfb Strategy-B SPA swap or a plain load) must still proceed;
+      // we only close the <dialog> so it does not linger over the swapped page.
+      // closeDialog() runs synchronously before navigation; the dialog's close
+      // restores documentElement overflow via the existing "close" listener.
+      if (this._results) {
+        this._resultsClickHandler = function(e) {
+          var t = e.target;
+          while (t && t !== self._results) {
+            if (t.tagName === "A") { self.closeDialog(); return; }
+            t = t.parentNode;
+          }
+        };
+        this._results.addEventListener("click", this._resultsClickHandler);
+      }
+
       // Global keyboard shortcut (⌘K / Ctrl+K to open)
       this._keydownHandler = function(e) {
         if ((e.metaKey || e.ctrlKey) && e.key === "k") {
@@ -205,6 +227,11 @@ export const SEARCH_WIDGET_SCRIPT = /* javascript */ `(function () {
       // body swap when this element is NOT persisted via
       // data-zfb-transition-persist (zudolab/zudo-doc#1523).
       this._afterNavHandler = function() {
+        // Backstop for the original bug (epic #2148): if the dialog is somehow
+        // still open after an SPA body swap (e.g. a nav path that bypassed the
+        // result-click handler), close it so it does not linger / flash over the
+        // newly-swapped page. Safe no-op when already closed.
+        if (self._dialog && self._dialog.open) self.closeDialog();
         var kbdEl2 = self.querySelector("[data-kbd-shortcut]");
         if (kbdEl2) kbdEl2.textContent = self._shortcut;
       };
@@ -219,6 +246,10 @@ export const SEARCH_WIDGET_SCRIPT = /* javascript */ `(function () {
       if (this._afterNavHandler) {
         document.removeEventListener(${JSON.stringify(AFTER_NAVIGATE_EVENT)}, this._afterNavHandler);
         this._afterNavHandler = null;
+      }
+      if (this._resultsClickHandler && this._results) {
+        this._results.removeEventListener("click", this._resultsClickHandler);
+        this._resultsClickHandler = null;
       }
       this.teardownSentinel();
     }

--- a/packages/create-zudo-doc/templates/base/pages/lib/_search-widget.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_search-widget.tsx
@@ -88,9 +88,17 @@ export function SearchWidget(props: SearchWidgetProps): JSX.Element {
             static HTML for no-JS users and crawlers. The browser treats
             it as a closed <dialog> until the custom element calls
             showModal(). */}
+        {/* z-modal / backdrop:z-modal-backdrop are defense-in-depth for the
+            SPA-swap window (zfb Strategy-B `zfb:after-swap`): a native
+            showModal() dialog normally sits in the top layer, but if it is
+            still open while the page body is swapped it can lose top-layer
+            promotion and fall back to z-index:auto, flashing behind the
+            header/sidebar. The explicit modal-tier z-index keeps it above all
+            chrome during that window. Intentionally redundant in the normal
+            (top-layer) case — do not remove as "redundant" (epic #2148). */}
         <dialog
           data-search-dialog
-          class="m-0 h-full w-full max-w-none border-none bg-transparent p-0 backdrop:bg-overlay/60 sm:mx-auto sm:my-[10vh] sm:h-auto sm:max-h-[80vh] sm:max-w-[52rem] sm:rounded-lg"
+          class="z-modal m-0 h-full w-full max-w-none border-none bg-transparent p-0 backdrop:z-modal-backdrop backdrop:bg-overlay/60 sm:mx-auto sm:my-[10vh] sm:h-auto sm:max-h-[80vh] sm:max-w-[52rem] sm:rounded-lg"
         >
           <div class="flex h-full flex-col overflow-hidden bg-surface sm:rounded-lg sm:border sm:border-muted">
             {/* ── Dialog header (input row) ─────────────────────────── */}

--- a/packages/create-zudo-doc/templates/base/scripts/gen-z-index.mjs
+++ b/packages/create-zudo-doc/templates/base/scripts/gen-z-index.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+// scripts/gen-z-index.mjs
+//
+// Codegen: rewrite the GENERATED:Z_INDEX marker block inside
+// src/styles/global.css from the single source of truth in
+// src/config/z-index-tokens.ts.
+//
+// The block is a Tailwind v4 `@theme { --z-index-<name>: <value>; }` for every
+// tier, so Tailwind generates `z-<name>` utilities (e.g. `--z-index-toolbar: 20`
+// → `.z-toolbar { z-index: 20 }`) and raw CSS can reference the same var via
+// `z-index: var(--z-index-<name>)`.
+//
+// Pure Node (fs only — NO npm deps). Idempotent: running twice produces no diff.
+//
+// Usage:
+//   node scripts/gen-z-index.mjs           # rewrite the block in global.css
+//   node scripts/gen-z-index.mjs --check   # verify committed block is up to date
+//                                          # (exit 1 on drift, no write)
+//
+// MAINTENANCE: edit src/config/z-index-tokens.ts (the source of truth), then run
+// `pnpm gen:z-index` and commit the regenerated global.css. Never hand-edit the
+// block between the BEGIN/END markers.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+
+const TOKENS_PATH = resolve(ROOT, "src/config/z-index-tokens.ts");
+const CSS_PATH = resolve(ROOT, "src/styles/global.css");
+
+const BEGIN_MARKER = "GENERATED:Z_INDEX_BEGIN";
+const END_MARKER = "GENERATED:Z_INDEX_END";
+
+/**
+ * Parse the Z_INDEX_TIERS array out of z-index-tokens.ts WITHOUT importing it
+ * (this script is a dependency-free .mjs and cannot resolve TypeScript). Reads
+ * each `{ name: "...", value: <n>, ... }` object literal. Throws on a malformed
+ * source so drift between the parser and the file surfaces loudly.
+ */
+function parseTiers(src) {
+  const arrayMatch = src.match(
+    /export const Z_INDEX_TIERS[^=]*=\s*\[([\s\S]*?)\];/,
+  );
+  if (!arrayMatch) {
+    throw new Error(
+      `Could not locate "export const Z_INDEX_TIERS = [ ... ]" in ${TOKENS_PATH}`,
+    );
+  }
+  const body = arrayMatch[1];
+  const tiers = [];
+  // Each tier is a `{ ... }` object literal; iterate top-level braces.
+  const objectRe = /\{([\s\S]*?)\}/g;
+  let m;
+  while ((m = objectRe.exec(body)) !== null) {
+    const obj = m[1];
+    const nameMatch = obj.match(/name:\s*"([^"]+)"/);
+    const valueMatch = obj.match(/value:\s*(-?\d+)/);
+    if (!nameMatch || !valueMatch) {
+      throw new Error(
+        `Malformed tier object in Z_INDEX_TIERS (missing name/value): ${obj.trim()}`,
+      );
+    }
+    tiers.push({ name: nameMatch[1], value: Number(valueMatch[1]) });
+  }
+  if (tiers.length === 0) {
+    throw new Error(`Z_INDEX_TIERS in ${TOKENS_PATH} parsed to an empty list`);
+  }
+  return tiers;
+}
+
+/**
+ * Build the full generated block (markers included). Two leading spaces of
+ * indentation match the surrounding `@theme` style in global.css.
+ */
+function buildBlock(tiers) {
+  const lines = [];
+  lines.push(`  /* ${BEGIN_MARKER}`);
+  lines.push(
+    `   * GENERATED:Z_INDEX — do not hand-edit; run pnpm gen:z-index.`,
+  );
+  lines.push(
+    `   * Source of truth: src/config/z-index-tokens.ts. Tailwind v4 reads the`,
+  );
+  lines.push(
+    `   * --z-index-<name> theme key and generates a z-<name> utility. */`,
+  );
+  lines.push(`  @theme {`);
+  for (const tier of tiers) {
+    lines.push(`    --z-index-${tier.name}: ${tier.value};`);
+  }
+  lines.push(`  }`);
+  lines.push(`  /* ${END_MARKER} */`);
+  return lines.join("\n");
+}
+
+/**
+ * Replace the existing BEGIN…END block in `css` with `block`. Throws if the
+ * markers are missing (the block must be seeded once by hand — see global.css).
+ */
+function replaceBlock(css, block) {
+  const beginIdx = css.indexOf(BEGIN_MARKER);
+  const endIdx = css.indexOf(END_MARKER);
+  if (beginIdx === -1 || endIdx === -1) {
+    throw new Error(
+      `Could not find ${BEGIN_MARKER} … ${END_MARKER} markers in ${CSS_PATH}.\n` +
+        `Seed the marker block once by hand, then re-run the generator.`,
+    );
+  }
+  // Expand to the full comment line that opens the block ("  /* GENERATED:...")
+  // and to the end of the closing "*/ " line so the whole region is replaced.
+  const lineStart = css.lastIndexOf("\n", beginIdx) + 1;
+  const afterEnd = css.indexOf("\n", endIdx);
+  const lineEnd = afterEnd === -1 ? css.length : afterEnd;
+  return css.slice(0, lineStart) + block + css.slice(lineEnd);
+}
+
+function main() {
+  const check = process.argv.includes("--check");
+
+  const tokensSrc = readFileSync(TOKENS_PATH, "utf8");
+  const css = readFileSync(CSS_PATH, "utf8");
+
+  const tiers = parseTiers(tokensSrc);
+  const block = buildBlock(tiers);
+  const next = replaceBlock(css, block);
+
+  if (check) {
+    if (next !== css) {
+      console.error(
+        "z-index codegen drift detected: src/styles/global.css is out of date.",
+      );
+      console.error("Run `pnpm gen:z-index` and commit the result.");
+      return 1;
+    }
+    console.log(
+      `OK — z-index @theme block is up to date (${tiers.length} tiers).`,
+    );
+    return 0;
+  }
+
+  if (next === css) {
+    console.log(
+      `z-index @theme block already up to date (${tiers.length} tiers); no change.`,
+    );
+    return 0;
+  }
+  writeFileSync(CSS_PATH, next);
+  console.log(
+    `Wrote z-index @theme block to src/styles/global.css (${tiers.length} tiers).`,
+  );
+  return 0;
+}
+
+process.exit(main());

--- a/packages/create-zudo-doc/templates/base/src/components/sidebar-toggle.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/sidebar-toggle.tsx
@@ -126,7 +126,7 @@ export default function SidebarToggle({
           the SSR DOM tree matches the hydrated tree (no subtree
           mount/unmount across the hydration boundary). */}
       <div
-        className={clsx("fixed inset-0 z-30 bg-overlay/30 lg:hidden", !open && "hidden")}
+        className={clsx("fixed inset-0 z-modal-backdrop bg-overlay/30 lg:hidden", !open && "hidden")}
         aria-hidden={!open}
         onClick={() => setOpen(false)}
       />
@@ -141,7 +141,7 @@ export default function SidebarToggle({
       <aside
         inert={!open}
         className={`
-          fixed top-[3.5rem] left-0 z-40 h-[calc(100vh-3.5rem)] w-[16rem] flex flex-col
+          fixed top-[3.5rem] left-0 z-modal h-[calc(100vh-3.5rem)] w-[16rem] flex flex-col
           border-r border-muted bg-bg transition-transform duration-200
           lg:hidden
           ${open ? "translate-x-0" : "-translate-x-full"}

--- a/packages/create-zudo-doc/templates/base/src/components/sidebar-toggle.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/sidebar-toggle.tsx
@@ -124,7 +124,12 @@ export default function SidebarToggle({
       {/* Backdrop overlay - mobile only.
           Rendered unconditionally; CSS `hidden` toggles visibility so
           the SSR DOM tree matches the hydrated tree (no subtree
-          mount/unmount across the hydration boundary). */}
+          mount/unmount across the hydration boundary).
+          `z-modal-backdrop` (50) intentionally sits ABOVE the header
+          (`z-toolbar`, 20): the open mobile drawer is a modal surface that
+          dims the whole viewport, header included. Closing is via tapping the
+          backdrop (onClick below), so the header hamburger being dimmed under
+          it is fine. */}
       <div
         className={clsx("fixed inset-0 z-modal-backdrop bg-overlay/30 lg:hidden", !open && "hidden")}
         aria-hidden={!open}

--- a/packages/create-zudo-doc/templates/base/src/components/sidebar-tree.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/sidebar-tree.tsx
@@ -419,7 +419,7 @@ function CategoryNode({
     <div className={`${depth === 0 ? "border-t border-muted" : ""} ${depth >= 1 && !isLast ? "relative" : ""}`}>
       {depth >= 1 && !isLast && isExpanded && (
         <div
-          className="absolute border-l border-solid border-muted z-10"
+          className="absolute border-l border-solid border-muted z-local-1"
           style={{
             left: connectorLeft(depth),
             top: 0,

--- a/packages/create-zudo-doc/templates/base/src/components/site-tree-nav.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/site-tree-nav.tsx
@@ -118,7 +118,7 @@ function CategoryNode({
     <div className={`${depth >= 1 && !isLast ? "relative" : ""}`}>
       {depth >= 1 && !isLast && open && (
         <div
-          className="absolute border-l border-dashed border-muted z-10"
+          className="absolute border-l border-dashed border-muted z-local-1"
           style={{
             left: connectorLeft(depth),
             top: 0,

--- a/packages/create-zudo-doc/templates/base/src/config/z-index-tokens.ts
+++ b/packages/create-zudo-doc/templates/base/src/config/z-index-tokens.ts
@@ -114,7 +114,7 @@ export const Z_INDEX_TIERS: ZIndexTier[] = [
     name: "tooltip",
     value: 80,
     purpose:
-      "reserved — highest steady UI layer (canonical scale; not yet used)",
+      "reserved — highest steady UI layer, below only the transient drag tier (canonical scale; not yet used)",
     kind: "global",
   },
   {

--- a/packages/create-zudo-doc/templates/base/src/config/z-index-tokens.ts
+++ b/packages/create-zudo-doc/templates/base/src/config/z-index-tokens.ts
@@ -1,0 +1,127 @@
+// z-index design tokens — single source of truth.
+//
+// This file is the ONE place z-index tiers are defined. The CSS `@theme` block
+// in `src/styles/global.css` is GENERATED from this list by
+// `scripts/gen-z-index.mjs` (run `pnpm gen:z-index`); never hand-edit the
+// generated block. `pnpm check:z-index` re-runs the generator into a buffer and
+// fails on drift, so the committed CSS can never silently diverge from this list.
+//
+// Strategy (from zudolab/zudo-css-wisdom z-index-strategy): semantic single-
+// namespace tokens — names describe ROLES, never magnitudes. One flat ordered
+// list. Values are deliberately gapped but otherwise arbitrary: renaming and
+// reordering is cheap, which is the whole point. Tailwind v4 reads the
+// `--z-index-<name>` theme key and generates a `z-<name>` utility, so e.g.
+// `@theme { --z-index-toolbar: 20 }` produces `.z-toolbar { z-index: 20 }`.
+//
+// `kind` distinguishes:
+//   - "global": a tier on the single global stacking scale (overlay chrome etc.)
+//   - "local":  anonymous reusable helpers for promoting a child WITHIN a parent
+//               stacking context (`isolation: isolate` / `position: relative`),
+//               not a position on the global scale.
+//
+// Rationale for the two zudo-doc-specific additions (NOT in the generic
+// overlay-centric strategy scale):
+//   - `sidebar` — persistent layout chrome (desktop sidebar, TOC, sidebar-toggle
+//     handle, resizer handle). The strategy's scale has no persistent-sidebar/TOC
+//     tier. `toolbar` (the sticky header) is deliberately placed ABOVE `sidebar`
+//     to preserve the existing header-wins ordering; they do not overlap
+//     spatially, but the historical relationship is kept explicit.
+//   - `drag` — transient drag affordance (sidebar-resizer ghost line). Replaces
+//     the old `z-9999` anti-pattern with a named top-of-steady-UI tier.
+//
+// `popover`, `toast`, and `tooltip` are reserved canonical tiers from the
+// strategy's scale — kept for completeness (and so downstream `create-zudo-doc`
+// users inherit the full scale) even though zudo-doc does not use them yet.
+
+export type ZIndexKind = "global" | "local";
+
+export interface ZIndexTier {
+  name: string;
+  value: number;
+  purpose: string;
+  kind: ZIndexKind;
+}
+
+export const Z_INDEX_TIERS: ZIndexTier[] = [
+  {
+    name: "content",
+    value: 0,
+    purpose: "default in-flow content (implicit baseline)",
+    kind: "global",
+  },
+  {
+    name: "local-1",
+    value: 1,
+    purpose: "child promotion inside an isolated parent stacking context",
+    kind: "local",
+  },
+  {
+    name: "local-2",
+    value: 2,
+    purpose: "child promotion inside an isolated parent stacking context",
+    kind: "local",
+  },
+  {
+    name: "local-3",
+    value: 3,
+    purpose: "child promotion inside an isolated parent stacking context",
+    kind: "local",
+  },
+  {
+    name: "sidebar",
+    value: 10,
+    purpose:
+      "persistent layout chrome: desktop sidebar, TOC, sidebar-toggle handle, resizer handle",
+    kind: "global",
+  },
+  {
+    name: "toolbar",
+    value: 20,
+    purpose: "sticky top header (sits above sidebar chrome)",
+    kind: "global",
+  },
+  {
+    name: "dropdown",
+    value: 30,
+    purpose: "header menus, version/language switchers",
+    kind: "global",
+  },
+  {
+    name: "popover",
+    value: 40,
+    purpose: "reserved — inline popovers (canonical scale; not yet used)",
+    kind: "global",
+  },
+  {
+    name: "modal-backdrop",
+    value: 50,
+    purpose: "mobile drawer backdrop, <dialog> ::backdrop",
+    kind: "global",
+  },
+  {
+    name: "modal",
+    value: 60,
+    purpose: "mobile sidebar drawer panel, search <dialog>",
+    kind: "global",
+  },
+  {
+    name: "toast",
+    value: 70,
+    purpose: "reserved — transient notifications (canonical scale; not yet used)",
+    kind: "global",
+  },
+  {
+    name: "tooltip",
+    value: 80,
+    purpose:
+      "reserved — highest steady UI layer (canonical scale; not yet used)",
+    kind: "global",
+  },
+  {
+    name: "drag",
+    value: 90,
+    purpose:
+      "transient drag affordance: sidebar-resizer ghost line (replaces the z-9999 anti-pattern)",
+    kind: "global",
+  },
+];

--- a/packages/create-zudo-doc/templates/base/src/styles/global.css
+++ b/packages/create-zudo-doc/templates/base/src/styles/global.css
@@ -727,7 +727,7 @@ pre[class^="syntect-"].word-wrap code {
   gap: var(--spacing-hsp-2xs);
   opacity: 0;
   transition: opacity 0.15s;
-  z-index: 1;
+  z-index: var(--z-index-local-1);
 }
 
 .code-block-wrapper:hover .code-buttons,
@@ -1183,7 +1183,7 @@ pre[class^="syntect-"] .line .highlighted-word {
   border: none;
   background: transparent;
   cursor: pointer;
-  z-index: 1;
+  z-index: var(--z-index-local-1);
   transition: opacity var(--default-transition-duration);
 }
 
@@ -1192,12 +1192,12 @@ pre[class^="syntect-"] .line .highlighted-word {
   position: absolute;
   inset: 0;
   background: color-mix(in oklch, var(--color-image-overlay-bg) 80%, transparent);
-  z-index: 0;
+  z-index: var(--z-index-local-1);
 }
 
 .zd-enlarge-btn > svg {
   position: relative;
-  z-index: 1;
+  z-index: var(--z-index-local-2);
   width: var(--spacing-icon-sm);
   height: var(--spacing-icon-sm);
   color: var(--color-image-overlay-fg);
@@ -1232,7 +1232,7 @@ dialog.zd-enlarge-dialog::backdrop {
   border: none;
   background: transparent;
   cursor: pointer;
-  z-index: 1;
+  z-index: var(--z-index-local-1);
   transition: opacity var(--default-transition-duration);
 }
 
@@ -1245,12 +1245,12 @@ dialog.zd-enlarge-dialog::backdrop {
   position: absolute;
   inset: 0;
   background: color-mix(in oklch, var(--color-image-overlay-bg) 80%, transparent);
-  z-index: 0;
+  z-index: var(--z-index-local-1);
 }
 
 .zd-enlarge-dialog-close > svg {
   position: relative;
-  z-index: 1;
+  z-index: var(--z-index-local-2);
   width: var(--spacing-icon-lg);
   height: var(--spacing-icon-lg);
   color: var(--color-image-overlay-fg);

--- a/packages/create-zudo-doc/templates/base/src/styles/global.css
+++ b/packages/create-zudo-doc/templates/base/src/styles/global.css
@@ -216,6 +216,37 @@
   --breakpoint-xl: 1280px;
 }
 
+/* ========================================
+ * Z-index tiers — semantic, single-namespace scale.
+ *
+ * The @theme block below is GENERATED from src/config/z-index-tokens.ts
+ * (the single source of truth) by `pnpm gen:z-index`. Tailwind v4 reads the
+ * --z-index-<name> theme key and generates a `z-<name>` utility, so e.g.
+ * --z-index-toolbar: 20 produces `.z-toolbar { z-index: 20 }`; raw CSS can
+ * also reference `z-index: var(--z-index-<name>)`. `pnpm check:z-index` fails
+ * on drift. Do NOT hand-edit between the BEGIN/END markers.
+ * ======================================== */
+  /* GENERATED:Z_INDEX_BEGIN
+   * GENERATED:Z_INDEX — do not hand-edit; run pnpm gen:z-index.
+   * Source of truth: src/config/z-index-tokens.ts. Tailwind v4 reads the
+   * --z-index-<name> theme key and generates a z-<name> utility. */
+  @theme {
+    --z-index-content: 0;
+    --z-index-local-1: 1;
+    --z-index-local-2: 2;
+    --z-index-local-3: 3;
+    --z-index-sidebar: 10;
+    --z-index-toolbar: 20;
+    --z-index-dropdown: 30;
+    --z-index-popover: 40;
+    --z-index-modal-backdrop: 50;
+    --z-index-modal: 60;
+    --z-index-toast: 70;
+    --z-index-tooltip: 80;
+    --z-index-drag: 90;
+  }
+  /* GENERATED:Z_INDEX_END */
+
 :root {
   /* Default responsive range; sidebar-resizer.ts allows 192–448px for explicit resizing */
   --zd-sidebar-w: clamp(14rem, 20vw, 22rem);

--- a/packages/create-zudo-doc/templates/features/sidebarToggle/files/src/components/desktop-sidebar-toggle.tsx
+++ b/packages/create-zudo-doc/templates/features/sidebarToggle/files/src/components/desktop-sidebar-toggle.tsx
@@ -101,7 +101,7 @@ export default function DesktopSidebarToggle() {
     <button
       type="button"
       onClick={() => setVisible((v) => !v)}
-      className="zd-desktop-sidebar-toggle hidden lg:flex fixed bottom-vsp-xl z-40 items-center justify-center w-[1.5rem] h-[3rem] bg-surface border border-muted border-l-0 rounded-r-DEFAULT text-muted cursor-pointer transition-[left,color] duration-200 ease-in-out hover:text-fg"
+      className="zd-desktop-sidebar-toggle hidden lg:flex fixed bottom-vsp-xl z-sidebar items-center justify-center w-[1.5rem] h-[3rem] bg-surface border border-muted border-l-0 rounded-r-DEFAULT text-muted cursor-pointer transition-[left,color] duration-200 ease-in-out hover:text-fg"
       aria-label={visible ? 'Hide sidebar' : 'Show sidebar'}
       aria-pressed={visible}
       data-zfb-transition-persist="desktop-sidebar-toggle"

--- a/packages/create-zudo-doc/templates/features/tauri/files/src/components/find-bar.tsx
+++ b/packages/create-zudo-doc/templates/features/tauri/files/src/components/find-bar.tsx
@@ -70,7 +70,7 @@ export function FindBar({ visible, onClose, findInPage, containerSelector }: Fin
   if (!visible) return null;
 
   return (
-    <div className="fixed top-[3.5rem] right-0 z-50 flex items-center gap-hsp-sm py-hsp-xs px-hsp-md bg-surface border-b border-l border-muted rounded-bl-lg shadow-md">
+    <div className="fixed top-[3.5rem] right-0 z-toolbar flex items-center gap-hsp-sm py-hsp-xs px-hsp-md bg-surface border-b border-l border-muted rounded-bl-lg shadow-md">
       <input
         ref={inputRef}
         className="w-48 py-[4px] px-hsp-sm rounded text-small bg-bg border border-muted text-fg outline-none focus:border-accent"

--- a/packages/create-zudo-doc/templates/features/tauri/files/src/components/find-bar.tsx
+++ b/packages/create-zudo-doc/templates/features/tauri/files/src/components/find-bar.tsx
@@ -70,7 +70,7 @@ export function FindBar({ visible, onClose, findInPage, containerSelector }: Fin
   if (!visible) return null;
 
   return (
-    <div className="fixed top-[3.5rem] right-0 z-toolbar flex items-center gap-hsp-sm py-hsp-xs px-hsp-md bg-surface border-b border-l border-muted rounded-bl-lg shadow-md">
+    <div className="fixed top-[3.5rem] right-0 z-dropdown flex items-center gap-hsp-sm py-hsp-xs px-hsp-md bg-surface border-b border-l border-muted rounded-bl-lg shadow-md">
       <input
         ref={inputRef}
         className="w-48 py-[4px] px-hsp-sm rounded text-small bg-bg border border-muted text-fg outline-none focus:border-accent"

--- a/packages/zudo-doc/src/doclayout/doc-layout-with-defaults.tsx
+++ b/packages/zudo-doc/src/doclayout/doc-layout-with-defaults.tsx
@@ -364,7 +364,7 @@ export function DocLayoutWithDefaults(
             // every page. Pages with bespoke chrome should pass
             // `headerOverride` to swap this out wholesale.
             <header
-              class="sticky top-0 z-50 flex h-[3.5rem] items-center justify-end border-b border-muted bg-surface px-hsp-lg"
+              class="sticky top-0 z-toolbar flex h-[3.5rem] items-center justify-end border-b border-muted bg-surface px-hsp-lg"
               data-header
             >
               <ThemeToggle />

--- a/packages/zudo-doc/src/doclayout/doc-layout.tsx
+++ b/packages/zudo-doc/src/doclayout/doc-layout.tsx
@@ -279,7 +279,7 @@ export function DocLayout(props: DocLayoutProps): JSX.Element {
             // landmark is still present (matches the Astro layout's mobile
             // SidebarToggle aside that was always in the DOM).
             class={showSidebar
-              ? "hidden lg:block fixed top-[3.5rem] left-0 z-30 w-[var(--zd-sidebar-w)] h-[calc(100vh-3.5rem)] overflow-y-auto bg-bg border-r border-muted pb-vsp-xl"
+              ? "hidden lg:block fixed top-[3.5rem] left-0 z-sidebar w-[var(--zd-sidebar-w)] h-[calc(100vh-3.5rem)] overflow-y-auto bg-bg border-r border-muted pb-vsp-xl"
               : "sr-only"
             }
             // Strategy B persist: data-zfb-transition-persist is set only when

--- a/packages/zudo-doc/src/header/header.tsx
+++ b/packages/zudo-doc/src/header/header.tsx
@@ -255,7 +255,7 @@ export function Header(props: HeaderProps): JSX.Element {
 
   return (
     <header
-      class="sticky top-0 z-50 flex h-[3.5rem] items-center border-b border-muted bg-surface px-hsp-lg"
+      class="sticky top-0 z-toolbar flex h-[3.5rem] items-center border-b border-muted bg-surface px-hsp-lg"
       data-header
       // Strategy B persist (zudolab/zudo-doc#1546): the header now carries
       // data-zfb-transition-persist when a locale-keyed persistKey is
@@ -324,7 +324,7 @@ export function Header(props: HeaderProps): JSX.Element {
             {"···"}
           </button>
           <ul
-            class="absolute right-0 top-full z-10 mt-vsp-3xs hidden min-w-[8rem] border border-muted rounded bg-surface shadow-lg whitespace-nowrap"
+            class="absolute right-0 top-full z-dropdown mt-vsp-3xs hidden min-w-[8rem] border border-muted rounded bg-surface shadow-lg whitespace-nowrap"
             data-nav-more-menu
           />
         </div>
@@ -419,7 +419,7 @@ function renderNavItem(
             />
           </svg>
         </a>
-        <div class="absolute left-0 top-full z-50 hidden group-hover:block group-focus-within:block pt-vsp-3xs">
+        <div class="absolute left-0 top-full z-dropdown hidden group-hover:block group-focus-within:block pt-vsp-3xs">
           <div class="min-w-[10rem] border border-muted rounded bg-surface shadow-lg py-vsp-3xs">
             {item.children.map((child) => {
               const childHref = urlHelpers.navHref(child.path, lang, currentVersion);

--- a/packages/zudo-doc/src/i18n-version/version-switcher.tsx
+++ b/packages/zudo-doc/src/i18n-version/version-switcher.tsx
@@ -213,7 +213,7 @@ export function VersionSwitcher(props: VersionSwitcherProps): VNode {
 
       <ul
         id={menuId}
-        class="absolute right-0 top-full z-10 mt-vsp-3xs hidden min-w-[8rem] border border-muted rounded bg-surface shadow-lg whitespace-nowrap py-vsp-3xs"
+        class="absolute right-0 top-full z-dropdown mt-vsp-3xs hidden min-w-[8rem] border border-muted rounded bg-surface shadow-lg whitespace-nowrap py-vsp-3xs"
         data-version-menu
       >
         <li>

--- a/packages/zudo-doc/src/sidebar-resizer/index.ts
+++ b/packages/zudo-doc/src/sidebar-resizer/index.ts
@@ -123,7 +123,7 @@ export function initSidebarResizer(): void {
     left: "calc(var(--zd-sidebar-w) - 20px)",
     width: "20px",
     cursor: "col-resize",
-    zIndex: "10",
+    zIndex: "var(--z-index-sidebar)",
     transition: "background 0.15s",
   });
 
@@ -209,7 +209,7 @@ export function initSidebarResizer(): void {
       height: "100vh",
       background: ACCENT_GHOST,
       pointerEvents: "none",
-      zIndex: "9999",
+      zIndex: "var(--z-index-drag)",
     });
     const sidebarRect = sidebar.getBoundingClientRect();
     const sidebarLeft = sidebarRect.left;

--- a/packages/zudo-doc/src/sidebar-resizer/sidebar-resizer-init.tsx
+++ b/packages/zudo-doc/src/sidebar-resizer/sidebar-resizer-init.tsx
@@ -82,7 +82,7 @@ export const SIDEBAR_RESIZER_INIT_SCRIPT = `(function(){
     // (top-[3.5rem], left:0, width:var(--zd-sidebar-w)). 20px hit area > native
     // y-scrollbar (~12-17px) keeps a draggable strip left of the scrollbar when
     // the sidebar overflows. zudolab/zudo-doc#1660
-    Object.assign(handle.style,{position:"fixed",top:"3.5rem",bottom:"0",left:"calc(var(--zd-sidebar-w) - 20px)",width:"20px",cursor:"col-resize",zIndex:"10",transition:"background 0.15s"});
+    Object.assign(handle.style,{position:"fixed",top:"3.5rem",bottom:"0",left:"calc(var(--zd-sidebar-w) - 20px)",width:"20px",cursor:"col-resize",zIndex:"var(--z-index-sidebar)",transition:"background 0.15s"});
 
     var dragging=false,focused=false;
 
@@ -117,7 +117,7 @@ export const SIDEBAR_RESIZER_INIT_SCRIPT = `(function(){
       document.documentElement.style.cursor="col-resize";
       document.documentElement.style.userSelect="none";
       var ghost=document.createElement("div");
-      Object.assign(ghost.style,{position:"fixed",top:"0",width:"2px",height:"100vh",background:ACCENT_GHOST,pointerEvents:"none",zIndex:"9999"});
+      Object.assign(ghost.style,{position:"fixed",top:"0",width:"2px",height:"100vh",background:ACCENT_GHOST,pointerEvents:"none",zIndex:"var(--z-index-drag)"});
       var sidebarRect=sidebar.getBoundingClientRect();
       var sidebarLeft=sidebarRect.left;
       ghost.style.left=sidebarLeft+sidebarRect.width+"px";

--- a/packages/zudo-doc/src/toc/toc.tsx
+++ b/packages/zudo-doc/src/toc/toc.tsx
@@ -73,7 +73,7 @@ export function Toc({ headings, title = "On this page" }: TocProps): VNode {
       className={cx(
         "hidden xl:flex flex-col",
         "w-[280px] shrink-0",
-        "sticky top-[3.5rem] self-start z-10",
+        "sticky top-[3.5rem] self-start z-sidebar",
         "pt-vsp-xl lg:pt-vsp-2xl",
         "h-[calc(100vh-3.5rem)]",
       )}

--- a/pages/lib/_search-widget-script.ts
+++ b/pages/lib/_search-widget-script.ts
@@ -135,6 +135,10 @@ export const SEARCH_WIDGET_SCRIPT = /* javascript */ `(function () {
       this._shortcut = "";
       this._resultCountTemplate = "";
       this._keydownHandler = null;
+      // Delegated click handler on the results container: closing the dialog
+      // when a result link is activated (epic #2148). Held so disconnectedCallback
+      // can detach it on body swap.
+      this._resultsClickHandler = null;
       this._observer = null;
       this._sentinel = null;
       this._isLoadingBatch = false;
@@ -191,6 +195,24 @@ export const SEARCH_WIDGET_SCRIPT = /* javascript */ `(function () {
         this._input.addEventListener("input", function() { self.handleInput(); });
       }
 
+      // Close-on-result-click (epic #2148): result links are created dynamically
+      // in renderResult(), so use one delegated listener on the results container
+      // instead of per-link handlers. We do NOT preventDefault — the link's own
+      // navigation (zfb Strategy-B SPA swap or a plain load) must still proceed;
+      // we only close the <dialog> so it does not linger over the swapped page.
+      // closeDialog() runs synchronously before navigation; the dialog's close
+      // restores documentElement overflow via the existing "close" listener.
+      if (this._results) {
+        this._resultsClickHandler = function(e) {
+          var t = e.target;
+          while (t && t !== self._results) {
+            if (t.tagName === "A") { self.closeDialog(); return; }
+            t = t.parentNode;
+          }
+        };
+        this._results.addEventListener("click", this._resultsClickHandler);
+      }
+
       // Global keyboard shortcut (⌘K / Ctrl+K to open)
       this._keydownHandler = function(e) {
         if ((e.metaKey || e.ctrlKey) && e.key === "k") {
@@ -205,6 +227,11 @@ export const SEARCH_WIDGET_SCRIPT = /* javascript */ `(function () {
       // body swap when this element is NOT persisted via
       // data-zfb-transition-persist (zudolab/zudo-doc#1523).
       this._afterNavHandler = function() {
+        // Backstop for the original bug (epic #2148): if the dialog is somehow
+        // still open after an SPA body swap (e.g. a nav path that bypassed the
+        // result-click handler), close it so it does not linger / flash over the
+        // newly-swapped page. Safe no-op when already closed.
+        if (self._dialog && self._dialog.open) self.closeDialog();
         var kbdEl2 = self.querySelector("[data-kbd-shortcut]");
         if (kbdEl2) kbdEl2.textContent = self._shortcut;
       };
@@ -219,6 +246,10 @@ export const SEARCH_WIDGET_SCRIPT = /* javascript */ `(function () {
       if (this._afterNavHandler) {
         document.removeEventListener(${JSON.stringify(AFTER_NAVIGATE_EVENT)}, this._afterNavHandler);
         this._afterNavHandler = null;
+      }
+      if (this._resultsClickHandler && this._results) {
+        this._results.removeEventListener("click", this._resultsClickHandler);
+        this._resultsClickHandler = null;
       }
       this.teardownSentinel();
     }

--- a/pages/lib/_search-widget.tsx
+++ b/pages/lib/_search-widget.tsx
@@ -88,9 +88,17 @@ export function SearchWidget(props: SearchWidgetProps): JSX.Element {
             static HTML for no-JS users and crawlers. The browser treats
             it as a closed <dialog> until the custom element calls
             showModal(). */}
+        {/* z-modal / backdrop:z-modal-backdrop are defense-in-depth for the
+            SPA-swap window (zfb Strategy-B `zfb:after-swap`): a native
+            showModal() dialog normally sits in the top layer, but if it is
+            still open while the page body is swapped it can lose top-layer
+            promotion and fall back to z-index:auto, flashing behind the
+            header/sidebar. The explicit modal-tier z-index keeps it above all
+            chrome during that window. Intentionally redundant in the normal
+            (top-layer) case — do not remove as "redundant" (epic #2148). */}
         <dialog
           data-search-dialog
-          class="m-0 h-full w-full max-w-none border-none bg-transparent p-0 backdrop:bg-overlay/60 sm:mx-auto sm:my-[10vh] sm:h-auto sm:max-h-[80vh] sm:max-w-[52rem] sm:rounded-lg"
+          class="z-modal m-0 h-full w-full max-w-none border-none bg-transparent p-0 backdrop:z-modal-backdrop backdrop:bg-overlay/60 sm:mx-auto sm:my-[10vh] sm:h-auto sm:max-h-[80vh] sm:max-w-[52rem] sm:rounded-lg"
         >
           <div class="flex h-full flex-col overflow-hidden bg-surface sm:rounded-lg sm:border sm:border-muted">
             {/* ── Dialog header (input row) ─────────────────────────── */}

--- a/scripts/check-b4push-ci-parity.mjs
+++ b/scripts/check-b4push-ci-parity.mjs
@@ -94,6 +94,14 @@ const REQUIRED_CI_GUARDS = [
     b4pushScript: "check:e2e-spec-naming",
     comment: "E2E spec naming guard (scripts/check-e2e-spec-naming.mjs, #2095)",
   },
+  {
+    // Z-index codegen drift: node scripts/gen-z-index.mjs --check (CI) /
+    // pnpm check:z-index (b4push). Fails if the generated @theme block in
+    // src/styles/global.css drifts from src/config/z-index-tokens.ts (#2148).
+    ciNeedle: "gen-z-index.mjs",
+    b4pushScript: "check:z-index",
+    comment: "Z-index codegen drift check (scripts/gen-z-index.mjs, #2148)",
+  },
 ];
 
 const ALLOWLIST_PATH = resolve(ROOT, ".b4push-ci-parity-allowlist");

--- a/scripts/gen-z-index.mjs
+++ b/scripts/gen-z-index.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+// scripts/gen-z-index.mjs
+//
+// Codegen: rewrite the GENERATED:Z_INDEX marker block inside
+// src/styles/global.css from the single source of truth in
+// src/config/z-index-tokens.ts.
+//
+// The block is a Tailwind v4 `@theme { --z-index-<name>: <value>; }` for every
+// tier, so Tailwind generates `z-<name>` utilities (e.g. `--z-index-toolbar: 20`
+// → `.z-toolbar { z-index: 20 }`) and raw CSS can reference the same var via
+// `z-index: var(--z-index-<name>)`.
+//
+// Pure Node (fs only — NO npm deps). Idempotent: running twice produces no diff.
+//
+// Usage:
+//   node scripts/gen-z-index.mjs           # rewrite the block in global.css
+//   node scripts/gen-z-index.mjs --check   # verify committed block is up to date
+//                                          # (exit 1 on drift, no write)
+//
+// MAINTENANCE: edit src/config/z-index-tokens.ts (the source of truth), then run
+// `pnpm gen:z-index` and commit the regenerated global.css. Never hand-edit the
+// block between the BEGIN/END markers.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+
+const TOKENS_PATH = resolve(ROOT, "src/config/z-index-tokens.ts");
+const CSS_PATH = resolve(ROOT, "src/styles/global.css");
+
+const BEGIN_MARKER = "GENERATED:Z_INDEX_BEGIN";
+const END_MARKER = "GENERATED:Z_INDEX_END";
+
+/**
+ * Parse the Z_INDEX_TIERS array out of z-index-tokens.ts WITHOUT importing it
+ * (this script is a dependency-free .mjs and cannot resolve TypeScript). Reads
+ * each `{ name: "...", value: <n>, ... }` object literal. Throws on a malformed
+ * source so drift between the parser and the file surfaces loudly.
+ */
+function parseTiers(src) {
+  const arrayMatch = src.match(
+    /export const Z_INDEX_TIERS[^=]*=\s*\[([\s\S]*?)\];/,
+  );
+  if (!arrayMatch) {
+    throw new Error(
+      `Could not locate "export const Z_INDEX_TIERS = [ ... ]" in ${TOKENS_PATH}`,
+    );
+  }
+  const body = arrayMatch[1];
+  const tiers = [];
+  // Each tier is a `{ ... }` object literal; iterate top-level braces.
+  const objectRe = /\{([\s\S]*?)\}/g;
+  let m;
+  while ((m = objectRe.exec(body)) !== null) {
+    const obj = m[1];
+    const nameMatch = obj.match(/name:\s*"([^"]+)"/);
+    const valueMatch = obj.match(/value:\s*(-?\d+)/);
+    if (!nameMatch || !valueMatch) {
+      throw new Error(
+        `Malformed tier object in Z_INDEX_TIERS (missing name/value): ${obj.trim()}`,
+      );
+    }
+    tiers.push({ name: nameMatch[1], value: Number(valueMatch[1]) });
+  }
+  if (tiers.length === 0) {
+    throw new Error(`Z_INDEX_TIERS in ${TOKENS_PATH} parsed to an empty list`);
+  }
+  return tiers;
+}
+
+/**
+ * Build the full generated block (markers included). Two leading spaces of
+ * indentation match the surrounding `@theme` style in global.css.
+ */
+function buildBlock(tiers) {
+  const lines = [];
+  lines.push(`  /* ${BEGIN_MARKER}`);
+  lines.push(
+    `   * GENERATED:Z_INDEX — do not hand-edit; run pnpm gen:z-index.`,
+  );
+  lines.push(
+    `   * Source of truth: src/config/z-index-tokens.ts. Tailwind v4 reads the`,
+  );
+  lines.push(
+    `   * --z-index-<name> theme key and generates a z-<name> utility. */`,
+  );
+  lines.push(`  @theme {`);
+  for (const tier of tiers) {
+    lines.push(`    --z-index-${tier.name}: ${tier.value};`);
+  }
+  lines.push(`  }`);
+  lines.push(`  /* ${END_MARKER} */`);
+  return lines.join("\n");
+}
+
+/**
+ * Replace the existing BEGIN…END block in `css` with `block`. Throws if the
+ * markers are missing (the block must be seeded once by hand — see global.css).
+ */
+function replaceBlock(css, block) {
+  const beginIdx = css.indexOf(BEGIN_MARKER);
+  const endIdx = css.indexOf(END_MARKER);
+  if (beginIdx === -1 || endIdx === -1) {
+    throw new Error(
+      `Could not find ${BEGIN_MARKER} … ${END_MARKER} markers in ${CSS_PATH}.\n` +
+        `Seed the marker block once by hand, then re-run the generator.`,
+    );
+  }
+  // Expand to the full comment line that opens the block ("  /* GENERATED:...")
+  // and to the end of the closing "*/ " line so the whole region is replaced.
+  const lineStart = css.lastIndexOf("\n", beginIdx) + 1;
+  const afterEnd = css.indexOf("\n", endIdx);
+  const lineEnd = afterEnd === -1 ? css.length : afterEnd;
+  return css.slice(0, lineStart) + block + css.slice(lineEnd);
+}
+
+function main() {
+  const check = process.argv.includes("--check");
+
+  const tokensSrc = readFileSync(TOKENS_PATH, "utf8");
+  const css = readFileSync(CSS_PATH, "utf8");
+
+  const tiers = parseTiers(tokensSrc);
+  const block = buildBlock(tiers);
+  const next = replaceBlock(css, block);
+
+  if (check) {
+    if (next !== css) {
+      console.error(
+        "z-index codegen drift detected: src/styles/global.css is out of date.",
+      );
+      console.error("Run `pnpm gen:z-index` and commit the result.");
+      return 1;
+    }
+    console.log(
+      `OK — z-index @theme block is up to date (${tiers.length} tiers).`,
+    );
+    return 0;
+  }
+
+  if (next === css) {
+    console.log(
+      `z-index @theme block already up to date (${tiers.length} tiers); no change.`,
+    );
+    return 0;
+  }
+  writeFileSync(CSS_PATH, next);
+  console.log(
+    `Wrote z-index @theme block to src/styles/global.css (${tiers.length} tiers).`,
+  );
+  return 0;
+}
+
+process.exit(main());

--- a/scripts/run-b4push.sh
+++ b/scripts/run-b4push.sh
@@ -10,29 +10,30 @@ set -euo pipefail
 #   4. Fixture settings drift check
 #   5. Tags audit (--ci)
 #   6. Design token lint
-#   7. E2E spec naming guard (#2095) — asserts fixture-prefix + no orphan specs
-#   8. B4push/CI parity check (guard manifest meta-check — #1967)
-#   9. Type checking (zfb check + workspace package typechecks)
-#  10. Root unit tests (test:unit) — builds @takazudo/zudo-doc as a side-effect
-#  11. Package tests (test:packages) — ~993 suite tests across workspace packages
-#  12. Package safelist check (#1994) — requires dist/safelist.css from step 10
-#  13. Build (zfb build)
-#  14. Link check
-#  15. HTML validation (html-validate dist/**/*.html)
-#  16. Automated preview smoke (blocking)
-#  17. Manual interactive smoke (operator-driven)
+#   7. Z-index codegen drift check (check:z-index — #2148)
+#   8. E2E spec naming guard (#2095) — asserts fixture-prefix + no orphan specs
+#   9. B4push/CI parity check (guard manifest meta-check — #1967)
+#  10. Type checking (zfb check + workspace package typechecks)
+#  11. Root unit tests (test:unit) — builds @takazudo/zudo-doc as a side-effect
+#  12. Package tests (test:packages) — ~993 suite tests across workspace packages
+#  13. Package safelist check (#1994) — requires dist/safelist.css from step 11
+#  14. Build (zfb build)
+#  15. Link check
+#  16. HTML validation (html-validate dist/**/*.html)
+#  17. Automated preview smoke (blocking)
+#  18. Manual interactive smoke (operator-driven)
 #
 # Playwright E2E runs in CI (pr-checks e2e job); b4push intentionally excludes
 # it for time-budget reasons — the bounded fast pass stays fast.
 #
 # Env overrides for non-interactive use:
-#   B4PUSH_SKIP_HTML_VALIDATE=1  — skip HTML validation (step 15)
+#   B4PUSH_SKIP_HTML_VALIDATE=1  — skip HTML validation (step 16)
 #   B4PUSH_SKIP_PREVIEW_SMOKE=1  — skip the automated preview smoke
 #   B4PUSH_SKIP_MANUAL_SMOKE=1   — skip the manual interactive smoke
 
 START_TIME=$(date +%s)
 FAILURES=()
-TOTAL_STEPS=17
+TOTAL_STEPS=18
 CURRENT_STEP=0
 
 step() {
@@ -50,7 +51,7 @@ skip() { echo "⏭  $1 (skipped)"; }
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
 # >>> b4push-ci-parity:guards
-# Steps 1–6 are lightweight guard gates. They are delimited by the markers
+# Steps 1–9 are lightweight guard gates. They are delimited by the markers
 # above/below so check-b4push-ci-parity.mjs can cross-check them against the
 # REQUIRED_CI_GUARDS manifest without brittle full-file parsing.
 
@@ -105,7 +106,20 @@ else
   fail "Design token lint"
 fi
 
-# ── Step 7: E2E spec naming guard (#2095) ─────────────
+# ── Step 7: Z-index codegen drift check ──────────────
+# Pure-Node check (scripts/gen-z-index.mjs --check) — re-runs the z-index
+# @theme codegen into a buffer and fails if src/styles/global.css drifts from
+# src/config/z-index-tokens.ts (the single source of truth). Also the
+# structural guard for CSS-file raw z-index: every z-index now flows through
+# this generated block.
+step "Z-index codegen drift check (check:z-index)"
+if (cd "$ROOT_DIR" && pnpm check:z-index); then
+  pass "Z-index codegen drift check passed"
+else
+  fail "Z-index codegen drift check"
+fi
+
+# ── Step 8: E2E spec naming guard (#2095) ─────────────
 # Pure-Node check — asserts (a) every e2e/*.spec.ts starts with a known
 # fixture prefix so Playwright's testMatch glob actually picks it up, and
 # (b) no *.spec.ts files exist outside e2e/ except those allowlisted in
@@ -117,7 +131,7 @@ else
   fail "E2E spec naming guard"
 fi
 
-# ── Step 8: B4push/CI parity check ───────────────────
+# ── Step 9: B4push/CI parity check ───────────────────
 # Pure-Node check — verifies every lightweight guard gate in this file also
 # has a corresponding CI job. See scripts/check-b4push-ci-parity.mjs.
 step "B4push/CI parity check (check:b4push-ci-parity)"
@@ -129,7 +143,7 @@ fi
 
 # <<< b4push-ci-parity:guards
 
-# ── Step 9: Type checking ─────────────────────────────
+# ── Step 10: Type checking ─────────────────────────────
 # Prefer `zfb check` (the post-cutover entry point). If it fails to
 # start (e.g. binary not yet built), fall back to `tsc --noEmit` so the
 # typecheck still gates pushes.
@@ -171,7 +185,7 @@ else
   fail "Package typechecks"
 fi
 
-# ── Step 10: Root unit tests ──────────────────────────
+# ── Step 11: Root unit tests ──────────────────────────
 # Root `test:unit` (vitest) guards src/**/__tests__ and scripts/__tests__,
 # which previously ran in no local gate and no CI workflow (#1856). Runs
 # before the expensive site build for fast logic-level feedback.
@@ -188,7 +202,7 @@ else
   fail "Root unit tests"
 fi
 
-# ── Step 11: Package tests ────────────────────────────
+# ── Step 12: Package tests ────────────────────────────
 # Runs all workspace package test suites (~993 tests). Closes the local/CI
 # asymmetry where package tests ran in CI but not in b4push (#1851/#1856).
 # dist/ is already built by step 10 — no extra prep needed.
@@ -199,7 +213,7 @@ else
   fail "Package tests"
 fi
 
-# ── Step 12: Package safelist check ──────────────────
+# ── Step 13: Package safelist check ──────────────────
 # Verifies that the generated dist/safelist.css in packages/zudo-doc/ covers
 # every responsive-variant + arbitrary-value utility class used in
 # packages/zudo-doc/src/**/*.tsx. Catches regressions where gen-safelist.mjs
@@ -212,7 +226,7 @@ else
   fail "Package safelist check"
 fi
 
-# ── Step 13: Build ────────────────────────────────────
+# ── Step 14: Build ────────────────────────────────────
 step "Build (zfb build)"
 if (cd "$ROOT_DIR" && pnpm build); then
   pass "Build passed"
@@ -220,7 +234,7 @@ else
   fail "Build"
 fi
 
-# ── Step 14: Link check ───────────────────────────────
+# ── Step 15: Link check ───────────────────────────────
 #
 # Strict on broken links + absolute MDX-source warnings (real 404s
 # / sub-path bypass). Trailing-slash warnings stay warn-only — they
@@ -240,7 +254,7 @@ else
   fail "Link check"
 fi
 
-# ── Step 15: HTML validation ──────────────────────────
+# ── Step 16: HTML validation ──────────────────────────
 step "HTML validation (html-validate)"
 if [[ "${B4PUSH_SKIP_HTML_VALIDATE:-}" == "1" ]]; then
   skip "HTML validation (B4PUSH_SKIP_HTML_VALIDATE=1)"
@@ -252,7 +266,7 @@ else
   fi
 fi
 
-# ── Step 16: Automated preview smoke (blocking) ──────
+# ── Step 17: Automated preview smoke (blocking) ──────
 step "Preview smoke (automated)"
 if [[ "${B4PUSH_SKIP_PREVIEW_SMOKE:-}" == "1" ]]; then
   skip "Preview smoke (B4PUSH_SKIP_PREVIEW_SMOKE=1)"
@@ -264,7 +278,7 @@ else
   fi
 fi
 
-# ── Step 17: Manual interactive smoke ────────────────
+# ── Step 18: Manual interactive smoke ────────────────
 step "Manual interactive smoke"
 if [[ "${B4PUSH_SKIP_MANUAL_SMOKE:-}" == "1" ]]; then
   skip "Manual smoke (B4PUSH_SKIP_MANUAL_SMOKE=1)"

--- a/src/components/desktop-sidebar-toggle.tsx
+++ b/src/components/desktop-sidebar-toggle.tsx
@@ -102,7 +102,7 @@ export default function DesktopSidebarToggle() {
     <button
       type="button"
       onClick={() => setVisible((v) => !v)}
-      className="zd-desktop-sidebar-toggle hidden lg:flex fixed bottom-vsp-xl z-40 items-center justify-center w-[1.5rem] h-[3rem] bg-surface border border-muted border-l-0 rounded-r-DEFAULT text-muted cursor-pointer transition-[left,color] duration-200 ease-in-out hover:text-fg"
+      className="zd-desktop-sidebar-toggle hidden lg:flex fixed bottom-vsp-xl z-sidebar items-center justify-center w-[1.5rem] h-[3rem] bg-surface border border-muted border-l-0 rounded-r-DEFAULT text-muted cursor-pointer transition-[left,color] duration-200 ease-in-out hover:text-fg"
       aria-label={visible ? 'Hide sidebar' : 'Show sidebar'}
       aria-pressed={visible}
       data-zfb-transition-persist="desktop-sidebar-toggle"

--- a/src/components/sidebar-toggle.tsx
+++ b/src/components/sidebar-toggle.tsx
@@ -126,7 +126,7 @@ export default function SidebarToggle({
           the SSR DOM tree matches the hydrated tree (no subtree
           mount/unmount across the hydration boundary). */}
       <div
-        className={clsx("fixed inset-0 z-30 bg-overlay/30 lg:hidden", !open && "hidden")}
+        className={clsx("fixed inset-0 z-modal-backdrop bg-overlay/30 lg:hidden", !open && "hidden")}
         aria-hidden={!open}
         onClick={() => setOpen(false)}
       />
@@ -141,7 +141,7 @@ export default function SidebarToggle({
       <aside
         inert={!open}
         className={`
-          fixed top-[3.5rem] left-0 z-40 h-[calc(100vh-3.5rem)] w-[16rem] flex flex-col
+          fixed top-[3.5rem] left-0 z-modal h-[calc(100vh-3.5rem)] w-[16rem] flex flex-col
           border-r border-muted bg-bg transition-transform duration-200
           lg:hidden
           ${open ? "translate-x-0" : "-translate-x-full"}

--- a/src/components/sidebar-toggle.tsx
+++ b/src/components/sidebar-toggle.tsx
@@ -124,7 +124,12 @@ export default function SidebarToggle({
       {/* Backdrop overlay - mobile only.
           Rendered unconditionally; CSS `hidden` toggles visibility so
           the SSR DOM tree matches the hydrated tree (no subtree
-          mount/unmount across the hydration boundary). */}
+          mount/unmount across the hydration boundary).
+          `z-modal-backdrop` (50) intentionally sits ABOVE the header
+          (`z-toolbar`, 20): the open mobile drawer is a modal surface that
+          dims the whole viewport, header included. Closing is via tapping the
+          backdrop (onClick below), so the header hamburger being dimmed under
+          it is fine. */}
       <div
         className={clsx("fixed inset-0 z-modal-backdrop bg-overlay/30 lg:hidden", !open && "hidden")}
         aria-hidden={!open}

--- a/src/components/sidebar-tree.tsx
+++ b/src/components/sidebar-tree.tsx
@@ -505,7 +505,7 @@ const CategoryNode = memo(function CategoryNode({
     <div className={`${depth === 0 ? "border-t border-muted" : ""} ${depth >= 1 && !isLast ? "relative" : ""}`}>
       {depth >= 1 && !isLast && isExpanded && (
         <div
-          className="absolute border-l border-solid border-muted z-10"
+          className="absolute border-l border-solid border-muted z-local-1"
           style={{
             left: connectorLeft(depth),
             top: 0,

--- a/src/components/site-tree-nav.tsx
+++ b/src/components/site-tree-nav.tsx
@@ -118,7 +118,7 @@ function CategoryNode({
     <div className={`${depth >= 1 && !isLast ? "relative" : ""}`}>
       {depth >= 1 && !isLast && open && (
         <div
-          className="absolute border-l border-dashed border-muted z-10"
+          className="absolute border-l border-dashed border-muted z-local-1"
           style={{
             left: connectorLeft(depth),
             top: 0,

--- a/src/config/z-index-tokens.ts
+++ b/src/config/z-index-tokens.ts
@@ -114,7 +114,7 @@ export const Z_INDEX_TIERS: ZIndexTier[] = [
     name: "tooltip",
     value: 80,
     purpose:
-      "reserved — highest steady UI layer (canonical scale; not yet used)",
+      "reserved — highest steady UI layer, below only the transient drag tier (canonical scale; not yet used)",
     kind: "global",
   },
   {

--- a/src/config/z-index-tokens.ts
+++ b/src/config/z-index-tokens.ts
@@ -1,0 +1,127 @@
+// z-index design tokens — single source of truth.
+//
+// This file is the ONE place z-index tiers are defined. The CSS `@theme` block
+// in `src/styles/global.css` is GENERATED from this list by
+// `scripts/gen-z-index.mjs` (run `pnpm gen:z-index`); never hand-edit the
+// generated block. `pnpm check:z-index` re-runs the generator into a buffer and
+// fails on drift, so the committed CSS can never silently diverge from this list.
+//
+// Strategy (from zudolab/zudo-css-wisdom z-index-strategy): semantic single-
+// namespace tokens — names describe ROLES, never magnitudes. One flat ordered
+// list. Values are deliberately gapped but otherwise arbitrary: renaming and
+// reordering is cheap, which is the whole point. Tailwind v4 reads the
+// `--z-index-<name>` theme key and generates a `z-<name>` utility, so e.g.
+// `@theme { --z-index-toolbar: 20 }` produces `.z-toolbar { z-index: 20 }`.
+//
+// `kind` distinguishes:
+//   - "global": a tier on the single global stacking scale (overlay chrome etc.)
+//   - "local":  anonymous reusable helpers for promoting a child WITHIN a parent
+//               stacking context (`isolation: isolate` / `position: relative`),
+//               not a position on the global scale.
+//
+// Rationale for the two zudo-doc-specific additions (NOT in the generic
+// overlay-centric strategy scale):
+//   - `sidebar` — persistent layout chrome (desktop sidebar, TOC, sidebar-toggle
+//     handle, resizer handle). The strategy's scale has no persistent-sidebar/TOC
+//     tier. `toolbar` (the sticky header) is deliberately placed ABOVE `sidebar`
+//     to preserve the existing header-wins ordering; they do not overlap
+//     spatially, but the historical relationship is kept explicit.
+//   - `drag` — transient drag affordance (sidebar-resizer ghost line). Replaces
+//     the old `z-9999` anti-pattern with a named top-of-steady-UI tier.
+//
+// `popover`, `toast`, and `tooltip` are reserved canonical tiers from the
+// strategy's scale — kept for completeness (and so downstream `create-zudo-doc`
+// users inherit the full scale) even though zudo-doc does not use them yet.
+
+export type ZIndexKind = "global" | "local";
+
+export interface ZIndexTier {
+  name: string;
+  value: number;
+  purpose: string;
+  kind: ZIndexKind;
+}
+
+export const Z_INDEX_TIERS: ZIndexTier[] = [
+  {
+    name: "content",
+    value: 0,
+    purpose: "default in-flow content (implicit baseline)",
+    kind: "global",
+  },
+  {
+    name: "local-1",
+    value: 1,
+    purpose: "child promotion inside an isolated parent stacking context",
+    kind: "local",
+  },
+  {
+    name: "local-2",
+    value: 2,
+    purpose: "child promotion inside an isolated parent stacking context",
+    kind: "local",
+  },
+  {
+    name: "local-3",
+    value: 3,
+    purpose: "child promotion inside an isolated parent stacking context",
+    kind: "local",
+  },
+  {
+    name: "sidebar",
+    value: 10,
+    purpose:
+      "persistent layout chrome: desktop sidebar, TOC, sidebar-toggle handle, resizer handle",
+    kind: "global",
+  },
+  {
+    name: "toolbar",
+    value: 20,
+    purpose: "sticky top header (sits above sidebar chrome)",
+    kind: "global",
+  },
+  {
+    name: "dropdown",
+    value: 30,
+    purpose: "header menus, version/language switchers",
+    kind: "global",
+  },
+  {
+    name: "popover",
+    value: 40,
+    purpose: "reserved — inline popovers (canonical scale; not yet used)",
+    kind: "global",
+  },
+  {
+    name: "modal-backdrop",
+    value: 50,
+    purpose: "mobile drawer backdrop, <dialog> ::backdrop",
+    kind: "global",
+  },
+  {
+    name: "modal",
+    value: 60,
+    purpose: "mobile sidebar drawer panel, search <dialog>",
+    kind: "global",
+  },
+  {
+    name: "toast",
+    value: 70,
+    purpose: "reserved — transient notifications (canonical scale; not yet used)",
+    kind: "global",
+  },
+  {
+    name: "tooltip",
+    value: 80,
+    purpose:
+      "reserved — highest steady UI layer (canonical scale; not yet used)",
+    kind: "global",
+  },
+  {
+    name: "drag",
+    value: 90,
+    purpose:
+      "transient drag affordance: sidebar-resizer ghost line (replaces the z-9999 anti-pattern)",
+    kind: "global",
+  },
+];

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -238,6 +238,37 @@
   --breakpoint-xl: 1280px;
 }
 
+/* ========================================
+ * Z-index tiers — semantic, single-namespace scale.
+ *
+ * The @theme block below is GENERATED from src/config/z-index-tokens.ts
+ * (the single source of truth) by `pnpm gen:z-index`. Tailwind v4 reads the
+ * --z-index-<name> theme key and generates a `z-<name>` utility, so e.g.
+ * --z-index-toolbar: 20 produces `.z-toolbar { z-index: 20 }`; raw CSS can
+ * also reference `z-index: var(--z-index-<name>)`. `pnpm check:z-index` fails
+ * on drift. Do NOT hand-edit between the BEGIN/END markers.
+ * ======================================== */
+  /* GENERATED:Z_INDEX_BEGIN
+   * GENERATED:Z_INDEX — do not hand-edit; run pnpm gen:z-index.
+   * Source of truth: src/config/z-index-tokens.ts. Tailwind v4 reads the
+   * --z-index-<name> theme key and generates a z-<name> utility. */
+  @theme {
+    --z-index-content: 0;
+    --z-index-local-1: 1;
+    --z-index-local-2: 2;
+    --z-index-local-3: 3;
+    --z-index-sidebar: 10;
+    --z-index-toolbar: 20;
+    --z-index-dropdown: 30;
+    --z-index-popover: 40;
+    --z-index-modal-backdrop: 50;
+    --z-index-modal: 60;
+    --z-index-toast: 70;
+    --z-index-tooltip: 80;
+    --z-index-drag: 90;
+  }
+  /* GENERATED:Z_INDEX_END */
+
 :root {
   /* Default responsive range; sidebar-resizer.ts allows 192–448px for explicit resizing. */
   --zd-sidebar-w: clamp(14rem, 20vw, 22rem);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1426,6 +1426,9 @@ dialog.zd-enlarge-dialog::backdrop {
 .page-loading-overlay {
   position: fixed;
   inset: 0;
+  /* Full-screen blocking load overlay — modal tier (was a raw z-index:9999).
+     It sits below the transient `drag` tier (sidebar-resizer ghost), which is
+     fine: a full page-load overlay and an active pointer-drag never coexist. */
   z-index: var(--z-index-modal);
   display: flex;
   align-items: center;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -724,7 +724,7 @@ pre[class^="syntect-"].word-wrap code {
   gap: var(--spacing-hsp-2xs);
   opacity: 0;
   transition: opacity 150ms;
-  z-index: 1;
+  z-index: var(--z-index-local-1);
 }
 
 .code-block-wrapper:hover .code-buttons,
@@ -1194,7 +1194,7 @@ pre[class^="syntect-"] .line .highlighted-word {
   border: none;
   background: transparent;
   cursor: pointer;
-  z-index: 1;
+  z-index: var(--z-index-local-1);
   transition: opacity var(--default-transition-duration);
 }
 
@@ -1203,12 +1203,12 @@ pre[class^="syntect-"] .line .highlighted-word {
   position: absolute;
   inset: 0;
   background: color-mix(in oklch, var(--color-image-overlay-bg) 80%, transparent);
-  z-index: 0;
+  z-index: var(--z-index-local-1);
 }
 
 .zd-enlarge-btn > svg {
   position: relative;
-  z-index: 1;
+  z-index: var(--z-index-local-2);
   width: var(--spacing-icon-sm);
   height: var(--spacing-icon-sm);
   color: var(--color-image-overlay-fg);
@@ -1243,7 +1243,7 @@ dialog.zd-enlarge-dialog::backdrop {
   border: none;
   background: transparent;
   cursor: pointer;
-  z-index: 1;
+  z-index: var(--z-index-local-1);
   transition: opacity var(--default-transition-duration);
 }
 
@@ -1256,12 +1256,12 @@ dialog.zd-enlarge-dialog::backdrop {
   position: absolute;
   inset: 0;
   background: color-mix(in oklch, var(--color-image-overlay-bg) 80%, transparent);
-  z-index: 0;
+  z-index: var(--z-index-local-1);
 }
 
 .zd-enlarge-dialog-close > svg {
   position: relative;
-  z-index: 1;
+  z-index: var(--z-index-local-2);
   width: var(--spacing-icon-lg);
   height: var(--spacing-icon-lg);
   color: var(--color-image-overlay-fg);
@@ -1426,7 +1426,7 @@ dialog.zd-enlarge-dialog::backdrop {
 .page-loading-overlay {
   position: fixed;
   inset: 0;
-  z-index: 9999;
+  z-index: var(--z-index-modal);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/zfb.config.ts
+++ b/zfb.config.ts
@@ -397,7 +397,7 @@ export default defineConfig({
   // functional, the host build would otherwise stat their absolute image
   // paths (e.g. /test-images/*.png) against the HOST public dir and warn.
   bundle: {
-    exclude: ["packages/md-plugins/__fixtures__/**", "e2e/fixtures/**"],
+    exclude: ["packages/md-plugins/__fixtures__/**", "e2e/fixtures/**", "_temp-resource/**"],
   },
   // Strip `.md` / `.mdx` from in-page `<a href>` and append a trailing
   // slash so author-written `[label](./other.mdx)` references resolve


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2148

---

## Summary

Epic #2148 — full adoption of the **zcss semantic z-index token strategy** across zudo-doc, plus the original search-dialog overlay fix. Replaces every ad-hoc `z-{n}` magic number with semantic, single-namespace tokens generated from a TypeScript source of truth, drift-checked in CI.

## What changed

- **Token system (A1 #2151):** `src/config/z-index-tokens.ts` is the source of truth; `scripts/gen-z-index.mjs` rewrites a `GENERATED:Z_INDEX` `@theme` block in `global.css` (Tailwind v4 generates `z-<name>` utilities); `pnpm check:z-index` drift-guards it (wired into b4push + CI parity). Mirrored into the `create-zudo-doc` template.
- **Migration (A2 #2152):** every z-index usage → semantic token. `content/local-N/sidebar/toolbar/dropdown/popover/modal-backdrop/modal/toast/tooltip/drag`. Header→`toolbar`, sidebar/TOC→`sidebar`, dropdowns→`dropdown`, mobile drawer→`modal`(+backdrop), resizer ghost→`drag`, pseudo-elements→`local-N`. Package safelist regenerated.
- **Search dialog (B #2153):** closes on result click (delegated handler + `zfb:after-swap` backstop, no `preventDefault` so SPA nav proceeds) and is hardened with `z-modal`/`backdrop:z-modal-backdrop` against the swap-window top-layer flash. New `e2e/smoke-search-dialog-close.spec.ts`.
- **Lint (A3 #2154):** `z-{n}` added to `.design-token-lint.json` prohibited.

## Tier scale

`content:0 · local-1/2/3 · sidebar:10 · toolbar:20 · dropdown:30 · popover:40 · modal-backdrop:50 · modal:60 · toast:70 · tooltip:80 · drag:90`

## Topics

- [x] A1 #2151 — token source of truth + codegen + drift check + `@theme` + b4push/CI + template mirror
- [x] A2 #2152 — migrate all z-index usages onto tokens
- [x] B #2153 — search dialog close-on-click + z-index hardening + E2E
- [x] A3 #2154 — raw-`z-{n}` lint prohibition

## Verification

`pnpm build` green (275 pages, semantic `z-*` utilities + `--z-index-*` vars emit), typecheck, `check:z-index`, `check:template-drift`, `check:package-safelist`, `check:b4push-ci-parity`, `check:e2e-spec-naming` all pass. 3-reviewer deep review found no bugs; polish applied.

## Follow-ups (raised as `agent-found`)

- #2156 — `pnpm lint:tokens` is a silent no-op under pnpm (upstream `@takazudo/zudo-design-token-lint` entry-guard vs symlink); the new `z-{n}` rule is correct but unenforced until the upstream fix. CSS side stays guarded by `check:z-index`.
- #2157 — other native dialogs (doc-history, ai-chat, image-enlarge) could get the same SPA-swap z-index defense.