### PR TITLE
fix(a11y): restore focus to doc-history trigger on modal close (#2303)

### DIFF
--- a/src/components/doc-history.tsx
+++ b/src/components/doc-history.tsx
@@ -473,9 +473,10 @@ export function DocHistory({ slug, locale, basePath = "/" }: DocHistoryProps) {
   }, [data, fetchPath]);
 
   function handleOpen(e: React.MouseEvent<HTMLButtonElement>) {
-    // Capture the trigger button BEFORE setState causes a re-render that
-    // unmounts it (it's only rendered when !isOpen). The hook reads this ref
-    // to restore focus when the dialog closes (a11y #2295).
+    // Capture the trigger so the dialog hook can restore focus to it on close
+    // (a11y #2295). The button now stays mounted while the panel is open (see
+    // the render below), so this ref stays a *connected* node — required for
+    // .focus() to actually land on close (zudolab/zudo-doc#2303).
     returnFocusRef.current = e.currentTarget;
     setView("revisions");
     fetchHistory();
@@ -527,20 +528,26 @@ export function DocHistory({ slug, locale, basePath = "/" }: DocHistoryProps) {
 
   return (
     <>
-      {/* History button */}
-      {!isOpen && (
-        <div className="flex justify-end mt-vsp-xl">
-          <button
-            type="button"
-            onClick={handleOpen}
-            className="doc-history-trigger flex items-center gap-hsp-xs px-hsp-md py-vsp-xs rounded-lg bg-surface border border-muted text-muted hover:text-fg hover:border-fg transition-colors"
-            aria-label="View document history"
-          >
-            <History className="h-icon-md w-icon-md" />
-            <span className="text-small">History</span>
-          </button>
-        </div>
-      )}
+      {/* History button. Kept mounted even while the panel is open: it sits
+          behind the full-screen showModal() dialog, which renders the rest of
+          the document inert, so the button is neither visible nor tabbable
+          while open. It must stay mounted so `returnFocusRef` (captured in
+          handleOpen) remains a *connected* node — the dialog hook restores
+          focus to it on close (a11y #2295). Conditionally unmounting it
+          (the old `{!isOpen && …}`) left the ref pointing at a detached node,
+          so `.focus()` no-op'd and focus fell to <body> on close
+          (zudolab/zudo-doc#2303). */}
+      <div className="flex justify-end mt-vsp-xl">
+        <button
+          type="button"
+          onClick={handleOpen}
+          className="doc-history-trigger flex items-center gap-hsp-xs px-hsp-md py-vsp-xs rounded-lg bg-surface border border-muted text-muted hover:text-fg hover:border-fg transition-colors"
+          aria-label="View document history"
+        >
+          <History className="h-icon-md w-icon-md" />
+          <span className="text-small">History</span>
+        </button>
+      </div>
 
       {/* Full-screen dialog — renders in top layer, above all stacking contexts */}
       {/* z-modal / backdrop:z-modal-backdrop are defense-in-depth for the


### PR DESCRIPTION
## Summary

While verifying #2303 (the Review Sweep mac-handoff) on a real browser, the **doc-history modal's focus-return-to-trigger was found broken** — closing the panel dropped focus to `<body>` instead of the "View document history" trigger. This was exactly the on-device a11y behavior the verification issue exists to catch (it passed typecheck/unit/build/E2E in CI but was never exercised in a real browser).

## Root cause

The trigger button was conditionally rendered (`{!isOpen && …}`), so opening the panel **unmounted** it. `returnFocusRef`, captured in `handleOpen`, then pointed at a **detached node** by close time. `useModalDialog`'s restore (`onDialogClose`) only guards with `instanceof HTMLElement` — not `isConnected` — so `.focus()` silently no-op'd and focus fell to `<body>`.

(The AI-chat modal was verified to work correctly — its trigger lives in the always-mounted header, so its captured ref stays connected.)

## Fix

Keep the doc-history trigger **mounted while the panel is open**. It sits behind the full-screen `showModal()` dialog, which renders the rest of the document inert, so it is neither visible nor tabbable while open — but the ref now stays a connected node and focus returns to it on close.

Minimal, contained change (one component); no change to the shared `useModalDialog` hook, so other modal consumers (AI-chat, image-enlarge, mermaid, color-tweak) are unaffected.

## Verification (production build + preview, real browser)

- ✅ Open: focus moves into the dialog ("Close history panel")
- ✅ Close via **Escape**: focus returns to "View document history" trigger
- ✅ Close via **Close button**: focus returns to trigger
- ✅ Trigger present in DOM while open but hidden behind the opaque modal (no visual regression)
- ✅ `pnpm check` (typecheck), `pnpm build` (314 pages), b4push suite (template-drift deferred to CI — macOS bash 3.2; file is allowlisted)

Part of the autonomous issue sweep. Closes #2303.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784752054&installation_id=130359969&pr_number=2310&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2310&signature=26f370493e00c4ddd1e8be2e73474bbd96dee456b65eaec5395734b91d7cc538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->