### PR TITLE
CategoryNav convention: teach the category-top pattern in the nav skill + generated doc set

### DIFF
--- a/.claude/skills/zudo-doc-navigation-design/SKILL.md
+++ b/.claude/skills/zudo-doc-navigation-design/SKILL.md
@@ -63,13 +63,36 @@ Before creating any new doc page, check this list:
 - [ ] Is the file name in kebab-case?
 - [ ] For bilingual projects: have you created the matching file under `src/content/docs-ja/` (or added `generated: true` if it is skipped)?
 
+## Category Top Page (index.mdx)
+
+Every category directory must have an `index.mdx`. This file is the **landing page** for that category — keep it short:
+
+- A 1–2 sentence intro describing what the category covers.
+- A `<CategoryNav category="<dir>" />` component that auto-renders links to sibling pages.
+- **No full content or prose beyond the intro.** Real documentation lives in sibling `.mdx` files under the same directory.
+
+The `category` prop value is the **top-level directory name** (e.g. `category="reference"` for `src/content/docs/reference/`). Do not include path separators or the full path.
+
+Example `index.mdx` for a `guides/` category:
+
+```mdx
+---
+title: Guides
+sidebar_position: 1
+---
+
+Step-by-step guides for common zudo-doc tasks.
+
+<CategoryNav category="guides" />
+```
+
 ## Checklist for Adding a New Category
 
 Before creating any new category directory:
 
 - [ ] Is this really a new category, or does it belong under an existing one? Default to "fewer categories."
 - [ ] Does it need a header nav entry, or is it a nested sidebar category inside an existing header entry?
-- [ ] Have you created `index.mdx` with a descriptive landing page and `sidebar_position`?
+- [ ] Have you created `index.mdx` with a short intro + `<CategoryNav>` (not full content) and `sidebar_position`?
 - [ ] If you added a header entry, does its `categoryMatch` value equal the new top-level directory name (single segment)?
 - [ ] Does the new category have at least 3 pages? Fewer than 3 usually means the pages belong under a broader category instead.
 
@@ -82,6 +105,7 @@ Before creating any new category directory:
 - **Missing `index.mdx` in category directories.** Category has no landing page.
 - **Multi-segment `categoryMatch`** (e.g. `"platforms/xbox"`). Breaks active highlighting — use a single top-level directory name.
 - **Reorganizing via config instead of filesystem.** If you are tempted to add a custom sidebar config override, the underlying filesystem is probably wrong. Fix the files instead.
+- **Stuffing a category `index.mdx` with full content/prose.** The index is a landing page — keep it to a short intro + `<CategoryNav>` and put real content in sibling files.
 
 ## When in Doubt
 

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -79,6 +79,62 @@ describe("scaffold — minimal (no i18n, search only, single dark scheme)", () =
     ).toBe(true);
   });
 
+  it("getting-started/index.mdx is a category-top with <CategoryNav", async () => {
+    const content = await fs.readFile(
+      projectPath(
+        "test-minimal",
+        "src/content/docs/getting-started/index.mdx",
+      ),
+      "utf-8",
+    );
+    expect(content).toContain("<CategoryNav");
+  });
+
+  it("getting-started/index.mdx does NOT contain an h1 heading (no '# ' line)", async () => {
+    const content = await fs.readFile(
+      projectPath(
+        "test-minimal",
+        "src/content/docs/getting-started/index.mdx",
+      ),
+      "utf-8",
+    );
+    const lines = content.split("\n");
+    const h1Lines = lines.filter((line) => /^# /.test(line));
+    expect(h1Lines).toHaveLength(0);
+  });
+
+  it("creates getting-started child docs (introduction.mdx and installation.mdx)", async () => {
+    expect(
+      await fs.pathExists(
+        projectPath(
+          "test-minimal",
+          "src/content/docs/getting-started/introduction.mdx",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      await fs.pathExists(
+        projectPath(
+          "test-minimal",
+          "src/content/docs/getting-started/installation.mdx",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("child docs contain sidebar_position frontmatter", async () => {
+    for (const child of ["introduction.mdx", "installation.mdx"]) {
+      const content = await fs.readFile(
+        projectPath(
+          "test-minimal",
+          `src/content/docs/getting-started/${child}`,
+        ),
+        "utf-8",
+      );
+      expect(content).toContain("sidebar_position:");
+    }
+  });
+
   it("does NOT create [locale] pages directory (i18n off)", async () => {
     expect(
       await fs.pathExists(projectPath("test-minimal", "src/pages/[locale]")),
@@ -341,6 +397,49 @@ describe("scaffold — full features (i18n, light-dark, all features)", () => {
         ),
       ),
     ).toBe(true);
+  });
+
+  it("docs-ja/getting-started/index.mdx is a category-top with <CategoryNav", async () => {
+    const content = await fs.readFile(
+      projectPath(
+        "test-full",
+        "src/content/docs-ja/getting-started/index.mdx",
+      ),
+      "utf-8",
+    );
+    expect(content).toContain("<CategoryNav");
+  });
+
+  it("creates docs-ja getting-started child docs (introduction.mdx and installation.mdx)", async () => {
+    expect(
+      await fs.pathExists(
+        projectPath(
+          "test-full",
+          "src/content/docs-ja/getting-started/introduction.mdx",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      await fs.pathExists(
+        projectPath(
+          "test-full",
+          "src/content/docs-ja/getting-started/installation.mdx",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("docs-ja child docs contain sidebar_position frontmatter", async () => {
+    for (const child of ["introduction.mdx", "installation.mdx"]) {
+      const content = await fs.readFile(
+        projectPath(
+          "test-full",
+          `src/content/docs-ja/getting-started/${child}`,
+        ),
+        "utf-8",
+      );
+      expect(content).toContain("sidebar_position:");
+    }
   });
 
   it("includes Claude Resources integration", async () => {

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -42,27 +42,115 @@ function shouldCopyBaseFile(srcAbs: string, baseDir: string): boolean {
 }
 
 const STARTER_CONTENT_EN = (siteName: string) => `---
-title: Welcome
+title: Getting Started
 sidebar_position: 1
 ---
 
-# Welcome to ${siteName}
+Welcome to ${siteName}. Choose a topic below to get started.
 
-This documentation site was created with [zudo-doc](https://github.com/zudolab/zudo-doc).
-
-## Getting Started
-
-Edit the files in \`src/content/docs/\` to add your documentation.
+<CategoryNav category="getting-started" />
 `;
 
 const STARTER_CONTENT_JA = () => `---
-title: ようこそ
+title: はじめに
 sidebar_position: 1
 ---
 
-# ようこそ
+ドキュメントへようこそ。以下のトピックから始めてください。
 
-このドキュメントサイトは [zudo-doc](https://github.com/zudolab/zudo-doc) で作成されました。
+<CategoryNav category="getting-started" />
+`;
+
+const STARTER_CHILD_INTRODUCTION_EN = (siteName: string) => `---
+title: Introduction
+sidebar_position: 1
+---
+
+## What is ${siteName}?
+
+${siteName} is a documentation site built with [zudo-doc](https://github.com/zudolab/zudo-doc), a minimal documentation framework powered by zfb, MDX, and Tailwind CSS.
+
+## Key Features
+
+- MDX authoring with rich component support
+- Fast static site generation via zfb
+- Tailwind CSS v4 for styling
+- Optional i18n, search, and more
+`;
+
+const STARTER_CHILD_INTRODUCTION_JA = (siteName: string) => `---
+title: はじめに
+sidebar_position: 1
+---
+
+## ${siteName} とは？
+
+${siteName} は [zudo-doc](https://github.com/zudolab/zudo-doc) で構築されたドキュメントサイトです。zfb・MDX・Tailwind CSS を使ったミニマルなドキュメントフレームワークです。
+
+## 主な機能
+
+- MDX によるリッチなコンポーネントサポート
+- zfb による高速な静的サイト生成
+- スタイリングには Tailwind CSS v4
+- i18n・検索などオプション機能も充実
+`;
+
+const STARTER_CHILD_INSTALLATION_EN = () => `---
+title: Installation
+sidebar_position: 2
+---
+
+## Requirements
+
+- Node.js 18 or later
+- pnpm (recommended), npm, yarn, or bun
+
+## Create a New Project
+
+Run the scaffolding tool to create a new project:
+
+\`\`\`sh
+pnpm create zudo-doc my-docs
+\`\`\`
+
+## Start the Dev Server
+
+\`\`\`sh
+cd my-docs
+pnpm install
+pnpm dev
+\`\`\`
+
+Open [http://localhost:4321](http://localhost:4321) to view your docs.
+`;
+
+const STARTER_CHILD_INSTALLATION_JA = () => `---
+title: インストール
+sidebar_position: 2
+---
+
+## 動作要件
+
+- Node.js 18 以降
+- pnpm（推奨）、npm、yarn、または bun
+
+## 新しいプロジェクトを作成する
+
+スキャフォールドツールを実行して新しいプロジェクトを作成します：
+
+\`\`\`sh
+pnpm create zudo-doc my-docs
+\`\`\`
+
+## 開発サーバーを起動する
+
+\`\`\`sh
+cd my-docs
+pnpm install
+pnpm dev
+\`\`\`
+
+[http://localhost:4321](http://localhost:4321) を開いてドキュメントを確認してください。
 `;
 
 const CHANGELOG_CONTENT_EN = () => `---
@@ -180,6 +268,24 @@ export async function scaffold(choices: UserChoices): Promise<void> {
     primaryContent,
   );
 
+  // Primary language child docs under getting-started/
+  const primaryIntroductionContent =
+    defaultLang === "ja"
+      ? STARTER_CHILD_INTRODUCTION_JA(escapedName)
+      : STARTER_CHILD_INTRODUCTION_EN(escapedName);
+  await fs.outputFile(
+    path.join(targetDir, "src/content/docs/getting-started/introduction.mdx"),
+    primaryIntroductionContent,
+  );
+  const primaryInstallationContent =
+    defaultLang === "ja"
+      ? STARTER_CHILD_INSTALLATION_JA()
+      : STARTER_CHILD_INSTALLATION_EN();
+  await fs.outputFile(
+    path.join(targetDir, "src/content/docs/getting-started/installation.mdx"),
+    primaryInstallationContent,
+  );
+
   // When i18n is ON, place secondary language content
   if (choices.features.includes("i18n")) {
     const secondaryLang = getSecondaryLang(defaultLang);
@@ -193,6 +299,30 @@ export async function scaffold(choices: UserChoices): Promise<void> {
     await fs.outputFile(
       path.join(targetDir, `${secondaryDir}/getting-started/index.mdx`),
       secondaryContent,
+    );
+
+    // Secondary language child docs under getting-started/
+    const secondaryIntroductionContent =
+      secondaryLang === "ja"
+        ? STARTER_CHILD_INTRODUCTION_JA(escapedName)
+        : STARTER_CHILD_INTRODUCTION_EN(escapedName);
+    await fs.outputFile(
+      path.join(
+        targetDir,
+        `${secondaryDir}/getting-started/introduction.mdx`,
+      ),
+      secondaryIntroductionContent,
+    );
+    const secondaryInstallationContent =
+      secondaryLang === "ja"
+        ? STARTER_CHILD_INSTALLATION_JA()
+        : STARTER_CHILD_INSTALLATION_EN();
+    await fs.outputFile(
+      path.join(
+        targetDir,
+        `${secondaryDir}/getting-started/installation.mdx`,
+      ),
+      secondaryInstallationContent,
     );
   }
 

--- a/src/content/docs-ja/getting-started/structuring-navigations.mdx
+++ b/src/content/docs-ja/getting-started/structuring-navigations.mdx
@@ -96,6 +96,23 @@ src/content/docs/guides/        ← サイドバーカテゴリ「Guides」
 
 各 `.mdx` ファイルがサイドバー項目として表示されます。サブディレクトリはネストされた折りたたみ可能なカテゴリになります。
 
+### カテゴリトップページ（index.mdx）
+
+各カテゴリディレクトリには、そのカテゴリの**ランディングページ**となる `index.mdx` を用意してください。内容はシンプルに保ちます。カテゴリの説明を 1〜2 文で書き、その後に `<CategoryNav>` コンポーネントを置くだけです。このコンポーネントは兄弟ページへのリンクを自動的に表示します。
+
+```mdx
+---
+title: Guides
+sidebar_position: 1
+---
+
+Step-by-step guides for common zudo-doc tasks.
+
+<CategoryNav category="guides" />
+```
+
+`category` プロパティにはトップレベルのディレクトリ名を指定します（例：`src/content/docs/guides/` なら `"guides"`）。index にドキュメントの本文を書かないでください。実際のドキュメントは同じディレクトリ内の兄弟 `.mdx` ファイルに置きましょう。
+
 ## 具体的な実例
 
 **ゲーム攻略 Wiki** を構築する場合のナビゲーション構造です。

--- a/src/content/docs/getting-started/structuring-navigations.mdx
+++ b/src/content/docs/getting-started/structuring-navigations.mdx
@@ -96,6 +96,23 @@ src/content/docs/guides/        ← sidebar category "Guides"
 
 Each `.mdx` file appears as a sidebar item. Subdirectories become nested collapsible categories.
 
+### Category Top Page (index.mdx)
+
+Every category directory should have an `index.mdx` that acts as the **landing page** for that category. Keep it minimal: a 1–2 sentence description of the category followed by a `<CategoryNav>` component, which automatically renders links to all sibling pages.
+
+```mdx
+---
+title: Guides
+sidebar_position: 1
+---
+
+Step-by-step guides for common zudo-doc tasks.
+
+<CategoryNav category="guides" />
+```
+
+The `category` prop is the top-level directory name (e.g. `"guides"` for `src/content/docs/guides/`). Do not put full documentation content in the index — keep real docs in sibling `.mdx` files under the same directory.
+
 ## Concrete Real-World Example
 
 Imagine building a **gaming wiki**. Here is how you would structure the navigation:


### PR DESCRIPTION
- epic
    - https://github.com/zudolab/zudo-doc/issues/2227

---

## Summary

Documents and demonstrates the showcase's **category top page** convention — a category `index.mdx` is a short intro + `<CategoryNav category="…" />` only, with real docs as sibling files underneath.

**Sub #2228 — docs/skill:**
- `.claude/skills/zudo-doc-navigation-design/SKILL.md` — new "Category Top Page (index.mdx)" section + a Common Mistakes entry + updated new-category checklist. (Auto-published to `/docs/claude-skills/zudo-doc-navigation-design/`.)
- `src/content/docs/getting-started/structuring-navigations.mdx` + JA mirror — same convention with an example (inside fenced code blocks, inert).

**Sub #2229 — generator initialized doc set:**
- `packages/create-zudo-doc/src/scaffold.ts` — `getting-started/index.mdx` is now a category-top (intro + `<CategoryNav>`, no `# h1`); added `introduction.mdx` + `installation.mdx` child docs with `sidebar_position`. Both EN and JA constants restructured; wired for primary + secondary languages.
- `scaffold.test.ts` — assertions for CategoryNav presence, h1-guard, child-doc existence, and `sidebar_position`.

## Verification

- `pnpm --filter create-zudo-doc build` ✅, scaffold tests **359 passed** ✅
- End-to-end: scaffolded a barebone project, `zfb build` succeeded (7 pages), and the built `getting-started/index.html` renders the `CategoryNav` cards linking to the Introduction + Installation child docs (no unrendered literal tag) ✅

Diff against `main` is exactly the 5 files above. (Earlier the branch appeared to carry a prior epic; that work — robots/noindex, #2218–#2225 — is already merged to `main`, so it is not part of this diff.)