### PR TITLE
fix: hide desktop sidebar toggle on no-sidebar pages

### DIFF
--- a/packages/create-zudo-doc/templates/base/pages/lib/_doc-page-shell.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_doc-page-shell.tsx
@@ -215,7 +215,7 @@ export function DocPageShell(props: DocPageShellProps): JSX.Element {
       }
       tocOverride={tocOverride}
       mobileTocOverride={mobileTocOverride}
-      afterSidebar={<SidebarPrepaint />}
+      afterSidebar={<SidebarPrepaint hideSidebar={hideSidebar} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
       bodyEndComponents={<DocBodyEnd />}
       enableClientRouter={settings.dynamicPageTransition}

--- a/packages/create-zudo-doc/templates/base/pages/lib/_sidebar-prepaint.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_sidebar-prepaint.tsx
@@ -23,15 +23,30 @@ import { Island } from "@takazudo/zfb";
 import { settings } from "@/config/settings";
 import DesktopSidebarToggle from "@/components/desktop-sidebar-toggle";
 
+/** Props for {@link SidebarPrepaint}. */
+export interface SidebarPrepaintProps {
+  /**
+   * Whether the current page hides the sidebar (`hide_sidebar: true`
+   * frontmatter). When true, the desktop toggle is meaningless — there is no
+   * visible sidebar to collapse — so the whole block is skipped. Without this
+   * gate the toggle button rendered on no-sidebar pages too (e.g. the
+   * `hide_sidebar` JA `/ja/docs/claude/` stub), where clicking it did nothing.
+   */
+  hideSidebar?: boolean;
+}
+
 /**
  * The `afterSidebar` slot content shared by all four doc-route page components.
  *
  * Returns the pre-paint localStorage script + `DesktopSidebarToggle` Island
- * when `settings.sidebarToggle` is enabled; returns `undefined` when it is
- * disabled (matching the conditional the route files used inline).
+ * when `settings.sidebarToggle` is enabled AND the page actually shows a
+ * sidebar; returns `undefined` when the toggle is disabled or the page hides
+ * the sidebar (matching the conditional the route files used inline).
  */
-export function SidebarPrepaint(): JSX.Element | undefined {
-  if (!settings.sidebarToggle) return undefined;
+export function SidebarPrepaint({
+  hideSidebar,
+}: SidebarPrepaintProps = {}): JSX.Element | undefined {
+  if (!settings.sidebarToggle || hideSidebar) return undefined;
 
   return (
     <>

--- a/packages/create-zudo-doc/templates/base/pages/lib/_sidebar-prepaint.tsx
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_sidebar-prepaint.tsx
@@ -26,11 +26,8 @@ import DesktopSidebarToggle from "@/components/desktop-sidebar-toggle";
 /** Props for {@link SidebarPrepaint}. */
 export interface SidebarPrepaintProps {
   /**
-   * Whether the current page hides the sidebar (`hide_sidebar: true`
-   * frontmatter). When true, the desktop toggle is meaningless — there is no
-   * visible sidebar to collapse — so the whole block is skipped. Without this
-   * gate the toggle button rendered on no-sidebar pages too (e.g. the
-   * `hide_sidebar` JA `/ja/docs/claude/` stub), where clicking it did nothing.
+   * Mirrors the page's `hide_sidebar: true` frontmatter. When true the desktop
+   * toggle is skipped — there is no visible sidebar for it to collapse.
    */
   hideSidebar?: boolean;
 }
@@ -45,16 +42,16 @@ export interface SidebarPrepaintProps {
  */
 export function SidebarPrepaint({
   hideSidebar,
-}: SidebarPrepaintProps = {}): JSX.Element | undefined {
+}: SidebarPrepaintProps): JSX.Element | undefined {
   if (!settings.sidebarToggle || hideSidebar) return undefined;
 
   return (
     <>
       {/* Pre-paint inline script: restore persisted sidebar visibility to
           <html data-sidebar-hidden> before first paint to avoid flash.
-          Runs unconditionally when sidebarToggle is enabled; the attribute
-          is only set when localStorage says "false" so the default (visible)
-          needs no attribute and causes no layout shift. */}
+          Rendered only when the toggle is enabled and the page shows a
+          sidebar; the attribute is only set when localStorage says "false"
+          so the default (visible) needs no attribute and causes no layout shift. */}
       <script dangerouslySetInnerHTML={{
         __html: `(function(){try{if(localStorage.getItem('zudo-doc-sidebar-visible')==='false'){document.documentElement.setAttribute('data-sidebar-hidden','');}}catch(e){}})();`,
       }} />

--- a/pages/lib/_doc-page-shell.tsx
+++ b/pages/lib/_doc-page-shell.tsx
@@ -215,7 +215,7 @@ export function DocPageShell(props: DocPageShellProps): JSX.Element {
       }
       tocOverride={tocOverride}
       mobileTocOverride={mobileTocOverride}
-      afterSidebar={<SidebarPrepaint />}
+      afterSidebar={<SidebarPrepaint hideSidebar={hideSidebar} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
       bodyEndComponents={<DocBodyEnd />}
       enableClientRouter={settings.dynamicPageTransition}

--- a/pages/lib/_sidebar-prepaint.tsx
+++ b/pages/lib/_sidebar-prepaint.tsx
@@ -23,15 +23,30 @@ import { Island } from "@takazudo/zfb";
 import { settings } from "@/config/settings";
 import DesktopSidebarToggle from "@/components/desktop-sidebar-toggle";
 
+/** Props for {@link SidebarPrepaint}. */
+export interface SidebarPrepaintProps {
+  /**
+   * Whether the current page hides the sidebar (`hide_sidebar: true`
+   * frontmatter). When true, the desktop toggle is meaningless — there is no
+   * visible sidebar to collapse — so the whole block is skipped. Without this
+   * gate the toggle button rendered on no-sidebar pages too (e.g. the
+   * `hide_sidebar` JA `/ja/docs/claude/` stub), where clicking it did nothing.
+   */
+  hideSidebar?: boolean;
+}
+
 /**
  * The `afterSidebar` slot content shared by all four doc-route page components.
  *
  * Returns the pre-paint localStorage script + `DesktopSidebarToggle` Island
- * when `settings.sidebarToggle` is enabled; returns `undefined` when it is
- * disabled (matching the conditional the route files used inline).
+ * when `settings.sidebarToggle` is enabled AND the page actually shows a
+ * sidebar; returns `undefined` when the toggle is disabled or the page hides
+ * the sidebar (matching the conditional the route files used inline).
  */
-export function SidebarPrepaint(): JSX.Element | undefined {
-  if (!settings.sidebarToggle) return undefined;
+export function SidebarPrepaint({
+  hideSidebar,
+}: SidebarPrepaintProps = {}): JSX.Element | undefined {
+  if (!settings.sidebarToggle || hideSidebar) return undefined;
 
   return (
     <>

--- a/pages/lib/_sidebar-prepaint.tsx
+++ b/pages/lib/_sidebar-prepaint.tsx
@@ -26,11 +26,8 @@ import DesktopSidebarToggle from "@/components/desktop-sidebar-toggle";
 /** Props for {@link SidebarPrepaint}. */
 export interface SidebarPrepaintProps {
   /**
-   * Whether the current page hides the sidebar (`hide_sidebar: true`
-   * frontmatter). When true, the desktop toggle is meaningless — there is no
-   * visible sidebar to collapse — so the whole block is skipped. Without this
-   * gate the toggle button rendered on no-sidebar pages too (e.g. the
-   * `hide_sidebar` JA `/ja/docs/claude/` stub), where clicking it did nothing.
+   * Mirrors the page's `hide_sidebar: true` frontmatter. When true the desktop
+   * toggle is skipped — there is no visible sidebar for it to collapse.
    */
   hideSidebar?: boolean;
 }
@@ -45,16 +42,16 @@ export interface SidebarPrepaintProps {
  */
 export function SidebarPrepaint({
   hideSidebar,
-}: SidebarPrepaintProps = {}): JSX.Element | undefined {
+}: SidebarPrepaintProps): JSX.Element | undefined {
   if (!settings.sidebarToggle || hideSidebar) return undefined;
 
   return (
     <>
       {/* Pre-paint inline script: restore persisted sidebar visibility to
           <html data-sidebar-hidden> before first paint to avoid flash.
-          Runs unconditionally when sidebarToggle is enabled; the attribute
-          is only set when localStorage says "false" so the default (visible)
-          needs no attribute and causes no layout shift. */}
+          Rendered only when the toggle is enabled and the page shows a
+          sidebar; the attribute is only set when localStorage says "false"
+          so the default (visible) needs no attribute and causes no layout shift. */}
       <script dangerouslySetInnerHTML={{
         __html: `(function(){try{if(localStorage.getItem('zudo-doc-sidebar-visible')==='false'){document.documentElement.setAttribute('data-sidebar-hidden','');}}catch(e){}})();`,
       }} />


### PR DESCRIPTION
## Summary

The desktop sidebar-toggle button (the `<` chevron pinned bottom-left) appeared on pages that have **no sidebar** — e.g. the `hide_sidebar: true` JA stub at [`/ja/docs/claude/`](https://zudo-doc.takazudomodular.com/ja/docs/claude/). On those pages there is no sidebar to collapse, so clicking the toggle did nothing.

Root cause: the toggle is mounted through the `afterSidebar` slot via `SidebarPrepaint`, which only gated on `settings.sidebarToggle` and ignored the page's `hide_sidebar` state.

## Changes

- `pages/lib/_sidebar-prepaint.tsx` — `SidebarPrepaint` now takes a `hideSidebar` prop and renders nothing (neither the toggle island nor the pre-paint localStorage script) when the page hides the sidebar.
- `pages/lib/_doc-page-shell.tsx` — threads the already-available `hideSidebar` into `SidebarPrepaint`.
- Mirrored both edits into the `create-zudo-doc` base template (`packages/create-zudo-doc/templates/base/pages/lib/`) to keep `check:template-drift` green.

## Test Plan

- `pnpm check:template-drift` ✅
- `pnpm check` (tsc) ✅
- `pnpm build` + inspected generated HTML:
  - `/ja/docs/claude/` (`hide_sidebar`): toggle **absent**, pre-paint script **absent** ✅
  - `/docs/guides/` (normal): toggle **present**, pre-paint script **present** ✅

SPA note: on soft navigation the toggle island is `data-zfb-transition-persist`-keyed, so it is dropped when the destination page's SSR omits it; `data-sidebar-hidden` is preserved by the router and has no visible effect on a no-sidebar page (content band is already full-width). No regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YS4c2JM3RxnbRZuXnyb18B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784720614&installation_id=130359969&pr_number=2304&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2304&signature=4724ff6fe9478e10220471cb467656749de33eec11278b13ad7b474f630f341b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->