### PR TITLE
chore(deps): bump @takazudo/zfb 0.1.0-next.47 → 0.1.0-next.48

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,9 +86,9 @@
   },
   "dependencies": {
     "@takazudo/zdtp": "0.2.3",
-    "@takazudo/zfb": "0.1.0-next.47",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.47",
-    "@takazudo/zfb-runtime": "0.1.0-next.47",
+    "@takazudo/zfb": "0.1.0-next.48",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.48",
+    "@takazudo/zfb-runtime": "0.1.0-next.48",
     "@takazudo/zudo-doc": "workspace:*",
     "@types/hast": "^3.0.4",
     "clsx": "^2.1.1",

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -3206,14 +3206,16 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
    * resolve_links for dir-style hrefs written from non-index pages
    * (Takazudo/zudo-front-builder#1030), and the data-file skip warning now
    * respects collection include/exclude globs (#1032). Now bumped to
-   * 0.1.0-next.47: next.42–next.44 were release-tooling, formatter-glob, and
+   * 0.1.0-next.48: next.42–next.44 were release-tooling, formatter-glob, and
    * embed-as-library enhancements; next.45 docs-only; next.46 opt-in dev
    * boot-lazy mode + client-router timer lifecycle fixes; next.47 dual
    * light/dark syntect themes (themeLight/themeDark, #1067) plus stricter
-   * build-start rejection of unknown theme names — additive, no consumer-facing
-   * breaking change. Generated package.json must pin all three.
+   * build-start rejection of unknown theme names; next.48 re-exports
+   * @takazudo/zfb/config from the zfb-shim.d.ts type shim — type-only fix,
+   * additive, no consumer-facing breaking change. Generated package.json must
+   * pin all three.
    */
-  it("pins @takazudo/zfb at 0.1.0-next.47", async () => {
+  it("pins @takazudo/zfb at 0.1.0-next.48", async () => {
     const choices: UserChoices = {
       projectName: "test-pin-bump",
       defaultLang: "en",
@@ -3224,10 +3226,10 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
     };
     await scaffold(choices);
     const pkg = await fs.readJson(projectPath("test-pin-bump", "package.json"));
-    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.47");
-    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.47");
+    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.48");
+    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.48");
     expect(pkg.dependencies["@takazudo/zfb-adapter-cloudflare"]).toBe(
-      "0.1.0-next.47",
+      "0.1.0-next.48",
     );
   });
 });

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -373,16 +373,18 @@ function generatePackageJson(choices: UserChoices) {
     // extraWatchPaths rebuilds, and TS-config-loader path canonicalization
     // (Takazudo/zudo-front-builder#1036–#1043). next.45: docs-only. next.46:
     // opt-in dev boot-lazy mode (#1057) + client-router timer lifecycle fixes —
-    // dev-server-only. next.47 (current pin): dual light/dark syntect themes
-    // (themeLight/themeDark on CodeHighlightConfig, --shiki-light/--shiki-dark,
-    // #1067) plus stricter build-start validation that rejects unknown theme
-    // names — additive; a fresh scaffold sets no explicit codeHighlight.theme so
-    // the default still applies. No consumer-facing / CLI breaking change.
-    "@takazudo/zfb": "0.1.0-next.47",
-    "@takazudo/zfb-runtime": "0.1.0-next.47",
+    // dev-server-only. next.47: dual light/dark syntect themes (themeLight/
+    // themeDark on CodeHighlightConfig, --shiki-light/--shiki-dark, #1067) plus
+    // stricter build-start validation that rejects unknown theme names. next.48
+    // (current pin): re-export @takazudo/zfb/config from the zfb-shim.d.ts type
+    // shim — type-only fix, additive; a fresh scaffold sets no explicit
+    // codeHighlight.theme so the default still applies. No consumer-facing / CLI
+    // breaking change.
+    "@takazudo/zfb": "0.1.0-next.48",
+    "@takazudo/zfb-runtime": "0.1.0-next.48",
     // zfb-adapter-cloudflare — required for any route with `prerender = false`.
     // Pinned in lockstep with @takazudo/zfb.
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.47",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.48",
     // @takazudo/zudo-doc — published from this monorepo via
     // .github/workflows/publish-zudo-doc.yml. The pin here is bumped in
     // lockstep by scripts/release-create-zudo-doc.sh whenever zudo-doc's

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -172,8 +172,8 @@
   ],
   "peerDependencies": {
     "preact": "^10.29.1",
-    "@takazudo/zfb": "^0.1.0-next.47",
-    "@takazudo/zfb-runtime": "^0.1.0-next.47",
+    "@takazudo/zfb": "^0.1.0-next.48",
+    "@takazudo/zfb-runtime": "^0.1.0-next.48",
     "@takazudo/zudo-doc-history-server": "workspace:^",
     "@takazudo/zdtp": "^0.2.3",
     "shiki": "^4.0.2"
@@ -201,7 +201,7 @@
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
     "vitest": "^4.1.0",
-    "@takazudo/zfb": "0.1.0-next.47",
-    "@takazudo/zfb-runtime": "0.1.0-next.47"
+    "@takazudo/zfb": "0.1.0-next.48",
+    "@takazudo/zfb-runtime": "0.1.0-next.48"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,14 +30,14 @@ importers:
         specifier: 0.2.3
         version: 0.2.3(preact@10.29.2)
       '@takazudo/zfb':
-        specifier: 0.1.0-next.47
-        version: 0.1.0-next.47
+        specifier: 0.1.0-next.48
+        version: 0.1.0-next.48
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.47
-        version: 0.1.0-next.47
+        specifier: 0.1.0-next.48
+        version: 0.1.0-next.48
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.47
-        version: 0.1.0-next.47(@takazudo/zfb@0.1.0-next.47)
+        specifier: 0.1.0-next.48
+        version: 0.1.0-next.48(@takazudo/zfb@0.1.0-next.48)
       '@takazudo/zudo-doc':
         specifier: workspace:*
         version: link:packages/zudo-doc
@@ -290,11 +290,11 @@ importers:
         version: 4.0.3
     devDependencies:
       '@takazudo/zfb':
-        specifier: 0.1.0-next.47
-        version: 0.1.0-next.47
+        specifier: 0.1.0-next.48
+        version: 0.1.0-next.48
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.47
-        version: 0.1.0-next.47(@takazudo/zfb@0.1.0-next.47)
+        specifier: 0.1.0-next.48
+        version: 0.1.0-next.48(@takazudo/zfb@0.1.0-next.48)
       '@types/node':
         specifier: ^25.3.5
         version: 25.3.5
@@ -1377,44 +1377,44 @@ packages:
     peerDependencies:
       preact: ^10.29.1
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.47':
-    resolution: {integrity: sha512-qbgPxyBvpVtghB9OZ2aUvBlKxbft1e/UdS1j3C2t+2yCtE6kyI60dermtlxl42Qs9rk7YE8tyZi79gCzbnY58Q==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.48':
+    resolution: {integrity: sha512-8YEXLmFavENv7Qii5LT0WQivkHmMMio69gZKYOLpaxNV8DXNPA4mmQQk+0l1h9xbrIx9c+k+H2DOi1wGym6jlA==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.47':
-    resolution: {integrity: sha512-+AsqqzzajEp2ml8Yf8hLfvIAK41CG5/Pg75n/MxwGS05je00XBqklY4mx2HytcWIbG9/9gusKuUhModrle8z5g==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.48':
+    resolution: {integrity: sha512-U4LeWLH4htVJX7+hTdJF9uj07f909skWD9ScnUk62poKd7NBs/sp+ZM8c8beMoarG5kGhG/bnAKB3LVOS3pUAQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.47':
-    resolution: {integrity: sha512-KX0L6ZbUQ1PfGG1ryF9yXrvz+wFU3WTB0FCVys+H4BAAL5VoDjSSyJUq8ewogtxVS1yW388xaKvPNtHJ5+nX9A==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.48':
+    resolution: {integrity: sha512-il3PewWS0kGp/b823e/ZQWvIqBKB6Vyq0QjhF+YDI62it1hXLX/VrwwBE2v/uFK0B9oRJjl7AUmgjyJhcT4QMA==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.47':
-    resolution: {integrity: sha512-+Ox7NvP6HCCuK2BnWV7XfT3UJCGPM/AhAPtR1q4fgmRbx+3p2Acd+SZb9au9v5NlP2/caw5/vDFr4bn88XS6FA==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.48':
+    resolution: {integrity: sha512-wvvrvqmexicesC13BOEpUZ2U6fgA02mTXpUgBTzEtAZITok0PLnDtEHBHZuwK9WYqMF+Ujjc1iFSISaa8DFYew==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.47':
-    resolution: {integrity: sha512-RM0FSDq1Gyph25lIwMdxMYVLCrI3OVy8s2IYgIJqqaBHXTZIQm54N2JU1oMzPNp5+P7HjextLFNT54zA1xcB5g==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.48':
+    resolution: {integrity: sha512-ealD9oFbh0T7IMpzZO9Z0Hirb9QSL5KH21fXTxnREH64w9z4uIZAUJrOVtbyOXdBaPq19L6j+gIiSSNS5F/vbg==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.47':
-    resolution: {integrity: sha512-02pliKgGHrhzkRzhrEwdPc46+vzOFFt0wx7Lijnmh+jcwMfvEHYGDsejaJQjj37qS7OZN8XJHbXVrNnzakKF8w==}
+  '@takazudo/zfb-runtime@0.1.0-next.48':
+    resolution: {integrity: sha512-xnL6wQzRBfvqS7mjppKji7GjSLu/TiD1y0G/Jobsohi4ZJMyH05ZAPN+oIUmoQA2bI25y/AFJ61Z5LTTOgDwCQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.47
+      '@takazudo/zfb': 0.1.0-next.48
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.47':
-    resolution: {integrity: sha512-Ogi5BTESgAM6jqtMIRgxoRX9/0tfLJEys7XyCo8yQk5Ao2xTJxN85wG4V4IxGlaypWHygv28vbZfEtr6758ipA==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.48':
+    resolution: {integrity: sha512-RHgDoVKMfUYCgVAhcoevwrzyVxJ08qYOYrkI/+wqehlGZD8wp+jxOGITl/mVUUq/k6q1HyyLCSiMesJcm+gOSQ==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.47':
-    resolution: {integrity: sha512-4mL+AI//ZqM34wNBEwzpeAIXQrFIjvrMuNL6vj37ncjK8T2I+tj4oqlK7Ca8BnaJlTUYzvlKP5uKElu871Sz8w==}
+  '@takazudo/zfb@0.1.0-next.48':
+    resolution: {integrity: sha512-xxZjlg3F8tjZNwK4Wel5N7hjCLUWbXbGPX258BR+eURegR1EhCuYq1WL2S7Ss3WdrSoDHEiZdgVQ83QD/gMZ0Q==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
@@ -4076,35 +4076,35 @@ snapshots:
       culori: 4.0.2
       preact: 10.29.2
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.47': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.48': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.47':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.48':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.47':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.48':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.47':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.48':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.47':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.48':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.47(@takazudo/zfb@0.1.0-next.47)':
+  '@takazudo/zfb-runtime@0.1.0-next.48(@takazudo/zfb@0.1.0-next.48)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.47
+      '@takazudo/zfb': 0.1.0-next.48
       hono: 4.12.23
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.47':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.48':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.47':
+  '@takazudo/zfb@0.1.0-next.48':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.47
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.47
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.47
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.47
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.47
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.48
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.48
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.48
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.48
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.48
 
   '@takazudo/zudo-design-token-lint@1.0.0(patch_hash=6a157fd850449b055cf64a8a7dd1faed5b1da9eebe6c81cca08488ac0de85182)':
     dependencies:


### PR DESCRIPTION
## Summary

Bumps the zfb toolchain from `0.1.0-next.47` to `0.1.0-next.48`.

next.48 re-exports `@takazudo/zfb/config` from the `zfb-shim.d.ts` type shim — a type-only, additive fix with no consumer-facing or CLI breaking change.

## Changes

Updated all four pin-parity locations (enforced by `scripts/check-pin-parity.mjs`) plus the lockfile:

- **Root `package.json`** — `@takazudo/zfb`, `@takazudo/zfb-runtime`, `@takazudo/zfb-adapter-cloudflare` → `0.1.0-next.48`
- **`packages/zudo-doc/package.json`** — `devDependencies` (exact) + `peerDependencies` (`^`) for `zfb` / `zfb-runtime`
- **`packages/create-zudo-doc/src/scaffold.ts`** — scaffold-emitted pins + explanatory comment
- **`packages/create-zudo-doc/src/__tests__/scaffold.test.ts`** — pin assertions + history comment
- **`pnpm-lock.yaml`** — regenerated via `pnpm install`

`@takazudo/zdtp` stays at `0.2.3` (already latest). Project version stays at `0.2.8` — this is a dependency bump only; a version roll happens separately via release tooling.

## Validation

- ✅ `pnpm check:pin-parity` — all 3 external + 2 internal + 4 workspace-package fields in lockstep
- ✅ `pnpm check` — tsc, no errors
- ✅ `pnpm build` — 279 pages built
- ✅ scaffold pin test passes

https://claude.ai/code/session_01JdBRKfKukK6p4bTZevxTq4

---
_Generated by [Claude Code](https://claude.ai/code/session_01JdBRKfKukK6p4bTZevxTq4)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784149551&installation_id=130359969&pr_number=2167&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2167&signature=d71c1052197cc7aa8434ff14acf6e64cf169aac6351facdba4eb363e8e024b28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->