### PR TITLE
chore(deps): bump @takazudo/zfb 0.1.0-next.48 → 0.1.0-next.49

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,9 +86,9 @@
   },
   "dependencies": {
     "@takazudo/zdtp": "0.2.3",
-    "@takazudo/zfb": "0.1.0-next.48",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.48",
-    "@takazudo/zfb-runtime": "0.1.0-next.48",
+    "@takazudo/zfb": "0.1.0-next.49",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.49",
+    "@takazudo/zfb-runtime": "0.1.0-next.49",
     "@takazudo/zudo-doc": "workspace:*",
     "@types/hast": "^3.0.4",
     "clsx": "^2.1.1",

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -3206,16 +3206,18 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
    * resolve_links for dir-style hrefs written from non-index pages
    * (Takazudo/zudo-front-builder#1030), and the data-file skip warning now
    * respects collection include/exclude globs (#1032). Now bumped to
-   * 0.1.0-next.48: next.42–next.44 were release-tooling, formatter-glob, and
+   * 0.1.0-next.49: next.42–next.44 were release-tooling, formatter-glob, and
    * embed-as-library enhancements; next.45 docs-only; next.46 opt-in dev
    * boot-lazy mode + client-router timer lifecycle fixes; next.47 dual
    * light/dark syntect themes (themeLight/themeDark, #1067) plus stricter
    * build-start rejection of unknown theme names; next.48 re-exports
-   * @takazudo/zfb/config from the zfb-shim.d.ts type shim — type-only fix,
-   * additive, no consumer-facing breaking change. Generated package.json must
-   * pin all three.
+   * @takazudo/zfb/config from the zfb-shim.d.ts type shim — type-only fix;
+   * next.49 client-router WebKit bfcache fix (re-sync history index +
+   * originalLocation on bfcache restore so browser Back after an SPA navigation
+   * returns to the previous page) — runtime-only bug fix, additive, no
+   * consumer-facing breaking change. Generated package.json must pin all three.
    */
-  it("pins @takazudo/zfb at 0.1.0-next.48", async () => {
+  it("pins @takazudo/zfb at 0.1.0-next.49", async () => {
     const choices: UserChoices = {
       projectName: "test-pin-bump",
       defaultLang: "en",
@@ -3226,10 +3228,10 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
     };
     await scaffold(choices);
     const pkg = await fs.readJson(projectPath("test-pin-bump", "package.json"));
-    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.48");
-    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.48");
+    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.49");
+    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.49");
     expect(pkg.dependencies["@takazudo/zfb-adapter-cloudflare"]).toBe(
-      "0.1.0-next.48",
+      "0.1.0-next.49",
     );
   });
 });

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -375,16 +375,19 @@ function generatePackageJson(choices: UserChoices) {
     // opt-in dev boot-lazy mode (#1057) + client-router timer lifecycle fixes —
     // dev-server-only. next.47: dual light/dark syntect themes (themeLight/
     // themeDark on CodeHighlightConfig, --shiki-light/--shiki-dark, #1067) plus
-    // stricter build-start validation that rejects unknown theme names. next.48
-    // (current pin): re-export @takazudo/zfb/config from the zfb-shim.d.ts type
-    // shim — type-only fix, additive; a fresh scaffold sets no explicit
-    // codeHighlight.theme so the default still applies. No consumer-facing / CLI
-    // breaking change.
-    "@takazudo/zfb": "0.1.0-next.48",
-    "@takazudo/zfb-runtime": "0.1.0-next.48",
+    // stricter build-start validation that rejects unknown theme names. next.48:
+    // re-export @takazudo/zfb/config from the zfb-shim.d.ts type shim — type-only
+    // fix, additive. next.49 (current pin): client-router WebKit bfcache fix —
+    // re-sync the history index + originalLocation on a bfcache restore so
+    // browser Back after an SPA navigation returns to the previous page instead
+    // of skipping an entry — runtime-only bug fix, additive. A fresh scaffold
+    // sets no explicit codeHighlight.theme so the default still applies. No
+    // consumer-facing / CLI breaking change.
+    "@takazudo/zfb": "0.1.0-next.49",
+    "@takazudo/zfb-runtime": "0.1.0-next.49",
     // zfb-adapter-cloudflare — required for any route with `prerender = false`.
     // Pinned in lockstep with @takazudo/zfb.
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.48",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.49",
     // @takazudo/zudo-doc — published from this monorepo via
     // .github/workflows/publish-zudo-doc.yml. The pin here is bumped in
     // lockstep by scripts/release-create-zudo-doc.sh whenever zudo-doc's

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -172,8 +172,8 @@
   ],
   "peerDependencies": {
     "preact": "^10.29.1",
-    "@takazudo/zfb": "^0.1.0-next.48",
-    "@takazudo/zfb-runtime": "^0.1.0-next.48",
+    "@takazudo/zfb": "^0.1.0-next.49",
+    "@takazudo/zfb-runtime": "^0.1.0-next.49",
     "@takazudo/zudo-doc-history-server": "workspace:^",
     "@takazudo/zdtp": "^0.2.3",
     "shiki": "^4.0.2"
@@ -201,7 +201,7 @@
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
     "vitest": "^4.1.0",
-    "@takazudo/zfb": "0.1.0-next.48",
-    "@takazudo/zfb-runtime": "0.1.0-next.48"
+    "@takazudo/zfb": "0.1.0-next.49",
+    "@takazudo/zfb-runtime": "0.1.0-next.49"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,14 +30,14 @@ importers:
         specifier: 0.2.3
         version: 0.2.3(preact@10.29.2)
       '@takazudo/zfb':
-        specifier: 0.1.0-next.48
-        version: 0.1.0-next.48
+        specifier: 0.1.0-next.49
+        version: 0.1.0-next.49
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.48
-        version: 0.1.0-next.48
+        specifier: 0.1.0-next.49
+        version: 0.1.0-next.49
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.48
-        version: 0.1.0-next.48(@takazudo/zfb@0.1.0-next.48)
+        specifier: 0.1.0-next.49
+        version: 0.1.0-next.49(@takazudo/zfb@0.1.0-next.49)
       '@takazudo/zudo-doc':
         specifier: workspace:*
         version: link:packages/zudo-doc
@@ -290,11 +290,11 @@ importers:
         version: 4.0.3
     devDependencies:
       '@takazudo/zfb':
-        specifier: 0.1.0-next.48
-        version: 0.1.0-next.48
+        specifier: 0.1.0-next.49
+        version: 0.1.0-next.49
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.48
-        version: 0.1.0-next.48(@takazudo/zfb@0.1.0-next.48)
+        specifier: 0.1.0-next.49
+        version: 0.1.0-next.49(@takazudo/zfb@0.1.0-next.49)
       '@types/node':
         specifier: ^25.3.5
         version: 25.3.5
@@ -1377,44 +1377,44 @@ packages:
     peerDependencies:
       preact: ^10.29.1
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.48':
-    resolution: {integrity: sha512-8YEXLmFavENv7Qii5LT0WQivkHmMMio69gZKYOLpaxNV8DXNPA4mmQQk+0l1h9xbrIx9c+k+H2DOi1wGym6jlA==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.49':
+    resolution: {integrity: sha512-1ilAvfQcTUHa4nmV0XU8zHPjIzfr0hUdJJACtklYYHkWVyemh1k9hoRUZm2MAKYVwye6BZV/p5x1zkxCYn3P2g==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.48':
-    resolution: {integrity: sha512-U4LeWLH4htVJX7+hTdJF9uj07f909skWD9ScnUk62poKd7NBs/sp+ZM8c8beMoarG5kGhG/bnAKB3LVOS3pUAQ==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.49':
+    resolution: {integrity: sha512-pUDptGa4L4mxfn7vThzpYDjszkuhvfLHwDuBBvZ/qC1Uz32/nqJJOxl8ZdwkzpfzYGkna1I9OzUUnx9QBv2Qiw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.48':
-    resolution: {integrity: sha512-il3PewWS0kGp/b823e/ZQWvIqBKB6Vyq0QjhF+YDI62it1hXLX/VrwwBE2v/uFK0B9oRJjl7AUmgjyJhcT4QMA==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.49':
+    resolution: {integrity: sha512-iJrktID8Momn3CHBzMjU31F6NzlnV89QM/v/iMiZGnEtLote6HJcXDstm5xoghbX2i6RynCJ0CTiUNu4meEAKQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.48':
-    resolution: {integrity: sha512-wvvrvqmexicesC13BOEpUZ2U6fgA02mTXpUgBTzEtAZITok0PLnDtEHBHZuwK9WYqMF+Ujjc1iFSISaa8DFYew==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.49':
+    resolution: {integrity: sha512-m0DsadTcMVAztEqnWhW21NYMGtE+78LRErYVi2eoLIrLD2VhwGeIl7dxx8qUBw2DS3Y/QiIkXC9WZbvhSQ68Mw==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.48':
-    resolution: {integrity: sha512-ealD9oFbh0T7IMpzZO9Z0Hirb9QSL5KH21fXTxnREH64w9z4uIZAUJrOVtbyOXdBaPq19L6j+gIiSSNS5F/vbg==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.49':
+    resolution: {integrity: sha512-aQYxEYIufy5DL9/J8uuCGsZATmmvT28x/TWrft4YzkCToEgGSbQgCE6p7XGOTvJWsQpSGq8nVwHbIjHb7os0dg==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.48':
-    resolution: {integrity: sha512-xnL6wQzRBfvqS7mjppKji7GjSLu/TiD1y0G/Jobsohi4ZJMyH05ZAPN+oIUmoQA2bI25y/AFJ61Z5LTTOgDwCQ==}
+  '@takazudo/zfb-runtime@0.1.0-next.49':
+    resolution: {integrity: sha512-5sg3EEOQbwe5FSP0dH/8eDNODlhJlWzc5sXGNSe9tnwy3EZeIV36zWy0nqhgEyjuaSnfgQPdkO1V/xX84IG/TQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.48
+      '@takazudo/zfb': 0.1.0-next.49
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.48':
-    resolution: {integrity: sha512-RHgDoVKMfUYCgVAhcoevwrzyVxJ08qYOYrkI/+wqehlGZD8wp+jxOGITl/mVUUq/k6q1HyyLCSiMesJcm+gOSQ==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.49':
+    resolution: {integrity: sha512-GMucMsaD3e2WYs4q8zK844CvAq88NPJRm7BnO6+AEsVB/Mfec/wD2oBbp94Q7eDr6PoJCTEFXO0o44fvgT6zrg==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.48':
-    resolution: {integrity: sha512-xxZjlg3F8tjZNwK4Wel5N7hjCLUWbXbGPX258BR+eURegR1EhCuYq1WL2S7Ss3WdrSoDHEiZdgVQ83QD/gMZ0Q==}
+  '@takazudo/zfb@0.1.0-next.49':
+    resolution: {integrity: sha512-IyZqXSjsS5mAleErx74LeNq/7ZvxJfBOqlUwl3Sz+0HcOAWj811Worevh+TZUiRo23MRgeoLFn83VJk185ftcg==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
@@ -4076,35 +4076,35 @@ snapshots:
       culori: 4.0.2
       preact: 10.29.2
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.48': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.49': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.48':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.49':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.48':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.49':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.48':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.49':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.48':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.49':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.48(@takazudo/zfb@0.1.0-next.48)':
+  '@takazudo/zfb-runtime@0.1.0-next.49(@takazudo/zfb@0.1.0-next.49)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.48
+      '@takazudo/zfb': 0.1.0-next.49
       hono: 4.12.23
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.48':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.49':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.48':
+  '@takazudo/zfb@0.1.0-next.49':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.48
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.48
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.48
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.48
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.48
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.49
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.49
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.49
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.49
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.49
 
   '@takazudo/zudo-design-token-lint@1.0.0(patch_hash=6a157fd850449b055cf64a8a7dd1faed5b1da9eebe6c81cca08488ac0de85182)':
     dependencies:


### PR DESCRIPTION
## Summary

Bumps `@takazudo/zfb`, `@takazudo/zfb-runtime`, and `@takazudo/zfb-adapter-cloudflare` from `0.1.0-next.48` to `0.1.0-next.49` across all pin-parity locations plus the lockfile.

next.49 is a **client-router bug fix** (runtime-only, additive — no breaking changes, no new config/API surface):

- Re-sync the history index on a WebKit bfcache restore so browser **Back** after an SPA navigation returns to the previous page instead of skipping an entry.
- Re-sync `originalLocation` on bfcache restore; adds a WebKit back-nav Playwright reproduction harness (T4 local-heavy lane, not run in CI).

This is relevant to zudo-doc, which uses zfb's SPA client-router — the fix applies automatically on reinstall.

## Changes

- `package.json` — root `dependencies` pins (zfb, zfb-runtime, zfb-adapter-cloudflare) → `0.1.0-next.49`
- `packages/zudo-doc/package.json` — `devDependencies` (exact) and `peerDependencies` (`^`) zfb pins → next.49
- `packages/create-zudo-doc/src/scaffold.ts` — scaffold-emitted pins → next.49 + version-history comment updated
- `packages/create-zudo-doc/src/__tests__/scaffold.test.ts` — pin assertions + `it(...)` title + comment → next.49
- `pnpm-lock.yaml` — regenerated via `pnpm install`

## Test Plan

- ✅ `pnpm check:pin-parity` — 3 external + 2 internal + 4 workspace-package fields verified at next.49
- ✅ `pnpm check` (typecheck / `tsc --noEmit`) — no errors
- ✅ create-zudo-doc scaffold pin test — passes (pins all three at next.49)
- ✅ `pnpm build` — 280 pages built
- ✅ `/codex-review` — no actionable findings
- CI (pin-parity job, build-site, build-history, e2e) on this PR