### PR TITLE
fix(create-zudo-doc): two generator bugs — duplicate settings import (#2172) + doc-skill gitignore/name drift (#2173)

### DIFF
--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -1288,7 +1288,7 @@ describe("scaffold — skillSymlinker feature", () => {
 });
 
 describe("scaffold — .gitignore skill block (#2173)", () => {
-  it("ignores the deterministic <projectName>-wisdom skill directory", async () => {
+  it("ignores the deterministic <projectName>-wisdom skill directory when skillSymlinker is on", async () => {
     const choices: UserChoices = {
       projectName: "gitignore-skill-proj",
       defaultLang: "en",
@@ -1308,9 +1308,49 @@ describe("scaffold — .gitignore skill block (#2173)", () => {
     expect(gitignore).toContain(
       ".claude/skills/gitignore-skill-proj-wisdom/docs",
     );
-    expect(gitignore).toContain(
+    // No i18n → the script never creates a docs-ja symlink, so no ignore entry.
+    expect(gitignore).not.toContain(
       ".claude/skills/gitignore-skill-proj-wisdom/docs-ja",
     );
+  });
+
+  it("ignores the docs-ja symlink only when i18n is also enabled", async () => {
+    const choices: UserChoices = {
+      projectName: "gitignore-skill-ja",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["skillSymlinker", "i18n"],
+      packageManager: "pnpm",
+    };
+    await scaffold(choices);
+    const gitignore = await fs.readFile(
+      projectPath("gitignore-skill-ja", ".gitignore"),
+      "utf-8",
+    );
+    expect(gitignore).toContain(
+      ".claude/skills/gitignore-skill-ja-wisdom/docs-ja",
+    );
+  });
+
+  it("emits no skill ignore block when skillSymlinker is off", async () => {
+    const choices: UserChoices = {
+      projectName: "gitignore-skill-none",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: [],
+      packageManager: "pnpm",
+    };
+    await scaffold(choices);
+    const gitignore = await fs.readFile(
+      projectPath("gitignore-skill-none", ".gitignore"),
+      "utf-8",
+    );
+    // The setup-doc-skill.sh script and `setup:doc-skill` npm script are gated
+    // on skillSymlinker, so its ignore entries must not be emitted without it.
+    expect(gitignore).not.toContain("# Generated doc-lookup skill");
+    expect(gitignore).not.toContain(".claude/skills/");
   });
 });
 

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -3660,3 +3660,29 @@ describe("scaffold — designTokenPanel zdtp gating (#2162)", () => {
     });
   });
 });
+
+// Regression guard for #2172: the base template already imports `settings`,
+// so the imageEnlarge feature must NOT inject a second
+// `import { settings } from "@/config/settings";` line — a duplicate would be
+// an illegal ES-module re-declaration of the same lexical binding.
+describe("scaffold — imageEnlarge does not duplicate the settings import (#2172)", () => {
+  it("pages/_mdx-components.ts imports settings exactly once when imageEnlarge is enabled", async () => {
+    const choices: UserChoices = {
+      projectName: "test-ie-dup-import",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search", "imageEnlarge"],
+      packageManager: "pnpm",
+    };
+    await scaffold(choices);
+    const content = await fs.readFile(
+      projectPath("test-ie-dup-import", "pages/_mdx-components.ts"),
+      "utf-8",
+    );
+    const matches = content.match(
+      /import\s*\{\s*settings\s*\}\s*from\s*["']@\/config\/settings["'];?/g,
+    );
+    expect(matches).toHaveLength(1);
+  });
+});

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -1287,6 +1287,33 @@ describe("scaffold — skillSymlinker feature", () => {
   });
 });
 
+describe("scaffold — .gitignore skill block (#2173)", () => {
+  it("ignores the deterministic <projectName>-wisdom skill directory", async () => {
+    const choices: UserChoices = {
+      projectName: "gitignore-skill-proj",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["skillSymlinker"],
+      packageManager: "pnpm",
+    };
+    await scaffold(choices);
+    const gitignore = await fs.readFile(
+      projectPath("gitignore-skill-proj", ".gitignore"),
+      "utf-8",
+    );
+    expect(gitignore).toContain(
+      ".claude/skills/gitignore-skill-proj-wisdom/SKILL.md",
+    );
+    expect(gitignore).toContain(
+      ".claude/skills/gitignore-skill-proj-wisdom/docs",
+    );
+    expect(gitignore).toContain(
+      ".claude/skills/gitignore-skill-proj-wisdom/docs-ja",
+    );
+  });
+});
+
 describe("scaffold — claudeSkills feature", () => {
   it("ships user-facing zudo-doc-* skills when enabled", async () => {
     const choices: UserChoices = {

--- a/packages/create-zudo-doc/src/features/image-enlarge.ts
+++ b/packages/create-zudo-doc/src/features/image-enlarge.ts
@@ -13,7 +13,7 @@ import type { FeatureModule } from "../compose.js";
  * feature, the server-side figure/button emission is re-implemented via an
  * MDX paragraph (p) component override in pages/_mdx-components.ts. When
  * imageEnlarge is enabled, three injections into the template file install:
- *   1. Additional imports: toChildArray + VNode from preact, settings.
+ *   1. Additional imports: toChildArray + VNode from preact.
  *   2. ENLARGE_SVG const + EnlargeableParagraph function definition.
  *   3. `p: EnlargeableParagraph` entry in the createMdxComponents return map.
  * When imageEnlarge is OFF, none of these are injected, so the override is
@@ -23,15 +23,17 @@ import type { FeatureModule } from "../compose.js";
 export const imageEnlargeFeature: FeatureModule = () => ({
   name: "imageEnlarge",
   injections: [
-    // 1. Import additions: toChildArray + VNode from preact, settings.
+    // 1. Import additions: toChildArray + VNode from preact.
     //    Inserted AFTER the `// @slot:mdx-components:enlarge-imports` anchor.
+    //    NOTE: `settings` is NOT injected here — the base template already
+    //    imports it (#2172); injecting it again caused a duplicate ES-module
+    //    lexical binding.
     {
       file: "pages/_mdx-components.ts",
       anchor: "// @slot:mdx-components:enlarge-imports",
       position: "after",
       content: `import { toChildArray } from "preact";
-import type { VNode } from "preact";
-import { settings } from "@/config/settings";`,
+import type { VNode } from "preact";`,
     },
     // 2. ENLARGE_SVG const + EnlargeableParagraph function.
     //    Inserted AFTER the `// @slot:mdx-components:enlarge-defs` anchor

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -240,41 +240,57 @@ export async function scaffold(choices: UserChoices): Promise<void> {
     JSON.stringify(pkg, null, 2) + "\n",
   );
 
-  await fs.outputFile(
-    path.join(targetDir, ".gitignore"),
-    [
-      "# Build output",
-      "node_modules",
-      "dist",
-      ".zfb",
-      "",
-      "# macOS",
-      ".DS_Store",
-      "",
-      "# Environment",
-      ".env",
-      ".env.local",
-      ".env.*.local",
-      "",
-      "# Logs",
-      "*.log",
-      "npm-debug.log*",
-      "yarn-debug.log*",
-      "pnpm-debug.log*",
-      "",
-      "# Cloudflare Wrangler",
-      ".wrangler/",
-      "",
-      // Generated doc-lookup skill (scripts/setup-doc-skill.sh). The skill name
-      // is deterministic — always `<projectName>-wisdom` — so these entries
-      // match the directory the script creates. Keep in sync with
-      // DEFAULT_SKILL_NAME in scripts/setup-doc-skill.sh.
+  const gitignoreLines = [
+    "# Build output",
+    "node_modules",
+    "dist",
+    ".zfb",
+    "",
+    "# macOS",
+    ".DS_Store",
+    "",
+    "# Environment",
+    ".env",
+    ".env.local",
+    ".env.*.local",
+    "",
+    "# Logs",
+    "*.log",
+    "npm-debug.log*",
+    "yarn-debug.log*",
+    "pnpm-debug.log*",
+    "",
+    "# Cloudflare Wrangler",
+    ".wrangler/",
+    "",
+  ];
+
+  // The doc-lookup skill is only generated when skillSymlinker is selected
+  // (the setup-doc-skill.sh script and `setup:doc-skill` npm script are gated
+  // on the same feature above), so only emit its ignore entries then —
+  // otherwise they would be dead rules that could silently hide an unrelated
+  // skill a user later installs under a matching name. The skill name is
+  // deterministic (always `<projectName>-wisdom`, matching DEFAULT_SKILL_NAME
+  // in scripts/setup-doc-skill.sh and the package name), so these entries match
+  // the directory the script creates. The docs-ja symlink only exists for i18n
+  // projects (the script creates it conditionally), so gate that line on i18n.
+  if (choices.features.includes("skillSymlinker")) {
+    gitignoreLines.push(
       "# Generated doc-lookup skill",
       `.claude/skills/${choices.projectName}-wisdom/SKILL.md`,
       `.claude/skills/${choices.projectName}-wisdom/docs`,
-      `.claude/skills/${choices.projectName}-wisdom/docs-ja`,
-      "",
-    ].join("\n"),
+    );
+    if (choices.features.includes("i18n")) {
+      gitignoreLines.push(
+        `.claude/skills/${choices.projectName}-wisdom/docs-ja`,
+      );
+    }
+    gitignoreLines.push("");
+  }
+
+  await fs.outputFile(
+    path.join(targetDir, ".gitignore"),
+    gitignoreLines.join("\n"),
   );
 
   // Emit an .npmrc exempting undici-types from pnpm's trust-downgrade policy.

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -265,6 +265,15 @@ export async function scaffold(choices: UserChoices): Promise<void> {
       "# Cloudflare Wrangler",
       ".wrangler/",
       "",
+      // Generated doc-lookup skill (scripts/setup-doc-skill.sh). The skill name
+      // is deterministic — always `<projectName>-wisdom` — so these entries
+      // match the directory the script creates. Keep in sync with
+      // DEFAULT_SKILL_NAME in scripts/setup-doc-skill.sh.
+      "# Generated doc-lookup skill",
+      `.claude/skills/${choices.projectName}-wisdom/SKILL.md`,
+      `.claude/skills/${choices.projectName}-wisdom/docs`,
+      `.claude/skills/${choices.projectName}-wisdom/docs-ja`,
+      "",
     ].join("\n"),
   );
 

--- a/scripts/__tests__/setup-doc-skill.test.ts
+++ b/scripts/__tests__/setup-doc-skill.test.ts
@@ -11,15 +11,15 @@ const TEST_SKILL_NAME = "test-wisdom";
 /**
  * Run setup-doc-skill.sh in the real project directory with a custom
  * HOME so the global symlink goes to a temp directory instead of ~/.claude/skills/.
- * The skill name is passed via stdin using execSync's input option.
+ * The skill name is passed as the first CLI arg — the script is non-interactive
+ * (deterministic name) since #2173, so it no longer reads the name from stdin.
  */
 function runScript(skillName: string, fakeHome: string): string {
   return execSync(
-    `bash "${SCRIPT_PATH}"`,
+    `bash "${SCRIPT_PATH}" "${skillName}"`,
     {
       cwd: PROJECT_ROOT,
       encoding: "utf-8",
-      input: skillName + "\n",
       timeout: 30_000,
       env: {
         ...process.env,

--- a/scripts/setup-doc-skill.sh
+++ b/scripts/setup-doc-skill.sh
@@ -13,12 +13,18 @@ ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 PROJECT_NAME=$(node -e "console.log(require('$ROOT_DIR/package.json').name || 'my-project')")
 DEFAULT_SKILL_NAME="${PROJECT_NAME}-wisdom"
 
-# Prompt for skill name
 echo ""
 echo "=== zudo-doc Skill Setup ==="
 echo ""
-read -rp "Skill name [$DEFAULT_SKILL_NAME]: " SKILL_NAME
-SKILL_NAME="${SKILL_NAME:-$DEFAULT_SKILL_NAME}"
+
+# Skill name is DETERMINISTIC: always `<projectName>-wisdom`. The scaffolded
+# .gitignore (emitted by create-zudo-doc) hard-codes this exact name, so the
+# generated skill directory must match it — an interactive prompt would let the
+# name drift from the gitignore entry and leave the skill showing as untracked
+# (zudolab/zudo-doc#2173). An explicit override is still allowed via the first
+# CLI arg or the SKILL_NAME env var (consumers who override must also update
+# their .gitignore), but never via an interactive prompt.
+SKILL_NAME="${1:-${SKILL_NAME:-$DEFAULT_SKILL_NAME}}"
 
 # Validate skill name (allow only alphanumeric, hyphens, underscores)
 if [[ ! "$SKILL_NAME" =~ ^[a-zA-Z0-9_-]+$ ]]; then


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2172
    - https://github.com/zudolab/zudo-doc/issues/2173

---

## Summary

Fixes two independent `create-zudo-doc` generator bugs found while migrating `zudo-test-wisdom`.

### #2172 — imageEnlarge injects a duplicate `settings` import
The base template `pages/_mdx-components.ts` already imports `settings`, and the `imageEnlarge` feature injected it again → duplicate ES-module lexical binding. Removed the `settings` import from the feature injection (kept `toChildArray` + `VNode`), updated the adjacent comments, and added a regression test asserting exactly one `import { settings }` in the generated file.

### #2173 — scaffolded doc-skill shows untracked (gitignore + non-deterministic name)
Two cooperating gaps caused the generated skill dir to show as untracked:
- `scaffold.ts` emitted **no** skill-ignore entry → consumers hand-added one, guessing the name.
- `setup-doc-skill.sh` picked the name via interactive `read -rp`, so the real dir could drift from any hand-added rule.

Fix:
- `scaffold.ts` now emits a `.claude/skills/<projectName>-wisdom/{SKILL.md,docs[,docs-ja]}` ignore block, derived from the same deterministic name the script uses.
- `setup-doc-skill.sh` dropped the interactive prompt — name is now deterministic (`${PROJECT_NAME}-wisdom`), still overridable via the first CLI arg or `SKILL_NAME` env var.

### Review follow-up (in this PR)
The `.gitignore` skill block is gated on the `skillSymlinker` feature (the script + npm script are gated the same way), and the `docs-ja` line is gated on `i18n` (the script only creates that symlink for i18n projects) — so non-skill / single-language scaffolds don't get dead ignore rules. Added positive, i18n, and negative tests.

## Verification
- `pnpm test` (create-zudo-doc): **347 passed**
- `pnpm build`: clean (`dist/` is gitignored for this package — built at publish via `prepublishOnly`)

## Notes
- `dist/` is **not** tracked for `create-zudo-doc` (root `.gitignore`), so no compiled artifacts are committed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1ugxd6WhMMZi313FxRgFc)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784220114&installation_id=130359969&pr_number=2174&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2174&signature=03a08e3a5bb8fb9bbb250ab4453f47373636071d1b863d6cd34e451fae3411f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->