### PR TITLE
docs(allowlist): reconcile stale desktop-sidebar-toggle prose (#2209)

### DIFF
--- a/.template-drift-allowlist
+++ b/.template-drift-allowlist
@@ -101,11 +101,22 @@ src/config/design-token-panel-config.ts
 src/lib/design-token-panel-bootstrap.ts
 src/utils/design-token-types.ts
 
-# W4A (#1732) — desktop-sidebar-toggle.tsx no longer drifts. Now that
-# @takazudo/zudo-doc is published and pinned in the generated package.json,
-# the template imports BEFORE_NAVIGATE_EVENT / AFTER_NAVIGATE_EVENT from
-# @takazudo/zudo-doc/transitions directly (was: inlined literals). Allowlist
-# entry removed; the file is now byte-identical between template and host.
+# W4A (#1732) — desktop-sidebar-toggle.tsx was briefly de-allowlisted here.
+# At the time, @takazudo/zudo-doc had just been published and pinned in the
+# generated package.json, so the single template copy imported
+# BEFORE_NAVIGATE_EVENT / AFTER_NAVIGATE_EVENT from @takazudo/zudo-doc/transitions
+# directly (was: inlined literals) and matched the host byte-for-byte, so the
+# entry was removed.
+#
+# SUPERSEDED by W6A (#1734; reconciled in #2209): the base template now ships a
+# no-op stub (templates/base/src/components/desktop-sidebar-toggle.tsx returns
+# null) while the host ships the real island (imports ChevronRight / ChevronLeft
+# from @takazudo/zudo-doc/icons), and the real implementation moved into the
+# sidebarToggle feature overlay (templates/features/sidebarToggle/, which inlines
+# its own chevron SVG). The drift-checked pair — base stub vs host — legitimately
+# differs again, so the entry is RE-allowlisted in the W6A block below (search:
+# src/components/desktop-sidebar-toggle.tsx). The "byte-identical / entry removed"
+# claim above describes the short-lived W4A state only and no longer holds today.
 
 # W3A (#1729 / generator-pages-migration Wave 3) — header-right-items moved into
 # @takazudo/zudo-doc/header for production. The host (this repo) imports
@@ -144,8 +155,10 @@ src/config/settings-types.ts
 # but the bundle shipped zero client-router code, so every internal link was
 # a full page reload). It now ships the REAL bootstrap, byte-identical to the
 # host src/components/client-router-bootstrap.tsx, so the drift checker
-# enforces parity going forward — same rationale as the W4A
-# desktop-sidebar-toggle de-allowlisting above.
+# enforces parity going forward — same principle the W4A block describes
+# (de-allowlist once the template matches the host byte-for-byte). Unlike
+# desktop-sidebar-toggle (which W6A later re-allowlisted, see above),
+# client-router-bootstrap has stayed byte-identical and remains de-allowlisted.
 #
 # design-token-panel-bootstrap.tsx stub was REMOVED from this list (#2162):
 # the base stub (a no-op that never carried "use client") was deleted as part


### PR DESCRIPTION
## Summary

Fixes #2209 — reconciles the contradictory prose in `.template-drift-allowlist` around `desktop-sidebar-toggle.tsx`.

The **W4A block** (lines ~104-108) claimed the allowlist entry was *removed* and the file was *byte-identical* between template and host. That state was short-lived: **W6A (#1734)** reintroduced a base **no-op stub** while the host kept the real island, so the entry is re-listed in the W6A block and the two drift-checked paths legitimately differ again. The W4A prose even described a `transitions` navigate-event import that no longer exists in any of the three files.

### What changed (comment-only)

- **Rewrote the W4A block** to record that W6A superseded it: base ships a no-op stub returning `null`; the host ships the real island importing `ChevronRight`/`ChevronLeft` from `@takazudo/zudo-doc/icons`; the real implementation moved into the `sidebarToggle` feature overlay (which inlines its own chevron `<svg>`). Dropped the misleading "byte-identical / entry removed" claim.
- **Fixed the client-router-bootstrap cross-reference** so it no longer cites the now-reversed desktop-sidebar-toggle de-allowlisting as a standing example — it now references the underlying principle and notes the W6A reversal.

### Verification

- Verified against actual file states: host (`@takazudo/zudo-doc/icons`), base stub (`return null`), feature overlay (inline `<svg>`, no icons import).
- **Live path entries untouched** — `pnpm check:template-drift` is green before and after.

### Note on the other recent issue

#2210 (CI flaky cache miss) was **already resolved** by the merged `topic/ci-artifact-handoff` work (PR #2211, on `main`), which switched the cross-job `dist-` cache to `upload-artifact`/`download-artifact` — durable fix #1 from that issue's own diagnosis. Closing it separately; no code needed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y4owDxPHxFAUAVrC51LuHA)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784305098&installation_id=130359969&pr_number=2212&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2212&signature=229d70bfd0d18972762e2b0f41a5f571a94849b475d25a46d4664e12b71fa1da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->