### PR TITLE
Mermaid SPA-nav blanking fix (#2181) + accumulated branch work → main

### DIFF
--- a/e2e/smoke-mermaid-spa.spec.ts
+++ b/e2e/smoke-mermaid-spa.spec.ts
@@ -1,0 +1,84 @@
+/**
+ * Regression test for #2181: Mermaid SVG stripped after SPA soft-navigation.
+ *
+ * Pre-fix behaviour: the mermaid reinit code ran a debounced cleanup at ~360ms
+ * after every `zfb:after-swap`, blanking the SVG container even when the
+ * diagram had already rendered correctly. The fix (#2184) prevents the stale
+ * debounce from firing on a page that is no longer "mid-swap".
+ *
+ * Test strategy:
+ *   1. Direct-load the mermaid page to warm the esm.sh module and confirm
+ *      baseline rendering.
+ *   2. SPA-navigate away (to a non-mermaid page) and back to the mermaid page.
+ *   3. Assert the SVG is present shortly after the swap AND still present and
+ *      non-empty after the ~300ms debounce window elapses.  Pre-fix code blanks
+ *      the SVG at ~360ms, so the late assertion fails against the old code and
+ *      passes against the committed fix.
+ */
+
+import { test, expect } from "./fixtures";
+import { spaClick } from "./nav-helpers";
+
+const MERMAID_PAGE = "/docs/guides/code-blocks-test";
+// Non-mermaid guides page used as the "away" destination.
+const AWAY_PAGE = "/docs/guides/page-1";
+
+// How long to wait after the first SVG-presence assertion before the
+// debounce-survival re-check. Must exceed the reinit debounce window (~300ms);
+// pre-fix code blanked the SVG at ~360ms after the swap, so 700ms is the
+// minimum that catches the regression while staying well inside the test timeout.
+const POST_DEBOUNCE_WAIT_MS = 700;
+
+test.describe("Mermaid: SPA soft-navigation regression (#2181)", () => {
+  test("mermaid diagram stays rendered after SPA nav away-and-back", async ({
+    page,
+    assertNoConsoleErrors,
+  }) => {
+    // ── Step 1: direct-load to warm the esm.sh mermaid module ────────────────
+    await page.goto(MERMAID_PAGE, { waitUntil: "load" });
+
+    const renderedLocator = page.locator("[data-mermaid-rendered]");
+    await renderedLocator.waitFor({ state: "attached", timeout: 30_000 });
+
+    // Confirm baseline SVG present on direct load.
+    await expect(renderedLocator.locator("svg")).toBeAttached();
+
+    // ── Step 2: SPA-navigate away, then back ─────────────────────────────────
+    const awayFired = await spaClick(page, AWAY_PAGE);
+    expect(awayFired, `zfb:after-swap did not fire navigating to ${AWAY_PAGE}`).toBe(true);
+
+    const backFired = await spaClick(page, MERMAID_PAGE);
+    expect(backFired, `zfb:after-swap did not fire navigating back to ${MERMAID_PAGE}`).toBe(true);
+
+    // ── Step 3a: SVG present shortly after the swap (~350ms check) ───────────
+    // The mermaid init fires asynchronously after zfb:after-swap; give it a
+    // generous window to render before the 300ms debounce deadline.
+    await expect(
+      page.locator("[data-mermaid-rendered] svg"),
+      "SVG should appear inside [data-mermaid-rendered] after SPA nav back",
+    ).toBeAttached({ timeout: 10_000 });
+
+    // ── Step 3b: SVG still present and non-empty AFTER the 300ms debounce ────
+    // Wait beyond the debounce window and re-assert.
+    // Pre-fix code blanks the SVG at ~360ms; this assertion catches that.
+    await page.waitForTimeout(POST_DEBOUNCE_WAIT_MS);
+
+    const svgContent = await page.evaluate(() => {
+      const svg = document.querySelector("[data-mermaid-rendered] svg");
+      return svg ? svg.innerHTML.trim() : null;
+    });
+
+    expect(
+      svgContent,
+      "SVG inside [data-mermaid-rendered] should still exist after the 300ms reinit debounce",
+    ).not.toBeNull();
+
+    expect(
+      svgContent,
+      "SVG should be non-empty after the 300ms reinit debounce (pre-fix stripped it to blank)",
+    ).not.toBe("");
+
+    // ── Optional: no console errors ───────────────────────────────────────────
+    assertNoConsoleErrors();
+  });
+});

--- a/e2e/smoke-mermaid-spa.spec.ts
+++ b/e2e/smoke-mermaid-spa.spec.ts
@@ -29,6 +29,13 @@ const AWAY_PAGE = "/docs/guides/page-1";
 // minimum that catches the regression while staying well inside the test timeout.
 const POST_DEBOUNCE_WAIT_MS = 700;
 
+// The smoke fixture enables the mermaid-enlarge feature, which injects an
+// "Enlarge diagram" <button> containing its OWN <svg> icon into the rendered
+// [data-mermaid-rendered] element. A bare `svg` descendant selector therefore
+// matches two svgs (the flowchart + the icon) and trips Playwright strict mode.
+// Target the mermaid flowchart svg specifically (mermaid emits class="flowchart").
+const DIAGRAM_SVG = "svg.flowchart";
+
 test.describe("Mermaid: SPA soft-navigation regression (#2181)", () => {
   test("mermaid diagram stays rendered after SPA nav away-and-back", async ({
     page,
@@ -41,7 +48,7 @@ test.describe("Mermaid: SPA soft-navigation regression (#2181)", () => {
     await renderedLocator.waitFor({ state: "attached", timeout: 30_000 });
 
     // Confirm baseline SVG present on direct load.
-    await expect(renderedLocator.locator("svg")).toBeAttached();
+    await expect(renderedLocator.locator(DIAGRAM_SVG)).toBeAttached();
 
     // ── Step 2: SPA-navigate away, then back ─────────────────────────────────
     const awayFired = await spaClick(page, AWAY_PAGE);
@@ -54,7 +61,7 @@ test.describe("Mermaid: SPA soft-navigation regression (#2181)", () => {
     // The mermaid init fires asynchronously after zfb:after-swap; give it a
     // generous window to render before the 300ms debounce deadline.
     await expect(
-      page.locator("[data-mermaid-rendered] svg"),
+      page.locator(`[data-mermaid-rendered] ${DIAGRAM_SVG}`),
       "SVG should appear inside [data-mermaid-rendered] after SPA nav back",
     ).toBeAttached({ timeout: 10_000 });
 
@@ -64,7 +71,7 @@ test.describe("Mermaid: SPA soft-navigation regression (#2181)", () => {
     await page.waitForTimeout(POST_DEBOUNCE_WAIT_MS);
 
     const svgContent = await page.evaluate(() => {
-      const svg = document.querySelector("[data-mermaid-rendered] svg");
+      const svg = document.querySelector("[data-mermaid-rendered] svg.flowchart");
       return svg ? svg.innerHTML.trim() : null;
     });
 

--- a/packages/zudo-doc/src/code-syntax/__tests__/mermaid-init.test.tsx
+++ b/packages/zudo-doc/src/code-syntax/__tests__/mermaid-init.test.tsx
@@ -147,6 +147,134 @@ describe("MERMAID_INIT_SCRIPT", () => {
       );
     expect(observesDataTheme).toBe(true);
   });
+
+  // zudolab/zudo-doc#2181 — Fix 2: reinitMermaid must regenerate from a
+  // cached source. mermaid.run consumes the diagram source text (replaces
+  // it with the SVG, sets data-processed), so the script caches the
+  // DECODED source into data-mermaid-src BEFORE running, and reinitMermaid
+  // restores it and clears data-processed so mermaid.run won't skip the
+  // node.
+  it("caches the diagram source into data-mermaid-src before running", () => {
+    expect(MERMAID_INIT_SCRIPT).toContain("data-mermaid-src");
+    // Must cache via textContent (decoded) — NOT innerHTML, which would
+    // re-encode entities and corrupt `-->` / `&` diagrams.
+    expect(MERMAID_INIT_SCRIPT).toContain("el.textContent");
+    expect(MERMAID_INIT_SCRIPT).not.toContain("el.innerHTML");
+  });
+
+  it("reinitMermaid restores the cached source and removes data-processed", () => {
+    // Without removing data-processed, mermaid.run skips the node and it
+    // stays blank. Both data-processed and data-mermaid-rendered must be
+    // removed so initMermaid regenerates cleanly.
+    expect(MERMAID_INIT_SCRIPT).toContain("data-processed");
+    expect(MERMAID_INIT_SCRIPT).toMatch(
+      /removeAttribute\(\s*"data-processed"\s*\)/,
+    );
+    expect(MERMAID_INIT_SCRIPT).toMatch(
+      /removeAttribute\(\s*"data-mermaid-rendered"\s*\)/,
+    );
+    // Restores the cached source so there is graph text to regenerate.
+    expect(MERMAID_INIT_SCRIPT).toContain('getAttribute("data-mermaid-src")');
+  });
+
+  // zudolab/zudo-doc#2181 — Fix 1: the observer must gate on a REAL
+  // theme/token change. zfb-runtime's swapRootAttributes removes+re-adds
+  // all :root attributes on every soft nav, so the observer over-fires
+  // unless it compares resolved state against the last-seen snapshot.
+  it("gates the observer on a real theme/token change", () => {
+    expect(MERMAID_INIT_SCRIPT).toContain("hasThemeStateChanged");
+    expect(MERMAID_INIT_SCRIPT).toContain("getComputedStyle");
+    // Cites the root cause so a future reader knows why the gate exists.
+    expect(MERMAID_INIT_SCRIPT).toContain("swapRootAttributes");
+  });
+
+  it("hasThemeStateChanged returns false when nothing tracked changed", () => {
+    const fn = extractHasThemeStateChanged(MERMAID_INIT_SCRIPT);
+    const state = {
+      theme: "light",
+      tokens: {
+        "--zd-bg": "#ffffff",
+        "--zd-mermaid-node-bg": "#eeeeee",
+        "--zd-mermaid-text": "#111111",
+        "--zd-mermaid-line": "#222222",
+        "--zd-mermaid-note-bg": "#333333",
+        "--zd-mermaid-label-bg": "#444444",
+      },
+    };
+    // Same values in a fresh object — an unrelated :root[style] mutation
+    // that touched no tracked token resolves to identical snapshots.
+    const same = {
+      theme: "light",
+      tokens: { ...state.tokens },
+    };
+    expect(fn(state, same)).toBe(false);
+  });
+
+  it("hasThemeStateChanged returns true on a real data-theme change", () => {
+    const fn = extractHasThemeStateChanged(MERMAID_INIT_SCRIPT);
+    const tokens = {
+      "--zd-bg": "#ffffff",
+      "--zd-mermaid-node-bg": "#eeeeee",
+      "--zd-mermaid-text": "#111111",
+      "--zd-mermaid-line": "#222222",
+      "--zd-mermaid-note-bg": "#333333",
+      "--zd-mermaid-label-bg": "#444444",
+    };
+    const prev = { theme: "light", tokens: { ...tokens } };
+    const next = { theme: "dark", tokens: { ...tokens } };
+    expect(fn(prev, next)).toBe(true);
+  });
+
+  it("hasThemeStateChanged returns true on a real tracked-token change", () => {
+    const fn = extractHasThemeStateChanged(MERMAID_INIT_SCRIPT);
+    const base = {
+      "--zd-bg": "#ffffff",
+      "--zd-mermaid-node-bg": "#eeeeee",
+      "--zd-mermaid-text": "#111111",
+      "--zd-mermaid-line": "#222222",
+      "--zd-mermaid-note-bg": "#333333",
+      "--zd-mermaid-label-bg": "#444444",
+    };
+    const prev = { theme: "light", tokens: { ...base } };
+    const next = {
+      theme: "light",
+      tokens: { ...base, "--zd-mermaid-text": "#999999" },
+    };
+    expect(fn(prev, next)).toBe(true);
+  });
+
+  it("hasThemeStateChanged treats first-paint empty->populated as a change", () => {
+    // CRITICAL: --zd-bg may be UNSET at first paint (empty string); the
+    // observer is exactly what reinits once ColorSchemeProvider populates
+    // the tokens, so empty -> real MUST count as a change, otherwise the
+    // first legitimate colorization is suppressed.
+    const fn = extractHasThemeStateChanged(MERMAID_INIT_SCRIPT);
+    const seed = {
+      theme: null,
+      tokens: {
+        "--zd-bg": "",
+        "--zd-mermaid-node-bg": "",
+        "--zd-mermaid-text": "",
+        "--zd-mermaid-line": "",
+        "--zd-mermaid-note-bg": "",
+        "--zd-mermaid-label-bg": "",
+      },
+    };
+    const populated = {
+      theme: "light",
+      tokens: {
+        "--zd-bg": "#ffffff",
+        "--zd-mermaid-node-bg": "#eeeeee",
+        "--zd-mermaid-text": "#111111",
+        "--zd-mermaid-line": "#222222",
+        "--zd-mermaid-note-bg": "#333333",
+        "--zd-mermaid-label-bg": "#444444",
+      },
+    };
+    expect(fn(seed, populated)).toBe(true);
+    // A missing prev snapshot (no seed at all) also counts as a change.
+    expect(fn(undefined, populated)).toBe(true);
+  });
 });
 
 /**
@@ -173,6 +301,41 @@ function extractParseLightDark(
     raw: string,
     theme: string | undefined,
   ) => string | null;
+}
+
+type ThemeSnapshot = {
+  theme: string | null;
+  tokens: Record<string, string>;
+};
+
+/**
+ * Pull `TRACKED_TOKENS` and `hasThemeStateChanged` out of the IIFE and
+ * return the change-detector as a callable. `hasThemeStateChanged`
+ * closes over `TRACKED_TOKENS`, so both declarations are re-emitted into
+ * the `new Function` body (zudolab/zudo-doc#2181).
+ */
+function extractHasThemeStateChanged(
+  script: string,
+): (
+  prev: ThemeSnapshot | undefined,
+  next: ThemeSnapshot,
+) => boolean {
+  const tokens = script.match(
+    /var\s+TRACKED_TOKENS\s*=\s*\[[\s\S]*?\];/,
+  );
+  const fn = script.match(
+    /function\s+hasThemeStateChanged\s*\([^)]*\)\s*\{[\s\S]*?\n\s{2}\}/,
+  );
+  if (!tokens) {
+    throw new Error("TRACKED_TOKENS not found in MERMAID_INIT_SCRIPT");
+  }
+  if (!fn) {
+    throw new Error("hasThemeStateChanged not found in MERMAID_INIT_SCRIPT");
+  }
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  return new Function(
+    `${tokens[0]}\n${fn[0]}\nreturn hasThemeStateChanged;`,
+  )() as (prev: ThemeSnapshot | undefined, next: ThemeSnapshot) => boolean;
 }
 
 describe("MERMAID_CDN_MODULE_URL", () => {

--- a/packages/zudo-doc/src/code-syntax/mermaid-init-script.ts
+++ b/packages/zudo-doc/src/code-syntax/mermaid-init-script.ts
@@ -168,6 +168,56 @@ export function buildMermaidInitScript(cdnUrl: string): string {
     return value;
   }
 
+  // The --zd-* tokens the value-reader v() consumes. The observer gate
+  // snapshots their RESOLVED computed values so a :root[style] mutation
+  // that touches none of them correctly no-ops, while one that changes a
+  // tracked token (or data-theme) re-renders (zudolab/zudo-doc#2181).
+  var TRACKED_TOKENS = [
+    "--zd-bg",
+    "--zd-mermaid-node-bg",
+    "--zd-mermaid-text",
+    "--zd-mermaid-line",
+    "--zd-mermaid-note-bg",
+    "--zd-mermaid-label-bg",
+  ];
+
+  /**
+   * Snapshot the active theme state: the data-theme attribute plus the
+   * RESOLVED computed value of every tracked token. getComputedStyle is
+   * read fresh (not the raw style-attribute string) so an unrelated
+   * :root[style] change does not look like a token change, and a real
+   * token change is caught even when written indirectly.
+   */
+  function captureThemeState() {
+    var cs = getComputedStyle(document.documentElement);
+    var tokens = {};
+    TRACKED_TOKENS.forEach(function (name) {
+      tokens[name] = cs.getPropertyValue(name).trim();
+    });
+    return {
+      theme: document.documentElement.getAttribute("data-theme"),
+      tokens: tokens,
+    };
+  }
+
+  /**
+   * Decide whether a genuine theme/token change occurred between two
+   * snapshots. Treats an empty/undefined -> real-value transition as a
+   * change: --zd-bg may be UNSET at first paint (luminance NaN); the
+   * observer is exactly what reinits once ColorSchemeProvider later
+   * populates the tokens, so that first colorization MUST still fire
+   * (zudolab/zudo-doc#2181).
+   */
+  function hasThemeStateChanged(prev, next) {
+    if (!prev) return true;
+    if (prev.theme !== next.theme) return true;
+    for (var i = 0; i < TRACKED_TOKENS.length; i++) {
+      var name = TRACKED_TOKENS[i];
+      if (prev.tokens[name] !== next.tokens[name]) return true;
+    }
+    return false;
+  }
+
   async function initMermaid() {
     var els = document.querySelectorAll("[data-mermaid]:not([data-mermaid-rendered])");
     if (els.length === 0) return;
@@ -264,6 +314,18 @@ export function buildMermaidInitScript(cdnUrl: string): string {
         theme: "base",
         themeVariables: themeVariables,
       });
+      // Cache each diagram's source BEFORE mermaid.run consumes it
+      // (mermaid replaces the graph text with the rendered <svg> and
+      // sets data-processed). Use textContent — the DECODED source
+      // mermaid consumes — NOT innerHTML, which would re-encode/decode
+      // entities and corrupt diagrams containing \`-->\` arrows or \`&\`.
+      // Only set when absent so repeated reinits keep the ORIGINAL
+      // source (zudolab/zudo-doc#2181).
+      els.forEach(function (el) {
+        if (!el.hasAttribute("data-mermaid-src")) {
+          el.setAttribute("data-mermaid-src", el.textContent);
+        }
+      });
       await mermaid.run({ nodes: Array.from(els) });
       els.forEach(function (el) { el.setAttribute("data-mermaid-rendered", ""); });
     } catch (e) {
@@ -271,14 +333,31 @@ export function buildMermaidInitScript(cdnUrl: string): string {
     }
   }
 
-  /** Re-render all mermaid diagrams (clear rendered state so initMermaid picks them up). */
+  /**
+   * Re-render all mermaid diagrams from their cached source text.
+   *
+   * By the time this runs, mermaid.run has already CONSUMED the source
+   * (replaced the graph text with the rendered <svg> and set
+   * data-processed), so clearing data-mermaid-rendered alone leaves the
+   * node permanently blank — initMermaid re-selects it but mermaid.run
+   * skips nodes that still have data-processed, and there is no source
+   * left to regenerate from. Restore the cached source, drop the SVG,
+   * and remove BOTH data-processed AND data-mermaid-rendered so the next
+   * initMermaid pass regenerates cleanly. Keep data-mermaid-src so
+   * repeated theme toggles keep working (zudolab/zudo-doc#2181).
+   */
   function reinitMermaid() {
     document.querySelectorAll("[data-mermaid-rendered]").forEach(function (el) {
-      el.removeAttribute("data-mermaid-rendered");
-      // Remove rendered SVG so mermaid regenerates from source text.
+      var src = el.getAttribute("data-mermaid-src");
+      if (src !== null) el.textContent = src;
       var svg = el.querySelector("svg");
       if (svg) svg.remove();
+      el.removeAttribute("data-processed");
+      el.removeAttribute("data-mermaid-rendered");
     });
+    // Refresh the theme snapshot now that the genuine change is applied,
+    // so the observer's gate measures the NEXT change against this state.
+    lastThemeState = captureThemeState();
     initMermaid();
   }
 
@@ -299,8 +378,26 @@ export function buildMermaidInitScript(cdnUrl: string): string {
   //     the new theme's hex picks from parseLightDark).
   // Debounced so a synchronous flip of both attributes triggers a
   // single re-render.
+  //
+  // zudolab/zudo-doc#2181: gate on a REAL theme/token change. zfb-runtime's
+  // client router (swapRootAttributes) removes+re-adds ALL :root attributes
+  // on every soft navigation, so unchanged data-theme/style still fire
+  // mutations — without this gate the observer reinits ~300ms after every
+  // nav and (combined with the old destructive reinit) blanks every
+  // diagram. New diagrams reached by soft-nav are already handled by the
+  // AFTER_NAVIGATE_EVENT -> initMermaid() listener above, so the observer
+  // only needs to fire for genuine theme/token changes.
+  //
+  // Seed the snapshot at script-eval time — BEFORE ColorSchemeProvider
+  // runs, so the tokens are likely empty. hasThemeStateChanged treats
+  // empty -> real as a change, so the first legitimate colorization still
+  // fires; reinitMermaid then refreshes the snapshot.
+  var lastThemeState = captureThemeState();
   var tweakTimer;
   new MutationObserver(function () {
+    var next = captureThemeState();
+    if (!hasThemeStateChanged(lastThemeState, next)) return;
+    lastThemeState = next;
     clearTimeout(tweakTimer);
     tweakTimer = setTimeout(reinitMermaid, 300);
   }).observe(document.documentElement, {


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2183
    - https://github.com/zudolab/zudo-doc/issues/2181

---

## Summary

Integrates the `claude/focused-maxwell-w4ath0` working branch into `main`. The headline new work is the **mermaid SPA-navigation blanking fix** (epic #2183, fixes #2181); the branch also carries prior accumulated work that had not yet reached `main` (zfb pin bumps, create-zudo-doc generator changes, llms-txt strip fixes, theme-toggle docs, header-right-items docs, etc. — each previously merged into this branch via its own sub-PR).

### Mermaid fix (#2181)

Mermaid diagrams went blank after a client-side (SPA) soft navigation. Two compounding defects in `packages/zudo-doc/src/code-syntax/mermaid-init-script.ts`:

1. **Theme `MutationObserver` over-fired on every soft nav** — zfb-runtime's `swapRootAttributes()` removes+re-adds all `:root` attributes on every swap, so unchanged `data-theme`/`style` counted as mutations and scheduled `reinitMermaid()` ~300ms after every nav. Now gated: the observer snapshots `data-theme` + the resolved `--zd-*` token values and bails unless something genuinely changed (empty→populated first-paint still fires).
2. **`reinitMermaid()` was destructive and could not regenerate** — by reinit time mermaid had consumed the source (`data-processed` set, graph text replaced by SVG). Now each diagram's source is cached verbatim into `data-mermaid-src` (via `textContent`) before the first run; `reinitMermaid` restores it and removes `data-processed` + `data-mermaid-rendered` so mermaid regenerates cleanly. Also fixes genuine theme-toggle re-renders.

### Tests

- Unit: 7 new assertions in `mermaid-init.test.tsx` (source caching round-trip, reinit removes `data-processed`/`data-mermaid-rendered`, observer change-detection branches incl. empty→populated). Full suite 544 passing.
- E2E: new `e2e/smoke-mermaid-spa.spec.ts` — warm-then-return SPA navigation into the mermaid page, asserts the SVG stays rendered across the 300ms reinit debounce (the authoritative regression guard; runs in CI's e2e job).

## Topic PRs / sub-issues

- #2184 — fix + unit tests (merged into this branch)
- #2185 — e2e regression test (merged into this branch)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ve5H56MaTn8hTLTnNLTos5)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784239333&installation_id=130359969&pr_number=2195&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2195&signature=fa55d722db180f379ab525d6ce6f755783095bcc1646f1f71c204548a290e2b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->