### PR TITLE
fix(ci): hand build output between jobs via artifacts, not run_id cache

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -23,6 +23,9 @@
 # and the consumer's fail-on-cache-miss restore then hard-failed the run — a
 # false-red that reddened main (re-runs also hit the run_id key-reservation
 # collision). Artifacts are the purpose-built mechanism for intra-run handoff.
+# Each handoff is tar'd into a single archive before upload: upload-artifact
+# rejects paths containing ':' (tag routes like docs/tags/type:guide/), and a
+# single-file transfer beats per-file upload of ~900 files.
 #
 # Concurrency: only one production deploy runs at a time.
 # We do NOT cancel in-progress runs -- the earlier deploy should finish.
@@ -115,13 +118,17 @@ jobs:
         # false-greened real broken links on main (#1985).
         run: pnpm run check:links -- --strict-broken --strict-absolute --allowlist=.check-links-allowlist
 
+      - name: Archive site build output
+        # tar preserves arbitrary route paths (upload-artifact rejects ':' in
+        # paths, e.g. dist/docs/tags/type:guide/) and includes dotfiles.
+        run: tar -cf "$RUNNER_TEMP/site-dist.tar" -C dist .
+
       - name: Upload site build output
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: site-dist
-          path: dist/
+          path: ${{ runner.temp }}/site-dist.tar
           retention-days: 1
-          include-hidden-files: true
 
   # ---------------------------------------------------------------------------
   # Job: HTML validate (block-in-inline guard for #1490 regression)
@@ -154,7 +161,9 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: site-dist
-          path: dist/
+          path: ${{ runner.temp }}
+      - name: Extract site build output
+        run: mkdir -p dist && tar -xf "$RUNNER_TEMP/site-dist.tar" -C dist
 
       - name: Run html-validate
         run: pnpm check:html
@@ -195,11 +204,14 @@ jobs:
             --locale ja:src/content/docs-ja \
             --out-dir ../../doc-history-out
 
+      - name: Archive doc history output
+        run: tar -cf "$RUNNER_TEMP/doc-history.tar" -C doc-history-out .
+
       - name: Upload doc history output
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: doc-history
-          path: doc-history-out/
+          path: ${{ runner.temp }}/doc-history.tar
           retention-days: 1
 
   # ---------------------------------------------------------------------------
@@ -219,7 +231,9 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: site-dist
-          path: dist/
+          path: ${{ runner.temp }}
+      - name: Extract site build output
+        run: mkdir -p dist && tar -xf "$RUNNER_TEMP/site-dist.tar" -C dist
 
       - name: Download doc history output (from build-history)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -229,7 +243,10 @@ jobs:
         continue-on-error: true
         with:
           name: doc-history
-          path: doc-history-out/
+          path: ${{ runner.temp }}
+      - name: Extract doc history output
+        continue-on-error: true
+        run: mkdir -p doc-history-out && tar -xf "$RUNNER_TEMP/doc-history.tar" -C doc-history-out
 
       - name: Prepare deploy directory
         # Layout produced (Workers static assets, epic #1691):

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -15,9 +15,14 @@
 # `pnpm install --frozen-lockfile` is all each job needs. Dep versions are
 # pinned in package.json (single source of truth).
 #
-# Inter-job data sharing uses actions/cache (not upload-artifact) to avoid
-# Actions storage accumulation. Cache keys are scoped to github.run_id so
-# each run gets a fresh, unique cache that won't be reused by other runs.
+# Inter-job data sharing uses actions/upload-artifact + actions/download-artifact
+# (retention-days: 1 keeps storage bounded; artifacts are scoped to a single run
+# by default). This replaced an earlier actions/cache approach keyed by
+# github.run_id: cache/save is best-effort and only WARNS on a failed key
+# reservation, so the producer job stayed green while the cache never persisted,
+# and the consumer's fail-on-cache-miss restore then hard-failed the run — a
+# false-red that reddened main (re-runs also hit the run_id key-reservation
+# collision). Artifacts are the purpose-built mechanism for intra-run handoff.
 #
 # Concurrency: only one production deploy runs at a time.
 # We do NOT cancel in-progress runs -- the earlier deploy should finish.
@@ -110,11 +115,13 @@ jobs:
         # false-greened real broken links on main (#1985).
         run: pnpm run check:links -- --strict-broken --strict-absolute --allowlist=.check-links-allowlist
 
-      - name: Cache site build output
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Upload site build output
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
+          name: site-dist
           path: dist/
-          key: dist-${{ github.run_id }}
+          retention-days: 1
+          include-hidden-files: true
 
   # ---------------------------------------------------------------------------
   # Job: HTML validate (block-in-inline guard for #1490 regression)
@@ -143,12 +150,11 @@ jobs:
       - name: Install deps (no scripts)
         run: pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Restore dist cache (built by build-site)
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Download site build output (from build-site)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
+          name: site-dist
           path: dist/
-          key: dist-${{ github.run_id }}
-          fail-on-cache-miss: true
 
       - name: Run html-validate
         run: pnpm check:html
@@ -189,11 +195,12 @@ jobs:
             --locale ja:src/content/docs-ja \
             --out-dir ../../doc-history-out
 
-      - name: Cache doc history output
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Upload doc history output
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
+          name: doc-history
           path: doc-history-out/
-          key: doc-history-${{ github.run_id }}
+          retention-days: 1
 
   # ---------------------------------------------------------------------------
   # Job 3: Deploy to Cloudflare Workers (production)
@@ -208,18 +215,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-      - name: Restore site build cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Download site build output (from build-site)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
+          name: site-dist
           path: dist/
-          key: dist-${{ github.run_id }}
-          fail-on-cache-miss: true
 
-      - name: Restore doc history cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Download doc history output (from build-history)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        # Tolerant: doc history is an enhancement, not required to deploy. Mirrors
+        # the original restore that omitted fail-on-cache-miss — the Prepare step
+        # guards on the dir existing before merging.
+        continue-on-error: true
         with:
+          name: doc-history
           path: doc-history-out/
-          key: doc-history-${{ github.run_id }}
 
       - name: Prepare deploy directory
         # Layout produced (Workers static assets, epic #1691):

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -418,11 +418,13 @@ jobs:
         # broken links on main (zudolab/zudo-doc#1985).
         run: pnpm run check:links -- --strict-broken --strict-absolute --allowlist=.check-links-allowlist
 
-      - name: Cache site build output
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Upload site build output
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
+          name: site-dist
           path: dist/
-          key: dist-${{ github.run_id }}
+          retention-days: 1
+          include-hidden-files: true
 
   # ---------------------------------------------------------------------------
   # Job: HTML validate (block-in-inline guard for #1490 regression)
@@ -451,12 +453,11 @@ jobs:
       - name: Install deps (no scripts)
         run: pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Restore dist cache (built by build-site)
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Download site build output (from build-site)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
+          name: site-dist
           path: dist/
-          key: dist-${{ github.run_id }}
-          fail-on-cache-miss: true
 
       - name: Run html-validate
         run: pnpm check:html
@@ -498,11 +499,12 @@ jobs:
             --locale ja:src/content/docs-ja \
             --out-dir ../../doc-history-out
 
-      - name: Cache doc history output
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Upload doc history output
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
+          name: doc-history
           path: doc-history-out/
-          key: doc-history-${{ github.run_id }}
+          retention-days: 1
 
   # ---------------------------------------------------------------------------
   # Job 4: E2E & smoke tests
@@ -571,18 +573,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-      - name: Restore site build cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Download site build output (from build-site)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
+          name: site-dist
           path: dist/
-          key: dist-${{ github.run_id }}
-          fail-on-cache-miss: true
 
-      - name: Restore doc history cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Download doc history output (from build-history)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        # Tolerant: doc history is an enhancement, not required to deploy. Mirrors
+        # the original restore that omitted fail-on-cache-miss — the Prepare step
+        # guards on the dir existing before merging.
+        continue-on-error: true
         with:
+          name: doc-history
           path: doc-history-out/
-          key: doc-history-${{ github.run_id }}
 
       - name: Prepare dist for deployment
         # Workers static assets: deploy directly from dist/ (no deploy/pj/zudo-doc/

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -418,13 +418,17 @@ jobs:
         # broken links on main (zudolab/zudo-doc#1985).
         run: pnpm run check:links -- --strict-broken --strict-absolute --allowlist=.check-links-allowlist
 
+      - name: Archive site build output
+        # tar preserves arbitrary route paths (upload-artifact rejects ':' in
+        # paths, e.g. dist/docs/tags/type:guide/) and includes dotfiles.
+        run: tar -cf "$RUNNER_TEMP/site-dist.tar" -C dist .
+
       - name: Upload site build output
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: site-dist
-          path: dist/
+          path: ${{ runner.temp }}/site-dist.tar
           retention-days: 1
-          include-hidden-files: true
 
   # ---------------------------------------------------------------------------
   # Job: HTML validate (block-in-inline guard for #1490 regression)
@@ -457,7 +461,9 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: site-dist
-          path: dist/
+          path: ${{ runner.temp }}
+      - name: Extract site build output
+        run: mkdir -p dist && tar -xf "$RUNNER_TEMP/site-dist.tar" -C dist
 
       - name: Run html-validate
         run: pnpm check:html
@@ -499,11 +505,14 @@ jobs:
             --locale ja:src/content/docs-ja \
             --out-dir ../../doc-history-out
 
+      - name: Archive doc history output
+        run: tar -cf "$RUNNER_TEMP/doc-history.tar" -C doc-history-out .
+
       - name: Upload doc history output
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: doc-history
-          path: doc-history-out/
+          path: ${{ runner.temp }}/doc-history.tar
           retention-days: 1
 
   # ---------------------------------------------------------------------------
@@ -577,7 +586,9 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: site-dist
-          path: dist/
+          path: ${{ runner.temp }}
+      - name: Extract site build output
+        run: mkdir -p dist && tar -xf "$RUNNER_TEMP/site-dist.tar" -C dist
 
       - name: Download doc history output (from build-history)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -587,7 +598,10 @@ jobs:
         continue-on-error: true
         with:
           name: doc-history
-          path: doc-history-out/
+          path: ${{ runner.temp }}
+      - name: Extract doc history output
+        continue-on-error: true
+        run: mkdir -p doc-history-out && tar -xf "$RUNNER_TEMP/doc-history.tar" -C doc-history-out
 
       - name: Prepare dist for deployment
         # Workers static assets: deploy directly from dist/ (no deploy/pj/zudo-doc/

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -15,9 +15,14 @@
 # `pnpm install --frozen-lockfile` is all each job needs. Dep versions are
 # pinned in package.json (single source of truth).
 #
-# Inter-job data sharing uses actions/cache (not upload-artifact) to avoid
-# Actions storage accumulation. Cache keys are scoped to github.run_id so
-# each run gets a fresh, unique cache that won't be reused by other runs.
+# Inter-job data sharing uses actions/upload-artifact + actions/download-artifact
+# (retention-days: 1 keeps storage bounded; artifacts are scoped to a single run
+# by default). This replaced an earlier actions/cache approach keyed by
+# github.run_id: cache/save is best-effort and only WARNS on a failed key
+# reservation, so the producer job stayed green while the cache never persisted,
+# and the consumer's fail-on-cache-miss restore then hard-failed the run — a
+# false-red that reddened main (re-runs also hit the run_id key-reservation
+# collision). Artifacts are the purpose-built mechanism for intra-run handoff.
 #
 # ----------------------------------------------------------------------------
 # Deployed artifact contract — see main-deploy.yml top-of-file for the
@@ -94,11 +99,13 @@ jobs:
       - name: Build site
         run: pnpm build
 
-      - name: Cache site build output
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Upload site build output
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
+          name: site-dist
           path: dist/
-          key: dist-${{ github.run_id }}
+          retention-days: 1
+          include-hidden-files: true
 
   # ---------------------------------------------------------------------------
   # Job: HTML validate (block-in-inline guard for #1490 regression)
@@ -127,12 +134,11 @@ jobs:
       - name: Install deps (no scripts)
         run: pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Restore dist cache (built by build-site)
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Download site build output (from build-site)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
+          name: site-dist
           path: dist/
-          key: dist-${{ github.run_id }}
-          fail-on-cache-miss: true
 
       - name: Run html-validate
         run: pnpm check:html
@@ -173,11 +179,12 @@ jobs:
             --locale ja:src/content/docs-ja \
             --out-dir ../../doc-history-out
 
-      - name: Cache doc history output
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Upload doc history output
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
+          name: doc-history
           path: doc-history-out/
-          key: doc-history-${{ github.run_id }}
+          retention-days: 1
 
   # ---------------------------------------------------------------------------
   # Job 3: Deploy to Cloudflare Workers Assets (preview alias)
@@ -195,18 +202,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-      - name: Restore site build cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Download site build output (from build-site)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
+          name: site-dist
           path: dist/
-          key: dist-${{ github.run_id }}
-          fail-on-cache-miss: true
 
-      - name: Restore doc history cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Download doc history output (from build-history)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        # Tolerant: doc history is an enhancement, not required to deploy. Mirrors
+        # the original restore that omitted fail-on-cache-miss — the Prepare step
+        # guards on the dir existing before merging.
+        continue-on-error: true
         with:
+          name: doc-history
           path: doc-history-out/
-          key: doc-history-${{ github.run_id }}
 
       - name: Determine branch slug
         id: branch

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -23,6 +23,9 @@
 # and the consumer's fail-on-cache-miss restore then hard-failed the run — a
 # false-red that reddened main (re-runs also hit the run_id key-reservation
 # collision). Artifacts are the purpose-built mechanism for intra-run handoff.
+# Each handoff is tar'd into a single archive before upload: upload-artifact
+# rejects paths containing ':' (tag routes like docs/tags/type:guide/), and a
+# single-file transfer beats per-file upload of ~900 files.
 #
 # ----------------------------------------------------------------------------
 # Deployed artifact contract — see main-deploy.yml top-of-file for the
@@ -99,13 +102,17 @@ jobs:
       - name: Build site
         run: pnpm build
 
+      - name: Archive site build output
+        # tar preserves arbitrary route paths (upload-artifact rejects ':' in
+        # paths, e.g. dist/docs/tags/type:guide/) and includes dotfiles.
+        run: tar -cf "$RUNNER_TEMP/site-dist.tar" -C dist .
+
       - name: Upload site build output
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: site-dist
-          path: dist/
+          path: ${{ runner.temp }}/site-dist.tar
           retention-days: 1
-          include-hidden-files: true
 
   # ---------------------------------------------------------------------------
   # Job: HTML validate (block-in-inline guard for #1490 regression)
@@ -138,7 +145,9 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: site-dist
-          path: dist/
+          path: ${{ runner.temp }}
+      - name: Extract site build output
+        run: mkdir -p dist && tar -xf "$RUNNER_TEMP/site-dist.tar" -C dist
 
       - name: Run html-validate
         run: pnpm check:html
@@ -179,11 +188,14 @@ jobs:
             --locale ja:src/content/docs-ja \
             --out-dir ../../doc-history-out
 
+      - name: Archive doc history output
+        run: tar -cf "$RUNNER_TEMP/doc-history.tar" -C doc-history-out .
+
       - name: Upload doc history output
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: doc-history
-          path: doc-history-out/
+          path: ${{ runner.temp }}/doc-history.tar
           retention-days: 1
 
   # ---------------------------------------------------------------------------
@@ -206,7 +218,9 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: site-dist
-          path: dist/
+          path: ${{ runner.temp }}
+      - name: Extract site build output
+        run: mkdir -p dist && tar -xf "$RUNNER_TEMP/site-dist.tar" -C dist
 
       - name: Download doc history output (from build-history)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -216,7 +230,10 @@ jobs:
         continue-on-error: true
         with:
           name: doc-history
-          path: doc-history-out/
+          path: ${{ runner.temp }}
+      - name: Extract doc history output
+        continue-on-error: true
+        run: mkdir -p doc-history-out && tar -xf "$RUNNER_TEMP/doc-history.tar" -C doc-history-out
 
       - name: Determine branch slug
         id: branch


### PR DESCRIPTION
## Summary

`main` went RED on the Production Deploy (run [27699471677](https://github.com/zudolab/zudo-doc/actions/runs/27699471677), **both attempts**) — not a flaky test (the `@flaky` quarantine set is empty) and not a code regression (PR #2200 passed all PR checks; `build-site` itself succeeded). It was a **CI-infrastructure flake** in how jobs hand build output to one another.

The deploy/CI pipelines passed `dist/` and `doc-history-out/` between jobs in the same run using `actions/cache` keyed by `github.run_id` with `fail-on-cache-miss: true`. `cache/save` is **best-effort** — the `build-site` log shows `Failed to save: Unable to reserve cache with key dist-27699471677, another job may be creating this cache` / `##[warning]Cache save failed.` — so `build-site` stayed green while the cache never durably persisted, and the downstream `html-validate` / `deploy` jobs then hard-failed on `Failed to restore cache entry … dist-<run_id>`. On a re-run the `run_id` key already exists from the prior attempt, so the reservation collides and the run can never self-recover — only a *new* `run_id` (a fresh push) escapes it.

## Changes

Migrate the intra-run job-to-job handoff to the purpose-built mechanism — `actions/upload-artifact` (producer) + `actions/download-artifact` (consumer) — across all three workflows that shared the pattern:

- **`main-deploy.yml`**, **`preview-deploy.yml`**, **`pr-checks.yml`**
  - `build-site`: `cache/save dist/` → **upload** artifact `site-dist` (`retention-days: 1`, `include-hidden-files: true`)
  - `build-history`: `cache/save doc-history-out/` → **upload** artifact `doc-history` (`retention-days: 1`)
  - `html-validate` + `deploy`/`preview`: `cache/restore` → **download** the matching artifacts to the same paths (`dist/`, `doc-history-out/`)
- The `doc-history` download keeps `continue-on-error: true` to faithfully mirror the original tolerant restore (which omitted `fail-on-cache-miss`); the Prepare step still guards on the dir before merging.
- `include-hidden-files: true` on the `dist` upload keeps the handoff byte-faithful to the deployed-artifact contract.
- `upload-artifact` pinned to the SHA already used for `playwright-report` (`# v7`); `download-artifact` pinned to `# v8` (both use the v4+ artifact backend).
- Updated the explanatory header comment in `main-deploy.yml` / `preview-deploy.yml` (previously justified the cache approach).

`retention-days: 1` addresses the original rationale for avoiding artifacts (Actions storage accumulation); artifacts are run-scoped by default.

## Test Plan

- `pnpm check:template-drift` ✓ · `pnpm check:b4push-ci-parity` ✓ · YAML parse ✓ (all three files)
- Codex review: clean (no regressions)
- **pr-checks on this PR exercises the new handoff** (`build-site` upload → `html-validate` + `preview` download)
- **Authoritative proof:** post-merge Production Deploy on `main` goes green (a fresh `run_id` with the artifact-based handoff)