### PR TITLE
harden(tauri): restrictive CSP + scope capabilities; document Mode 2 trust (#2240)

### DIFF
--- a/packages/create-zudo-doc/templates/features/tauri/files/src-tauri/capabilities/default.json
+++ b/packages/create-zudo-doc/templates/features/tauri/files/src-tauri/capabilities/default.json
@@ -1,10 +1,7 @@
 {
   "identifier": "default",
-  "description": "Default capabilities for the main window",
+  "description": "Default capabilities for the main window. The shipped offline reader loads the embedded dist/ via the tauri:// protocol (WebviewUrl::App), so it needs no remote-origin grant. The previous `remote.urls: http://localhost:*/**` grant was dropped (zudolab/zudo-doc#2240) so no localhost-served page can reach core:default. `cargo tauri dev` still loads http://localhost:4321, but the zudo-doc site invokes no Tauri commands, so it does not need the grant either.",
   "windows": ["main"],
-  "remote": {
-    "urls": ["http://localhost:*/**"]
-  },
   "permissions": [
     "core:default"
   ]

--- a/packages/create-zudo-doc/templates/features/tauri/files/src-tauri/tauri.conf.json
+++ b/packages/create-zudo-doc/templates/features/tauri/files/src-tauri/tauri.conf.json
@@ -10,7 +10,7 @@
   "app": {
     "windows": [],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data:; font-src 'self' data: https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; script-src 'self' 'unsafe-inline' https://esm.sh; connect-src 'self' https://esm.sh https://cdn.jsdelivr.net"
     }
   },
   "bundle": {

--- a/packages/create-zudo-doc/templates/features/tauriDev/files/src-tauri-dev/capabilities/default.json
+++ b/packages/create-zudo-doc/templates/features/tauriDev/files/src-tauri-dev/capabilities/default.json
@@ -1,6 +1,6 @@
 {
   "identifier": "default",
-  "description": "Default capabilities for the main window",
+  "description": "Default capabilities for the main window. TRUST NOTE (zudolab/zudo-doc#2240): Mode 2 displays an arbitrary, user-configured localhost project in this webview, and `remote.urls` grants core:default to any http://localhost:*/** origin. Combined with withGlobalTauri (required by frontend/index.html's launch-error listener + retry_launch invoke), a malicious dependency in the wrapped project would gain Tauri reach. This is an accepted trust assumption for a developer-only wrapper: only point Mode 2 at projects you trust. The grant is intentionally dev-scoped (localhost only). Narrowing it to the single configured port, or splitting the local-frontend capability from the remote-project capability, is tracked as a future hardening.",
   "windows": ["main"],
   "remote": { "urls": ["http://localhost:*/**"] },
   "permissions": ["core:default"]

--- a/src-tauri-dev/capabilities/default.json
+++ b/src-tauri-dev/capabilities/default.json
@@ -1,6 +1,6 @@
 {
   "identifier": "default",
-  "description": "Default capabilities for the main window",
+  "description": "Default capabilities for the main window. TRUST NOTE (zudolab/zudo-doc#2240): Mode 2 displays an arbitrary, user-configured localhost project in this webview, and `remote.urls` grants core:default to any http://localhost:*/** origin. Combined with withGlobalTauri (required by frontend/index.html's launch-error listener + retry_launch invoke), a malicious dependency in the wrapped project would gain Tauri reach. This is an accepted trust assumption for a developer-only wrapper: only point Mode 2 at projects you trust. The grant is intentionally dev-scoped (localhost only). Narrowing it to the single configured port, or splitting the local-frontend capability from the remote-project capability, is tracked as a future hardening.",
   "windows": ["main"],
   "remote": { "urls": ["http://localhost:*/**"] },
   "permissions": ["core:default"]

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -65,3 +65,54 @@ For the shipped configurable dev wrapper, see `../src-tauri-dev/`.
   Keep this field alongside `beforeDevCommand`.
 - `bundle.active: false` — bundling is opt-in; pass `--bundles` flags to `cargo tauri build`
   when creating distributable installers.
+
+## Security hardening (zudolab/zudo-doc#2240)
+
+Both Tauri apps previously shipped `"csp": null` and an over-broad
+`remote.urls: ["http://localhost:*/**"]` capability. This was tightened:
+
+### Mode 1 (this directory) — Content Security Policy
+
+`app.security.csp` is now a restrictive policy instead of `null`. The reader
+serves only the local `dist/` (via `tauri://`), so the policy locks down
+exfiltration vectors (`default-src 'self'`, `connect-src` limited to self +
+the two CDNs the content genuinely uses, `object-src 'none'`,
+`frame-ancestors 'none'`) while still allowing the doc content to render:
+
+- `script-src … https://esm.sh` — Mermaid is loaded at runtime via
+  `import("https://esm.sh/mermaid@11…")` (`packages/zudo-doc/src/code-syntax/mermaid-init-script.ts`).
+- `style-src` / `font-src … https://cdn.jsdelivr.net` — KaTeX CSS + fonts are
+  pulled from jsDelivr when a page uses math (`packages/zudo-doc/src/head/doc-head.tsx`).
+- `'unsafe-inline'` on `script-src`/`style-src` — the site relies on inline
+  pre-paint scripts (sidebar/theme/page-loading) and inline `style=` attributes.
+  Exfiltration is still blocked by `connect-src`/`img-src`/`default-src`.
+- `api.anthropic.com` is **not** allowlisted: the AI-chat client calls it
+  **server-side** (`pages/api/_ai-chat-client.ts`), never from the browser, and
+  the offline reader has no server anyway.
+
+> **On-device verification still required (mac).** This CSP was reasoned from the
+> site's measured resource use but has **not** been verified inside a built Tauri
+> webview. In particular, when a CSP is set Tauri injects a nonce for its own IPC
+> script, which can cause the browser to ignore `'unsafe-inline'` and block the
+> site's inline pre-paint scripts. Run `cargo tauri build` (or `cargo tauri dev`)
+> and confirm the reader still renders — Mermaid diagrams, KaTeX math, code
+> highlighting, sidebar/theme pre-paint — before relying on the bundled app.
+> `bundle.active` is `false`, so nothing ships this CSP until a deliberate bundle.
+
+### Capabilities — `remote.urls`
+
+`capabilities/default.json` dropped the `remote` block. The shipped reader uses
+`tauri://` and needs no remote grant; `cargo tauri dev` loads `localhost:4321`
+but the doc site invokes no Tauri commands, so it needs none either.
+
+### Mode 2 (`../src-tauri-dev/`) — `withGlobalTauri` trust assumption
+
+Mode 2 keeps `withGlobalTauri: true` and its localhost `remote.urls` grant
+because its own `frontend/index.html` requires them (it listens for
+`launch-error` events and invokes the `retry_launch` command via
+`window.__TAURI__`). Disabling either would break the wrapper's error/retry UI.
+The residual risk — a malicious dependency in the *wrapped* project gaining
+Tauri reach — is documented as an accepted trust assumption in
+`../src-tauri-dev/capabilities/default.json` (only point Mode 2 at trusted
+projects). A future hardening could split the local-frontend capability from the
+remote-project one so the wrapped site inherits no command access.

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,10 +1,7 @@
 {
   "identifier": "default",
-  "description": "Default capabilities for the main window",
+  "description": "Default capabilities for the main window. The shipped offline reader loads the embedded dist/ via the tauri:// protocol (WebviewUrl::App), so it needs no remote-origin grant. The previous `remote.urls: http://localhost:*/**` grant was dropped (zudolab/zudo-doc#2240) so no localhost-served page can reach core:default. `cargo tauri dev` still loads http://localhost:4321, but the zudo-doc site invokes no Tauri commands, so it does not need the grant either.",
   "windows": ["main"],
-  "remote": {
-    "urls": ["http://localhost:*/**"]
-  },
   "permissions": [
     "core:default"
   ]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -10,7 +10,7 @@
   "app": {
     "windows": [],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data:; font-src 'self' data: https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; script-src 'self' 'unsafe-inline' https://esm.sh; connect-src 'self' https://esm.sh https://cdn.jsdelivr.net"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Summary

Hardens both Tauri apps' weak defaults flagged in #2240 (`csp: null`, over-broad `remote.urls`). Implements the issue's three recommendations within what's safely verifiable.

### Mode 1 — `src-tauri/` (shipped offline reader)
- **Restrictive CSP** (was `null`): `default-src 'self'`, `connect-src`/`img-src` locked down (closes exfiltration), `object-src 'none'`, `frame-ancestors 'none'`. Allows the two CDNs the content genuinely uses — `esm.sh` (Mermaid runtime `import()`) and `cdn.jsdelivr.net` (KaTeX) — plus `'unsafe-inline'` for the inline pre-paint scripts/styles. `api.anthropic.com` deliberately **not** allowlisted (AI-chat is server-side only).
- **Dropped `remote.urls`**: the shipped reader uses `tauri://`; `cargo tauri dev` loads a doc site that invokes no Tauri commands. Neither needs a localhost grant.

### Mode 2 — `src-tauri-dev/` (configurable dev wrapper)
- **Kept** `withGlobalTauri` + localhost `remote.urls` — verified that `frontend/index.html` genuinely needs them (it uses `window.__TAURI__` for the `launch-error` listener + `retry_launch` invoke; disabling either breaks the wrapper's error/retry UI).
- **Documented the trust assumption** (the issue's explicit alternative to gating `withGlobalTauri`): the wrapped localhost project inherits command access, so only point Mode 2 at trusted projects. Captured in the capability `description` + README.

### Generator
Mirrored the hardened config into the `create-zudo-doc` `tauri`/`tauriDev` feature templates so scaffolded projects inherit the same defaults (Feature Change Checklist; templates stay byte-identical → drift-clean). All 376 create-zudo-doc package tests pass.

## ⚠️ On-device verification still required (mac)

The Mode 1 CSP is **reasoned from the site's measured resource use but NOT verified inside a built Tauri webview**. Specifically, when a CSP is set, Tauri injects a nonce for its IPC script which can cause the browser to ignore `'unsafe-inline'` and **block the site's inline pre-paint scripts**. Before the offline reader is bundled, run `cargo tauri build` (or `cargo tauri dev`) and confirm rendering — Mermaid, KaTeX, code highlighting, sidebar/theme pre-paint. Documented in `src-tauri/README.md`. `bundle.active` is `false`, so nothing ships this CSP until a deliberate bundle.

## Validation
- ✅ All JSON valid; CSP well-formed
- ✅ `create-zudo-doc` package tests (376) pass
- ✅ No JS/build impact (Tauri config + README + templates only)
- ⏳ On-device Tauri rendering check — tracked as a `mac` follow-up

Part of the autonomous issue sweep. Refs #2240 (kept open for the on-device CSP check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784752697&installation_id=130359969&pr_number=2312&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2312&signature=419a86c60e1ee4f2453470e372674a6857092d54b631289a68e10210794bbb73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->