### PR TITLE
chore(deps): bump @takazudo/zfb trio next.50 → next.51

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,9 +86,9 @@
   },
   "dependencies": {
     "@takazudo/zdtp": "0.2.3",
-    "@takazudo/zfb": "0.1.0-next.50",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.50",
-    "@takazudo/zfb-runtime": "0.1.0-next.50",
+    "@takazudo/zfb": "0.1.0-next.51",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.51",
+    "@takazudo/zfb-runtime": "0.1.0-next.51",
     "@takazudo/zudo-doc": "workspace:*",
     "@types/hast": "^3.0.4",
     "clsx": "^2.1.1",

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -3284,10 +3284,14 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
    * returns to the previous page); next.50 client-router fix to commit the SPA
    * history entry before the View Transition so on WebKit/iOS a single browser
    * Back creates a distinct entry instead of falling off the site — both
-   * runtime-only bug fixes, additive, no consumer-facing breaking change.
+   * runtime-only bug fixes, additive, no consumer-facing breaking change. Now
+   * bumped to 0.1.0-next.51: additive public-API surface (VNode/VNodeArray/
+   * VNodeObject exported from "@takazudo/zfb", #972) plus removal of the no-op
+   * linkValidation.allowExternal knob (#925) — both non-breaking for a fresh
+   * scaffold.
    * Generated package.json must pin all three.
    */
-  it("pins @takazudo/zfb at 0.1.0-next.50", async () => {
+  it("pins @takazudo/zfb at 0.1.0-next.51", async () => {
     const choices: UserChoices = {
       projectName: "test-pin-bump",
       defaultLang: "en",
@@ -3298,10 +3302,10 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
     };
     await scaffold(choices);
     const pkg = await fs.readJson(projectPath("test-pin-bump", "package.json"));
-    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.50");
-    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.50");
+    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.51");
+    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.51");
     expect(pkg.dependencies["@takazudo/zfb-adapter-cloudflare"]).toBe(
-      "0.1.0-next.50",
+      "0.1.0-next.51",
     );
   });
 });

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -409,14 +409,17 @@ function generatePackageJson(choices: UserChoices) {
     // pin): client-router fix to commit the SPA history entry BEFORE the View
     // Transition, so on WebKit/iOS a single browser Back after an SPA navigation
     // creates a distinct history entry instead of falling off the site —
-    // runtime-only bug fix, additive. A fresh scaffold sets no explicit
-    // codeHighlight.theme so the default still applies. No consumer-facing /
-    // CLI breaking change.
-    "@takazudo/zfb": "0.1.0-next.50",
-    "@takazudo/zfb-runtime": "0.1.0-next.50",
+    // runtime-only bug fix, additive. next.51 (current pin): additive public-API
+    // surface — VNode/VNodeArray/VNodeObject are now exported from
+    // "@takazudo/zfb" (#972) — plus removal of the no-op linkValidation.allowExternal
+    // knob (#925); both are non-breaking for a fresh scaffold. A fresh scaffold
+    // sets no explicit codeHighlight.theme so the default still applies. No
+    // consumer-facing / CLI breaking change.
+    "@takazudo/zfb": "0.1.0-next.51",
+    "@takazudo/zfb-runtime": "0.1.0-next.51",
     // zfb-adapter-cloudflare — required for any route with `prerender = false`.
     // Pinned in lockstep with @takazudo/zfb.
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.50",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.51",
     // @takazudo/zudo-doc — published from this monorepo via
     // .github/workflows/publish-zudo-doc.yml. The pin here is bumped in
     // lockstep by scripts/release-create-zudo-doc.sh whenever zudo-doc's

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -172,8 +172,8 @@
   ],
   "peerDependencies": {
     "preact": "^10.29.1",
-    "@takazudo/zfb": "^0.1.0-next.50",
-    "@takazudo/zfb-runtime": "^0.1.0-next.50",
+    "@takazudo/zfb": "^0.1.0-next.51",
+    "@takazudo/zfb-runtime": "^0.1.0-next.51",
     "@takazudo/zudo-doc-history-server": "workspace:^",
     "@takazudo/zdtp": "^0.2.3",
     "shiki": "^4.0.2"
@@ -201,7 +201,7 @@
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
     "vitest": "^4.1.0",
-    "@takazudo/zfb": "0.1.0-next.50",
-    "@takazudo/zfb-runtime": "0.1.0-next.50"
+    "@takazudo/zfb": "0.1.0-next.51",
+    "@takazudo/zfb-runtime": "0.1.0-next.51"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,14 +30,14 @@ importers:
         specifier: 0.2.3
         version: 0.2.3(preact@10.29.2)
       '@takazudo/zfb':
-        specifier: 0.1.0-next.50
-        version: 0.1.0-next.50
+        specifier: 0.1.0-next.51
+        version: 0.1.0-next.51
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.50
-        version: 0.1.0-next.50
+        specifier: 0.1.0-next.51
+        version: 0.1.0-next.51
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.50
-        version: 0.1.0-next.50(@takazudo/zfb@0.1.0-next.50)
+        specifier: 0.1.0-next.51
+        version: 0.1.0-next.51(@takazudo/zfb@0.1.0-next.51)
       '@takazudo/zudo-doc':
         specifier: workspace:*
         version: link:packages/zudo-doc
@@ -290,11 +290,11 @@ importers:
         version: 4.0.3
     devDependencies:
       '@takazudo/zfb':
-        specifier: 0.1.0-next.50
-        version: 0.1.0-next.50
+        specifier: 0.1.0-next.51
+        version: 0.1.0-next.51
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.50
-        version: 0.1.0-next.50(@takazudo/zfb@0.1.0-next.50)
+        specifier: 0.1.0-next.51
+        version: 0.1.0-next.51(@takazudo/zfb@0.1.0-next.51)
       '@types/node':
         specifier: ^25.3.5
         version: 25.3.5
@@ -1377,44 +1377,44 @@ packages:
     peerDependencies:
       preact: ^10.29.1
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.50':
-    resolution: {integrity: sha512-SmslsMWuy8D/zWVtfXt/lQ1+Y83foyOmDaryEjH7N8POUTpLTCekgM02C10ZrPtX9zz7XbdE542ZYkCYrVmDTg==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.51':
+    resolution: {integrity: sha512-wP5smQs1K0dL5LLzFR/74UaBxXXVlWA+T53mpiNGC6vcGMz/zdZYHqA5fTvDCmGyeKqVjApMOTg1MNhf32nrSA==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.50':
-    resolution: {integrity: sha512-MxVczSZi8NILq/IpCpl9YZ5OtfiJ/M4ZAc3ua8fBLHnKUMa78I7GMtQ1N8TlPm5td3kptYQJd1VU4CKd68EWfQ==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.51':
+    resolution: {integrity: sha512-m/A81tg0tXEpsGd1opr8NSOA1HhMDonWuDvZgctRcKRmeBcSe2/YCpcfy0SKbzIYv9got1GB9OnfA6Wj175vRg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.50':
-    resolution: {integrity: sha512-6nl256lf2SnzwC0dDd75CpkQeGATP15EmVFsljsS3hUWafWD9CRv1dkxqWFKbvXzivioNN2D6T3HCxOspIiHqg==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.51':
+    resolution: {integrity: sha512-IlbEDu7mH/e3RGHJ4fI+hQQF+GyfSUwrQQKcnnq+WKQj3GwaSCds6dFN3fSTcpTrmBviKQOJ7nZxlFVMwpemWg==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.50':
-    resolution: {integrity: sha512-rCwlYc3o/yPRiCeLLOIuFfb0OMUgcXyOgljt/0eboIvAGl2K4AkP7L84/Vs6tDKblFPwzClyceHWxCAEHV7heA==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.51':
+    resolution: {integrity: sha512-0zVftz3RECCCAcjFX6Cuv2OBP3C9qynPI4sjTTJz1IZKnqk3FxaPi0Tr6duaTH3IwrnrprGvvrh+5kMEnQlaRw==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.50':
-    resolution: {integrity: sha512-cYhXzM5lnPIsG8ktAx353Bm+PkNvd4IuFbbzFbty0yc4MlDaPGdGj2kFjf9GxQPx64UM1X728ICFy1O7Kw3q5g==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.51':
+    resolution: {integrity: sha512-RtaDvNoev7GynTW3q/ssfVGTyGS9pWn/QZCUewEK6o7+K7wNrTowDQmv8QWiplAsmAiUnlnlTTr1b2We1vyZgA==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.50':
-    resolution: {integrity: sha512-BjL3VGtBuIh910esU9zCqz5BykcJLcP/rOv8H7dles0xLJOxddOceZzcDxj8QhUzxezYeaX+0VDVS8/YZ+Pz8Q==}
+  '@takazudo/zfb-runtime@0.1.0-next.51':
+    resolution: {integrity: sha512-nmYm8xQyWLi6TeBpVGemW9n2wtsIvPpU3R2TCz8bbPNUDIJC5QPwgNfSXuME4Mtid2Bp/kFKRe5Mcbh5viumwA==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.50
+      '@takazudo/zfb': 0.1.0-next.51
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.50':
-    resolution: {integrity: sha512-GvbzxVnAM9RR9M1AFyp1t7EpjZ2/VkA3rrWp+MxXibAKS4I0us9yb6NLgMkLeWeI90QE6A35d0IJWbua8Jc9sQ==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.51':
+    resolution: {integrity: sha512-+oj6NpmuDJMQuYFtGwICa1c4L/xdxqQx+VnVvK4JSCTXws+qwmM8D3ZAy4Tu8BUH+CYMUlfZePMeIvDCmqwiRQ==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.50':
-    resolution: {integrity: sha512-YW6ZQT9GtTYS+5kKJLeRCoiGwUw+fxhObdwiU/OE8ehrf92X21y8d5pMVWu20O1vgGIzSKXV7jZSLhWPZ1xVbA==}
+  '@takazudo/zfb@0.1.0-next.51':
+    resolution: {integrity: sha512-H49e8yCWd/GXrLt85LvZpkwE4AjcFUxFNkOXSJOyPUtyEcQ/hSe8zqR9lJSRWADDDIJ6rd94WjcOoc4dWWECtQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
@@ -2154,8 +2154,8 @@ packages:
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
-  hono@4.12.23:
-    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
+  hono@4.12.25:
+    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
     engines: {node: '>=16.9.0'}
 
   html-validate@10.15.0:
@@ -4076,35 +4076,35 @@ snapshots:
       culori: 4.0.2
       preact: 10.29.2
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.50': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.51': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.50':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.51':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.50':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.51':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.50':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.51':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.50':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.51':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.50(@takazudo/zfb@0.1.0-next.50)':
+  '@takazudo/zfb-runtime@0.1.0-next.51(@takazudo/zfb@0.1.0-next.51)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.50
-      hono: 4.12.23
+      '@takazudo/zfb': 0.1.0-next.51
+      hono: 4.12.25
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.50':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.51':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.50':
+  '@takazudo/zfb@0.1.0-next.51':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.50
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.50
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.50
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.50
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.50
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.51
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.51
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.51
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.51
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.51
 
   '@takazudo/zudo-design-token-lint@1.0.0(patch_hash=6a157fd850449b055cf64a8a7dd1faed5b1da9eebe6c81cca08488ac0de85182)':
     dependencies:
@@ -4961,7 +4961,7 @@ snapshots:
 
   headers-polyfill@4.0.3: {}
 
-  hono@4.12.23: {}
+  hono@4.12.25: {}
 
   html-validate@10.15.0(vitest@4.1.0(@types/node@25.3.5)(msw@2.12.12(@types/node@25.3.5)(typescript@5.9.3))(vite@7.3.5(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))):
     dependencies:


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2191
- epic
    - https://github.com/zudolab/zudo-doc/issues/2189

---

## Summary

Bump the `@takazudo/zfb` trio from `0.1.0-next.50` → `0.1.0-next.51` (current npm `latest`/`next`) across every lockstep pin source enforced by `scripts/check-pin-parity.mjs`, and regenerate the lockfile. `@takazudo/zdtp` is left at `0.2.3` (already latest) — this is a zfb-only bump.

`next.51` is non-breaking for this project: the public API additions (`VNode`/`VNodeArray`/`VNodeObject` exported from `@takazudo/zfb`, upstream #972) are additive, and the removed `linkValidation.allowExternal` knob (upstream #925) was a no-op we never set.

## Changes

- **`package.json`** (root `dependencies`) → `zfb`, `zfb-runtime`, `zfb-adapter-cloudflare` at `0.1.0-next.51`
- **`packages/zudo-doc/package.json`** → `peerDependencies` `^0.1.0-next.51`, `devDependencies` exact `0.1.0-next.51` (zfb + zfb-runtime)
- **`packages/create-zudo-doc/src/scaffold.ts`** → the three generator literal pins, plus the narrative comment
- **`packages/create-zudo-doc/src/__tests__/scaffold.test.ts`** → pin assertions, test title, and historical-narrative comment updated to `next.51`
- **`pnpm-lock.yaml`** → regenerated via `pnpm install`

## Test Plan

Validated locally:

- `pnpm check:pin-parity` → OK (3 external + 2 internal + 4 workspace-package fields)
- `pnpm check` (typecheck) → no errors
- `pnpm test` (root unit + all package tests, incl. updated scaffold pin test) → all pass
- `pnpm build` → 281 pages
- `pnpm b4push` steps 1–17 (full automated suite) → all green (step 18 is a manual human smoke, N/A in CI)

CI `pr-checks` runs the full suite + Playwright E2E on this PR.

Closes #2191

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzkoUHUamDD1hcTCeDiU1f)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784238591&installation_id=130359969&pr_number=2192&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2192&signature=64bb5afafbf1e8059c20964f8f2f63c60ba6fb200605e0930be0f5d62b10d718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->