### PR TITLE
chore(deps): bump @takazudo/zfb stack to 0.1.0-next.59

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,9 +86,9 @@
   },
   "dependencies": {
     "@takazudo/zdtp": "0.2.3",
-    "@takazudo/zfb": "0.1.0-next.58",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.58",
-    "@takazudo/zfb-runtime": "0.1.0-next.58",
+    "@takazudo/zfb": "0.1.0-next.59",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.59",
+    "@takazudo/zfb-runtime": "0.1.0-next.59",
     "@takazudo/zudo-doc": "workspace:*",
     "diff": "^8.0.3",
     "gray-matter": "^4.0.3",

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -3454,9 +3454,11 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
    * no consumer-facing breaking change.
    * Bumped to 0.1.0-next.58: routine upstream prerelease adoption
    * (next.58) — no consumer-facing breaking change.
+   * Bumped to 0.1.0-next.59: routine upstream prerelease adoption
+   * (next.59) — no consumer-facing breaking change.
    * Generated package.json must pin all three.
    */
-  it("pins @takazudo/zfb at 0.1.0-next.58", async () => {
+  it("pins @takazudo/zfb at 0.1.0-next.59", async () => {
     const choices: UserChoices = {
       projectName: "test-pin-bump",
       defaultLang: "en",
@@ -3467,10 +3469,10 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
     };
     await scaffold(choices);
     const pkg = await fs.readJson(projectPath("test-pin-bump", "package.json"));
-    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.58");
-    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.58");
+    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.59");
+    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.59");
     expect(pkg.dependencies["@takazudo/zfb-adapter-cloudflare"]).toBe(
-      "0.1.0-next.58",
+      "0.1.0-next.59",
     );
   });
 });

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -557,11 +557,11 @@ function generatePackageJson(choices: UserChoices) {
     // stability, multi-valued response headers (e.g. multiple Set-Cookie),
     // supplementary-plane CJK reading-time, plus CLI/server/runtime hardening
     // and render perf passes. No consumer-facing / CLI breaking change.
-    "@takazudo/zfb": "0.1.0-next.58",
-    "@takazudo/zfb-runtime": "0.1.0-next.58",
+    "@takazudo/zfb": "0.1.0-next.59",
+    "@takazudo/zfb-runtime": "0.1.0-next.59",
     // zfb-adapter-cloudflare — required for any route with `prerender = false`.
     // Pinned in lockstep with @takazudo/zfb.
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.58",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.59",
     // @takazudo/zudo-doc — published from this monorepo via
     // .github/workflows/publish-zudo-doc.yml. The pin here is bumped in
     // lockstep by scripts/release-create-zudo-doc.sh whenever zudo-doc's

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -174,8 +174,8 @@
   ],
   "peerDependencies": {
     "preact": "^10.29.1",
-    "@takazudo/zfb": "^0.1.0-next.58",
-    "@takazudo/zfb-runtime": "^0.1.0-next.58",
+    "@takazudo/zfb": "^0.1.0-next.59",
+    "@takazudo/zfb-runtime": "^0.1.0-next.59",
     "@takazudo/zudo-doc-history-server": "^0.2.15",
     "@takazudo/zdtp": "^0.2.3",
     "shiki": "^4.0.2"
@@ -203,7 +203,7 @@
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
     "vitest": "^4.1.0",
-    "@takazudo/zfb": "0.1.0-next.58",
-    "@takazudo/zfb-runtime": "0.1.0-next.58"
+    "@takazudo/zfb": "0.1.0-next.59",
+    "@takazudo/zfb-runtime": "0.1.0-next.59"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,14 +30,14 @@ importers:
         specifier: 0.2.3
         version: 0.2.3(preact@10.29.2)
       '@takazudo/zfb':
-        specifier: 0.1.0-next.58
-        version: 0.1.0-next.58
+        specifier: 0.1.0-next.59
+        version: 0.1.0-next.59
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.58
-        version: 0.1.0-next.58
+        specifier: 0.1.0-next.59
+        version: 0.1.0-next.59
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.58
-        version: 0.1.0-next.58(@takazudo/zfb@0.1.0-next.58)
+        specifier: 0.1.0-next.59
+        version: 0.1.0-next.59(@takazudo/zfb@0.1.0-next.59)
       '@takazudo/zudo-doc':
         specifier: workspace:*
         version: link:packages/zudo-doc
@@ -266,11 +266,11 @@ importers:
         version: 4.0.3
     devDependencies:
       '@takazudo/zfb':
-        specifier: 0.1.0-next.58
-        version: 0.1.0-next.58
+        specifier: 0.1.0-next.59
+        version: 0.1.0-next.59
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.58
-        version: 0.1.0-next.58(@takazudo/zfb@0.1.0-next.58)
+        specifier: 0.1.0-next.59
+        version: 0.1.0-next.59(@takazudo/zfb@0.1.0-next.59)
       '@types/node':
         specifier: ^25.3.5
         version: 25.3.5
@@ -1353,48 +1353,48 @@ packages:
     peerDependencies:
       preact: ^10.29.1
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.58':
-    resolution: {integrity: sha512-TvpYhngkgWUxuCaKn1n53NDglpBzLZKA4bhFSCh5diVW5ph+7Hiok0fyoTAsp08dUJifYai4EnguhoZPtyEWWw==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.59':
+    resolution: {integrity: sha512-+fOwZCMoKJ1nUzvvPsiyZta0ZWiwGzxkvoV6+vmCQd/WArYpDAVY+uAHKuhkKt59EenMWHQLE4ijKRmXqNfMjg==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.58':
-    resolution: {integrity: sha512-bYBDnBnGpTq4+4+osIobXX45cjDe/gKltUYA6CXanmTMxyUOEp0d2I0linPcgsDZSr2Nl4PR/tLyMtzvhThQFw==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.59':
+    resolution: {integrity: sha512-Ib8PVF6Y4Pa77SHn3ue3OK1Qe642OjX6tZ7bcKVyL3E1YQr95JIVMGPSxaO7iFMXzInAEdhZ507B1PewssV9Sw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.58':
-    resolution: {integrity: sha512-un4ZR7c2ekJ5D8vgpCD/+JSLfiMIwz0aQkpPJq0Z4QhxUgiSEROxVQvPuh+BEPQtIhN5JhKYwxem9uUec8L+YA==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.59':
+    resolution: {integrity: sha512-fCaQ4lobR/ZrqwVftqXRxsQ6ykYrTMIheXkdUBzOBfEwcxLoi4RGce9PGxub9rZa79r3TxcJyAfmkl4TxA4Iyw==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.58':
-    resolution: {integrity: sha512-d1hQ/sRfobZ1T15fiC2Rj5504Gljqo/s89UffUSzRQwUqtOu+eMrpN1LHxxuqlvJ53wO+/KyDxpjpcl48YVvPA==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.59':
+    resolution: {integrity: sha512-EBBkuTURO12HgWylKYlWGiqIhm/5EUVBrZNz3+G4YtHIDSoHrGDBrD3QB1zYSCwTfiT1sq1cBRcmWYFtiUtfmw==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.58':
-    resolution: {integrity: sha512-m/cqQAXQPz4MLhr1ISPiIIn9VdvHhii+ZuFYIsxo+22/pTMbaypNi6hXYGeS53lNoF8wtFMPilE+wlVc6KbbzA==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.59':
+    resolution: {integrity: sha512-yGEjVZtvlF72uQ0jwjeVrPIlk+wbMYK2fqx1aAEBoz5u97InZZy2nAtrIG9j64b98Q5YTeDm6HtJhQfHHfZlwg==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.58':
-    resolution: {integrity: sha512-y69V707KEWxjUgHnFyXfNZzRdQKyhTb/s/JkoeRjWZnVe165RYNofBh4kOBxht/CYn3mGtp5M7OEBO45XVG+1w==}
+  '@takazudo/zfb-runtime@0.1.0-next.59':
+    resolution: {integrity: sha512-aRtJCSdzG09sYIs28xY3t2+1TaxSlkXOGcEj+/HBhispaWeNgfHByFWy5SGV7UCOM1zK7TX7eeEek1ObikOpbQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.58
+      '@takazudo/zfb': 0.1.0-next.59
       react: ^19.2.3
     peerDependenciesMeta:
       react:
         optional: true
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.58':
-    resolution: {integrity: sha512-jxAqgF/xwvz/49cFRS7B/omReHE1DGxTmX4LpujVs7pBctCDkZgbrKRdZQ8UcxZdOHIGQ6Ysznwk8YSPh1M6PA==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.59':
+    resolution: {integrity: sha512-etPUT2kpQnNPI9Icozf11u7fFiK+kGopjUmJnlws2GJIuAcV8L8AcONgf9dmvoyvbl1HAIo0gsTYxKWgU+rwUQ==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.58':
-    resolution: {integrity: sha512-ixi6yHZgIUdhF3taIwaOFdT7aHOdaxNxmgwQcShkvUIYiqwxuef/56/VRCOHa1I5GJKhp2/efWTUfUsOJAT7dQ==}
+  '@takazudo/zfb@0.1.0-next.59':
+    resolution: {integrity: sha512-8TdjlSz2ohBiKFYbeQOj52R539dMJ6A0XPwWuajd/Bxg9cSV+KUjEmUtdyR2Wpa7GvUda0FLUVTDVnXxDUY+Lw==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
     peerDependencies:
@@ -4062,35 +4062,35 @@ snapshots:
       culori: 4.0.2
       preact: 10.29.2
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.58': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.59': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.58':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.59':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.58':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.59':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.58':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.59':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.58':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.59':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.58(@takazudo/zfb@0.1.0-next.58)':
+  '@takazudo/zfb-runtime@0.1.0-next.59(@takazudo/zfb@0.1.0-next.59)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.58
+      '@takazudo/zfb': 0.1.0-next.59
       hono: 4.12.25
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.58':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.59':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.58':
+  '@takazudo/zfb@0.1.0-next.59':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.58
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.58
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.58
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.58
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.58
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.59
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.59
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.59
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.59
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.59
 
   '@takazudo/zudo-design-token-lint@1.0.0(patch_hash=6a157fd850449b055cf64a8a7dd1faed5b1da9eebe6c81cca08488ac0de85182)':
     dependencies:


### PR DESCRIPTION
## Summary

Bumps the zfb upstream toolchain family from `0.1.0-next.58` → `0.1.0-next.59` across all pin-map locations. zdtp stays at `0.2.3` (already latest).

### Pins updated (lockstep)
- Root `package.json` `dependencies` — `@takazudo/zfb`, `@takazudo/zfb-runtime`, `@takazudo/zfb-adapter-cloudflare`
- `packages/zudo-doc/package.json` — `devDependencies` (exact) + `peerDependencies` (`^`)
- `packages/create-zudo-doc/src/scaffold.ts` — all three scaffold pins
- `packages/create-zudo-doc/src/__tests__/scaffold.test.ts` — `.toBe(...)` assertions + comment
- `pnpm-lock.yaml` — regenerated

### Verification
- `pnpm check:pin-parity` — 3 external + 2 internal + 4 workspace-package fields consistent
- `pnpm b4push` — all automated steps pass (typecheck, root unit + package/scaffold tests, build of 312 pages, link check, HTML validation, preview smoke)
- next.59 Linux binary present; peer coupling unaffected (zfb peers on react, zdtp on preact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZkLqWyG9aaHVpv9xYr4JD)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784730399&installation_id=130359969&pr_number=2309&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2309&signature=86d7d81b8483c8c8442c0b0b829c5f5f087c7ecc6e6f44431f96bbc36067076c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->