### PR TITLE
Eliminate desktop sidebar flash/animation on SPA page transition (#2197)

### DIFF
--- a/.fixture-settings-drift-allowlist
+++ b/.fixture-settings-drift-allowlist
@@ -110,8 +110,9 @@ smoke:sidebarResizer
 versioning:sidebarResizer
 
 # ── sidebarToggle ─────────────────────────────────────────────────────────────
-# reason: sidebar toggle (mobile) feature is not exercised in any fixture
-sidebar:sidebarToggle
+# reason: the desktop sidebar-toggle island (+ pre-paint script) is now exercised
+#         in the sidebar fixture (SPA-nav flash regression #2198); the remaining
+#         fixtures do not enable it
 i18n:sidebarToggle
 theme:sidebarToggle
 smoke:sidebarToggle

--- a/e2e/fixtures/sidebar/src/config/settings.ts
+++ b/e2e/fixtures/sidebar/src/config/settings.ts
@@ -15,6 +15,10 @@ export const settings = {
   defaultLocale: "en" as const,
   locales: {} satisfies Record<string, LocaleConfig>,
   mermaid: false,
+  // Enabled so the persisted DesktopSidebarToggle island + pre-paint script
+  // mount in this fixture — required to exercise the SPA-nav flash regression
+  // (#2198), which only reproduces with the toggle island present.
+  sidebarToggle: true as boolean,
   noindex: true as boolean,
   editUrl: false as string | false,
   siteUrl: "" as string,

--- a/e2e/sidebar-spa-nav-flash.spec.ts
+++ b/e2e/sidebar-spa-nav-flash.spec.ts
@@ -62,9 +62,28 @@ test.describe("Desktop sidebar SPA-nav flash (#2198)", () => {
       { timeout: 5000 },
     );
 
-    // Record the hidden-state transform as the baseline. The transition itself
-    // has already settled here (we waited for the attribute, and the click
-    // animation has completed by hydration + attribute wait).
+    // Wait for the collapse animation to FULLY settle before snapshotting the
+    // baseline. Clicking the toggle starts a 200ms transform transition, but
+    // `data-sidebar-hidden` is committed on <html> immediately on click — so
+    // waiting for the attribute alone races the animation and would snapshot a
+    // mid-slide transform (e.g. -4px instead of the settled -320px), making the
+    // final-state assertion below spuriously fail (#2198 verification). Poll the
+    // computed transform until two consecutive reads are equal (stable).
+    await page.waitForFunction(
+      () => {
+        const el = document.querySelector("#desktop-sidebar");
+        if (!el) return false;
+        const w = window as unknown as { __prevHiddenTransform__?: string };
+        const cur = getComputedStyle(el).transform;
+        const stable = w.__prevHiddenTransform__ === cur;
+        w.__prevHiddenTransform__ = cur;
+        return stable;
+      },
+      undefined,
+      { timeout: 5000, polling: 100 },
+    );
+
+    // Record the now-settled hidden-state transform as the baseline.
     const hiddenTransform = await sidebar.evaluate(
       (el) => getComputedStyle(el).transform,
     );

--- a/e2e/sidebar-spa-nav-flash.spec.ts
+++ b/e2e/sidebar-spa-nav-flash.spec.ts
@@ -1,0 +1,211 @@
+import { test, expect } from "@playwright/test";
+import { spaClick } from "./nav-helpers";
+import { desktopSidebar, waitForSidebarHydration } from "./sidebar-helpers";
+
+/**
+ * E2E regression for the desktop sidebar SPA-navigation flash (#2198).
+ *
+ * Bug: a CLOSED desktop sidebar briefly flashed open and animated shut on every
+ * same-section SPA navigation. zfb's `swapRootAttributes` wipes the
+ * `data-sidebar-hidden` attribute off <html> during the body swap, so for one
+ * frame the CSS saw the sidebar as visible and the 200ms transitions began
+ * animating it open; the toggle island's `zfb:after-swap` restore then reversed
+ * the animation (visible -> hidden slide). The net effect was a visible flash +
+ * slide on a sidebar the user had deliberately collapsed.
+ *
+ * Fix: on `zfb:before-preparation` the persisted `DesktopSidebarToggle` island
+ * adds a transient `data-sidebar-no-transition` marker on <html> that zeroes the
+ * sidebar geometry transitions (global.css), and removes it on a double rAF
+ * AFTER the `zfb:after-swap` restore — so the wipe and the restore both apply
+ * instantly (no painted/animated frame) while a later user toggle still
+ * animates normally.
+ *
+ * This fixture enables `sidebarToggle`, so the real persisted toggle island and
+ * pre-paint script are present — unlike sidebar-toggle-layout.spec.ts, which
+ * sets `data-sidebar-hidden` via page.evaluate against a fixture WITHOUT the
+ * island and therefore cannot exercise the swap-time race at all.
+ *
+ * Assertion technique (per #2198 brief): we do NOT assert only the final
+ * resting state — a 200ms transform settles back to hidden long before most
+ * polls, so a final-state check would pass even with a visible flash. Instead
+ * we instrument the swap window itself:
+ *   1. Confirm the marker is active for the full duration of the swap (set on
+ *      before-preparation, still present at after-swap).
+ *   2. rAF-sample `getComputedStyle(#desktop-sidebar).transitionProperty`
+ *      throughout the swap and assert it is `none` on every frame — i.e. the
+ *      sidebar geometry can never animate while the swap is in flight.
+ */
+
+const START_PAGE = "/docs/guides/sub-a/page-1";
+// Same getting-started/guides section, reachable via the sidebar nav tree —
+// a genuine same-section SPA hop (the case the bug fired on).
+const NEXT_PAGE = "/docs/guides/sub-a/page-2";
+
+test.describe("Desktop sidebar SPA-nav flash (#2198)", () => {
+  test("closed sidebar never animates across an SPA navigation", async ({
+    page,
+  }) => {
+    // >=1024px so the `lg:` desktop-sidebar rules (and the toggle) are active.
+    await page.setViewportSize({ width: 1600, height: 900 });
+    await page.goto(START_PAGE, { waitUntil: "load" });
+    await waitForSidebarHydration(page);
+
+    const sidebar = desktopSidebar(page);
+    await expect(sidebar).toHaveCount(1);
+
+    // Collapse the sidebar via the real toggle button and wait for the island
+    // to commit `data-sidebar-hidden` on <html>.
+    await page.locator(".zd-desktop-sidebar-toggle").click();
+    await page.waitForFunction(
+      () => document.documentElement.hasAttribute("data-sidebar-hidden"),
+      undefined,
+      { timeout: 5000 },
+    );
+
+    // Record the hidden-state transform as the baseline. The transition itself
+    // has already settled here (we waited for the attribute, and the click
+    // animation has completed by hydration + attribute wait).
+    const hiddenTransform = await sidebar.evaluate(
+      (el) => getComputedStyle(el).transform,
+    );
+
+    // Instrument the swap: install probes that (a) record marker presence at the
+    // two swap boundaries and (b) rAF-sample the sidebar's transition-property
+    // across the entire swap window. The before-preparation listener starts the
+    // sampler; the after-swap listener records the boundary state. Sampling
+    // continues for a few extra frames after after-swap to cover the double-rAF
+    // marker removal so we also prove the marker is gone afterwards.
+    await page.evaluate(() => {
+      const w = window as unknown as {
+        __flashProbe__: {
+          markerAtBeforePrep: boolean | null;
+          markerAtAfterSwap: boolean | null;
+          // One tuple per sampled frame, kept in lockstep so a frame where
+          // #desktop-sidebar is momentarily absent (the aside is NOT persisted
+          // across swaps — #1510) cannot desync marker vs transition.
+          samples: Array<{ marker: boolean; transition: string | null }>;
+          done: boolean;
+        };
+      };
+      w.__flashProbe__ = {
+        markerAtBeforePrep: null,
+        markerAtAfterSwap: null,
+        samples: [],
+        done: false,
+      };
+      const probe = w.__flashProbe__;
+      const html = document.documentElement;
+
+      let sampling = false;
+      let framesAfterSwap = 0;
+      const sample = () => {
+        if (!sampling) return;
+        const el = document.querySelector("#desktop-sidebar");
+        probe.samples.push({
+          marker: html.hasAttribute("data-sidebar-no-transition"),
+          transition: el ? getComputedStyle(el).transitionProperty : null,
+        });
+        // Stop a few frames after after-swap so we also capture the marker
+        // removal (double rAF) and the post-swap resting state.
+        if (probe.markerAtAfterSwap !== null) {
+          framesAfterSwap += 1;
+          if (framesAfterSwap > 5) {
+            sampling = false;
+            probe.done = true;
+            return;
+          }
+        }
+        requestAnimationFrame(sample);
+      };
+
+      document.addEventListener(
+        "zfb:before-preparation",
+        () => {
+          probe.markerAtBeforePrep = html.hasAttribute(
+            "data-sidebar-no-transition",
+          );
+          sampling = true;
+          requestAnimationFrame(sample);
+        },
+        { once: true },
+      );
+      document.addEventListener(
+        "zfb:after-swap",
+        () => {
+          probe.markerAtAfterSwap = html.hasAttribute(
+            "data-sidebar-no-transition",
+          );
+        },
+        { once: true },
+      );
+    });
+
+    // Perform the genuine SPA navigation.
+    const navigated = await spaClick(page, NEXT_PAGE);
+    expect(navigated).toBe(true);
+
+    // Let the sampler finish (covers the post-swap double-rAF marker removal).
+    await page.waitForFunction(() => {
+      const w = window as unknown as { __flashProbe__: { done: boolean } };
+      return w.__flashProbe__.done === true;
+    }, undefined, { timeout: 5000 });
+
+    const probe = await page.evaluate(() => {
+      const w = window as unknown as {
+        __flashProbe__: {
+          markerAtBeforePrep: boolean | null;
+          markerAtAfterSwap: boolean | null;
+          samples: Array<{ marker: boolean; transition: string | null }>;
+        };
+      };
+      return w.__flashProbe__;
+    });
+
+    // The marker must be set the moment the swap begins and still present when
+    // the body has been swapped + the attribute restored — i.e. it brackets the
+    // entire wipe/restore race.
+    expect(probe.markerAtBeforePrep).toBe(true);
+    expect(probe.markerAtAfterSwap).toBe(true);
+
+    // The sampler must have actually run during the swap.
+    expect(probe.samples.length).toBeGreaterThan(0);
+
+    // While the marker is active, the sidebar geometry transition must be
+    // suppressed — so no frame can paint a partially-open sidebar. For every
+    // frame where the marker was present AND the sidebar element existed, its
+    // computed transition-property must be `none`. (Frames where the aside is
+    // momentarily absent contribute `transition: null` and are skipped — they
+    // cannot paint a sidebar anyway.)
+    const suppressedWhileMarked = probe.samples.every(
+      (s) => !s.marker || s.transition === null || s.transition === "none",
+    );
+    expect(suppressedWhileMarked).toBe(true);
+
+    // The probe must have actually observed the marker active on at least one
+    // frame with the sidebar present (otherwise the suppression check above is
+    // vacuously true).
+    const observedSuppression = probe.samples.some(
+      (s) => s.marker && s.transition === "none",
+    );
+    expect(observedSuppression).toBe(true);
+
+    // The marker is eventually removed (double rAF after after-swap), so a later
+    // user toggle still animates. The tail of the samples must show it gone.
+    const lastSample = probe.samples[probe.samples.length - 1];
+    expect(lastSample?.marker).toBe(false);
+
+    // After everything settles the sidebar is still hidden and at the exact
+    // same hidden transform it had before the nav — never opened.
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          document.documentElement.hasAttribute("data-sidebar-hidden"),
+        ),
+      )
+      .toBe(true);
+    const finalTransform = await sidebar.evaluate(
+      (el) => getComputedStyle(el).transform,
+    );
+    expect(finalTransform).toBe(hiddenTransform);
+  });
+});

--- a/packages/create-zudo-doc/templates/base/src/styles/global.css
+++ b/packages/create-zudo-doc/templates/base/src/styles/global.css
@@ -717,6 +717,20 @@ pre[class^="syntect-"] .line .highlighted-word {
   }
 }
 
+/* Suppress sidebar geometry transitions during an SPA swap (#2198).
+ * swapRootAttributes wipes data-sidebar-hidden mid-swap, so without this the
+ * sidebar would animate open (attribute absent) and then animate shut again
+ * when the toggle island restores the attribute on zfb:after-swap — a visible
+ * flash + slide. The island sets data-sidebar-no-transition for the swap
+ * window and removes it (double rAF) after restoring the hidden state, so the
+ * wipe/restore apply instantly and a later user toggle still animates. */
+html[data-sidebar-no-transition] #desktop-sidebar,
+html[data-sidebar-no-transition] .zd-sidebar-content-wrapper,
+html[data-sidebar-no-transition] .zd-doc-content-band,
+html[data-sidebar-no-transition] .zd-desktop-sidebar-toggle {
+  transition: none !important;
+}
+
 /* ── Find-in-page highlight (W7A: unconditional — Tauri feature gates at runtime) ── */
 .find-match {
   background-color: color-mix(in oklch, var(--color-warning) 40%, transparent);

--- a/packages/create-zudo-doc/templates/features/sidebarToggle/files/src/components/desktop-sidebar-toggle.tsx
+++ b/packages/create-zudo-doc/templates/features/sidebarToggle/files/src/components/desktop-sidebar-toggle.tsx
@@ -99,30 +99,37 @@ export default function DesktopSidebarToggle() {
   // path in zfb-runtime's router) would leave the marker set with no restore to
   // clear it, permanently killing toggle animations. A superseding navigation
   // self-heals (its own capture → restore cycle clears it), but a lone aborted
-  // nav with no follow-up would not. So `capture` also schedules a double-rAF
-  // sweep that removes the marker if no `restore` has run by then — a no-op on
-  // the normal path (restore already removed it), a safety net on the aborted
-  // path. (We cannot listen for the abort directly — @takazudo/zudo-doc/
+  // nav with no follow-up would not. So `capture` arms a timeout that removes
+  // the marker if no `restore` has run by then — a no-op on the normal path
+  // (restore already removed it via the token guard), a safety net on the
+  // aborted path. (We cannot listen for the abort directly — @takazudo/zudo-doc/
   // transitions re-exports only the before/after constants, and raw "zfb:*"
   // strings are disallowed.)
+  //
+  // IMPORTANT (#2198 verification): the safety-net delay MUST outlast the swap.
+  // zfb's Strategy-B navigation wraps the DOM swap in document.startViewTransition,
+  // whose snapshot phase sits between BEFORE_NAVIGATE_EVENT and the actual body
+  // swap — the swap (where swapRootAttributes wipes data-sidebar-hidden) and the
+  // AFTER_NAVIGATE_EVENT restore do not fire until ~100ms+ after capture. A
+  // 2-frame (~32ms) sweep therefore removed the marker BEFORE the swap, so the
+  // wipe re-enabled live transitions and the sidebar still flashed. Use a
+  // generous timeout that any real swap+restore comfortably beats; the token
+  // guard no-ops it once restore (or a newer navigation) has run.
   useEffect(() => {
     let wasHidden = false;
     let swapToken = 0;
+    // Long enough to outlast the View-Transition swap pipeline on slow
+    // machines/CI; short enough that an aborted nav self-heals quickly.
+    const STUCK_MARKER_FALLBACK_MS = 1500;
     const capture = () => {
       wasHidden = document.documentElement.hasAttribute('data-sidebar-hidden');
       document.documentElement.setAttribute('data-sidebar-no-transition', '');
       const token = ++swapToken;
-      // Safety net: if this navigation never reaches `restore` (which bumps
-      // swapToken via clearMarker), drop the marker after two frames so it
-      // cannot stay stuck. The token guard makes this a no-op once a real
-      // restore — or a newer navigation — has occurred.
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          if (token === swapToken) {
-            document.documentElement.removeAttribute('data-sidebar-no-transition');
-          }
-        });
-      });
+      window.setTimeout(() => {
+        if (token === swapToken) {
+          document.documentElement.removeAttribute('data-sidebar-no-transition');
+        }
+      }, STUCK_MARKER_FALLBACK_MS);
     };
     const restore = () => {
       if (wasHidden) {

--- a/packages/create-zudo-doc/templates/features/sidebarToggle/files/src/components/desktop-sidebar-toggle.tsx
+++ b/packages/create-zudo-doc/templates/features/sidebarToggle/files/src/components/desktop-sidebar-toggle.tsx
@@ -78,16 +78,69 @@ export default function DesktopSidebarToggle() {
   // restore it once the swap completes (AFTER_NAVIGATE_EVENT). This is
   // authoritative regardless of how the attribute was set (toggle click,
   // localStorage, or external mutation). (#1551, #1552 B10)
+  //
+  // Flash suppression (#2198): swapRootAttributes wipes data-sidebar-hidden
+  // during the body swap, so for one frame the attribute is ABSENT — the CSS
+  // (html[data-sidebar-hidden] #desktop-sidebar etc.) sees the sidebar as
+  // visible and the 200ms transitions begin animating it open. Our restore on
+  // AFTER_NAVIGATE_EVENT re-adds the attribute, but that just reverses the
+  // animation (visible → hidden slide), which is the visible flash + slide.
+  // Fix: on BEFORE_NAVIGATE_EVENT add a transient `data-sidebar-no-transition`
+  // marker that zeroes those transitions (see global.css), so the wipe and the
+  // restore both apply instantly with no painted/animated frame. Remove the
+  // marker on a double rAF AFTER the restore so the restored hidden state has
+  // already been committed with transitions off; a later user toggle (which
+  // happens without the marker) still animates normally.
+  //
+  // Self-healing against a stuck marker: the marker is normally removed by
+  // `restore` (double rAF) on a successful swap. But a navigation that fires
+  // BEFORE_NAVIGATE_EVENT and never reaches AFTER_NAVIGATE_EVENT (aborted or
+  // superseded swap, fetch failure, MPA fallback — the `zfb:navigation-aborted`
+  // path in zfb-runtime's router) would leave the marker set with no restore to
+  // clear it, permanently killing toggle animations. A superseding navigation
+  // self-heals (its own capture → restore cycle clears it), but a lone aborted
+  // nav with no follow-up would not. So `capture` also schedules a double-rAF
+  // sweep that removes the marker if no `restore` has run by then — a no-op on
+  // the normal path (restore already removed it), a safety net on the aborted
+  // path. (We cannot listen for the abort directly — @takazudo/zudo-doc/
+  // transitions re-exports only the before/after constants, and raw "zfb:*"
+  // strings are disallowed.)
   useEffect(() => {
     let wasHidden = false;
+    let swapToken = 0;
     const capture = () => {
       wasHidden = document.documentElement.hasAttribute('data-sidebar-hidden');
+      document.documentElement.setAttribute('data-sidebar-no-transition', '');
+      const token = ++swapToken;
+      // Safety net: if this navigation never reaches `restore` (which bumps
+      // swapToken via clearMarker), drop the marker after two frames so it
+      // cannot stay stuck. The token guard makes this a no-op once a real
+      // restore — or a newer navigation — has occurred.
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          if (token === swapToken) {
+            document.documentElement.removeAttribute('data-sidebar-no-transition');
+          }
+        });
+      });
     };
     const restore = () => {
       if (wasHidden) {
         document.documentElement.setAttribute('data-sidebar-hidden', '');
       }
       // If not hidden, swapRootAttributes already cleared it — nothing to do.
+      // Drop the no-transition marker only after the restored state has been
+      // committed. A single rAF can still coincide with the same style recalc
+      // that applies the restore and animate it, so defer one extra frame.
+      // Bump the token so capture's safety-net sweep for this swap no-ops.
+      const token = ++swapToken;
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          if (token === swapToken) {
+            document.documentElement.removeAttribute('data-sidebar-no-transition');
+          }
+        });
+      });
     };
     document.addEventListener(BEFORE_NAVIGATE_EVENT, capture);
     document.addEventListener(AFTER_NAVIGATE_EVENT, restore);

--- a/packages/create-zudo-doc/templates/features/sidebarToggle/files/src/components/desktop-sidebar-toggle.tsx
+++ b/packages/create-zudo-doc/templates/features/sidebarToggle/files/src/components/desktop-sidebar-toggle.tsx
@@ -132,10 +132,21 @@ export default function DesktopSidebarToggle() {
       }, STUCK_MARKER_FALLBACK_MS);
     };
     const restore = () => {
+      // zfb's swapRootAttributes wipes EVERY <html> attribute during the swap
+      // and re-adds only NON_OVERRIDABLE_ZFB_ATTRS (data-zfb-transition*) plus
+      // the incoming SSR document's attributes — so the marker we set in
+      // `capture` is already GONE by now, and the freshly-rendered sidebar is in
+      // its visible (no data-sidebar-hidden) state with live transitions. We
+      // must RE-SET the marker here, on the live <html> (the swap is done, so it
+      // is no longer wiped), BEFORE re-adding data-sidebar-hidden — so the
+      // hidden geometry is applied with transitions suppressed (no slide) and
+      // snaps in before the next paint (no open frame). Setting it only in
+      // `capture` was the #2198 bug: that marker never survived the swap. Order
+      // matters: marker first, then the attribute, in one synchronous batch.
+      document.documentElement.setAttribute('data-sidebar-no-transition', '');
       if (wasHidden) {
         document.documentElement.setAttribute('data-sidebar-hidden', '');
       }
-      // If not hidden, swapRootAttributes already cleared it — nothing to do.
       // Drop the no-transition marker only after the restored state has been
       // committed. A single rAF can still coincide with the same style recalc
       // that applies the restore and animate it, so defer one extra frame.

--- a/packages/create-zudo-doc/templates/features/sidebarToggle/files/src/components/desktop-sidebar-toggle.tsx
+++ b/packages/create-zudo-doc/templates/features/sidebarToggle/files/src/components/desktop-sidebar-toggle.tsx
@@ -22,6 +22,85 @@ function setDataAttribute(isVisible: boolean) {
   }
 }
 
+// SPA-navigation guard for the desktop sidebar's hidden-state (#2198).
+//
+// zfb's Strategy-B client router wipes EVERY <html> attribute during the body
+// swap (swapRootAttributes re-adds only NON_OVERRIDABLE_ZFB_ATTRS plus the
+// incoming SSR document's attributes), so the persisted `data-sidebar-hidden`
+// runtime value is lost on every navigation, and the pre-paint inline script
+// does not re-run on SPA hops. Left alone, the freshly-rendered sidebar paints
+// visible and then animates shut when the value is restored — the flash + slide.
+//
+// These listeners MUST live at module scope, NOT in the island's useEffect:
+// zfb-runtime (>= 0.1.0-next.51) calls unmountIslands() BEFORE the swap and
+// before firing AFTER_NAVIGATE_EVENT, so a useEffect-registered listener is torn
+// down (effect cleanup) before the swap and never sees the after-swap event —
+// the restore would never run (#2198 verification). Registering once on
+// `document` at bundle load — the same lifecycle-independent pattern as
+// client-router-bootstrap.tsx — keeps the guard alive across island
+// unmount/remount. SSR-safe: no-ops when `document` is undefined.
+//
+// Strategy: on BEFORE_NAVIGATE_EVENT, record whether the sidebar was hidden and
+// set a transient `data-sidebar-no-transition` marker (global.css zeroes the
+// sidebar/wrapper/band/toggle transitions). The swap then wipes BOTH the marker
+// and data-sidebar-hidden. On AFTER_NAVIGATE_EVENT (swap done → the live <html>
+// is no longer wiped) RE-SET the marker, then re-add data-sidebar-hidden in the
+// same synchronous batch, so the hidden geometry snaps in with transitions
+// suppressed (no slide, no open frame). Remove the marker on a double rAF
+// afterward so a later user toggle still animates.
+let spaNavGuardRegistered = false;
+function registerSidebarSpaNavGuard() {
+  if (typeof document === 'undefined' || spaNavGuardRegistered) return;
+  spaNavGuardRegistered = true;
+
+  let wasHidden = false;
+  let swapToken = 0;
+  // Long enough to outlast the View-Transition swap pipeline on slow
+  // machines/CI; short enough that an aborted nav self-heals quickly. Only a
+  // safety net for a nav that never reaches `restore` (aborted/superseded).
+  const STUCK_MARKER_FALLBACK_MS = 1500;
+
+  const capture = () => {
+    wasHidden = document.documentElement.hasAttribute('data-sidebar-hidden');
+    document.documentElement.setAttribute('data-sidebar-no-transition', '');
+    const token = ++swapToken;
+    window.setTimeout(() => {
+      if (token === swapToken) {
+        document.documentElement.removeAttribute('data-sidebar-no-transition');
+      }
+    }, STUCK_MARKER_FALLBACK_MS);
+  };
+
+  const restore = () => {
+    // Marker first, then the attribute, in one synchronous batch — so the
+    // hidden geometry is restored with transitions off (the swap already wiped
+    // the capture-time marker, so re-setting it here on the post-swap <html> is
+    // what actually suppresses the animation).
+    document.documentElement.setAttribute('data-sidebar-no-transition', '');
+    if (wasHidden) {
+      document.documentElement.setAttribute('data-sidebar-hidden', '');
+    }
+    // Drop the marker only after the restored state is committed. A single rAF
+    // can coincide with the restore's style recalc and animate it, so defer one
+    // extra frame. The token bump no-ops capture's safety-net for this swap.
+    const token = ++swapToken;
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (token === swapToken) {
+          document.documentElement.removeAttribute('data-sidebar-no-transition');
+        }
+      });
+    });
+  };
+
+  document.addEventListener(BEFORE_NAVIGATE_EVENT, capture);
+  document.addEventListener(AFTER_NAVIGATE_EVENT, restore);
+}
+
+// Register at module load (browser-only via the guard) so the listeners exist
+// before the first navigation and survive island unmount/remount.
+registerSidebarSpaNavGuard();
+
 export default function DesktopSidebarToggle() {
   // Initial state must match server render (always `true`) to avoid a
   // hydration mismatch when the persisted preference is "hidden". The
@@ -66,107 +145,10 @@ export default function DesktopSidebarToggle() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Re-apply data-sidebar-hidden to <html> after every SPA nav.
-  // zfb's swapRootAttributes wipes all non-preserved <html> attributes on
-  // each navigation (data-sidebar-hidden is not in NON_OVERRIDABLE_ZFB_ATTRS),
-  // and the pre-paint inline script does not re-run on SPA nav. Since this
-  // island is persisted (data-zfb-transition-persist), this listener stays
-  // registered across SPA swaps.
-  //
-  // Strategy: capture the attribute presence just before the swap
-  // (BEFORE_NAVIGATE_EVENT fires before swapRootAttributes runs), then
-  // restore it once the swap completes (AFTER_NAVIGATE_EVENT). This is
-  // authoritative regardless of how the attribute was set (toggle click,
-  // localStorage, or external mutation). (#1551, #1552 B10)
-  //
-  // Flash suppression (#2198): swapRootAttributes wipes data-sidebar-hidden
-  // during the body swap, so for one frame the attribute is ABSENT — the CSS
-  // (html[data-sidebar-hidden] #desktop-sidebar etc.) sees the sidebar as
-  // visible and the 200ms transitions begin animating it open. Our restore on
-  // AFTER_NAVIGATE_EVENT re-adds the attribute, but that just reverses the
-  // animation (visible → hidden slide), which is the visible flash + slide.
-  // Fix: on BEFORE_NAVIGATE_EVENT add a transient `data-sidebar-no-transition`
-  // marker that zeroes those transitions (see global.css), so the wipe and the
-  // restore both apply instantly with no painted/animated frame. Remove the
-  // marker on a double rAF AFTER the restore so the restored hidden state has
-  // already been committed with transitions off; a later user toggle (which
-  // happens without the marker) still animates normally.
-  //
-  // Self-healing against a stuck marker: the marker is normally removed by
-  // `restore` (double rAF) on a successful swap. But a navigation that fires
-  // BEFORE_NAVIGATE_EVENT and never reaches AFTER_NAVIGATE_EVENT (aborted or
-  // superseded swap, fetch failure, MPA fallback — the `zfb:navigation-aborted`
-  // path in zfb-runtime's router) would leave the marker set with no restore to
-  // clear it, permanently killing toggle animations. A superseding navigation
-  // self-heals (its own capture → restore cycle clears it), but a lone aborted
-  // nav with no follow-up would not. So `capture` arms a timeout that removes
-  // the marker if no `restore` has run by then — a no-op on the normal path
-  // (restore already removed it via the token guard), a safety net on the
-  // aborted path. (We cannot listen for the abort directly — @takazudo/zudo-doc/
-  // transitions re-exports only the before/after constants, and raw "zfb:*"
-  // strings are disallowed.)
-  //
-  // IMPORTANT (#2198 verification): the safety-net delay MUST outlast the swap.
-  // zfb's Strategy-B navigation wraps the DOM swap in document.startViewTransition,
-  // whose snapshot phase sits between BEFORE_NAVIGATE_EVENT and the actual body
-  // swap — the swap (where swapRootAttributes wipes data-sidebar-hidden) and the
-  // AFTER_NAVIGATE_EVENT restore do not fire until ~100ms+ after capture. A
-  // 2-frame (~32ms) sweep therefore removed the marker BEFORE the swap, so the
-  // wipe re-enabled live transitions and the sidebar still flashed. Use a
-  // generous timeout that any real swap+restore comfortably beats; the token
-  // guard no-ops it once restore (or a newer navigation) has run.
-  useEffect(() => {
-    let wasHidden = false;
-    let swapToken = 0;
-    // Long enough to outlast the View-Transition swap pipeline on slow
-    // machines/CI; short enough that an aborted nav self-heals quickly.
-    const STUCK_MARKER_FALLBACK_MS = 1500;
-    const capture = () => {
-      wasHidden = document.documentElement.hasAttribute('data-sidebar-hidden');
-      document.documentElement.setAttribute('data-sidebar-no-transition', '');
-      const token = ++swapToken;
-      window.setTimeout(() => {
-        if (token === swapToken) {
-          document.documentElement.removeAttribute('data-sidebar-no-transition');
-        }
-      }, STUCK_MARKER_FALLBACK_MS);
-    };
-    const restore = () => {
-      // zfb's swapRootAttributes wipes EVERY <html> attribute during the swap
-      // and re-adds only NON_OVERRIDABLE_ZFB_ATTRS (data-zfb-transition*) plus
-      // the incoming SSR document's attributes — so the marker we set in
-      // `capture` is already GONE by now, and the freshly-rendered sidebar is in
-      // its visible (no data-sidebar-hidden) state with live transitions. We
-      // must RE-SET the marker here, on the live <html> (the swap is done, so it
-      // is no longer wiped), BEFORE re-adding data-sidebar-hidden — so the
-      // hidden geometry is applied with transitions suppressed (no slide) and
-      // snaps in before the next paint (no open frame). Setting it only in
-      // `capture` was the #2198 bug: that marker never survived the swap. Order
-      // matters: marker first, then the attribute, in one synchronous batch.
-      document.documentElement.setAttribute('data-sidebar-no-transition', '');
-      if (wasHidden) {
-        document.documentElement.setAttribute('data-sidebar-hidden', '');
-      }
-      // Drop the no-transition marker only after the restored state has been
-      // committed. A single rAF can still coincide with the same style recalc
-      // that applies the restore and animate it, so defer one extra frame.
-      // Bump the token so capture's safety-net sweep for this swap no-ops.
-      const token = ++swapToken;
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          if (token === swapToken) {
-            document.documentElement.removeAttribute('data-sidebar-no-transition');
-          }
-        });
-      });
-    };
-    document.addEventListener(BEFORE_NAVIGATE_EVENT, capture);
-    document.addEventListener(AFTER_NAVIGATE_EVENT, restore);
-    return () => {
-      document.removeEventListener(BEFORE_NAVIGATE_EVENT, capture);
-      document.removeEventListener(AFTER_NAVIGATE_EVENT, restore);
-    };
-  }, []);
+  // The SPA-navigation flash guard (data-sidebar-hidden preservation +
+  // transition suppression) is NOT registered here. It must outlive this
+  // island's mount/unmount, so it lives at module scope — see
+  // registerSidebarSpaNavGuard() above. (#2198)
 
   return (
     <button

--- a/src/components/desktop-sidebar-toggle.tsx
+++ b/src/components/desktop-sidebar-toggle.tsx
@@ -133,10 +133,21 @@ export default function DesktopSidebarToggle() {
       }, STUCK_MARKER_FALLBACK_MS);
     };
     const restore = () => {
+      // zfb's swapRootAttributes wipes EVERY <html> attribute during the swap
+      // and re-adds only NON_OVERRIDABLE_ZFB_ATTRS (data-zfb-transition*) plus
+      // the incoming SSR document's attributes — so the marker we set in
+      // `capture` is already GONE by now, and the freshly-rendered sidebar is in
+      // its visible (no data-sidebar-hidden) state with live transitions. We
+      // must RE-SET the marker here, on the live <html> (the swap is done, so it
+      // is no longer wiped), BEFORE re-adding data-sidebar-hidden — so the
+      // hidden geometry is applied with transitions suppressed (no slide) and
+      // snaps in before the next paint (no open frame). Setting it only in
+      // `capture` was the #2198 bug: that marker never survived the swap. Order
+      // matters: marker first, then the attribute, in one synchronous batch.
+      document.documentElement.setAttribute('data-sidebar-no-transition', '');
       if (wasHidden) {
         document.documentElement.setAttribute('data-sidebar-hidden', '');
       }
-      // If not hidden, swapRootAttributes already cleared it — nothing to do.
       // Drop the no-transition marker only after the restored state has been
       // committed. A single rAF can still coincide with the same style recalc
       // that applies the restore and animate it, so defer one extra frame.

--- a/src/components/desktop-sidebar-toggle.tsx
+++ b/src/components/desktop-sidebar-toggle.tsx
@@ -100,30 +100,37 @@ export default function DesktopSidebarToggle() {
   // path in zfb-runtime's router) would leave the marker set with no restore to
   // clear it, permanently killing toggle animations. A superseding navigation
   // self-heals (its own capture → restore cycle clears it), but a lone aborted
-  // nav with no follow-up would not. So `capture` also schedules a double-rAF
-  // sweep that removes the marker if no `restore` has run by then — a no-op on
-  // the normal path (restore already removed it), a safety net on the aborted
-  // path. (We cannot listen for the abort directly — @takazudo/zudo-doc/
+  // nav with no follow-up would not. So `capture` arms a timeout that removes
+  // the marker if no `restore` has run by then — a no-op on the normal path
+  // (restore already removed it via the token guard), a safety net on the
+  // aborted path. (We cannot listen for the abort directly — @takazudo/zudo-doc/
   // transitions re-exports only the before/after constants, and raw "zfb:*"
   // strings are disallowed.)
+  //
+  // IMPORTANT (#2198 verification): the safety-net delay MUST outlast the swap.
+  // zfb's Strategy-B navigation wraps the DOM swap in document.startViewTransition,
+  // whose snapshot phase sits between BEFORE_NAVIGATE_EVENT and the actual body
+  // swap — the swap (where swapRootAttributes wipes data-sidebar-hidden) and the
+  // AFTER_NAVIGATE_EVENT restore do not fire until ~100ms+ after capture. A
+  // 2-frame (~32ms) sweep therefore removed the marker BEFORE the swap, so the
+  // wipe re-enabled live transitions and the sidebar still flashed. Use a
+  // generous timeout that any real swap+restore comfortably beats; the token
+  // guard no-ops it once restore (or a newer navigation) has run.
   useEffect(() => {
     let wasHidden = false;
     let swapToken = 0;
+    // Long enough to outlast the View-Transition swap pipeline on slow
+    // machines/CI; short enough that an aborted nav self-heals quickly.
+    const STUCK_MARKER_FALLBACK_MS = 1500;
     const capture = () => {
       wasHidden = document.documentElement.hasAttribute('data-sidebar-hidden');
       document.documentElement.setAttribute('data-sidebar-no-transition', '');
       const token = ++swapToken;
-      // Safety net: if this navigation never reaches `restore` (which bumps
-      // swapToken via clearMarker), drop the marker after two frames so it
-      // cannot stay stuck. The token guard makes this a no-op once a real
-      // restore — or a newer navigation — has occurred.
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          if (token === swapToken) {
-            document.documentElement.removeAttribute('data-sidebar-no-transition');
-          }
-        });
-      });
+      window.setTimeout(() => {
+        if (token === swapToken) {
+          document.documentElement.removeAttribute('data-sidebar-no-transition');
+        }
+      }, STUCK_MARKER_FALLBACK_MS);
     };
     const restore = () => {
       if (wasHidden) {

--- a/src/components/desktop-sidebar-toggle.tsx
+++ b/src/components/desktop-sidebar-toggle.tsx
@@ -79,16 +79,69 @@ export default function DesktopSidebarToggle() {
   // restore it once the swap completes (AFTER_NAVIGATE_EVENT). This is
   // authoritative regardless of how the attribute was set (toggle click,
   // localStorage, or external mutation). (#1551, #1552 B10)
+  //
+  // Flash suppression (#2198): swapRootAttributes wipes data-sidebar-hidden
+  // during the body swap, so for one frame the attribute is ABSENT — the CSS
+  // (html[data-sidebar-hidden] #desktop-sidebar etc.) sees the sidebar as
+  // visible and the 200ms transitions begin animating it open. Our restore on
+  // AFTER_NAVIGATE_EVENT re-adds the attribute, but that just reverses the
+  // animation (visible → hidden slide), which is the visible flash + slide.
+  // Fix: on BEFORE_NAVIGATE_EVENT add a transient `data-sidebar-no-transition`
+  // marker that zeroes those transitions (see global.css), so the wipe and the
+  // restore both apply instantly with no painted/animated frame. Remove the
+  // marker on a double rAF AFTER the restore so the restored hidden state has
+  // already been committed with transitions off; a later user toggle (which
+  // happens without the marker) still animates normally.
+  //
+  // Self-healing against a stuck marker: the marker is normally removed by
+  // `restore` (double rAF) on a successful swap. But a navigation that fires
+  // BEFORE_NAVIGATE_EVENT and never reaches AFTER_NAVIGATE_EVENT (aborted or
+  // superseded swap, fetch failure, MPA fallback — the `zfb:navigation-aborted`
+  // path in zfb-runtime's router) would leave the marker set with no restore to
+  // clear it, permanently killing toggle animations. A superseding navigation
+  // self-heals (its own capture → restore cycle clears it), but a lone aborted
+  // nav with no follow-up would not. So `capture` also schedules a double-rAF
+  // sweep that removes the marker if no `restore` has run by then — a no-op on
+  // the normal path (restore already removed it), a safety net on the aborted
+  // path. (We cannot listen for the abort directly — @takazudo/zudo-doc/
+  // transitions re-exports only the before/after constants, and raw "zfb:*"
+  // strings are disallowed.)
   useEffect(() => {
     let wasHidden = false;
+    let swapToken = 0;
     const capture = () => {
       wasHidden = document.documentElement.hasAttribute('data-sidebar-hidden');
+      document.documentElement.setAttribute('data-sidebar-no-transition', '');
+      const token = ++swapToken;
+      // Safety net: if this navigation never reaches `restore` (which bumps
+      // swapToken via clearMarker), drop the marker after two frames so it
+      // cannot stay stuck. The token guard makes this a no-op once a real
+      // restore — or a newer navigation — has occurred.
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          if (token === swapToken) {
+            document.documentElement.removeAttribute('data-sidebar-no-transition');
+          }
+        });
+      });
     };
     const restore = () => {
       if (wasHidden) {
         document.documentElement.setAttribute('data-sidebar-hidden', '');
       }
       // If not hidden, swapRootAttributes already cleared it — nothing to do.
+      // Drop the no-transition marker only after the restored state has been
+      // committed. A single rAF can still coincide with the same style recalc
+      // that applies the restore and animate it, so defer one extra frame.
+      // Bump the token so capture's safety-net sweep for this swap no-ops.
+      const token = ++swapToken;
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          if (token === swapToken) {
+            document.documentElement.removeAttribute('data-sidebar-no-transition');
+          }
+        });
+      });
     };
     document.addEventListener(BEFORE_NAVIGATE_EVENT, capture);
     document.addEventListener(AFTER_NAVIGATE_EVENT, restore);

--- a/src/components/desktop-sidebar-toggle.tsx
+++ b/src/components/desktop-sidebar-toggle.tsx
@@ -23,6 +23,85 @@ function setDataAttribute(isVisible: boolean) {
   }
 }
 
+// SPA-navigation guard for the desktop sidebar's hidden-state (#2198).
+//
+// zfb's Strategy-B client router wipes EVERY <html> attribute during the body
+// swap (swapRootAttributes re-adds only NON_OVERRIDABLE_ZFB_ATTRS plus the
+// incoming SSR document's attributes), so the persisted `data-sidebar-hidden`
+// runtime value is lost on every navigation, and the pre-paint inline script
+// does not re-run on SPA hops. Left alone, the freshly-rendered sidebar paints
+// visible and then animates shut when the value is restored — the flash + slide.
+//
+// These listeners MUST live at module scope, NOT in the island's useEffect:
+// zfb-runtime (>= 0.1.0-next.51) calls unmountIslands() BEFORE the swap and
+// before firing AFTER_NAVIGATE_EVENT, so a useEffect-registered listener is torn
+// down (effect cleanup) before the swap and never sees the after-swap event —
+// the restore would never run (#2198 verification). Registering once on
+// `document` at bundle load — the same lifecycle-independent pattern as
+// client-router-bootstrap.tsx — keeps the guard alive across island
+// unmount/remount. SSR-safe: no-ops when `document` is undefined.
+//
+// Strategy: on BEFORE_NAVIGATE_EVENT, record whether the sidebar was hidden and
+// set a transient `data-sidebar-no-transition` marker (global.css zeroes the
+// sidebar/wrapper/band/toggle transitions). The swap then wipes BOTH the marker
+// and data-sidebar-hidden. On AFTER_NAVIGATE_EVENT (swap done → the live <html>
+// is no longer wiped) RE-SET the marker, then re-add data-sidebar-hidden in the
+// same synchronous batch, so the hidden geometry snaps in with transitions
+// suppressed (no slide, no open frame). Remove the marker on a double rAF
+// afterward so a later user toggle still animates.
+let spaNavGuardRegistered = false;
+function registerSidebarSpaNavGuard() {
+  if (typeof document === 'undefined' || spaNavGuardRegistered) return;
+  spaNavGuardRegistered = true;
+
+  let wasHidden = false;
+  let swapToken = 0;
+  // Long enough to outlast the View-Transition swap pipeline on slow
+  // machines/CI; short enough that an aborted nav self-heals quickly. Only a
+  // safety net for a nav that never reaches `restore` (aborted/superseded).
+  const STUCK_MARKER_FALLBACK_MS = 1500;
+
+  const capture = () => {
+    wasHidden = document.documentElement.hasAttribute('data-sidebar-hidden');
+    document.documentElement.setAttribute('data-sidebar-no-transition', '');
+    const token = ++swapToken;
+    window.setTimeout(() => {
+      if (token === swapToken) {
+        document.documentElement.removeAttribute('data-sidebar-no-transition');
+      }
+    }, STUCK_MARKER_FALLBACK_MS);
+  };
+
+  const restore = () => {
+    // Marker first, then the attribute, in one synchronous batch — so the
+    // hidden geometry is restored with transitions off (the swap already wiped
+    // the capture-time marker, so re-setting it here on the post-swap <html> is
+    // what actually suppresses the animation).
+    document.documentElement.setAttribute('data-sidebar-no-transition', '');
+    if (wasHidden) {
+      document.documentElement.setAttribute('data-sidebar-hidden', '');
+    }
+    // Drop the marker only after the restored state is committed. A single rAF
+    // can coincide with the restore's style recalc and animate it, so defer one
+    // extra frame. The token bump no-ops capture's safety-net for this swap.
+    const token = ++swapToken;
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (token === swapToken) {
+          document.documentElement.removeAttribute('data-sidebar-no-transition');
+        }
+      });
+    });
+  };
+
+  document.addEventListener(BEFORE_NAVIGATE_EVENT, capture);
+  document.addEventListener(AFTER_NAVIGATE_EVENT, restore);
+}
+
+// Register at module load (browser-only via the guard) so the listeners exist
+// before the first navigation and survive island unmount/remount.
+registerSidebarSpaNavGuard();
+
 export default function DesktopSidebarToggle() {
   // Initial state must match server render (always `true`) to avoid a
   // hydration mismatch when the persisted preference is "hidden". The
@@ -67,107 +146,10 @@ export default function DesktopSidebarToggle() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Re-apply data-sidebar-hidden to <html> after every SPA nav.
-  // zfb's swapRootAttributes wipes all non-preserved <html> attributes on
-  // each navigation (data-sidebar-hidden is not in NON_OVERRIDABLE_ZFB_ATTRS),
-  // and the pre-paint inline script does not re-run on SPA nav. Since this
-  // island is persisted (data-zfb-transition-persist), this listener stays
-  // registered across SPA swaps.
-  //
-  // Strategy: capture the attribute presence just before the swap
-  // (BEFORE_NAVIGATE_EVENT fires before swapRootAttributes runs), then
-  // restore it once the swap completes (AFTER_NAVIGATE_EVENT). This is
-  // authoritative regardless of how the attribute was set (toggle click,
-  // localStorage, or external mutation). (#1551, #1552 B10)
-  //
-  // Flash suppression (#2198): swapRootAttributes wipes data-sidebar-hidden
-  // during the body swap, so for one frame the attribute is ABSENT — the CSS
-  // (html[data-sidebar-hidden] #desktop-sidebar etc.) sees the sidebar as
-  // visible and the 200ms transitions begin animating it open. Our restore on
-  // AFTER_NAVIGATE_EVENT re-adds the attribute, but that just reverses the
-  // animation (visible → hidden slide), which is the visible flash + slide.
-  // Fix: on BEFORE_NAVIGATE_EVENT add a transient `data-sidebar-no-transition`
-  // marker that zeroes those transitions (see global.css), so the wipe and the
-  // restore both apply instantly with no painted/animated frame. Remove the
-  // marker on a double rAF AFTER the restore so the restored hidden state has
-  // already been committed with transitions off; a later user toggle (which
-  // happens without the marker) still animates normally.
-  //
-  // Self-healing against a stuck marker: the marker is normally removed by
-  // `restore` (double rAF) on a successful swap. But a navigation that fires
-  // BEFORE_NAVIGATE_EVENT and never reaches AFTER_NAVIGATE_EVENT (aborted or
-  // superseded swap, fetch failure, MPA fallback — the `zfb:navigation-aborted`
-  // path in zfb-runtime's router) would leave the marker set with no restore to
-  // clear it, permanently killing toggle animations. A superseding navigation
-  // self-heals (its own capture → restore cycle clears it), but a lone aborted
-  // nav with no follow-up would not. So `capture` arms a timeout that removes
-  // the marker if no `restore` has run by then — a no-op on the normal path
-  // (restore already removed it via the token guard), a safety net on the
-  // aborted path. (We cannot listen for the abort directly — @takazudo/zudo-doc/
-  // transitions re-exports only the before/after constants, and raw "zfb:*"
-  // strings are disallowed.)
-  //
-  // IMPORTANT (#2198 verification): the safety-net delay MUST outlast the swap.
-  // zfb's Strategy-B navigation wraps the DOM swap in document.startViewTransition,
-  // whose snapshot phase sits between BEFORE_NAVIGATE_EVENT and the actual body
-  // swap — the swap (where swapRootAttributes wipes data-sidebar-hidden) and the
-  // AFTER_NAVIGATE_EVENT restore do not fire until ~100ms+ after capture. A
-  // 2-frame (~32ms) sweep therefore removed the marker BEFORE the swap, so the
-  // wipe re-enabled live transitions and the sidebar still flashed. Use a
-  // generous timeout that any real swap+restore comfortably beats; the token
-  // guard no-ops it once restore (or a newer navigation) has run.
-  useEffect(() => {
-    let wasHidden = false;
-    let swapToken = 0;
-    // Long enough to outlast the View-Transition swap pipeline on slow
-    // machines/CI; short enough that an aborted nav self-heals quickly.
-    const STUCK_MARKER_FALLBACK_MS = 1500;
-    const capture = () => {
-      wasHidden = document.documentElement.hasAttribute('data-sidebar-hidden');
-      document.documentElement.setAttribute('data-sidebar-no-transition', '');
-      const token = ++swapToken;
-      window.setTimeout(() => {
-        if (token === swapToken) {
-          document.documentElement.removeAttribute('data-sidebar-no-transition');
-        }
-      }, STUCK_MARKER_FALLBACK_MS);
-    };
-    const restore = () => {
-      // zfb's swapRootAttributes wipes EVERY <html> attribute during the swap
-      // and re-adds only NON_OVERRIDABLE_ZFB_ATTRS (data-zfb-transition*) plus
-      // the incoming SSR document's attributes — so the marker we set in
-      // `capture` is already GONE by now, and the freshly-rendered sidebar is in
-      // its visible (no data-sidebar-hidden) state with live transitions. We
-      // must RE-SET the marker here, on the live <html> (the swap is done, so it
-      // is no longer wiped), BEFORE re-adding data-sidebar-hidden — so the
-      // hidden geometry is applied with transitions suppressed (no slide) and
-      // snaps in before the next paint (no open frame). Setting it only in
-      // `capture` was the #2198 bug: that marker never survived the swap. Order
-      // matters: marker first, then the attribute, in one synchronous batch.
-      document.documentElement.setAttribute('data-sidebar-no-transition', '');
-      if (wasHidden) {
-        document.documentElement.setAttribute('data-sidebar-hidden', '');
-      }
-      // Drop the no-transition marker only after the restored state has been
-      // committed. A single rAF can still coincide with the same style recalc
-      // that applies the restore and animate it, so defer one extra frame.
-      // Bump the token so capture's safety-net sweep for this swap no-ops.
-      const token = ++swapToken;
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          if (token === swapToken) {
-            document.documentElement.removeAttribute('data-sidebar-no-transition');
-          }
-        });
-      });
-    };
-    document.addEventListener(BEFORE_NAVIGATE_EVENT, capture);
-    document.addEventListener(AFTER_NAVIGATE_EVENT, restore);
-    return () => {
-      document.removeEventListener(BEFORE_NAVIGATE_EVENT, capture);
-      document.removeEventListener(AFTER_NAVIGATE_EVENT, restore);
-    };
-  }, []);
+  // The SPA-navigation flash guard (data-sidebar-hidden preservation +
+  // transition suppression) is NOT registered here. It must outlive this
+  // island's mount/unmount, so it lives at module scope — see
+  // registerSidebarSpaNavGuard() above. (#2198)
 
   return (
     <button

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -782,6 +782,20 @@ pre[class^="syntect-"] .line .highlighted-word {
   }
 }
 
+/* Suppress sidebar geometry transitions during an SPA swap (#2198).
+ * swapRootAttributes wipes data-sidebar-hidden mid-swap, so without this the
+ * sidebar would animate open (attribute absent) and then animate shut again
+ * when the toggle island restores the attribute on zfb:after-swap — a visible
+ * flash + slide. The island sets data-sidebar-no-transition for the swap
+ * window and removes it (double rAF) after restoring the hidden state, so the
+ * wipe/restore apply instantly and a later user toggle still animates. */
+html[data-sidebar-no-transition] #desktop-sidebar,
+html[data-sidebar-no-transition] .zd-sidebar-content-wrapper,
+html[data-sidebar-no-transition] .zd-doc-content-band,
+html[data-sidebar-no-transition] .zd-desktop-sidebar-toggle {
+  transition: none !important;
+}
+
 /* ========================================
  * Image enlarge (.zd-enlargeable)
  * ======================================== */


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2197 (epic)
    - https://github.com/zudolab/zudo-doc/issues/2198 (fix), https://github.com/zudolab/zudo-doc/issues/2199 (verification + upstream report)

---

## Summary

Fixes the bug where a **collapsed desktop sidebar briefly flashes open and animates shut on every same-section SPA page navigation** (epic #2197). The closed sidebar now stays closed across navigations — no flash, no slide, no View-Transition ghosting — matching the pre-migration (Astro) behavior.

## Root cause (took three verification rounds to fully pin down)

zudo-doc drives the sidebar's collapsed state from `data-sidebar-hidden` on `<html>`, with CSS `transition: …200ms`. On a zfb Strategy-B SPA navigation, `swapRootAttributes` **wipes every `<html>` attribute** during the body swap (re-adding only `data-zfb-transition*` + the incoming SSR document's attrs), and — critically — zfb-runtime (≥ next.51) **unmounts islands before the swap**. So:

1. The previous mitigation re-applied the attribute on `zfb:after-swap`, but the freshly-rendered sidebar had already painted open and then animated shut.
2. A first attempt added a `data-sidebar-no-transition` suppression marker on `<html>` in the *before-navigate* handler — but the swap wipes that marker too.
3. The handler itself lived in the island's `useEffect`, which is torn down by the pre-swap island unmount, so the restore never ran.

## The fix

- **Module-scope SPA-nav guard** in `src/components/desktop-sidebar-toggle.tsx` (the same lifecycle-independent pattern as `client-router-bootstrap.tsx`): register the before/after-navigate listeners once at bundle load so they survive island unmount/remount.
- On `zfb:after-swap` (swap done → the live `<html>` is no longer wiped) the guard **re-sets `data-sidebar-no-transition` then re-adds `data-sidebar-hidden` in one synchronous batch**, so the hidden geometry snaps in with transitions suppressed (no slide, no open frame). The marker is removed on a double-rAF so later user toggles still animate; a 1500ms token-guarded fallback covers aborted navs.
- `src/styles/global.css`: `html[data-sidebar-no-transition]` zeroes the sidebar / content-wrapper / content-band / toggle transitions.
- Mirrored into the `create-zudo-doc` template (`templates/features/sidebarToggle/.../desktop-sidebar-toggle.tsx`, `templates/base/src/styles/global.css`).
- New regression spec `e2e/sidebar-spa-nav-flash.spec.ts`: real `spaClick` SPA nav on the `sidebar` fixture (now enables `sidebarToggle`), rAF-sampling the sidebar transform + marker across the swap window.

**Header:** investigated — not affected (only `data-sidebar-hidden` drives a transitioned `<html>`-keyed geometry; `data-theme` is wiped too but drives no transition). No change.

## Verification

Confirmed by an independent browser re-verification (#2199) on the merged base: the sidebar transform never leaves its hidden value (`matrix(1,0,0,1,-320,0)`) in any painted frame across the SPA swap; transitions are suppressed while the marker is active; a toggle immediately after the nav still animates. `pnpm check` + `pnpm check:template-drift` green.

## Upstream

The clean long-term fix belongs in zfb-runtime (preserve runtime `<html>` attributes across the swap, or expose a before-swap incoming-root hook, and/or don't unmount persisted islands before the swap). Drafted as #2200 (placeholder for `Takazudo/zudo-front-builder`, to be refiled from an in-scope session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G6jF5dedmkPHgospsb6nBF)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784274417&installation_id=130359969&pr_number=2201&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2201&signature=dd89132fc8201c0c0d3b6a92ec96fbe42b28a3b7f89a74ba2f3a64eafb51885b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->