### PR TITLE
fix(content): inner flow spacing + roomier bottom padding for admonitions

### DIFF
--- a/packages/zudo-doc/src/content.css
+++ b/packages/zudo-doc/src/content.css
@@ -271,19 +271,22 @@
  * rules must live here explicitly. Closes zudolab/zudo-doc#1357 / #1444 / #1456.
  *
  * Spacing: the box carries NO margin — the separating gap to the next block is
- * supplied by that block's flow-space `margin-top` (the owl rule above). The
- * snug bottom padding keeps the body tight inside the box without inflating
- * that gap. (A missing bottom margin on the box is intentional in the flow
- * model — do NOT add one; see zudolab/zudo-doc#2188 for why the per-element
- * margin model that needed it was retired.)
+ * supplied by that block's flow-space `margin-top` (the page owl above). Blocks
+ * INSIDE `.admonition-body` get their own shorter flow gap (vsp-sm) via the
+ * nested owl below, since the page owl only reaches direct children of
+ * `.zd-content`; the box's vsp-sm bottom padding then gives the last block room
+ * so it isn't cramped against the edge. (A missing bottom margin on the box is
+ * intentional in the flow model — do NOT add one; see zudolab/zudo-doc#2188 for
+ * why the per-element margin model that needed it was retired.)
  * ======================================== */
 
 [data-admonition] {
   border-left: 4px solid var(--color-muted);
-  /* Asymmetric padding mirrors the Astro reference (`pt-vsp-md pb-vsp-2xs`) —
-   * generous space at the top, snug at the bottom — so the title row sits
-   * under generous breathing room without inflating the bottom gap. */
-  padding: var(--spacing-vsp-md) var(--spacing-hsp-lg) var(--spacing-vsp-2xs);
+  /* Generous top padding gives the title row breathing room; the bottom uses
+   * the same vsp-sm as the body inner flow (below) so the last block isn't
+   * cramped against the box edge. (Was pb-vsp-2xs — too tight once the body
+   * has multiple flowed blocks; zudolab/zudo-doc#2417.) */
+  padding: var(--spacing-vsp-md) var(--spacing-hsp-lg) var(--spacing-vsp-sm);
   background-color: color-mix(in srgb, var(--color-muted) 12%, var(--color-bg));
   border-radius: 0 var(--radius-DEFAULT) var(--radius-DEFAULT) 0;
 }
@@ -299,6 +302,19 @@
  * Matches the Astro reference (`<span class="mr-hsp-2xs">📝</span>` etc.). */
 .admonition-title::before {
   margin-right: var(--spacing-hsp-2xs);
+}
+
+/* Flow spacing between blocks INSIDE an admonition body. The page-level
+ * `.zd-content > * + *` owl only reaches direct children of `.zd-content`, so
+ * nested blocks here had no inter-element gap (zudolab/zudo-doc#2417). The
+ * admonition is a narrower scope than the page flow, so a shorter gap
+ * (vsp-sm < the page's vsp-md) reads as natural. Layered in `zd-flow` for the
+ * same reason as the page owl: it must beat preflight's `* { margin: 0 }` but
+ * lose to an unlayered `mt-*` utility on a nested block. */
+@layer zd-flow {
+  .admonition-body > :where(* + *) {
+    margin-top: var(--spacing-vsp-sm);
+  }
 }
 
 .admonition-body > :first-child {


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2417
    - epic: https://github.com/zudolab/zudo-doc/issues/2416

---

## Summary

Blocks **inside** an admonition body (e.g. a paragraph followed by a code block) had no vertical spacing, and the admonition box bottom padding was too tight. Root cause: the page-level vertical-rhythm owl `.zd-content > :where(* + *)` only matches **direct children of `.zd-content`**, so blocks nested in `.admonition-body` got zero inter-element gap.

Fix follows the css-wisdom flow-utility pattern (single-direction `margin-top`, flex/grid-safe):

- Add an **admonition-scoped** flow owl `.admonition-body > :where(* + *)` using the shorter `--spacing-vsp-sm` (20px). A narrower scope than the page flow reads naturally with a tighter rhythm than the page's `--spacing-vsp-md` (24px). Layered in `zd-flow` for the same cascade reason as the page owl (beat preflight's `* { margin: 0 }`, lose to unlayered `mt-*` utilities).
- Bump the admonition box bottom padding from `--spacing-vsp-2xs` (7px) to `--spacing-vsp-sm` (20px) so the last block isn't cramped against the edge.

The page-level `.zd-content > * + *` flow is intentionally left unchanged (it keeps its larger `vsp-md` gap for basic markdown flow).

## Changes

- `packages/zudo-doc/src/content.css`
  - `[data-admonition]` bottom padding `vsp-2xs` → `vsp-sm` (+ comment update)
  - new `@layer zd-flow { .admonition-body > :where(* + *) { margin-top: var(--spacing-vsp-sm) } }`

`content.css` is the single source of truth for `.zd-content` typography (`@import`ed by both the showcase `global.css` and the `create-zudo-doc` template) — no per-project copy to sync. The package build copies `src/content.css` → `dist/content.css` via `scripts/copy-content-css.mjs`.

## Test Plan

- On a doc page with a multi-block admonition (e.g. the introduction page's "Want to explore the full project?" Note), confirm consecutive inner blocks have `margin-top: 1.25rem` (`--spacing-vsp-sm`) and the box bottom padding is `1.25rem`.
- Confirm the page-level content flow gap is unchanged.
- CI: `pnpm check` + build (regenerates `dist/content.css`).

> Note: visual rendering not verified in this web environment — flagged for a Mac check (see linked `mac` follow-up).

---
_Generated by [Claude Code](https://claude.ai/code/session_012tU3VSvxqvAKNaKZ77T7ut)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2418"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785255065&installation_id=130359969&pr_number=2418&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2418&signature=9a67689b7500ca817b2d8747913e18b1427cc5ec8fd7b8fc0873d8de69ed71a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->