### PR TITLE
chore(deps): bump @takazudo/zfb stack to 0.1.0-next.54

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,9 +85,9 @@
   },
   "dependencies": {
     "@takazudo/zdtp": "0.2.3",
-    "@takazudo/zfb": "0.1.0-next.53",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.53",
-    "@takazudo/zfb-runtime": "0.1.0-next.53",
+    "@takazudo/zfb": "0.1.0-next.54",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.54",
+    "@takazudo/zfb-runtime": "0.1.0-next.54",
     "@takazudo/zudo-doc": "workspace:*",
     "diff": "^8.0.3",
     "gray-matter": "^4.0.3",

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -3441,12 +3441,15 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
    * ClientRouter({ preserveHtmlAttrs }) option (zfb#1104) so runtime <html>
    * attributes (data-sidebar-hidden / data-theme) survive SPA swaps
    * (zudolab/zudo-doc#2200) — additive, non-breaking for a fresh scaffold.
-   * Now bumped to 0.1.0-next.53: zfb-content GFM-autolink fix terminating the
+   * Bumped to 0.1.0-next.53: zfb-content GFM-autolink fix terminating the
    * autolink path at CJK boundaries (zfb#1105) - content-rendering bug fix,
    * additive, no consumer-facing breaking change.
+   * Now bumped to 0.1.0-next.54: bug-fix + perf release (cross-OS CSS hash
+   * stability, multi-valued response headers, supplementary-plane CJK
+   * reading-time, CLI/server/runtime hardening) — no breaking changes.
    * Generated package.json must pin all three.
    */
-  it("pins @takazudo/zfb at 0.1.0-next.53", async () => {
+  it("pins @takazudo/zfb at 0.1.0-next.54", async () => {
     const choices: UserChoices = {
       projectName: "test-pin-bump",
       defaultLang: "en",
@@ -3457,10 +3460,10 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
     };
     await scaffold(choices);
     const pkg = await fs.readJson(projectPath("test-pin-bump", "package.json"));
-    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.53");
-    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.53");
+    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.54");
+    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.54");
     expect(pkg.dependencies["@takazudo/zfb-adapter-cloudflare"]).toBe(
-      "0.1.0-next.53",
+      "0.1.0-next.54",
     );
   });
 });

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -548,15 +548,19 @@ function generatePackageJson(choices: UserChoices) {
     // `ClientRouter({ preserveHtmlAttrs })` option (zfb#1104) — consumers can
     // declare runtime `<html>` attribute names to preserve across SPA swaps so
     // e.g. `data-sidebar-hidden` / `data-theme` survive (zudolab/zudo-doc#2200).
-    // Additive, non-breaking for a fresh scaffold. next.53 (current pin):
+    // Additive, non-breaking for a fresh scaffold. next.53:
     // zfb-content GFM-autolink fix — terminate the autolink path at CJK
     // boundaries (zfb#1105). Content-rendering bug fix, additive; relevant for
     // CJK (e.g. Japanese) docs. No consumer-facing / CLI breaking change.
-    "@takazudo/zfb": "0.1.0-next.53",
-    "@takazudo/zfb-runtime": "0.1.0-next.53",
+    // next.54 (current pin): bug-fix + perf release — cross-OS CSS hash
+    // stability, multi-valued response headers (e.g. multiple Set-Cookie),
+    // supplementary-plane CJK reading-time, plus CLI/server/runtime hardening
+    // and render perf passes. No consumer-facing / CLI breaking change.
+    "@takazudo/zfb": "0.1.0-next.54",
+    "@takazudo/zfb-runtime": "0.1.0-next.54",
     // zfb-adapter-cloudflare — required for any route with `prerender = false`.
     // Pinned in lockstep with @takazudo/zfb.
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.53",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.54",
     // @takazudo/zudo-doc — published from this monorepo via
     // .github/workflows/publish-zudo-doc.yml. The pin here is bumped in
     // lockstep by scripts/release-create-zudo-doc.sh whenever zudo-doc's

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -173,8 +173,8 @@
   ],
   "peerDependencies": {
     "preact": "^10.29.1",
-    "@takazudo/zfb": "^0.1.0-next.53",
-    "@takazudo/zfb-runtime": "^0.1.0-next.53",
+    "@takazudo/zfb": "^0.1.0-next.54",
+    "@takazudo/zfb-runtime": "^0.1.0-next.54",
     "@takazudo/zudo-doc-history-server": "^0.2.15",
     "@takazudo/zdtp": "^0.2.3",
     "shiki": "^4.0.2"
@@ -202,7 +202,7 @@
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
     "vitest": "^4.1.0",
-    "@takazudo/zfb": "0.1.0-next.53",
-    "@takazudo/zfb-runtime": "0.1.0-next.53"
+    "@takazudo/zfb": "0.1.0-next.54",
+    "@takazudo/zfb-runtime": "0.1.0-next.54"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,14 +30,14 @@ importers:
         specifier: 0.2.3
         version: 0.2.3(preact@10.29.2)
       '@takazudo/zfb':
-        specifier: 0.1.0-next.53
-        version: 0.1.0-next.53
+        specifier: 0.1.0-next.54
+        version: 0.1.0-next.54
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.53
-        version: 0.1.0-next.53
+        specifier: 0.1.0-next.54
+        version: 0.1.0-next.54
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.53
-        version: 0.1.0-next.53(@takazudo/zfb@0.1.0-next.53)
+        specifier: 0.1.0-next.54
+        version: 0.1.0-next.54(@takazudo/zfb@0.1.0-next.54)
       '@takazudo/zudo-doc':
         specifier: workspace:*
         version: link:packages/zudo-doc
@@ -266,11 +266,11 @@ importers:
         version: 4.0.3
     devDependencies:
       '@takazudo/zfb':
-        specifier: 0.1.0-next.53
-        version: 0.1.0-next.53
+        specifier: 0.1.0-next.54
+        version: 0.1.0-next.54
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.53
-        version: 0.1.0-next.53(@takazudo/zfb@0.1.0-next.53)
+        specifier: 0.1.0-next.54
+        version: 0.1.0-next.54(@takazudo/zfb@0.1.0-next.54)
       '@types/node':
         specifier: ^25.3.5
         version: 25.3.5
@@ -1353,46 +1353,55 @@ packages:
     peerDependencies:
       preact: ^10.29.1
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.53':
-    resolution: {integrity: sha512-OCcil6XTYLQgO/8djT3WvLPzhgm2FbA1RT9vYePFIKTnz8BNx61oxiCUWrkWmwX8ac6K5f3rQL5xpsXTQR3CzQ==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.54':
+    resolution: {integrity: sha512-ZQvaeSiIHZkh3w2MPczWzFIt1dGy3DGWmeg4omkNPNiECHyWBc0a1ZU9B6+d/13IeP++z1lIek8KsH53TsQAjQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.53':
-    resolution: {integrity: sha512-UZMEukrgfHeQ5+y14xrXXAPOAq6QI1LI6y+dNxPNmmZSJIjrzRAFU0TjPAQiltl2ZdUsszv17udqc2scemc4lA==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.54':
+    resolution: {integrity: sha512-5fyrbUKCJzgKwf2WgEsuSA8Nf0jd6PisdlA2XctdtJ66CxDspauE5s4oAP1cGK+KDDnXF01+lf8PNtRvPMojcA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.53':
-    resolution: {integrity: sha512-2HUkqqs+XrJLLw18OCv7Ky6EEXegIOhd7R8Xrqr8w+GbVv6Nw4TxHLLhjb9Qr97FlwMJ9mVewPYlBLYiDJjTqw==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.54':
+    resolution: {integrity: sha512-j6fYeQr6eEEwMz1+JX37shtq5p1ifxi2D8tswIS5HOM4im/gLp+oL5i5sLO5f9kGPxxx+c2rdaIkKQ1WPmJxxw==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.53':
-    resolution: {integrity: sha512-RixlNp1m7DBGqq9PWGMYtxmgg3GIbvYeI13zzMGez47UMRSpglH93Gg3LgSwpBs5c8oaPgLFQHn3pDDJDN9yog==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.54':
+    resolution: {integrity: sha512-GmtvZcG2cAKdCArSGgcTEPIubbH3VKRDK10Jwr2wkCYzyrb4vt2fkY2RFCdvUMdMLK9sdg+uw9/mpBiCE46IaQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.53':
-    resolution: {integrity: sha512-xyCvdL97WkhdBwxIagVq/xZuAzCaypwNUNDaQ7itxq/tfbBt2oyVv5H7vcEW/oG0RXRTFJMABJH2G+Y/9VZkbQ==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.54':
+    resolution: {integrity: sha512-NKj5KBWLyd7yW2DP1mPlHoN3Xdo6evAzmA8gknnSjq0p8lmv7KeIzFdV6x6O0ofywxtxiWZMtT2Km8ThbjpbBQ==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.53':
-    resolution: {integrity: sha512-5i7+VjHr8P0o1R9fnCmU/mp6fadg1CZm42GqH9njomwAj+41pz1MQ+T0iQru8PCiTtLG9B+Inbv/dXdGTKWvLA==}
+  '@takazudo/zfb-runtime@0.1.0-next.54':
+    resolution: {integrity: sha512-9Y+0mv2MXDwwH+yAgNc8yCsK9k/XnAS5b2eYoAhJwxbXjGnNG8f50Fd39BeAkNVb8iaO0Cdq4hfJgOU3+MIXxw==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.53
+      '@takazudo/zfb': 0.1.0-next.54
+      react: ^19.2.3
+    peerDependenciesMeta:
+      react:
+        optional: true
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.53':
-    resolution: {integrity: sha512-F3AgrTycPsA9/eQm8E141EvWkc+oBaDwI4m1H/kGfuwQJiX8vcrFqZTLy33FfYKxfKqA3TLaRu4rwoO7t2g6vA==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.54':
+    resolution: {integrity: sha512-enMGYkBTO98vuoCpBG3FHLCGB3nYkmhgv7icrN8GG4Mfb7x6G7x7C6zAirz62tPA/4x2BDi7RBh/wXK/xnlx1A==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.53':
-    resolution: {integrity: sha512-iwed5oRyMWyvE6VB6H0jE6qyIQ24R1M4uUzIeN38VJf1xqKJiCglNwP1J8dduhDEX0F1jtsWrBexfHxnp6K/vw==}
+  '@takazudo/zfb@0.1.0-next.54':
+    resolution: {integrity: sha512-8q3ItuyTH4JRqkHxvjiJQWyA+39UtY5gwkJgePDnBSDbIpOsWdZk8W1Xrq/je4sB2T4kA7tRkoiv4cTcoBCh7g==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
+    peerDependencies:
+      react: ^19.2.3
+    peerDependenciesMeta:
+      react:
+        optional: true
 
   '@takazudo/zudo-design-token-lint@1.0.0':
     resolution: {integrity: sha512-/v82OdkGRH+2f3Y0d0haBIE6iVNbpYByYEra2DivbnNANpI27FWmqswkvBTfm/3nMeEWUW4MIW175B/djTfu3A==}
@@ -4053,35 +4062,35 @@ snapshots:
       culori: 4.0.2
       preact: 10.29.2
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.53': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.54': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.53':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.54':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.53':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.54':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.53':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.54':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.53':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.54':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.53(@takazudo/zfb@0.1.0-next.53)':
+  '@takazudo/zfb-runtime@0.1.0-next.54(@takazudo/zfb@0.1.0-next.54)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.53
+      '@takazudo/zfb': 0.1.0-next.54
       hono: 4.12.25
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.53':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.54':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.53':
+  '@takazudo/zfb@0.1.0-next.54':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.53
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.53
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.53
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.53
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.53
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.54
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.54
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.54
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.54
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.54
 
   '@takazudo/zudo-design-token-lint@1.0.0(patch_hash=6a157fd850449b055cf64a8a7dd1faed5b1da9eebe6c81cca08488ac0de85182)':
     dependencies:


### PR DESCRIPTION
## Summary

Bump the `@takazudo/zfb` toolchain from `0.1.0-next.53` to `0.1.0-next.54` across all pin-parity-linked sources.

`next.54` is a **bug-fix + perf release — no breaking changes** (no "Breaking changes" section in the upstream changelog). Highlights: cross-OS CSS hash stability, multi-valued response header preservation (e.g. multiple `Set-Cookie`), supplementary-plane CJK in reading-time, several CLI/server/runtime hardening fixes, and rendering perf passes. Additive, no consumer-facing / CLI breaking change.

Other `@takazudo` deps (`zdtp` 0.2.3, `zudo-design-token-lint` ^1.0.0, `zudo-doc-history-server` ^0.2.15) are already at their latest published versions — nothing to bump there. `mdx-formatter` is invoked via `pnpm dlx` with no pin, so there is no dep entry to bump.

## Changes

Bumped `next.53 → next.54` in all five pin-parity-linked locations (the same set the `check:pin-parity` gate enforces):

- `package.json` — root `dependencies`: `@takazudo/zfb`, `@takazudo/zfb-runtime`, `@takazudo/zfb-adapter-cloudflare`
- `packages/zudo-doc/package.json` — `devDependencies` (exact) + `peerDependencies` (`^`) for `@takazudo/zfb` and `@takazudo/zfb-runtime`
- `packages/create-zudo-doc/src/scaffold.ts` — generated-project scaffold pins (+ updated version-history comment)
- `packages/create-zudo-doc/src/__tests__/scaffold.test.ts` — pin assertions + test name + comment
- `pnpm-lock.yaml` — resolved to `0.1.0-next.54`

No version bump / changelog entry — those belong to the separate `/l-make-release` step (per the established convention; the deps bump and the release are distinct commits).

## Test Plan

- `pnpm check:pin-parity` — green
- Full `b4push` suite (18 steps, manual smoke skipped): format check, template/fixture/pin drift gates, tags audit, design-token lint, z-index drift, e2e spec-naming, b4push↔CI parity, typecheck, root unit tests, **package tests (incl. the scaffold pin test)**, package safelist, build, link check, HTML validation, preview smoke — all pass
- Codex review of the diff — clean, no actionable findings