### PR TITLE
fix(create-zudo-doc): provide optional diff peer unconditionally so barebone projects build (#2342)

### DIFF
--- a/packages/create-zudo-doc/src/__tests__/barebone-build.slow.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/barebone-build.slow.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Barebone build regression test (#2342 / #2379).
+ *
+ * Guards the generated-project build for the **all-optional-features-OFF**
+ * scaffold — the configuration that was unprotected (preset-swap covers only
+ * the i18n-on case).
+ *
+ * ## Why this exists — do NOT weaken into a plain scaffold snapshot test
+ *
+ * With `packageOwnedRoutes` defaulting ON (1.0), the always-copied host base
+ * template `pages/lib/_doc-history-area.tsx` statically imports the real
+ * `DocHistory` from `@takazudo/zudo-doc/doc-history` (to keep zfb's island
+ * scanner chain page→stub→DocHistory walkable). That pulls
+ * `@takazudo/zudo-doc/dist/doc-history/index.js`'s `await import("diff")` into
+ * EVERY generated bundle — even a barebone, docHistory-off project. `diff` is
+ * a peerDependency of `@takazudo/zudo-doc`, so the scaffold must add it to the
+ * generated `package.json` unconditionally; if it only added `diff` when the
+ * docHistory feature was selected, a barebone `zfb build` would fail at esbuild
+ * with `Could not resolve "diff"` (the regression this test locks down).
+ *
+ * The real gate is the end-to-end `zfb build` succeeding — a unit assertion
+ * that `diff` is in the generated deps would NOT catch the next hidden peer
+ * (we add a cheap dep-presence assertion too, but the build is the gate).
+ *
+ * ## Tier
+ *
+ * Scaffolds a real project, `pnpm install`s against the public registry, and
+ * runs a full `zfb build` — minutes per run, so it lives in the slow tier
+ * (`pnpm test:slow`), excluded from `pnpm test` and `pnpm b4push`.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import fs from "fs-extra";
+import os from "node:os";
+import path from "node:path";
+import { scaffold } from "../scaffold.js";
+import type { UserChoices } from "../prompts.js";
+import { runOrThrow, installScaffoldedDeps } from "./slow-build-helpers.js";
+
+const TEMP_PREFIX = "create-zudo-doc-barebone-build-";
+const PROJECT_NAME = "barebone-build-test";
+
+// Barebone: every optional feature OFF. `features: []` means no i18n, no
+// search, no docHistory, no designTokenPanel, etc. — the exact shape that the
+// #2342 `diff`-resolution regression broke.
+const choices: UserChoices = {
+  projectName: PROJECT_NAME,
+  defaultLang: "en",
+  colorSchemeMode: "single",
+  singleScheme: "Default Dark",
+  features: [],
+  packageManager: "pnpm",
+};
+
+let tempDir: string;
+let projectDir: string;
+let originalCwd: string;
+
+beforeAll(async () => {
+  originalCwd = process.cwd();
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), TEMP_PREFIX));
+  process.chdir(tempDir);
+
+  // 1. Scaffold the barebone project.
+  await scaffold(choices);
+  projectDir = path.join(tempDir, PROJECT_NAME);
+
+  // 2. Install + build. A `Could not resolve "diff"` (or any other unresolved
+  //    always-bundled peer) makes `zfb build` exit non-zero, which throws here
+  //    and fails the suite — that failure IS the regression signal.
+  installScaffoldedDeps(projectDir);
+  runOrThrow("pnpm build", projectDir, { SKIP_DOC_HISTORY: "1" });
+}, 5 * 60 * 1000);
+
+afterAll(async () => {
+  process.chdir(originalCwd);
+  if (tempDir && (await fs.pathExists(tempDir))) {
+    await fs.remove(tempDir);
+  }
+});
+
+describe("barebone (all features off) generated project", () => {
+  it("scaffolds the always-bundled `diff` peer into the generated package.json", async () => {
+    // Cheap pinpoint guard for the specific #2342 regression. NOT a substitute
+    // for the build gate below — it would not catch a different hidden peer.
+    const pkg = await fs.readJson(path.join(projectDir, "package.json"));
+    expect(pkg.dependencies?.diff).toBeDefined();
+  });
+
+  it("builds with `zfb build` (no unresolved esbuild imports)", async () => {
+    // The build already ran in beforeAll; a failure there would have aborted
+    // the suite. Assert the static output was emitted as the success signal.
+    const indexHtml = path.join(projectDir, "dist", "index.html");
+    expect(await fs.pathExists(indexHtml)).toBe(true);
+  });
+});

--- a/packages/create-zudo-doc/src/__tests__/preset-swap.slow.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/preset-swap.slow.test.ts
@@ -30,142 +30,16 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { execSync } from "node:child_process";
 import fs from "fs-extra";
 import os from "node:os";
 import path from "node:path";
 import { scaffold } from "../scaffold.js";
 import type { UserChoices } from "../prompts.js";
+// Robust scaffold→install→build plumbing (with transient-flake install retry)
+// is shared with barebone-build.slow.test.ts — see ./slow-build-helpers.ts.
+import { runOrThrow, installScaffoldedDeps } from "./slow-build-helpers.js";
 
 const TEMP_PREFIX = "create-zudo-doc-preset-swap-";
-
-/**
- * Wrapper around execSync that captures combined stdout/stderr and re-throws
- * with the captured output appended to the error message. Without this, a
- * failed `pnpm install` or `pnpm build` inside `beforeAll` surfaces only
- * vitest's generic "command failed" error and the actual diagnostic output
- * is lost.
- */
-function runOrThrow(
-  cmd: string,
-  cwd: string,
-  extraEnv: NodeJS.ProcessEnv = {},
-): void {
-  try {
-    execSync(cmd, {
-      cwd,
-      stdio: "pipe",
-      env: { ...process.env, ...extraEnv },
-    });
-  } catch (err) {
-    const e = err as { stdout?: Buffer; stderr?: Buffer; message?: string };
-    const stdout = e.stdout?.toString() ?? "";
-    const stderr = e.stderr?.toString() ?? "";
-    throw new Error(
-      `Command failed: ${cmd}\n  cwd: ${cwd}\n--- stdout ---\n${stdout}\n--- stderr ---\n${stderr}`,
-    );
-  }
-}
-
-/**
- * Resilient `pnpm install` for the network-dependent install step.
- *
- * This test resolves the scaffolded project's deps against the public npm
- * registry. The generated `package.json` pins ranges (e.g. `@types/node`
- * `^22.0.0`), so a fresh patch release can land in the range that is not yet
- * in the local pnpm store — pnpm then has to fetch it, and that fetch can
- * transiently fail (registry hiccup, network blip). This is exactly the
- * nightly-exam failure tracked in zudolab/zudo-doc#2123: a one-off
- * `--prefer-offline` install of `@types/node@22.19.21`'s transitive
- * `undici-types` failed to download, even though the version range itself is
- * healthy and installs fine on a warm store.
- *
- * Strategy: try `--prefer-offline` first (fast once the store is warm). If
- * it fails with a transient network/registry error, retry with full online
- * resolution using exponential backoff. Only after all attempts are exhausted
- * do we surface the captured diagnostics. Non-transient failures (e.g. a
- * genuinely bad version pin that 404s every time) are re-thrown immediately
- * once we have confirmed it is not a transient error class, since repeated
- * retries would only add latency.
- *
- * Why broader error matching (zudolab/zudo-doc#2123, zudolab/zudo-doc#2270):
- * The original narrow retry caught some undici fetch failures but missed
- * ECONNRESET, ETIMEDOUT, registry 5xx responses surfaced as non-zero exit
- * without a recognisable pnpm error code, and mid-stream undici drops that
- * pnpm formats as "fetch failed" / "UND_ERR_SOCKET" in stderr. The revised
- * heuristic treats any of those patterns as transient and worth retrying,
- * while still letting genuine resolution failures (missing package, version
- * constraint impossible) propagate after the final attempt.
- */
-
-/** Patterns that indicate a transient network / registry error worth retrying. */
-const TRANSIENT_ERROR_PATTERNS = [
-  /ECONNRESET/,
-  /ETIMEDOUT/,
-  /ECONNREFUSED/,
-  /ENOTFOUND/,
-  /EAI_AGAIN/,
-  /fetch failed/i,
-  /UND_ERR/,
-  /undici/i,
-  /network\s+error/i,
-  /socket\s+hang\s+up/i,
-  // Registry 5xx responses: pnpm prints the status line in stderr
-  /50[0-9]\s/,
-  // pnpm's own "GET https://registry…" fetch-failure lines
-  /GET https?:\/\/.+\s+5\d{2}/,
-];
-
-function isTransientInstallError(err: unknown): boolean {
-  const e = err as { stdout?: Buffer; stderr?: Buffer; message?: string };
-  const combined = [
-    e.message ?? "",
-    e.stdout?.toString() ?? "",
-    e.stderr?.toString() ?? "",
-  ].join("\n");
-  return TRANSIENT_ERROR_PATTERNS.some((re) => re.test(combined));
-}
-
-function installScaffoldedDeps(cwd: string): void {
-  // Attempt 0: prefer-offline (fast when store is warm).
-  // Attempts 1-4: full online resolution with exponential backoff.
-  // Total: 5 attempts, backoff ceiling ~16s per inter-attempt gap.
-  // Rationale for 5 attempts: zudolab/zudo-doc#2123 shows single-attempt
-  // flakes; zudolab/zudo-doc#2270 observed two back-to-back hiccups before
-  // recovery, so 2 retries were still not enough in the worst case.
-  const attempts = [
-    "pnpm install --prefer-offline --ignore-workspace",
-    "pnpm install --ignore-workspace",
-    "pnpm install --ignore-workspace",
-    "pnpm install --ignore-workspace",
-    "pnpm install --ignore-workspace",
-  ];
-  let lastErr: unknown;
-  for (const [i, cmd] of attempts.entries()) {
-    try {
-      runOrThrow(cmd, cwd);
-      return;
-    } catch (err) {
-      lastErr = err;
-      const isLast = i === attempts.length - 1;
-      if (!isLast) {
-        // Only retry if the error looks transient. A genuine resolution
-        // failure (bad pin, impossible constraint) fails identically on every
-        // attempt — retrying only wastes nightly-exam minutes.
-        if (!isTransientInstallError(err)) {
-          throw err;
-        }
-        // Synchronous exponential backoff: 2s, 4s, 8s, 16s. The surrounding
-        // execSync is already blocking, so a blocking sleep here is fine and
-        // avoids turning beforeAll async-racy. Atomics.wait is the standard
-        // no-busy-loop synchronous sleep idiom.
-        const waitMs = 2000 * Math.pow(2, i);
-        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, waitMs);
-      }
-    }
-  }
-  throw lastErr;
-}
 
 let tempDir: string;
 let projectDir: string;

--- a/packages/create-zudo-doc/src/__tests__/slow-build-helpers.ts
+++ b/packages/create-zudo-doc/src/__tests__/slow-build-helpers.ts
@@ -1,0 +1,110 @@
+/**
+ * Shared helpers for the slow tier (`*.slow.test.ts`, run via `pnpm test:slow`).
+ *
+ * These integration tests scaffold a real project, `pnpm install` against the
+ * public registry, and run a full `zfb build`. The install step is
+ * network-dependent and occasionally hits transient registry/network flakes
+ * (zudolab/zudo-doc#2123, #2270), so the install helper retries with backoff.
+ *
+ * Extracted from preset-swap.slow.test.ts so multiple slow tests can share the
+ * exact same robust scaffold→install→build plumbing. This file has no `.test.`
+ * suffix, so neither vitest config collects it as a test.
+ */
+
+import { execSync } from "node:child_process";
+
+/**
+ * Wrapper around execSync that captures combined stdout/stderr and re-throws
+ * with the captured output appended to the error message. Without this, a
+ * failed `pnpm install` or `pnpm build` surfaces only vitest's generic
+ * "command failed" error and the actual diagnostic output is lost.
+ */
+export function runOrThrow(
+  cmd: string,
+  cwd: string,
+  extraEnv: NodeJS.ProcessEnv = {},
+): void {
+  try {
+    execSync(cmd, {
+      cwd,
+      stdio: "pipe",
+      env: { ...process.env, ...extraEnv },
+    });
+  } catch (err) {
+    const e = err as { stdout?: Buffer; stderr?: Buffer; message?: string };
+    const stdout = e.stdout?.toString() ?? "";
+    const stderr = e.stderr?.toString() ?? "";
+    throw new Error(
+      `Command failed: ${cmd}\n  cwd: ${cwd}\n--- stdout ---\n${stdout}\n--- stderr ---\n${stderr}`,
+    );
+  }
+}
+
+/** Patterns that indicate a transient network / registry error worth retrying. */
+const TRANSIENT_ERROR_PATTERNS = [
+  /ECONNRESET/,
+  /ETIMEDOUT/,
+  /ECONNREFUSED/,
+  /ENOTFOUND/,
+  /EAI_AGAIN/,
+  /fetch failed/i,
+  /UND_ERR/,
+  /undici/i,
+  /network\s+error/i,
+  /socket\s+hang\s+up/i,
+  // Registry 5xx responses: pnpm prints the status line in stderr
+  /50[0-9]\s/,
+  // pnpm's own "GET https://registry…" fetch-failure lines
+  /GET https?:\/\/.+\s+5\d{2}/,
+];
+
+function isTransientInstallError(err: unknown): boolean {
+  const e = err as { stdout?: Buffer; stderr?: Buffer; message?: string };
+  const combined = [
+    e.message ?? "",
+    e.stdout?.toString() ?? "",
+    e.stderr?.toString() ?? "",
+  ].join("\n");
+  return TRANSIENT_ERROR_PATTERNS.some((re) => re.test(combined));
+}
+
+/**
+ * Resilient `pnpm install` for the network-dependent install step.
+ *
+ * Attempt 0 uses `--prefer-offline` (fast when the store is warm); attempts
+ * 1-4 fall back to full online resolution with exponential backoff (2s, 4s,
+ * 8s, 16s). A genuine resolution failure (bad pin, impossible constraint)
+ * fails identically on every attempt, so non-transient errors propagate
+ * immediately rather than wasting retries. See zudolab/zudo-doc#2123 / #2270
+ * for why 5 attempts and the broad transient-error heuristic.
+ */
+export function installScaffoldedDeps(cwd: string): void {
+  const attempts = [
+    "pnpm install --prefer-offline --ignore-workspace",
+    "pnpm install --ignore-workspace",
+    "pnpm install --ignore-workspace",
+    "pnpm install --ignore-workspace",
+    "pnpm install --ignore-workspace",
+  ];
+  let lastErr: unknown;
+  for (const [i, cmd] of attempts.entries()) {
+    try {
+      runOrThrow(cmd, cwd);
+      return;
+    } catch (err) {
+      lastErr = err;
+      const isLast = i === attempts.length - 1;
+      if (!isLast) {
+        if (!isTransientInstallError(err)) {
+          throw err;
+        }
+        // Synchronous exponential backoff: 2s, 4s, 8s, 16s. Atomics.wait is
+        // the standard no-busy-loop synchronous sleep idiom; the surrounding
+        // execSync is already blocking.
+        const waitMs = 2000 * Math.pow(2, i);
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, waitMs);
+      }
+    }
+  }
+  throw lastErr;
+}

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -644,6 +644,16 @@ function generatePackageJson(choices: UserChoices) {
     // consumer-build verification — the import lives in the mirrored
     // pages, not behind any feature gate. Same pin as host.
     katex: "^0.16.38",
+    // diff — required at build time by EVERY generated project, not just
+    // docHistory ones. The always-copied host base template
+    // `pages/lib/_doc-history-area.tsx` statically imports the real
+    // `DocHistory` from `@takazudo/zudo-doc/doc-history` (to keep zfb's island
+    // scanner chain page→stub→DocHistory walkable), which pulls
+    // `@takazudo/zudo-doc/dist/doc-history/index.js`'s `await import("diff")`
+    // into the bundle. With packageOwnedRoutes default ON (1.0), a
+    // docHistory-off project still bundles that path, so without `diff` here
+    // `zfb build` fails at esbuild with "Could not resolve 'diff'" (#2342).
+    diff: "^8.0.3",
   };
 
   const devDeps: Record<string, string> = {
@@ -662,7 +672,9 @@ function generatePackageJson(choices: UserChoices) {
   }
 
   if (choices.features.includes("docHistory")) {
-    deps["diff"] = "^8.0.3";
+    // (diff is now an unconditional base dep — see the `deps` block above:
+    // packageOwnedRoutes always bundles the doc-history-area path, so diff is
+    // required regardless of this feature flag.)
     // @takazudo/zudo-doc has @takazudo/zudo-doc-history-server as an optional
     // peer dep. When docHistory is selected the zfb plugin
     // (@takazudo/zudo-doc/plugins/doc-history) eagerly imports

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -653,6 +653,9 @@ function generatePackageJson(choices: UserChoices) {
     // into the bundle. With packageOwnedRoutes default ON (1.0), a
     // docHistory-off project still bundles that path, so without `diff` here
     // `zfb build` fails at esbuild with "Could not resolve 'diff'" (#2342).
+    // `diff` is an *optional* peerDependency of @takazudo/zudo-doc, so a
+    // missing copy produces no `pnpm install` warning — which is why this gap
+    // shipped silently and only surfaced at build time.
     diff: "^8.0.3",
   };
 

--- a/packages/create-zudo-doc/vitest.slow.config.ts
+++ b/packages/create-zudo-doc/vitest.slow.config.ts
@@ -12,6 +12,13 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["src/__tests__/**/*.slow.test.ts"],
+    // Run slow files SEQUENTIALLY. Each scaffolds a project + `pnpm install` +
+    // a full zfb build (Rust pipeline + esbuild); running two at once on the
+    // nightly CI runner (2-4 cores) doubles peak CPU/memory AND doubles the
+    // concurrent registry-fetch surface that `installScaffoldedDeps` retries
+    // for. Back-to-back is safer and each file already runs in its own forked
+    // process (so the per-file `process.chdir` dance stays isolated).
+    fileParallelism: false,
     // 5 minutes per test — scaffold + pnpm install + zfb build can be slow
     // on a cold pnpm store.
     testTimeout: 5 * 60 * 1000,


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2379
    - https://github.com/zudolab/zudo-doc/issues/2378 (epic)
    - https://github.com/zudolab/zudo-doc/issues/2342 (nightly chain)

---

## Summary

`create-zudo-doc@1.0.0` generated projects **failed `zfb build`** whenever the `docHistory` feature was OFF (e.g. a barebone scaffold). This is the live tail of the #2342 nightly chain (preset-export → copy-public → **diff**).

**Root cause:** `packageOwnedRoutes` defaults ON since 1.0, so the always-copied host base template `templates/base/pages/lib/_doc-history-area.tsx` statically imports the real `DocHistory` from `@takazudo/zudo-doc/doc-history` (intentional — keeps zfb's island-scanner chain page→stub→DocHistory walkable). That pulls `@takazudo/zudo-doc/dist/doc-history/index.js`'s `await import("diff")` into **every** generated bundle. But the scaffold only added the `diff` peer dep when `docHistory` was enabled — and `diff` is an *optional* peer of `@takazudo/zudo-doc`, so its absence produced no `pnpm install` warning and the gap surfaced only at build time as `✘ [ERROR] Could not resolve "diff"`.

## Changes

- **`scaffold.ts`** — move `diff: "^8.0.3"` out of the `docHistory` conditional into the unconditional generated `deps` (next to the other always-bundled peers preact/shiki/zod/katex). Audit confirmed `diff` is the **only** mis-gated always-bundled peer; `@takazudo/zudo-doc-history-server` and `@takazudo/zdtp` stay correctly feature-gated.
- **`__tests__/barebone-build.slow.test.ts`** (new) — true-barebone (all optional features OFF) scaffold→install→`zfb build` regression test; the previously-unprotected case (preset-swap only covered i18n-on). The build succeeding is the gate; a cheap dep-presence assertion is secondary.
- **`__tests__/slow-build-helpers.ts`** (new) — extract the shared install-retry / build plumbing, reused by both slow tests.
- **`preset-swap.slow.test.ts`** — refactor to import the shared helpers (byte-faithful, no behavior change).
- **`vitest.slow.config.ts`** — `fileParallelism: false` so the two slow files run back-to-back (avoids doubled CPU/memory + doubled registry-flake surface on the nightly runner).

## Test Plan

- `pnpm --filter create-zudo-doc test` — 369 unit tests pass.
- `pnpm --filter create-zudo-doc test:slow` — 6/6 (preset-swap + barebone) pass; barebone builds against published `@takazudo/zudo-doc@1.0.0`.
- `pnpm check:template-drift`, `pnpm check:fixture-settings-drift`, package `tsc --noEmit` — all clean.

## Release

Intentionally **no version bump / publish** — `ZUDO_DOC_PIN` stays `^1.0.0`. The fix lands on `main` unreleased; the 1.0.1 publish is batched later.
