### PR TITLE
chore(deps): bump @takazudo/zfb family 0.1.0-next.44 → next.47

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,9 +86,9 @@
   },
   "dependencies": {
     "@takazudo/zdtp": "0.2.0-next.2",
-    "@takazudo/zfb": "0.1.0-next.44",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.44",
-    "@takazudo/zfb-runtime": "0.1.0-next.44",
+    "@takazudo/zfb": "0.1.0-next.47",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.47",
+    "@takazudo/zfb-runtime": "0.1.0-next.47",
     "@takazudo/zudo-doc": "workspace:*",
     "@types/hast": "^3.0.4",
     "clsx": "^2.1.1",

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -3188,13 +3188,14 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
    * resolve_links for dir-style hrefs written from non-index pages
    * (Takazudo/zudo-front-builder#1030), and the data-file skip warning now
    * respects collection include/exclude globs (#1032). Now bumped to
-   * 0.1.0-next.44: next.42/next.43 were release-tooling + formatter-glob fixes;
-   * next.44 is embed-as-library enhancements only (ServerBuilder::with_page_cache,
-   * opt-in ExternalInvalidationHook, TS-config-loader path canonicalization) —
-   * no consumer-facing breaking change. Generated package.json must pin all
-   * three.
+   * 0.1.0-next.47: next.42–next.44 were release-tooling, formatter-glob, and
+   * embed-as-library enhancements; next.45 docs-only; next.46 opt-in dev
+   * boot-lazy mode + client-router timer lifecycle fixes; next.47 dual
+   * light/dark syntect themes (themeLight/themeDark, #1067) plus stricter
+   * build-start rejection of unknown theme names — additive, no consumer-facing
+   * breaking change. Generated package.json must pin all three.
    */
-  it("pins @takazudo/zfb at 0.1.0-next.44", async () => {
+  it("pins @takazudo/zfb at 0.1.0-next.47", async () => {
     const choices: UserChoices = {
       projectName: "test-pin-bump",
       defaultLang: "en",
@@ -3205,10 +3206,10 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
     };
     await scaffold(choices);
     const pkg = await fs.readJson(projectPath("test-pin-bump", "package.json"));
-    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.44");
-    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.44");
+    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.47");
+    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.47");
     expect(pkg.dependencies["@takazudo/zfb-adapter-cloudflare"]).toBe(
-      "0.1.0-next.44",
+      "0.1.0-next.47",
     );
   });
 });

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -354,15 +354,21 @@ function generatePackageJson(choices: UserChoices) {
     // include/exclude globs (#1032). No consumer-facing breaking change.
     // next.42/next.43: release-tooling + formatter-glob fixes only (npm-publish
     // idempotency, gitignored-artifact excludes). No consumer-facing change.
-    // next.44 (current pin): embed-as-library enhancements only — ServerBuilder
-    // ::with_page_cache for live content, an opt-in ExternalInvalidationHook to
-    // narrow extraWatchPaths rebuilds, and TS-config-loader path canonicalization
-    // (Takazudo/zudo-front-builder#1036–#1043). No consumer-facing / CLI change.
-    "@takazudo/zfb": "0.1.0-next.44",
-    "@takazudo/zfb-runtime": "0.1.0-next.44",
+    // next.44: embed-as-library enhancements only — ServerBuilder::with_page_cache
+    // for live content, an opt-in ExternalInvalidationHook to narrow
+    // extraWatchPaths rebuilds, and TS-config-loader path canonicalization
+    // (Takazudo/zudo-front-builder#1036–#1043). next.45: docs-only. next.46:
+    // opt-in dev boot-lazy mode (#1057) + client-router timer lifecycle fixes —
+    // dev-server-only. next.47 (current pin): dual light/dark syntect themes
+    // (themeLight/themeDark on CodeHighlightConfig, --shiki-light/--shiki-dark,
+    // #1067) plus stricter build-start validation that rejects unknown theme
+    // names — additive; a fresh scaffold sets no explicit codeHighlight.theme so
+    // the default still applies. No consumer-facing / CLI breaking change.
+    "@takazudo/zfb": "0.1.0-next.47",
+    "@takazudo/zfb-runtime": "0.1.0-next.47",
     // zfb-adapter-cloudflare — required for any route with `prerender = false`.
     // Pinned in lockstep with @takazudo/zfb.
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.44",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.47",
     // @takazudo/zudo-doc — published from this monorepo via
     // .github/workflows/publish-zudo-doc.yml. The pin here is bumped in
     // lockstep by scripts/release-create-zudo-doc.sh whenever zudo-doc's

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -172,8 +172,8 @@
   ],
   "peerDependencies": {
     "preact": "^10.29.1",
-    "@takazudo/zfb": "^0.1.0-next.44",
-    "@takazudo/zfb-runtime": "^0.1.0-next.44",
+    "@takazudo/zfb": "^0.1.0-next.47",
+    "@takazudo/zfb-runtime": "^0.1.0-next.47",
     "@takazudo/zudo-doc-history-server": "workspace:^",
     "@takazudo/zdtp": "^0.2.0-next.2",
     "shiki": "^4.0.2"
@@ -201,7 +201,7 @@
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
     "vitest": "^4.1.0",
-    "@takazudo/zfb": "0.1.0-next.44",
-    "@takazudo/zfb-runtime": "0.1.0-next.44"
+    "@takazudo/zfb": "0.1.0-next.47",
+    "@takazudo/zfb-runtime": "0.1.0-next.47"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,14 +30,14 @@ importers:
         specifier: 0.2.0-next.2
         version: 0.2.0-next.2(preact@10.29.2)
       '@takazudo/zfb':
-        specifier: 0.1.0-next.44
-        version: 0.1.0-next.44
+        specifier: 0.1.0-next.47
+        version: 0.1.0-next.47
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.44
-        version: 0.1.0-next.44
+        specifier: 0.1.0-next.47
+        version: 0.1.0-next.47
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.44
-        version: 0.1.0-next.44(@takazudo/zfb@0.1.0-next.44)
+        specifier: 0.1.0-next.47
+        version: 0.1.0-next.47(@takazudo/zfb@0.1.0-next.47)
       '@takazudo/zudo-doc':
         specifier: workspace:*
         version: link:packages/zudo-doc
@@ -290,11 +290,11 @@ importers:
         version: 4.0.3
     devDependencies:
       '@takazudo/zfb':
-        specifier: 0.1.0-next.44
-        version: 0.1.0-next.44
+        specifier: 0.1.0-next.47
+        version: 0.1.0-next.47
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.44
-        version: 0.1.0-next.44(@takazudo/zfb@0.1.0-next.44)
+        specifier: 0.1.0-next.47
+        version: 0.1.0-next.47(@takazudo/zfb@0.1.0-next.47)
       '@types/node':
         specifier: ^25.3.5
         version: 25.3.5
@@ -1377,44 +1377,44 @@ packages:
     peerDependencies:
       preact: ^10.29.1
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.44':
-    resolution: {integrity: sha512-qH85aARkLElWD04aMKY0laEGii/h6n6zWfAwIAYvP6ZJzfp8OiY2J66FFXG2KelcVmem6RM0heNbTXsCEWPTQQ==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.47':
+    resolution: {integrity: sha512-qbgPxyBvpVtghB9OZ2aUvBlKxbft1e/UdS1j3C2t+2yCtE6kyI60dermtlxl42Qs9rk7YE8tyZi79gCzbnY58Q==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.44':
-    resolution: {integrity: sha512-T0LiNS/zvDKRipn5vyam4MvcNWtDXDTn/Ldjt8uTw6xlabxOLlqbMxidR00U5hF1RMVGjzpqEwHK3Rwtf1aU6Q==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.47':
+    resolution: {integrity: sha512-+AsqqzzajEp2ml8Yf8hLfvIAK41CG5/Pg75n/MxwGS05je00XBqklY4mx2HytcWIbG9/9gusKuUhModrle8z5g==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.44':
-    resolution: {integrity: sha512-ccl3j/Ks8JQIr67df0aOG51UBXPYlcADymmuxzrhVKs8f14LsG17ZyTMDQVN+mrRCwq69TXdmmsKCqX0UouYaw==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.47':
+    resolution: {integrity: sha512-KX0L6ZbUQ1PfGG1ryF9yXrvz+wFU3WTB0FCVys+H4BAAL5VoDjSSyJUq8ewogtxVS1yW388xaKvPNtHJ5+nX9A==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.44':
-    resolution: {integrity: sha512-YlX73IIse50JxdollPVn5vs6pKdKLLlTxJu6D/U8rZmx0HIhx+/z27zywy3vfIuK11bxkGMRxJNT41uHJ6eJuA==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.47':
+    resolution: {integrity: sha512-+Ox7NvP6HCCuK2BnWV7XfT3UJCGPM/AhAPtR1q4fgmRbx+3p2Acd+SZb9au9v5NlP2/caw5/vDFr4bn88XS6FA==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.44':
-    resolution: {integrity: sha512-WRzAHKBAx9e+SS0x95uaLewgViUhmaH+Q4NgiVjEVMSj6pAc6/6RIhwehRjyN+MnnrVmJHyb6f+oawP//cnCjw==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.47':
+    resolution: {integrity: sha512-RM0FSDq1Gyph25lIwMdxMYVLCrI3OVy8s2IYgIJqqaBHXTZIQm54N2JU1oMzPNp5+P7HjextLFNT54zA1xcB5g==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.44':
-    resolution: {integrity: sha512-sZX9wdAIM54X5LjwuSDFw4VG6VoyQ8GZbiKVyl9O//F7ZyFuuVVF2d3MZCS5J6PxRG/fOm0F6su8atkCZJngTg==}
+  '@takazudo/zfb-runtime@0.1.0-next.47':
+    resolution: {integrity: sha512-02pliKgGHrhzkRzhrEwdPc46+vzOFFt0wx7Lijnmh+jcwMfvEHYGDsejaJQjj37qS7OZN8XJHbXVrNnzakKF8w==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.44
+      '@takazudo/zfb': 0.1.0-next.47
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.44':
-    resolution: {integrity: sha512-pZHPxZpFFmBvtZPo75kCQtly9DYtc2/gA6hgXkxhTlhAFlDmOe3IfaYiWDnGBMN0Gv8K/IcbakO0oRsaaEzp4Q==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.47':
+    resolution: {integrity: sha512-Ogi5BTESgAM6jqtMIRgxoRX9/0tfLJEys7XyCo8yQk5Ao2xTJxN85wG4V4IxGlaypWHygv28vbZfEtr6758ipA==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.44':
-    resolution: {integrity: sha512-RZ4LyXjCAhZJzuw/NGyNfxXb57QExVwZeY0ngoR2GBssGNLxCDgWG8LRuXaDWAef6ZF0x0FQYwsY8VIDr1t3xQ==}
+  '@takazudo/zfb@0.1.0-next.47':
+    resolution: {integrity: sha512-4mL+AI//ZqM34wNBEwzpeAIXQrFIjvrMuNL6vj37ncjK8T2I+tj4oqlK7Ca8BnaJlTUYzvlKP5uKElu871Sz8w==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
@@ -4076,35 +4076,35 @@ snapshots:
       culori: 4.0.2
       preact: 10.29.2
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.44': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.47': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.44':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.47':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.44':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.47':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.44':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.47':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.44':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.47':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.44(@takazudo/zfb@0.1.0-next.44)':
+  '@takazudo/zfb-runtime@0.1.0-next.47(@takazudo/zfb@0.1.0-next.47)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.44
+      '@takazudo/zfb': 0.1.0-next.47
       hono: 4.12.23
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.44':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.47':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.44':
+  '@takazudo/zfb@0.1.0-next.47':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.44
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.44
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.44
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.44
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.44
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.47
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.47
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.47
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.47
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.47
 
   '@takazudo/zudo-design-token-lint@1.0.0(patch_hash=6a157fd850449b055cf64a8a7dd1faed5b1da9eebe6c81cca08488ac0de85182)':
     dependencies:


### PR DESCRIPTION
## Summary

Bump the `@takazudo/zfb` engine family — `@takazudo/zfb`, `@takazudo/zfb-runtime`, `@takazudo/zfb-adapter-cloudflare` — from `0.1.0-next.44` to `0.1.0-next.47`, keeping every pin-parity source in lockstep.

## Changes

- **Root `package.json`** — 3 zfb `dependencies` pins → `0.1.0-next.47`
- **`packages/zudo-doc/package.json`** — `devDependencies` (exact) + `peerDependencies` (`^`) for `@takazudo/zfb` and `@takazudo/zfb-runtime`
- **`packages/create-zudo-doc/src/scaffold.ts`** — generated-scaffold pins for all three packages + refreshed version-history comment (next.45–47)
- **`packages/create-zudo-doc/src/__tests__/scaffold.test.ts`** — pin-bump assertions, test title, and comment
- **`pnpm-lock.yaml`** — regenerated via `pnpm install`

## Upstream delta (next.44 → next.47)

- **next.45** — docs-only.
- **next.46** — opt-in dev boot-lazy mode (#1057) + client-router timer lifecycle fixes; dev-server-only.
- **next.47** — dual light/dark syntect themes (`themeLight`/`themeDark` on `CodeHighlightConfig`, `--shiki-light`/`--shiki-dark`, #1067) + stricter build-start rejection of unknown theme names. Additive; this repo sets no explicit `codeHighlight.theme`, so the default still applies and the build is unaffected.

## Test Plan

- `pnpm check:pin-parity` ✓ (all 3 external + 2 internal + 4 workspace-package fields lockstep)
- `pnpm check` (tsc) ✓
- `pnpm build` ✓ (276 pages)
- Full test suite ✓ — root unit + all package tests (331 create-zudo-doc incl. pin-bump test, 530 zudo-doc, 37 doc-history, 80 md-plugins, search-worker)
- `/codex-review` ✓ — no findings

## Notes
- Created via `/x-as-pr -m -a`. zdtp is unchanged (its `@next` is still `0.2.0-next.2`).