### PR TITLE
chore(deps): bump @takazudo/zfb 0.1.0-next.49 → 0.1.0-next.50

### DIFF
--- a/e2e/versioning.spec.ts
+++ b/e2e/versioning.spec.ts
@@ -193,7 +193,11 @@ test.describe("Versioning: version switcher interaction", () => {
     // `<slug>/` form, which is what the static asset server serves), so
     // the matcher accepts either shape.
     await page.waitForURL(/\/v\/1\.0\/docs\/getting-started\/?$/);
-    const content = await page.textContent("body");
-    expect(content).toContain("version 1.0");
+    // zfb's client-router (>= zfb 0.1.0-next.50) commits the SPA history entry
+    // BEFORE the View Transition content swap, so waitForURL can resolve before
+    // the destination page's body is in the DOM. Use a web-first auto-retrying
+    // assertion to wait for the swapped content instead of reading textContent
+    // once (which races the swap and reads the stale source page).
+    await expect(page.locator("body")).toContainText("version 1.0");
   });
 });

--- a/package.json
+++ b/package.json
@@ -86,9 +86,9 @@
   },
   "dependencies": {
     "@takazudo/zdtp": "0.2.3",
-    "@takazudo/zfb": "0.1.0-next.49",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.49",
-    "@takazudo/zfb-runtime": "0.1.0-next.49",
+    "@takazudo/zfb": "0.1.0-next.50",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.50",
+    "@takazudo/zfb-runtime": "0.1.0-next.50",
     "@takazudo/zudo-doc": "workspace:*",
     "@types/hast": "^3.0.4",
     "clsx": "^2.1.1",

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -3206,7 +3206,7 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
    * resolve_links for dir-style hrefs written from non-index pages
    * (Takazudo/zudo-front-builder#1030), and the data-file skip warning now
    * respects collection include/exclude globs (#1032). Now bumped to
-   * 0.1.0-next.49: next.42–next.44 were release-tooling, formatter-glob, and
+   * 0.1.0-next.50: next.42–next.44 were release-tooling, formatter-glob, and
    * embed-as-library enhancements; next.45 docs-only; next.46 opt-in dev
    * boot-lazy mode + client-router timer lifecycle fixes; next.47 dual
    * light/dark syntect themes (themeLight/themeDark, #1067) plus stricter
@@ -3214,10 +3214,13 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
    * @takazudo/zfb/config from the zfb-shim.d.ts type shim — type-only fix;
    * next.49 client-router WebKit bfcache fix (re-sync history index +
    * originalLocation on bfcache restore so browser Back after an SPA navigation
-   * returns to the previous page) — runtime-only bug fix, additive, no
-   * consumer-facing breaking change. Generated package.json must pin all three.
+   * returns to the previous page); next.50 client-router fix to commit the SPA
+   * history entry before the View Transition so on WebKit/iOS a single browser
+   * Back creates a distinct entry instead of falling off the site — both
+   * runtime-only bug fixes, additive, no consumer-facing breaking change.
+   * Generated package.json must pin all three.
    */
-  it("pins @takazudo/zfb at 0.1.0-next.49", async () => {
+  it("pins @takazudo/zfb at 0.1.0-next.50", async () => {
     const choices: UserChoices = {
       projectName: "test-pin-bump",
       defaultLang: "en",
@@ -3228,10 +3231,10 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
     };
     await scaffold(choices);
     const pkg = await fs.readJson(projectPath("test-pin-bump", "package.json"));
-    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.49");
-    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.49");
+    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.50");
+    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.50");
     expect(pkg.dependencies["@takazudo/zfb-adapter-cloudflare"]).toBe(
-      "0.1.0-next.49",
+      "0.1.0-next.50",
     );
   });
 });

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -377,17 +377,21 @@ function generatePackageJson(choices: UserChoices) {
     // themeDark on CodeHighlightConfig, --shiki-light/--shiki-dark, #1067) plus
     // stricter build-start validation that rejects unknown theme names. next.48:
     // re-export @takazudo/zfb/config from the zfb-shim.d.ts type shim — type-only
-    // fix, additive. next.49 (current pin): client-router WebKit bfcache fix —
+    // fix, additive. next.49: client-router WebKit bfcache fix —
     // re-sync the history index + originalLocation on a bfcache restore so
     // browser Back after an SPA navigation returns to the previous page instead
-    // of skipping an entry — runtime-only bug fix, additive. A fresh scaffold
-    // sets no explicit codeHighlight.theme so the default still applies. No
-    // consumer-facing / CLI breaking change.
-    "@takazudo/zfb": "0.1.0-next.49",
-    "@takazudo/zfb-runtime": "0.1.0-next.49",
+    // of skipping an entry — runtime-only bug fix, additive. next.50 (current
+    // pin): client-router fix to commit the SPA history entry BEFORE the View
+    // Transition, so on WebKit/iOS a single browser Back after an SPA navigation
+    // creates a distinct history entry instead of falling off the site —
+    // runtime-only bug fix, additive. A fresh scaffold sets no explicit
+    // codeHighlight.theme so the default still applies. No consumer-facing /
+    // CLI breaking change.
+    "@takazudo/zfb": "0.1.0-next.50",
+    "@takazudo/zfb-runtime": "0.1.0-next.50",
     // zfb-adapter-cloudflare — required for any route with `prerender = false`.
     // Pinned in lockstep with @takazudo/zfb.
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.49",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.50",
     // @takazudo/zudo-doc — published from this monorepo via
     // .github/workflows/publish-zudo-doc.yml. The pin here is bumped in
     // lockstep by scripts/release-create-zudo-doc.sh whenever zudo-doc's

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -172,8 +172,8 @@
   ],
   "peerDependencies": {
     "preact": "^10.29.1",
-    "@takazudo/zfb": "^0.1.0-next.49",
-    "@takazudo/zfb-runtime": "^0.1.0-next.49",
+    "@takazudo/zfb": "^0.1.0-next.50",
+    "@takazudo/zfb-runtime": "^0.1.0-next.50",
     "@takazudo/zudo-doc-history-server": "workspace:^",
     "@takazudo/zdtp": "^0.2.3",
     "shiki": "^4.0.2"
@@ -201,7 +201,7 @@
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
     "vitest": "^4.1.0",
-    "@takazudo/zfb": "0.1.0-next.49",
-    "@takazudo/zfb-runtime": "0.1.0-next.49"
+    "@takazudo/zfb": "0.1.0-next.50",
+    "@takazudo/zfb-runtime": "0.1.0-next.50"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,14 +30,14 @@ importers:
         specifier: 0.2.3
         version: 0.2.3(preact@10.29.2)
       '@takazudo/zfb':
-        specifier: 0.1.0-next.49
-        version: 0.1.0-next.49
+        specifier: 0.1.0-next.50
+        version: 0.1.0-next.50
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.49
-        version: 0.1.0-next.49
+        specifier: 0.1.0-next.50
+        version: 0.1.0-next.50
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.49
-        version: 0.1.0-next.49(@takazudo/zfb@0.1.0-next.49)
+        specifier: 0.1.0-next.50
+        version: 0.1.0-next.50(@takazudo/zfb@0.1.0-next.50)
       '@takazudo/zudo-doc':
         specifier: workspace:*
         version: link:packages/zudo-doc
@@ -290,11 +290,11 @@ importers:
         version: 4.0.3
     devDependencies:
       '@takazudo/zfb':
-        specifier: 0.1.0-next.49
-        version: 0.1.0-next.49
+        specifier: 0.1.0-next.50
+        version: 0.1.0-next.50
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.49
-        version: 0.1.0-next.49(@takazudo/zfb@0.1.0-next.49)
+        specifier: 0.1.0-next.50
+        version: 0.1.0-next.50(@takazudo/zfb@0.1.0-next.50)
       '@types/node':
         specifier: ^25.3.5
         version: 25.3.5
@@ -1377,44 +1377,44 @@ packages:
     peerDependencies:
       preact: ^10.29.1
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.49':
-    resolution: {integrity: sha512-1ilAvfQcTUHa4nmV0XU8zHPjIzfr0hUdJJACtklYYHkWVyemh1k9hoRUZm2MAKYVwye6BZV/p5x1zkxCYn3P2g==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.50':
+    resolution: {integrity: sha512-SmslsMWuy8D/zWVtfXt/lQ1+Y83foyOmDaryEjH7N8POUTpLTCekgM02C10ZrPtX9zz7XbdE542ZYkCYrVmDTg==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.49':
-    resolution: {integrity: sha512-pUDptGa4L4mxfn7vThzpYDjszkuhvfLHwDuBBvZ/qC1Uz32/nqJJOxl8ZdwkzpfzYGkna1I9OzUUnx9QBv2Qiw==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.50':
+    resolution: {integrity: sha512-MxVczSZi8NILq/IpCpl9YZ5OtfiJ/M4ZAc3ua8fBLHnKUMa78I7GMtQ1N8TlPm5td3kptYQJd1VU4CKd68EWfQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.49':
-    resolution: {integrity: sha512-iJrktID8Momn3CHBzMjU31F6NzlnV89QM/v/iMiZGnEtLote6HJcXDstm5xoghbX2i6RynCJ0CTiUNu4meEAKQ==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.50':
+    resolution: {integrity: sha512-6nl256lf2SnzwC0dDd75CpkQeGATP15EmVFsljsS3hUWafWD9CRv1dkxqWFKbvXzivioNN2D6T3HCxOspIiHqg==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.49':
-    resolution: {integrity: sha512-m0DsadTcMVAztEqnWhW21NYMGtE+78LRErYVi2eoLIrLD2VhwGeIl7dxx8qUBw2DS3Y/QiIkXC9WZbvhSQ68Mw==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.50':
+    resolution: {integrity: sha512-rCwlYc3o/yPRiCeLLOIuFfb0OMUgcXyOgljt/0eboIvAGl2K4AkP7L84/Vs6tDKblFPwzClyceHWxCAEHV7heA==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.49':
-    resolution: {integrity: sha512-aQYxEYIufy5DL9/J8uuCGsZATmmvT28x/TWrft4YzkCToEgGSbQgCE6p7XGOTvJWsQpSGq8nVwHbIjHb7os0dg==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.50':
+    resolution: {integrity: sha512-cYhXzM5lnPIsG8ktAx353Bm+PkNvd4IuFbbzFbty0yc4MlDaPGdGj2kFjf9GxQPx64UM1X728ICFy1O7Kw3q5g==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.49':
-    resolution: {integrity: sha512-5sg3EEOQbwe5FSP0dH/8eDNODlhJlWzc5sXGNSe9tnwy3EZeIV36zWy0nqhgEyjuaSnfgQPdkO1V/xX84IG/TQ==}
+  '@takazudo/zfb-runtime@0.1.0-next.50':
+    resolution: {integrity: sha512-BjL3VGtBuIh910esU9zCqz5BykcJLcP/rOv8H7dles0xLJOxddOceZzcDxj8QhUzxezYeaX+0VDVS8/YZ+Pz8Q==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.49
+      '@takazudo/zfb': 0.1.0-next.50
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.49':
-    resolution: {integrity: sha512-GMucMsaD3e2WYs4q8zK844CvAq88NPJRm7BnO6+AEsVB/Mfec/wD2oBbp94Q7eDr6PoJCTEFXO0o44fvgT6zrg==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.50':
+    resolution: {integrity: sha512-GvbzxVnAM9RR9M1AFyp1t7EpjZ2/VkA3rrWp+MxXibAKS4I0us9yb6NLgMkLeWeI90QE6A35d0IJWbua8Jc9sQ==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.49':
-    resolution: {integrity: sha512-IyZqXSjsS5mAleErx74LeNq/7ZvxJfBOqlUwl3Sz+0HcOAWj811Worevh+TZUiRo23MRgeoLFn83VJk185ftcg==}
+  '@takazudo/zfb@0.1.0-next.50':
+    resolution: {integrity: sha512-YW6ZQT9GtTYS+5kKJLeRCoiGwUw+fxhObdwiU/OE8ehrf92X21y8d5pMVWu20O1vgGIzSKXV7jZSLhWPZ1xVbA==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
@@ -4076,35 +4076,35 @@ snapshots:
       culori: 4.0.2
       preact: 10.29.2
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.49': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.50': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.49':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.50':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.49':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.50':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.49':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.50':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.49':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.50':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.49(@takazudo/zfb@0.1.0-next.49)':
+  '@takazudo/zfb-runtime@0.1.0-next.50(@takazudo/zfb@0.1.0-next.50)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.49
+      '@takazudo/zfb': 0.1.0-next.50
       hono: 4.12.23
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.49':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.50':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.49':
+  '@takazudo/zfb@0.1.0-next.50':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.49
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.49
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.49
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.49
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.49
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.50
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.50
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.50
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.50
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.50
 
   '@takazudo/zudo-design-token-lint@1.0.0(patch_hash=6a157fd850449b055cf64a8a7dd1faed5b1da9eebe6c81cca08488ac0de85182)':
     dependencies:


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2170

---

## Summary

Bump the `@takazudo/zfb` npm trio (`zfb`, `zfb-runtime`, `zfb-adapter-cloudflare`) from `0.1.0-next.49` to `0.1.0-next.50` across all pin-parity locations + the lockfile.

**What next.50 contains:** `fix(zfb-runtime): commit ClientRouter history entry before the View Transition` (refs zudolab/zzmod#662). On WebKit (all iOS browsers, incl. iOS Chrome), a `history.pushState()` issued inside `document.startViewTransition()` is not reliably committed as a distinct back/forward entry, so one Back press falls off the site. next.50 writes the SPA history entry **before** the View Transition. Runtime-only, additive — no config/API surface change.

## Changes

- `package.json` — root deps: zfb trio → `0.1.0-next.50` (exact)
- `packages/zudo-doc/package.json` — peerDeps `^0.1.0-next.50`, devDeps `0.1.0-next.50` (zfb + zfb-runtime)
- `packages/create-zudo-doc/src/scaffold.ts` — emitted scaffold pins → next.50 (+ comment block updated)
- `packages/create-zudo-doc/src/__tests__/scaffold.test.ts` — pin-test title + 3 assertions → next.50 (+ historical comment updated)
- `pnpm-lock.yaml` — regenerated (0 next.49 remnants, 33 next.50 entries for the trio)
- **`e2e/versioning.spec.ts`** — hardened one nav test that raced the content swap (see below)

`@takazudo/zdtp` (0.2.3) and the internal `@takazudo/zudo-doc*` pins are untouched.

## One test adjustment (no production code change)

`versioning.spec.ts` › "version link navigates to versioned page" read `textContent("body")` **once** right after `waitForURL`. Because next.50 commits the SPA history entry **before** the View Transition swap, `waitForURL` now resolves before the destination body is in the DOM, so the one-shot read raced the swap and saw the stale source page. Switched to a web-first auto-retrying assertion (`await expect(locator).toContainText(...)`) that waits for the swapped content. **Latent test race exposed by the (correct) upstream reorder — not a zfb bug, so no `/dev-upstream-report` filed.** Reproduced locally against next.50, confirmed green after the fix.

## Test Plan

- ✅ `pnpm check:pin-parity` — green (3 external + 2 internal + 4 workspace-package fields)
- ✅ `pnpm check` — typecheck, no errors
- ✅ scaffold pin test — 343 tests pass
- ✅ `pnpm build` — 283 pages built
- ✅ versioning e2e fixture — 24 tests pass (incl. the previously-racy nav test)

**Note:** the underlying fix is a WebKit/iOS back-navigation runtime behavior — green CI confirms the bump integrates, but does not confirm the iOS Back behavior itself (that needs a real iOS browser). Build-green ≠ fix-confirmed.