### PR TITLE
fix(mermaid): contain enlarged diagram and stop edge-label clipping

### DIFF
--- a/packages/create-zudo-doc/templates/base/src/components/mermaid-enlarge.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/mermaid-enlarge.tsx
@@ -73,7 +73,7 @@ const DIAGRAM_SVG_SELECTOR = ":scope > svg";
 // re-render that regenerates the inner `<svg>` doesn't drop or duplicate it.
 const BTN_INJECTED_ATTR = "data-mermaid-enlarge-ready";
 
-// Zoom step + clamps. scale 1 = diagram fills the dialog width.
+// Zoom step + clamps. scale 1 = diagram fits the dialog (contain).
 const ZOOM_STEP = 1.25;
 const MIN_SCALE = 1;
 const MAX_SCALE = 4;
@@ -123,7 +123,7 @@ interface OpenDiagram {
 export default function MermaidEnlarge() {
   const [open, setOpen] = useState<OpenDiagram | null>(null);
 
-  // Zoom/pan state. scale 1 = diagram fills the dialog width; translate 0,0.
+  // Zoom/pan state. scale 1 = diagram fits the dialog (contain); translate 0,0.
   const [scale, setScale] = useState(1);
   const [translate, setTranslate] = useState({ x: 0, y: 0 });
   const [panActive, setPanActive] = useState(false);

--- a/packages/create-zudo-doc/templates/base/src/styles/global.css
+++ b/packages/create-zudo-doc/templates/base/src/styles/global.css
@@ -1336,15 +1336,29 @@ dialog.zd-mermaid-dialog::backdrop {
   will-change: transform;
 }
 
-/* SVG sizing reset — mermaid's cloned svg carries inline width/height/max-width
- * (in px); without neutralizing it the diagram renders tiny inside the dialog.
- * Force it to fill the viewport at scale 1. Scoped to .zd-mermaid-transform (the
- * cloned-diagram wrapper) so it does NOT hit the toolbar / close-button icon svgs
- * that also live inside the dialog. */
+/* SVG sizing — fit the cloned mermaid svg inside the dialog like
+ * object-fit:contain. The svg fills the viewport box (100% x 100%) and its
+ * viewBox content is letterboxed/centered by the default
+ * preserveAspectRatio="xMidYMid meet". A TALL diagram (e.g. a state diagram) no
+ * longer gets forced to full dialog width with `height:auto` driving the height
+ * far past the viewport via its aspect ratio — it now shrinks to fit the height
+ * instead. max-width/max-height !important neutralize the inline px sizing
+ * mermaid bakes onto the svg (without it the diagram renders tiny). Scoped to
+ * .zd-mermaid-transform (the cloned-diagram wrapper) so it does NOT hit the
+ * toolbar / close-button icon svgs that also live inside the dialog. */
 .zd-mermaid-transform svg {
   max-width: 100% !important;
+  max-height: 100% !important;
   width: 100%;
-  height: auto;
+  height: 100%;
+}
+
+/* Edge labels (e.g. "Yes"/"No") render inside a tightly-sized <foreignObject>;
+ * when the cloned diagram is upscaled to fill the dialog, sub-pixel overflow
+ * makes the browser clip the last glyph at the foreignObject's right edge.
+ * Letting the foreignObject overflow render keeps the full label visible. */
+.zd-mermaid-transform svg foreignObject {
+  overflow: visible;
 }
 
 /* Toolbar — bottom-center pill of zoom/pan controls. */

--- a/src/components/mermaid-enlarge.tsx
+++ b/src/components/mermaid-enlarge.tsx
@@ -74,7 +74,7 @@ const DIAGRAM_SVG_SELECTOR = ":scope > svg";
 // re-render that regenerates the inner `<svg>` doesn't drop or duplicate it.
 const BTN_INJECTED_ATTR = "data-mermaid-enlarge-ready";
 
-// Zoom step + clamps. scale 1 = diagram fills the dialog width.
+// Zoom step + clamps. scale 1 = diagram fits the dialog (contain).
 const ZOOM_STEP = 1.25;
 const MIN_SCALE = 1;
 const MAX_SCALE = 4;
@@ -124,7 +124,7 @@ interface OpenDiagram {
 export default function MermaidEnlarge() {
   const [open, setOpen] = useState<OpenDiagram | null>(null);
 
-  // Zoom/pan state. scale 1 = diagram fills the dialog width; translate 0,0.
+  // Zoom/pan state. scale 1 = diagram fits the dialog (contain); translate 0,0.
   const [scale, setScale] = useState(1);
   const [translate, setTranslate] = useState({ x: 0, y: 0 });
   const [panActive, setPanActive] = useState(false);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1364,15 +1364,29 @@ dialog.zd-mermaid-dialog::backdrop {
   will-change: transform;
 }
 
-/* SVG sizing reset — mermaid's cloned svg carries inline width/height/max-width
- * (in px); without neutralizing it the diagram renders tiny inside the dialog.
- * Force it to fill the viewport at scale 1. Scoped to .zd-mermaid-transform (the
- * cloned-diagram wrapper) so it does NOT hit the toolbar / close-button icon svgs
- * that also live inside the dialog. */
+/* SVG sizing — fit the cloned mermaid svg inside the dialog like
+ * object-fit:contain. The svg fills the viewport box (100% x 100%) and its
+ * viewBox content is letterboxed/centered by the default
+ * preserveAspectRatio="xMidYMid meet". A TALL diagram (e.g. a state diagram) no
+ * longer gets forced to full dialog width with `height:auto` driving the height
+ * far past the viewport via its aspect ratio — it now shrinks to fit the height
+ * instead. max-width/max-height !important neutralize the inline px sizing
+ * mermaid bakes onto the svg (without it the diagram renders tiny). Scoped to
+ * .zd-mermaid-transform (the cloned-diagram wrapper) so it does NOT hit the
+ * toolbar / close-button icon svgs that also live inside the dialog. */
 .zd-mermaid-transform svg {
   max-width: 100% !important;
+  max-height: 100% !important;
   width: 100%;
-  height: auto;
+  height: 100%;
+}
+
+/* Edge labels (e.g. "Yes"/"No") render inside a tightly-sized <foreignObject>;
+ * when the cloned diagram is upscaled to fill the dialog, sub-pixel overflow
+ * makes the browser clip the last glyph at the foreignObject's right edge.
+ * Letting the foreignObject overflow render keeps the full label visible. */
+.zd-mermaid-transform svg foreignObject {
+  overflow: visible;
 }
 
 /* Toolbar — bottom-center pill of zoom/pan controls. */


### PR DESCRIPTION
## Summary

Two bugs in the mermaid enlarge (zoom/pan) dialog on `/docs/components/mermaid-diagrams/`:

1. **Over-zoomed on open.** The cloned svg was forced to `width:100%; height:auto`, so a tall diagram (e.g. the state diagram) filled the dialog width and its aspect ratio drove the height far past the viewport — the dialog opened "super zoomed".
2. **Edge labels clipped.** `Yes`/`No` (and other edge labels) had their last glyph cut off at the right edge.

## Changes

- `src/styles/global.css` (`.zd-mermaid-transform svg`): fit the svg like `object-fit:contain` — the svg fills the `100% x 100%` viewport box and its viewBox is letterboxed/centered by the default `preserveAspectRatio="xMidYMid meet"`. Both wide and tall diagrams now fit on open. `max-width`/`max-height: 100% !important` neutralize mermaid's inline px sizing.
- New rule `.zd-mermaid-transform svg foreignObject { overflow: visible; }` — edge labels render in a tightly-sized `<foreignObject>`; on upscale, sub-pixel overflow clipped the last glyph. Letting it overflow keeps the full label visible.
- Updated stale "scale 1 = fills the dialog width" comments in `mermaid-enlarge.tsx` to "fits the dialog (contain)".
- Mirrored both changes into the `create-zudo-doc` base template.

## Test Plan

- Open the enlarge dialog on a wide flowchart → fills width, `Yes`/`No` labels fully visible.
- Open it on a tall state diagram → fits within the viewport instead of opening over-zoomed.
- Zoom in still works (transform multiplies from the contained base).

> 🖥️ Implemented on Claude Code web — the final visual/browser check could not run here, so the rendered result is unverified. Needs a Mac verification pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZoUmSM9witURe5hhZnnsf)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784238966&installation_id=130359969&pr_number=2193&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2193&signature=d062da07cb3cd346734275a4ccc7c4354f8cb4075d5434fdd5d012717f7fbb92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->