### PR TITLE
chore(deps): bump @takazudo/zdtp to 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     }
   },
   "dependencies": {
-    "@takazudo/zdtp": "0.3.3",
+    "@takazudo/zdtp": "0.4.1",
     "@takazudo/zfb": "0.1.0-next.71",
     "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.71",
     "@takazudo/zfb-runtime": "0.1.0-next.71",

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -584,7 +584,7 @@ describe("scaffold — designTokenPanel package.json wiring", () => {
     const pkg = await fs.readJson(
       projectPath("test-zdtp-deps", "package.json"),
     );
-    expect(pkg.dependencies["@takazudo/zdtp"]).toBe("0.3.3");
+    expect(pkg.dependencies["@takazudo/zdtp"]).toBe("0.4.1");
   });
 });
 

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -706,7 +706,7 @@ function generatePackageJson(choices: UserChoices) {
   if (choices.features.includes("designTokenPanel")) {
     // @takazudo/zdtp requires preact >= 10.29.1 — see the preact floor comment
     // above (~line 382) for why the floor is set there and the coupling this creates.
-    deps["@takazudo/zdtp"] = "0.3.3";
+    deps["@takazudo/zdtp"] = "0.4.1";
   }
 
   if (choices.features.includes("tagGovernance")) {

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -534,7 +534,7 @@
     "@takazudo/zfb": "^0.1.0-next.71",
     "@takazudo/zfb-runtime": "^0.1.0-next.71",
     "@takazudo/zudo-doc-history-server": "^1.2.0",
-    "@takazudo/zdtp": "^0.3.3",
+    "@takazudo/zdtp": "^0.4.1",
     "shiki": "^4.0.2",
     "zod": "^4.3.6",
     "katex": "^0.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
   .:
     dependencies:
       '@takazudo/zdtp':
-        specifier: 0.3.3
-        version: 0.3.3(preact@10.29.2)
+        specifier: 0.4.1
+        version: 0.4.1(preact@10.29.2)
       '@takazudo/zfb':
         specifier: 0.1.0-next.71
         version: 0.1.0-next.71
@@ -256,8 +256,8 @@ importers:
   packages/zudo-doc:
     dependencies:
       '@takazudo/zdtp':
-        specifier: ^0.3.3
-        version: 0.3.3(preact@10.29.2)
+        specifier: ^0.4.1
+        version: 0.4.1(preact@10.29.2)
       '@takazudo/zudo-doc-history-server':
         specifier: ^1.2.0
         version: 1.2.0
@@ -1370,8 +1370,8 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
 
-  '@takazudo/zdtp@0.3.3':
-    resolution: {integrity: sha512-H46oqGxQLACoHQL1YqcxMLX0AmFRPKYR1FdeNcP3ihkX5Rc73ERyesnK2cM2xFrNMoWSI135LeiqN5l4w56hAA==}
+  '@takazudo/zdtp@0.4.1':
+    resolution: {integrity: sha512-Pn1jx1FdrOVIv2S08IfSwhF9VhvLEuVySCkY/BiOodPZihkqwZ4I4fl5vuxvM3BJX+0tVvRq9tIClgU4MmOPGQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
     peerDependencies:
@@ -4081,7 +4081,7 @@ snapshots:
       tailwindcss: 4.2.1
       vite: 7.3.5(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
 
-  '@takazudo/zdtp@0.3.3(preact@10.29.2)':
+  '@takazudo/zdtp@0.4.1(preact@10.29.2)':
     dependencies:
       culori: 4.0.2
       preact: 10.29.2


### PR DESCRIPTION
## Summary

Bump the `@takazudo/zdtp` toolchain dependency from **0.3.3 → 0.4.1** (latest published). The zfb family (`@takazudo/zfb`, `-runtime`, `-adapter-cloudflare`) is already on its latest `0.1.0-next.71` and is unchanged.

zdtp's `preact` peer (`^10.29.1`) is unchanged between 0.3.3 and 0.4.1 and is satisfied by the existing pin; it has no zfb coupling.

## Changes

- `package.json` — root dependency pin `0.3.3 → 0.4.1`
- `packages/zudo-doc/package.json` — `peerDependencies` pin `^0.3.3 → ^0.4.1`
- `packages/create-zudo-doc/src/scaffold.ts` — generated scaffold pin `0.3.3 → 0.4.1`
- `packages/create-zudo-doc/src/__tests__/scaffold.test.ts` — `.toBe("0.4.1")` assertion
- `pnpm-lock.yaml` — regenerated (zdtp only)

## Test Plan

Local `pnpm b4push` passed every substantive step: typecheck, root unit tests, package tests (incl. the updated scaffold assertion), build (zdtp 0.4.1 compiled cleanly — no API/config breakage), `check:pin-parity`, link check, HTML validation, preview smoke (6/6). The two non-green steps were environmental only: template-drift (local macOS bash 3.2 < required 4+ — runs on CI) and the interactive manual smoke (no TTY). CI validates the template-drift check on Linux.

> Note: a `create-zudo-doc` release (`/l-make-release`) is warranted because scaffold pins changed, but is intentionally deferred — other work will be bundled before the next lockstep release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785340568&installation_id=130359969&pr_number=2444&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2444&signature=b9505183ad484fdbc0bb935623e6f328627407dcbb32de657bf2477aaf964296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->