### PR TITLE
fix(view-transition): neutralize root group under prefers-reduced-motion

### DIFF
--- a/packages/create-zudo-doc/templates/base/src/styles/global.css
+++ b/packages/create-zudo-doc/templates/base/src/styles/global.css
@@ -640,10 +640,16 @@ pre[class^="syntect-"] .line .highlighted-word {
  * transition settles immediately — no cross-fade, no translateY slide.
  * Covers the root cross-fade and the #2072 :only-child entry/exit rules;
  * the both-sides chrome layers are already animation: none above. Equal
- * specificity per selector, but later in source order, so these win. */
+ * specificity per selector, but later in source order, so these win.
+ * ::view-transition-group(root) must be neutralized too (zudolab/zzmod#845):
+ * the UA animates the root group for its full duration even when the old/new
+ * root snapshots are at animation: none, leaving a brief frozen,
+ * non-interactive frame. The chrome groups are already animation: none in the
+ * unconditional chrome block above, so only the root group is added here. */
 @media (prefers-reduced-motion: reduce) {
   ::view-transition-old(root),
   ::view-transition-new(root),
+  ::view-transition-group(root),
   ::view-transition-old(zfb-header):only-child,
   ::view-transition-old(zfb-sidebar):only-child,
   ::view-transition-old(zfb-footer):only-child,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1166,10 +1166,16 @@ dialog.zd-mermaid-dialog::backdrop {
  * transition settles immediately — no cross-fade, no translateY slide.
  * Covers the root cross-fade and the #2072 :only-child entry/exit rules;
  * the both-sides chrome layers are already animation: none above. Equal
- * specificity per selector, but later in source order, so these win. */
+ * specificity per selector, but later in source order, so these win.
+ * ::view-transition-group(root) must be neutralized too (zudolab/zzmod#845):
+ * the UA animates the root group for its full duration even when the old/new
+ * root snapshots are at animation: none, leaving a brief frozen,
+ * non-interactive frame. The chrome groups are already animation: none in the
+ * unconditional chrome block above, so only the root group is added here. */
 @media (prefers-reduced-motion: reduce) {
   ::view-transition-old(root),
   ::view-transition-new(root),
+  ::view-transition-group(root),
   ::view-transition-old(zfb-header):only-child,
   ::view-transition-old(zfb-sidebar):only-child,
   ::view-transition-old(zfb-footer):only-child,


### PR DESCRIPTION
## Summary

The `@media (prefers-reduced-motion: reduce)` view-transition block neutralized `::view-transition-old(root)` / `::view-transition-new(root)` (plus the `:only-child` chrome entry/exit layers) to `animation: none`, but omitted `::view-transition-group(root)`. The UA default keeps animating the root *group* for its full duration even when the old/new snapshots are frozen, so a reduced-motion user got a brief (~0.25s) frozen, non-interactive root snapshot instead of a true instant swap. (The both-sides chrome *groups* were already `animation: none` in the unconditional chrome block, so only the root group was missed.)

## Origin

Cross-repo upstream item surfaced by **zudolab/zzmod#845**. zzmod already fixed its own side in zzmod#844 with a deliberate one-selector divergence from this template; landing the fix here lets zzmod re-align on its next template-diff reconciliation. zzmod#845 lives in a different repository and is referenced (not closed) by this PR.

## Changes

- `src/styles/global.css` — added `::view-transition-group(root)` to the reduced-motion selector list; extended the explanatory comment.
- `packages/create-zudo-doc/templates/base/src/styles/global.css` — identical edit, keeping the showcase and the `create-zudo-doc` base template in exact sync (the file is template-drift-allowlisted, so divergence here is not caught automatically).

The two reduced-motion blocks are verified byte-identical after the change.

## Test Plan

- `pnpm check` (typecheck) and the standard CI suite (build, link/html checks, e2e) gate the change.
- Manual: with OS "reduce motion" enabled, SPA navigation performs an instant root swap (no lingering frozen root frame); with reduced motion off, the cross-fade is unchanged.