### PR TITLE
Head Extras 2.0.1: settings.head hook + zfb next.71 + lockstep 2.0.1 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,9 +87,9 @@
   },
   "dependencies": {
     "@takazudo/zdtp": "0.3.3",
-    "@takazudo/zfb": "0.1.0-next.70",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.70",
-    "@takazudo/zfb-runtime": "0.1.0-next.70",
+    "@takazudo/zfb": "0.1.0-next.71",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.71",
+    "@takazudo/zfb-runtime": "0.1.0-next.71",
     "@takazudo/zudo-doc": "workspace:*",
     "diff": "^8.0.3",
     "gray-matter": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zudo-doc",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/create-zudo-doc/package.json
+++ b/packages/create-zudo-doc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-zudo-doc",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Create a new zudo-doc documentation site",
   "license": "MIT",
   "author": "Takeshi Takatsudo",

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -3617,9 +3617,11 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
    * Bumped to 0.1.0-next.70: re-aligned with the root package.json pins after
    * the scaffold pin lagged at next.69 (broke check-pin-parity). No
    * consumer-facing change.
+   * Bumped to 0.1.0-next.71: routine toolchain bump carrying the zfb
+   * external-@import hoisting work. No consumer-facing change.
    * Generated package.json must pin all three.
    */
-  it("pins @takazudo/zfb at 0.1.0-next.70", async () => {
+  it("pins @takazudo/zfb at 0.1.0-next.71", async () => {
     const choices: UserChoices = {
       projectName: "test-pin-bump",
       defaultLang: "en",
@@ -3630,10 +3632,10 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
     };
     await scaffold(choices);
     const pkg = await fs.readJson(projectPath("test-pin-bump", "package.json"));
-    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.70");
-    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.70");
+    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.71");
+    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.71");
     expect(pkg.dependencies["@takazudo/zfb-adapter-cloudflare"]).toBe(
-      "0.1.0-next.70",
+      "0.1.0-next.71",
     );
   });
 });

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -21,7 +21,7 @@ export { getSecondaryLang };
  *
  * Bumped in lockstep by scripts/release-create-zudo-doc.sh.
  */
-export const ZUDO_DOC_PIN = "^2.0.0";
+export const ZUDO_DOC_PIN = "^2.0.1";
 
 /**
  * Files in `templates/base/**` that must never be copied into a generated
@@ -693,7 +693,7 @@ function generatePackageJson(choices: UserChoices) {
     // @takazudo/zudo-doc/integrations/doc-history which in turn imports
     // @takazudo/zudo-doc-history-server/git-history. Without this dep the
     // plugin host fails at init with ERR_MODULE_NOT_FOUND — W8A (#1739).
-    deps["@takazudo/zudo-doc-history-server"] = "^2.0.0";
+    deps["@takazudo/zudo-doc-history-server"] = "^2.0.1";
     // tsx is no longer needed here: the relocated package plugin imports the
     // runner directly (no `tsx -e` spawn) since the package ships compiled
     // dist/ — package-first migration #2321 (#2337).

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -597,15 +597,16 @@ function generatePackageJson(choices: UserChoices) {
     // lockstep with the root package.json pins. No consumer-facing / CLI change.
     // next.69: routine toolchain bump from next.68, adopted in
     // lockstep with the root package.json pins. No consumer-facing / CLI change.
-    // next.70 (current pin): routine toolchain bump from next.69, re-aligned
-    // with the root package.json pins (root was bumped in b5489acf; this
-    // scaffold pin lagged at next.69 and broke check-pin-parity). No
-    // consumer-facing / CLI change.
-    "@takazudo/zfb": "0.1.0-next.70",
-    "@takazudo/zfb-runtime": "0.1.0-next.70",
+    // next.70: routine toolchain bump from next.69, re-aligned with the root
+    // package.json pins (root was bumped in b5489acf; this scaffold pin lagged
+    // at next.69 and broke check-pin-parity). No consumer-facing / CLI change.
+    // next.71 (current pin): routine toolchain bump from next.70, carrying the
+    // zfb external-@import hoisting work. No consumer-facing / CLI change.
+    "@takazudo/zfb": "0.1.0-next.71",
+    "@takazudo/zfb-runtime": "0.1.0-next.71",
     // zfb-adapter-cloudflare — required for any route with `prerender = false`.
     // Pinned in lockstep with @takazudo/zfb.
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.70",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.71",
     // @takazudo/zudo-doc — published from this monorepo via
     // .github/workflows/publish-zudo-doc.yml. The pin here is bumped in
     // lockstep by scripts/release-create-zudo-doc.sh whenever zudo-doc's

--- a/packages/create-zudo-doc/templates/base/src/config/settings-types.ts
+++ b/packages/create-zudo-doc/templates/base/src/config/settings-types.ts
@@ -30,6 +30,7 @@ export type {
   TagPlacement,
   VersionConfig,
   MetaTagsConfig,
+  SiteHeadConfig,
   Settings,
 } from "@takazudo/zudo-doc/settings";
 

--- a/packages/doc-history-server/package.json
+++ b/packages/doc-history-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@takazudo/zudo-doc-history-server",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "description": "Standalone doc git-history service for zudo-doc — HTTP server + CLI batch generator. Decouples expensive `git log --follow` calls from the main build pipeline.",
   "license": "MIT",

--- a/packages/zudo-doc/API.md
+++ b/packages/zudo-doc/API.md
@@ -234,6 +234,7 @@ These fields are the stable contract. The snapshot guard locks this set.
 | `githubAutolinksRepo?` | `string` | `"owner/repo"` for `#123` / SHA autolinks |
 | `siteUrl` | `string` | Canonical site URL (for sitemap, OG) |
 | `metaTags` | `MetaTagsConfig` | `<meta>` tag configuration |
+| `head?` | `SiteHeadConfig` | Site-wide `<head>` extras injected into every page. Supports `preconnect`, `preload`, `stylesheets`, `alternateLinks`, and `meta` descriptors. Stylesheet entries accept `async: true` for non-render-blocking loading via the `media="print" + onload` pattern with a `<noscript>` fallback. Absent (the default) emits nothing — byte-identical to the pre-2.0.1 baseline. |
 | `sitemap` | `boolean` | Enable sitemap generation |
 | `docMetainfo` | `boolean` | Enable doc metadata area (Created/Updated/Author) |
 | `docTags` | `boolean` | Enable doc tags display |

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@takazudo/zudo-doc",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "description": "zudo-doc framework primitives layer that sits on top of zfb's engine — sidebar, theme, TOC, breadcrumb, layouts, head injection, View Transitions, SSR-skip wrappers (per ADR-003).",
   "license": "MIT",

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -531,8 +531,8 @@
   ],
   "peerDependencies": {
     "preact": "^10.29.1",
-    "@takazudo/zfb": "^0.1.0-next.70",
-    "@takazudo/zfb-runtime": "^0.1.0-next.70",
+    "@takazudo/zfb": "^0.1.0-next.71",
+    "@takazudo/zfb-runtime": "^0.1.0-next.71",
     "@takazudo/zudo-doc-history-server": "^1.2.0",
     "@takazudo/zdtp": "^0.3.3",
     "shiki": "^4.0.2",
@@ -575,7 +575,7 @@
     "typescript": "^5.0.0",
     "vitest": "^4.1.0",
     "zod": "^4.3.6",
-    "@takazudo/zfb": "0.1.0-next.70",
-    "@takazudo/zfb-runtime": "0.1.0-next.70"
+    "@takazudo/zfb": "0.1.0-next.71",
+    "@takazudo/zfb-runtime": "0.1.0-next.71"
   }
 }

--- a/packages/zudo-doc/src/__tests__/public-api-snapshot.test.ts
+++ b/packages/zudo-doc/src/__tests__/public-api-snapshot.test.ts
@@ -232,6 +232,7 @@ describe("Settings public field set snapshot", () => {
         "githubAutolinksRepo",
         "siteUrl",
         "metaTags",
+        "head",
         "sitemap",
         "docMetainfo",
         "docTags",

--- a/packages/zudo-doc/src/head-with-defaults/__tests__/head-with-defaults.test.tsx
+++ b/packages/zudo-doc/src/head-with-defaults/__tests__/head-with-defaults.test.tsx
@@ -172,6 +172,36 @@ describe("HeadWithDefaults — SiteHeadConfig head extras", () => {
     );
   });
 
+  it("stylesheet (async:true) with media: onload swaps to the configured media and <noscript> carries it", () => {
+    // Regression (review #2435): an async stylesheet that also sets `media`
+    // must swap to THAT media on load (not unconditionally "all"), and the
+    // <noscript> fallback must carry the configured media too.
+    const ctx = makeFakeChromeContext({
+      settings: {
+        head: {
+          stylesheets: [
+            {
+              href: "https://cdn.example.com/print.css",
+              media: "print",
+              async: true,
+            },
+          ],
+        },
+      },
+    });
+    const HeadWithDefaults = createHeadWithDefaults(ctx);
+    const out = render(<HeadWithDefaults title="Test" />);
+    // Initial media stays "print" (the non-render-blocking trick); onload swaps
+    // to the configured media ("print"), NOT "all".
+    expect(out).toContain(
+      '<link rel="stylesheet" href="https://cdn.example.com/print.css" media="print" onload="this.media=\'print\'"/>',
+    );
+    // The <noscript> fallback must include the configured media.
+    expect(out).toContain(
+      '<noscript><link rel="stylesheet" href="https://cdn.example.com/print.css" media="print"></noscript>',
+    );
+  });
+
   it("alternateLinks: emits <link rel={rel} href> with optional type and title", () => {
     const ctx = makeFakeChromeContext({
       settings: {

--- a/packages/zudo-doc/src/head-with-defaults/__tests__/head-with-defaults.test.tsx
+++ b/packages/zudo-doc/src/head-with-defaults/__tests__/head-with-defaults.test.tsx
@@ -1,0 +1,270 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+// head-with-defaults unit tests — SiteHeadConfig extras emission.
+//
+// Mirrors the exact-string assertion style of src/head/__tests__/doc-head.test.tsx.
+// Each test builds a ChromeContext via makeFakeChromeContext, constructs the
+// HeadWithDefaults component, renders it with preact-render-to-string, and
+// asserts the emitted HTML string.
+//
+// Key coverage:
+//   - Each descriptor type (preconnect, preload, stylesheet, alternateLinks, meta)
+//   - async:true stylesheet → literal `onload="this.media='all'"` + media="print" + <noscript>
+//   - Absent settings.head → head-extras fragment not emitted (byte-parity baseline)
+
+import { describe, it, expect } from "vitest";
+import { render } from "preact-render-to-string";
+import { createHeadWithDefaults } from "../index.js";
+import { makeFakeChromeContext } from "../../__tests__/fixtures/fake-chrome-context.js";
+
+describe("HeadWithDefaults — SiteHeadConfig head extras", () => {
+  it("baseline: emits nothing extra when settings.head is absent", () => {
+    const ctx = makeFakeChromeContext({});
+    const HeadWithDefaults = createHeadWithDefaults(ctx);
+    const out = render(<HeadWithDefaults title="Test" />);
+    // Head extras specific to SiteHeadConfig should not appear.
+    expect(out).not.toContain('rel="preconnect"');
+    expect(out).not.toContain('rel="preload"');
+    expect(out).not.toContain('rel="stylesheet"');
+    expect(out).not.toContain("<noscript>");
+  });
+
+  it("preconnect: emits <link rel='preconnect'> with crossorigin", () => {
+    const ctx = makeFakeChromeContext({
+      settings: {
+        head: {
+          preconnect: [
+            { href: "https://fonts.googleapis.com", crossorigin: "anonymous" },
+          ],
+        },
+      },
+    });
+    const HeadWithDefaults = createHeadWithDefaults(ctx);
+    const out = render(<HeadWithDefaults title="Test" />);
+    expect(out).toContain(
+      '<link rel="preconnect" href="https://fonts.googleapis.com" crossorigin="anonymous"/>',
+    );
+  });
+
+  it("preconnect: omits crossorigin when not supplied", () => {
+    const ctx = makeFakeChromeContext({
+      settings: {
+        head: {
+          preconnect: [{ href: "https://cdn.example.com" }],
+        },
+      },
+    });
+    const HeadWithDefaults = createHeadWithDefaults(ctx);
+    const out = render(<HeadWithDefaults title="Test" />);
+    expect(out).toContain('<link rel="preconnect" href="https://cdn.example.com"/>');
+    expect(out).not.toContain("crossorigin");
+  });
+
+  it("preload: emits <link rel='preload'> with as, type, crossorigin", () => {
+    const ctx = makeFakeChromeContext({
+      settings: {
+        head: {
+          preload: [
+            {
+              href: "/fonts/myfont.woff2",
+              as: "font",
+              type: "font/woff2",
+              crossorigin: "anonymous",
+            },
+          ],
+        },
+      },
+    });
+    const HeadWithDefaults = createHeadWithDefaults(ctx);
+    const out = render(<HeadWithDefaults title="Test" />);
+    expect(out).toContain(
+      '<link rel="preload" as="font" href="/fonts/myfont.woff2" type="font/woff2" crossorigin="anonymous"/>',
+    );
+  });
+
+  it("preload: omits optional fields when absent", () => {
+    const ctx = makeFakeChromeContext({
+      settings: {
+        head: {
+          preload: [{ href: "/img/hero.png", as: "image" }],
+        },
+      },
+    });
+    const HeadWithDefaults = createHeadWithDefaults(ctx);
+    const out = render(<HeadWithDefaults title="Test" />);
+    expect(out).toContain('<link rel="preload" as="image" href="/img/hero.png"/>');
+  });
+
+  it("stylesheet (plain): emits <link rel='stylesheet'> with media and crossorigin", () => {
+    const ctx = makeFakeChromeContext({
+      settings: {
+        head: {
+          stylesheets: [
+            {
+              href: "https://cdn.jsdelivr.net/npm/katex@0.16/dist/katex.min.css",
+              crossorigin: "anonymous",
+              media: "print",
+            },
+          ],
+        },
+      },
+    });
+    const HeadWithDefaults = createHeadWithDefaults(ctx);
+    const out = render(<HeadWithDefaults title="Test" />);
+    expect(out).toContain(
+      '<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16/dist/katex.min.css" media="print" crossorigin="anonymous"/>',
+    );
+    // Plain stylesheet must NOT emit a noscript fallback.
+    expect(out).not.toContain("<noscript>");
+  });
+
+  it("stylesheet (async:true): emits media='print' + literal onload + <noscript> fallback", () => {
+    // This test pins the EXACT SSR string for the async stylesheet pattern.
+    // preact-render-to-string emits string-valued on* props as literal HTML
+    // attributes (only function-valued event handlers are stripped), so the
+    // `onload` workaround (spreading { onload: "this.media='all'" } as any)
+    // must produce a literal `onload="this.media='all'"` attribute.
+    const ctx = makeFakeChromeContext({
+      settings: {
+        head: {
+          stylesheets: [
+            {
+              href: "https://cdn.example.com/style.css",
+              async: true,
+            },
+          ],
+        },
+      },
+    });
+    const HeadWithDefaults = createHeadWithDefaults(ctx);
+    const out = render(<HeadWithDefaults title="Test" />);
+    // The <link> must carry media="print" and the literal onload attribute.
+    expect(out).toContain(
+      '<link rel="stylesheet" href="https://cdn.example.com/style.css" media="print" onload="this.media=\'all\'"/>',
+    );
+    // The <noscript> fallback must follow with a plain (non-self-closing) inner link.
+    expect(out).toContain(
+      '<noscript><link rel="stylesheet" href="https://cdn.example.com/style.css"></noscript>',
+    );
+  });
+
+  it("stylesheet (async:true) with crossorigin: crossorigin emitted on both link and noscript inner link", () => {
+    const ctx = makeFakeChromeContext({
+      settings: {
+        head: {
+          stylesheets: [
+            {
+              href: "https://cdn.example.com/style.css",
+              crossorigin: "anonymous",
+              async: true,
+            },
+          ],
+        },
+      },
+    });
+    const HeadWithDefaults = createHeadWithDefaults(ctx);
+    const out = render(<HeadWithDefaults title="Test" />);
+    expect(out).toContain(
+      '<link rel="stylesheet" href="https://cdn.example.com/style.css" crossorigin="anonymous" media="print" onload="this.media=\'all\'"/>',
+    );
+    expect(out).toContain(
+      '<noscript><link rel="stylesheet" href="https://cdn.example.com/style.css" crossorigin="anonymous"></noscript>',
+    );
+  });
+
+  it("alternateLinks: emits <link rel={rel} href> with optional type and title", () => {
+    const ctx = makeFakeChromeContext({
+      settings: {
+        head: {
+          alternateLinks: [
+            {
+              rel: "alternate",
+              href: "/rss.xml",
+              type: "application/rss+xml",
+              title: "RSS Feed",
+            },
+          ],
+        },
+      },
+    });
+    const HeadWithDefaults = createHeadWithDefaults(ctx);
+    const out = render(<HeadWithDefaults title="Test" />);
+    expect(out).toContain(
+      '<link rel="alternate" href="/rss.xml" type="application/rss+xml" title="RSS Feed"/>',
+    );
+  });
+
+  it("meta: emits <meta name content>", () => {
+    const ctx = makeFakeChromeContext({
+      settings: {
+        head: {
+          meta: [{ name: "theme-color", content: "#ffffff" }],
+        },
+      },
+    });
+    const HeadWithDefaults = createHeadWithDefaults(ctx);
+    const out = render(<HeadWithDefaults title="Test" />);
+    expect(out).toContain('<meta name="theme-color" content="#ffffff"/>');
+  });
+
+  it("meta: emits <meta property content> (Open Graph style)", () => {
+    const ctx = makeFakeChromeContext({
+      settings: {
+        head: {
+          meta: [{ property: "og:locale:alternate", content: "ja_JP" }],
+        },
+      },
+    });
+    const HeadWithDefaults = createHeadWithDefaults(ctx);
+    const out = render(<HeadWithDefaults title="Test" />);
+    expect(out).toContain('<meta property="og:locale:alternate" content="ja_JP"/>');
+  });
+
+  it("emit order: preconnect → preload → stylesheets → alternateLinks → meta", () => {
+    const ctx = makeFakeChromeContext({
+      settings: {
+        head: {
+          preconnect: [{ href: "https://fonts.googleapis.com" }],
+          preload: [{ href: "/fonts/f.woff2", as: "font" }],
+          stylesheets: [{ href: "/extra.css" }],
+          alternateLinks: [{ rel: "alternate", href: "/rss.xml" }],
+          meta: [{ name: "theme-color", content: "#fff" }],
+        },
+      },
+    });
+    const HeadWithDefaults = createHeadWithDefaults(ctx);
+    const out = render(<HeadWithDefaults title="Test" />);
+    const markers = [
+      'rel="preconnect"',
+      'rel="preload"',
+      'rel="stylesheet"',
+      'rel="alternate"',
+      'name="theme-color"',
+    ];
+    let last = -1;
+    for (const marker of markers) {
+      const idx = out.indexOf(marker);
+      expect(idx, `expected to find ${marker} after position ${last}`).toBeGreaterThan(last);
+      last = idx;
+    }
+  });
+
+  it("multiple descriptors of the same type are emitted in order", () => {
+    const ctx = makeFakeChromeContext({
+      settings: {
+        head: {
+          preconnect: [
+            { href: "https://first.example.com" },
+            { href: "https://second.example.com" },
+          ],
+        },
+      },
+    });
+    const HeadWithDefaults = createHeadWithDefaults(ctx);
+    const out = render(<HeadWithDefaults title="Test" />);
+    const i1 = out.indexOf("first.example.com");
+    const i2 = out.indexOf("second.example.com");
+    expect(i1).toBeGreaterThan(0);
+    expect(i2).toBeGreaterThan(i1);
+  });
+});

--- a/packages/zudo-doc/src/head-with-defaults/index.tsx
+++ b/packages/zudo-doc/src/head-with-defaults/index.tsx
@@ -190,13 +190,14 @@ export function createHeadWithDefaults<S extends Settings = Settings>(
                     href={s.href}
                     {...(s.crossorigin ? { crossorigin: s.crossorigin } : {})}
                     media="print"
+                    // Swap to the configured media (default "all") once loaded.
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    {...({ onload: "this.media='all'" } as any)}
+                    {...({ onload: `this.media='${s.media ?? "all"}'` } as any)}
                   />
                   <noscript
                     key={`${i}-noscript`}
                     dangerouslySetInnerHTML={{
-                      __html: `<link rel="stylesheet" href="${s.href.replace(/"/g, "&quot;")}"${s.crossorigin ? ` crossorigin="${s.crossorigin}"` : ""}>`,
+                      __html: `<link rel="stylesheet" href="${s.href.replace(/"/g, "&quot;")}"${s.media ? ` media="${s.media}"` : ""}${s.crossorigin ? ` crossorigin="${s.crossorigin}"` : ""}>`,
                     }}
                   />
                 </>

--- a/packages/zudo-doc/src/head-with-defaults/index.tsx
+++ b/packages/zudo-doc/src/head-with-defaults/index.tsx
@@ -147,6 +147,88 @@ export function createHeadWithDefaults<S extends Settings = Settings>(
         <link rel="icon" type="image/png" sizes="32x32" href={withBase("/favicon-32x32.png")} />
         <link rel="icon" type="image/png" sizes="16x16" href={withBase("/favicon-16x16.png")} />
         {canonical !== undefined && <link rel="canonical" href={canonical} />}
+        {/* Site-wide <head> extras from settings.head (SiteHeadConfig).
+            The entire block is gated on ctx.settings.head being present so that
+            the DEFAULT path (no settings.head) emits NOTHING — keeping the
+            page output byte-identical to the pre-2.0.1 baseline (#2425). */}
+        {ctx.settings.head && (
+          <>
+            {/* preconnect → preload → stylesheets → alternateLinks → meta */}
+            {ctx.settings.head.preconnect?.map((p, i) => (
+              <link
+                key={i}
+                rel="preconnect"
+                href={p.href}
+                {...(p.crossorigin ? { crossorigin: p.crossorigin } : {})}
+              />
+            ))}
+            {ctx.settings.head.preload?.map((p, i) => (
+              <link
+                key={i}
+                rel="preload"
+                as={p.as}
+                href={p.href}
+                {...(p.type ? { type: p.type } : {})}
+                {...(p.crossorigin ? { crossorigin: p.crossorigin } : {})}
+              />
+            ))}
+            {ctx.settings.head.stylesheets?.map((s, i) =>
+              s.async ? (
+                // Non-render-blocking async stylesheet:
+                //   <link rel="stylesheet" href media="print" onload="this.media='all'">
+                //   <noscript><link rel="stylesheet" href></noscript>
+                //
+                // SSR note: preact-render-to-string emits string-valued on* props as
+                // literal HTML attributes (only function-valued event handlers are
+                // stripped). We use `as any` to bypass Preact's JSX types, which
+                // expect a function for onload. The new unit test pins the exact
+                // emitted string to guard this contract.
+                <>
+                  <link
+                    key={`${i}-link`}
+                    rel="stylesheet"
+                    href={s.href}
+                    {...(s.crossorigin ? { crossorigin: s.crossorigin } : {})}
+                    media="print"
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    {...({ onload: "this.media='all'" } as any)}
+                  />
+                  <noscript
+                    key={`${i}-noscript`}
+                    dangerouslySetInnerHTML={{
+                      __html: `<link rel="stylesheet" href="${s.href.replace(/"/g, "&quot;")}"${s.crossorigin ? ` crossorigin="${s.crossorigin}"` : ""}>`,
+                    }}
+                  />
+                </>
+              ) : (
+                <link
+                  key={i}
+                  rel="stylesheet"
+                  href={s.href}
+                  {...(s.media ? { media: s.media } : {})}
+                  {...(s.crossorigin ? { crossorigin: s.crossorigin } : {})}
+                />
+              ),
+            )}
+            {ctx.settings.head.alternateLinks?.map((a, i) => (
+              <link
+                key={i}
+                rel={a.rel}
+                href={a.href}
+                {...(a.type ? { type: a.type } : {})}
+                {...(a.title ? { title: a.title } : {})}
+              />
+            ))}
+            {ctx.settings.head.meta?.map((m, i) => (
+              <meta
+                key={i}
+                {...(m.name ? { name: m.name } : {})}
+                {...(m.property ? { property: m.property } : {})}
+                content={m.content}
+              />
+            ))}
+          </>
+        )}
       </>
     );
   }

--- a/packages/zudo-doc/src/head/types.ts
+++ b/packages/zudo-doc/src/head/types.ts
@@ -91,3 +91,56 @@ export interface HeadProps {
     crossorigin?: "anonymous" | "use-credentials";
   }>;
 }
+
+// ── Named serializable descriptors for SiteHeadConfig ────────────────────────
+//
+// These reuse the same shapes as the DEAD `HeadProps` link-descriptor fields
+// above (stylesheets / alternateLinks / preload) while adding the two
+// SiteHeadConfig-specific extras: `media?` and `async?` on stylesheets.
+// `HeadProps` / `DocHead` are NOT changed — the descriptors are defined
+// separately so the new config surface and the existing head primitive stay
+// independently evolvable.
+
+/** Stylesheet link descriptor for {@link SiteHeadConfig}. */
+export interface HeadStylesheet {
+  href: string;
+  crossorigin?: "anonymous" | "use-credentials";
+  /** CSS media attribute applied to the `<link media>` attribute. */
+  media?: string;
+  /**
+   * When `true`, loads the stylesheet non-render-blocking via the
+   * `media="print" + onload="this.media='all'"` pattern, plus a
+   * `<noscript><link rel="stylesheet" href>` fallback.
+   * Plain (absent or `false`) emits a normal `<link rel="stylesheet">`.
+   */
+  async?: boolean;
+}
+
+/** Preconnect hint descriptor for {@link SiteHeadConfig}. */
+export interface HeadPreconnect {
+  href: string;
+  crossorigin?: "anonymous" | "use-credentials";
+}
+
+/** Preload hint descriptor for {@link SiteHeadConfig}. */
+export interface HeadPreload {
+  href: string;
+  as: string;
+  type?: string;
+  crossorigin?: "anonymous" | "use-credentials";
+}
+
+/** Meta tag descriptor for {@link SiteHeadConfig}. */
+export interface HeadMeta {
+  name?: string;
+  property?: string;
+  content: string;
+}
+
+/** Alternate link descriptor for {@link SiteHeadConfig}. */
+export interface HeadAlternateLink {
+  rel: string;
+  href: string;
+  type?: string;
+  title?: string;
+}

--- a/packages/zudo-doc/src/settings.ts
+++ b/packages/zudo-doc/src/settings.ts
@@ -225,6 +225,28 @@ export interface MetaTagsConfig {
 }
 
 /**
+ * Site-wide custom `<head>` extras injected into every page via
+ * {@link HeadWithDefaults}. All fields are JSON-serializable (no VNodes or
+ * callables) — settings objects are `JSON.stringify`'d in the
+ * route-injection path (`@takazudo/zudo-doc/plugins/routes`), so
+ * non-serializable values would be silently dropped.
+ *
+ * Emit order: preconnect → preload → stylesheets → alternateLinks → meta.
+ *
+ * Note: `HtmlPreviewConfig.head` (a raw-HTML string scoped to the
+ * HTML-preview iframe sandbox, see {@link HtmlPreviewConfig}) is unrelated
+ * to this interface — that field injects content only into the preview
+ * sandbox, not the page `<head>`. This interface is site-wide.
+ */
+export interface SiteHeadConfig {
+  preconnect?: { href: string; crossorigin?: "anonymous" | "use-credentials" }[];
+  stylesheets?: { href: string; crossorigin?: "anonymous" | "use-credentials"; media?: string; async?: boolean }[];
+  preload?: { href: string; as: string; type?: string; crossorigin?: "anonymous" | "use-credentials" }[];
+  meta?: { name?: string; property?: string; content: string }[];
+  alternateLinks?: { rel: string; href: string; type?: string; title?: string }[];
+}
+
+/**
  * The full zudo-doc project settings interface.
  *
  * Consumer projects declare their concrete settings object using `satisfies Settings`
@@ -253,6 +275,17 @@ export interface Settings {
   githubAutolinksRepo?: string;
   siteUrl: string;
   metaTags: MetaTagsConfig;
+  /**
+   * Site-wide custom `<head>` extras — see {@link SiteHeadConfig}.
+   *
+   * Optional. When absent (the common case), no extra elements are emitted and
+   * the page output is byte-identical to the pre-2.0.1 baseline (the #2425
+   * route-injection byte-hashes remain green).
+   *
+   * Note: the iframe-scoped `htmlPreview.head` ({@link HtmlPreviewConfig.head})
+   * is unrelated to this field — it targets only the HTML-preview sandbox.
+   */
+  head?: SiteHeadConfig;
   sitemap: boolean;
   docMetainfo: boolean;
   docTags: boolean;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,14 +30,14 @@ importers:
         specifier: 0.3.3
         version: 0.3.3(preact@10.29.2)
       '@takazudo/zfb':
-        specifier: 0.1.0-next.70
-        version: 0.1.0-next.70
+        specifier: 0.1.0-next.71
+        version: 0.1.0-next.71
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.70
-        version: 0.1.0-next.70
+        specifier: 0.1.0-next.71
+        version: 0.1.0-next.71
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.70
-        version: 0.1.0-next.70(@takazudo/zfb@0.1.0-next.70)
+        specifier: 0.1.0-next.71
+        version: 0.1.0-next.71(@takazudo/zfb@0.1.0-next.71)
       '@takazudo/zudo-doc':
         specifier: workspace:*
         version: link:packages/zudo-doc
@@ -281,11 +281,11 @@ importers:
         version: 1.1.1
     devDependencies:
       '@takazudo/zfb':
-        specifier: 0.1.0-next.70
-        version: 0.1.0-next.70
+        specifier: 0.1.0-next.71
+        version: 0.1.0-next.71
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.70
-        version: 0.1.0-next.70(@takazudo/zfb@0.1.0-next.70)
+        specifier: 0.1.0-next.71
+        version: 0.1.0-next.71(@takazudo/zfb@0.1.0-next.71)
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
@@ -1377,48 +1377,48 @@ packages:
     peerDependencies:
       preact: ^10.29.1
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.70':
-    resolution: {integrity: sha512-N1BLWLaBeL40R3lQbvjoPM05wGUgrYl4yWOwJLy4cf2pGDhr6gPZmz0XuK2Jxh2n3gnuL/7AvPqiEFu5UkXvIw==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.71':
+    resolution: {integrity: sha512-NLWkcNQKk43vBlgOYtm9nPb7UlCdIElT6jb+Qm+Q15KxjWKShgumyESjFVrncL/c78LZQ3nU9fm79ERuAUpyMw==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.70':
-    resolution: {integrity: sha512-u/zMGOw/OxykcrRnkNt668tXFl8N2HE4vnhcOPoGkaKR7nipp2mubGKMlTVnp80pEdDHbE8Cc4oAbKPZkd++Tg==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.71':
+    resolution: {integrity: sha512-+qv+Do28yrS/ON8EMABivS/0meFI7JaumBhGtzmllW8Vx/8LjwYDOyWeqRriA1TnF9dHjz9bt/13mSYZ/PPZjA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.70':
-    resolution: {integrity: sha512-9bmmddMIryzn46Bhd/KPzNwfq3FapHN/v8AvEKGS+/FnCozHoS/oYFJg0B9/DP3JQza+yRTNstFl7RadCU7CSA==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.71':
+    resolution: {integrity: sha512-gIzznh56SX2MyuIgdARx7ynJFjoY1pluItt0RsZr4f36gnb3/FpN2Q+0mMVXbLL/gZEZUbyrzOuDOaHnX5H0jA==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.70':
-    resolution: {integrity: sha512-pakIl759w3tEX5iAQYzBsr3N1MjcbEvAJDZQ6gPKLo+PLZ1IFwRWeCZrKz/Uhfm1H3+M9R5CXxCpM9pfgOig6g==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.71':
+    resolution: {integrity: sha512-F+MR0yQju0931TXyK8OHoZFsskjeFMxethqmPsWV5NHZCh+RidopImRckqozszj0Qy2Zsy03BcNzbvhQYesm6Q==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.70':
-    resolution: {integrity: sha512-e0UrJj4/gqiGx4HXD3DvU4IFO++V32cRHBz+PcvOfdUD/0N0Oo+y0erBe+nAcqI5wJmZ+mEEViKQoDX8BfxTeA==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.71':
+    resolution: {integrity: sha512-pMeRRScJsuovlvhgn5I9aGH0L8cKEtj8CtWShcb9EXZaQCsNeIjRB445h1OvL8XZdS0mbxG8qzVvqT4ZRQsrKg==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.70':
-    resolution: {integrity: sha512-pSgTdQbQz/Si+VBZGgc/QDcoT+S6rmjedz6alKaIfyrZka6VY4mQ74v9dJEP7QP1sGy7xUVNzl/i7MEAQUWIZA==}
+  '@takazudo/zfb-runtime@0.1.0-next.71':
+    resolution: {integrity: sha512-s6DQLHzZszIeNTFNeIlQAbMC1s17RXM8Xd51O9QCyhUsCoC2oNAbBUd2LwTR6vztnXDZTIBp6IjkqeNLXXFG2A==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.70
+      '@takazudo/zfb': 0.1.0-next.71
       react: ^19.2.3
     peerDependenciesMeta:
       react:
         optional: true
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.70':
-    resolution: {integrity: sha512-mvdvUP9BoUVltPIeK2cTBPfd/IBEyWXeGgfyyqJnLz3OSDdgJRlE8sHGGHJwvKyAQgb0h/AgVikh2Bu5/rIcAA==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.71':
+    resolution: {integrity: sha512-IW/UM7BPtc/29c4l+kHdAsmQs5qN/V3LUhsWXkdwG6zxWF8HlHsiEug7SuU9iJSW1gKoVb4Zh8t60AE/EbBFIQ==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.70':
-    resolution: {integrity: sha512-9YLqCmH0+Ww2tB71MTMf6kvj+/Rb2up26X0yUcIFTGgo31kYy57Ti833g92alvAa/2vrmAfDcl5Q9pSNGR2Y1g==}
+  '@takazudo/zfb@0.1.0-next.71':
+    resolution: {integrity: sha512-fJyYTLtvh8vIo95qIO+bXcACWVPyeeLJ8Hj2trL2xFLZeY36H1xNmg9PgtYa4z0g5LazSE7EBaB4P/03nsA1bw==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
     peerDependencies:
@@ -4086,35 +4086,35 @@ snapshots:
       culori: 4.0.2
       preact: 10.29.2
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.70': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.71': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.70':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.71':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.70':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.71':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.70':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.71':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.70':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.71':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.70(@takazudo/zfb@0.1.0-next.70)':
+  '@takazudo/zfb-runtime@0.1.0-next.71(@takazudo/zfb@0.1.0-next.71)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.70
+      '@takazudo/zfb': 0.1.0-next.71
       hono: 4.12.25
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.70':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.71':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.70':
+  '@takazudo/zfb@0.1.0-next.71':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.70
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.70
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.70
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.70
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.70
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.71
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.71
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.71
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.71
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.71
 
   '@takazudo/zudo-design-token-lint@1.0.0(patch_hash=6a157fd850449b055cf64a8a7dd1faed5b1da9eebe6c81cca08488ac0de85182)':
     dependencies:

--- a/src/config/settings-types.ts
+++ b/src/config/settings-types.ts
@@ -27,5 +27,6 @@ export type {
   TagPlacement,
   VersionConfig,
   MetaTagsConfig,
+  SiteHeadConfig,
   Settings,
 } from "@takazudo/zudo-doc/settings";

--- a/src/content/docs-ja/changelog/2.0.1.mdx
+++ b/src/content/docs-ja/changelog/2.0.1.mdx
@@ -1,0 +1,17 @@
+---
+title: 2.0.1
+description: 2.0.1のリリースノート。
+sidebar_position: 1041
+---
+
+リリース日: 2026-06-29
+
+これは**パッチ**リリースです。2.0.0「Collapse Wiring Shells」で失われていたホスト側の接続点である `settings.head` の `<head>` 注入フックを追加し、zfb ツールチェーンを `0.1.0-next.71` に更新します。`settings.head` を設定しなければ、出力されるHTMLは 2.0.0 と**バイト単位で同一**です。
+
+### 機能
+
+- `@takazudo/zudo-doc`: カスタム `<head>` コンテンツ（`preconnect`・`preload`・`stylesheets`・`alternateLinks`・`meta` の各ディスクリプタ）を、単一のライブ head エミッタ経由ですべてのページ種別（トップページ・ドキュメントページ・タグ・バージョン・404）に注入する、新しい任意フィールド `settings.head: SiteHeadConfig` を追加しました。`stylesheets` の各エントリは `async: true` を指定でき、レンダリングをブロックしない読み込み（`media="print"` + `onload` によるメディア切り替えパターンと `<noscript>` フォールバック）になります。フィールドはシリアライズ可能なデータのみのため、パッケージ注入ルートにも届きます。`settings.head` が無い場合は何も出力せず、2.0.0 とバイト単位で同一の出力を保ちます。 (0c50a080, 32bae945, #2435)
+
+### その他の変更
+
+- `@takazudo/zfb` ツールチェーン（`@takazudo/zfb`・`@takazudo/zfb-runtime`・`@takazudo/zfb-adapter-cloudflare`）を `0.1.0-next.70` から `0.1.0-next.71` に更新しました。 (d0fe255f, #2435)

--- a/src/content/docs/changelog/2.0.1.mdx
+++ b/src/content/docs/changelog/2.0.1.mdx
@@ -1,0 +1,17 @@
+---
+title: 2.0.1
+description: Release notes for 2.0.1.
+sidebar_position: 1041
+---
+
+Released: 2026-06-29
+
+This is a **patch** release. It adds the `settings.head` site-`<head>` injection hook — the host-level seam that 2.0.0 "Collapse Wiring Shells" left missing — and bumps the zfb toolchain to `0.1.0-next.71`. With no `settings.head` configured, rendered output is **byte-identical** to 2.0.0.
+
+### Features
+
+- `@takazudo/zudo-doc`: new optional `settings.head: SiteHeadConfig` field that injects custom `<head>` content — `preconnect`, `preload`, `stylesheets`, `alternateLinks`, and `meta` descriptors — on every page type (homepages, doc pages, tags, versions, 404) via the single live head emitter. `stylesheets` entries accept `async: true` for non-render-blocking loading (the `media="print"` + `onload` media-swap pattern with a `<noscript>` fallback). The field is serializable data only, so it also reaches package-injected routes. Absent `settings.head` emits nothing, keeping output byte-identical to 2.0.0. (0c50a080, 32bae945, #2435)
+
+### Other Changes
+
+- Bumped the `@takazudo/zfb` toolchain — `@takazudo/zfb`, `@takazudo/zfb-runtime`, `@takazudo/zfb-adapter-cloudflare` — from `0.1.0-next.70` to `0.1.0-next.71`. (d0fe255f, #2435)


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2437

---

## Summary

Implements epic #2437 (supersedes spec #2435): the **`settings.head` site-`<head>` injection hook**, a zfb toolchain bump, and the lockstep **2.0.1** release.

### `settings.head: SiteHeadConfig` (#2438)
New optional, serializable `Settings` field that injects custom `<head>` content — `preconnect`, `preload`, `stylesheets`, `alternateLinks`, `meta` — on **every** page type via the single live head emitter (`createHeadWithDefaults`). This is the host seam 2.0.0 "Collapse Wiring Shells" left missing. `stylesheets` entries support `async: true` (non-render-blocking `media="print"` + `onload` swap with `<noscript>` fallback, now respecting a configured `media`). Serializable-only, so it also reaches package-injected routes. **Default (no `settings.head`) emits nothing → byte-identical output → #2425 route-injection hashes stay green.** New `SiteHeadConfig` re-exported from host + template `settings-types.ts`; API.md row + public-API snapshot updated.

### zfb toolchain bump (#2439)
`@takazudo/zfb` / `-runtime` / `-adapter-cloudflare` `0.1.0-next.70 → 0.1.0-next.71` across all pin-parity locations + lockfile. (zdtp untouched.)

### Lockstep 2.0.1 release (#2441)
All 4 packages `2.0.0 → 2.0.1`, scaffold internal pins `^2.0.1`, EN/JA changelog filled.

## Verification
- Integration confirm (#2440): package build + **826 tests**, full SSG build (332 pages), `test:packages`, pin-parity, typecheck — all green on the combined base.
- Code review (codex): 1 P2 (async stylesheet ignoring `media`) found + fixed + regression-tested.
- `B4PUSH_SKIP_MANUAL_SMOKE=1 pnpm b4push`: **all 20 checks passed.**

## Topic commits
- `0c50a080` feat: settings.head SiteHeadConfig
- `32bae945` fix: async stylesheet respects media
- `d0fe255f` chore(deps): zfb next.71
- `08049f10` chore(release): lockstep 2.0.1

## Human-gated (NOT in this PR)
After merge to `main` + CI green: a human runs the manual interactive smoke and publishes the three GitHub Draft Releases in order — `zudo-doc-history-server-2.0.1` (→ @takazudo/zudo-doc-history-server) → `zudo-doc-v2.0.1` (→ @takazudo/zudo-doc) → `v2.0.1` (→ create-zudo-doc). See RELEASE.md.
