### PR TITLE
fix(create-zudo-doc): emit Claude headerNav entry when claudeResources enabled

### DIFF
--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -1245,6 +1245,43 @@ describe("scaffold — changelog feature", () => {
     );
     expect(content).not.toContain("/docs/changelog");
   });
+
+  it("headerNav includes Claude when claudeResources enabled", async () => {
+    const choices: UserChoices = {
+      projectName: "test-claude-nav-on",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search", "claudeResources"],
+      packageManager: "pnpm",
+    };
+    await scaffold(choices);
+    const content = await fs.readFile(
+      projectPath("test-claude-nav-on", "src/config/settings.ts"),
+      "utf-8",
+    );
+    // The "claude" categoryMatch is what drives both the header link and the
+    // groupSatelliteNodes() nesting of claude-md/claude-skills/... on the index.
+    expect(content).toContain('categoryMatch: "claude"');
+    expect(content).toContain("/docs/claude");
+  });
+
+  it("headerNav does NOT include Claude when claudeResources disabled", async () => {
+    const choices: UserChoices = {
+      projectName: "test-claude-nav-off",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search"],
+      packageManager: "pnpm",
+    };
+    await scaffold(choices);
+    const content = await fs.readFile(
+      projectPath("test-claude-nav-off", "src/config/settings.ts"),
+      "utf-8",
+    );
+    expect(content).not.toContain('categoryMatch: "claude"');
+  });
 });
 
 describe("scaffold — skillSymlinker feature", () => {

--- a/packages/create-zudo-doc/src/settings-gen.ts
+++ b/packages/create-zudo-doc/src/settings-gen.ts
@@ -294,6 +294,15 @@ export function generateSettingsFile(choices: UserChoices): string {
   lines.push(
     `    { label: "Getting Started", path: "/docs/getting-started", categoryMatch: "getting-started" },`,
   );
+  // The "claude" categoryMatch is load-bearing beyond the header link: getCategoryOrder()
+  // derives the satellite-grouping prefixes from headerNav, so without this entry
+  // groupSatelliteNodes() never nests claude-md/claude-skills/... under the "claude"
+  // overview node and they spread out as separate top-level cards on the index sitemap.
+  if (choices.features.includes("claudeResources")) {
+    lines.push(
+      `    { label: "Claude", path: "/docs/claude", categoryMatch: "claude" },`,
+    );
+  }
   if (choices.features.includes("changelog")) {
     lines.push(
       `    { label: "Changelog", path: "/docs/changelog", categoryMatch: "changelog" },`,


### PR DESCRIPTION
## Problem

A freshly scaffolded project (`create-zudo-doc`) with the **claudeResources** feature rendered the Claude doc set differently from the official showcase:

- **Bug:** the index sitemap showed `Claude` (empty card) + `CLAUDE.md` + `Skills` + … as **separate, spread-out top-level cards**, and the header nav had **no "Claude" item**.
- **Expected (showcase):** "Claude" in the header nav, and a single big "Claude" parent category nesting `CLAUDE.md` / `Skills` / `Commands` / `Agents`.

## Root cause

`packages/create-zudo-doc/src/settings-gen.ts` generated `headerNav` with only "Getting Started" and (optionally) "Changelog" — it never emitted a "Claude" entry, even when `claudeResources` was selected.

That entry is load-bearing beyond the header link: `getCategoryOrder()` (`src/utils/nav-scope.ts`) derives the satellite-grouping prefixes from `headerNav` `categoryMatch` values, and `groupSatelliteNodes()` (`src/utils/docs.ts`) needs `"claude"` in that list to nest the `claude-*` satellites under the `claude` overview node. Without it, no grouping → spread-out cards. The generator's `pages/index.tsx` is byte-identical to the host's, so the rendering code was never the problem — only the generated config.

## Fix

- `settings-gen.ts` now emits `{ label: "Claude", path: "/docs/claude", categoryMatch: "claude" }` when the `claudeResources` feature is enabled (placed before the optional Changelog entry, mirroring host ordering). Plain `label` matches the generated nav's style — no `labelKey`/i18n entries needed.
- Added scaffold tests asserting the entry is present when `claudeResources` is enabled and absent when disabled.

## Verification

- `pnpm --filter create-zudo-doc build` — clean.
- `pnpm --filter create-zudo-doc test` — 350 passed (incl. 2 new tests).
- No new settings **field** added (only `headerNav` content) → no fixture-settings-drift change required.

Closes #2233. Part of #2232.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01En5vArNsiSEAs1eVt1eLq2)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784474158&installation_id=130359969&pr_number=2234&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2234&signature=9643f1dcc768c6b3c0c0bce28690d33dd821a4808c1cd2e4c4b2846b14878163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->