### PR TITLE
ClientRouter Opt-Out: let consumers disable the SPA router / page transitions (#2273)

### DIFF
--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -4033,6 +4033,113 @@ describe("scaffold — dynamicPageTransition feature (#2267)", () => {
     );
     expect(content).toContain("dynamicPageTransition: false");
   });
+
+  // #2276: every <DocLayoutWithDefaults> render site must thread
+  // enableClientRouter={settings.dynamicPageTransition} so the SPA router is
+  // gated per-page by the settings flag.
+  it("feature ON: _doc-page-shell.tsx contains enableClientRouter={settings.dynamicPageTransition}", async () => {
+    const choices: UserChoices = {
+      projectName: "test-dpt-on-ecr-shell",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search", "dynamicPageTransition"],
+      packageManager: "pnpm",
+    };
+    await scaffold(choices);
+    const content = await fs.readFile(
+      projectPath("test-dpt-on-ecr-shell", "pages/lib/_doc-page-shell.tsx"),
+      "utf-8",
+    );
+    expect(content).toContain("enableClientRouter={settings.dynamicPageTransition}");
+  });
+
+  it("feature OFF: _doc-page-shell.tsx contains enableClientRouter={settings.dynamicPageTransition}", async () => {
+    const choices: UserChoices = {
+      projectName: "test-dpt-off-ecr-shell",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search"],
+      packageManager: "pnpm",
+    };
+    await scaffold(choices);
+    const content = await fs.readFile(
+      projectPath("test-dpt-off-ecr-shell", "pages/lib/_doc-page-shell.tsx"),
+      "utf-8",
+    );
+    // The prop must be present regardless of feature state — the value
+    // (settings.dynamicPageTransition) is false at runtime when feature is off.
+    expect(content).toContain("enableClientRouter={settings.dynamicPageTransition}");
+  });
+
+  it("feature ON: pages/index.tsx contains enableClientRouter={settings.dynamicPageTransition}", async () => {
+    const choices: UserChoices = {
+      projectName: "test-dpt-on-ecr-index",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search", "dynamicPageTransition"],
+      packageManager: "pnpm",
+    };
+    await scaffold(choices);
+    const content = await fs.readFile(
+      projectPath("test-dpt-on-ecr-index", "pages/index.tsx"),
+      "utf-8",
+    );
+    expect(content).toContain("enableClientRouter={settings.dynamicPageTransition}");
+  });
+
+  it("feature OFF: pages/index.tsx contains enableClientRouter={settings.dynamicPageTransition}", async () => {
+    const choices: UserChoices = {
+      projectName: "test-dpt-off-ecr-index",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search"],
+      packageManager: "pnpm",
+    };
+    await scaffold(choices);
+    const content = await fs.readFile(
+      projectPath("test-dpt-off-ecr-index", "pages/index.tsx"),
+      "utf-8",
+    );
+    expect(content).toContain("enableClientRouter={settings.dynamicPageTransition}");
+  });
+
+  it("feature ON: pages/404.tsx contains enableClientRouter={settings.dynamicPageTransition}", async () => {
+    const choices: UserChoices = {
+      projectName: "test-dpt-on-ecr-404",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search", "dynamicPageTransition"],
+      packageManager: "pnpm",
+    };
+    await scaffold(choices);
+    const content = await fs.readFile(
+      projectPath("test-dpt-on-ecr-404", "pages/404.tsx"),
+      "utf-8",
+    );
+    expect(content).toContain("enableClientRouter={settings.dynamicPageTransition}");
+  });
+
+  it("feature OFF: pages/404.tsx contains enableClientRouter={settings.dynamicPageTransition}", async () => {
+    const choices: UserChoices = {
+      projectName: "test-dpt-off-ecr-404",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search"],
+      packageManager: "pnpm",
+    };
+    await scaffold(choices);
+    const content = await fs.readFile(
+      projectPath("test-dpt-off-ecr-404", "pages/404.tsx"),
+      "utf-8",
+    );
+    expect(content).toContain("enableClientRouter={settings.dynamicPageTransition}");
+  });
 });
 
 describe("scaffold — noindex feature (#2218)", () => {

--- a/packages/create-zudo-doc/src/features/dynamic-page-transition.ts
+++ b/packages/create-zudo-doc/src/features/dynamic-page-transition.ts
@@ -3,10 +3,15 @@ import type { FeatureModule } from "../compose.js";
 /**
  * Dynamic page transition feature.
  *
- * When enabled, wires the SPA client-side router (ClientRouterBootstrap
- * island) and the page-loading overlay (PageLoadingOverlay, pure SSR) into
- * body-end-islands, and injects the View-Transitions CSS + page-loading
- * overlay CSS into global.css.
+ * When enabled:
+ * - Sets `enableClientRouter={settings.dynamicPageTransition}` on every
+ *   `<DocLayoutWithDefaults>` render site — the SSR `<ClientRouter />` render
+ *   self-activates the SPA router on the client as a top-level module side
+ *   effect (primary activation path).
+ * - Wires the ClientRouterBootstrap island and the PageLoadingOverlay (pure
+ *   SSR) into body-end-islands — the island is now a redundant fallback;
+ *   PageLoadingOverlay provides the loading spinner UI.
+ * - Injects the View-Transitions CSS + page-loading overlay CSS into global.css.
  *
  * Bug fix (#2265): the page-loading overlay CSS (.page-loading-overlay /
  * .page-loading-spinner / @keyframes page-loading-spin / [data-zd-nav-pending])

--- a/packages/create-zudo-doc/templates/base/pages/404.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/404.tsx
@@ -34,7 +34,6 @@ export default function NotFoundPage(): JSX.Element {
       head={<HeadWithDefaults title={title} />}
       lang={locale}
       noindex={true}
-      enableClientRouter={settings.dynamicPageTransition}
       hideSidebar={true}
       hideToc={true}
       // Empty fragment suppresses DocLayoutWithDefaults' empty-data default
@@ -45,6 +44,7 @@ export default function NotFoundPage(): JSX.Element {
       headerOverride={<HeaderWithDefaults lang={locale} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
       bodyEndComponents={<BodyEndIslands basePath={settings.base ?? "/"} />}
+      enableClientRouter={settings.dynamicPageTransition}
     >
       <div class="min-h-[60vh] flex flex-col items-center justify-center px-hsp-2xl py-vsp-xl">
         <h1 class="text-display font-bold mb-vsp-md">404</h1>

--- a/packages/create-zudo-doc/templates/base/pages/404.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/404.tsx
@@ -34,6 +34,7 @@ export default function NotFoundPage(): JSX.Element {
       head={<HeadWithDefaults title={title} />}
       lang={locale}
       noindex={true}
+      enableClientRouter={settings.dynamicPageTransition}
       hideSidebar={true}
       hideToc={true}
       // Empty fragment suppresses DocLayoutWithDefaults' empty-data default

--- a/packages/create-zudo-doc/templates/base/pages/index.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/index.tsx
@@ -63,7 +63,6 @@ export default function IndexPage(): JSX.Element {
       head={<HeadWithDefaults title={settings.siteName} />}
       lang={locale}
       noindex={settings.noindex}
-      enableClientRouter={settings.dynamicPageTransition}
       hideSidebar={true}
       hideToc={true}
       // Empty fragment suppresses DocLayoutWithDefaults' empty-data default
@@ -74,6 +73,7 @@ export default function IndexPage(): JSX.Element {
       headerOverride={<HeaderWithDefaults lang={locale} currentPath={withBase("/")} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
       bodyEndComponents={<BodyEndIslands basePath={settings.base ?? "/"} />}
+      enableClientRouter={settings.dynamicPageTransition}
     >
       {/* Hero: logo left, title+desc+links right, block centered */}
       <div class="flex justify-center mb-vsp-xl">

--- a/packages/create-zudo-doc/templates/base/pages/index.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/index.tsx
@@ -63,6 +63,7 @@ export default function IndexPage(): JSX.Element {
       head={<HeadWithDefaults title={settings.siteName} />}
       lang={locale}
       noindex={settings.noindex}
+      enableClientRouter={settings.dynamicPageTransition}
       hideSidebar={true}
       hideToc={true}
       // Empty fragment suppresses DocLayoutWithDefaults' empty-data default

--- a/packages/create-zudo-doc/templates/base/pages/lib/_doc-body-end.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_doc-body-end.tsx
@@ -18,8 +18,14 @@ import { SidebarResizerInit } from "@takazudo/zudo-doc/sidebar-resizer";
 
 /**
  * The `bodyEndComponents` slot content shared by all four doc-route page
- * components: `BodyEndIslands` (modal overlays, client-router bootstrap,
- * image-enlarge) and the optional `SidebarResizerInit` drag handle.
+ * components: `BodyEndIslands` (modal overlays, image-enlarge, and — when
+ * dynamicPageTransition is enabled — the ClientRouterBootstrap island) and
+ * the optional `SidebarResizerInit` drag handle.
+ *
+ * Note: the SPA router is primarily activated by `enableClientRouter` on
+ * `DocLayoutWithDefaults` (SSR render). The ClientRouterBootstrap island
+ * inside BodyEndIslands is now redundant for that activation path; it
+ * remains as a belt-and-suspenders fallback.
  */
 export function DocBodyEnd(): JSX.Element {
   return (

--- a/packages/create-zudo-doc/templates/base/pages/lib/_doc-body-end.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_doc-body-end.tsx
@@ -18,14 +18,14 @@ import { SidebarResizerInit } from "@takazudo/zudo-doc/sidebar-resizer";
 
 /**
  * The `bodyEndComponents` slot content shared by all four doc-route page
- * components: `BodyEndIslands` (modal overlays, image-enlarge, and — when
- * dynamicPageTransition is enabled — the ClientRouterBootstrap island) and
- * the optional `SidebarResizerInit` drag handle.
- *
- * Note: the SPA router is primarily activated by `enableClientRouter` on
- * `DocLayoutWithDefaults` (SSR render). The ClientRouterBootstrap island
- * inside BodyEndIslands is now redundant for that activation path; it
- * remains as a belt-and-suspenders fallback.
+ * components: `BodyEndIslands` (modal overlays, optional client-router
+ * bootstrap when `dynamicPageTransition` is on, image-enlarge) and the
+ * optional `SidebarResizerInit` drag handle. Whether the client-router
+ * bootstrap island is included depends on `settings.dynamicPageTransition`
+ * (gated inside `BodyEndIslands`). The SSR `<ClientRouter />` mounted by
+ * `DocLayout` self-activates when `enableClientRouter` is `true`; the
+ * island here is redundant for that activation path and kept only for the
+ * `when="load"` hydration slot.
  */
 export function DocBodyEnd(): JSX.Element {
   return (

--- a/packages/create-zudo-doc/templates/base/pages/lib/_doc-page-shell.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_doc-page-shell.tsx
@@ -182,6 +182,7 @@ export function DocPageShell(props: DocPageShellProps): JSX.Element {
       head={<HeadWithDefaults title={title} description={description} canonical={canonical} />}
       lang={locale}
       noindex={settings.noindex}
+      enableClientRouter={settings.dynamicPageTransition}
       hideSidebar={hideSidebar}
       hideToc={hideToc}
       headings={headings}

--- a/packages/create-zudo-doc/templates/base/pages/lib/_doc-page-shell.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_doc-page-shell.tsx
@@ -182,7 +182,6 @@ export function DocPageShell(props: DocPageShellProps): JSX.Element {
       head={<HeadWithDefaults title={title} description={description} canonical={canonical} />}
       lang={locale}
       noindex={settings.noindex}
-      enableClientRouter={settings.dynamicPageTransition}
       hideSidebar={hideSidebar}
       hideToc={hideToc}
       headings={headings}
@@ -219,6 +218,7 @@ export function DocPageShell(props: DocPageShellProps): JSX.Element {
       afterSidebar={<SidebarPrepaint />}
       footerOverride={<FooterWithDefaults lang={locale} />}
       bodyEndComponents={<DocBodyEnd />}
+      enableClientRouter={settings.dynamicPageTransition}
     >
       {kind === "autoIndex" ? (
         /* Auto-index page: category without an index.mdx.

--- a/packages/create-zudo-doc/templates/features/docTags/files/pages/lib/_tag-pages.tsx
+++ b/packages/create-zudo-doc/templates/features/docTags/files/pages/lib/_tag-pages.tsx
@@ -129,6 +129,7 @@ export function TagDetailPageView({
       // undefined relies on Preact treating an undefined prop as absent.
       lang={isDefault ? undefined : locale}
       noindex={settings.noindex}
+      enableClientRouter={settings.dynamicPageTransition}
       hideSidebar={true}
       hideToc={true}
       // Empty fragment suppresses DocLayoutWithDefaults' empty-data default
@@ -187,6 +188,7 @@ export function TagsIndexPageView({ locale }: { locale: string }): JSX.Element {
       // Same undefined-≡-absent reliance as TagDetailPageView above.
       lang={isDefault ? undefined : locale}
       noindex={settings.noindex}
+      enableClientRouter={settings.dynamicPageTransition}
       hideSidebar={true}
       hideToc={true}
       // Empty fragment suppresses DocLayoutWithDefaults' empty-data default

--- a/packages/create-zudo-doc/templates/features/docTags/files/pages/lib/_tag-pages.tsx
+++ b/packages/create-zudo-doc/templates/features/docTags/files/pages/lib/_tag-pages.tsx
@@ -129,7 +129,6 @@ export function TagDetailPageView({
       // undefined relies on Preact treating an undefined prop as absent.
       lang={isDefault ? undefined : locale}
       noindex={settings.noindex}
-      enableClientRouter={settings.dynamicPageTransition}
       hideSidebar={true}
       hideToc={true}
       // Empty fragment suppresses DocLayoutWithDefaults' empty-data default
@@ -143,6 +142,7 @@ export function TagDetailPageView({
       breadcrumbOverride={<Breadcrumb items={breadcrumbItems} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
       bodyEndComponents={<BodyEndIslands basePath={settings.base ?? "/"} />}
+      enableClientRouter={settings.dynamicPageTransition}
     >
       <h1 class="text-heading font-bold mb-vsp-xs">{pageTitle}</h1>
       <p class="text-muted mb-vsp-lg">{countText}</p>
@@ -188,7 +188,6 @@ export function TagsIndexPageView({ locale }: { locale: string }): JSX.Element {
       // Same undefined-≡-absent reliance as TagDetailPageView above.
       lang={isDefault ? undefined : locale}
       noindex={settings.noindex}
-      enableClientRouter={settings.dynamicPageTransition}
       hideSidebar={true}
       hideToc={true}
       // Empty fragment suppresses DocLayoutWithDefaults' empty-data default
@@ -200,6 +199,7 @@ export function TagsIndexPageView({ locale }: { locale: string }): JSX.Element {
       breadcrumbOverride={<Breadcrumb items={breadcrumbItems} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
       bodyEndComponents={<BodyEndIslands basePath={settings.base ?? "/"} />}
+      enableClientRouter={settings.dynamicPageTransition}
     >
       <h1 class="text-heading font-bold mb-vsp-lg">{pageTitle}</h1>
       {!settings.docTags || tags.length === 0 ? (

--- a/packages/create-zudo-doc/templates/features/dynamicPageTransition/files/src/components/client-router-bootstrap.tsx
+++ b/packages/create-zudo-doc/templates/features/dynamicPageTransition/files/src/components/client-router-bootstrap.tsx
@@ -47,11 +47,18 @@ import "@takazudo/zfb-runtime/client-router";
 import type { JSX } from "preact";
 
 /**
- * Renders nothing. The SSR `<ClientRouter />` rendered by DocLayout (when
- * `enableClientRouter` is true) self-activates on the client as a top-level
- * module side effect — this island is now a redundant belt-and-suspenders
- * fallback. The island marker keeps the client-router barrel in the bundle
- * for environments where the SSR path alone is insufficient.
+ * Renders nothing. The island marker exists only so zfb's island scanner
+ * walks page → BodyEndIslands → ClientRouterBootstrap and includes the
+ * client-router barrel in the per-island bundle, where the side-effect
+ * import above can fire on the client.
+ *
+ * Note: the SSR `<ClientRouter />` mounted by `DocLayout` (via
+ * `enableClientRouter`) self-activates the SPA router when its head meta
+ * tags reach the browser. This host island is therefore a no-op for
+ * router activation — it is kept only for the `when="load"` hydration
+ * slot and bundle inclusion. The actual on/off gate is
+ * `enableClientRouter` on `<DocLayoutWithDefaults>`, set to
+ * `settings.dynamicPageTransition` at every call site.
  */
 function ClientRouterBootstrap(): JSX.Element | null {
   return null;

--- a/packages/create-zudo-doc/templates/features/dynamicPageTransition/files/src/components/client-router-bootstrap.tsx
+++ b/packages/create-zudo-doc/templates/features/dynamicPageTransition/files/src/components/client-router-bootstrap.tsx
@@ -47,10 +47,11 @@ import "@takazudo/zfb-runtime/client-router";
 import type { JSX } from "preact";
 
 /**
- * Renders nothing. The island marker exists only so zfb's island scanner
- * walks page → BodyEndIslands → ClientRouterBootstrap and includes the
- * client-router barrel in the per-island bundle, where the side-effect
- * import above can fire on the client.
+ * Renders nothing. The SSR `<ClientRouter />` rendered by DocLayout (when
+ * `enableClientRouter` is true) self-activates on the client as a top-level
+ * module side effect — this island is now a redundant belt-and-suspenders
+ * fallback. The island marker keeps the client-router barrel in the bundle
+ * for environments where the SSR path alone is insufficient.
  */
 function ClientRouterBootstrap(): JSX.Element | null {
   return null;

--- a/packages/create-zudo-doc/templates/features/i18n/files/pages/[locale]/index.tsx
+++ b/packages/create-zudo-doc/templates/features/i18n/files/pages/[locale]/index.tsx
@@ -107,6 +107,7 @@ export default function LocaleIndexPage({ params }: PageArgs): JSX.Element {
       head={<HeadWithDefaults title={settings.siteName} />}
       lang={locale}
       noindex={settings.noindex}
+      enableClientRouter={settings.dynamicPageTransition}
       hideSidebar={true}
       hideToc={true}
       // Empty fragment suppresses DocLayoutWithDefaults' empty-data default

--- a/packages/create-zudo-doc/templates/features/i18n/files/pages/[locale]/index.tsx
+++ b/packages/create-zudo-doc/templates/features/i18n/files/pages/[locale]/index.tsx
@@ -107,7 +107,6 @@ export default function LocaleIndexPage({ params }: PageArgs): JSX.Element {
       head={<HeadWithDefaults title={settings.siteName} />}
       lang={locale}
       noindex={settings.noindex}
-      enableClientRouter={settings.dynamicPageTransition}
       hideSidebar={true}
       hideToc={true}
       // Empty fragment suppresses DocLayoutWithDefaults' empty-data default
@@ -118,6 +117,7 @@ export default function LocaleIndexPage({ params }: PageArgs): JSX.Element {
       headerOverride={<HeaderWithDefaults lang={locale as Locale} currentPath={withBase(`/${locale}/`)} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
       bodyEndComponents={<BodyEndIslands basePath={settings.base ?? "/"} />}
+      enableClientRouter={settings.dynamicPageTransition}
     >
       {/* Hero: logo left, title+desc+links right, block centered */}
       <div class="flex justify-center mb-vsp-xl">

--- a/packages/create-zudo-doc/templates/features/versioning/files/pages/lib/_versions-page.tsx
+++ b/packages/create-zudo-doc/templates/features/versioning/files/pages/lib/_versions-page.tsx
@@ -63,6 +63,7 @@ export function VersionsPageView({ locale }: { locale: string }): JSX.Element {
       head={<HeadWithDefaults title={pageTitle} />}
       lang={locale}
       noindex={settings.noindex}
+      enableClientRouter={settings.dynamicPageTransition}
       hideSidebar={true}
       hideToc={true}
       // Empty fragment suppresses DocLayoutWithDefaults' empty-data default

--- a/packages/create-zudo-doc/templates/features/versioning/files/pages/lib/_versions-page.tsx
+++ b/packages/create-zudo-doc/templates/features/versioning/files/pages/lib/_versions-page.tsx
@@ -63,7 +63,6 @@ export function VersionsPageView({ locale }: { locale: string }): JSX.Element {
       head={<HeadWithDefaults title={pageTitle} />}
       lang={locale}
       noindex={settings.noindex}
-      enableClientRouter={settings.dynamicPageTransition}
       hideSidebar={true}
       hideToc={true}
       // Empty fragment suppresses DocLayoutWithDefaults' empty-data default
@@ -74,6 +73,7 @@ export function VersionsPageView({ locale }: { locale: string }): JSX.Element {
       headerOverride={<HeaderWithDefaults lang={locale as Locale} currentPath={withBase(`${prefix}/docs/versions`)} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
       bodyEndComponents={<BodyEndIslands basePath={settings.base ?? "/"} />}
+      enableClientRouter={settings.dynamicPageTransition}
     >
       <VersionsPageContent
         latestHref={latestHref}

--- a/packages/zudo-doc/src/doclayout/__tests__/doc-layout-client-router-gating.test.tsx
+++ b/packages/zudo-doc/src/doclayout/__tests__/doc-layout-client-router-gating.test.tsx
@@ -1,0 +1,54 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+/**
+ * SSG HTML-presence test for `enableClientRouter` gating in `<DocLayout>` /
+ * `<DocLayoutWithDefaults>`.
+ *
+ * Acceptance contract for S1 (ClientRouter Opt-Out epic #2274): when
+ * `enableClientRouter={false}` is passed, the zfb SPA soft-swap router must
+ * NOT be mounted — meaning the `<meta name="zfb-view-transitions-enabled">`,
+ * `<meta name="zfb-preserve-html-attrs">`, and the route-announcer emitted by
+ * `ClientRouter()` must all be absent from the SSG output. With the prop
+ * omitted or set to `true`, those meta tags must appear (default/enabled path).
+ */
+
+import { describe, expect, it } from "vitest";
+import { render } from "preact-render-to-string";
+import { DocLayoutWithDefaults } from "../doc-layout-with-defaults.js";
+
+describe("DocLayoutWithDefaults — ClientRouter gating", () => {
+  it("omits ClientRouter meta when enableClientRouter={false}", () => {
+    const html = render(
+      <DocLayoutWithDefaults title="No Router" enableClientRouter={false}>
+        <p>body</p>
+      </DocLayoutWithDefaults>,
+    );
+
+    expect(html).not.toContain('name="zfb-view-transitions-enabled"');
+    expect(html).not.toContain('name="zfb-preserve-html-attrs"');
+    // Route-announcer emitted by ClientRouter — absent when router is off.
+    expect(html).not.toContain("route-announcer");
+  });
+
+  it("includes ClientRouter meta when enableClientRouter is omitted (default=true)", () => {
+    const html = render(
+      <DocLayoutWithDefaults title="With Router">
+        <p>body</p>
+      </DocLayoutWithDefaults>,
+    );
+
+    expect(html).toContain('name="zfb-view-transitions-enabled"');
+    expect(html).toContain('name="zfb-preserve-html-attrs"');
+  });
+
+  it("includes ClientRouter meta when enableClientRouter={true}", () => {
+    const html = render(
+      <DocLayoutWithDefaults title="Router Explicit True" enableClientRouter={true}>
+        <p>body</p>
+      </DocLayoutWithDefaults>,
+    );
+
+    expect(html).toContain('name="zfb-view-transitions-enabled"');
+    expect(html).toContain('name="zfb-preserve-html-attrs"');
+  });
+});

--- a/packages/zudo-doc/src/doclayout/doc-layout.tsx
+++ b/packages/zudo-doc/src/doclayout/doc-layout.tsx
@@ -182,6 +182,15 @@ export interface DocLayoutProps extends DocLayoutHtmlAttrs {
    * the sidebar resizer) inject into the scripts slot specifically.
    */
   bodyEndScripts?: ComponentChildren;
+
+  /**
+   * When `false`, the zfb SPA soft-swap router (`ClientRouter`) is not
+   * mounted — the page uses plain full-page navigation instead. This
+   * also omits the `zfb-view-transitions-enabled` /
+   * `zfb-preserve-html-attrs` meta tags and the route-announcer that
+   * `ClientRouter` emits. Defaults to `true` (router enabled).
+   */
+  enableClientRouter?: boolean;
 }
 
 /**
@@ -222,6 +231,7 @@ export function DocLayout(props: DocLayoutProps): JSX.Element {
     footer,
     bodyEndComponents,
     bodyEndScripts,
+    enableClientRouter = true,
   } = props;
 
   // `hasSidebar` tracks whether sidebar content was supplied at all.
@@ -291,9 +301,11 @@ export function DocLayout(props: DocLayoutProps): JSX.Element {
           array of structural VNode objects — Preact's JSX typing does not
           directly accept that array shape, but at runtime the elements are
           valid VNode descriptors. */}
-        {ClientRouter({
-          preserveHtmlAttrs: ["data-sidebar-hidden", "data-theme", "style"],
-        }) as unknown as JSX.Element}
+        {enableClientRouter !== false
+          ? (ClientRouter({
+              preserveHtmlAttrs: ["data-sidebar-hidden", "data-theme", "style"],
+            }) as unknown as JSX.Element)
+          : null}
         {head}
       </head>
       <body class="min-h-screen antialiased">

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -44,6 +44,7 @@ export default function NotFoundPage(): JSX.Element {
       headerOverride={<HeaderWithDefaults lang={locale} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
       bodyEndComponents={<BodyEndIslands basePath={settings.base ?? "/"} />}
+      enableClientRouter={settings.dynamicPageTransition}
     >
       <div class="min-h-[60vh] flex flex-col items-center justify-center px-hsp-2xl py-vsp-xl">
         <h1 class="text-display font-bold mb-vsp-md">404</h1>

--- a/pages/[locale]/index.tsx
+++ b/pages/[locale]/index.tsx
@@ -117,6 +117,7 @@ export default function LocaleIndexPage({ params }: PageArgs): JSX.Element {
       headerOverride={<HeaderWithDefaults lang={locale as Locale} currentPath={withBase(`/${locale}/`)} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
       bodyEndComponents={<BodyEndIslands basePath={settings.base ?? "/"} />}
+      enableClientRouter={settings.dynamicPageTransition}
     >
       {/* Hero: logo left, title+desc+links right, block centered */}
       <div class="flex justify-center mb-vsp-xl">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -73,6 +73,7 @@ export default function IndexPage(): JSX.Element {
       headerOverride={<HeaderWithDefaults lang={locale} currentPath={withBase("/")} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
       bodyEndComponents={<BodyEndIslands basePath={settings.base ?? "/"} />}
+      enableClientRouter={settings.dynamicPageTransition}
     >
       {/* Hero: logo left, title+desc+links right, block centered */}
       <div class="flex justify-center mb-vsp-xl">

--- a/pages/lib/_doc-body-end.tsx
+++ b/pages/lib/_doc-body-end.tsx
@@ -18,8 +18,14 @@ import { SidebarResizerInit } from "@takazudo/zudo-doc/sidebar-resizer";
 
 /**
  * The `bodyEndComponents` slot content shared by all four doc-route page
- * components: `BodyEndIslands` (modal overlays, client-router bootstrap,
- * image-enlarge) and the optional `SidebarResizerInit` drag handle.
+ * components: `BodyEndIslands` (modal overlays, optional client-router
+ * bootstrap when `dynamicPageTransition` is on, image-enlarge) and the
+ * optional `SidebarResizerInit` drag handle. Whether the client-router
+ * bootstrap island is included depends on `settings.dynamicPageTransition`
+ * (gated inside `BodyEndIslands`). The SSR `<ClientRouter />` mounted by
+ * `DocLayout` self-activates when `enableClientRouter` is `true`; the
+ * island here is redundant for that activation path and kept only for the
+ * `when="load"` hydration slot.
  */
 export function DocBodyEnd(): JSX.Element {
   return (

--- a/pages/lib/_doc-page-shell.tsx
+++ b/pages/lib/_doc-page-shell.tsx
@@ -218,6 +218,7 @@ export function DocPageShell(props: DocPageShellProps): JSX.Element {
       afterSidebar={<SidebarPrepaint />}
       footerOverride={<FooterWithDefaults lang={locale} />}
       bodyEndComponents={<DocBodyEnd />}
+      enableClientRouter={settings.dynamicPageTransition}
     >
       {kind === "autoIndex" ? (
         /* Auto-index page: category without an index.mdx.

--- a/pages/lib/_tag-pages.tsx
+++ b/pages/lib/_tag-pages.tsx
@@ -142,6 +142,7 @@ export function TagDetailPageView({
       breadcrumbOverride={<Breadcrumb items={breadcrumbItems} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
       bodyEndComponents={<BodyEndIslands basePath={settings.base ?? "/"} />}
+      enableClientRouter={settings.dynamicPageTransition}
     >
       <h1 class="text-heading font-bold mb-vsp-xs">{pageTitle}</h1>
       <p class="text-muted mb-vsp-lg">{countText}</p>
@@ -198,6 +199,7 @@ export function TagsIndexPageView({ locale }: { locale: string }): JSX.Element {
       breadcrumbOverride={<Breadcrumb items={breadcrumbItems} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
       bodyEndComponents={<BodyEndIslands basePath={settings.base ?? "/"} />}
+      enableClientRouter={settings.dynamicPageTransition}
     >
       <h1 class="text-heading font-bold mb-vsp-lg">{pageTitle}</h1>
       {!settings.docTags || tags.length === 0 ? (

--- a/pages/lib/_versions-page.tsx
+++ b/pages/lib/_versions-page.tsx
@@ -73,6 +73,7 @@ export function VersionsPageView({ locale }: { locale: string }): JSX.Element {
       headerOverride={<HeaderWithDefaults lang={locale as Locale} currentPath={withBase(`${prefix}/docs/versions`)} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
       bodyEndComponents={<BodyEndIslands basePath={settings.base ?? "/"} />}
+      enableClientRouter={settings.dynamicPageTransition}
     >
       <VersionsPageContent
         latestHref={latestHref}

--- a/src/components/client-router-bootstrap.tsx
+++ b/src/components/client-router-bootstrap.tsx
@@ -51,6 +51,14 @@ import type { JSX } from "preact";
  * walks page → BodyEndIslands → ClientRouterBootstrap and includes the
  * client-router barrel in the per-island bundle, where the side-effect
  * import above can fire on the client.
+ *
+ * Note: the SSR `<ClientRouter />` mounted by `DocLayout` (via
+ * `enableClientRouter`) self-activates the SPA router when its head meta
+ * tags reach the browser. This host island is therefore a no-op for
+ * router activation — it is kept only for the `when="load"` hydration
+ * slot and bundle inclusion. The actual on/off gate is
+ * `enableClientRouter` on `<DocLayoutWithDefaults>`, set to
+ * `settings.dynamicPageTransition` at every call site.
  */
 function ClientRouterBootstrap(): JSX.Element | null {
   return null;


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2273

---

## Summary

Adds a supported opt-out so a consuming site can run **plain full-page navigation** instead of the zfb Strategy-B SPA soft-swap router (`ClientRouter`). Closes the gap in #2272.

Before: `ClientRouter({...})` was rendered unconditionally in `<head>` (`doc-layout.tsx`), self-activating on hydration; there was no way to turn it off from host code, and the existing `dynamicPageTransition` setting only gated the *redundant* host island — not the load-bearing SSR render.

## What changed

**Package (`@takazudo/zudo-doc`)** — new settings-agnostic prop:
- `enableClientRouter?: boolean` (default `true`, backward-compatible) on `DocLayoutProps` + `DocLayoutWithDefaultsProps`.
- Gates the single `ClientRouter({...})` render in `doc-layout.tsx`. When `false`, the router, its route-announcer, and its `zfb-view-transitions-enabled` / `zfb-preserve-html-attrs` meta are all omitted (the meta is emitted by the call itself).
- New unit test (`doc-layout-client-router-gating.test.tsx`) asserts both branches.

**Showcase host** — reuses the existing `dynamicPageTransition` setting:
- Every `DocLayoutWithDefaults` render site passes `enableClientRouter={settings.dynamicPageTransition}`. This **fixes the latent bug** where `dynamicPageTransition: false` did not actually stop the router.
- Clarified the now-misleading `client-router-bootstrap` comments (the SSR `<ClientRouter />` self-activates; the island is redundant).

**Generator (`create-zudo-doc`)** — mirrored the host wiring + comment fixes into the templates (`check:template-drift` clean) and extended `scaffold.test.ts`. (Pinned package-version bump + publish deferred to the next lockstep `l-make-release`.)

## ⚠️ Backward-compat note (release notes)

Reusing `dynamicPageTransition` means any existing consumer already on `dynamicPageTransition: false` will now correctly get full-page navigation (today, due to the latent bug, they still get the SPA router). Default (`true`) sites are unaffected.

## Verification

- **Behaviour (the issue's repro), real headless-browser:** ON (default) → click internal link → `window.__s` survives + 0 full loads (soft swap). OFF → `window.__s` wiped + fresh navigation (full reload). Both PASS.
- Built HTML: 0/305 pages carry the router meta with `dynamicPageTransition: false`; present with `true`.
- 553 package unit tests + 376 generator tests green; `pnpm check` clean; `check:template-drift` clean.

## Review note (codex)

Codex raised a P2 (static import of `ClientRouter` could run the runtime's browser `init()` regardless of the prop, for a *client-hydrated* DocLayout consumer). **Refuted for this architecture:** `DocLayoutWithDefaults` is an SSR-only `<html>` shell (never hydrated as a client island), and the zfb-runtime client-router interceptor self-gates on the SSR meta tag at runtime — which the opt-out removes. Empirically confirmed by the OFF-state full-reload browser test (interception did not fire). No issue raised (refuted, not deferred).

## Sub-issues

- #2274 (S1 package) · #2275 (S2 host) · #2276 (S3 generator) · #2277 (S4 behaviour confirm) — all merged into this base.