### PR TITLE
fix(header): highlight nav item by big category, not just URL path

### DIFF
--- a/packages/create-zudo-doc/templates/base/pages/lib/_header-with-defaults.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_header-with-defaults.tsx
@@ -311,6 +311,7 @@ export function HeaderWithDefaults(
       lang={lang}
       currentPath={currentPath}
       currentVersion={currentVersion}
+      activeCategory={navSection}
       sidebarToggle={sidebarToggle}
       themeToggle={themeToggle}
       search={searchWidget}

--- a/packages/zudo-doc/src/header/__tests__/nav-active.test.ts
+++ b/packages/zudo-doc/src/header/__tests__/nav-active.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   computeActiveNavPath,
   isNavItemActive,
+  isNavItemActiveByCategory,
   pathForMatch,
   type NavItemLike,
 } from "../nav-active.js";
@@ -119,5 +120,59 @@ describe("isNavItemActive", () => {
     const flat: NavItemLike = { path: "/blog/" };
     expect(isNavItemActive(flat, "/blog/")).toBe(true);
     expect(isNavItemActive(flat, "/docs/")).toBe(false);
+  });
+});
+
+describe("isNavItemActiveByCategory", () => {
+  const gettingStarted: NavItemLike = {
+    path: "/docs/getting-started",
+    categoryMatch: "getting-started",
+  };
+  const learn: NavItemLike = {
+    path: "/docs/guides",
+    categoryMatch: "guides",
+    children: [
+      { path: "/docs/guides", categoryMatch: "guides" },
+      { path: "/docs/components", categoryMatch: "components" },
+      { path: "/docs/markdown-features", categoryMatch: "markdown-features" },
+    ],
+  };
+
+  it("matches when the item's own categoryMatch equals the active category", () => {
+    // The reported bug: a sub-page under "Getting Started" (e.g.
+    // /docs/getting-started/installation) must light up the top-level item.
+    expect(isNavItemActiveByCategory(gettingStarted, "getting-started")).toBe(
+      true,
+    );
+  });
+
+  it("matches a parent when one of its children claims the active category", () => {
+    expect(isNavItemActiveByCategory(learn, "components")).toBe(true);
+    expect(isNavItemActiveByCategory(learn, "markdown-features")).toBe(true);
+    expect(isNavItemActiveByCategory(learn, "guides")).toBe(true);
+  });
+
+  it("returns false when no category matches", () => {
+    expect(isNavItemActiveByCategory(gettingStarted, "guides")).toBe(false);
+    expect(isNavItemActiveByCategory(learn, "reference")).toBe(false);
+  });
+
+  it("returns false when the active category is undefined", () => {
+    expect(isNavItemActiveByCategory(gettingStarted, undefined)).toBe(false);
+    expect(isNavItemActiveByCategory(learn, undefined)).toBe(false);
+  });
+
+  it("does not match an item that carries no categoryMatch", () => {
+    const bare: NavItemLike = { path: "/docs/reference" };
+    expect(isNavItemActiveByCategory(bare, "reference")).toBe(false);
+  });
+
+  it("collapses to a single comparison for a child entry (no children)", () => {
+    const child: NavItemLike = {
+      path: "/docs/components",
+      categoryMatch: "components",
+    };
+    expect(isNavItemActiveByCategory(child, "components")).toBe(true);
+    expect(isNavItemActiveByCategory(child, "guides")).toBe(false);
   });
 });

--- a/packages/zudo-doc/src/header/header.tsx
+++ b/packages/zudo-doc/src/header/header.tsx
@@ -41,6 +41,7 @@ import type { ComponentChildren, JSX, VNode } from "preact";
 import {
   computeActiveNavPath,
   isNavItemActive,
+  isNavItemActiveByCategory,
   pathForMatch,
 } from "./nav-active.js";
 import { NAV_OVERFLOW_SCRIPT } from "./nav-overflow-script.js";
@@ -89,6 +90,16 @@ export interface HeaderProps {
   currentPath?: string;
   /** Optional active version slug. Forwarded into `navHref` for nav links. */
   currentVersion?: string;
+
+  /**
+   * The page's resolved "big category" (the host's nav section — see
+   * `getNavSectionForSlug`). When supplied, the header highlights the
+   * nav item whose `categoryMatch` (or a child's) equals this value,
+   * which is the authoritative "page is under this category" signal.
+   * Falls back to URL-path matching when omitted (home, 404, tag, and
+   * version pages carry no section).
+   */
+  activeCategory?: string;
 
   /**
    * Children projected into the mobile `<SidebarToggle>` island —
@@ -229,6 +240,7 @@ export function Header(props: HeaderProps): JSX.Element {
     lang,
     currentPath = "",
     currentVersion,
+    activeCategory,
     sidebarSlot,
     sidebarToggle,
     themeToggle,
@@ -308,6 +320,7 @@ export function Header(props: HeaderProps): JSX.Element {
         {headerNav.map((item) => renderNavItem(
           item,
           activeNavPath,
+          activeCategory,
           lang,
           currentVersion,
           urlHelpers,
@@ -372,12 +385,17 @@ function SidebarSlotFallback({
 function renderNavItem(
   item: HeaderNavItem,
   activeNavPath: string | undefined,
+  activeCategory: string | undefined,
   lang: Locale | undefined,
   currentVersion: string | undefined,
   urlHelpers: HeaderUrlHelpers,
   i18n: HeaderI18n,
 ): VNode {
-  const isActive = isNavItemActive(item, activeNavPath);
+  // Prefer category matching (the page's resolved big category) and fall
+  // back to URL-path matching when the host supplies no `activeCategory`.
+  const isActive =
+    isNavItemActiveByCategory(item, activeCategory) ||
+    isNavItemActive(item, activeNavPath);
   const href = urlHelpers.navHref(item.path, lang, currentVersion);
   const label = item.labelKey ? i18n.t(item.labelKey, lang) : item.label;
 
@@ -426,7 +444,9 @@ function renderNavItem(
               const childLabel = child.labelKey
                 ? i18n.t(child.labelKey, lang)
                 : child.label;
-              const childActive = activeNavPath === child.path;
+              const childActive =
+                isNavItemActiveByCategory(child, activeCategory) ||
+                activeNavPath === child.path;
               return (
                 <a
                   href={childHref}

--- a/packages/zudo-doc/src/header/header.tsx
+++ b/packages/zudo-doc/src/header/header.tsx
@@ -391,8 +391,10 @@ function renderNavItem(
   urlHelpers: HeaderUrlHelpers,
   i18n: HeaderI18n,
 ): VNode {
-  // Prefer category matching (the page's resolved big category) and fall
-  // back to URL-path matching when the host supplies no `activeCategory`.
+  // Category matching (the page's resolved big category) is the primary
+  // signal; URL-path matching stays as a secondary fallback so items that
+  // declare no `categoryMatch`, and pages with no resolved section (home,
+  // 404, tag, version), still highlight as they did before.
   const isActive =
     isNavItemActiveByCategory(item, activeCategory) ||
     isNavItemActive(item, activeNavPath);

--- a/packages/zudo-doc/src/header/nav-active.ts
+++ b/packages/zudo-doc/src/header/nav-active.ts
@@ -112,15 +112,10 @@ export function isNavItemActiveByCategory(
   activeCategory: string | undefined,
 ): boolean {
   if (activeCategory == null) return false;
-  if (item.categoryMatch != null && item.categoryMatch === activeCategory) {
-    return true;
-  }
-  if (
-    item.children?.some(
-      (child) =>
-        child.categoryMatch != null && child.categoryMatch === activeCategory,
-    )
-  ) {
+  // `activeCategory` is non-null here, so a plain `===` already rejects an
+  // entry whose `categoryMatch` is undefined — no extra null guard needed.
+  if (item.categoryMatch === activeCategory) return true;
+  if (item.children?.some((child) => child.categoryMatch === activeCategory)) {
     return true;
   }
   return false;

--- a/packages/zudo-doc/src/header/nav-active.ts
+++ b/packages/zudo-doc/src/header/nav-active.ts
@@ -8,7 +8,14 @@
 /** Minimal shape the active-path resolver needs from a header nav item. */
 export interface NavItemLike {
   path: string;
-  children?: { path: string }[];
+  /**
+   * The "big category" this nav entry claims (mirrors the host's
+   * `getNavSectionForSlug` / sidebar `categoryMatch`). When the host knows
+   * which category the current page belongs to, category matching is
+   * preferred over URL-path heuristics — see `isNavItemActiveByCategory`.
+   */
+  categoryMatch?: string;
+  children?: { path: string; categoryMatch?: string }[];
 }
 
 /**
@@ -80,5 +87,41 @@ export function isNavItemActive(
 ): boolean {
   if (activeNavPath === item.path) return true;
   if (item.children?.some((child) => activeNavPath === child.path)) return true;
+  return false;
+}
+
+/**
+ * Category-based active-state predicate. A nav entry is active when its
+ * own `categoryMatch` equals the page's resolved big category
+ * (`activeCategory`), or when any of its children claim that category.
+ *
+ * This is the authoritative "is the page under this big category?" check
+ * — it mirrors how the sidebar scopes its tree (`getNavSectionForSlug`),
+ * so the header highlight stays correct even when a category's page URLs
+ * do not share a prefix with the nav item's `path` (the case the older
+ * path-only heuristic missed). Callers prefer this over `isNavItemActive`
+ * and fall back to path matching when `activeCategory` is absent (e.g.
+ * home, 404, tag, and version pages, which carry no nav section).
+ *
+ * Works for both top-level items and child items: a child has no
+ * `children` of its own, so the call collapses to a single
+ * `categoryMatch` comparison.
+ */
+export function isNavItemActiveByCategory(
+  item: NavItemLike,
+  activeCategory: string | undefined,
+): boolean {
+  if (activeCategory == null) return false;
+  if (item.categoryMatch != null && item.categoryMatch === activeCategory) {
+    return true;
+  }
+  if (
+    item.children?.some(
+      (child) =>
+        child.categoryMatch != null && child.categoryMatch === activeCategory,
+    )
+  ) {
+    return true;
+  }
   return false;
 }

--- a/pages/lib/_header-with-defaults.tsx
+++ b/pages/lib/_header-with-defaults.tsx
@@ -311,6 +311,7 @@ export function HeaderWithDefaults(
       lang={lang}
       currentPath={currentPath}
       currentVersion={currentVersion}
+      activeCategory={navSection}
       sidebarToggle={sidebarToggle}
       themeToggle={themeToggle}
       search={searchWidget}


### PR DESCRIPTION
## Summary

On a page like `/docs/getting-started/installation/`, the top-level **Getting Started** header nav item was not highlighted even though the page is under that big category.

Root cause: the header active-state was derived **purely from URL `path`-prefix matching** (`isNavItemActive` / `computeActiveNavPath`), even though every header nav item already carries a `categoryMatch` — the authoritative "big category" the sidebar uses via `getNavSectionForSlug`. Path matching only lights up a top-level item when the page URL happens to share a prefix with the nav item's `path`, so it is fragile for any category whose page URLs don't align with its header `path`. The category signal (`navSection`) was already computed host-side and passed to `<Header>` for the sidebar, but was **never used for the header highlight**.

## Changes

- `packages/zudo-doc/src/header/nav-active.ts` — add `categoryMatch` to `NavItemLike`; add `isNavItemActiveByCategory(item, activeCategory)` (matches the item's own `categoryMatch` or any child's; collapses to a single comparison for child entries).
- `packages/zudo-doc/src/header/header.tsx` — accept a new optional `activeCategory` prop; prefer category matching for both top-level items and dropdown children, falling back to the existing path matching when no section is known.
- `pages/lib/_header-with-defaults.tsx` (showcase) **and** the `create-zudo-doc` template counterpart — pass `activeCategory={navSection}` into `<Header>`.
- Tests: added `isNavItemActiveByCategory` coverage in `nav-active.test.ts`.

Backward compatible: `activeCategory` is optional; pages without a nav section (home, 404, tag, version) keep the previous URL-path behavior.

## Test Plan

- `pnpm --filter @takazudo/zudo-doc test` → 550 passed.
- `pnpm check` (typecheck) → clean.
- `pnpm check:template-drift` → no drift (showcase + template kept in sync).
- Rebuilt the site and inspected emitted HTML across categories:
  - `/docs/getting-started/installation/` (EN + JA) → **Getting Started** active ✓
  - `/docs/components/tabs/`, `/docs/markdown-features/` → **Learn** active (+ dropdown child marked active) ✓
  - `/docs/reference/`, `/docs/develop/` → respective item active ✓
  - `/docs/concepts/...` (no header item) and home → nothing active ✓ (unchanged)

> Note: the current `main` source already highlighted Getting Started via path matching in a fresh build, so the live site was likely a stale deploy. This change makes the highlight robust by driving it off the page's actual big category (the user's stated intent), and merging triggers a fresh deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y33rBzGbEH8p1wf9fqUzep)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784320576&installation_id=130359969&pr_number=2213&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2213&signature=a083ca2aad65ced4e3db96f4b2eb3da6575e62edd1dad47dd602602ac564260f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->