### PR TITLE
fix(mermaid): enlarge zoom toolbar 2×, move to bottom-right, no text-select in pan mode

### DIFF
--- a/packages/create-zudo-doc/templates/base/src/styles/global.css
+++ b/packages/create-zudo-doc/templates/base/src/styles/global.css
@@ -920,6 +920,10 @@ dialog.zd-mermaid-dialog::backdrop {
 
 .zd-mermaid-viewport[data-pan-active] {
   cursor: grab;
+  /* In pan mode a drag should pan, not select diagram text. Scoped to
+   * [data-pan-active] so text stays selectable when pan mode is off. */
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 .zd-mermaid-viewport[data-pan-active]:active {
@@ -960,15 +964,14 @@ dialog.zd-mermaid-dialog::backdrop {
   overflow: visible;
 }
 
-/* Toolbar — bottom-center pill of zoom/pan controls. */
+/* Toolbar — bottom-right pill of zoom/pan controls (2× sized buttons). */
 .zd-mermaid-toolbar {
   position: absolute;
   bottom: var(--spacing-image-overlay-inset);
-  left: 50%;
-  transform: translateX(-50%);
+  right: var(--spacing-image-overlay-inset);
   display: flex;
-  gap: var(--spacing-hsp-2xs);
-  padding: var(--spacing-hsp-2xs);
+  gap: var(--spacing-hsp-xs);
+  padding: var(--spacing-hsp-xs);
   border: 1px solid var(--color-muted);
   border-radius: var(--radius-DEFAULT);
   background: color-mix(in oklch, var(--color-surface) 92%, transparent);
@@ -979,8 +982,8 @@ dialog.zd-mermaid-dialog::backdrop {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: var(--spacing-icon-lg);
-  height: var(--spacing-icon-lg);
+  width: calc(var(--spacing-icon-lg) * 2);
+  height: calc(var(--spacing-icon-lg) * 2);
   padding: var(--spacing-vsp-2xs);
   border: none;
   border-radius: var(--radius-DEFAULT);
@@ -1007,8 +1010,8 @@ dialog.zd-mermaid-dialog::backdrop {
 }
 
 .zd-mermaid-tool-btn > svg {
-  width: var(--spacing-icon-md);
-  height: var(--spacing-icon-md);
+  width: calc(var(--spacing-icon-md) * 2);
+  height: calc(var(--spacing-icon-md) * 2);
 }
 
 /* @slot:global-css:feature-styles */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -974,6 +974,10 @@ dialog.zd-mermaid-dialog::backdrop {
 
 .zd-mermaid-viewport[data-pan-active] {
   cursor: grab;
+  /* In pan mode a drag should pan, not select diagram text. Scoped to
+   * [data-pan-active] so text stays selectable when pan mode is off. */
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 .zd-mermaid-viewport[data-pan-active]:active {
@@ -1014,15 +1018,14 @@ dialog.zd-mermaid-dialog::backdrop {
   overflow: visible;
 }
 
-/* Toolbar — bottom-center pill of zoom/pan controls. */
+/* Toolbar — bottom-right pill of zoom/pan controls (2× sized buttons). */
 .zd-mermaid-toolbar {
   position: absolute;
   bottom: var(--spacing-image-overlay-inset);
-  left: 50%;
-  transform: translateX(-50%);
+  right: var(--spacing-image-overlay-inset);
   display: flex;
-  gap: var(--spacing-hsp-2xs);
-  padding: var(--spacing-hsp-2xs);
+  gap: var(--spacing-hsp-xs);
+  padding: var(--spacing-hsp-xs);
   border: 1px solid var(--color-muted);
   border-radius: var(--radius-DEFAULT);
   background: color-mix(in oklch, var(--color-surface) 92%, transparent);
@@ -1033,8 +1036,8 @@ dialog.zd-mermaid-dialog::backdrop {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: var(--spacing-icon-lg);
-  height: var(--spacing-icon-lg);
+  width: calc(var(--spacing-icon-lg) * 2);
+  height: calc(var(--spacing-icon-lg) * 2);
   padding: var(--spacing-vsp-2xs);
   border: none;
   border-radius: var(--radius-DEFAULT);
@@ -1061,8 +1064,8 @@ dialog.zd-mermaid-dialog::backdrop {
 }
 
 .zd-mermaid-tool-btn > svg {
-  width: var(--spacing-icon-md);
-  height: var(--spacing-icon-md);
+  width: calc(var(--spacing-icon-md) * 2);
+  height: calc(var(--spacing-icon-md) * 2);
 }
 
 /* ========================================


### PR DESCRIPTION
## Summary

Two tweaks to the mermaid diagram zoom/pan dialog (`src/components/mermaid-enlarge.tsx` + `src/styles/global.css`):

1. **Bigger, repositioned toolbar.** The bottom-center utility pill (zoom in / zoom out / pan toggle) was too small. Buttons and their icons are now **2×** (`calc(var(--spacing-icon-lg) * 2)` / `calc(var(--spacing-icon-md) * 2)`), the pill gap/padding bumped from `hsp-2xs` → `hsp-xs` for proportion, and the toolbar moved from **bottom-center → bottom-right** of the dialog.
2. **No text selection while panning.** When zoomed in and pan mode is active, dragging near diagram text used to select the text. `user-select` is now disabled on the pan viewport, scoped to `[data-pan-active]` — so text stays selectable when pan mode is off.

Both changes are CSS-only (change 2 rides the existing `data-pan-active` attribute the component already sets when `panActive && zoomed`).

## Changes

- `src/styles/global.css` — `.zd-mermaid-toolbar` reposition + size, `.zd-mermaid-tool-btn` (+ `> svg`) 2×, `.zd-mermaid-viewport[data-pan-active]` `user-select: none`.
- `packages/create-zudo-doc/templates/base/src/styles/global.css` — same edits mirrored into the generator base template (template-drift parity).

## Test Plan

- Open a mermaid diagram → enlarge → confirm the toolbar sits bottom-right and the buttons are noticeably larger.
- Zoom in, enable pan mode, drag across a label → confirm it pans without selecting text; disable pan mode → text selectable again.
- E2e `e2e/smoke-mermaid-enlarge.spec.ts` asserts button enablement by aria-label only — unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnvPh4uTN1x4m9FJXFLBMN)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784285484&installation_id=130359969&pr_number=2202&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2202&signature=1c56daafc61dd8143e90321fb1f4e3ef435c3689544f8c3e3fc15e8c03937f42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->