### PR TITLE
Apply accent color to category-nav description on hover

### DIFF
--- a/packages/zudo-doc/src/nav-indexing/category-nav.tsx
+++ b/packages/zudo-doc/src/nav-indexing/category-nav.tsx
@@ -81,7 +81,7 @@ export function CategoryNav(props: CategoryNavProps): JSX.Element | null {
             {child.label}
           </span>
           {child.description && (
-            <span class="mt-vsp-2xs block text-small text-muted group-hover:underline group-focus-visible:underline">
+            <span class="mt-vsp-2xs block text-small text-muted group-hover:text-accent group-hover:underline group-focus-visible:text-accent group-focus-visible:underline">
               {child.description}
             </span>
           )}


### PR DESCRIPTION
## Summary

On `CategoryNav` cards, hovering shifts the **border** to accent (`hover:border-accent`) and the **title** is always accent (`text-accent`), but the **description** stayed muted on hover — only gaining an underline. This makes the hover feedback feel incomplete.

This change adds `group-hover:text-accent` / `group-focus-visible:text-accent` to the description span so it adopts the accent color on hover/focus, matching the border and title. It mirrors the existing pattern already used in `_doc-pager.tsx` (`underline group-hover:text-accent`).

## Why it's not a specificity trap

The `group-hover:` variant compiles to a two-class descendant selector (`.group:hover .group-hover\:text-accent`), which outranks the base single-class `.text-muted` — so the accent color wins on hover with no `!important` or ordering tricks needed.

## Changes

- `packages/zudo-doc/src/nav-indexing/category-nav.tsx` — description span gains `group-hover:text-accent group-focus-visible:text-accent` alongside the existing underline variants.

The component ships from the shared `@takazudo/zudo-doc` package (both the showcase and `create-zudo-doc` template import it), so no template counterpart needs syncing. The regenerated package safelist (`gen-safelist.mjs`, run on build/install) picks up the new utility classes for consumers.

## Test Plan

- `pnpm --filter @takazudo/zudo-doc test` — 563 tests pass
- Verified the new utilities land in both `dist/nav-indexing/category-nav.js` and `dist/safelist.css` after build


---
_Generated by [Claude Code](https://claude.ai/code/session_01JjLqwSRZ42wQNQxz7PSptu)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784721838&installation_id=130359969&pr_number=2306&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2306&signature=ea6208f078e49fcc815848227c16cb42abde89f24357e5d303b2eb533b6faa4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->