### PR TITLE
ci: retry CSS-shape smoke-gate fetches (fix flaky post-deploy 404)

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -312,9 +312,13 @@ jobs:
         run: |
           set -euo pipefail
           PROD_URL="https://zudo-doc.takazudomodular.com"
-          CSS_PATH=$(curl -fsSL "$PROD_URL/" | grep -oE 'href="[^"]*assets/styles-[^"]*\.css"' | head -1 | sed 's/href="//;s/"$//')
+          # Retry both fetches: right after `wrangler deploy` the homepage HTML can
+          # reference a new hashed styles-<hash>.css before that asset has propagated to
+          # the edge, so an immediate curl 404s. --retry-all-errors retries HTTP 4xx too
+          # (plain --retry does not). Propagation race, not a real failure (#2236).
+          CSS_PATH=$(curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors "$PROD_URL/" | grep -oE 'href="[^"]*assets/styles-[^"]*\.css"' | head -1 | sed 's/href="//;s/"$//')
           [ -n "$CSS_PATH" ] || { echo "::error::no CSS link found in $PROD_URL/"; exit 1; }
-          curl -fsSL "${PROD_URL}${CSS_PATH}" -o /tmp/deployed-css.css
+          curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors "${PROD_URL}${CSS_PATH}" -o /tmp/deployed-css.css
 
           CSS_BYTES=$(wc -c < /tmp/deployed-css.css)
           MIN_CSS_BYTES=50000  # post-zfb#159 split-import fix (in pin 9239267) drops leaked Tailwind defaults; healthy baseline ~64-66 KB (down from pre-fix ~77.7 KB). Threshold sits well above the ~30-40 KB broken-scanner floor with headroom for future intentional shrinkage.

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -684,9 +684,13 @@ jobs:
           DEPLOY_URL: ${{ steps.cf-deploy.outputs.deploy_url }}
         run: |
           set -euo pipefail
-          CSS_PATH=$(curl -fsSL "$DEPLOY_URL/" | grep -oE 'href="[^"]*assets/styles-[^"]*\.css"' | head -1 | sed 's/href="//;s/"$//')
+          # Retry both fetches: right after deploy the homepage HTML can reference a new
+          # hashed styles-<hash>.css before that asset has propagated, so an immediate
+          # curl 404s. --retry-all-errors retries HTTP 4xx too (plain --retry does not).
+          # Propagation race, not a real failure (#2236).
+          CSS_PATH=$(curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors "$DEPLOY_URL/" | grep -oE 'href="[^"]*assets/styles-[^"]*\.css"' | head -1 | sed 's/href="//;s/"$//')
           [ -n "$CSS_PATH" ] || { echo "::error::no CSS link found in $DEPLOY_URL/"; exit 1; }
-          curl -fsSL "${DEPLOY_URL}${CSS_PATH}" -o /tmp/deployed-css.css
+          curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors "${DEPLOY_URL}${CSS_PATH}" -o /tmp/deployed-css.css
 
           CSS_BYTES=$(wc -c < /tmp/deployed-css.css)
           MIN_CSS_BYTES=50000  # post-zfb#159 split-import fix (in pin 9239267) drops leaked Tailwind defaults; healthy baseline ~64-66 KB (down from pre-fix ~77.7 KB). Threshold sits well above the ~30-40 KB broken-scanner floor with headroom for future intentional shrinkage.

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -343,10 +343,14 @@ jobs:
           DEPLOY_URL: ${{ steps.deploy.outputs.deploy_url }}
         run: |
           set -euo pipefail
-          CSS_PATH=$(curl -fsSL "$DEPLOY_URL/" | grep -oE 'href="[^"]*assets/styles-[^"]*\.css"' | head -1 | sed 's/href="//;s/"$//')
+          # Retry both fetches: right after deploy the homepage HTML can reference a new
+          # hashed styles-<hash>.css before that asset has propagated, so an immediate
+          # curl 404s. --retry-all-errors retries HTTP 4xx too (plain --retry does not).
+          # Propagation race, not a real failure (#2236).
+          CSS_PATH=$(curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors "$DEPLOY_URL/" | grep -oE 'href="[^"]*assets/styles-[^"]*\.css"' | head -1 | sed 's/href="//;s/"$//')
           [ -n "$CSS_PATH" ] || { echo "::error::no CSS link found in $DEPLOY_URL/"; exit 1; }
           # CSS href is root-relative (/assets/...); prepend the deploy origin.
-          curl -fsSL "${DEPLOY_URL}${CSS_PATH}" -o /tmp/deployed-css.css
+          curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors "${DEPLOY_URL}${CSS_PATH}" -o /tmp/deployed-css.css
 
           CSS_BYTES=$(wc -c < /tmp/deployed-css.css)
           MIN_CSS_BYTES=50000  # post-zfb#159 split-import fix (in pin 9239267) drops leaked Tailwind defaults; healthy baseline ~64-66 KB (down from pre-fix ~77.7 KB). Threshold sits well above the ~30-40 KB broken-scanner floor with headroom for future intentional shrinkage.


### PR DESCRIPTION
## Summary

The `CSS-shape smoke gate (#1395)` step fetched the live homepage and then the hashed `styles-<hash>.css` asset with a plain `curl -fsSL` and **no retry**. Immediately after `wrangler deploy`, the homepage HTML can reference a freshly-hashed CSS filename before that asset has propagated to the Cloudflare edge, so the asset fetch transiently **404s** and fails the deploy. Any PR that changes CSS content can trip this.

Observed on PR #2235's post-merge **Production Deploy** (`curl: (22) ... 404`); a no-op re-run passed and production was verified healthy — confirming a pure propagation race.

## Changes

Add `--retry 5 --retry-delay 3 --retry-all-errors` to **both** the homepage and the asset fetch in all three gate copies, kept in exact sync:

- `.github/workflows/main-deploy.yml`
- `.github/workflows/preview-deploy.yml`
- `.github/workflows/pr-checks.yml`

`--retry-all-errors` is required because `--retry` alone does not retry HTTP 4xx. Validation thresholds (bytes / `@media` / leaked-token counts) are unchanged — only the fetch gains propagation tolerance.

## Test Plan

- All three workflow files validated as well-formed YAML.
- This PR's own `pr-checks` run exercises the patched gate (preview deploy → smoke gate with retries).

Closes #2236.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784478098&installation_id=130359969&pr_number=2237&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2237&signature=3633a65b78b633be860871a8c0c8733859d82c0a239f6f14849ec4497d8b201c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->