### PR TITLE
chore: deps sweep — remove 8 stale/redundant dependencies

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,0 @@
-dist/
-node_modules/
-worktrees/
-__inbox/

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "onlyBuiltDependencies": [
       "esbuild",
       "lefthook",
-      "sharp",
       "workerd"
     ],
     "overrides": {
@@ -90,15 +89,12 @@
     "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.51",
     "@takazudo/zfb-runtime": "0.1.0-next.51",
     "@takazudo/zudo-doc": "workspace:*",
-    "@types/hast": "^3.0.4",
-    "clsx": "^2.1.1",
     "diff": "^8.0.3",
     "gray-matter": "^4.0.3",
     "katex": "^0.16.38",
     "mermaid": "^11.15.0",
     "preact": "^10.29.1",
     "preact-render-to-string": "^6.6.6",
-    "rehype-katex": "^7.0.1",
     "shiki": "^4.0.2",
     "zod": "^4.3.6"
   },
@@ -107,7 +103,6 @@
     "@playwright/test": "1.58.2",
     "@tailwindcss/vite": "^4.2.1",
     "@takazudo/zudo-design-token-lint": "^1.0.0",
-    "@types/mdast": "^4.0.4",
     "@types/node": "^25.3.5",
     "@types/pluralize": "^0.0.33",
     "@types/react": "^19.2.14",
@@ -115,12 +110,9 @@
     "chokidar": "^4.0.0",
     "html-validate": "^10.15.0",
     "lefthook": "^2.1.4",
-    "msw": "^2.12.12",
     "npm-run-all2": "^7.0.2",
     "picocolors": "^1.1.1",
     "pluralize": "^8.0.0",
-    "prettier": "^3.8.1",
-    "sharp": "^0.34.5",
     "string-similarity": "^4.0.4",
     "tailwindcss": "^4.2.1",
     "tsx": "^4.21.0",
@@ -128,10 +120,5 @@
     "vite": "^7.3.2",
     "vitest": "^4.1.0",
     "wrangler": "4.85.0"
-  },
-  "msw": {
-    "workerDirectory": [
-      "public"
-    ]
   }
 }

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -1755,6 +1755,13 @@ describe("scaffold — plugin copying and settings", () => {
     expect(pkg.dependencies["unist-util-visit"]).toBeUndefined();
   });
 
+  it("does NOT include clsx in dependencies (F1 — dead dep)", async () => {
+    const pkg = await fs.readJson(
+      projectPath("test-minimal", "package.json"),
+    );
+    expect(pkg.dependencies["clsx"]).toBeUndefined();
+  });
+
   it("includes html-validate in devDependencies", async () => {
     const pkg = await fs.readJson(
       projectPath("test-minimal", "package.json"),

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -454,7 +454,6 @@ function generatePackageJson(choices: UserChoices) {
     "preact-render-to-string": "^6.6.6",
     shiki: "^4.0.2",
     "@shikijs/transformers": "^4.0.0",
-    clsx: "^2.1.0",
     "gray-matter": "^4.0.0",
     mermaid: "^11.12.3",
     "remark-cjk-friendly": "^2.0.1",

--- a/packages/create-zudo-doc/templates/base/src/components/sidebar-toggle.tsx
+++ b/packages/create-zudo-doc/templates/base/src/components/sidebar-toggle.tsx
@@ -6,7 +6,6 @@
 // packages/zudo-doc/src/theme-toggle/index.tsx. Type references via
 // the global React namespace still resolve via @types/react.
 import { useState, useEffect } from "preact/hooks";
-import clsx from "clsx";
 // After zudolab/zudo-doc#1335 (E2 task 2 half B) the host components
 // pull lifecycle event names from the v2 transitions module rather
 // than hard-coding `astro:*` literals.
@@ -17,6 +16,9 @@ import type { LocaleLink } from "@/types/locale";
 // Types-only subpath (`./sidebar/types`) sidesteps the JSX type-graph
 // pulled in by `./sidebar`'s runtime barrel.
 import type { SidebarRootMenuItem } from "@takazudo/zudo-doc/sidebar/types";
+
+const cx = (...classes: Array<string | false | null | undefined>) =>
+  classes.filter(Boolean).join(" ");
 
 // Mobile drawer hosts the SidebarTree directly (rather than receiving it as
 // JSX children) so the tree's data props ride across the SSR → hydrate
@@ -90,7 +92,7 @@ export default function SidebarToggle({
         {/* X icon — visible only when open */}
         <svg
           xmlns="http://www.w3.org/2000/svg"
-          className={clsx("h-icon-lg w-icon-lg", !open && "hidden")}
+          className={cx("h-icon-lg w-icon-lg", !open && "hidden")}
           aria-hidden="true"
           fill="none"
           viewBox="0 0 24 24"
@@ -106,7 +108,7 @@ export default function SidebarToggle({
         {/* Hamburger icon — visible only when closed */}
         <svg
           xmlns="http://www.w3.org/2000/svg"
-          className={clsx("h-icon-lg w-icon-lg", open && "hidden")}
+          className={cx("h-icon-lg w-icon-lg", open && "hidden")}
           aria-hidden="true"
           fill="none"
           viewBox="0 0 24 24"
@@ -131,7 +133,7 @@ export default function SidebarToggle({
           backdrop (onClick below), so the header hamburger being dimmed under
           it is fine. */}
       <div
-        className={clsx("fixed inset-0 z-modal-backdrop bg-overlay/30 lg:hidden", !open && "hidden")}
+        className={cx("fixed inset-0 z-modal-backdrop bg-overlay/30 lg:hidden", !open && "hidden")}
         aria-hidden={!open}
         onClick={() => setOpen(false)}
       />

--- a/packages/md-plugins/package.json
+++ b/packages/md-plugins/package.json
@@ -11,7 +11,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "github-slugger": "^2.0.0",
     "gray-matter": "^4.0.3",
     "unist-util-visit": "^5.1.0"
   },

--- a/packages/zudo-doc/src/toc/cx.ts
+++ b/packages/zudo-doc/src/toc/cx.ts
@@ -2,11 +2,10 @@
  * Tiny `clsx`-style class name joiner. Accepts strings, falsy values,
  * and arrays/objects of the same — only truthy strings survive.
  *
- * The host project depends on `clsx`, but framework primitives keep
- * their dependency surface minimal so that a downstream consumer of
- * `@takazudo/zudo-doc/toc` does not need an extra runtime dep just
- * for class name composition. The behavior here is the subset the TOC
- * primitives use; see clsx for the full feature set.
+ * Framework primitives keep their dependency surface minimal so that a
+ * downstream consumer of `@takazudo/zudo-doc/toc` does not need an extra
+ * runtime dep just for class name composition. The behavior here is the
+ * subset the TOC primitives use; see `clsx` for the full feature set.
  */
 type ClassValue =
   | string

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,12 +41,6 @@ importers:
       '@takazudo/zudo-doc':
         specifier: workspace:*
         version: link:packages/zudo-doc
-      '@types/hast':
-        specifier: ^3.0.4
-        version: 3.0.4
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
       diff:
         specifier: ^8.0.3
         version: 8.0.3
@@ -65,9 +59,6 @@ importers:
       preact-render-to-string:
         specifier: ^6.6.6
         version: 6.6.6(preact@10.29.2)
-      rehype-katex:
-        specifier: ^7.0.1
-        version: 7.0.1
       shiki:
         specifier: ^4.0.2
         version: 4.0.2
@@ -87,9 +78,6 @@ importers:
       '@takazudo/zudo-design-token-lint':
         specifier: ^1.0.0
         version: 1.0.0(patch_hash=6a157fd850449b055cf64a8a7dd1faed5b1da9eebe6c81cca08488ac0de85182)
-      '@types/mdast':
-        specifier: ^4.0.4
-        version: 4.0.4
       '@types/node':
         specifier: ^25.3.5
         version: 25.3.5
@@ -111,9 +99,6 @@ importers:
       lefthook:
         specifier: ^2.1.4
         version: 2.1.4
-      msw:
-        specifier: ^2.12.12
-        version: 2.12.12(@types/node@25.3.5)(typescript@5.9.3)
       npm-run-all2:
         specifier: ^7.0.2
         version: 7.0.2
@@ -123,12 +108,6 @@ importers:
       pluralize:
         specifier: ^8.0.0
         version: 8.0.0
-      prettier:
-        specifier: ^3.8.1
-        version: 3.8.1
-      sharp:
-        specifier: ^0.34.5
-        version: 0.34.5
       string-similarity:
         specifier: ^4.0.4
         version: 4.0.4
@@ -202,9 +181,6 @@ importers:
 
   packages/md-plugins:
     dependencies:
-      github-slugger:
-        specifier: ^2.0.0
-        version: 2.0.0
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -1716,10 +1692,6 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
-  clsx@2.1.1:
-    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
-    engines: {node: '>=6'}
-
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -2088,9 +2060,6 @@ packages:
 
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
-
-  github-slugger@2.0.0:
-    resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
@@ -2784,11 +2753,6 @@ packages:
 
   preact@10.29.2:
     resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
-
-  prettier@3.8.1:
-    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
-    engines: {node: '>=14'}
-    hasBin: true
 
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -3629,7 +3593,8 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@inquirer/ansi@1.0.2': {}
+  '@inquirer/ansi@1.0.2':
+    optional: true
 
   '@inquirer/ansi@2.0.5': {}
 
@@ -3656,6 +3621,7 @@ snapshots:
       '@inquirer/type': 3.0.10(@types/node@25.3.5)
     optionalDependencies:
       '@types/node': 25.3.5
+    optional: true
 
   '@inquirer/confirm@6.0.12(@types/node@25.3.5)':
     dependencies:
@@ -3690,6 +3656,7 @@ snapshots:
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 25.3.5
+    optional: true
 
   '@inquirer/core@11.1.9(@types/node@25.3.5)':
     dependencies:
@@ -3725,7 +3692,8 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.3.5
 
-  '@inquirer/figures@1.0.15': {}
+  '@inquirer/figures@1.0.15':
+    optional: true
 
   '@inquirer/figures@2.0.5': {}
 
@@ -3798,6 +3766,7 @@ snapshots:
   '@inquirer/type@3.0.10(@types/node@25.3.5)':
     optionalDependencies:
       '@types/node': 25.3.5
+    optional: true
 
   '@inquirer/type@4.0.5(@types/node@25.3.5)':
     optionalDependencies:
@@ -3848,15 +3817,19 @@ snapshots:
       is-node-process: 1.2.0
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
+    optional: true
 
-  '@open-draft/deferred-promise@2.2.0': {}
+  '@open-draft/deferred-promise@2.2.0':
+    optional: true
 
   '@open-draft/logger@0.3.0':
     dependencies:
       is-node-process: 1.2.0
       outvariant: 1.4.3
+    optional: true
 
-  '@open-draft/until@2.1.0': {}
+  '@open-draft/until@2.1.0':
+    optional: true
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -4280,7 +4253,8 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@types/statuses@2.0.6': {}
+  '@types/statuses@2.0.6':
+    optional: true
 
   '@types/string-similarity@4.0.2': {}
 
@@ -4426,8 +4400,7 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
-
-  clsx@2.1.1: {}
+    optional: true
 
   color-convert@2.0.1:
     dependencies:
@@ -4762,7 +4735,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.4
       '@esbuild/win32-x64': 0.27.4
 
-  escalade@3.2.0: {}
+  escalade@3.2.0:
+    optional: true
 
   escape-string-regexp@5.0.0: {}
 
@@ -4821,15 +4795,14 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  get-caller-file@2.0.5: {}
+  get-caller-file@2.0.5:
+    optional: true
 
   get-east-asian-width@1.5.0: {}
 
   get-tsconfig@4.13.6:
     dependencies:
       resolve-pkg-maps: 1.0.0
-
-  github-slugger@2.0.0: {}
 
   glob@10.5.0:
     dependencies:
@@ -4848,7 +4821,8 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  graphql@16.13.1: {}
+  graphql@16.13.1:
+    optional: true
 
   gray-matter@4.0.3:
     dependencies:
@@ -4959,7 +4933,8 @@ snapshots:
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
 
-  headers-polyfill@4.0.3: {}
+  headers-polyfill@4.0.3:
+    optional: true
 
   hono@4.12.25: {}
 
@@ -5005,7 +4980,8 @@ snapshots:
 
   is-hexadecimal@2.0.1: {}
 
-  is-node-process@1.2.0: {}
+  is-node-process@1.2.0:
+    optional: true
 
   is-plain-obj@4.1.0: {}
 
@@ -5649,8 +5625,10 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/node'
+    optional: true
 
-  mute-stream@2.0.0: {}
+  mute-stream@2.0.0:
+    optional: true
 
   mute-stream@3.0.0: {}
 
@@ -5687,7 +5665,8 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  outvariant@1.4.3: {}
+  outvariant@1.4.3:
+    optional: true
 
   package-json-from-dist@1.0.1: {}
 
@@ -5775,8 +5754,6 @@ snapshots:
       preact: 10.29.2
 
   preact@10.29.2: {}
-
-  prettier@3.8.1: {}
 
   prompts@2.4.2:
     dependencies:
@@ -5886,7 +5863,8 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  require-directory@2.1.1: {}
+  require-directory@2.1.1:
+    optional: true
 
   require-from-string@2.0.2: {}
 
@@ -5894,7 +5872,8 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
-  rettime@0.10.1: {}
+  rettime@0.10.1:
+    optional: true
 
   robust-predicates@3.0.2: {}
 
@@ -6013,11 +5992,13 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  statuses@2.0.2: {}
+  statuses@2.0.2:
+    optional: true
 
   std-env@4.0.0: {}
 
-  strict-event-emitter@0.5.1: {}
+  strict-event-emitter@0.5.1:
+    optional: true
 
   string-similarity@4.0.4: {}
 
@@ -6062,7 +6043,8 @@ snapshots:
 
   supports-color@10.2.2: {}
 
-  tagged-tag@1.0.0: {}
+  tagged-tag@1.0.0:
+    optional: true
 
   tailwindcss@4.2.1: {}
 
@@ -6089,15 +6071,18 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
-  tldts-core@7.0.26: {}
+  tldts-core@7.0.26:
+    optional: true
 
   tldts@7.0.26:
     dependencies:
       tldts-core: 7.0.26
+    optional: true
 
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.0.26
+    optional: true
 
   tree-kill@1.2.2: {}
 
@@ -6150,6 +6135,7 @@ snapshots:
   type-fest@5.4.4:
     dependencies:
       tagged-tag: 1.0.0
+    optional: true
 
   typescript@5.9.3: {}
 
@@ -6210,7 +6196,8 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  until-async@3.0.2: {}
+  until-async@3.0.2:
+    optional: true
 
   uuid@14.0.0: {}
 
@@ -6358,6 +6345,7 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+    optional: true
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -6373,9 +6361,11 @@ snapshots:
 
   ws@8.21.0: {}
 
-  y18n@5.0.8: {}
+  y18n@5.0.8:
+    optional: true
 
-  yargs-parser@21.1.1: {}
+  yargs-parser@21.1.1:
+    optional: true
 
   yargs@17.7.2:
     dependencies:
@@ -6386,8 +6376,10 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+    optional: true
 
-  yoctocolors-cjs@2.1.3: {}
+  yoctocolors-cjs@2.1.3:
+    optional: true
 
   youch-core@0.3.3:
     dependencies:

--- a/src/components/sidebar-toggle.tsx
+++ b/src/components/sidebar-toggle.tsx
@@ -6,7 +6,6 @@
 // packages/zudo-doc/src/theme-toggle/index.tsx. Type references via
 // the global React namespace still resolve via @types/react.
 import { useState, useEffect } from "preact/hooks";
-import clsx from "clsx";
 // After zudolab/zudo-doc#1335 (E2 task 2 half B) the host components
 // pull lifecycle event names from the v2 transitions module rather
 // than hard-coding `astro:*` literals.
@@ -17,6 +16,9 @@ import type { LocaleLink } from "@/types/locale";
 // Types-only subpath (`./sidebar/types`) sidesteps the JSX type-graph
 // pulled in by `./sidebar`'s runtime barrel.
 import type { SidebarRootMenuItem } from "@takazudo/zudo-doc/sidebar/types";
+
+const cx = (...classes: Array<string | false | null | undefined>) =>
+  classes.filter(Boolean).join(" ");
 
 // Mobile drawer hosts the SidebarTree directly (rather than receiving it as
 // JSX children) so the tree's data props ride across the SSR → hydrate
@@ -90,7 +92,7 @@ export default function SidebarToggle({
         {/* X icon — visible only when open */}
         <svg
           xmlns="http://www.w3.org/2000/svg"
-          className={clsx("h-icon-lg w-icon-lg", !open && "hidden")}
+          className={cx("h-icon-lg w-icon-lg", !open && "hidden")}
           aria-hidden="true"
           fill="none"
           viewBox="0 0 24 24"
@@ -106,7 +108,7 @@ export default function SidebarToggle({
         {/* Hamburger icon — visible only when closed */}
         <svg
           xmlns="http://www.w3.org/2000/svg"
-          className={clsx("h-icon-lg w-icon-lg", open && "hidden")}
+          className={cx("h-icon-lg w-icon-lg", open && "hidden")}
           aria-hidden="true"
           fill="none"
           viewBox="0 0 24 24"
@@ -131,7 +133,7 @@ export default function SidebarToggle({
           backdrop (onClick below), so the header hamburger being dimmed under
           it is fine. */}
       <div
-        className={clsx("fixed inset-0 z-modal-backdrop bg-overlay/30 lg:hidden", !open && "hidden")}
+        className={cx("fixed inset-0 z-modal-backdrop bg-overlay/30 lg:hidden", !open && "hidden")}
         aria-hidden={!open}
         onClick={() => setOpen(false)}
       />


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2204 (epic)
    - https://github.com/zudolab/zudo-doc/issues/2205 (removal)
    - https://github.com/zudolab/zudo-doc/issues/2206 (validation)

---

## Summary

Dependency audit + cleanup. Removed 8 genuinely stale/redundant dependencies; kept 3 that look removable on a naive grep but have real usage.

### Removed (8)
- **Root `dependencies`:** `clsx` (3 trivial calls in `sidebar-toggle.tsx` → tiny inline `cx` joiner; host + create-zudo-doc template kept byte-identical), `rehype-katex` (only `md-plugins` tests use it, which declare their own)
- **Root `devDependencies`:** `@types/hast`, `@types/mdast` (no root usage; md-plugins owns its own), `msw` (never imported + orphaned `"msw"` config block removed), `prettier` (no config/script/import + `.prettierignore` deleted), `sharp` (Astro-era leftover + removed from `pnpm.onlyBuiltDependencies`)
- **`packages/md-plugins`:** `github-slugger` (zero imports)

Also: `create-zudo-doc` scaffold no longer emits `clsx` in generated projects (+ a scaffold.test dead-dep assertion), and the now-inverted rationale comment in `packages/zudo-doc/src/toc/cx.ts` was corrected.

### Kept — investigated, NOT removable
- **`preact-render-to-string`** — zfb's emitted SSR `entry.mjs` imports `renderToString`; removing it breaks `pnpm build` (caught in plan review).
- **`shiki`** — dynamic `import("shiki")` in the html-preview-wrapper; satisfies an optional peer dep.
- **`mermaid`** — `scaffold.test.ts` enforces it as an unconditional dep of generated projects.

## Validation (all green)
`pnpm install` (lockfile refreshed, deps dropped) · `pnpm check` (typecheck) · `pnpm build` (286 pages) · `pnpm test` (unit + all package suites) · guards: template-drift, pin-parity, package-safelist, fixture-settings-drift.

Planned via `/big-plan`, implemented via `/x-wt-teams`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BqC1CUCV6nug7YqUmS4kqj)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784289785&installation_id=130359969&pr_number=2207&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2207&signature=59f9274514997d3230e1d06c6b528ee45ad97ee2f399512b7e5216a577dfbc89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->