### PR TITLE
fix(header): update nav active highlight on SPA client-router swaps

### DIFF
--- a/packages/zudo-doc/src/header/nav-overflow-script.ts
+++ b/packages/zudo-doc/src/header/nav-overflow-script.ts
@@ -35,8 +35,111 @@ import { AFTER_NAVIGATE_EVENT } from "../transitions/page-events.js";
 export const NAV_OVERFLOW_SCRIPT = `(function () {
   var cleanupNavOverflow = null;
 
+  function trimSlashes(p) {
+    while (p.length > 1 && p.charAt(p.length - 1) === "/") p = p.slice(0, -1);
+    return p || "/";
+  }
+
+  function navPathname(a) {
+    try { return trimSlashes(new URL(a.href, location.href).pathname); }
+    catch (e) { return ""; }
+  }
+
+  function isUnderPath(cur, p) {
+    if (!p) return false;
+    if (cur === p) return true;
+    return p !== "/" && cur.indexOf(p + "/") === 0;
+  }
+
+  // Recompute which header nav item is "active" from the CURRENT URL and
+  // repaint the highlight. SSR sets the active item on first paint, but the
+  // header is persisted across same-locale client-router swaps
+  // (data-zfb-transition-persist), so without this the highlight would stay
+  // frozen on the page where the header was first rendered. Mirrors the
+  // sidebar island's client-side approach (match location.pathname against
+  // each entry's href) and the SSR longest-match + dropdown-parent rules.
+  // URL-based: hrefs and location.pathname both carry the base + locale
+  // prefix, so they compare directly without stripping.
+  function applyActiveNav() {
+    var nav = document.querySelector("[data-header-nav]");
+    if (!nav) return;
+    var topItems = Array.from(nav.querySelectorAll(":scope > [data-nav-item]"));
+    if (topItems.length === 0) return;
+
+    var cur = trimSlashes(location.pathname);
+
+    // Deepest (longest) nav path the current URL lives under, across both
+    // top-level and dropdown-child paths — matches computeActiveNavPath.
+    var activePath = "";
+    topItems.forEach(function (it) {
+      var isDropdown = it.hasAttribute("data-nav-item-dropdown");
+      var topA = isDropdown ? it.querySelector(":scope > a") : it;
+      if (topA) {
+        var tp = navPathname(topA);
+        if (isUnderPath(cur, tp) && tp.length > activePath.length) activePath = tp;
+      }
+      if (isDropdown) {
+        it.querySelectorAll(":scope > div a").forEach(function (c) {
+          var cp = navPathname(c);
+          if (isUnderPath(cur, cp) && cp.length > activePath.length) activePath = cp;
+        });
+      }
+    });
+
+    function setTopActive(a, active) {
+      if (!a) return;
+      if (active) {
+        a.classList.add("bg-fg", "text-bg");
+        a.classList.remove("text-muted", "hover:underline", "focus:underline");
+        a.setAttribute("aria-current", "page");
+      } else {
+        a.classList.remove("bg-fg", "text-bg");
+        a.classList.add("text-muted", "hover:underline", "focus:underline");
+        a.removeAttribute("aria-current");
+      }
+    }
+
+    topItems.forEach(function (it) {
+      var isDropdown = it.hasAttribute("data-nav-item-dropdown");
+      var topA = isDropdown ? it.querySelector(":scope > a") : it;
+      var topActive = false;
+
+      if (isDropdown) {
+        var parentMatch = !!topA && navPathname(topA) === activePath && activePath !== "";
+        var anyChild = false;
+        it.querySelectorAll(":scope > div a").forEach(function (c) {
+          var childActive = navPathname(c) === activePath && activePath !== "";
+          if (childActive) {
+            anyChild = true;
+            c.setAttribute("data-active", "");
+            c.classList.add("font-bold", "text-accent");
+            c.classList.remove("text-fg");
+          } else {
+            c.removeAttribute("data-active");
+            c.classList.remove("font-bold", "text-accent");
+            c.classList.add("text-fg");
+          }
+        });
+        topActive = parentMatch || anyChild;
+        var svg = topA ? topA.querySelector("svg") : null;
+        if (svg) {
+          if (topActive) { svg.classList.add("text-bg"); svg.classList.remove("text-muted"); }
+          else { svg.classList.add("text-muted"); svg.classList.remove("text-bg"); }
+        }
+      } else {
+        topActive = activePath !== "" && navPathname(topA) === activePath;
+      }
+
+      setTopActive(topA, topActive);
+    });
+  }
+
   function initNavOverflow() {
     if (cleanupNavOverflow) cleanupNavOverflow();
+
+    // Repaint the active highlight for the current URL before measuring /
+    // cloning, so the overflow "···" menu mirrors the correct active state.
+    applyActiveNav();
 
     var nav = document.querySelector("[data-header-nav]");
     var moreContainer = document.querySelector("[data-nav-more]");


### PR DESCRIPTION
## Summary

Follow-up to #2213 (category-based header highlight). The header highlight was correct on full page load but **did not update during zfb client-router (SPA) page transitions** — only a hard reload lit the correct item.

**Root cause:** the header is persisted across same-locale View-Transition swaps via `data-zfb-transition-persist`, so its SSR-computed active markers (`bg-fg text-bg`, `aria-current`, dropdown-child `data-active`) stay frozen on the page where the header was first rendered. The inline nav script re-ran on the after-swap event, but only to recompute **overflow** — it never moved the active highlight.

## Changes

`packages/zudo-doc/src/header/nav-overflow-script.ts` — add an `applyActiveNav()` pass, run on every init / after-swap (before the overflow rebuild so the "···" clones mirror the right state). It recomputes the active item from the current URL and repaints:

- top-level item → `bg-fg text-bg` + `aria-current`
- dropdown parent → active when it **or any child** matches (+ chevron color)
- dropdown child → `data-active` + `font-bold text-accent`
- clears the previously-active item

Mirrors the **sidebar island's** established client-side approach (match `location.pathname` against each entry's href) and the SSR longest-match + dropdown-parent rules, so SPA behavior stays consistent with the category/path SSR highlight for the showcase. URL-based — hrefs and `location.pathname` both carry the base + locale prefix, so they compare directly. The script lives in the shared package, so the generator template inherits the fix automatically.

## Test Plan

- Built the site and drove a **headless Chromium** through real client-router (SPA) navigations on the preview server:
  - `/docs/reference/` load → Reference active ✓
  - SPA → Getting Started → highlight follows, Reference cleared ✓
  - SPA → Learn (dropdown parent, via parent path) → Learn active ✓
  - SPA → Components (Learn dropdown **child**) → Learn parent active + Components child `data-active`, Getting Started cleared ✓
- Emitted-script syntax-checked (`new Function(...)`), `pnpm check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y33rBzGbEH8p1wf9fqUzep)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784324828&installation_id=130359969&pr_number=2215&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2215&signature=bf6db7b3c93766c3948e2e54345ebe533763101ed64032953a99a6b5d0aa5215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->