### PR TITLE
fix(llms-txt): strip JSX/MDX block comments from llms.txt / llms-full.txt output

### DIFF
--- a/packages/zudo-doc/src/integrations/llms-txt/__tests__/load.test.ts
+++ b/packages/zudo-doc/src/integrations/llms-txt/__tests__/load.test.ts
@@ -61,3 +61,34 @@ describe("loadDocEntries frontmatter slug override", () => {
     expect(entries[0]?.url).toBe("https://example.com/ja/docs/quickstart");
   });
 });
+
+describe("loadDocEntries JSX comment stripping (zudo-doc#2175)", () => {
+  it("does not let a leading JSX comment become the fallback description", () => {
+    writeDoc(
+      "claude/index.mdx",
+      'title: "Claude"',
+      "{/* The EN /docs/claude/ index does NOT exist as a static page */}\n\n## Heading\n\nBody prose.",
+    );
+
+    const entries = loadDocEntries({ contentDir, locale: null, base: "" });
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.description).not.toContain("{/");
+    expect(entries[0]?.description).not.toContain("does NOT exist");
+    expect(entries[0]?.description).toBe("Heading");
+  });
+
+  it("strips a multi-line JSX comment from the full-text body", () => {
+    writeDoc(
+      "guides/intro.mdx",
+      'title: "Intro"\ndescription: "An intro"',
+      "Welcome.\n\n{/* a maintenance note\nspanning several\nlines */}\n\nMore prose.",
+    );
+
+    const entries = loadDocEntries({ contentDir, locale: null, base: "" });
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.content).not.toContain("{/*");
+    expect(entries[0]?.content).not.toContain("maintenance note");
+    expect(entries[0]?.content).toContain("Welcome.");
+    expect(entries[0]?.content).toContain("More prose.");
+  });
+});

--- a/packages/zudo-doc/src/integrations/llms-txt/__tests__/strip.test.ts
+++ b/packages/zudo-doc/src/integrations/llms-txt/__tests__/strip.test.ts
@@ -27,9 +27,7 @@ describe("stripImportsAndJsx JSX comment removal (zudo-doc#2175)", () => {
     expect(out).toContain("Trailing prose.");
   });
 
-  it("does not leave a stray `{/` from the angle-bracket tag rule", () => {
-    // The legacy emitter mangled `{/* ... */}` into a leading `{/` because
-    // the tag rule partially matched it; the new rule removes it cleanly.
+  it("removes a bare comment entirely (it previously leaked whole into the body)", () => {
     const out = stripImportsAndJsx("{/* The EN /docs/x index does NOT exist */}");
     expect(out).toBe("");
   });

--- a/packages/zudo-doc/src/integrations/llms-txt/__tests__/strip.test.ts
+++ b/packages/zudo-doc/src/integrations/llms-txt/__tests__/strip.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { stripImportsAndJsx } from "../strip.js";
+
+describe("stripImportsAndJsx JSX comment removal (zudo-doc#2175)", () => {
+  it("removes a single-line JSX/MDX block comment", () => {
+    const out = stripImportsAndJsx("{/* internal note */}\n\nReal body.");
+    expect(out).not.toContain("{/*");
+    expect(out).not.toContain("internal note");
+    expect(out).toContain("Real body.");
+  });
+
+  it("removes a multi-line JSX/MDX block comment at any position", () => {
+    const input = [
+      "## Heading",
+      "",
+      "{/* a comment",
+      "spanning multiple",
+      "lines */}",
+      "",
+      "Trailing prose.",
+    ].join("\n");
+    const out = stripImportsAndJsx(input);
+    expect(out).not.toContain("{/*");
+    expect(out).not.toContain("*/}");
+    expect(out).not.toContain("spanning multiple");
+    expect(out).toContain("## Heading");
+    expect(out).toContain("Trailing prose.");
+  });
+
+  it("does not leave a stray `{/` from the angle-bracket tag rule", () => {
+    // The legacy emitter mangled `{/* ... */}` into a leading `{/` because
+    // the tag rule partially matched it; the new rule removes it cleanly.
+    const out = stripImportsAndJsx("{/* The EN /docs/x index does NOT exist */}");
+    expect(out).toBe("");
+  });
+});

--- a/packages/zudo-doc/src/integrations/llms-txt/strip.ts
+++ b/packages/zudo-doc/src/integrations/llms-txt/strip.ts
@@ -29,9 +29,9 @@ export function stripImportsAndJsx(content: string): string {
       // Remove export statements
       .replace(/^export\s+.*$/gm, "")
       // Remove JSX/MDX block comments ({/* ... */}) — they never render to
-      // users in MDX, so they must not leak into the plain-text feed. Runs
-      // before the tag rule below so the comment is removed whole rather than
-      // partially mangled into a stray `{/` (zudo-doc#2175).
+      // users in MDX, so they must not leak into the plain-text feed
+      // (zudo-doc#2175). Placed before the tag rule defensively, so a comment
+      // that embeds a JSX tag ({/* <Foo /> */}) is removed whole.
       .replace(/\{\/\*[\s\S]*?\*\/\}/g, "")
       // Remove all HTML/JSX tags (both uppercase components and lowercase elements)
       .replace(/<\/?[a-zA-Z][a-zA-Z0-9]*[^>]*>/g, "")

--- a/packages/zudo-doc/src/integrations/llms-txt/strip.ts
+++ b/packages/zudo-doc/src/integrations/llms-txt/strip.ts
@@ -2,8 +2,10 @@
  * Markdown / JSX text-stripping helpers.
  *
  * `stripImportsAndJsx` matches the legacy Astro emitter's behaviour
- * byte-for-byte. Any change here is a behaviour change and must be
- * reflected in the byte-equality fixture corpus.
+ * byte-for-byte, with one deliberate divergence: it also strips JSX/MDX
+ * block comments (the `{/*`-delimited MDX comment form), which the legacy
+ * emitter leaked (zudo-doc#2175). Any other change here is a behaviour
+ * change and must be reflected in the byte-equality fixture corpus.
  *
  * `stripMarkdown` (used to derive a fallback `description` from the body
  * when frontmatter doesn't carry one) lives in the shared `md-utils`
@@ -26,6 +28,11 @@ export function stripImportsAndJsx(content: string): string {
       .replace(/^import\s+.*$/gm, "")
       // Remove export statements
       .replace(/^export\s+.*$/gm, "")
+      // Remove JSX/MDX block comments ({/* ... */}) — they never render to
+      // users in MDX, so they must not leak into the plain-text feed. Runs
+      // before the tag rule below so the comment is removed whole rather than
+      // partially mangled into a stray `{/` (zudo-doc#2175).
+      .replace(/\{\/\*[\s\S]*?\*\/\}/g, "")
       // Remove all HTML/JSX tags (both uppercase components and lowercase elements)
       .replace(/<\/?[a-zA-Z][a-zA-Z0-9]*[^>]*>/g, "")
       // Collapse excessive blank lines

--- a/packages/zudo-doc/src/md-utils/__tests__/md-utils.test.ts
+++ b/packages/zudo-doc/src/md-utils/__tests__/md-utils.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { isExcluded, slugToUrl, type MdDocFrontmatter } from "../index.js";
+import {
+  isExcluded,
+  slugToUrl,
+  stripMarkdown,
+  type MdDocFrontmatter,
+} from "../index.js";
 
 // Consolidates the formerly-duplicated is-excluded suites of the
 // search-index and llms-txt integrations (zudo-doc#2024) — both now run
@@ -24,6 +29,27 @@ describe("md-utils isExcluded", () => {
     expect(isExcluded({ title: "Guides", category_no_page: false })).toBe(
       false,
     );
+  });
+});
+
+describe("md-utils stripMarkdown JSX comment removal (zudo-doc#2175)", () => {
+  it("removes a leading single-line JSX comment so it can't become a summary", () => {
+    const stripped = stripMarkdown("{/* internal note */}\n\nReal first line.");
+    const firstLine = stripped
+      .split("\n")
+      .find((l) => l.trim().length > 0);
+    expect(firstLine).toBe("Real first line.");
+    expect(stripped).not.toContain("internal note");
+  });
+
+  it("removes a multi-line JSX comment from the body", () => {
+    const stripped = stripMarkdown(
+      "Intro line.\n\n{/* a comment\nspanning lines */}\n\nOutro line.",
+    );
+    expect(stripped).not.toContain("{/*");
+    expect(stripped).not.toContain("spanning lines");
+    expect(stripped).toContain("Intro line.");
+    expect(stripped).toContain("Outro line.");
   });
 });
 

--- a/packages/zudo-doc/src/md-utils/index.ts
+++ b/packages/zudo-doc/src/md-utils/index.ts
@@ -58,8 +58,8 @@ export function stripMarkdown(md: string): string {
       .replace(/`[^`]+`/g, "")
       // Remove JSX/MDX block comments ({/* ... */}) — they never render to
       // users in MDX, so a leading comment must not become a page's fallback
-      // description (zudo-doc#2175). Runs before the HTML-tag rule so the
-      // braces aren't left behind.
+      // description (zudo-doc#2175). Must precede the emphasis rule below,
+      // which would otherwise mangle the `/* … */` asterisks into `{/ … /}`.
       .replace(/\{\/\*[\s\S]*?\*\/\}/g, "")
       // Remove HTML tags
       .replace(/<[^>]+>/g, "")

--- a/packages/zudo-doc/src/md-utils/index.ts
+++ b/packages/zudo-doc/src/md-utils/index.ts
@@ -45,8 +45,10 @@ export interface MdDocFrontmatter {
  * Strip markdown formatting to plain text. Conservative-by-design — the
  * regex pipeline matches the legacy Astro integrations byte-for-byte so
  * search excerpts and llms-txt descriptions stay byte-equal across the
- * cutover. Do not add new rules without also updating the byte-equality
- * fixtures (topic-plugin-audit).
+ * cutover, with one deliberate divergence: it also strips JSX/MDX block
+ * comments (the `{/*`-delimited MDX comment form), which the legacy
+ * pipeline leaked into descriptions (zudo-doc#2175). Do not add other new
+ * rules without also updating the byte-equality fixtures (topic-plugin-audit).
  */
 export function stripMarkdown(md: string): string {
   return (
@@ -54,6 +56,11 @@ export function stripMarkdown(md: string): string {
       // Remove code blocks
       .replace(/```[\s\S]*?```/g, "")
       .replace(/`[^`]+`/g, "")
+      // Remove JSX/MDX block comments ({/* ... */}) — they never render to
+      // users in MDX, so a leading comment must not become a page's fallback
+      // description (zudo-doc#2175). Runs before the HTML-tag rule so the
+      // braces aren't left behind.
+      .replace(/\{\/\*[\s\S]*?\*\/\}/g, "")
       // Remove HTML tags
       .replace(/<[^>]+>/g, "")
       // Remove headings markers


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2175

---

## Summary

JSX/MDX block comments (`{/* … */}`) never render to users in MDX, but they leaked verbatim into both LLM feeds because neither raw-text stripper matched brace-delimited comments — only angle-bracket tags. Fixes #2175.

- **`llms.txt`** — when a page had no frontmatter `description`, the fallback summary is the first non-blank body line. A leading `{/* … */}` comment became the page summary (and the emphasis rule mangled it into a stray `{/ … /}` — visible in the live `ja/llms.txt`).
- **`llms-full.txt`** — per-page bodies emitted JSX comments intact at any position.

## Changes

- **`packages/zudo-doc/src/integrations/llms-txt/strip.ts`** — `stripImportsAndJsx` (the `llms-full.txt` body path) now removes `{/* … */}` with `/\{\/\*[\s\S]*?\*\/\}/g`, placed before the tag rule.
- **`packages/zudo-doc/src/md-utils/index.ts`** — `stripMarkdown` (the `llms.txt` summary-fallback path, also shared with search-index) gets the same rule, placed before the emphasis rule that was the actual cause of the stray-`{/` mangling. This also keeps JSX comments out of search excerpts.
- Updated the "byte-for-byte parity with the legacy Astro emitter" maintenance comments in both files to record this as a deliberate divergence.
- **Regression tests** (there was no prior coverage):
    - new `__tests__/strip.test.ts` — single-line, multi-line, and bare-comment removal for `stripImportsAndJsx`
    - `__tests__/load.test.ts` — a leading comment does not become the fallback description; a multi-line body comment is absent from `llms-full.txt` content
    - `md-utils/__tests__/md-utils.test.ts` — direct `stripMarkdown` coverage for leading single-line and multi-line comments

## Test Plan

- `pnpm exec tsc --noEmit` — clean
- Full `@takazudo/zudo-doc` vitest suite — 537 passed (17 in the affected files)
- Reviewed by two parallel reviewers; applied the one accuracy finding (corrected a misleading comment about which regex caused the stray `{/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYxUSUt6NQFMhpnSHaQmZb)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784236088&installation_id=130359969&pr_number=2182&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2182&signature=cc3e5c16778464679c46be6ed409777c6af7b72fe70805974028d97b5e0556e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->