### PR TITLE
chore(deps): bump @takazudo/zfb stack to 0.1.0-next.53

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,9 +85,9 @@
   },
   "dependencies": {
     "@takazudo/zdtp": "0.2.3",
-    "@takazudo/zfb": "0.1.0-next.52",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.52",
-    "@takazudo/zfb-runtime": "0.1.0-next.52",
+    "@takazudo/zfb": "0.1.0-next.53",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.53",
+    "@takazudo/zfb-runtime": "0.1.0-next.53",
     "@takazudo/zudo-doc": "workspace:*",
     "diff": "^8.0.3",
     "gray-matter": "^4.0.3",

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -3305,9 +3305,12 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
    * ClientRouter({ preserveHtmlAttrs }) option (zfb#1104) so runtime <html>
    * attributes (data-sidebar-hidden / data-theme) survive SPA swaps
    * (zudolab/zudo-doc#2200) — additive, non-breaking for a fresh scaffold.
+   * Now bumped to 0.1.0-next.53: zfb-content GFM-autolink fix terminating the
+   * autolink path at CJK boundaries (zfb#1105) - content-rendering bug fix,
+   * additive, no consumer-facing breaking change.
    * Generated package.json must pin all three.
    */
-  it("pins @takazudo/zfb at 0.1.0-next.52", async () => {
+  it("pins @takazudo/zfb at 0.1.0-next.53", async () => {
     const choices: UserChoices = {
       projectName: "test-pin-bump",
       defaultLang: "en",
@@ -3318,10 +3321,10 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
     };
     await scaffold(choices);
     const pkg = await fs.readJson(projectPath("test-pin-bump", "package.json"));
-    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.52");
-    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.52");
+    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.53");
+    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.53");
     expect(pkg.dependencies["@takazudo/zfb-adapter-cloudflare"]).toBe(
-      "0.1.0-next.52",
+      "0.1.0-next.53",
     );
   });
 });

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -414,16 +414,19 @@ function generatePackageJson(choices: UserChoices) {
     // "@takazudo/zfb" (#972) — plus removal of the no-op linkValidation.allowExternal
     // knob (#925); both are non-breaking for a fresh scaffold. A fresh scaffold
     // sets no explicit codeHighlight.theme so the default still applies. No
-    // consumer-facing / CLI breaking change. next.52 (current pin): adds the
+    // consumer-facing / CLI breaking change. next.52: adds the
     // `ClientRouter({ preserveHtmlAttrs })` option (zfb#1104) — consumers can
     // declare runtime `<html>` attribute names to preserve across SPA swaps so
     // e.g. `data-sidebar-hidden` / `data-theme` survive (zudolab/zudo-doc#2200).
-    // Additive, non-breaking for a fresh scaffold.
-    "@takazudo/zfb": "0.1.0-next.52",
-    "@takazudo/zfb-runtime": "0.1.0-next.52",
+    // Additive, non-breaking for a fresh scaffold. next.53 (current pin):
+    // zfb-content GFM-autolink fix — terminate the autolink path at CJK
+    // boundaries (zfb#1105). Content-rendering bug fix, additive; relevant for
+    // CJK (e.g. Japanese) docs. No consumer-facing / CLI breaking change.
+    "@takazudo/zfb": "0.1.0-next.53",
+    "@takazudo/zfb-runtime": "0.1.0-next.53",
     // zfb-adapter-cloudflare — required for any route with `prerender = false`.
     // Pinned in lockstep with @takazudo/zfb.
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.52",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.53",
     // @takazudo/zudo-doc — published from this monorepo via
     // .github/workflows/publish-zudo-doc.yml. The pin here is bumped in
     // lockstep by scripts/release-create-zudo-doc.sh whenever zudo-doc's

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -173,8 +173,8 @@
   ],
   "peerDependencies": {
     "preact": "^10.29.1",
-    "@takazudo/zfb": "^0.1.0-next.52",
-    "@takazudo/zfb-runtime": "^0.1.0-next.52",
+    "@takazudo/zfb": "^0.1.0-next.53",
+    "@takazudo/zfb-runtime": "^0.1.0-next.53",
     "@takazudo/zudo-doc-history-server": "workspace:^",
     "@takazudo/zdtp": "^0.2.3",
     "shiki": "^4.0.2"
@@ -202,7 +202,7 @@
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
     "vitest": "^4.1.0",
-    "@takazudo/zfb": "0.1.0-next.52",
-    "@takazudo/zfb-runtime": "0.1.0-next.52"
+    "@takazudo/zfb": "0.1.0-next.53",
+    "@takazudo/zfb-runtime": "0.1.0-next.53"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,14 +30,14 @@ importers:
         specifier: 0.2.3
         version: 0.2.3(preact@10.29.2)
       '@takazudo/zfb':
-        specifier: 0.1.0-next.52
-        version: 0.1.0-next.52
+        specifier: 0.1.0-next.53
+        version: 0.1.0-next.53
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.52
-        version: 0.1.0-next.52
+        specifier: 0.1.0-next.53
+        version: 0.1.0-next.53
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.52
-        version: 0.1.0-next.52(@takazudo/zfb@0.1.0-next.52)
+        specifier: 0.1.0-next.53
+        version: 0.1.0-next.53(@takazudo/zfb@0.1.0-next.53)
       '@takazudo/zudo-doc':
         specifier: workspace:*
         version: link:packages/zudo-doc
@@ -266,11 +266,11 @@ importers:
         version: 4.0.3
     devDependencies:
       '@takazudo/zfb':
-        specifier: 0.1.0-next.52
-        version: 0.1.0-next.52
+        specifier: 0.1.0-next.53
+        version: 0.1.0-next.53
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.52
-        version: 0.1.0-next.52(@takazudo/zfb@0.1.0-next.52)
+        specifier: 0.1.0-next.53
+        version: 0.1.0-next.53(@takazudo/zfb@0.1.0-next.53)
       '@types/node':
         specifier: ^25.3.5
         version: 25.3.5
@@ -1353,44 +1353,44 @@ packages:
     peerDependencies:
       preact: ^10.29.1
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.52':
-    resolution: {integrity: sha512-Afh1eZ9r/lICuft+9jLFZeageL+n9JsX1g5b0gPZOUeg1LorQILA3B/PDmxtXvdGnNbgp1lYFZDDq+zlNLd/Jg==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.53':
+    resolution: {integrity: sha512-OCcil6XTYLQgO/8djT3WvLPzhgm2FbA1RT9vYePFIKTnz8BNx61oxiCUWrkWmwX8ac6K5f3rQL5xpsXTQR3CzQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.52':
-    resolution: {integrity: sha512-MHVlCzB3UIT56EcqCU//ymOAKcWzLcKoxYLMzpSPuD0CDk3BckLCnX6DbMSRtXTl/e7/plvzZCTRamizaOhVYw==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.53':
+    resolution: {integrity: sha512-UZMEukrgfHeQ5+y14xrXXAPOAq6QI1LI6y+dNxPNmmZSJIjrzRAFU0TjPAQiltl2ZdUsszv17udqc2scemc4lA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.52':
-    resolution: {integrity: sha512-J308r5UhPZJ4jg294Wi9TcOZlXMksqFZa7BkIHfdH0Z64ECQSyRK2mnnQa8+nLcqDBK6V4e5DfODrX7c3J2+NQ==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.53':
+    resolution: {integrity: sha512-2HUkqqs+XrJLLw18OCv7Ky6EEXegIOhd7R8Xrqr8w+GbVv6Nw4TxHLLhjb9Qr97FlwMJ9mVewPYlBLYiDJjTqw==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.52':
-    resolution: {integrity: sha512-3aoVmJXtRgTWvUdYieZOrRJ2RD5r4NWSojIdeFtWVzBhurBClPpoE8vWksMMAa8yd8ikmuoWeH4f3sTCiG6mjg==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.53':
+    resolution: {integrity: sha512-RixlNp1m7DBGqq9PWGMYtxmgg3GIbvYeI13zzMGez47UMRSpglH93Gg3LgSwpBs5c8oaPgLFQHn3pDDJDN9yog==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.52':
-    resolution: {integrity: sha512-3eQnMOujVhD+OPcpdPldjGy23tFC2aqPBFOR66l2qsuDNSJJgVwT2YLHtCp8YHZn0byJkVpC+/DYSUzOTrkUYw==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.53':
+    resolution: {integrity: sha512-xyCvdL97WkhdBwxIagVq/xZuAzCaypwNUNDaQ7itxq/tfbBt2oyVv5H7vcEW/oG0RXRTFJMABJH2G+Y/9VZkbQ==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.52':
-    resolution: {integrity: sha512-bJTCgDlLnREtFO3zJSrvKm3qEUKne3JIyDecFczacWM3Mo0SHAXxBWNbGg2LSNFjstE10aA0bL2eEC2RnK2ERA==}
+  '@takazudo/zfb-runtime@0.1.0-next.53':
+    resolution: {integrity: sha512-5i7+VjHr8P0o1R9fnCmU/mp6fadg1CZm42GqH9njomwAj+41pz1MQ+T0iQru8PCiTtLG9B+Inbv/dXdGTKWvLA==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.52
+      '@takazudo/zfb': 0.1.0-next.53
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.52':
-    resolution: {integrity: sha512-9u4wG+b2FRIuwmYSL7DrN9+5R5j580TJquGNuP8Y9+8eXpDcUfR1lHEo5YYmd6UphIHkEh0Be40QyyoMqMzdNw==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.53':
+    resolution: {integrity: sha512-F3AgrTycPsA9/eQm8E141EvWkc+oBaDwI4m1H/kGfuwQJiX8vcrFqZTLy33FfYKxfKqA3TLaRu4rwoO7t2g6vA==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.52':
-    resolution: {integrity: sha512-bbBKIfJa++Gh/YOpQRjA6GzK1RCOq1BnDpkwvIlC1BIjgorR/fUChFaVb8CSAyjpA0RiAgQ9bfiXYYHq/Mlb7w==}
+  '@takazudo/zfb@0.1.0-next.53':
+    resolution: {integrity: sha512-iwed5oRyMWyvE6VB6H0jE6qyIQ24R1M4uUzIeN38VJf1xqKJiCglNwP1J8dduhDEX0F1jtsWrBexfHxnp6K/vw==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
@@ -4049,35 +4049,35 @@ snapshots:
       culori: 4.0.2
       preact: 10.29.2
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.52': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.53': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.52':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.53':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.52':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.53':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.52':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.53':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.52':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.53':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.52(@takazudo/zfb@0.1.0-next.52)':
+  '@takazudo/zfb-runtime@0.1.0-next.53(@takazudo/zfb@0.1.0-next.53)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.52
+      '@takazudo/zfb': 0.1.0-next.53
       hono: 4.12.25
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.52':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.53':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.52':
+  '@takazudo/zfb@0.1.0-next.53':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.52
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.52
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.52
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.52
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.52
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.53
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.53
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.53
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.53
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.53
 
   '@takazudo/zudo-design-token-lint@1.0.0(patch_hash=6a157fd850449b055cf64a8a7dd1faed5b1da9eebe6c81cca08488ac0de85182)':
     dependencies:


### PR DESCRIPTION
## Summary

Bump the `@takazudo/zfb` toolchain from `0.1.0-next.52` to the latest `@next` (`0.1.0-next.53`). `@takazudo/zdtp` is left at `0.2.3` (its latest is unchanged).

next.53 is a **content-rendering bug-fix release**: it terminates GFM autolinks at CJK boundaries (zfb#1105) — directly relevant to this project's Japanese docs. Additive, no consumer-facing / CLI breaking change. next.52's runtime feature (`preserveHtmlAttrs`) was already in our tree.

## Changes

Bumped across all **five pin-parity-linked sources** (gated by `scripts/check-pin-parity.mjs`) so they stay in lockstep:

- `package.json` — root `dependencies`: `@takazudo/zfb`, `@takazudo/zfb-runtime`, `@takazudo/zfb-adapter-cloudflare` → `0.1.0-next.53`
- `packages/zudo-doc/package.json` — `devDependencies` (exact `0.1.0-next.53`) + `peerDependencies` (`^0.1.0-next.53`) for zfb + zfb-runtime
- `packages/create-zudo-doc/src/scaffold.ts` — the three pins emitted into scaffolded downstream projects → `0.1.0-next.53` (so a fresh `create-zudo-doc` scaffold pulls next.53)
- `packages/create-zudo-doc/src/__tests__/scaffold.test.ts` — pin assertions updated to `0.1.0-next.53`
- `pnpm-lock.yaml` — relocked

Internal package pins (`@takazudo/zudo-doc`, `@takazudo/zudo-doc-history-server`) are intentionally **untouched** — those move with the release version via `/l-make-release`.

## Test Plan

- `pnpm check:pin-parity` — ✅ all 5 sources in lockstep at next.53
- `pnpm b4push` automated suite (21 checks: typecheck × 4, root + package tests, build, link check, HTML validation, preview smoke, drift/parity gates) — ✅ all green
- `/codex-review` — ✅ no introduced correctness issues
- Only the interactive manual-smoke step is skipped (requires a human; not part of CI)