### PR TITLE
fix: dialog SPA-swap z-index defense (#2157) + restore token-lint enforcement (#2156)

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,9 @@
       "yaml@2": ">=2.8.3 <3",
       "brace-expansion@2": ">=2.0.3 <3",
       "brace-expansion@5": ">=5.0.6 <6"
+    },
+    "patchedDependencies": {
+      "@takazudo/zudo-design-token-lint@1.0.0": "patches/@takazudo__zudo-design-token-lint@1.0.0.patch"
     }
   },
   "dependencies": {
@@ -86,8 +89,8 @@
     "@takazudo/zfb": "0.1.0-next.44",
     "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.44",
     "@takazudo/zfb-runtime": "0.1.0-next.44",
-    "@types/hast": "^3.0.4",
     "@takazudo/zudo-doc": "workspace:*",
+    "@types/hast": "^3.0.4",
     "clsx": "^2.1.1",
     "diff": "^8.0.3",
     "gray-matter": "^4.0.3",
@@ -103,12 +106,12 @@
     "@inquirer/prompts": "^8.4.2",
     "@playwright/test": "1.58.2",
     "@tailwindcss/vite": "^4.2.1",
+    "@takazudo/zudo-design-token-lint": "^1.0.0",
     "@types/mdast": "^4.0.4",
     "@types/node": "^25.3.5",
     "@types/pluralize": "^0.0.33",
     "@types/react": "^19.2.14",
     "@types/string-similarity": "^4.0.2",
-    "@takazudo/zudo-design-token-lint": "^1.0.0",
     "chokidar": "^4.0.0",
     "html-validate": "^10.15.0",
     "lefthook": "^2.1.4",

--- a/packages/create-zudo-doc/templates/features/docHistory/files/src/components/doc-history.tsx
+++ b/packages/create-zudo-doc/templates/features/docHistory/files/src/components/doc-history.tsx
@@ -559,10 +559,17 @@ export function DocHistory({ slug, locale, basePath = "/" }: DocHistoryProps) {
       )}
 
       {/* Full-screen dialog — renders in top layer, above all stacking contexts */}
+      {/* z-modal / backdrop:z-modal-backdrop are defense-in-depth for the
+          SPA-swap window: clicking a history entry link swaps the page body
+          while this dialog is still open, and a native showModal() dialog can
+          momentarily lose top-layer promotion and fall back to z-index:auto,
+          flashing behind the header/sidebar. The explicit modal-tier z-index
+          keeps it above all chrome during that window. Intentionally redundant
+          in the normal (top-layer) case — do not remove as "redundant". */}
       <dialog
         ref={dialogRef}
         aria-label="Document revision history"
-        className="doc-history-panel fixed inset-0 m-0 h-full w-full max-h-full max-w-full bg-bg border-none p-0 backdrop:bg-bg/30"
+        className="doc-history-panel z-modal fixed inset-0 m-0 h-full w-full max-h-full max-w-full bg-bg border-none p-0 backdrop:z-modal-backdrop backdrop:bg-bg/30"
         style={{ color: "var(--color-fg)" }}
       >
         {/* Panel header */}

--- a/packages/create-zudo-doc/templates/features/imageEnlarge/files/src/components/image-enlarge.tsx
+++ b/packages/create-zudo-doc/templates/features/imageEnlarge/files/src/components/image-enlarge.tsx
@@ -18,8 +18,17 @@ interface ImageData {
 // agree on class string and inline style — otherwise the dist HTML and the
 // post-hydration DOM disagree on size / position and the first interaction
 // flashes. Sourcing both from the same constants closes the drift gap.
+//
+// z-modal / backdrop:z-modal-backdrop are defense-in-depth for the SPA-swap
+// window: if this dialog is still open while the page body is swapped, a native
+// showModal() dialog can lose top-layer promotion and fall back to z-index:auto,
+// flashing behind the header/sidebar. `backdrop:z-modal-backdrop` targets the
+// native `::backdrop` (present for every showModal() dialog even with no backdrop
+// tint). The explicit modal-tier z-index keeps it above all chrome during that
+// window. Intentionally redundant in the normal (top-layer) case — do not remove
+// as "redundant".
 const DIALOG_CLASS =
-  "zd-enlarge-dialog mx-auto max-h-[90vh] max-w-[90vw] overflow-hidden border border-muted bg-surface p-0";
+  "zd-enlarge-dialog z-modal mx-auto max-h-[90vh] max-w-[90vw] overflow-hidden border border-muted bg-surface p-0 backdrop:z-modal-backdrop";
 // Center the modal with `inset: 0; margin: auto` rather than a transform.
 // A `transform` on the dialog would establish a containing block for its
 // `position: fixed` descendants, which would trap the `.zd-enlarge-dialog-close`

--- a/patches/@takazudo__zudo-design-token-lint@1.0.0.patch
+++ b/patches/@takazudo__zudo-design-token-lint@1.0.0.patch
@@ -1,0 +1,22 @@
+diff --git a/dist/cli.js b/dist/cli.js
+index f9b520dde7af992a6c0307ac0e04e3478375ce65..b82782e77c6749e2c9a448a569848073e9823b37 100755
+--- a/dist/cli.js
++++ b/dist/cli.js
+@@ -10,7 +10,7 @@
+  */
+ import { glob } from 'glob';
+ import chalk from 'chalk';
+-import { readFileSync } from 'node:fs';
++import { readFileSync, realpathSync } from 'node:fs';
+ import { fileURLToPath } from 'node:url';
+ import { dirname, join, isAbsolute, resolve } from 'node:path';
+ import { loadConfig, compileConfig } from './config.js';
+@@ -170,7 +170,7 @@ export async function runMain(opts) {
+ // Detect if this module is being run directly (vs imported by tests).
+ const isMain = (() => {
+     try {
+-        return process.argv[1] === fileURLToPath(import.meta.url);
++        return realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
+     }
+     catch {
+         return false;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,11 @@ overrides:
   brace-expansion@2: '>=2.0.3 <3'
   brace-expansion@5: '>=5.0.6 <6'
 
+patchedDependencies:
+  '@takazudo/zudo-design-token-lint@1.0.0':
+    hash: 6a157fd850449b055cf64a8a7dd1faed5b1da9eebe6c81cca08488ac0de85182
+    path: patches/@takazudo__zudo-design-token-lint@1.0.0.patch
+
 importers:
 
   .:
@@ -81,7 +86,7 @@ importers:
         version: 4.2.1(vite@7.3.5(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
       '@takazudo/zudo-design-token-lint':
         specifier: ^1.0.0
-        version: 1.0.0
+        version: 1.0.0(patch_hash=6a157fd850449b055cf64a8a7dd1faed5b1da9eebe6c81cca08488ac0de85182)
       '@types/mdast':
         specifier: ^4.0.4
         version: 4.0.4
@@ -4101,7 +4106,7 @@ snapshots:
       '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.44
       '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.44
 
-  '@takazudo/zudo-design-token-lint@1.0.0':
+  '@takazudo/zudo-design-token-lint@1.0.0(patch_hash=6a157fd850449b055cf64a8a7dd1faed5b1da9eebe6c81cca08488ac0de85182)':
     dependencies:
       chalk: 5.6.2
       glob: 10.5.0

--- a/src/components/ai-chat-modal.tsx
+++ b/src/components/ai-chat-modal.tsx
@@ -163,10 +163,17 @@ export default function AiChatModal({ basePath }: AiChatModalProps) {
   }
 
   return (
+    // z-modal / backdrop:z-modal-backdrop are defense-in-depth for the SPA-swap
+    // window (zfb Strategy-B `zfb:before-swap`): if this dialog is still open
+    // while the page body is swapped, a native showModal() dialog can lose
+    // top-layer promotion and fall back to z-index:auto, flashing behind the
+    // header/sidebar. The explicit modal-tier z-index keeps it above all chrome
+    // during that window. Intentionally redundant in the normal (top-layer)
+    // case — do not remove as "redundant" (epic #2148 / issue #2157).
     <dialog
       ref={dialogRef}
       onClick={handleBackdropClick}
-      className="m-0 h-dvh max-h-none w-dvw max-w-none border-none bg-surface p-0 text-fg backdrop:bg-bg/80 lg:m-auto lg:h-[90vh] lg:max-h-[90vh] lg:w-[90vw] lg:max-w-[52.5rem] lg:border-solid lg:border lg:border-fg"
+      className="z-modal m-0 h-dvh max-h-none w-dvw max-w-none border-none bg-surface p-0 text-fg backdrop:z-modal-backdrop backdrop:bg-bg/80 lg:m-auto lg:h-[90vh] lg:max-h-[90vh] lg:w-[90vw] lg:max-w-[52.5rem] lg:border-solid lg:border lg:border-fg"
     >
       <div className="flex h-full flex-col">
         {/* Header */}

--- a/src/components/doc-history.tsx
+++ b/src/components/doc-history.tsx
@@ -527,10 +527,18 @@ export function DocHistory({ slug, locale, basePath = "/" }: DocHistoryProps) {
       )}
 
       {/* Full-screen dialog — renders in top layer, above all stacking contexts */}
+      {/* z-modal / backdrop:z-modal-backdrop are defense-in-depth for the
+          SPA-swap window (zfb Strategy-B `zfb:after-swap`): clicking a history
+          entry link swaps the page body while this dialog is still open, and a
+          native showModal() dialog can momentarily lose top-layer promotion and
+          fall back to z-index:auto, flashing behind the header/sidebar. The
+          explicit modal-tier z-index keeps it above all chrome during that
+          window. Intentionally redundant in the normal (top-layer) case — do
+          not remove as "redundant" (epic #2148 / issue #2157). */}
       <dialog
         ref={dialogRef}
         aria-label="Document revision history"
-        className="doc-history-panel fixed inset-0 m-0 h-full w-full max-h-full max-w-full bg-bg border-none p-0 backdrop:bg-bg/30"
+        className="doc-history-panel z-modal fixed inset-0 m-0 h-full w-full max-h-full max-w-full bg-bg border-none p-0 backdrop:z-modal-backdrop backdrop:bg-bg/30"
         style={{ color: "var(--color-fg)" }}
       >
         {/* Panel header */}

--- a/src/components/image-enlarge.tsx
+++ b/src/components/image-enlarge.tsx
@@ -28,8 +28,18 @@ interface ImageData {
 // dist HTML and the post-hydration DOM disagree on size / position
 // and the first interaction flashes. Sourcing both from the same
 // constants closes the drift gap GCO flagged in light-review.
+//
+// z-modal / backdrop:z-modal-backdrop are defense-in-depth for the SPA-swap
+// window (zfb Strategy-B `zfb:after-swap`): if this dialog is still open while
+// the page body is swapped, a native showModal() dialog can lose top-layer
+// promotion and fall back to z-index:auto, flashing behind the header/sidebar.
+// `backdrop:z-modal-backdrop` targets the native `::backdrop` (present for every
+// showModal() dialog even with no backdrop tint). The explicit modal-tier
+// z-index keeps it above all chrome during that window. Intentionally redundant
+// in the normal (top-layer) case — do not remove as "redundant" (epic #2148 /
+// issue #2157).
 const DIALOG_CLASS =
-  "zd-enlarge-dialog mx-auto max-h-[90vh] max-w-[90vw] overflow-hidden border border-muted bg-surface p-0";
+  "zd-enlarge-dialog z-modal mx-auto max-h-[90vh] max-w-[90vw] overflow-hidden border border-muted bg-surface p-0 backdrop:z-modal-backdrop";
 // Center the modal with `inset: 0; margin: auto` rather than a transform.
 // A `transform` on the dialog would establish a containing block for its
 // `position: fixed` descendants, which would trap the `.zd-enlarge-dialog-close`


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2157
    - https://github.com/zudolab/zudo-doc/issues/2156

---

## Summary

Two independent, parallel topics handled in one base branch.

### #2157 — SPA-swap z-index defense on the remaining native `<dialog>` overlays
B #2153 (epic #2148) hardened the search `<dialog>` against the SPA-swap "top-layer-loss flash": while a native `showModal()` dialog is open and the page body is swapped (zfb Strategy-B navigation), the dialog can momentarily lose top-layer promotion and fall back to `z-index:auto`, flashing behind the header/sidebar. The fix is defense-in-depth: an explicit `z-modal` on the dialog and `backdrop:z-modal-backdrop` on its `::backdrop`.

This applies the same defense to the three other `showModal()` overlays that lacked it:
- `src/components/doc-history.tsx` — prime candidate (history entries are links → SPA swap while open; closes on `zfb:after-swap`)
- `src/components/ai-chat-modal.tsx` (closes on `zfb:before-swap`)
- `src/components/image-enlarge.tsx` — edit in the shared `DIALOG_CLASS` so the hydrated dialog and the SSR placeholder stay in lockstep

All three already close on navigation via `useModalDialog(navigateEvent)`; this PR adds only the z-index defense-in-depth, with a comment on each explaining why it must not be removed as "redundant". Mirrored into the `create-zudo-doc` feature templates (docHistory / imageEnlarge); the host components are content-allowlisted for template drift.

### #2156 — restore `pnpm lint:tokens` enforcement (pnpm patch)
`pnpm lint:tokens` was a silent no-op under pnpm: the upstream `@takazudo/zudo-design-token-lint` `dist/cli.js` gates `runMain()` on `process.argv[1] === fileURLToPath(import.meta.url)`, but under pnpm `argv[1]` is the `.bin` symlink while `import.meta.url` resolves to the real `.pnpm` store path → never equal → `runMain()` never ran → exit 0, zero output. So the b4push/CI "token lint" step was inert.

The clean fix is upstream (a release with a symlink-tolerant `isMain`) + a pin bump here. As an **in-repo workaround until then**, this PR adds a `pnpm patch` that makes the `isMain` check compare `realpathSync()` of both paths:
- `patches/@takazudo__zudo-design-token-lint@1.0.0.patch`
- `pnpm.patchedDependencies` entry in `package.json` (+ lockfile)

**Verified:** before → `pnpm lint:tokens` silently exits 0; after → it scans 71 files, and a scratch file with `z-50 p-7 text-red-500` is caught (3 violations, exit 1). Deliberately NOT templated into `create-zudo-doc` (temporary workaround); remove the patch + entry once upstream ships the fix and the pin is bumped.

## Verification
- `pnpm check` (typecheck) — pass
- `pnpm check:z-index` (codegen drift) — pass
- `pnpm lint:tokens` before/after proof — pass (now enforces)
- `pnpm check:template-drift` — pass in CI (Template Drift Check green)
- `/deep-review` (codex) — no actionable findings