### PR TITLE
chore(deps): bump @takazudo/zfb stack to 0.1.0-next.62

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,9 +86,9 @@
   },
   "dependencies": {
     "@takazudo/zdtp": "0.3.3",
-    "@takazudo/zfb": "0.1.0-next.61",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.61",
-    "@takazudo/zfb-runtime": "0.1.0-next.61",
+    "@takazudo/zfb": "0.1.0-next.62",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.62",
+    "@takazudo/zfb-runtime": "0.1.0-next.62",
     "@takazudo/zudo-doc": "workspace:*",
     "diff": "^8.0.3",
     "gray-matter": "^4.0.3",

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -3516,9 +3516,13 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
    * (next.60) — no consumer-facing breaking change.
    * Bumped to 0.1.0-next.61: routine upstream prerelease adoption
    * (next.61) — no consumer-facing breaking change.
+   * Bumped to 0.1.0-next.62: routine upstream prerelease adoption
+   * (next.62) — carries build-time package-owned-routes capability
+   * (injectRoute in build, definePreset, presets[], addClientEntry) plus
+   * router/build fixes. No consumer-facing breaking change.
    * Generated package.json must pin all three.
    */
-  it("pins @takazudo/zfb at 0.1.0-next.61", async () => {
+  it("pins @takazudo/zfb at 0.1.0-next.62", async () => {
     const choices: UserChoices = {
       projectName: "test-pin-bump",
       defaultLang: "en",
@@ -3529,10 +3533,10 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
     };
     await scaffold(choices);
     const pkg = await fs.readJson(projectPath("test-pin-bump", "package.json"));
-    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.61");
-    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.61");
+    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.62");
+    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.62");
     expect(pkg.dependencies["@takazudo/zfb-adapter-cloudflare"]).toBe(
-      "0.1.0-next.61",
+      "0.1.0-next.62",
     );
   });
 });

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -557,11 +557,11 @@ function generatePackageJson(choices: UserChoices) {
     // stability, multi-valued response headers (e.g. multiple Set-Cookie),
     // supplementary-plane CJK reading-time, plus CLI/server/runtime hardening
     // and render perf passes. No consumer-facing / CLI breaking change.
-    "@takazudo/zfb": "0.1.0-next.61",
-    "@takazudo/zfb-runtime": "0.1.0-next.61",
+    "@takazudo/zfb": "0.1.0-next.62",
+    "@takazudo/zfb-runtime": "0.1.0-next.62",
     // zfb-adapter-cloudflare — required for any route with `prerender = false`.
     // Pinned in lockstep with @takazudo/zfb.
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.61",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.62",
     // @takazudo/zudo-doc — published from this monorepo via
     // .github/workflows/publish-zudo-doc.yml. The pin here is bumped in
     // lockstep by scripts/release-create-zudo-doc.sh whenever zudo-doc's

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -240,8 +240,8 @@
   ],
   "peerDependencies": {
     "preact": "^10.29.1",
-    "@takazudo/zfb": "^0.1.0-next.61",
-    "@takazudo/zfb-runtime": "^0.1.0-next.61",
+    "@takazudo/zfb": "^0.1.0-next.62",
+    "@takazudo/zfb-runtime": "^0.1.0-next.62",
     "@takazudo/zudo-doc-history-server": "^0.2.21",
     "@takazudo/zdtp": "^0.3.3",
     "shiki": "^4.0.2",
@@ -275,7 +275,7 @@
     "typescript": "^5.0.0",
     "vitest": "^4.1.0",
     "zod": "^4.3.6",
-    "@takazudo/zfb": "0.1.0-next.61",
-    "@takazudo/zfb-runtime": "0.1.0-next.61"
+    "@takazudo/zfb": "0.1.0-next.62",
+    "@takazudo/zfb-runtime": "0.1.0-next.62"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,14 +30,14 @@ importers:
         specifier: 0.3.3
         version: 0.3.3(preact@10.29.2)
       '@takazudo/zfb':
-        specifier: 0.1.0-next.61
-        version: 0.1.0-next.61
+        specifier: 0.1.0-next.62
+        version: 0.1.0-next.62
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.61
-        version: 0.1.0-next.61
+        specifier: 0.1.0-next.62
+        version: 0.1.0-next.62
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.61
-        version: 0.1.0-next.61(@takazudo/zfb@0.1.0-next.61)
+        specifier: 0.1.0-next.62
+        version: 0.1.0-next.62(@takazudo/zfb@0.1.0-next.62)
       '@takazudo/zudo-doc':
         specifier: workspace:*
         version: link:packages/zudo-doc
@@ -269,11 +269,11 @@ importers:
         version: 0.16.38
     devDependencies:
       '@takazudo/zfb':
-        specifier: 0.1.0-next.61
-        version: 0.1.0-next.61
+        specifier: 0.1.0-next.62
+        version: 0.1.0-next.62
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.61
-        version: 0.1.0-next.61(@takazudo/zfb@0.1.0-next.61)
+        specifier: 0.1.0-next.62
+        version: 0.1.0-next.62(@takazudo/zfb@0.1.0-next.62)
       '@types/node':
         specifier: ^25.3.5
         version: 25.3.5
@@ -1359,48 +1359,48 @@ packages:
     peerDependencies:
       preact: ^10.29.1
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.61':
-    resolution: {integrity: sha512-Unua3gZ6KuB/fRGn+jwMj9gggn4RjgzPIttPVfHmdnJ23ag3NcNeGYIfg1XFR6IuDDWAUzj7mJSF/KEPVF5Eug==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.62':
+    resolution: {integrity: sha512-ACfDX+lqtuetDc29EsFj2MA+RXoev90n5rhKyLAvwnY7Z8GIOPUq8VS7hyB3sw7zvZ+lNZ89HWf/XYbBSi8FJA==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.61':
-    resolution: {integrity: sha512-VYUgyecDvfP3y7X6tqRBcHEzUmLgvS4q4dAYA7fOMw03iXBmu5t1OF7UgxSVGw2FVcp/JRj4y17rgoEJHlKb+w==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.62':
+    resolution: {integrity: sha512-IIo/v/1ND3+i9ZHp2XBYhJwpVsVrbA5t0zWlGops7XSQFnI0dDW3IyeBPlMKIHaADE4BesgLPbBJ00IfE9DW+g==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.61':
-    resolution: {integrity: sha512-rrtjB4H6hmKwjhyfmFaZTk2fH0hERcA3hZJ3mV4cKP2TjmWguBtQkCH4n48f4XwqXH5Sk28jl5E+/OTdFuIeGw==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.62':
+    resolution: {integrity: sha512-cyn8ned2MUaeFIrjgtNmrlyEQyGQ2QF0QYyM8hTKSjWcicW47i16GV5cm4d4q3Z1rudVltDUIJK34QfrQdGRmg==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.61':
-    resolution: {integrity: sha512-azz46n4XPsN0Qqf/gZ/ZxTK0XEXIEURn1Awkev44Vv0gEqvoZxe83kUt9aEjxl1PDk1DRwvxCeXzgoG65mdWvg==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.62':
+    resolution: {integrity: sha512-13bmvDAHBZYLpeBWZyqXTtIcJPpS++PwTR2mWlO+5nMBQ+Q90cUXzVgBhAbDhreG6oqRQ3Nbj/kov2mCxVJ73A==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.61':
-    resolution: {integrity: sha512-C+yetzbJ+AB/t/sC4MrO22l87bN9Jn1ytUG0EeumsgnYvxkuouYaAisTDi2/AGorFeHMtEDn20IQXwhiZG42kA==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.62':
+    resolution: {integrity: sha512-ldhn3MPihC35z3JUOmVhli7V+Kt+HkI9o0SpFZ3jPrJs7XEnIAv4fWRWPmjAXzX8CkNXx3qm7OKqyCyrjgyJYA==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.61':
-    resolution: {integrity: sha512-8taqBBayIOAYb0X1D7uzLAulqb1J9QKG88sZILvH2MErgMGcRZlNVej4wf5piJTgVv5X47LnCur9D1Bh2RdXog==}
+  '@takazudo/zfb-runtime@0.1.0-next.62':
+    resolution: {integrity: sha512-kqVCd7qhjn8vMXsSK3CCojb8c0GqZVXTsvs0IzaaS0c6ZZi/XKJph0ajNK0O8yWU2WZRDLRVllIjqtXlLU9zjg==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.61
+      '@takazudo/zfb': 0.1.0-next.62
       react: ^19.2.3
     peerDependenciesMeta:
       react:
         optional: true
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.61':
-    resolution: {integrity: sha512-Y82jRPUWSbMo1+LH43kMCaZtmyDLdtnaAqlkAEqh5NovbUQF5yacO5xnp/c2ugGqwXsziXhKLLrMcfKW09P39A==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.62':
+    resolution: {integrity: sha512-QPa7daVbgBGtWIPXTzNp0KBkSjPUkSa9/pxEGKDBdHEJDCCam2NutIEBahAcIa/WQOT/ntAeg31Jk8Zbss9I9g==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.61':
-    resolution: {integrity: sha512-1Ru2n6IxnnipwL4ZDAv011EVoAwpyg+vxOh0754DLd6iUyP6yZKZI9aLoVeIqWu9geoYfO2lSFnvVLPeJpdpFA==}
+  '@takazudo/zfb@0.1.0-next.62':
+    resolution: {integrity: sha512-HMBgjhTL9dBby/51HIIkT0CQgHW//ZRAmOu/UQKZGfYInvU7w3abfQBwb4t5vBBmmSaCnrIpvK+666biLF3kgQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
     peerDependencies:
@@ -4068,35 +4068,35 @@ snapshots:
       culori: 4.0.2
       preact: 10.29.2
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.61': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.62': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.61':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.62':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.61':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.62':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.61':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.62':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.61':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.62':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.61(@takazudo/zfb@0.1.0-next.61)':
+  '@takazudo/zfb-runtime@0.1.0-next.62(@takazudo/zfb@0.1.0-next.62)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.61
+      '@takazudo/zfb': 0.1.0-next.62
       hono: 4.12.25
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.61':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.62':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.61':
+  '@takazudo/zfb@0.1.0-next.62':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.61
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.61
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.61
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.61
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.61
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.62
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.62
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.62
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.62
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.62
 
   '@takazudo/zudo-design-token-lint@1.0.0(patch_hash=6a157fd850449b055cf64a8a7dd1faed5b1da9eebe6c81cca08488ac0de85182)':
     dependencies:


### PR DESCRIPTION
## What

Bumps the `@takazudo/zfb` stack from `0.1.0-next.61` → `0.1.0-next.62` across **all** pin locations (governed by `check:pin-parity`):

- root `package.json` `dependencies` — `@takazudo/zfb`, `@takazudo/zfb-runtime`, `@takazudo/zfb-adapter-cloudflare`
- `packages/create-zudo-doc/src/scaffold.ts` — emitted downstream pins (all three)
- `packages/create-zudo-doc/src/__tests__/scaffold.test.ts` — pin assertions + changelog comment
- `packages/zudo-doc/package.json` — `devDependencies` (exact) + `peerDependencies` (`^`)
- `pnpm-lock.yaml`

`@takazudo/zdtp` is already at its latest (`0.3.3`) — unchanged.

## Why

`next.62` carries router/build fixes plus the **build-time package-owned-routes capability** (injectRoute-in-build, `definePreset`, `presets[]`, `addClientEntry`) that the package-first migration's Epic 3 depends on. Doing this bump first means Epic 2 and Epic 3 both run on the engine version Epic 3 needs.

## Verification (run locally on persisted state)

- ✅ `check:pin-parity` — all 9 fields in lockstep at `next.62`
- ✅ `b4push` steps 1–18 — template-drift, typecheck against new types, **2171** unit/package tests (incl. updated scaffold assertions), 315-page build, link check, HTML validation, deploy-shape preview smoke (step 19 is the human-gated manual smoke)
- ✅ full Playwright e2e — **220 passed, 0 failed** across all 5 fixtures (smoke 171, sidebar 8, i18n 12, theme 5, versioning 24), covering island hydration, VT/SPA navigation, search, theme toggle, doc-history, i18n, versioning

This is an internal engine bump; the create-zudo-doc npm release is deferred to the Epic 3 1.0 cutover per the migration roadmap (#2341).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784928910&installation_id=130359969&pr_number=2343&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2343&signature=a34db9d35dec01d56e6dcb0e74f232d31f2afeb70507bf6b0f30f04c948e4022"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->