### PR TITLE
docs(skill): fix l-generator-cli-tester expectations post-collapse (closes #2433)

### DIFF
--- a/.claude/skills/l-generator-cli-tester/SKILL.md
+++ b/.claude/skills/l-generator-cli-tester/SKILL.md
@@ -195,7 +195,7 @@ Check that expected files exist or don't exist in `__inbox/generator-test-<patte
 
 Use these tables to verify. Check each file with `test -e <path>`.
 
-> **Note on `theme-toggle.tsx`**: this component always ships on disk as part of the base template — whether it renders at runtime is gated by the `colorMode` setting. The expectation tables below therefore only assert PRESENT for the `light-dark` and `all-features` patterns and do not assert ABSENT elsewhere.
+> **Note on `theme-toggle.tsx`**: as of the Collapse Wiring Shells change (zudolab/zudo-doc#2420, v2.0.0) the theme toggle is provided by `@takazudo/zudo-doc` — generated projects no longer ship `src/components/theme-toggle.tsx` on disk (it collapsed into the package). The expectation tables below assert ABSENT for it.
 >
 > **Note on file extensions**: all components are `.tsx` — there are no `.astro` files in the generated project. The generator uses zfb/Preact, not Astro.
 
@@ -266,7 +266,7 @@ Use these tables to verify. Check each file with `test -e <path>`.
 
 | File | Expected |
 |------|----------|
-| `src/components/theme-toggle.tsx` | PRESENT |
+| `src/components/theme-toggle.tsx` | ABSENT |
 | `src/integrations/claude-resources/` | ABSENT |
 | `src/config/design-token-panel-config.ts` | ABSENT |
 
@@ -287,17 +287,17 @@ Use these tables to verify. Check each file with `test -e <path>`.
 | `src/content/docs/changelog/index.mdx` | PRESENT |
 | `src/integrations/claude-resources/generate.ts` | PRESENT |
 | `src/integrations/claude-resources/escape-for-mdx.ts` | PRESENT |
-| `src/components/theme-toggle.tsx` | PRESENT |
+| `src/components/theme-toggle.tsx` | ABSENT |
 | `src/config/design-token-panel-config.ts` | PRESENT |
 | `src/lib/design-token-panel-bootstrap.ts` | PRESENT |
 | `src/components/doc-history.tsx` | PRESENT |
 | `src/components/desktop-sidebar-toggle.tsx` | PRESENT |
-| `src/scripts/sidebar-resizer.ts` | PRESENT |
+| `src/scripts/sidebar-resizer.ts` | ABSENT |
 | `src/components/image-enlarge.tsx` | PRESENT |
 | `src/utils/github.ts` | PRESENT |
 | `scripts/tags-audit.ts` | PRESENT |
 | `scripts/tags-suggest.ts` | PRESENT |
-| `pages/docs/tags/index.tsx` | PRESENT |
+| `pages/docs/tags/index.tsx` | ABSENT |
 
 ## Step 7: Verify Settings
 


### PR DESCRIPTION
Closes #2433.

After the Collapse Wiring Shells change (#2420, v2.0.0), generated projects no longer ship `src/components/theme-toggle.tsx`, `src/scripts/sidebar-resizer.ts`, or `pages/docs/tags/index.tsx` (collapsed into `@takazudo/zudo-doc` / package-owned routes). The `l-generator-cli-tester` `all-features` (and `light-dark` theme-toggle) expectation tables asserted PRESENT for these — flipped to ABSENT, and updated the theme-toggle note. Verified absent by the #2430 GENTEST HARD GATE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2434"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785286566&installation_id=130359969&pr_number=2434&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2434&signature=e9401dd6b08fd25294179b634c16faad78d0883f93ba2c72e9fbae59bfe31f44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->