### PR TITLE
Package Route Inheritance: package-owned routes inherit host i18n/theme/islands + gate fix (#2403)

### DIFF
--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -2745,6 +2745,9 @@ describe("scaffold — zfb.config.ts shape (topic-config-generators)", () => {
       // markdown features, codeHighlight, resolveMarkdownLinks, and trailingSlash
       // to zudoDocPreset() from @takazudo/zudo-doc/preset. The generated config
       // spreads the result and keeps only the host-owned shell fields.
+      // S5 (#2408): translations + colorSchemes forwarded unconditionally so
+      // generated projects get the same route-label and color-scheme resolution
+      // on package-owned routes as the host.
       const config = await fs.readFile(
         projectPath("test-zfb-minimal", "zfb.config.ts"),
         "utf-8",
@@ -2753,7 +2756,13 @@ describe("scaffold — zfb.config.ts shape (topic-config-generators)", () => {
         'import { zudoDocPreset } from "@takazudo/zudo-doc/preset"',
       );
       expect(config).toContain(
-        "...zudoDocPreset({ settings, buildDocsSchema, directiveVocabulary })",
+        'import { translations } from "./src/config/i18n"',
+      );
+      expect(config).toContain(
+        'import { colorSchemes } from "./src/config/color-schemes"',
+      );
+      expect(config).toContain(
+        "...zudoDocPreset({ settings, buildDocsSchema, directiveVocabulary, translations, colorSchemes })",
       );
       // The inline boilerplate must NOT appear — it lives inside the preset.
       expect(config).not.toContain("  collections,");
@@ -2882,6 +2891,7 @@ describe("scaffold — zfb.config.ts shape (topic-config-generators)", () => {
       // driven by settings.* at zfb-load time inside zudoDocPreset().
       // No inline locale loops, plugin conditionals, or docHistory/llmsTxt/
       // claudeResources mentions are needed in the generated file.
+      // S5 (#2408): translations + colorSchemes forwarded unconditionally.
       const config = await fs.readFile(
         projectPath("test-zfb-full", "zfb.config.ts"),
         "utf-8",
@@ -2890,7 +2900,13 @@ describe("scaffold — zfb.config.ts shape (topic-config-generators)", () => {
         'import { zudoDocPreset } from "@takazudo/zudo-doc/preset"',
       );
       expect(config).toContain(
-        "...zudoDocPreset({ settings, buildDocsSchema, directiveVocabulary })",
+        'import { translations } from "./src/config/i18n"',
+      );
+      expect(config).toContain(
+        'import { colorSchemes } from "./src/config/color-schemes"',
+      );
+      expect(config).toContain(
+        "...zudoDocPreset({ settings, buildDocsSchema, directiveVocabulary, translations, colorSchemes })",
       );
       // Inline collection loops must NOT appear — they live in the preset.
       expect(config).not.toContain("Object.entries(settings.locales)");

--- a/packages/create-zudo-doc/src/__tests__/zfb-config-gen.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/zfb-config-gen.test.ts
@@ -33,11 +33,17 @@ describe("generateZfbConfig", () => {
     expect(result).toContain(
       'import { buildDocsSchema } from "./src/config/docs-schema"',
     );
+    expect(result).toContain(
+      'import { translations } from "./src/config/i18n"',
+    );
+    expect(result).toContain(
+      'import { colorSchemes } from "./src/config/color-schemes"',
+    );
     expect(result).toContain("export default defineConfig({");
 
-    // Must spread the preset result
+    // Must spread the preset result with translations + colorSchemes forwarded
     expect(result).toContain(
-      "...zudoDocPreset({ settings, buildDocsSchema, directiveVocabulary })",
+      "...zudoDocPreset({ settings, buildDocsSchema, directiveVocabulary, translations, colorSchemes })",
     );
 
     // Host-owned shell fields must be present

--- a/packages/create-zudo-doc/src/zfb-config-gen.ts
+++ b/packages/create-zudo-doc/src/zfb-config-gen.ts
@@ -31,6 +31,8 @@ export function generateZfbConfig(_choices: UserChoices): string {
   lines.push(`import { zudoDocPreset } from "@takazudo/zudo-doc/preset";`);
   lines.push(`import { settings } from "./src/config/settings";`);
   lines.push(`import { buildDocsSchema } from "./src/config/docs-schema";`);
+  lines.push(`import { translations } from "./src/config/i18n";`);
+  lines.push(`import { colorSchemes } from "./src/config/color-schemes";`);
   lines.push(``);
 
   // --- Directive vocabulary ---
@@ -59,7 +61,7 @@ export function generateZfbConfig(_choices: UserChoices): string {
   lines.push(`  base: settings.base,`);
   lines.push(``);
   lines.push(`  // ── Preset-owned fields (content collections, plugins, markdown, …) ────────`);
-  lines.push(`  ...zudoDocPreset({ settings, buildDocsSchema, directiveVocabulary }),`);
+  lines.push(`  ...zudoDocPreset({ settings, buildDocsSchema, directiveVocabulary, translations, colorSchemes }),`);
   lines.push(`});`);
 
   return lines.join("\n") + "\n";

--- a/packages/create-zudo-doc/templates/base/src/config/i18n.ts
+++ b/packages/create-zudo-doc/templates/base/src/config/i18n.ts
@@ -55,7 +55,7 @@ export function detectLocaleFromPath(path: string): Locale {
 }
 
 /** UI string translations */
-const translations: Record<string, Record<string, string>> = {
+export const translations: Record<string, Record<string, string>> = {
   en: {
     "nav.gettingStarted": "Getting Started",
     "nav.learn": "Learn",

--- a/packages/zudo-doc/API.md
+++ b/packages/zudo-doc/API.md
@@ -91,6 +91,7 @@ The full `package.json#exports` keyset is the contract. Any addition or removal 
 | `./doc-page-props` | Doc page props types |
 | `./doc-content-header` | Doc content header (title area) |
 | `./doc-body-end` | Doc body end area |
+| `./doc-body-end-islands` | Package-default body-end islands factory (package-owned routes) |
 | `./doc-metainfo-area` | Doc metadata area (dates, author) |
 | `./doc-history-area` | Doc history dropdown area |
 | `./doc-tags-area` | Doc tags area |

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -392,6 +392,10 @@
       "types": "./dist/doc-body-end/index.d.ts",
       "default": "./dist/doc-body-end/index.js"
     },
+    "./doc-body-end-islands": {
+      "types": "./dist/doc-body-end-islands/index.d.ts",
+      "default": "./dist/doc-body-end-islands/index.js"
+    },
     "./doc-history-area": {
       "types": "./dist/doc-history-area/index.d.ts",
       "default": "./dist/doc-history-area/index.js"

--- a/packages/zudo-doc/src/__tests__/preset.test.ts
+++ b/packages/zudo-doc/src/__tests__/preset.test.ts
@@ -380,26 +380,95 @@ describe("zudoDocPreset plugins (bare-specifier descriptors)", () => {
       expect(warnSpy).not.toHaveBeenCalled();
     });
 
-    it("does NOT warn when packageOwnedRoutes is true", () => {
+    it("does NOT warn (about packageOwnedRoutes=false) when packageOwnedRoutes is true and bindings are supplied", () => {
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       zudoDocPreset({
         settings: { ...fixtureSettings, packageOwnedRoutes: true },
         buildDocsSchema: buildFixtureSchema,
         directiveVocabulary: fixtureDirectives,
+        // Supply both bindings so neither #2404 nor #2405 warning fires.
+        translations: { en: { "doc.allTags": "All Tags" } },
+        colorSchemes: { "Default Dark": { background: "#000", foreground: "#fff", cursor: "#fff", selectionBg: "#444", selectionFg: "#fff", palette: ["#000","#000","#000","#000","#000","#000","#000","#000","#000","#000","#000","#000","#000","#000","#000","#000"] } },
       });
       expect(warnSpy).not.toHaveBeenCalled();
     });
 
-    it("does NOT warn when packageOwnedRoutes is omitted (default-on)", () => {
+    it("does NOT warn (about packageOwnedRoutes=false) when packageOwnedRoutes is omitted and bindings are supplied (default-on)", () => {
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       const { packageOwnedRoutes: _omitted, ...settingsWithoutFlag } = fixtureSettings;
       zudoDocPreset({
         settings: settingsWithoutFlag,
         buildDocsSchema: buildFixtureSchema,
         directiveVocabulary: fixtureDirectives,
+        // Supply both bindings so neither #2404 nor #2405 warning fires.
+        translations: { en: { "doc.allTags": "All Tags" } },
+        colorSchemes: { "Default Dark": { background: "#000", foreground: "#fff", cursor: "#fff", selectionBg: "#444", selectionFg: "#fff", palette: ["#000","#000","#000","#000","#000","#000","#000","#000","#000","#000","#000","#000","#000","#000","#000","#000"] } },
       });
       expect(warnSpy).not.toHaveBeenCalled();
     });
+  });
+});
+
+// ── #2405 warning: packageOwnedRoutes on but host bindings missing ────────────
+describe("zudoDocPreset silent-degradation diagnostic (#2405)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("warns when packageOwnedRoutes is on and colorSchemes is absent", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    zudoDocPreset({
+      settings: { ...fixtureSettings, packageOwnedRoutes: true },
+      buildDocsSchema: buildFixtureSchema,
+      directiveVocabulary: fixtureDirectives,
+      translations: { en: { "doc.allTags": "All Tags" } },
+      // colorSchemes intentionally absent
+    });
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy.mock.calls[0]?.[0]).toContain("colorSchemes");
+    expect(warnSpy.mock.calls[0]?.[0]).toContain("packageOwnedRoutes is on");
+  });
+
+  it("warns when packageOwnedRoutes is on and translations is absent", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    zudoDocPreset({
+      settings: { ...fixtureSettings, packageOwnedRoutes: true },
+      buildDocsSchema: buildFixtureSchema,
+      directiveVocabulary: fixtureDirectives,
+      // translations intentionally absent
+      colorSchemes: { "Default Dark": { background: "#000", foreground: "#fff", cursor: "#fff", selectionBg: "#444", selectionFg: "#fff", palette: ["#000","#000","#000","#000","#000","#000","#000","#000","#000","#000","#000","#000","#000","#000","#000","#000"] } },
+    });
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy.mock.calls[0]?.[0]).toContain("translations");
+    expect(warnSpy.mock.calls[0]?.[0]).toContain("packageOwnedRoutes is on");
+  });
+
+  it("does NOT warn when packageOwnedRoutes is off (about missing bindings)", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+      // suppress the #2404 'packageOwnedRoutes is off' warning
+    });
+    zudoDocPreset({
+      settings: { ...fixtureSettings, packageOwnedRoutes: false },
+      buildDocsSchema: buildFixtureSchema,
+      directiveVocabulary: fixtureDirectives,
+      // no colorSchemes, no translations — but routes are off so no binding warning
+    });
+    // The only warn emitted is the #2404 one (packageOwnedRoutes is off + content configured).
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy.mock.calls[0]?.[0]).toContain("packageOwnedRoutes is off");
+    expect(warnSpy.mock.calls[0]?.[0]).not.toContain("packageOwnedRoutes is on");
+  });
+
+  it("does NOT warn when both translations and colorSchemes are supplied", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    zudoDocPreset({
+      settings: { ...fixtureSettings, packageOwnedRoutes: true },
+      buildDocsSchema: buildFixtureSchema,
+      directiveVocabulary: fixtureDirectives,
+      translations: { en: { "doc.allTags": "All Tags" } },
+      colorSchemes: { "Default Dark": { background: "#000", foreground: "#fff", cursor: "#fff", selectionBg: "#444", selectionFg: "#fff", palette: ["#000","#000","#000","#000","#000","#000","#000","#000","#000","#000","#000","#000","#000","#000","#000","#000"] } },
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/zudo-doc/src/__tests__/preset.test.ts
+++ b/packages/zudo-doc/src/__tests__/preset.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { createRequire } from "node:module";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -333,6 +333,73 @@ describe("zudoDocPreset plugins (bare-specifier descriptors)", () => {
       tagVocabulary: [{ id: "ai" }],
     });
     expect((routes?.options as { settings: { packageOwnedRoutes?: boolean } }).settings.packageOwnedRoutes).toBe(true);
+  });
+
+  // ── default-on gate (#2404) ──────────────────────────────────────────────
+  it("includes the routes plugin when packageOwnedRoutes is omitted (default-on, #2404)", () => {
+    const { packageOwnedRoutes: _omitted, ...settingsWithoutFlag } = fixtureSettings;
+    const r = zudoDocPreset({
+      settings: settingsWithoutFlag,
+      buildDocsSchema: buildFixtureSchema,
+      directiveVocabulary: fixtureDirectives,
+    });
+    expect(r.plugins.map((p) => p.name)).toContain("@takazudo/zudo-doc/plugins/routes");
+    expect(r.plugins[0]?.name).toBe("@takazudo/zudo-doc/plugins/routes");
+  });
+
+  // ── explicit-false + content configured → diagnostic warning (#2404) ─────
+  describe("explicit false + configured content emits console.warn (#2404)", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("warns when packageOwnedRoutes is false and docsDir is set", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      zudoDocPreset({
+        settings: { ...fixtureSettings, packageOwnedRoutes: false },
+        buildDocsSchema: buildFixtureSchema,
+        directiveVocabulary: fixtureDirectives,
+      });
+      expect(warnSpy).toHaveBeenCalledOnce();
+      expect(warnSpy.mock.calls[0]?.[0]).toContain("packageOwnedRoutes is off but doc content is configured");
+    });
+
+    it("does NOT warn when packageOwnedRoutes is false and content roots are all empty", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      zudoDocPreset({
+        settings: {
+          ...fixtureSettings,
+          packageOwnedRoutes: false,
+          docsDir: "",
+          locales: {},
+          versions: false,
+        },
+        buildDocsSchema: buildFixtureSchema,
+        directiveVocabulary: fixtureDirectives,
+      });
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("does NOT warn when packageOwnedRoutes is true", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      zudoDocPreset({
+        settings: { ...fixtureSettings, packageOwnedRoutes: true },
+        buildDocsSchema: buildFixtureSchema,
+        directiveVocabulary: fixtureDirectives,
+      });
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("does NOT warn when packageOwnedRoutes is omitted (default-on)", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { packageOwnedRoutes: _omitted, ...settingsWithoutFlag } = fixtureSettings;
+      zudoDocPreset({
+        settings: settingsWithoutFlag,
+        buildDocsSchema: buildFixtureSchema,
+        directiveVocabulary: fixtureDirectives,
+      });
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/packages/zudo-doc/src/__tests__/public-api-snapshot.test.ts
+++ b/packages/zudo-doc/src/__tests__/public-api-snapshot.test.ts
@@ -56,6 +56,7 @@ describe("package.json exports keyset snapshot", () => {
         "./desktop-sidebar-toggle-island",
         "./details",
         "./doc-body-end",
+        "./doc-body-end-islands",
         "./doc-content-header",
         "./doc-history",
         "./doc-history-area",

--- a/packages/zudo-doc/src/__tests__/route-injection-build.test.ts
+++ b/packages/zudo-doc/src/__tests__/route-injection-build.test.ts
@@ -177,6 +177,60 @@ describe("A2 no-stub: injected routes render correct HTML (packageOwnedRoutes:tr
     // The MDX source includes this phrase; renderDocPage renders it into the HTML.
     expect(html).toContain("injected-route-render-proof");
   });
+
+  // #2406 / #2401(c): the package-default BodyEndIslands replaces the old no-op
+  // BodyEndIslandsStub. The route-injection fixture ships aiAssistant /
+  // imageEnlarge / mermaid OFF, so NO island marker (and no AI-assistant
+  // landmark) must reach the SSG output — the feature-off gating end-to-end.
+  it("body-end islands: /404 HTML has NO island markers when the flags are off", () => {
+    const html = readBuiltHtml(fixtureDir, "404.html");
+    expect(html).not.toContain("data-zfb-island-skip-ssr");
+    expect(html).not.toContain('data-zfb-island-skip-ssr="AiChatModal"');
+    expect(html).not.toContain('data-zfb-island-skip-ssr="ImageEnlarge"');
+    expect(html).not.toContain('data-zfb-island-skip-ssr="MermaidEnlarge"');
+    expect(html).not.toContain("AI Assistant");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Case A2 — Package-island markers ON: flipping the serializable settings flags
+//           emits the package-default BodyEndIslands island markers in the SSG
+//           HTML of a package-owned route (#2406 / #2401(c)). imageEnlarge +
+//           mermaid are enabled (NOT aiAssistant — that would inject the
+//           /api/ai-chat route, irrelevant here); the focused unit test
+//           (src/doc-body-end-islands/__tests__) covers the aiAssistant marker.
+// ---------------------------------------------------------------------------
+
+/** Flip the package-island flags ON in a fixture's settings.ts (it ships them
+ *  OFF) so the route-context virtual module carries them true. */
+function enablePackageIslands(dir: string): void {
+  const settingsPath = join(dir, "src/config/settings.ts");
+  const src = readFileSync(settingsPath, "utf-8")
+    .replace(/imageEnlarge:\s*false/, "imageEnlarge: true")
+    .replace(/mermaid:\s*false/, "mermaid: true");
+  writeFileSync(settingsPath, src);
+}
+
+describe("A2 islands-on: package route HTML carries island markers when flags ON", () => {
+  let fixtureDir: string;
+
+  it("setup: fixture builds with imageEnlarge + mermaid enabled", { timeout: 180_000 }, () => {
+    fixtureDir = setupFixture({ emptyPages: true });
+    enablePackageIslands(fixtureDir);
+    runZfbBuild(fixtureDir);
+  });
+
+  it("islands: /404 HTML carries the ImageEnlarge skip-ssr marker + dialog shell", () => {
+    const html = readBuiltHtml(fixtureDir, "404.html");
+    expect(html).toContain('data-zfb-island-skip-ssr="ImageEnlarge"');
+    expect(html).toContain("zd-enlarge-dialog");
+  });
+
+  it("islands: /404 HTML carries the MermaidEnlarge skip-ssr marker + dialog shell", () => {
+    const html = readBuiltHtml(fixtureDir, "404.html");
+    expect(html).toContain('data-zfb-island-skip-ssr="MermaidEnlarge"');
+    expect(html).toContain("zd-mermaid-dialog");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/zudo-doc/src/doc-body-end-islands/__tests__/body-end-islands.test.tsx
+++ b/packages/zudo-doc/src/doc-body-end-islands/__tests__/body-end-islands.test.tsx
@@ -1,0 +1,100 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+/**
+ * SSG marker test for the package-default body-end islands (#2406 / #2401(c)).
+ *
+ * `createBodyEndIslands({ settings })` returns the `BodyEndIslands` component
+ * that package-owned routes render at their body-end slot. This proves that:
+ *
+ *   1. With a package-island flag ON, the corresponding skip-ssr island marker
+ *      (`data-zfb-island-skip-ssr="<Component>"`) AND its SSR fallback markup
+ *      reach the static HTML.
+ *   2. With a flag OFF, that marker + landmark is ABSENT (matches host gating —
+ *      a feature-off route ships neither a dead marker nor a misleading
+ *      landmark, zudolab/zudo-doc#2058).
+ *   3. The three flags gate independently.
+ *
+ * The skip-ssr marker name is derived by zfb's `captureComponentName` from each
+ * island's pinned `displayName` (AiChatModal / ImageEnlarge / MermaidEnlarge).
+ *
+ * Pattern: src/image-enlarge/__tests__/image-enlarge-ssg.test.tsx.
+ */
+
+import { describe, expect, it } from "vitest";
+import { render } from "preact-render-to-string";
+import { createBodyEndIslands } from "../index.js";
+
+const ALL_ON = { aiAssistant: true, imageEnlarge: true, mermaid: true };
+const ALL_OFF = { aiAssistant: false, imageEnlarge: false, mermaid: false };
+
+function renderIslands(settings: {
+  aiAssistant: boolean;
+  imageEnlarge: boolean;
+  mermaid: boolean;
+}): string {
+  const BodyEndIslands = createBodyEndIslands({ settings });
+  return render(<BodyEndIslands basePath="/" />);
+}
+
+describe("BodyEndIslands — all package-island flags ON", () => {
+  const html = renderIslands(ALL_ON);
+
+  it("emits the AiChatModal skip-ssr island marker", () => {
+    expect(html).toContain('data-zfb-island-skip-ssr="AiChatModal"');
+  });
+
+  it("emits the sr-only 'AI Assistant' landmark heading + body-label fallback", () => {
+    expect(html).toContain("AI Assistant");
+    expect(html).toContain("Ask a question about the documentation.");
+  });
+
+  it("emits the ImageEnlarge skip-ssr island marker + dialog-shell fallback", () => {
+    expect(html).toContain('data-zfb-island-skip-ssr="ImageEnlarge"');
+    expect(html).toContain("zd-enlarge-dialog");
+  });
+
+  it("emits the MermaidEnlarge skip-ssr island marker + dialog-shell fallback", () => {
+    expect(html).toContain('data-zfb-island-skip-ssr="MermaidEnlarge"');
+    expect(html).toContain("zd-mermaid-dialog");
+  });
+});
+
+describe("BodyEndIslands — all package-island flags OFF", () => {
+  const html = renderIslands(ALL_OFF);
+
+  it("emits no island markers when every flag is off", () => {
+    expect(html).not.toContain("data-zfb-island-skip-ssr");
+    expect(html).not.toContain('data-zfb-island="');
+  });
+
+  it("emits neither the AI Assistant landmark nor any enlarge dialog", () => {
+    expect(html).not.toContain("AI Assistant");
+    expect(html).not.toContain("zd-enlarge-dialog");
+    expect(html).not.toContain("zd-mermaid-dialog");
+  });
+});
+
+describe("BodyEndIslands — flags gate independently", () => {
+  it("imageEnlarge ON alone emits only the ImageEnlarge marker", () => {
+    const html = renderIslands({
+      aiAssistant: false,
+      imageEnlarge: true,
+      mermaid: false,
+    });
+    expect(html).toContain('data-zfb-island-skip-ssr="ImageEnlarge"');
+    expect(html).not.toContain('data-zfb-island-skip-ssr="AiChatModal"');
+    expect(html).not.toContain('data-zfb-island-skip-ssr="MermaidEnlarge"');
+  });
+
+  it("aiAssistant ON alone emits only the AiChatModal marker + landmark", () => {
+    const html = renderIslands({
+      aiAssistant: true,
+      imageEnlarge: false,
+      mermaid: false,
+    });
+    expect(html).toContain('data-zfb-island-skip-ssr="AiChatModal"');
+    expect(html).toContain("AI Assistant");
+    expect(html).not.toContain('data-zfb-island-skip-ssr="ImageEnlarge"');
+    expect(html).not.toContain('data-zfb-island-skip-ssr="MermaidEnlarge"');
+  });
+});

--- a/packages/zudo-doc/src/doc-body-end-islands/index.tsx
+++ b/packages/zudo-doc/src/doc-body-end-islands/index.tsx
@@ -1,0 +1,145 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+// doc-body-end-islands — the PACKAGE-DEFAULT body-end islands for package-owned
+// routes (#2406 / #2401(c)).
+//
+// Package-owned routes (404 / index / locale-index / docs / versions / tags)
+// wire their `bodyEndComponents` slot through `routes/_chrome.tsx`. Before this
+// module they used a no-op `BodyEndIslandsStub` that rendered `<></>`, so the
+// island markers for AiChatModal / ImageEnlarge / MermaidEnlarge never reached
+// the DOM — image-enlarge / mermaid-enlarge / AI-chat were dead on `/404` and
+// every package route. This factory reconstructs the PACKAGE-ISLAND subset of
+// the host's `pages/lib/_body-end-islands.tsx` from the serializable `settings`
+// flags the route-context virtual module already carries.
+//
+// SCOPE — package islands ONLY (gated on serializable settings):
+//   - aiAssistant  → `<h2 sr-only>AI Assistant</h2>` + skip-ssr AiChatModal
+//   - imageEnlarge → idle skip-ssr ImageEnlarge   (SSR dialog-shell fallback)
+//   - mermaid      → idle skip-ssr MermaidEnlarge (SSR dialog-shell fallback)
+// It deliberately OMITS the host-owned bootstraps that helper also wires
+// (`ClientRouterBootstrap`, `DesignTokenPanelBootstrap`): those import from
+// `@/components/*` and are NOT reconstructable from package settings.
+//
+// WHY A FACTORY (and not a component that imports `settings` itself): this
+// module compiles to `dist/`, which a published consumer resolves INSIDE
+// node_modules. zfb's esbuild bundler does NOT run the route-context virtual-
+// module resolver on imports whose realpath is under node_modules (the S1
+// #2370 gap; the routes plugin stages only `routes-src/` outside node_modules,
+// not `dist/`). So this module must NOT import `routes/_context` — its
+// transitive `virtual:zudo-doc-route-context` import would dangle. Instead
+// `_chrome.tsx` (which DOES read the staged virtual-module `settings`) injects
+// the flags here, mirroring every other `createX({ settings, … })` factory in
+// that file.
+//
+// ISLAND-SCANNER / displayName: the real island components are imported at
+// module top-level so the scanner walks route → _chrome → here → component.
+// AiChatModal / ImageEnlarge / MermaidEnlarge each pin `displayName` internally
+// (src/{ai-chat-modal,image-enlarge,mermaid-enlarge}), so zfb's
+// `captureComponentName` emits a stable `data-zfb-island-skip-ssr="<name>"`
+// marker — no call-site pinning needed here.
+
+import type { JSX, VNode } from "preact";
+import { Island } from "@takazudo/zfb";
+import { AiChatModal } from "../ai-chat-modal/index.js";
+import { ImageEnlarge, ImageEnlargeSsrFallback } from "../image-enlarge/index.js";
+import { MermaidEnlarge, MermaidEnlargeSsrFallback } from "../mermaid-enlarge/index.js";
+
+/** Default sr-only label rendered as the AiChatModal SSR fallback. Mirrors the
+ *  host helper's default verbatim so assistive tech can discover the chat
+ *  entrypoint in static HTML before JS hydration. English-only; pass
+ *  `aiChatBodyLabel` to localise. */
+const DEFAULT_AI_CHAT_BODY_LABEL = "Ask a question about the documentation.";
+
+/** The `settings` subset this factory reads — the three package-island flags.
+ *  A structural subset so the host can pass its full `Settings` object. */
+export interface BodyEndIslandsSettings {
+  aiAssistant: boolean;
+  imageEnlarge: boolean;
+  mermaid: boolean;
+}
+
+/** Dependencies injected by `_chrome.tsx` (carries the virtual-module settings). */
+export interface BodyEndIslandsDeps {
+  settings: BodyEndIslandsSettings;
+}
+
+/** Props for the produced `BodyEndIslands` component. */
+export interface BodyEndIslandsProps {
+  /** Base path the AI chat modal uses to construct API URLs. */
+  basePath: string;
+  /**
+   * Sr-only label rendered as the AiChatModal SSR fallback. Defaults to the
+   * English string; pass a locale-translated string for non-default locales so
+   * screen readers announce the chat entrypoint correctly before hydration.
+   */
+  aiChatBodyLabel?: string;
+}
+
+/**
+ * Build the package-default `BodyEndIslands` component bound to the host's
+ * serializable `settings` flags. The produced component matches the
+ * `createDocBodyEnd` `BodyEndIslands` slot contract
+ * (`(props: { basePath: string }) => JSX.Element`).
+ */
+export function createBodyEndIslands(
+  deps: BodyEndIslandsDeps,
+): (props: BodyEndIslandsProps) => JSX.Element {
+  const { settings } = deps;
+
+  function BodyEndIslands({
+    basePath,
+    aiChatBodyLabel = DEFAULT_AI_CHAT_BODY_LABEL,
+  }: BodyEndIslandsProps): JSX.Element {
+    // Gated on `settings.aiAssistant` (zudolab/zudo-doc#2058): when off, neither
+    // the AiChatModal island marker nor the sr-only "AI Assistant" landmark
+    // heading reach the SSG output. The marker is ALWAYS emitted when the flag
+    // is on (skip-ssr Island wrapping the real AiChatModal) so zfb's island
+    // scanner registers the constructor and does not strip the bundle. The
+    // sr-only <p> fallback keeps the body label in static HTML for screen
+    // readers before hydration.
+    const aiAssistant = settings.aiAssistant ? (
+      <>
+        <h2 class="sr-only">AI Assistant</h2>
+        {
+          Island({
+            ssrFallback: <p class="sr-only">{aiChatBodyLabel}</p>,
+            children: <AiChatModal basePath={basePath} />,
+          }) as unknown as VNode
+        }
+      </>
+    ) : null;
+
+    // Gated on `settings.imageEnlarge`. The SSR fallback is the empty, closed
+    // `<dialog class="zd-enlarge-dialog …">` shell so the dist HTML carries one
+    // dialog from the start; hydration (when="idle") swaps in the real
+    // ImageEnlarge component.
+    const imageEnlarge = settings.imageEnlarge
+      ? (Island({
+          when: "idle",
+          ssrFallback: <ImageEnlargeSsrFallback />,
+          children: <ImageEnlarge />,
+        }) as unknown as VNode)
+      : null;
+
+    // Gated on `settings.mermaid`. Mirrors imageEnlarge: empty closed
+    // `<dialog class="zd-mermaid-dialog …">` SSR fallback; hydration injects the
+    // enlarge button into each rendered diagram container.
+    const mermaidEnlarge = settings.mermaid
+      ? (Island({
+          when: "idle",
+          ssrFallback: <MermaidEnlargeSsrFallback />,
+          children: <MermaidEnlarge />,
+        }) as unknown as VNode)
+      : null;
+
+    return (
+      <>
+        {aiAssistant}
+        {imageEnlarge}
+        {mermaidEnlarge}
+      </>
+    );
+  }
+
+  return BodyEndIslands;
+}

--- a/packages/zudo-doc/src/plugins/routes.ts
+++ b/packages/zudo-doc/src/plugins/routes.ts
@@ -73,6 +73,7 @@ interface RoutesPluginOptions {
   settings: RoutesSettings;
   translations: Record<string, Record<string, string>>;
   tagVocabulary: ReadonlyArray<Record<string, unknown>>;
+  colorSchemes: Record<string, unknown> | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -160,6 +161,7 @@ const plugin = definePlugin({
     const settings = options.settings ?? {};
     const translations = options.translations ?? {};
     const tagVocabulary = options.tagVocabulary ?? [];
+    const colorSchemes = options.colorSchemes ?? null;
 
     // (1) Route-context virtual module — SERIALIZABLE DATA ONLY (Decision 1).
     // `JSON.stringify` is the boundary that enforces "no functions / no
@@ -173,6 +175,7 @@ const plugin = definePlugin({
           settings,
           translations,
           tagVocabulary,
+          colorSchemes,
         })};\n`,
     );
 

--- a/packages/zudo-doc/src/preset.ts
+++ b/packages/zudo-doc/src/preset.ts
@@ -81,13 +81,15 @@ export interface PresetSettings {
   claudeResources?: PresetClaudeResourcesConfig | false;
   /** "owner/repo" — when set, enables `#123` / SHA autolinks in markdown. Omit to disable entirely. */
   githubAutolinksRepo?: string;
-  /** When `true`, the preset adds the package-owned route-injection plugin
-   *  (`@takazudo/zudo-doc/plugins/routes`). On by default since the fast-follow
-   *  (#2372): the showcase and create-zudo-doc both EMIT `packageOwnedRoutes: true`
-   *  into their generated `settings.ts`. `buildPlugins` reads this value truthily
-   *  and does NO central defaulting — a hand-written settings object that OMITS the
-   *  field is treated as off; set it explicitly to control injection.
-   *  See `docs/adr/route-injection-seam.md`. */
+  /**
+   * When `true` (the **default** when omitted — #2404), the preset adds the
+   * package-owned route-injection plugin (`@takazudo/zudo-doc/plugins/routes`).
+   * Set explicitly to `false` to opt out — only needed for projects shipping
+   * their own `pages/*.tsx` stubs for every doc route. When `false` AND doc
+   * content is configured (`docsDir` non-empty and/or locales/versions set),
+   * a single `console.warn` is emitted per build as a heads-up (the build
+   * succeeds). See `docs/adr/route-injection-seam.md`. (#2404)
+   */
   packageOwnedRoutes?: boolean;
   /** Gate for the `/docs/tags` + `/docs/tags/[tag]` injected routes. */
   docTags?: boolean;
@@ -399,18 +401,40 @@ function buildPlugins(
     Object.entries(settings.locales).map(([code, locale]) => [code, { dir: locale.dir }]),
   );
 
+  // Effective value: default-on (#2404 — fixes the silent empty build). An
+  // omitted field is treated as `true`; explicit `false` stays the opt-out.
+  const effectivePackageOwnedRoutes = settings.packageOwnedRoutes ?? true;
+
+  // Build-time diagnostic (#2404): when routes are explicitly turned off AND
+  // doc content is configured, emit a single actionable warning. Do NOT inspect
+  // the filesystem — this runs inside the config eval; the node-free guard
+  // (preset.test.ts) rejects any reachable `node:*` import.
+  if (!effectivePackageOwnedRoutes) {
+    const contentConfigured =
+      (typeof settings.docsDir === "string" && settings.docsDir.length > 0) ||
+      Object.keys(settings.locales).length > 0 ||
+      (Array.isArray(settings.versions) && settings.versions.length > 0);
+    if (contentConfigured) {
+      console.warn(
+        "zudo-doc: packageOwnedRoutes is off but doc content is configured — " +
+          "no doc routes will be injected; the build will produce only host pages/. " +
+          "Set packageOwnedRoutes: true in settings.",
+      );
+    }
+  }
+
   return [
-    // Package-owned route injection — dormant by default (Decision 4). The
-    // descriptor is a BARE SPECIFIER, never an imported plugin function: the
-    // preset's node-free eval-graph guard (preset.test.ts) bundles this module
-    // under --platform=neutral, and importing the plugin would drag its
+    // Package-owned route injection — default-on (#2404). The descriptor is a
+    // BARE SPECIFIER, never an imported plugin function: the preset's node-free
+    // eval-graph guard (preset.test.ts) bundles this module under
+    // --platform=neutral, and importing the plugin would drag its
     // `injectRoute`/`node:*` graph into the config eval. The plugin's `setup`
     // hook reads `options` to (a) emit the route-context virtual module
     // (serializable settings/translations/tagVocabulary only) and (b) derive
     // the route catalog from `settings.locales` / `settings.versions`. Listed
     // FIRST so an injected route is registered before the other plugins'
     // preBuild work runs (ordering is cosmetic — injection happens in `setup`).
-    ...(settings.packageOwnedRoutes
+    ...(effectivePackageOwnedRoutes
       ? [
           {
             name: "@takazudo/zudo-doc/plugins/routes",

--- a/packages/zudo-doc/src/preset.ts
+++ b/packages/zudo-doc/src/preset.ts
@@ -34,6 +34,7 @@
  */
 
 import { z } from "zod";
+import type { ColorScheme } from "./color-scheme-utils.js";
 
 // ---------------------------------------------------------------------------
 // Input contract — structurally typed so the preset is portable to every
@@ -159,6 +160,19 @@ export interface ZudoDocPresetArgs {
    * `settings.packageOwnedRoutes` is true. Optional — defaults to `[]`.
    */
   tagVocabulary?: readonly PresetTagVocabularyEntry[];
+  /**
+   * The host's color-scheme palette map (`src/config/color-schemes.ts`
+   * `colorSchemes`). Only consumed when `settings.packageOwnedRoutes` is true
+   * — rides into the route-context virtual module so the package-owned routes
+   * (incl. `/404`) can emit the correct `--zd-*` CSS custom properties.
+   *
+   * Serializable JSON (ColorScheme has no function-valued fields), so it
+   * round-trips through `JSON.stringify` losslessly.
+   *
+   * Optional — when absent, package-owned routes fall back to `DEFAULT_SCHEME`
+   * (a neutral grey ramp). See `routes/_chrome.tsx`.
+   */
+  colorSchemes?: Record<string, ColorScheme>;
 }
 
 // ---------------------------------------------------------------------------
@@ -233,6 +247,7 @@ export function zudoDocPreset({
   directiveVocabulary,
   translations,
   tagVocabulary,
+  colorSchemes,
 }: ZudoDocPresetArgs): ZudoDocPresetResult {
   // `z.toJSONSchema` is a runtime call but the result is a stable JSON
   // document. Compute it once and reuse the same object across every
@@ -241,7 +256,7 @@ export function zudoDocPreset({
 
   return {
     collections: buildCollections(settings, docsSchemaJson),
-    plugins: buildPlugins(settings, { translations, tagVocabulary }),
+    plugins: buildPlugins(settings, { translations, tagVocabulary, colorSchemes }),
     markdown: {
       features: buildMarkdownFeatures(settings, directiveVocabulary),
       ...(settings.cjkFriendly !== undefined ? { cjkFriendly: settings.cjkFriendly } : {}),
@@ -391,6 +406,7 @@ function buildPlugins(
   routeContext: {
     translations?: PresetTranslations;
     tagVocabulary?: readonly PresetTagVocabularyEntry[];
+    colorSchemes?: Record<string, ColorScheme>;
   },
 ): PresetPlugin[] {
   const localeArray = Object.entries(settings.locales).map(([code, locale]) => ({
@@ -404,6 +420,33 @@ function buildPlugins(
   // Effective value: default-on (#2404 — fixes the silent empty build). An
   // omitted field is treated as `true`; explicit `false` stays the opt-out.
   const effectivePackageOwnedRoutes = settings.packageOwnedRoutes ?? true;
+
+  // Build-time diagnostic (#2405): when packageOwnedRoutes is on but
+  // translations/colorSchemes were not passed, emit ONE actionable warning so
+  // consumers know their package-owned routes will render with fallback i18n /
+  // grey theme. Emitted only when content is configured (i.e. the routes
+  // actually render) and not the false-positive case of a bare config with no
+  // docs. Do NOT inspect the filesystem here.
+  if (effectivePackageOwnedRoutes) {
+    const contentConfiguredForWarn =
+      (typeof settings.docsDir === "string" && settings.docsDir.length > 0) ||
+      Object.keys(settings.locales).length > 0 ||
+      (Array.isArray(settings.versions) && settings.versions.length > 0);
+    const translationsMissing =
+      !routeContext.translations || Object.keys(routeContext.translations).length === 0;
+    const colorSchemesMissing = !routeContext.colorSchemes;
+    if (contentConfiguredForWarn && (translationsMissing || colorSchemesMissing)) {
+      const missing = [
+        ...(translationsMissing ? ["translations"] : []),
+        ...(colorSchemesMissing ? ["colorSchemes"] : []),
+      ].join(" and/or ");
+      console.warn(
+        `zudo-doc: packageOwnedRoutes is on but ${missing} were not passed to zudoDocPreset — ` +
+          "package-owned routes (incl. /404) will render with fallback i18n/theme. " +
+          "Pass them to inherit host bindings.",
+      );
+    }
+  }
 
   // Build-time diagnostic (#2404): when routes are explicitly turned off AND
   // doc content is configured, emit a single actionable warning. Do NOT inspect
@@ -445,6 +488,7 @@ function buildPlugins(
               settings: settings as unknown as Record<string, unknown>,
               translations: routeContext.translations ?? {},
               tagVocabulary: routeContext.tagVocabulary ?? [],
+              colorSchemes: routeContext.colorSchemes ?? null,
             },
           },
         ]

--- a/packages/zudo-doc/src/routes/404.tsx
+++ b/packages/zudo-doc/src/routes/404.tsx
@@ -10,7 +10,7 @@ import {
   HeadWithDefaults,
   HeaderWithDefaults,
   FooterWithDefaults,
-  BodyEndIslandsStub,
+  BodyEndIslands,
   composeMetaTitle,
 } from "./_chrome.js";
 
@@ -31,7 +31,7 @@ export default function NotFoundPage(): JSX.Element {
       sidebarOverride={<></>}
       headerOverride={<HeaderWithDefaults lang={locale} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
-      bodyEndComponents={<BodyEndIslandsStub basePath={settings.base ?? "/"} />}
+      bodyEndComponents={<BodyEndIslands basePath={settings.base ?? "/"} />}
       enableClientRouter={settings.dynamicPageTransition}
     >
       <div class="min-h-[60vh] flex flex-col items-center justify-center px-hsp-2xl py-vsp-xl">

--- a/packages/zudo-doc/src/routes/_chrome.tsx
+++ b/packages/zudo-doc/src/routes/_chrome.tsx
@@ -52,6 +52,7 @@ import {
   firstRoutedHref,
   collectTags,
   stableDocs,
+  colorSchemes,
 } from "./_context.js";
 import type { CategoryMeta, DocNavNode } from "./_docs-helpers.js";
 
@@ -162,14 +163,38 @@ function SearchWidgetBound(props: {
 
 export const composeMetaTitle = createComposeMetaTitle(settings.siteName);
 
+// Scheme-selection: resolve the active color scheme(s) from the host
+// `colorSchemes` map supplied via the virtual module. Falls back to
+// `DEFAULT_SCHEME` for any missing key or when `colorSchemes` is absent.
+// `generateCssCustomProperties` is called in single-scheme mode
+// (`settings.colorMode` is false); `generateLightDarkCssProperties` in
+// light/dark mode. Both delegate to DEFAULT_SCHEME when `colorSchemes` is null.
+function resolveHostScheme(key: string): ColorScheme {
+  if (!colorSchemes) return DEFAULT_SCHEME;
+  return colorSchemes[key] ?? DEFAULT_SCHEME;
+}
+
 export const HeadWithDefaults = createHeadWithDefaults({
   settings,
   composeMetaTitle,
   withBase,
   absoluteUrl,
-  generateCssCustomProperties: () => generateCssCustomProperties(DEFAULT_SCHEME),
-  generateLightDarkCssProperties: () =>
-    generateLightDarkCssProperties(DEFAULT_SCHEME, DEFAULT_SCHEME),
+  // Called only in single-scheme mode (colorMode false): resolve via settings.colorScheme.
+  generateCssCustomProperties: () =>
+    generateCssCustomProperties(resolveHostScheme(settings.colorScheme)),
+  // Called only in light/dark mode (colorMode truthy): resolve the pair.
+  generateLightDarkCssProperties: () => {
+    const cm = settings.colorMode;
+    if (cm) {
+      return generateLightDarkCssProperties(
+        resolveHostScheme(cm.lightScheme),
+        resolveHostScheme(cm.darkScheme),
+      );
+    }
+    // Should not be reached (head-with-defaults only calls this when colorMode
+    // is truthy), but guard the contract by falling back to DEFAULT_SCHEME.
+    return generateLightDarkCssProperties(DEFAULT_SCHEME, DEFAULT_SCHEME);
+  },
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/zudo-doc/src/routes/_chrome.tsx
+++ b/packages/zudo-doc/src/routes/_chrome.tsx
@@ -68,6 +68,7 @@ import { createFooterWithDefaults } from "../footer-with-defaults/index.js";
 import { createSidebarWithDefaults } from "../sidebar-with-defaults/index.js";
 import { createSidebarPrepaint } from "../sidebar-prepaint/index.js";
 import { createDocBodyEnd } from "../doc-body-end/index.js";
+import { createBodyEndIslands } from "../doc-body-end-islands/index.js";
 import { createDocPager } from "../doc-pager/index.js";
 import { createDocPageShell } from "../doc-page-shell/index.js";
 import { createDocContentHeader } from "../doc-content-header/index.js";
@@ -129,12 +130,12 @@ const docHistoryMeta: Record<string, never> = {};
  *  tree. The project `sidebars` config is host-bound (A2). */
 const sidebarsConfig: Record<string, never> = {};
 
-/** Package no-op body-end islands. The host's `BodyEndIslands` wires project
- *  island bootstraps (client-router / design-token-panel) that cannot live in
- *  the package; the package default renders nothing. */
-function BodyEndIslandsStub(_props: { basePath: string }): JSX.Element {
-  return <></>;
-}
+/** Package-default body-end islands — the package-island subset of the host's
+ *  `BodyEndIslands` (AiChatModal / ImageEnlarge / MermaidEnlarge), reconstructed
+ *  from the serializable virtual-module `settings` flags (#2406 / #2401(c)).
+ *  The host-owned bootstraps (client-router / design-token-panel) cannot live
+ *  in the package, so they are NOT included here — A2/S4 re-homes those. */
+const BodyEndIslands = createBodyEndIslands({ settings });
 
 /** Package no-op DocHistory island stub — renders an empty fragment (the
  *  `DocHistoryComponent` contract requires a VNode, not null). */
@@ -297,7 +298,7 @@ export const SidebarWithDefaults = createSidebarWithDefaults({
 });
 
 const SidebarPrepaint = createSidebarPrepaint({ sidebarToggle: settings.sidebarToggle });
-const DocBodyEnd = createDocBodyEnd({ settings, BodyEndIslands: BodyEndIslandsStub });
+const DocBodyEnd = createDocBodyEnd({ settings, BodyEndIslands });
 const DocPager = createDocPager({ t });
 
 // ---------------------------------------------------------------------------
@@ -520,7 +521,7 @@ export const VersionsPageView = createVersionsPageView({
     HeadWithDefaults,
     HeaderWithDefaults,
     FooterWithDefaults,
-    BodyEndIslands: BodyEndIslandsStub,
+    BodyEndIslands,
   },
 });
 
@@ -538,15 +539,16 @@ const tagPages = createTagPages({
     HeadWithDefaults,
     HeaderWithDefaults,
     FooterWithDefaults,
-    BodyEndIslands: BodyEndIslandsStub,
+    BodyEndIslands,
     DocHistoryArea: DocHistoryArea as never,
   },
 });
 
 export const { collectTagMapForLocale, TagDetailPageView, TagsIndexPageView } = tagPages;
 
-// Re-export the locale-aware site-tree wrapper for the index entrypoints.
-export { SiteTreeNavWrapper, BodyEndIslandsStub };
+// Re-export the locale-aware site-tree wrapper + the package-default body-end
+// islands for the index entrypoints.
+export { SiteTreeNavWrapper, BodyEndIslands };
 
 // Bring the doc-route-entries builder + types into the chrome surface so the
 // doc entrypoints import a single module.

--- a/packages/zudo-doc/src/routes/_context.ts
+++ b/packages/zudo-doc/src/routes/_context.ts
@@ -34,6 +34,7 @@
 import { routeContext } from "virtual:zudo-doc-route-context";
 
 import type { Settings } from "../settings.js";
+import type { ColorScheme } from "../color-scheme-utils.js";
 import type { FactoryI18n } from "../factory-context/index.js";
 import { makeUrlHelpers, type UrlHelpers } from "../url-helpers/index.js";
 import {
@@ -84,6 +85,7 @@ export interface RouteContextPayload {
   settings: Settings;
   translations: Record<string, Record<string, string>>;
   tagVocabulary: readonly TagVocabularyEntry[];
+  colorSchemes: Record<string, ColorScheme> | null;
 }
 
 /** The serializable route-context (from the virtual module). */
@@ -91,6 +93,9 @@ export const ctx = routeContext as unknown as RouteContextPayload;
 export const settings: Settings = ctx.settings;
 const translations = ctx.translations;
 const tagVocabulary = ctx.tagVocabulary;
+/** Host color-scheme palette map. `null` when not supplied — `_chrome.tsx`
+ *  falls back to `DEFAULT_SCHEME` in that case. */
+export const colorSchemes: Record<string, ColorScheme> | null = ctx.colorSchemes;
 
 // ---------------------------------------------------------------------------
 // i18n — reconstruct a FactoryI18n from settings + translations (Decision 1).

--- a/packages/zudo-doc/src/routes/_virtual.d.ts
+++ b/packages/zudo-doc/src/routes/_virtual.d.ts
@@ -4,12 +4,16 @@
 // — so this declaration gives the package route entrypoints a typed import.
 //
 // The payload is SERIALIZABLE DATA ONLY (ADR Decision 1): `settings`,
-// `translations`, `tagVocabulary`. `_context.ts` narrows it to the concrete
-// `RouteContextPayload` at the seam.
+// `translations`, `tagVocabulary`, `colorSchemes`. `_context.ts` narrows it
+// to the concrete `RouteContextPayload` at the seam.
 declare module "virtual:zudo-doc-route-context" {
   export const routeContext: {
     settings: unknown;
     translations: Record<string, Record<string, string>>;
     tagVocabulary: ReadonlyArray<Record<string, unknown>>;
+    /** Host color-scheme palette map. `null` when the caller did not pass
+     *  `colorSchemes` to `zudoDocPreset` — `_chrome.tsx` falls back to
+     *  `DEFAULT_SCHEME` in that case. */
+    colorSchemes: Record<string, unknown> | null;
   };
 }

--- a/packages/zudo-doc/src/routes/index.tsx
+++ b/packages/zudo-doc/src/routes/index.tsx
@@ -28,7 +28,7 @@ import {
   HeadWithDefaults,
   HeaderWithDefaults,
   FooterWithDefaults,
-  BodyEndIslandsStub,
+  BodyEndIslands,
   composeMetaTitle,
 } from "./_chrome.js";
 
@@ -67,7 +67,7 @@ export default function IndexPage(): JSX.Element {
       sidebarOverride={<></>}
       headerOverride={<HeaderWithDefaults lang={locale} currentPath={withBase("/")} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
-      bodyEndComponents={<BodyEndIslandsStub basePath={settings.base ?? "/"} />}
+      bodyEndComponents={<BodyEndIslands basePath={settings.base ?? "/"} />}
       enableClientRouter={settings.dynamicPageTransition}
     >
       <div class="flex justify-center mb-vsp-xl">

--- a/packages/zudo-doc/src/routes/locale-index.tsx
+++ b/packages/zudo-doc/src/routes/locale-index.tsx
@@ -28,7 +28,7 @@ import {
   HeadWithDefaults,
   HeaderWithDefaults,
   FooterWithDefaults,
-  BodyEndIslandsStub,
+  BodyEndIslands,
   composeMetaTitle,
 } from "./_chrome.js";
 
@@ -83,7 +83,7 @@ export default function LocaleIndexPage({ params }: PageArgs): JSX.Element {
       sidebarOverride={<></>}
       headerOverride={<HeaderWithDefaults lang={locale} currentPath={withBase(`/${locale}/`)} />}
       footerOverride={<FooterWithDefaults lang={locale} />}
-      bodyEndComponents={<BodyEndIslandsStub basePath={settings.base ?? "/"} />}
+      bodyEndComponents={<BodyEndIslands basePath={settings.base ?? "/"} />}
       enableClientRouter={settings.dynamicPageTransition}
     >
       <div class="flex justify-center mb-vsp-xl">

--- a/packages/zudo-doc/src/settings.ts
+++ b/packages/zudo-doc/src/settings.ts
@@ -287,17 +287,19 @@ export interface Settings {
   headerRightItems: HeaderRightItem[];
   /**
    * Build-time package-owned route injection (epic Package-First Finale #2356,
-   * ADR `docs/adr/route-injection-seam.md`). When `true`, the preset adds the
-   * `@takazudo/zudo-doc/plugins/routes` plugin, which injects the doc routes
-   * from the package instead of requiring project-shipped `pages/*.tsx` stubs.
+   * ADR `docs/adr/route-injection-seam.md`). When `true` (the **default** when
+   * omitted — #2404), the preset adds the `@takazudo/zudo-doc/plugins/routes`
+   * plugin, which injects the doc routes from the package instead of requiring
+   * project-shipped `pages/*.tsx` stubs.
    *
-   * On by default since the fast-follow (#2372 — upstream zfb dev-render support
-   * landed): the showcase and create-zudo-doc emit `packageOwnedRoutes: true` into
-   * their generated `settings.ts`. The preset reads this value truthily with no
-   * central defaulting, so a hand-written settings object that omits the field is
-   * treated as off. Any injected route whose URL shape collides with a kept
-   * `pages/` stub is silently dropped (user `pages/` wins), so existing stubs
-   * are a harmless no-op.
+   * Set explicitly to `false` only if your project ships its own `pages/*.tsx`
+   * stubs for every doc route. Any injected route whose URL shape collides with
+   * a kept `pages/` stub is silently dropped (user `pages/` wins), so existing
+   * stubs are a harmless no-op if you later re-enable this.
+   *
+   * When `false` AND doc content is configured (`docsDir` non-empty and/or
+   * locales/versions set), a single `console.warn` is emitted per build to
+   * flag a potentially-empty build (#2404). No throw — the build succeeds.
    */
   packageOwnedRoutes?: boolean;
 }

--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -55,7 +55,7 @@ export function detectLocaleFromPath(path: string): Locale {
 }
 
 /** UI string translations */
-const translations: Record<string, Record<string, string>> = {
+export const translations: Record<string, Record<string, string>> = {
   en: {
     "search.placeholder": "Type to search...",
     "search.shortcutHint": "to open search from anywhere",

--- a/zfb.config.ts
+++ b/zfb.config.ts
@@ -2,6 +2,8 @@ import { defineConfig } from "zfb/config";
 import { zudoDocPreset } from "@takazudo/zudo-doc/preset";
 import { settings } from "./src/config/settings";
 import { buildDocsSchema } from "./src/config/docs-schema";
+import { translations } from "./src/config/i18n";
+import { colorSchemes } from "./src/config/color-schemes";
 
 // The canonical seven directives for this showcase. Keys are directive names;
 // values are the JSX component names registered in pages/_mdx-components.ts.
@@ -37,5 +39,5 @@ export default defineConfig({
   adapter: "@takazudo/zfb-adapter-cloudflare",
 
   // ── Preset-owned fields (collections, plugins, markdown, codeHighlight, …) ─
-  ...zudoDocPreset({ settings, buildDocsSchema, directiveVocabulary }),
+  ...zudoDocPreset({ settings, buildDocsSchema, directiveVocabulary, translations, colorSchemes }),
 });


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2403

---

## Summary

Implements epic #2403 — fixes two facets of the package-owned-routes injection seam (closes #2401 and #2402):

- **#2402** — `zudoDocPreset` no longer silently injects zero routes when `settings.packageOwnedRoutes` is omitted. The gate now defaults on (`?? true`); an explicit `false` with configured doc content emits a single build-time `console.warn` (settings-based, no filesystem — preserves the node-free eval-graph guard).
- **#2401** — package-owned routes (docs catch-all, `/404`, sitemap, robots, tags, versions) now inherit the host's bindings instead of falling back to package defaults:
  - **(a) i18n** — host `translations` are forwarded into `zudoDocPreset` (host `zfb.config.ts` + the `create-zudo-doc` generator), so package routes resolve UI strings instead of rendering raw keys.
  - **(b) theme** — a new serializable `colorSchemes` arg rides the `virtual:zudo-doc-route-context` module; `_chrome.tsx` builds `HeadWithDefaults` from the host palette (with `DEFAULT_SCHEME` fallback) instead of the hardcoded `#000000` grey ramp.
  - **(c) islands** — a package-default `BodyEndIslands` (package islands only: AiChatModal / ImageEnlarge / MermaidEnlarge), reconstructed from the serializable `settings` flags, replaces the no-op `BodyEndIslandsStub` across all package route entrypoints — so island markers reach the DOM on `/404` and every package route.

## Sub-issues (all merged into this base)
- #2404 (S1) gate default-on + diagnostic
- #2405 (S2) theme: colorSchemes through the seam
- #2406 (S3) islands: package-default BodyEndIslands
- #2407 (S4) host showcase wiring
- #2408 (S5) generator forwarding + drift sync
- #2409 (S6) confirm

## Verification
- End-to-end on built `dist/404.html` (package-owned): resolved UI strings (no raw keys), `--zd-bg: light-dark(#e2ddda,#181818)` (host palette), `data-zfb-island` markers for the three islands.
- `pnpm check` clean; `pnpm test` green (1034 root unit + 806 zudo-doc + 370 create-zudo-doc + 174 other package tests); full showcase build = 326 pages; template-drift clean.
- Codex deep-review: no actionable regressions.

## Follow-up (not in this PR)
Merging does not ship to consumer sites — they consume published `@takazudo/zudo-doc`. A follow-up `/l-make-release` (+ create-zudo-doc pin bump) publishes the fix.