### PR TITLE
Update zfb to next.52 + preserve runtime <html> attrs across SPA swaps (retire #2198 sidebar flash workaround)

### DIFF
--- a/e2e/sidebar-spa-nav-flash.spec.ts
+++ b/e2e/sidebar-spa-nav-flash.spec.ts
@@ -3,37 +3,37 @@ import { spaClick } from "./nav-helpers";
 import { desktopSidebar, waitForSidebarHydration } from "./sidebar-helpers";
 
 /**
- * E2E regression for the desktop sidebar SPA-navigation flash (#2198).
+ * E2E regression for the desktop sidebar SPA-navigation flash (#2198 / #2200).
  *
  * Bug: a CLOSED desktop sidebar briefly flashed open and animated shut on every
- * same-section SPA navigation. zfb's `swapRootAttributes` wipes the
- * `data-sidebar-hidden` attribute off <html> during the body swap, so for one
- * frame the CSS saw the sidebar as visible and the 200ms transitions began
- * animating it open; the toggle island's `zfb:after-swap` restore then reversed
- * the animation (visible -> hidden slide). The net effect was a visible flash +
- * slide on a sidebar the user had deliberately collapsed.
+ * same-section SPA navigation. zfb's `swapRootAttributes` copied the incoming
+ * server-rendered document's `<html>` attributes over the live root during the
+ * body swap, dropping the runtime `data-sidebar-hidden` value — so for one frame
+ * the CSS saw the sidebar as visible and the 200ms transitions began animating
+ * it open.
  *
- * Fix: on `zfb:before-preparation` the persisted `DesktopSidebarToggle` island
- * adds a transient `data-sidebar-no-transition` marker on <html> that zeroes the
- * sidebar geometry transitions (global.css), and removes it on a double rAF
- * AFTER the `zfb:after-swap` restore — so the wipe and the restore both apply
- * instantly (no painted/animated frame) while a later user toggle still
- * animates normally.
+ * Fix (#2200): doc-layout now mounts
+ * `<ClientRouter preserveHtmlAttrs={["data-sidebar-hidden", "data-theme"]} />`
+ * (zfb-runtime >= 0.1.0-next.52, zfb#1104). The router re-applies those runtime
+ * attributes within the same synchronous swap, before paint, so the attribute is
+ * NEVER absent on a painted frame and the freshly-swapped `<aside>` renders
+ * directly in its hidden state (a newly-inserted element has no prior computed
+ * value to transition from). The host-side capture/restore +
+ * `data-sidebar-no-transition` guard was retired.
  *
  * This fixture enables `sidebarToggle`, so the real persisted toggle island and
  * pre-paint script are present — unlike sidebar-toggle-layout.spec.ts, which
  * sets `data-sidebar-hidden` via page.evaluate against a fixture WITHOUT the
  * island and therefore cannot exercise the swap-time race at all.
  *
- * Assertion technique (per #2198 brief): we do NOT assert only the final
- * resting state — a 200ms transform settles back to hidden long before most
- * polls, so a final-state check would pass even with a visible flash. Instead
- * we instrument the swap window itself:
- *   1. Confirm the marker is active for the full duration of the swap (set on
- *      before-preparation, still present at after-swap).
- *   2. rAF-sample `getComputedStyle(#desktop-sidebar).transitionProperty`
- *      throughout the swap and assert it is `none` on every frame — i.e. the
- *      sidebar geometry can never animate while the swap is in flight.
+ * Assertion technique: we do NOT assert only the final resting state — a 200ms
+ * transform settles back to hidden long before most polls, so a final-state
+ * check would pass even with a visible flash. Instead we instrument the swap
+ * window itself and prove the invariant directly:
+ *   1. `data-sidebar-hidden` is present at before-preparation AND after-swap, and
+ *      on EVERY rAF-sampled frame of the swap (the attribute is never wiped).
+ *   2. On every frame where `#desktop-sidebar` exists, its computed transform is
+ *      the settled hidden transform — i.e. the sidebar can never paint open.
  */
 
 const START_PAGE = "/docs/guides/sub-a/page-1";
@@ -41,8 +41,8 @@ const START_PAGE = "/docs/guides/sub-a/page-1";
 // a genuine same-section SPA hop (the case the bug fired on).
 const NEXT_PAGE = "/docs/guides/sub-a/page-2";
 
-test.describe("Desktop sidebar SPA-nav flash (#2198)", () => {
-  test("closed sidebar never animates across an SPA navigation", async ({
+test.describe("Desktop sidebar SPA-nav flash (#2198 / #2200)", () => {
+  test("closed sidebar's data-sidebar-hidden survives an SPA navigation (never flashes open)", async ({
     page,
   }) => {
     // >=1024px so the `lg:` desktop-sidebar rules (and the toggle) are active.
@@ -52,6 +52,18 @@ test.describe("Desktop sidebar SPA-nav flash (#2198)", () => {
 
     const sidebar = desktopSidebar(page);
     await expect(sidebar).toHaveCount(1);
+
+    // The fix is wired via the SSR meta the ClientRouter emits — assert it lists
+    // data-sidebar-hidden, so a regression that drops the option fails loudly
+    // here rather than only as a flaky timing failure below.
+    const preserved = await page.evaluate(() => {
+      const meta = document.querySelector(
+        'meta[name="zfb-preserve-html-attrs"]',
+      );
+      return meta?.getAttribute("content") ?? null;
+    });
+    expect(preserved).not.toBeNull();
+    expect(preserved!.toLowerCase()).toContain("data-sidebar-hidden");
 
     // Collapse the sidebar via the real toggle button and wait for the island
     // to commit `data-sidebar-hidden` on <html>.
@@ -66,8 +78,7 @@ test.describe("Desktop sidebar SPA-nav flash (#2198)", () => {
     // baseline. Clicking the toggle starts a 200ms transform transition, but
     // `data-sidebar-hidden` is committed on <html> immediately on click — so
     // waiting for the attribute alone races the animation and would snapshot a
-    // mid-slide transform (e.g. -4px instead of the settled -320px), making the
-    // final-state assertion below spuriously fail (#2198 verification). Poll the
+    // mid-slide transform (e.g. -4px instead of the settled -320px). Poll the
     // computed transform until two consecutive reads are equal (stable).
     await page.waitForFunction(
       () => {
@@ -88,27 +99,26 @@ test.describe("Desktop sidebar SPA-nav flash (#2198)", () => {
       (el) => getComputedStyle(el).transform,
     );
 
-    // Instrument the swap: install probes that (a) record marker presence at the
-    // two swap boundaries and (b) rAF-sample the sidebar's transition-property
-    // across the entire swap window. The before-preparation listener starts the
-    // sampler; the after-swap listener records the boundary state. Sampling
-    // continues for a few extra frames after after-swap to cover the double-rAF
-    // marker removal so we also prove the marker is gone afterwards.
+    // Instrument the swap: rAF-sample, across the entire swap window, whether
+    // `data-sidebar-hidden` is present on <html> and the sidebar's transform.
+    // The before-preparation listener starts the sampler; the after-swap
+    // listener records the boundary state. Sampling continues a few frames past
+    // after-swap to cover the post-swap resting state.
     await page.evaluate(() => {
       const w = window as unknown as {
         __flashProbe__: {
-          markerAtBeforePrep: boolean | null;
-          markerAtAfterSwap: boolean | null;
+          hiddenAtBeforePrep: boolean | null;
+          hiddenAtAfterSwap: boolean | null;
           // One tuple per sampled frame, kept in lockstep so a frame where
           // #desktop-sidebar is momentarily absent (the aside is NOT persisted
-          // across swaps — #1510) cannot desync marker vs transition.
-          samples: Array<{ marker: boolean; transition: string | null }>;
+          // across swaps — #1510) cannot desync the hidden flag vs transform.
+          samples: Array<{ hidden: boolean; transform: string | null }>;
           done: boolean;
         };
       };
       w.__flashProbe__ = {
-        markerAtBeforePrep: null,
-        markerAtAfterSwap: null,
+        hiddenAtBeforePrep: null,
+        hiddenAtAfterSwap: null,
         samples: [],
         done: false,
       };
@@ -121,12 +131,10 @@ test.describe("Desktop sidebar SPA-nav flash (#2198)", () => {
         if (!sampling) return;
         const el = document.querySelector("#desktop-sidebar");
         probe.samples.push({
-          marker: html.hasAttribute("data-sidebar-no-transition"),
-          transition: el ? getComputedStyle(el).transitionProperty : null,
+          hidden: html.hasAttribute("data-sidebar-hidden"),
+          transform: el ? getComputedStyle(el).transform : null,
         });
-        // Stop a few frames after after-swap so we also capture the marker
-        // removal (double rAF) and the post-swap resting state.
-        if (probe.markerAtAfterSwap !== null) {
+        if (probe.hiddenAtAfterSwap !== null) {
           framesAfterSwap += 1;
           if (framesAfterSwap > 5) {
             sampling = false;
@@ -140,9 +148,7 @@ test.describe("Desktop sidebar SPA-nav flash (#2198)", () => {
       document.addEventListener(
         "zfb:before-preparation",
         () => {
-          probe.markerAtBeforePrep = html.hasAttribute(
-            "data-sidebar-no-transition",
-          );
+          probe.hiddenAtBeforePrep = html.hasAttribute("data-sidebar-hidden");
           sampling = true;
           requestAnimationFrame(sample);
         },
@@ -151,9 +157,7 @@ test.describe("Desktop sidebar SPA-nav flash (#2198)", () => {
       document.addEventListener(
         "zfb:after-swap",
         () => {
-          probe.markerAtAfterSwap = html.hasAttribute(
-            "data-sidebar-no-transition",
-          );
+          probe.hiddenAtAfterSwap = html.hasAttribute("data-sidebar-hidden");
         },
         { once: true },
       );
@@ -163,55 +167,54 @@ test.describe("Desktop sidebar SPA-nav flash (#2198)", () => {
     const navigated = await spaClick(page, NEXT_PAGE);
     expect(navigated).toBe(true);
 
-    // Let the sampler finish (covers the post-swap double-rAF marker removal).
-    await page.waitForFunction(() => {
-      const w = window as unknown as { __flashProbe__: { done: boolean } };
-      return w.__flashProbe__.done === true;
-    }, undefined, { timeout: 5000 });
+    // Let the sampler finish (covers the post-swap resting state).
+    await page.waitForFunction(
+      () => {
+        const w = window as unknown as { __flashProbe__: { done: boolean } };
+        return w.__flashProbe__.done === true;
+      },
+      undefined,
+      { timeout: 5000 },
+    );
 
     const probe = await page.evaluate(() => {
       const w = window as unknown as {
         __flashProbe__: {
-          markerAtBeforePrep: boolean | null;
-          markerAtAfterSwap: boolean | null;
-          samples: Array<{ marker: boolean; transition: string | null }>;
+          hiddenAtBeforePrep: boolean | null;
+          hiddenAtAfterSwap: boolean | null;
+          samples: Array<{ hidden: boolean; transform: string | null }>;
         };
       };
       return w.__flashProbe__;
     });
 
-    // The marker must be set the moment the swap begins and still present when
-    // the body has been swapped + the attribute restored — i.e. it brackets the
-    // entire wipe/restore race.
-    expect(probe.markerAtBeforePrep).toBe(true);
-    expect(probe.markerAtAfterSwap).toBe(true);
+    // The attribute is present when the swap begins and STILL present once the
+    // body has been swapped — i.e. zfb-runtime preserved it across the wipe.
+    expect(probe.hiddenAtBeforePrep).toBe(true);
+    expect(probe.hiddenAtAfterSwap).toBe(true);
 
     // The sampler must have actually run during the swap.
     expect(probe.samples.length).toBeGreaterThan(0);
 
-    // While the marker is active, the sidebar geometry transition must be
-    // suppressed — so no frame can paint a partially-open sidebar. For every
-    // frame where the marker was present AND the sidebar element existed, its
-    // computed transition-property must be `none`. (Frames where the aside is
-    // momentarily absent contribute `transition: null` and are skipped — they
-    // cannot paint a sidebar anyway.)
-    const suppressedWhileMarked = probe.samples.every(
-      (s) => !s.marker || s.transition === null || s.transition === "none",
-    );
-    expect(suppressedWhileMarked).toBe(true);
+    // `data-sidebar-hidden` must be present on EVERY painted frame of the swap —
+    // there is no frame where the CSS could see the sidebar as visible.
+    const hiddenEveryFrame = probe.samples.every((s) => s.hidden);
+    expect(hiddenEveryFrame).toBe(true);
 
-    // The probe must have actually observed the marker active on at least one
-    // frame with the sidebar present (otherwise the suppression check above is
-    // vacuously true).
-    const observedSuppression = probe.samples.some(
-      (s) => s.marker && s.transition === "none",
+    // For every frame where the sidebar element existed, it was at the settled
+    // hidden transform — never partially or fully open. (Frames where the aside
+    // is momentarily absent contribute `transform: null` and are skipped.)
+    const neverPaintedOpen = probe.samples.every(
+      (s) => s.transform === null || s.transform === hiddenTransform,
     );
-    expect(observedSuppression).toBe(true);
+    expect(neverPaintedOpen).toBe(true);
 
-    // The marker is eventually removed (double rAF after after-swap), so a later
-    // user toggle still animates. The tail of the samples must show it gone.
-    const lastSample = probe.samples[probe.samples.length - 1];
-    expect(lastSample?.marker).toBe(false);
+    // Non-vacuous: at least one frame observed the sidebar present at the hidden
+    // transform during the swap window.
+    const observedHiddenSidebar = probe.samples.some(
+      (s) => s.transform === hiddenTransform,
+    );
+    expect(observedHiddenSidebar).toBe(true);
 
     // After everything settles the sidebar is still hidden and at the exact
     // same hidden transform it had before the nav — never opened.

--- a/package.json
+++ b/package.json
@@ -85,9 +85,9 @@
   },
   "dependencies": {
     "@takazudo/zdtp": "0.2.3",
-    "@takazudo/zfb": "0.1.0-next.51",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.51",
-    "@takazudo/zfb-runtime": "0.1.0-next.51",
+    "@takazudo/zfb": "0.1.0-next.52",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.52",
+    "@takazudo/zfb-runtime": "0.1.0-next.52",
     "@takazudo/zudo-doc": "workspace:*",
     "diff": "^8.0.3",
     "gray-matter": "^4.0.3",

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -254,14 +254,14 @@ describe("scaffold — minimal (no i18n, search only, single dark scheme)", () =
 });
 
 describe("scaffold — sidebarToggle feature", () => {
-  // W4A (#1732): @takazudo/zudo-doc is now a runtime dep of every scaffold
-  // (published via .github/workflows/publish-zudo-doc.yml), so the
-  // desktop-sidebar-toggle component imports BEFORE_NAVIGATE_EVENT /
-  // AFTER_NAVIGATE_EVENT from @takazudo/zudo-doc/transitions directly
-  // instead of inlining them as string literals. The two tests below were
-  // previously asserting the inverse (v2 absent), which encoded the
-  // "v2 is workspace-private/unpublished" constraint that W4A removes.
-  it("desktop-sidebar-toggle.tsx imports lifecycle events from @takazudo/zudo-doc/transitions", async () => {
+  // #2200: the desktop-sidebar-toggle no longer carries a host-side SPA-nav
+  // flash guard. zfb-runtime >= 0.1.0-next.52 preserves runtime <html>
+  // attributes across swaps via <ClientRouter preserveHtmlAttrs={[…]} /> (mounted
+  // in @takazudo/zudo-doc's doc-layout), so `data-sidebar-hidden` survives the
+  // swap before paint. The component just persists the toggle state — it does
+  // NOT import the navigation lifecycle events or set the
+  // `data-sidebar-no-transition` marker (the retired #2198 workaround).
+  it("desktop-sidebar-toggle.tsx persists sidebar state without a host-side SPA-nav flash guard (#2200)", async () => {
     const choices: UserChoices = {
       projectName: "test-sidebar-toggle-on",
       defaultLang: "en",
@@ -278,11 +278,17 @@ describe("scaffold — sidebarToggle feature", () => {
       ),
       "utf-8",
     );
-    expect(content).toMatch(
+    // Still persists the collapsed state to <html> + localStorage.
+    expect(content).toContain("data-sidebar-hidden");
+    expect(content).toContain("SIDEBAR_STORAGE_KEY");
+    // The retired #2198 workaround must be gone: no lifecycle-event import,
+    // no per-swap capture/restore guard, no transition-suppression marker.
+    expect(content).not.toMatch(
       /from\s+['"]@takazudo\/zudo-doc\/transitions['"]/,
     );
-    expect(content).toContain("BEFORE_NAVIGATE_EVENT");
-    expect(content).toContain("AFTER_NAVIGATE_EVENT");
+    expect(content).not.toContain("BEFORE_NAVIGATE_EVENT");
+    expect(content).not.toContain("AFTER_NAVIGATE_EVENT");
+    expect(content).not.toContain("data-sidebar-no-transition");
   });
 
   it("generated package.json pins @takazudo/zudo-doc (W4A — runtime dep)", async () => {
@@ -3295,10 +3301,13 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
    * bumped to 0.1.0-next.51: additive public-API surface (VNode/VNodeArray/
    * VNodeObject exported from "@takazudo/zfb", #972) plus removal of the no-op
    * linkValidation.allowExternal knob (#925) — both non-breaking for a fresh
-   * scaffold.
+   * scaffold. Now bumped to 0.1.0-next.52: adds the
+   * ClientRouter({ preserveHtmlAttrs }) option (zfb#1104) so runtime <html>
+   * attributes (data-sidebar-hidden / data-theme) survive SPA swaps
+   * (zudolab/zudo-doc#2200) — additive, non-breaking for a fresh scaffold.
    * Generated package.json must pin all three.
    */
-  it("pins @takazudo/zfb at 0.1.0-next.51", async () => {
+  it("pins @takazudo/zfb at 0.1.0-next.52", async () => {
     const choices: UserChoices = {
       projectName: "test-pin-bump",
       defaultLang: "en",
@@ -3309,10 +3318,10 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
     };
     await scaffold(choices);
     const pkg = await fs.readJson(projectPath("test-pin-bump", "package.json"));
-    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.51");
-    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.51");
+    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.52");
+    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.52");
     expect(pkg.dependencies["@takazudo/zfb-adapter-cloudflare"]).toBe(
-      "0.1.0-next.51",
+      "0.1.0-next.52",
     );
   });
 });

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -414,12 +414,16 @@ function generatePackageJson(choices: UserChoices) {
     // "@takazudo/zfb" (#972) — plus removal of the no-op linkValidation.allowExternal
     // knob (#925); both are non-breaking for a fresh scaffold. A fresh scaffold
     // sets no explicit codeHighlight.theme so the default still applies. No
-    // consumer-facing / CLI breaking change.
-    "@takazudo/zfb": "0.1.0-next.51",
-    "@takazudo/zfb-runtime": "0.1.0-next.51",
+    // consumer-facing / CLI breaking change. next.52 (current pin): adds the
+    // `ClientRouter({ preserveHtmlAttrs })` option (zfb#1104) — consumers can
+    // declare runtime `<html>` attribute names to preserve across SPA swaps so
+    // e.g. `data-sidebar-hidden` / `data-theme` survive (zudolab/zudo-doc#2200).
+    // Additive, non-breaking for a fresh scaffold.
+    "@takazudo/zfb": "0.1.0-next.52",
+    "@takazudo/zfb-runtime": "0.1.0-next.52",
     // zfb-adapter-cloudflare — required for any route with `prerender = false`.
     // Pinned in lockstep with @takazudo/zfb.
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.51",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.52",
     // @takazudo/zudo-doc — published from this monorepo via
     // .github/workflows/publish-zudo-doc.yml. The pin here is bumped in
     // lockstep by scripts/release-create-zudo-doc.sh whenever zudo-doc's

--- a/packages/create-zudo-doc/templates/base/src/styles/global.css
+++ b/packages/create-zudo-doc/templates/base/src/styles/global.css
@@ -717,19 +717,10 @@ pre[class^="syntect-"] .line .highlighted-word {
   }
 }
 
-/* Suppress sidebar geometry transitions during an SPA swap (#2198).
- * swapRootAttributes wipes data-sidebar-hidden mid-swap, so without this the
- * sidebar would animate open (attribute absent) and then animate shut again
- * when the toggle island restores the attribute on zfb:after-swap — a visible
- * flash + slide. The island sets data-sidebar-no-transition for the swap
- * window and removes it (double rAF) after restoring the hidden state, so the
- * wipe/restore apply instantly and a later user toggle still animates. */
-html[data-sidebar-no-transition] #desktop-sidebar,
-html[data-sidebar-no-transition] .zd-sidebar-content-wrapper,
-html[data-sidebar-no-transition] .zd-doc-content-band,
-html[data-sidebar-no-transition] .zd-desktop-sidebar-toggle {
-  transition: none !important;
-}
+/* The SPA-swap flash guard (`data-sidebar-no-transition`) was removed once
+ * doc-layout adopted <ClientRouter preserveHtmlAttrs={["data-sidebar-hidden",
+ * ...]} /> (zfb-runtime >= 0.1.0-next.52): the attribute now survives the swap
+ * before paint, so no sidebar geometry transition fires mid-swap. */
 
 /* ── Find-in-page highlight (W7A: unconditional — Tauri feature gates at runtime) ── */
 .find-match {

--- a/packages/create-zudo-doc/templates/features/sidebarToggle/files/src/components/desktop-sidebar-toggle.tsx
+++ b/packages/create-zudo-doc/templates/features/sidebarToggle/files/src/components/desktop-sidebar-toggle.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useEffect, useRef } from 'preact/hooks';
-import { BEFORE_NAVIGATE_EVENT, AFTER_NAVIGATE_EVENT } from '@takazudo/zudo-doc/transitions';
 
 export const SIDEBAR_STORAGE_KEY = 'zudo-doc-sidebar-visible';
 
@@ -22,93 +21,13 @@ function setDataAttribute(isVisible: boolean) {
   }
 }
 
-// SPA-navigation guard for the desktop sidebar's hidden-state (#2198).
-//
-// zfb's Strategy-B client router wipes EVERY <html> attribute during the body
-// swap (swapRootAttributes re-adds only NON_OVERRIDABLE_ZFB_ATTRS plus the
-// incoming SSR document's attributes), so the persisted `data-sidebar-hidden`
-// runtime value is lost on every navigation, and the pre-paint inline script
-// does not re-run on SPA hops. Left alone, the freshly-rendered sidebar paints
-// visible and then animates shut when the value is restored — the flash + slide.
-//
-// These listeners MUST live at module scope, NOT in the island's useEffect:
-// zfb-runtime (>= 0.1.0-next.51) calls unmountIslands() BEFORE the swap and
-// before firing AFTER_NAVIGATE_EVENT, so a useEffect-registered listener is torn
-// down (effect cleanup) before the swap and never sees the after-swap event —
-// the restore would never run (#2198 verification). Registering once on
-// `document` at bundle load — the same lifecycle-independent pattern as
-// client-router-bootstrap.tsx — keeps the guard alive across island
-// unmount/remount. SSR-safe: no-ops when `document` is undefined.
-//
-// Strategy: on BEFORE_NAVIGATE_EVENT, record whether the sidebar was hidden and
-// set a transient `data-sidebar-no-transition` marker (global.css zeroes the
-// sidebar/wrapper/band/toggle transitions). The swap then wipes BOTH the marker
-// and data-sidebar-hidden. On AFTER_NAVIGATE_EVENT (swap done → the live <html>
-// is no longer wiped) RE-SET the marker, then re-add data-sidebar-hidden in the
-// same synchronous batch, so the hidden geometry snaps in with transitions
-// suppressed (no slide, no open frame). Remove the marker on a double rAF
-// afterward so a later user toggle still animates.
-let spaNavGuardRegistered = false;
-function registerSidebarSpaNavGuard() {
-  if (typeof document === 'undefined' || spaNavGuardRegistered) return;
-  spaNavGuardRegistered = true;
-
-  let wasHidden = false;
-  let swapToken = 0;
-  // Long enough to outlast the View-Transition swap pipeline on slow
-  // machines/CI; short enough that an aborted nav self-heals quickly. Only a
-  // safety net for a nav that never reaches `restore` (aborted/superseded).
-  const STUCK_MARKER_FALLBACK_MS = 1500;
-
-  const capture = () => {
-    wasHidden = document.documentElement.hasAttribute('data-sidebar-hidden');
-    document.documentElement.setAttribute('data-sidebar-no-transition', '');
-    const token = ++swapToken;
-    window.setTimeout(() => {
-      if (token === swapToken) {
-        document.documentElement.removeAttribute('data-sidebar-no-transition');
-      }
-    }, STUCK_MARKER_FALLBACK_MS);
-  };
-
-  const restore = () => {
-    // Marker first, then the attribute, in one synchronous batch — so the
-    // hidden geometry is restored with transitions off (the swap already wiped
-    // the capture-time marker, so re-setting it here on the post-swap <html> is
-    // what actually suppresses the animation).
-    document.documentElement.setAttribute('data-sidebar-no-transition', '');
-    if (wasHidden) {
-      document.documentElement.setAttribute('data-sidebar-hidden', '');
-    }
-    // Drop the marker only after the restored state is committed. A single rAF
-    // can coincide with the restore's style recalc and animate it, so defer one
-    // extra frame. The token bump no-ops capture's safety-net for this swap.
-    const token = ++swapToken;
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        if (token === swapToken) {
-          document.documentElement.removeAttribute('data-sidebar-no-transition');
-        }
-      });
-    });
-  };
-
-  document.addEventListener(BEFORE_NAVIGATE_EVENT, capture);
-  document.addEventListener(AFTER_NAVIGATE_EVENT, restore);
-}
-
-// Register at module load (browser-only via the guard) so the listeners exist
-// before the first navigation and survive island unmount/remount.
-registerSidebarSpaNavGuard();
-
 export default function DesktopSidebarToggle() {
   // Initial state must match server render (always `true`) to avoid a
   // hydration mismatch when the persisted preference is "hidden". The
   // doc-layout's pre-paint inline script applies `data-sidebar-hidden`
   // to <html> from localStorage *before* this island mounts, so the
   // visual state stays correct; we only need to sync this island's
-  // React state to the persisted preference after hydration. Same
-  // pattern as packages/zudo-doc/src/theme-toggle/index.tsx (commit 9aebd8e).
+  // React state to the persisted preference after hydration.
   const [visible, setVisible] = useState<boolean>(true);
   // Tracks whether the hydration sync (below) has run. The persistence
   // effect below skips the very first mount so we don't overwrite the
@@ -145,10 +64,11 @@ export default function DesktopSidebarToggle() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // The SPA-navigation flash guard (data-sidebar-hidden preservation +
-  // transition suppression) is NOT registered here. It must outlive this
-  // island's mount/unmount, so it lives at module scope — see
-  // registerSidebarSpaNavGuard() above. (#2198)
+  // The SPA-navigation flash (a collapsed sidebar briefly painting open on
+  // every soft swap) is handled upstream: doc-layout mounts
+  // <ClientRouter preserveHtmlAttrs={["data-sidebar-hidden", ...]} /> so
+  // zfb-runtime (>= 0.1.0-next.52) re-applies the runtime attribute across the
+  // swap before paint. No host-side capture/restore guard is needed.
 
   return (
     <button

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -173,8 +173,8 @@
   ],
   "peerDependencies": {
     "preact": "^10.29.1",
-    "@takazudo/zfb": "^0.1.0-next.51",
-    "@takazudo/zfb-runtime": "^0.1.0-next.51",
+    "@takazudo/zfb": "^0.1.0-next.52",
+    "@takazudo/zfb-runtime": "^0.1.0-next.52",
     "@takazudo/zudo-doc-history-server": "workspace:^",
     "@takazudo/zdtp": "^0.2.3",
     "shiki": "^4.0.2"
@@ -202,7 +202,7 @@
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
     "vitest": "^4.1.0",
-    "@takazudo/zfb": "0.1.0-next.51",
-    "@takazudo/zfb-runtime": "0.1.0-next.51"
+    "@takazudo/zfb": "0.1.0-next.52",
+    "@takazudo/zfb-runtime": "0.1.0-next.52"
   }
 }

--- a/packages/zudo-doc/src/doclayout/doc-layout.tsx
+++ b/packages/zudo-doc/src/doclayout/doc-layout.tsx
@@ -260,11 +260,26 @@ export function DocLayout(props: DocLayoutProps): JSX.Element {
           Strategy B SPA router. Emits the opt-in meta tags and the global
           .zfb-route-announcer stylesheet. Intercepts same-origin link
           clicks and swaps the DOM via document.startViewTransition.
+
+          preserveHtmlAttrs (zfb-runtime >= 0.1.0-next.52, zfb#1104): names the
+          *runtime* `<html>` attributes that islands set from localStorage and
+          that the SSR document does not carry. Without this, swapRootAttributes
+          copies the incoming server-rendered root's attributes over the live
+          root on every SPA swap and drops these — the sidebar flashes open
+          (`data-sidebar-hidden` lost) and the theme can revert
+          (`data-theme`). Listing them here makes the router re-apply their
+          current value within the same synchronous swap (before paint), which
+          retires the host-side flash workaround that zudolab/zudo-doc#2198
+          shipped and resolves zudolab/zudo-doc#2200. Must be the same list on
+          every page (read from the outgoing page's meta at swap time).
+
           Cast through `unknown` because ClientRouter() returns a readonly
           array of structural VNode objects — Preact's JSX typing does not
           directly accept that array shape, but at runtime the elements are
           valid VNode descriptors. */}
-        {ClientRouter() as unknown as JSX.Element}
+        {ClientRouter({
+          preserveHtmlAttrs: ["data-sidebar-hidden", "data-theme"],
+        }) as unknown as JSX.Element}
         {head}
       </head>
       <body class="min-h-screen antialiased">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,14 +30,14 @@ importers:
         specifier: 0.2.3
         version: 0.2.3(preact@10.29.2)
       '@takazudo/zfb':
-        specifier: 0.1.0-next.51
-        version: 0.1.0-next.51
+        specifier: 0.1.0-next.52
+        version: 0.1.0-next.52
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.51
-        version: 0.1.0-next.51
+        specifier: 0.1.0-next.52
+        version: 0.1.0-next.52
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.51
-        version: 0.1.0-next.51(@takazudo/zfb@0.1.0-next.51)
+        specifier: 0.1.0-next.52
+        version: 0.1.0-next.52(@takazudo/zfb@0.1.0-next.52)
       '@takazudo/zudo-doc':
         specifier: workspace:*
         version: link:packages/zudo-doc
@@ -266,11 +266,11 @@ importers:
         version: 4.0.3
     devDependencies:
       '@takazudo/zfb':
-        specifier: 0.1.0-next.51
-        version: 0.1.0-next.51
+        specifier: 0.1.0-next.52
+        version: 0.1.0-next.52
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.51
-        version: 0.1.0-next.51(@takazudo/zfb@0.1.0-next.51)
+        specifier: 0.1.0-next.52
+        version: 0.1.0-next.52(@takazudo/zfb@0.1.0-next.52)
       '@types/node':
         specifier: ^25.3.5
         version: 25.3.5
@@ -1353,44 +1353,44 @@ packages:
     peerDependencies:
       preact: ^10.29.1
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.51':
-    resolution: {integrity: sha512-wP5smQs1K0dL5LLzFR/74UaBxXXVlWA+T53mpiNGC6vcGMz/zdZYHqA5fTvDCmGyeKqVjApMOTg1MNhf32nrSA==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.52':
+    resolution: {integrity: sha512-Afh1eZ9r/lICuft+9jLFZeageL+n9JsX1g5b0gPZOUeg1LorQILA3B/PDmxtXvdGnNbgp1lYFZDDq+zlNLd/Jg==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.51':
-    resolution: {integrity: sha512-m/A81tg0tXEpsGd1opr8NSOA1HhMDonWuDvZgctRcKRmeBcSe2/YCpcfy0SKbzIYv9got1GB9OnfA6Wj175vRg==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.52':
+    resolution: {integrity: sha512-MHVlCzB3UIT56EcqCU//ymOAKcWzLcKoxYLMzpSPuD0CDk3BckLCnX6DbMSRtXTl/e7/plvzZCTRamizaOhVYw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.51':
-    resolution: {integrity: sha512-IlbEDu7mH/e3RGHJ4fI+hQQF+GyfSUwrQQKcnnq+WKQj3GwaSCds6dFN3fSTcpTrmBviKQOJ7nZxlFVMwpemWg==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.52':
+    resolution: {integrity: sha512-J308r5UhPZJ4jg294Wi9TcOZlXMksqFZa7BkIHfdH0Z64ECQSyRK2mnnQa8+nLcqDBK6V4e5DfODrX7c3J2+NQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.51':
-    resolution: {integrity: sha512-0zVftz3RECCCAcjFX6Cuv2OBP3C9qynPI4sjTTJz1IZKnqk3FxaPi0Tr6duaTH3IwrnrprGvvrh+5kMEnQlaRw==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.52':
+    resolution: {integrity: sha512-3aoVmJXtRgTWvUdYieZOrRJ2RD5r4NWSojIdeFtWVzBhurBClPpoE8vWksMMAa8yd8ikmuoWeH4f3sTCiG6mjg==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.51':
-    resolution: {integrity: sha512-RtaDvNoev7GynTW3q/ssfVGTyGS9pWn/QZCUewEK6o7+K7wNrTowDQmv8QWiplAsmAiUnlnlTTr1b2We1vyZgA==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.52':
+    resolution: {integrity: sha512-3eQnMOujVhD+OPcpdPldjGy23tFC2aqPBFOR66l2qsuDNSJJgVwT2YLHtCp8YHZn0byJkVpC+/DYSUzOTrkUYw==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.51':
-    resolution: {integrity: sha512-nmYm8xQyWLi6TeBpVGemW9n2wtsIvPpU3R2TCz8bbPNUDIJC5QPwgNfSXuME4Mtid2Bp/kFKRe5Mcbh5viumwA==}
+  '@takazudo/zfb-runtime@0.1.0-next.52':
+    resolution: {integrity: sha512-bJTCgDlLnREtFO3zJSrvKm3qEUKne3JIyDecFczacWM3Mo0SHAXxBWNbGg2LSNFjstE10aA0bL2eEC2RnK2ERA==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.51
+      '@takazudo/zfb': 0.1.0-next.52
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.51':
-    resolution: {integrity: sha512-+oj6NpmuDJMQuYFtGwICa1c4L/xdxqQx+VnVvK4JSCTXws+qwmM8D3ZAy4Tu8BUH+CYMUlfZePMeIvDCmqwiRQ==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.52':
+    resolution: {integrity: sha512-9u4wG+b2FRIuwmYSL7DrN9+5R5j580TJquGNuP8Y9+8eXpDcUfR1lHEo5YYmd6UphIHkEh0Be40QyyoMqMzdNw==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.51':
-    resolution: {integrity: sha512-H49e8yCWd/GXrLt85LvZpkwE4AjcFUxFNkOXSJOyPUtyEcQ/hSe8zqR9lJSRWADDDIJ6rd94WjcOoc4dWWECtQ==}
+  '@takazudo/zfb@0.1.0-next.52':
+    resolution: {integrity: sha512-bbBKIfJa++Gh/YOpQRjA6GzK1RCOq1BnDpkwvIlC1BIjgorR/fUChFaVb8CSAyjpA0RiAgQ9bfiXYYHq/Mlb7w==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
@@ -4049,35 +4049,35 @@ snapshots:
       culori: 4.0.2
       preact: 10.29.2
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.51': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.52': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.51':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.52':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.51':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.52':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.51':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.52':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.51':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.52':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.51(@takazudo/zfb@0.1.0-next.51)':
+  '@takazudo/zfb-runtime@0.1.0-next.52(@takazudo/zfb@0.1.0-next.52)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.51
+      '@takazudo/zfb': 0.1.0-next.52
       hono: 4.12.25
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.51':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.52':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.51':
+  '@takazudo/zfb@0.1.0-next.52':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.51
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.51
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.51
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.51
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.51
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.52
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.52
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.52
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.52
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.52
 
   '@takazudo/zudo-design-token-lint@1.0.0(patch_hash=6a157fd850449b055cf64a8a7dd1faed5b1da9eebe6c81cca08488ac0de85182)':
     dependencies:

--- a/src/components/desktop-sidebar-toggle.tsx
+++ b/src/components/desktop-sidebar-toggle.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useEffect, useRef } from 'preact/hooks';
-import { BEFORE_NAVIGATE_EVENT, AFTER_NAVIGATE_EVENT } from '@takazudo/zudo-doc/transitions';
 import { ChevronRight, ChevronLeft } from '@takazudo/zudo-doc/icons';
 
 export const SIDEBAR_STORAGE_KEY = 'zudo-doc-sidebar-visible';
@@ -22,85 +21,6 @@ function setDataAttribute(isVisible: boolean) {
     document.documentElement.setAttribute('data-sidebar-hidden', '');
   }
 }
-
-// SPA-navigation guard for the desktop sidebar's hidden-state (#2198).
-//
-// zfb's Strategy-B client router wipes EVERY <html> attribute during the body
-// swap (swapRootAttributes re-adds only NON_OVERRIDABLE_ZFB_ATTRS plus the
-// incoming SSR document's attributes), so the persisted `data-sidebar-hidden`
-// runtime value is lost on every navigation, and the pre-paint inline script
-// does not re-run on SPA hops. Left alone, the freshly-rendered sidebar paints
-// visible and then animates shut when the value is restored — the flash + slide.
-//
-// These listeners MUST live at module scope, NOT in the island's useEffect:
-// zfb-runtime (>= 0.1.0-next.51) calls unmountIslands() BEFORE the swap and
-// before firing AFTER_NAVIGATE_EVENT, so a useEffect-registered listener is torn
-// down (effect cleanup) before the swap and never sees the after-swap event —
-// the restore would never run (#2198 verification). Registering once on
-// `document` at bundle load — the same lifecycle-independent pattern as
-// client-router-bootstrap.tsx — keeps the guard alive across island
-// unmount/remount. SSR-safe: no-ops when `document` is undefined.
-//
-// Strategy: on BEFORE_NAVIGATE_EVENT, record whether the sidebar was hidden and
-// set a transient `data-sidebar-no-transition` marker (global.css zeroes the
-// sidebar/wrapper/band/toggle transitions). The swap then wipes BOTH the marker
-// and data-sidebar-hidden. On AFTER_NAVIGATE_EVENT (swap done → the live <html>
-// is no longer wiped) RE-SET the marker, then re-add data-sidebar-hidden in the
-// same synchronous batch, so the hidden geometry snaps in with transitions
-// suppressed (no slide, no open frame). Remove the marker on a double rAF
-// afterward so a later user toggle still animates.
-let spaNavGuardRegistered = false;
-function registerSidebarSpaNavGuard() {
-  if (typeof document === 'undefined' || spaNavGuardRegistered) return;
-  spaNavGuardRegistered = true;
-
-  let wasHidden = false;
-  let swapToken = 0;
-  // Long enough to outlast the View-Transition swap pipeline on slow
-  // machines/CI; short enough that an aborted nav self-heals quickly. Only a
-  // safety net for a nav that never reaches `restore` (aborted/superseded).
-  const STUCK_MARKER_FALLBACK_MS = 1500;
-
-  const capture = () => {
-    wasHidden = document.documentElement.hasAttribute('data-sidebar-hidden');
-    document.documentElement.setAttribute('data-sidebar-no-transition', '');
-    const token = ++swapToken;
-    window.setTimeout(() => {
-      if (token === swapToken) {
-        document.documentElement.removeAttribute('data-sidebar-no-transition');
-      }
-    }, STUCK_MARKER_FALLBACK_MS);
-  };
-
-  const restore = () => {
-    // Marker first, then the attribute, in one synchronous batch — so the
-    // hidden geometry is restored with transitions off (the swap already wiped
-    // the capture-time marker, so re-setting it here on the post-swap <html> is
-    // what actually suppresses the animation).
-    document.documentElement.setAttribute('data-sidebar-no-transition', '');
-    if (wasHidden) {
-      document.documentElement.setAttribute('data-sidebar-hidden', '');
-    }
-    // Drop the marker only after the restored state is committed. A single rAF
-    // can coincide with the restore's style recalc and animate it, so defer one
-    // extra frame. The token bump no-ops capture's safety-net for this swap.
-    const token = ++swapToken;
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        if (token === swapToken) {
-          document.documentElement.removeAttribute('data-sidebar-no-transition');
-        }
-      });
-    });
-  };
-
-  document.addEventListener(BEFORE_NAVIGATE_EVENT, capture);
-  document.addEventListener(AFTER_NAVIGATE_EVENT, restore);
-}
-
-// Register at module load (browser-only via the guard) so the listeners exist
-// before the first navigation and survive island unmount/remount.
-registerSidebarSpaNavGuard();
 
 export default function DesktopSidebarToggle() {
   // Initial state must match server render (always `true`) to avoid a
@@ -146,10 +66,14 @@ export default function DesktopSidebarToggle() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // The SPA-navigation flash guard (data-sidebar-hidden preservation +
-  // transition suppression) is NOT registered here. It must outlive this
-  // island's mount/unmount, so it lives at module scope — see
-  // registerSidebarSpaNavGuard() above. (#2198)
+  // The SPA-navigation flash (a collapsed sidebar briefly painting open on
+  // every soft swap, because swapRootAttributes wiped `data-sidebar-hidden`
+  // mid-swap) is now handled upstream: doc-layout mounts
+  // <ClientRouter preserveHtmlAttrs={["data-sidebar-hidden", ...]} /> so
+  // zfb-runtime (>= 0.1.0-next.52) re-applies the runtime attribute within
+  // the synchronous swap, before paint. The old host-side capture/restore +
+  // `data-sidebar-no-transition` guard (#2198) was retired in favour of that
+  // (zudolab/zudo-doc#2200).
 
   return (
     <button

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -782,19 +782,11 @@ pre[class^="syntect-"] .line .highlighted-word {
   }
 }
 
-/* Suppress sidebar geometry transitions during an SPA swap (#2198).
- * swapRootAttributes wipes data-sidebar-hidden mid-swap, so without this the
- * sidebar would animate open (attribute absent) and then animate shut again
- * when the toggle island restores the attribute on zfb:after-swap — a visible
- * flash + slide. The island sets data-sidebar-no-transition for the swap
- * window and removes it (double rAF) after restoring the hidden state, so the
- * wipe/restore apply instantly and a later user toggle still animates. */
-html[data-sidebar-no-transition] #desktop-sidebar,
-html[data-sidebar-no-transition] .zd-sidebar-content-wrapper,
-html[data-sidebar-no-transition] .zd-doc-content-band,
-html[data-sidebar-no-transition] .zd-desktop-sidebar-toggle {
-  transition: none !important;
-}
+/* The SPA-swap flash guard (`data-sidebar-no-transition`) was removed once
+ * doc-layout adopted <ClientRouter preserveHtmlAttrs={["data-sidebar-hidden",
+ * ...]} /> (zfb-runtime >= 0.1.0-next.52): the attribute now survives the swap
+ * before paint, so the sidebar never wipes-and-restores and no geometry
+ * transition fires mid-swap. Retires the #2198 workaround (zudolab/zudo-doc#2200). */
 
 /* ========================================
  * Image enlarge (.zd-enlargeable)


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2200

---

## Summary

Bumps the `@takazudo/zfb` stack `0.1.0-next.51` → `0.1.0-next.52` and adopts the new `ClientRouter({ preserveHtmlAttrs })` API (zfb#1104) so runtime `<html>` attributes that islands set from `localStorage` survive zfb's Strategy-B SPA soft-swaps.

`doc-layout` now mounts the router with `preserveHtmlAttrs: ["data-sidebar-hidden", "data-theme"]`. zfb-runtime re-applies those attributes within the synchronous swap (before paint), so the collapsed sidebar never wipes-and-restores. This **retires the host-side sidebar flash workaround** shipped in #2198 and resolves the upstream-tracking issue #2200 (closed).

## Changes

- **deps / pin parity:** `zfb`, `zfb-runtime`, `zfb-adapter-cloudflare` → `next.52` across root `package.json`, `packages/zudo-doc/package.json` (dev exact + peer `^`), and the `create-zudo-doc` scaffold pins; refreshed lockfile (zfb-only diff). `check:pin-parity` green.
- **adopt preserveHtmlAttrs:** `packages/zudo-doc/src/doclayout/doc-layout.tsx` mounts `ClientRouter({ preserveHtmlAttrs: ["data-sidebar-hidden", "data-theme"] })` (emitted as `<meta name="zfb-preserve-html-attrs">` on every page).
- **retire #2198 workaround (host + create-zudo-doc template):** removed the module-scope SPA-nav capture/restore guard from `desktop-sidebar-toggle.tsx` (kept state persistence) and the now-dead `html[data-sidebar-no-transition]` rule from `global.css`.
- **e2e:** rewrote `e2e/sidebar-spa-nav-flash.spec.ts` to assert the new invariant — `data-sidebar-hidden` present on every painted frame of the swap (never wiped), the sidebar never paints open, and the `zfb-preserve-html-attrs` meta is wired.
- **tests:** bumped `scaffold.test.ts` pin assertions to next.52 and rewrote the sidebar-toggle template test to assert the guard is gone.

## Test Plan

- `pnpm check` ✓ · `pnpm b4push` automated steps ✓ (build / link check / HTML validation / preview smoke)
- `check:pin-parity` ✓ · `check:template-drift` ✓
- e2e **sidebar + theme** suites ✓ (12/12), incl. the rewritten flash regression and "theme persists across View Transition navigation"
- Verified built `dist/`: preserve meta on all 287 pages, `data-sidebar-no-transition` absent
- Two independent Opus reviews (codex fell back): approved, no high/medium findings

> Note: `@takazudo/zudo-doc` is published lockstep — a `create-zudo-doc` release (`/l-make-release`) follows this merge so generated projects pick up the new shell + pins.