### PR TITLE
feat(create-zudo-doc): scaffold setup:doc-skill-silent variant

### DIFF
--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -1405,6 +1405,9 @@ describe("scaffold — skillSymlinker feature", () => {
     expect(pkg.scripts["setup:doc-skill"]).toBe(
       "bash scripts/setup-doc-skill.sh",
     );
+    expect(pkg.scripts["setup:doc-skill-silent"]).toBe(
+      "bash scripts/setup-doc-skill.sh --silent",
+    );
   });
 
   it("does NOT include setup-doc-skill.sh when disabled", async () => {
@@ -1426,6 +1429,7 @@ describe("scaffold — skillSymlinker feature", () => {
       projectPath("test-symlinker-off", "package.json"),
     );
     expect(pkg.scripts["setup:doc-skill"]).toBeUndefined();
+    expect(pkg.scripts["setup:doc-skill-silent"]).toBeUndefined();
   });
 });
 

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -690,6 +690,8 @@ function generatePackageJson(choices: UserChoices) {
 
   if (choices.features.includes("skillSymlinker")) {
     scripts["setup:doc-skill"] = "bash scripts/setup-doc-skill.sh";
+    scripts["setup:doc-skill-silent"] =
+      "bash scripts/setup-doc-skill.sh --silent";
   }
 
   const runCmd = choices.packageManager === "npm" || choices.packageManager === "bun" ? `${choices.packageManager} run` : choices.packageManager;

--- a/scripts/__tests__/setup-doc-skill.test.ts
+++ b/scripts/__tests__/setup-doc-skill.test.ts
@@ -115,4 +115,24 @@ describe("setup-doc-skill.sh", () => {
     expect(skillMd).toContain("Japanese Documentation");
     expect(skillMd).toContain("docs-ja");
   });
+
+  it("accepts the --silent flag without treating it as the skill name", () => {
+    // Scaffolded sites expose `setup:doc-skill-silent` =
+    // `bash scripts/setup-doc-skill.sh --silent`. The flag must be consumed,
+    // never mistaken for the positional skill-name override.
+    execSync(`bash "${SCRIPT_PATH}" --silent "${TEST_SKILL_NAME}"`, {
+      cwd: PROJECT_ROOT,
+      encoding: "utf-8",
+      timeout: 30_000,
+      env: { ...process.env, HOME: fakeHome },
+    });
+
+    // Skill is created under the real name, not a skill literally named "--silent".
+    expect(
+      existsSync(join(fakeHome, ".claude", "skills", TEST_SKILL_NAME)),
+    ).toBe(true);
+    expect(
+      existsSync(join(PROJECT_ROOT, ".claude", "skills", "--silent")),
+    ).toBe(false);
+  });
 });

--- a/scripts/setup-doc-skill.sh
+++ b/scripts/setup-doc-skill.sh
@@ -7,6 +7,20 @@ set -euo pipefail
 # the user-scope skills directory (~/.claude/skills/).
 # ────────────────────────────────────────────────────────
 
+# Accept --silent (alias -y) for parity with the consuming-site convention:
+# scaffolded sites expose `setup:doc-skill-silent` = `bash scripts/setup-doc-skill.sh
+# --silent`. This script is already non-interactive (the skill name is deterministic
+# — see below), so the flag is a no-op here; it is consumed only so it is never
+# mistaken for the positional skill-name override (`$1`).
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --silent|-y) shift ;;
+    --) shift; break ;;
+    -*) echo "Error: unknown flag '$1'" >&2; exit 1 ;;
+    *) break ;;
+  esac
+done
+
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
 # Read project name from package.json


### PR DESCRIPTION
## What

Newly-scaffolded sites now get a **`setup:doc-skill-silent`** npm script (`bash scripts/setup-doc-skill.sh --silent`) alongside `setup:doc-skill`, and the master `scripts/setup-doc-skill.sh` now accepts/consumes a `--silent` (alias `-y`) flag.

## Why

The web-env SessionStart bootstrap (`~/.claude/scripts/setup-web-wisdom.sh`) symlinks each wisdom skill on a fresh container and now calls `npm run setup:doc-skill-silent`. The existing `*-wisdom` sites already gained this script; this closes the gap so **newly-scaffolded** repos inherit it too.

## Details

- `scaffold.ts` emits `setup:doc-skill-silent` whenever `skillSymlinker` is enabled (right next to `setup:doc-skill`).
- The master `setup-doc-skill.sh` is already non-interactive (deterministic skill name, since #2173). It uses `$1` as an optional skill-name override, so `--silent` had to be parsed and consumed first — otherwise it would be mistaken for the skill name. The flag is therefore a no-op here, kept purely for parity with the consuming-site convention.

## Tests

- `scaffold.test.ts`: asserts the silent script is emitted with `skillSymlinker` on and absent when off.
- `setup-doc-skill.test.ts`: asserts `--silent <name>` resolves to `<name>` and never creates a skill literally named `--silent`.
- Local: create-zudo-doc suite 376/376, master-script test 7/7, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784752360&installation_id=130359969&pr_number=2311&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2311&signature=f4b191c9cc1f5c6ead091b838868117f0244c5203d2ab9185c64cb8659132855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->