### PR TITLE
fix(create-zudo-doc): give admonition blocks bottom spacing in generated global.css

### DIFF
--- a/packages/create-zudo-doc/templates/base/src/styles/global.css
+++ b/packages/create-zudo-doc/templates/base/src/styles/global.css
@@ -558,6 +558,12 @@ body {
   padding: var(--spacing-vsp-md) var(--spacing-hsp-lg) var(--spacing-vsp-2xs);
   background-color: color-mix(in srgb, var(--color-muted) 12%, var(--color-bg));
   border-radius: 0 var(--radius-DEFAULT) var(--radius-DEFAULT) 0;
+  /* External gap to the next block. In this per-element rhythm model every
+     .zd-content block owns its margin-bottom; the admonition needs one too —
+     the snug bottom *padding* above is internal only, and the following
+     paragraph's flow margin-top is zeroed by `.zd-content :where(p)`, so
+     without this the box would collapse onto the next paragraph. */
+  margin-bottom: var(--spacing-vsp-md);
 }
 
 .admonition-title {


### PR DESCRIPTION
## Problem

In projects scaffolded by `create-zudo-doc`, a Note/admonition block (`div.admonition.admonition-note`) renders with **no bottom spacing** — the next paragraph butts directly against the box.

## Root cause

The base template's `.zd-content` stylesheet uses a **per-element-margin** rhythm model: every content block (`p`, `ul`, `ol`, `blockquote`, `table`…) owns its `margin-bottom: var(--spacing-vsp-md)`, and `.zd-content :where(p)` additionally sets `margin-top: 0`. The `[data-admonition]` box was the **only** content block with no `margin-bottom` (only padding, deliberately snug at the bottom).

So `admonition → paragraph` collapses to a zero gap: the box contributes no bottom margin, and the following paragraph's flow `margin-top` is zeroed by `.zd-content :where(p)`. (`admonition → heading` still gaps, because headings carry their own `margin-top` — matching the observed symptom.)

## Fix

Add `margin-bottom: var(--spacing-vsp-md)` to `[data-admonition]` in `packages/create-zudo-doc/templates/base/src/styles/global.css`, so it matches every other content block. A comment is added so the new declaration isn't removed later (the adjacent padding comment says "snug bottom", which could otherwise mislead).

This is a **targeted patch within the template's current (legacy) spacing model**. The deeper issue — the template `global.css` having drifted into a different spacing model than the showcase — is tracked separately (see linked issue).

## Verification

- `pnpm build` + **347/347** `create-zudo-doc` tests pass
- Scaffolded a fresh project from the built generator → confirmed the generated `global.css` contains the `margin-bottom`
- Live showcase `src/styles/global.css` left untouched (it's on the flow-space model and already correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784237489&installation_id=130359969&pr_number=2187&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2187&signature=18a6335f9e94d9e9e5811fc65c5a38aee865df8771c7214c5fe7e8c0886bc62c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->