### PR TITLE
chore(deps): bump @takazudo toolchain (zfb next.60, zdtp 0.3.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,10 +85,10 @@
     }
   },
   "dependencies": {
-    "@takazudo/zdtp": "0.2.3",
-    "@takazudo/zfb": "0.1.0-next.59",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.59",
-    "@takazudo/zfb-runtime": "0.1.0-next.59",
+    "@takazudo/zdtp": "0.3.2",
+    "@takazudo/zfb": "0.1.0-next.60",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.60",
+    "@takazudo/zfb-runtime": "0.1.0-next.60",
     "@takazudo/zudo-doc": "workspace:*",
     "diff": "^8.0.3",
     "gray-matter": "^4.0.3",

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -540,7 +540,7 @@ describe("scaffold — designTokenPanel package.json wiring", () => {
     const pkg = await fs.readJson(
       projectPath("test-zdtp-deps", "package.json"),
     );
-    expect(pkg.dependencies["@takazudo/zdtp"]).toBe("0.2.3");
+    expect(pkg.dependencies["@takazudo/zdtp"]).toBe("0.3.2");
   });
 });
 
@@ -3460,9 +3460,11 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
    * (next.58) — no consumer-facing breaking change.
    * Bumped to 0.1.0-next.59: routine upstream prerelease adoption
    * (next.59) — no consumer-facing breaking change.
+   * Bumped to 0.1.0-next.60: routine upstream prerelease adoption
+   * (next.60) — no consumer-facing breaking change.
    * Generated package.json must pin all three.
    */
-  it("pins @takazudo/zfb at 0.1.0-next.59", async () => {
+  it("pins @takazudo/zfb at 0.1.0-next.60", async () => {
     const choices: UserChoices = {
       projectName: "test-pin-bump",
       defaultLang: "en",
@@ -3473,10 +3475,10 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
     };
     await scaffold(choices);
     const pkg = await fs.readJson(projectPath("test-pin-bump", "package.json"));
-    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.59");
-    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.59");
+    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.60");
+    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.60");
     expect(pkg.dependencies["@takazudo/zfb-adapter-cloudflare"]).toBe(
-      "0.1.0-next.59",
+      "0.1.0-next.60",
     );
   });
 });

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -557,11 +557,11 @@ function generatePackageJson(choices: UserChoices) {
     // stability, multi-valued response headers (e.g. multiple Set-Cookie),
     // supplementary-plane CJK reading-time, plus CLI/server/runtime hardening
     // and render perf passes. No consumer-facing / CLI breaking change.
-    "@takazudo/zfb": "0.1.0-next.59",
-    "@takazudo/zfb-runtime": "0.1.0-next.59",
+    "@takazudo/zfb": "0.1.0-next.60",
+    "@takazudo/zfb-runtime": "0.1.0-next.60",
     // zfb-adapter-cloudflare — required for any route with `prerender = false`.
     // Pinned in lockstep with @takazudo/zfb.
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.59",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.60",
     // @takazudo/zudo-doc — published from this monorepo via
     // .github/workflows/publish-zudo-doc.yml. The pin here is bumped in
     // lockstep by scripts/release-create-zudo-doc.sh whenever zudo-doc's
@@ -649,7 +649,7 @@ function generatePackageJson(choices: UserChoices) {
   if (choices.features.includes("designTokenPanel")) {
     // @takazudo/zdtp requires preact >= 10.29.1 — see the preact floor comment
     // above (~line 382) for why the floor is set there and the coupling this creates.
-    deps["@takazudo/zdtp"] = "0.2.3";
+    deps["@takazudo/zdtp"] = "0.3.2";
   }
 
   if (choices.features.includes("tagGovernance")) {

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -174,10 +174,10 @@
   ],
   "peerDependencies": {
     "preact": "^10.29.1",
-    "@takazudo/zfb": "^0.1.0-next.59",
-    "@takazudo/zfb-runtime": "^0.1.0-next.59",
-    "@takazudo/zudo-doc-history-server": "^0.2.15",
-    "@takazudo/zdtp": "^0.2.3",
+    "@takazudo/zfb": "^0.1.0-next.60",
+    "@takazudo/zfb-runtime": "^0.1.0-next.60",
+    "@takazudo/zudo-doc-history-server": "^0.2.21",
+    "@takazudo/zdtp": "^0.3.2",
     "shiki": "^4.0.2"
   },
   "peerDependenciesMeta": {
@@ -203,7 +203,7 @@
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
     "vitest": "^4.1.0",
-    "@takazudo/zfb": "0.1.0-next.59",
-    "@takazudo/zfb-runtime": "0.1.0-next.59"
+    "@takazudo/zfb": "0.1.0-next.60",
+    "@takazudo/zfb-runtime": "0.1.0-next.60"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,17 +27,17 @@ importers:
   .:
     dependencies:
       '@takazudo/zdtp':
-        specifier: 0.2.3
-        version: 0.2.3(preact@10.29.2)
+        specifier: 0.3.2
+        version: 0.3.2(preact@10.29.2)
       '@takazudo/zfb':
-        specifier: 0.1.0-next.59
-        version: 0.1.0-next.59
+        specifier: 0.1.0-next.60
+        version: 0.1.0-next.60
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.59
-        version: 0.1.0-next.59
+        specifier: 0.1.0-next.60
+        version: 0.1.0-next.60
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.59
-        version: 0.1.0-next.59(@takazudo/zfb@0.1.0-next.59)
+        specifier: 0.1.0-next.60
+        version: 0.1.0-next.60(@takazudo/zfb@0.1.0-next.60)
       '@takazudo/zudo-doc':
         specifier: workspace:*
         version: link:packages/zudo-doc
@@ -256,21 +256,21 @@ importers:
   packages/zudo-doc:
     dependencies:
       '@takazudo/zdtp':
-        specifier: ^0.2.3
-        version: 0.2.3(preact@10.29.2)
+        specifier: ^0.3.2
+        version: 0.3.2(preact@10.29.2)
       '@takazudo/zudo-doc-history-server':
-        specifier: ^0.2.15
-        version: 0.2.15
+        specifier: ^0.2.21
+        version: 0.2.21
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
     devDependencies:
       '@takazudo/zfb':
-        specifier: 0.1.0-next.59
-        version: 0.1.0-next.59
+        specifier: 0.1.0-next.60
+        version: 0.1.0-next.60
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.59
-        version: 0.1.0-next.59(@takazudo/zfb@0.1.0-next.59)
+        specifier: 0.1.0-next.60
+        version: 0.1.0-next.60(@takazudo/zfb@0.1.0-next.60)
       '@types/node':
         specifier: ^25.3.5
         version: 25.3.5
@@ -1346,55 +1346,55 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
 
-  '@takazudo/zdtp@0.2.3':
-    resolution: {integrity: sha512-yXAX1NLUrcME0IhDQalUVjIgDC5ZP5oiu94/ioXWtB9ljZhwv/SAlet21D7RWT4uzNkZ/ROZTtXDAoy0730F/A==}
+  '@takazudo/zdtp@0.3.2':
+    resolution: {integrity: sha512-XrbkYVlCX7TdIQ3SEzXbA/u4wHfbbgM8xxqkEBo+tNhUOySAlRW9Y44KsZtNea/tYso92XySjVcebIuIy09BvQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
     peerDependencies:
       preact: ^10.29.1
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.59':
-    resolution: {integrity: sha512-+fOwZCMoKJ1nUzvvPsiyZta0ZWiwGzxkvoV6+vmCQd/WArYpDAVY+uAHKuhkKt59EenMWHQLE4ijKRmXqNfMjg==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.60':
+    resolution: {integrity: sha512-SH9mGGyWTHySLYfyjQDj1sHO5rvBzIS6u7FWNHSEs1kV3aADrMqpt9akcC+vFkccK76hLJPL1hrvA2fvm6PEEg==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.59':
-    resolution: {integrity: sha512-Ib8PVF6Y4Pa77SHn3ue3OK1Qe642OjX6tZ7bcKVyL3E1YQr95JIVMGPSxaO7iFMXzInAEdhZ507B1PewssV9Sw==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.60':
+    resolution: {integrity: sha512-Iq4tjLOG1no6Fs55OEb0hDG06IL+eU7c8L7Ky2yiPv2qETwv9izjQA/A/iLn9aEhjGiTNxv2b3BwviyXO3YhYg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.59':
-    resolution: {integrity: sha512-fCaQ4lobR/ZrqwVftqXRxsQ6ykYrTMIheXkdUBzOBfEwcxLoi4RGce9PGxub9rZa79r3TxcJyAfmkl4TxA4Iyw==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.60':
+    resolution: {integrity: sha512-bCWrIOlvkviRKdNSEzFUibL3wBslIdl2+6S4+0GiSTfEbb0FegQKAZ/ngMuVSc5UZMHDmaQcNkZqrAf7v5QRGQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.59':
-    resolution: {integrity: sha512-EBBkuTURO12HgWylKYlWGiqIhm/5EUVBrZNz3+G4YtHIDSoHrGDBrD3QB1zYSCwTfiT1sq1cBRcmWYFtiUtfmw==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.60':
+    resolution: {integrity: sha512-8jyf168N9njmhcc6If1ezBv1xUf/QvyfYcyBQnIuaKqstFNJnVEwFweRfLeWKRkGspGE3VT6mXJFUE2e0V80oQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.59':
-    resolution: {integrity: sha512-yGEjVZtvlF72uQ0jwjeVrPIlk+wbMYK2fqx1aAEBoz5u97InZZy2nAtrIG9j64b98Q5YTeDm6HtJhQfHHfZlwg==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.60':
+    resolution: {integrity: sha512-KC0jBbTtIA1SxdgS5AHoUbUNTzh+yTyGYx9rpnIpqoM5ndhix3GoSx3KXPN+szZPq79xBqjEcNe1C3Eih2VERA==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.59':
-    resolution: {integrity: sha512-aRtJCSdzG09sYIs28xY3t2+1TaxSlkXOGcEj+/HBhispaWeNgfHByFWy5SGV7UCOM1zK7TX7eeEek1ObikOpbQ==}
+  '@takazudo/zfb-runtime@0.1.0-next.60':
+    resolution: {integrity: sha512-sgw6haLbnWyYhyQ7KKknpseHhHRpmF8YDrna7NXdidIt8OrpDmjCSHEtPSpvMqPRmZQiZs7AY0VcxMbROPnUHA==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.59
+      '@takazudo/zfb': 0.1.0-next.60
       react: ^19.2.3
     peerDependenciesMeta:
       react:
         optional: true
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.59':
-    resolution: {integrity: sha512-etPUT2kpQnNPI9Icozf11u7fFiK+kGopjUmJnlws2GJIuAcV8L8AcONgf9dmvoyvbl1HAIo0gsTYxKWgU+rwUQ==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.60':
+    resolution: {integrity: sha512-sZvADz2k3mNH3UjKvvyFmA/aRfjxDcJrlQcqaOzjXtuuYiaExQP06+KZw+4Js4cqbftbRGD3LQfuN0y5ZYP6Rg==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.59':
-    resolution: {integrity: sha512-8TdjlSz2ohBiKFYbeQOj52R539dMJ6A0XPwWuajd/Bxg9cSV+KUjEmUtdyR2Wpa7GvUda0FLUVTDVnXxDUY+Lw==}
+  '@takazudo/zfb@0.1.0-next.60':
+    resolution: {integrity: sha512-/7j+N48i6Q/FZqWgMmTeYuH/vxcCIZ6grr2SopNUecL8sZsl2MxxjQku3Jy2HxwUTKbl3wuhvsuRJ9ssatt3VQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
     peerDependencies:
@@ -1408,8 +1408,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@takazudo/zudo-doc-history-server@0.2.15':
-    resolution: {integrity: sha512-IKrXOMJCBDzpcZVYiv2b1bPGeEIIxaSIepvIiRjySD6uBPF+tAzHfoKkpxQDJGn4f3crWdNEnuUCLO/sGYpP/A==}
+  '@takazudo/zudo-doc-history-server@0.2.21':
+    resolution: {integrity: sha512-l3zZNWipVyjt+mS1MKDBYetPlC7+AFRXjh8ZfMiI+bvrDlkes1+0Q2BO6h8OVMn6oqvDSU32HNUJum1fueHv3A==}
     hasBin: true
 
   '@types/chai@5.2.3':
@@ -4057,47 +4057,47 @@ snapshots:
       tailwindcss: 4.2.1
       vite: 7.3.5(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
 
-  '@takazudo/zdtp@0.2.3(preact@10.29.2)':
+  '@takazudo/zdtp@0.3.2(preact@10.29.2)':
     dependencies:
       culori: 4.0.2
       preact: 10.29.2
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.59': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.60': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.59':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.60':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.59':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.60':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.59':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.60':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.59':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.60':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.59(@takazudo/zfb@0.1.0-next.59)':
+  '@takazudo/zfb-runtime@0.1.0-next.60(@takazudo/zfb@0.1.0-next.60)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.59
+      '@takazudo/zfb': 0.1.0-next.60
       hono: 4.12.25
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.59':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.60':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.59':
+  '@takazudo/zfb@0.1.0-next.60':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.59
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.59
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.59
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.59
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.59
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.60
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.60
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.60
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.60
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.60
 
   '@takazudo/zudo-design-token-lint@1.0.0(patch_hash=6a157fd850449b055cf64a8a7dd1faed5b1da9eebe6c81cca08488ac0de85182)':
     dependencies:
       chalk: 5.6.2
       glob: 10.5.0
 
-  '@takazudo/zudo-doc-history-server@0.2.15': {}
+  '@takazudo/zudo-doc-history-server@0.2.21': {}
 
   '@types/chai@5.2.3':
     dependencies:


### PR DESCRIPTION
## Summary

Routine first-party dependency bump of the `@takazudo/*` toolchain to latest, performed via `/dev-bump-zudo-deps` and kept in lockstep across **every** pin-parity location (root `package.json`, `packages/zudo-doc/package.json`, and the `create-zudo-doc` scaffold + its tests).

## Changes

- **`@takazudo/zfb`, `zfb-runtime`, `zfb-adapter-cloudflare`**: `0.1.0-next.59` → `0.1.0-next.60` (routine upstream prerelease; `zfb-runtime` peers `@takazudo/zfb@next.60`, satisfied by the lockstep move)
- **`@takazudo/zdtp`**: `0.2.3` → `0.3.2` (minor; preact peer `^10.29.1` unchanged → no preact-floor change, typecheck confirms no API break)
- **`@takazudo/zudo-doc-history-server`** peer in `packages/zudo-doc`: `^0.2.15` → `^0.2.21` (realigns a stale peer range with the current `0.2.21` release line)
- `packages/create-zudo-doc/src/scaffold.ts` pins + `scaffold.test.ts` assertions updated alongside the `package.json` bumps so `check:pin-parity` and the package tests stay green
- `pnpm-lock.yaml` updated

Historical references (changelog `0.2.21.mdx`, "shikiTheme optional as of zdtp 0.2.3" notes) were intentionally left untouched — they record facts about past releases.

> Note: the `scaffold.ts` pin bump means a follow-up `create-zudo-doc` release (`/l-make-release`) is what propagates `next.60` / zdtp `0.3.2` to freshly-scaffolded downstream projects. This PR only updates the showcase repo + generator source.

## Test Plan

- `check:pin-parity` ✅ (3 external + 2 internal + 4 workspace-package fields in lockstep)
- `pnpm check` (typecheck) ✅ — zdtp 0.3.2 type-compatible
- `pnpm b4push` steps 1–18 ✅ (format, template/fixture drift, tags, token lint, z-index, e2e naming, flaky guard, b4push/CI parity, typecheck, unit + package tests, safelist, build, link check, HTML validation, preview smoke). Step 19 is the interactive manual smoke (not runnable headless).
- CI (incl. E2E, the one gate not in b4push) verified on this PR.