### PR TITLE
fix(sidebar-resizer): preserve dragged width across SPA navigations

### DIFF
--- a/e2e/sidebar-resizer-spa-nav-width.spec.ts
+++ b/e2e/sidebar-resizer-spa-nav-width.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from "@playwright/test";
+import { spaClick } from "./nav-helpers";
+import { desktopSidebar, waitForSidebarHydration } from "./sidebar-helpers";
+
+/**
+ * E2E regression for the sidebar-resizer width loss on SPA navigation (#2227).
+ *
+ * Bug: after the user dragged the sidebar wider, the chosen width
+ * (`--zd-sidebar-w`, written to the live `<html>` element's inline `style`)
+ * was lost on every same-document SPA navigation. zfb's `swapRootAttributes`
+ * copies the incoming server-rendered document's `<html>` attributes over the
+ * live root during the body swap; since this layout never server-renders an
+ * `htmlStyle`, the incoming root carries no `style` attribute, so the live
+ * `--zd-sidebar-w` was wiped and the sidebar snapped back to the CSS default
+ * (`clamp(14rem, 20vw, 22rem)`). A subsequent reload restored the width from
+ * localStorage (SidebarResizerRestore runs pre-paint), which is exactly why the
+ * bug only manifested on soft navigations.
+ *
+ * Fix (#2227): doc-layout now mounts
+ * `<ClientRouter preserveHtmlAttrs={["data-sidebar-hidden", "data-theme", "style"]} />`.
+ * Adding `style` makes the router re-apply the live root's whole inline `style`
+ * (carrying `--zd-sidebar-w`) within the same synchronous swap, before paint —
+ * the same mechanism that keeps `data-sidebar-hidden` / `data-theme` across
+ * swaps (#2200).
+ *
+ * Test technique: this mirrors sidebar-toggle-layout.spec.ts — it sets the
+ * runtime root state directly via `page.evaluate` rather than enabling the full
+ * resizer island in the fixture. The bug lives entirely in the attribute-swap
+ * path, which is feature-independent: any inline root `style` set at runtime is
+ * what `swapRootAttributes` either drops or preserves. Setting `--zd-sidebar-w`
+ * by hand reproduces precisely the post-drag runtime state, and the sidebar's
+ * `w-[var(--zd-sidebar-w)]` class consumes it whether or not the resizer is on.
+ */
+
+const START_PAGE = "/docs/guides/sub-a/page-1";
+// Same getting-started/guides section, reachable via the sidebar nav tree —
+// a genuine same-section SPA hop.
+const NEXT_PAGE = "/docs/guides/sub-a/page-2";
+
+const WIDE = 400;
+
+test.describe("Sidebar-resizer width across SPA nav (#2227)", () => {
+  test("a runtime --zd-sidebar-w survives an SPA navigation (sidebar stays wide)", async ({
+    page,
+  }) => {
+    // >=1024px so the `lg:` desktop-sidebar rules are active.
+    await page.setViewportSize({ width: 1600, height: 900 });
+    await page.goto(START_PAGE, { waitUntil: "load" });
+    await waitForSidebarHydration(page);
+
+    const sidebar = desktopSidebar(page);
+    await expect(sidebar).toHaveCount(1);
+
+    // The fix is wired via the SSR meta the ClientRouter emits — assert it lists
+    // `style`, so a regression that drops it from preserveHtmlAttrs fails loudly
+    // here rather than only as a flaky width difference below.
+    const preserved = await page.evaluate(() => {
+      const meta = document.querySelector(
+        'meta[name="zfb-preserve-html-attrs"]',
+      );
+      return meta?.getAttribute("content") ?? null;
+    });
+    expect(preserved).not.toBeNull();
+    expect(preserved!.toLowerCase().split(/\s+/)).toContain("style");
+
+    // Simulate a drag: write the chosen width to the live root inline style,
+    // exactly as the resizer's applyWidth() does.
+    await page.evaluate((w) => {
+      document.documentElement.style.setProperty("--zd-sidebar-w", `${w}px`);
+    }, WIDE);
+
+    // Sanity: the widened value is actually applied before we navigate. (The
+    // CSS default at this viewport resolves to ~320px, so 400px is a clear,
+    // discriminating widening.)
+    await expect
+      .poll(() => sidebar.evaluate((el) => el.getBoundingClientRect().width))
+      .toBeCloseTo(WIDE, 0);
+
+    // Perform the genuine SPA navigation.
+    const navigated = await spaClick(page, NEXT_PAGE);
+    expect(navigated).toBe(true);
+
+    // The inline custom property must still be present on <html> after the swap
+    // — i.e. zfb-runtime preserved the root `style` across the wipe.
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          document.documentElement.style
+            .getPropertyValue("--zd-sidebar-w")
+            .trim(),
+        ),
+      )
+      .toBe(`${WIDE}px`);
+
+    // And the rendered sidebar is still at the widened width, not the default.
+    await expect
+      .poll(() => desktopSidebar(page).evaluate((el) =>
+        el.getBoundingClientRect().width,
+      ))
+      .toBeCloseTo(WIDE, 0);
+  });
+});

--- a/packages/zudo-doc/src/doclayout/doc-layout.tsx
+++ b/packages/zudo-doc/src/doclayout/doc-layout.tsx
@@ -273,12 +273,26 @@ export function DocLayout(props: DocLayoutProps): JSX.Element {
           shipped and resolves zudolab/zudo-doc#2200. Must be the same list on
           every page (read from the outgoing page's meta at swap time).
 
+          `style` is preserved for the same reason: the sidebar-resizer island
+          (gated on settings.sidebarResizer) writes the user's dragged width to
+          `--zd-sidebar-w` in the live root's inline `style`, and a reload
+          re-applies it pre-paint from localStorage (SidebarResizerRestore) —
+          but neither runs on an SPA swap, so without preserving `style` the
+          swap drops `--zd-sidebar-w` and the widened sidebar snaps back to the
+          CSS default on every soft navigation (zudolab/zudo-doc#2227). Preserve
+          is by attribute *name* (swapRootAttributes re-applies the whole live
+          `style` last), which is safe here because this layout never renders a
+          server-side `htmlStyle` — the only inline root style is runtime state
+          we want to keep. A no-op when the resizer is disabled (no inline
+          style is ever set), so it stays unconditional and keeps the meta
+          identical on every page.
+
           Cast through `unknown` because ClientRouter() returns a readonly
           array of structural VNode objects — Preact's JSX typing does not
           directly accept that array shape, but at runtime the elements are
           valid VNode descriptors. */}
         {ClientRouter({
-          preserveHtmlAttrs: ["data-sidebar-hidden", "data-theme"],
+          preserveHtmlAttrs: ["data-sidebar-hidden", "data-theme", "style"],
         }) as unknown as JSX.Element}
         {head}
       </head>

--- a/packages/zudo-doc/src/sidebar-resizer/sidebar-resizer-init.tsx
+++ b/packages/zudo-doc/src/sidebar-resizer/sidebar-resizer-init.tsx
@@ -18,6 +18,15 @@
 // instance handle DOM is rebuilt each time and the existing-handle guard
 // (`sidebar.querySelector("["+HANDLE_MARKER+"]")`) keeps re-runs idempotent.
 //
+// NOTE: this re-init only rebuilds the drag *handle*. The persisted *width*
+// (`--zd-sidebar-w` on the live root's inline style) survives the swap on its
+// own — the doc-layout shell mounts <ClientRouter preserveHtmlAttrs={[…,
+// "style"]} />, so zfb-runtime re-applies the live root `style` within the
+// synchronous swap (before paint). Re-applying the width here would be both
+// redundant and flash-prone (it runs after the swap, not within it), so this
+// script deliberately leaves width persistence to that upstream mechanism
+// (zudolab/zudo-doc#2227).
+//
 // Pre-paint restore (SidebarResizerRestore / SIDEBAR_RESIZER_RESTORE_SCRIPT):
 // the init script above only mutates `--zd-sidebar-w` in response to user
 // input. Without a separate pre-paint reader, a page reload after a drag


### PR DESCRIPTION
## Summary

Fixes the sidebar-resizer bug where a sidebar dragged wider on page A snapped back to the default width when navigating to page B via the client-side (SPA) router — even though a full reload correctly restored the dragged width.

**Root cause.** The resizer writes the chosen width to `--zd-sidebar-w` in the live `<html>` element's inline `style`. On a same-document SPA swap, zfb-runtime's `swapRootAttributes` copies the *incoming* server-rendered root's attributes over the live root. This layout never server-renders an `htmlStyle`, so the incoming root has no `style` attribute → the live `--zd-sidebar-w` was wiped and the sidebar reverted to the CSS default (`clamp(14rem, 20vw, 22rem)`). Reload still worked because `SidebarResizerRestore` re-applies the width pre-paint from `localStorage` — which is exactly why the bug was SPA-navigation-only.

**Fix.** Add `"style"` to the doc-layout `<ClientRouter preserveHtmlAttrs={[…]} />` list. `preserveHtmlAttrs` preserves attributes by name and re-applies the live value within the same synchronous swap (before paint) — the identical mechanism that already keeps `data-sidebar-hidden` / `data-theme` across swaps (#2200). Since the only inline root `style` in this framework is runtime state (the resizer's width), preserving it is precisely "keep the runtime root state the SSR doc doesn't carry." It is a no-op when the resizer is disabled (nothing sets an inline root style), so it stays unconditional and keeps the preserve-meta identical on every page.

## Changes

- `packages/zudo-doc/src/doclayout/doc-layout.tsx` — add `"style"` to `preserveHtmlAttrs`; expand the rationale comment.
- `packages/zudo-doc/src/sidebar-resizer/sidebar-resizer-init.tsx` — cross-reference note: the after-swap re-init rebuilds only the drag *handle*; the *width* survives swaps via doc-layout's `preserveHtmlAttrs`, deliberately not re-applied here (would be redundant and flash-prone).
- `e2e/sidebar-resizer-spa-nav-width.spec.ts` — new regression (sidebar fixture): a runtime `--zd-sidebar-w` set before an SPA hop must still be present (and the sidebar still wide) after the swap; also asserts the preserve-meta lists `style`.

## Test Plan

- `pnpm check` — clean.
- `pnpm test` — all unit/package tests pass (create-zudo-doc 352, zudo-doc 550, md-plugins).
- New e2e runs in CI (pr-checks e2e job, sidebar fixture) and is the browser-level verification of the fix.

Notes: the shared shell owns the `preserveHtmlAttrs` list (consumed by both the showcase and every `create-zudo-doc` project), so there is no template counterpart to sync. Changelog/version are intentionally untouched — this repo writes changelog entries at release time via `/l-make-release`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvUJxWNXAXkhDFVSvpkVQx)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784394893&installation_id=130359969&pr_number=2231&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2231&signature=c61413542d58d4b1f39f8f774233fbdb7362ba4166d4fdfb8517501919912e3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->