### PR TITLE
fix(zudo-doc): widen stale history-server peer floor to ^2.0.1 + first-party peer-parity guard + ChromeContext runtime guard (#2445)

### DIFF
--- a/packages/zudo-doc/API.md
+++ b/packages/zudo-doc/API.md
@@ -415,14 +415,16 @@ The following field is documented here for completeness but is **explicitly excl
 
 ### 2.0 — page-chrome factories take a single `ChromeContext`
 
-Every public page-chrome factory (`createFooterWithDefaults`, `createHeaderWithDefaults`,
+Every public page-chrome factory now takes the unified `ChromeContext` (from `./factory-context`)
+instead of the pre-2.0 per-factory narrow context or deps-bag. This covers both the
+component-level chrome factories (`createFooterWithDefaults`, `createHeaderWithDefaults`,
 `createSidebarWithDefaults`, `createHeadWithDefaults`, `createDocTagsArea`,
 `createDocHistoryArea`, `createDocContentHeader`, `createDocMetainfoArea`,
-`createDocBodyEnd`) now takes the unified `ChromeContext` (from `./factory-context`)
-instead of the pre-2.0 per-factory narrow context or deps-bag. The `ChromeContext`
-includes a required `hostBindings` field. Passing a pre-2.0 deps-bag compiles under
-tsc but throws at runtime — the factories now surface a clear actionable error
-(`hostBindings` missing) instead of an opaque TypeError.
+`createDocBodyEnd`) and the page-level composition factories (`createRenderDocPage`,
+`createDocPageShell`, `createTagPages`, `createVersionsPageView`, `createDocPager`).
+The `ChromeContext` includes a required `hostBindings` field. Passing a pre-2.0 deps-bag
+compiles under tsc but throws at runtime — the factories now surface a clear actionable
+error (`hostBindings` missing or null) instead of an opaque TypeError.
 
 **Upgrade path:** use `createChrome(routeContext, hostBindings?)` (from `./chrome`)
 to assemble a `ChromeContext` before calling the factories, or import the unified

--- a/packages/zudo-doc/API.md
+++ b/packages/zudo-doc/API.md
@@ -411,6 +411,25 @@ The following field is documented here for completeness but is **explicitly excl
 
 ---
 
+## Migration Notes
+
+### 2.0 — page-chrome factories take a single `ChromeContext`
+
+Every public page-chrome factory (`createFooterWithDefaults`, `createHeaderWithDefaults`,
+`createSidebarWithDefaults`, `createHeadWithDefaults`, `createDocTagsArea`,
+`createDocHistoryArea`, `createDocContentHeader`, `createDocMetainfoArea`,
+`createDocBodyEnd`) now takes the unified `ChromeContext` (from `./factory-context`)
+instead of the pre-2.0 per-factory narrow context or deps-bag. The `ChromeContext`
+includes a required `hostBindings` field. Passing a pre-2.0 deps-bag compiles under
+tsc but throws at runtime — the factories now surface a clear actionable error
+(`hostBindings` missing) instead of an opaque TypeError.
+
+**Upgrade path:** use `createChrome(routeContext, hostBindings?)` (from `./chrome`)
+to assemble a `ChromeContext` before calling the factories, or import the unified
+type from `./factory-context` and construct it directly.
+
+---
+
 ## MAJOR Version Intent
 
 The Collapse Wiring Shells epic (#2420) introduced a breaking API change: every

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -538,7 +538,7 @@
     "preact": "^10.29.1",
     "@takazudo/zfb": "^0.1.0-next.71",
     "@takazudo/zfb-runtime": "^0.1.0-next.71",
-    "@takazudo/zudo-doc-history-server": "^1.2.0",
+    "@takazudo/zudo-doc-history-server": "^2.0.1",
     "@takazudo/zdtp": "^0.4.1",
     "shiki": "^4.0.2",
     "zod": "^4.3.6",

--- a/packages/zudo-doc/src/chrome/__tests__/assert-chrome-context.test.ts
+++ b/packages/zudo-doc/src/chrome/__tests__/assert-chrome-context.test.ts
@@ -1,0 +1,68 @@
+// assert-chrome-context unit tests (#2455).
+//
+// Verifies the runtime guard:
+//   - A valid ChromeContext (from makeFakeChromeContext) → no throw.
+//   - An object lacking `hostBindings` (pre-2.0 deps-bag shape) → throws with
+//     a message mentioning the 2.0 migration and API.md.
+
+import { describe, it, expect } from "vitest";
+import { assertChromeContext } from "../assert-chrome-context.js";
+import { makeFakeChromeContext } from "../../__tests__/fixtures/fake-chrome-context.js";
+
+describe("assertChromeContext", () => {
+  it("does not throw for a valid ChromeContext from makeFakeChromeContext", () => {
+    const ctx = makeFakeChromeContext();
+    expect(() => assertChromeContext(ctx, "createTestFactory")).not.toThrow();
+  });
+
+  it("throws when ctx is null", () => {
+    expect(() => assertChromeContext(null, "createTestFactory")).toThrow(
+      /createTestFactory/,
+    );
+  });
+
+  it("throws when ctx is undefined", () => {
+    expect(() =>
+      assertChromeContext(undefined as unknown as { hostBindings?: unknown }, "createTestFactory"),
+    ).toThrow(/createTestFactory/);
+  });
+
+  it("throws when ctx lacks hostBindings (pre-2.0 deps-bag shape)", () => {
+    const oldDepsLikeBag = {
+      settings: {},
+      i18n: {},
+      components: {},
+      // hostBindings is intentionally absent — this is the pre-2.0 shape
+    };
+    expect(() =>
+      assertChromeContext(oldDepsLikeBag, "createFooterWithDefaults"),
+    ).toThrow(/createFooterWithDefaults/);
+  });
+
+  it("throws with a message pointing at 2.0 migration and API.md", () => {
+    const oldDepsLikeBag = { settings: {}, i18n: {} };
+    let caught: Error | undefined;
+    try {
+      assertChromeContext(oldDepsLikeBag, "createHeaderWithDefaults");
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught).toBeDefined();
+    expect(caught?.message).toContain("createHeaderWithDefaults");
+    expect(caught?.message).toContain("hostBindings");
+    expect(caught?.message).toContain("2.0");
+    expect(caught?.message).toContain("API.md");
+  });
+
+  it("does not throw when hostBindings is present (even if empty)", () => {
+    const ctxWithBindings = {
+      settings: {},
+      i18n: {},
+      components: {},
+      hostBindings: {},
+    };
+    expect(() =>
+      assertChromeContext(ctxWithBindings, "createSidebarWithDefaults"),
+    ).not.toThrow();
+  });
+});

--- a/packages/zudo-doc/src/chrome/__tests__/assert-chrome-context.test.ts
+++ b/packages/zudo-doc/src/chrome/__tests__/assert-chrome-context.test.ts
@@ -65,4 +65,16 @@ describe("assertChromeContext", () => {
       assertChromeContext(ctxWithBindings, "createSidebarWithDefaults"),
     ).not.toThrow();
   });
+
+  it("throws when hostBindings is null (null-safe guard)", () => {
+    const ctxWithNullBindings = {
+      settings: {},
+      i18n: {},
+      components: {},
+      hostBindings: null,
+    };
+    expect(() =>
+      assertChromeContext(ctxWithNullBindings as unknown as { hostBindings?: unknown }, "createDocPageShell"),
+    ).toThrow(/createDocPageShell/);
+  });
 });

--- a/packages/zudo-doc/src/chrome/assert-chrome-context.ts
+++ b/packages/zudo-doc/src/chrome/assert-chrome-context.ts
@@ -26,7 +26,7 @@ export function assertChromeContext(
   ctx: { hostBindings?: unknown } | null | undefined,
   factoryName: string,
 ): void {
-  if (ctx == null || (ctx as Record<string, unknown>).hostBindings === undefined) {
+  if (ctx == null || (ctx as Record<string, unknown>).hostBindings == null) {
     throw new Error(
       `\`${factoryName}\` received a context without \`hostBindings\` — the 2.0 factories take a single ChromeContext, not the pre-2.0 deps-bag. See packages/zudo-doc/API.md.`,
     );

--- a/packages/zudo-doc/src/chrome/assert-chrome-context.ts
+++ b/packages/zudo-doc/src/chrome/assert-chrome-context.ts
@@ -22,10 +22,12 @@
  *
  * See packages/zudo-doc/API.md — "Migration Notes" for upgrade instructions.
  */
-export function assertChromeContext(
-  ctx: { hostBindings?: unknown } | null | undefined,
-  factoryName: string,
-): void {
+// `ctx` is typed `unknown` on purpose: this is a runtime validator of
+// *untrusted* input (a consumer may pass the pre-2.0 deps-bag, which TS cannot
+// reject at the call site — that is exactly the failure mode this guard exists
+// to catch). The production factory call sites pass a `ChromeContext`, which is
+// assignable to `unknown`; the narrowing happens inside.
+export function assertChromeContext(ctx: unknown, factoryName: string): void {
   if (ctx == null || (ctx as Record<string, unknown>).hostBindings == null) {
     throw new Error(
       `\`${factoryName}\` received a context without \`hostBindings\` — the 2.0 factories take a single ChromeContext, not the pre-2.0 deps-bag. See packages/zudo-doc/API.md.`,

--- a/packages/zudo-doc/src/chrome/assert-chrome-context.ts
+++ b/packages/zudo-doc/src/chrome/assert-chrome-context.ts
@@ -1,0 +1,34 @@
+// assert-chrome-context — narrow runtime guard for the 2.0 ChromeContext
+// parameter contract (epic Collapse Wiring Shells #2420, guard #2455).
+//
+// The 2.0 factories take a single unified ChromeContext whose `hostBindings`
+// field is REQUIRED. A consumer still passing the pre-2.0 per-factory deps-bag
+// compiles fine under tsc but crashes at runtime when the factory dereferences
+// `ctx.hostBindings.tagVocabulary` (or similar). This helper surfaces a clear
+// actionable error instead of an opaque TypeError.
+//
+// IMPORTANT: this file must remain pure and node-free. It is imported by the
+// page-chrome factories (footer-with-defaults, header-with-defaults, etc.) which
+// are NOT in the preset eval graph — but they must not pull in node builtins
+// either. No imports here; all logic is inline.
+
+/**
+ * Assert that `ctx` is a fully-wired 2.0 ChromeContext (i.e. has `hostBindings`).
+ *
+ * Throws an actionable Error when the caller passes a bare pre-2.0 deps-bag
+ * instead of the unified ChromeContext the 2.0 factories require. This catches
+ * runtime crashes (`Cannot read properties of undefined (reading 'tagVocabulary')`)
+ * at the factory boundary instead of deep inside the component render.
+ *
+ * See packages/zudo-doc/API.md — "Migration Notes" for upgrade instructions.
+ */
+export function assertChromeContext(
+  ctx: { hostBindings?: unknown } | null | undefined,
+  factoryName: string,
+): void {
+  if (ctx == null || (ctx as Record<string, unknown>).hostBindings === undefined) {
+    throw new Error(
+      `\`${factoryName}\` received a context without \`hostBindings\` — the 2.0 factories take a single ChromeContext, not the pre-2.0 deps-bag. See packages/zudo-doc/API.md.`,
+    );
+  }
+}

--- a/packages/zudo-doc/src/doc-body-end/index.tsx
+++ b/packages/zudo-doc/src/doc-body-end/index.tsx
@@ -17,6 +17,7 @@ import { SidebarResizerInit } from "../sidebar-resizer/index.js";
 import type { ChromeContext } from "../factory-context/index.js";
 import type { Settings } from "../settings.js";
 import { deriveBodyEndIslands } from "../chrome/derive.js";
+import { assertChromeContext } from "../chrome/assert-chrome-context.js";
 
 /** Settings subset read by the DocBodyEnd factory. */
 export interface DocBodyEndSettings {
@@ -35,6 +36,7 @@ export interface DocBodyEndSettings {
 export function createDocBodyEnd<S extends Settings = Settings>(
   ctx: ChromeContext<S>,
 ): () => JSX.Element {
+  assertChromeContext(ctx, "createDocBodyEnd");
   const settings = ctx.settings as unknown as DocBodyEndSettings;
   const BodyEndIslands = deriveBodyEndIslands(ctx) as (props: {
     basePath: string;

--- a/packages/zudo-doc/src/doc-content-header/index.tsx
+++ b/packages/zudo-doc/src/doc-content-header/index.tsx
@@ -16,6 +16,7 @@ import type { ChromeContext } from "../factory-context/index.js";
 import type { Settings } from "../settings.js";
 import { createDocMetainfoArea } from "../doc-metainfo-area/index.js";
 import { createDocTagsArea } from "../doc-tags-area/index.js";
+import { assertChromeContext } from "../chrome/assert-chrome-context.js";
 
 export type { FrontmatterCellRenderer };
 
@@ -94,6 +95,7 @@ interface DocContentHeaderProps {
 export function createDocContentHeader<S extends Settings = Settings>(
   ctx: ChromeContext<S>,
 ): (props: DocContentHeaderProps) => JSX.Element {
+  assertChromeContext(ctx, "createDocContentHeader");
   const t = ctx.t;
   const buildFrontmatterPreviewEntries = (ctx.hostBindings.buildFrontmatterPreviewEntries ??
     (() => [])) as DocContentHeaderDeps["buildFrontmatterPreviewEntries"];

--- a/packages/zudo-doc/src/doc-history-area/index.tsx
+++ b/packages/zudo-doc/src/doc-history-area/index.tsx
@@ -26,6 +26,7 @@ import type { Settings } from "../settings.js";
 import { toHistorySlug } from "../slug/index.js";
 import { buildGitHubSourceUrl as buildGitHubSourceUrlBase } from "../github-helpers/index.js";
 import { deriveDocHistorySlot } from "../chrome/derive.js";
+import { assertChromeContext } from "../chrome/assert-chrome-context.js";
 
 /** Per-entry metadata shape from the doc-history manifest. */
 export interface DocHistoryMetaEntry {
@@ -95,6 +96,7 @@ export interface DocHistoryAreaProps {
 export function createDocHistoryArea<S extends Settings = Settings>(
   ctx: ChromeContext<S>,
 ): (props: DocHistoryAreaProps) => VNode | null {
+  assertChromeContext(ctx, "createDocHistoryArea");
   const settings = ctx.settings as unknown as DocHistoryAreaSettings;
   const defaultLocale = ctx.defaultLocale;
   const docHistoryMeta = (ctx.hostBindings.docHistoryMeta ?? {}) as Record<

--- a/packages/zudo-doc/src/doc-metainfo-area/index.tsx
+++ b/packages/zudo-doc/src/doc-metainfo-area/index.tsx
@@ -18,6 +18,7 @@ import { DocMetainfo } from "../metainfo/index.js";
 import type { ChromeContext } from "../factory-context/index.js";
 import type { Settings } from "../settings.js";
 import { toHistorySlug } from "../slug/index.js";
+import { assertChromeContext } from "../chrome/assert-chrome-context.js";
 
 // BCP-47 locale tag mapping used by Intl.DateTimeFormat.
 // Originally mirrored from `src/utils/git-info.ts` (removed in S1 #1928).
@@ -78,6 +79,7 @@ export interface DocMetainfoAreaProps {
 export function createDocMetainfoArea<S extends Settings = Settings>(
   ctx: ChromeContext<S>,
 ): (props: DocMetainfoAreaProps) => VNode | null {
+  assertChromeContext(ctx, "createDocMetainfoArea");
   const settings = ctx.settings as unknown as DocMetainfoAreaSettings;
   const defaultLocale = ctx.defaultLocale;
   const docHistoryMeta = (ctx.hostBindings.docHistoryMeta ?? {}) as Record<

--- a/packages/zudo-doc/src/doc-page-renderer/index.tsx
+++ b/packages/zudo-doc/src/doc-page-renderer/index.tsx
@@ -28,6 +28,7 @@ import { createDocContentHeader } from "../doc-content-header/index.js";
 import { createDocMetainfoArea } from "../doc-metainfo-area/index.js";
 import { createDocHistoryArea } from "../doc-history-area/index.js";
 import { deriveMdxComponents, deriveInlineVersionSwitcher } from "../chrome/derive.js";
+import { assertChromeContext } from "../chrome/assert-chrome-context.js";
 
 export type { DocPageBaseProps };
 
@@ -162,6 +163,7 @@ export interface DocPageRendererDeps {
 export function createRenderDocPage<S extends Settings = Settings>(
   ctx: ChromeContext<S>,
 ): (props: DocPageBaseProps, opts: RenderDocPageOptions) => JSX.Element {
+  assertChromeContext(ctx, "createRenderDocPage");
   const docsUrl = ctx.docsUrl;
   const versionedDocsUrl = ctx.versionedDocsUrl;
   const absoluteUrl = ctx.absoluteUrl;

--- a/packages/zudo-doc/src/doc-page-shell/index.tsx
+++ b/packages/zudo-doc/src/doc-page-shell/index.tsx
@@ -31,6 +31,7 @@ import { createFooterWithDefaults } from "../footer-with-defaults/index.js";
 import { createDocBodyEnd } from "../doc-body-end/index.js";
 import { createDocPager } from "../doc-pager/index.js";
 import { deriveComposeMetaTitle } from "../chrome/derive.js";
+import { assertChromeContext } from "../chrome/assert-chrome-context.js";
 
 /** A heading item for the TOC. */
 export interface DocPageHeading {
@@ -176,6 +177,7 @@ export interface DocPageShellDeps {
 export function createDocPageShell<S extends Settings = Settings>(
   ctx: ChromeContext<S>,
 ): (props: DocPageShellProps) => JSX.Element {
+  assertChromeContext(ctx, "createDocPageShell");
   const settings = ctx.settings as unknown as DocPageShellSettings;
   const composeMetaTitle = deriveComposeMetaTitle(ctx);
   const HeadWithDefaults = createHeadWithDefaults(ctx);

--- a/packages/zudo-doc/src/doc-pager/index.tsx
+++ b/packages/zudo-doc/src/doc-pager/index.tsx
@@ -11,6 +11,7 @@ import type { JSX } from "preact";
 import { ChevronLeft, ChevronRight } from "../icons/index.js";
 import type { ChromeContext } from "../factory-context/index.js";
 import type { Settings } from "../settings.js";
+import { assertChromeContext } from "../chrome/assert-chrome-context.js";
 
 // NavNode is a superset; we only need the fields the pager uses.
 interface PagerNode {
@@ -35,6 +36,7 @@ export interface DocPagerProps {
 export function createDocPager<S extends Settings = Settings>(
   ctx: ChromeContext<S>,
 ): (props: DocPagerProps) => JSX.Element {
+  assertChromeContext(ctx, "createDocPager");
   const t = ctx.t;
 
   /**

--- a/packages/zudo-doc/src/doc-tags-area/index.tsx
+++ b/packages/zudo-doc/src/doc-tags-area/index.tsx
@@ -13,6 +13,7 @@ import { DocTags } from "../metainfo/index.js";
 import type { TagVocabularyEntry, TagGovernanceMode, Settings } from "../settings.js";
 import { resolvePageTags } from "../tag-helpers/index.js";
 import type { ChromeContext } from "../factory-context/index.js";
+import { assertChromeContext } from "../chrome/assert-chrome-context.js";
 
 /** Settings subset read by the DocTagsArea factory. */
 export interface DocTagsAreaSettings {
@@ -41,6 +42,7 @@ export interface DocTagsAreaProps {
 export function createDocTagsArea<S extends Settings = Settings>(
   ctx: ChromeContext<S>,
 ): (props: DocTagsAreaProps) => VNode | null {
+  assertChromeContext(ctx, "createDocTagsArea");
   const settings = ctx.settings as unknown as DocTagsAreaSettings;
   const defaultLocale = ctx.defaultLocale;
   const withBase = ctx.withBase;

--- a/packages/zudo-doc/src/footer-with-defaults/index.tsx
+++ b/packages/zudo-doc/src/footer-with-defaults/index.tsx
@@ -14,6 +14,7 @@ import { Footer } from "../footer/index.js";
 import type { FooterLinkColumn, FooterTagColumn } from "../footer/index.js";
 import type { ChromeContext } from "../factory-context/index.js";
 import type { Settings } from "../settings.js";
+import { assertChromeContext } from "../chrome/assert-chrome-context.js";
 
 /** Tag info returned by the host's `collectTags` (what the factory sees). */
 export interface FooterTagInfo {
@@ -69,6 +70,7 @@ export interface FooterWithDefaultsSettings {
 export function createFooterWithDefaults<S extends Settings = Settings>(
   ctx: ChromeContext<S>,
 ): (props: { lang?: string }) => VNode {
+  assertChromeContext(ctx, "createFooterWithDefaults");
   const settings = ctx.settings as unknown as FooterWithDefaultsSettings;
   const defaultLocale = ctx.defaultLocale;
   const tagVocabulary = (ctx.hostBindings.tagVocabulary ??

--- a/packages/zudo-doc/src/head-with-defaults/index.tsx
+++ b/packages/zudo-doc/src/head-with-defaults/index.tsx
@@ -20,6 +20,7 @@ import type { ColorSchemeProviderColorMode } from "../theme/color-scheme-provide
 import type { ChromeContext } from "../factory-context/index.js";
 import type { Settings } from "../settings.js";
 import { deriveComposeMetaTitle, deriveColorSchemeGenerators } from "../chrome/derive.js";
+import { assertChromeContext } from "../chrome/assert-chrome-context.js";
 
 export interface HeadWithDefaultsProps {
   /** Page title forwarded to og:title. Required. */
@@ -63,6 +64,7 @@ export interface HeadWithDefaultsSettings {
 export function createHeadWithDefaults<S extends Settings = Settings>(
   ctx: ChromeContext<S>,
 ): (props: HeadWithDefaultsProps) => JSX.Element {
+  assertChromeContext(ctx, "createHeadWithDefaults");
   const settings = ctx.settings as unknown as HeadWithDefaultsSettings;
   const composeMetaTitle = deriveComposeMetaTitle(ctx);
   const withBase = ctx.withBase;

--- a/packages/zudo-doc/src/header-with-defaults/index.tsx
+++ b/packages/zudo-doc/src/header-with-defaults/index.tsx
@@ -21,6 +21,7 @@ import { SidebarToggle } from "../sidebar-toggle-island/index.js";
 import type { ChromeContext } from "../factory-context/index.js";
 import type { Settings } from "../settings.js";
 import { buildGitHubRepoUrl as buildGitHubRepoUrlBase } from "../github-helpers/index.js";
+import { assertChromeContext } from "../chrome/assert-chrome-context.js";
 import { deriveNavDataPrep, deriveSearchWidgetSlot } from "../chrome/derive.js";
 import type { SidebarNavNode, SidebarRootMenuItem } from "../sidebar/types.js";
 import type { LocaleLink } from "../url-helpers/index.js";
@@ -79,6 +80,7 @@ export interface HeaderWithDefaultsSettings {
 export function createHeaderWithDefaults<S extends Settings = Settings>(
   ctx: ChromeContext<S>,
 ): (props: HeaderWithDefaultsProps) => JSX.Element {
+  assertChromeContext(ctx, "createHeaderWithDefaults");
   const settings = ctx.settings as unknown as HeaderWithDefaultsSettings;
   const defaultLocale = ctx.defaultLocale;
   const locales = ctx.locales;

--- a/packages/zudo-doc/src/sidebar-with-defaults/index.tsx
+++ b/packages/zudo-doc/src/sidebar-with-defaults/index.tsx
@@ -15,6 +15,7 @@ import type { SidebarNavNode, SidebarRootMenuItem } from "../sidebar/types.js";
 import type { ChromeContext } from "../factory-context/index.js";
 import type { Settings } from "../settings.js";
 import { deriveNavDataPrep } from "../chrome/derive.js";
+import { assertChromeContext } from "../chrome/assert-chrome-context.js";
 import type { LocaleLink } from "../url-helpers/index.js";
 
 export type { SidebarNavNode, SidebarRootMenuItem };
@@ -46,6 +47,7 @@ export interface SidebarWithDefaultsProps {
 export function createSidebarWithDefaults<S extends Settings = Settings>(
   ctx: ChromeContext<S>,
 ): (props: SidebarWithDefaultsProps) => JSX.Element {
+  assertChromeContext(ctx, "createSidebarWithDefaults");
   const defaultLocale = ctx.defaultLocale;
   const localeCount = ctx.locales.length;
   const t = ctx.t;

--- a/packages/zudo-doc/src/tag-pages/index.tsx
+++ b/packages/zudo-doc/src/tag-pages/index.tsx
@@ -42,6 +42,7 @@ import { createHeaderWithDefaults } from "../header-with-defaults/index.js";
 import { createFooterWithDefaults } from "../footer-with-defaults/index.js";
 import { createDocHistoryArea } from "../doc-history-area/index.js";
 import { deriveComposeMetaTitle, deriveBodyEndIslands } from "../chrome/derive.js";
+import { assertChromeContext } from "../chrome/assert-chrome-context.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -155,6 +156,7 @@ export interface TagPagesAPI {
 export function createTagPages<S extends Settings = Settings>(
   ctx: ChromeContext<S>,
 ): TagPagesAPI {
+  assertChromeContext(ctx, "createTagPages");
   const settings = ctx.settings as unknown as TagPagesSettings;
   const defaultLocale = ctx.defaultLocale;
   const t = ctx.t;

--- a/packages/zudo-doc/src/versions-page/index.tsx
+++ b/packages/zudo-doc/src/versions-page/index.tsx
@@ -18,6 +18,7 @@ import { createHeadWithDefaults } from "../head-with-defaults/index.js";
 import { createHeaderWithDefaults } from "../header-with-defaults/index.js";
 import { createFooterWithDefaults } from "../footer-with-defaults/index.js";
 import { deriveComposeMetaTitle, deriveBodyEndIslands } from "../chrome/derive.js";
+import { assertChromeContext } from "../chrome/assert-chrome-context.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -78,6 +79,7 @@ export interface VersionsPageViewProps {
 export function createVersionsPageView<S extends Settings = Settings>(
   ctx: ChromeContext<S>,
 ): (props: VersionsPageViewProps) => JSX.Element {
+  assertChromeContext(ctx, "createVersionsPageView");
   const settings = ctx.settings as unknown as VersionsPageSettings;
   const defaultLocale = ctx.defaultLocale;
   const t = ctx.t;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,8 +259,8 @@ importers:
         specifier: ^0.4.1
         version: 0.4.1(preact@10.29.2)
       '@takazudo/zudo-doc-history-server':
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^2.0.1
+        version: 2.0.1
       diff:
         specifier: ^8.0.0
         version: 8.0.3
@@ -1432,8 +1432,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@takazudo/zudo-doc-history-server@1.2.0':
-    resolution: {integrity: sha512-vnAUJSf73cj3sO/VjT213Bhhl3MyZGEqmuN/WY0/Fguo1vulujywLsIPe4jApsD/9iYtFyrDbSX96RlQtvpy+g==}
+  '@takazudo/zudo-doc-history-server@2.0.1':
+    resolution: {integrity: sha512-+FkywbPF7Dopji8Er5gonS/4gHcvXHV6lLqcDBkI93Osb2q1AXWZk1e+owZYHBleerWRt/73EAGRmLwZpN2P8Q==}
     hasBin: true
 
   '@types/chai@5.2.3':
@@ -4121,7 +4121,7 @@ snapshots:
       chalk: 5.6.2
       glob: 10.5.0
 
-  '@takazudo/zudo-doc-history-server@1.2.0': {}
+  '@takazudo/zudo-doc-history-server@2.0.1': {}
 
   '@types/chai@5.2.3':
     dependencies:

--- a/scripts/check-pin-parity.mjs
+++ b/scripts/check-pin-parity.mjs
@@ -46,10 +46,13 @@ const SCAFFOLD_TS_PATH = resolve(
 const ZUDO_DOC_PKG_PATH = resolve(ROOT_DIR, "packages/zudo-doc/package.json");
 
 // External upstream packages: scaffold pin must equal root dependencies[pkg].
+// @takazudo/zdtp is included here so the scaffold's emitted zdtp pin is
+// parity-checked against root dependencies — same staleness class as #2381 / #2445.
 const PINNED_PACKAGES = [
   "@takazudo/zfb",
   "@takazudo/zfb-runtime",
   "@takazudo/zfb-adapter-cloudflare",
+  "@takazudo/zdtp",
 ];
 
 // Internal packages published from this monorepo: scaffold pin (caret/tilde
@@ -70,6 +73,33 @@ const INTERNAL_PINNED_PACKAGES = [
 //   peerDependencies — ^<root pin> (downstream compatibility range)
 // Note: @takazudo/zfb-adapter-cloudflare is NOT in packages/zudo-doc — only these two.
 const ZUDO_DOC_ZFB_PACKAGES = ["@takazudo/zfb", "@takazudo/zfb-runtime"];
+
+// First-party peer floors in packages/zudo-doc/package.json peerDependencies.
+// These peers were previously unguarded and went stale on the 2.0.1 major bump
+// (#2381 / #2445). Adding them here catches the same staleness class whenever
+// the version or an external pin changes.
+//
+// Source-of-truth distinction:
+//   lockstep  — co-released with this repo; source = root package.json `version`
+//   pinned    — external dep pinned in root `dependencies`; source = that dep string
+//
+// Insurance: both sources are exact strings today (no leading ^/~). The check
+// below rejects a future ranged source value that would produce a malformed `^^…`
+// expected peer, making the breakage loud rather than silently wrong.
+const FIRST_PARTY_PEER_CHECKS = [
+  {
+    pkg: "@takazudo/zudo-doc-history-server",
+    sourceKind: "lockstep (root version)",
+    // Released at the same lockstep version as the root package.
+    getSource: (rootPkg) => rootPkg.version,
+  },
+  {
+    pkg: "@takazudo/zdtp",
+    sourceKind: 'pinned (root dependencies["@takazudo/zdtp"])',
+    // External dependency pinned in root dependencies — NOT lockstep.
+    getSource: (rootPkg) => rootPkg.dependencies?.["@takazudo/zdtp"],
+  },
+];
 
 /**
  * Extract the literal version string for `pkgName` from scaffold.ts.
@@ -242,9 +272,62 @@ function main() {
     }
   }
 
+  // ── First-party peer floors in packages/zudo-doc peerDependencies ────────────
+  // Guards the recurrence class from #2381 / #2445: the zfb ZUDO_DOC_ZFB_PACKAGES
+  // loop above only covers the zfb pair; these two first-party peers were unguarded
+  // and went stale on the 2.0.1 major bump. This block catches the same pattern.
+  for (const { pkg, sourceKind, getSource } of FIRST_PARTY_PEER_CHECKS) {
+    const sourceValue = getSource(rootPkg);
+
+    if (!sourceValue) {
+      mismatches.push({
+        pkg,
+        reason: `Source value not found — ${sourceKind}`,
+        expected: "(could not determine)",
+        actual: zudoDocPkg.peerDependencies?.[pkg] ?? "(missing)",
+        file: ZUDO_DOC_PKG_PATH,
+        field: "peerDependencies",
+        kind: "first-party-peer",
+      });
+      continue;
+    }
+
+    // Insurance: assert source is an exact string with no leading ^/~.
+    // Today both lockstep (root version) and pinned (root dependencies) sources
+    // are bare version strings. A future change that makes one a range would
+    // produce a malformed `^^…` expected peer — fail loudly instead.
+    if (/^[\^~]/.test(sourceValue)) {
+      mismatches.push({
+        pkg,
+        reason: `Source value ${JSON.stringify(sourceValue)} has a leading ^/~ (${sourceKind}) — cannot derive a clean expected peer; fix the source to be an exact string`,
+        expected: `^${sourceValue} (MALFORMED — double-caret)`,
+        actual: zudoDocPkg.peerDependencies?.[pkg] ?? "(missing)",
+        file: ZUDO_DOC_PKG_PATH,
+        field: "peerDependencies",
+        kind: "first-party-peer",
+      });
+      continue;
+    }
+
+    const expectedPeer = `^${sourceValue}`;
+    const actualPeer = zudoDocPkg.peerDependencies?.[pkg];
+
+    if (actualPeer !== expectedPeer) {
+      mismatches.push({
+        pkg,
+        reason: `First-party peer floor drift — stale floor will reject the current ${sourceKind} (#2381 / #2445)`,
+        expected: expectedPeer,
+        actual: actualPeer ?? "(missing)",
+        file: ZUDO_DOC_PKG_PATH,
+        field: "peerDependencies",
+        kind: "first-party-peer",
+      });
+    }
+  }
+
   if (mismatches.length === 0) {
     console.log(
-      `OK — pin parity verified for ${PINNED_PACKAGES.length} external + ${INTERNAL_PINNED_PACKAGES.length} internal + ${ZUDO_DOC_ZFB_PACKAGES.length * 2} workspace-package field(s):`,
+      `OK — pin parity verified for ${PINNED_PACKAGES.length} external + ${INTERNAL_PINNED_PACKAGES.length} internal + ${ZUDO_DOC_ZFB_PACKAGES.length * 2} workspace-package field(s) + ${FIRST_PARTY_PEER_CHECKS.length} first-party peer floor(s):`,
     );
     for (const pkgName of PINNED_PACKAGES) {
       console.log(`  ${pkgName} = ${rootPkg.dependencies[pkgName]}`);
@@ -264,6 +347,12 @@ function main() {
         `  packages/zudo-doc peerDependencies[${pkgName}] = ${zudoDocPkg.peerDependencies?.[pkgName]} (^${rootPin})`,
       );
     }
+    for (const { pkg, getSource } of FIRST_PARTY_PEER_CHECKS) {
+      const sourceValue = getSource(rootPkg);
+      console.log(
+        `  packages/zudo-doc peerDependencies[${pkg}] = ${zudoDocPkg.peerDependencies?.[pkg]} (matched ^${sourceValue})`,
+      );
+    }
     return 0;
   }
 
@@ -281,6 +370,12 @@ function main() {
       console.error(`  [${m.pkg}]  ${m.reason}`);
       console.error(`    expected (release version): ${m.rootPin}`);
       console.error(`    scaffold.ts:                ${m.scaffoldPin ?? "(missing)"}`);
+    } else if (m.kind === "first-party-peer") {
+      console.error(`  [${m.pkg}]  ${m.reason}`);
+      console.error(`    file:     ${m.file}`);
+      console.error(`    field:    ${m.field}`);
+      console.error(`    expected: ${m.expected}`);
+      console.error(`    actual:   ${m.actual}`);
     } else {
       // workspace-package
       console.error(`  [${m.pkg}]  ${m.reason}`);


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2455
    - https://github.com/zudolab/zudo-doc/issues/2454 (epic)
    - https://github.com/zudolab/zudo-doc/issues/2445 (superseded source)

---

## Summary

Fixes the live parts of #2445 (2nd recurrence of the #2381 stale-first-party-peer-floor bug class).

**Part A — packaging fix + systemic parity guard**
- `packages/zudo-doc/package.json`: `@takazudo/zudo-doc-history-server` peer floor `^1.2.0` → `^2.0.1` (lockstep-strict = `^<root version>`). The doc/history family releases in lockstep at the root `version` (`2.0.1`); the old `^1.2.0` floor (with `.npmrc auto-install-peers=true`) forced pnpm to resolve a **stale published `1.2.0`** instead of the co-released `2.0.1`. (`@takazudo/zdtp` was already correct at `^0.4.1`.)
- `scripts/check-pin-parity.mjs`: new `FIRST_PARTY_PEER_CHECKS` block asserts both first-party peer floors stay in sync with their source-of-truth (history-server → root `version`; zdtp → root `dependencies["@takazudo/zdtp"]`) — a stale floor now FAILS the check, so a future major bump can't silently re-stale it (the systemic fix for this recurrence). Also folds the sibling gap: added `@takazudo/zdtp` to `PINNED_PACKAGES` (scaffold↔root-dep parity). Includes leading-`^/~` double-caret insurance. Semver-free.
- `pnpm-lock.yaml` regenerated — history-server now resolves `2.0.1` (drops the stale external `1.2.0`).

**Part B — ChromeContext runtime guard + migration note (secondary finding)**
- New `packages/zudo-doc/src/chrome/assert-chrome-context.ts`: `assertChromeContext(ctx, factoryName)` (pure, node-free; null-safe `== null`) throws a clear, actionable error when a consumer passes the pre-2.0 deps-bag (missing the required `hostBindings`) instead of the opaque `TypeError: ... reading 'tagVocabulary'`.
- Called at the top of **all 14** public `ChromeContext` factories (the 4 main-chrome + 5 doc-area + 5 page-level composition factories).
- New vitest coverage; 2.0 migration note added to `packages/zudo-doc/API.md`.

## Review
Opus code review: Part A solid (every parity failure-mode independently verified); Part B's initial 9-factory scope had a coverage gap (3 directly-callable public factories still threw the opaque error) — closed in the follow-up commit (now all 14 guarded + null-safe + migration note broadened).

## Test Plan
- `node scripts/check-pin-parity.mjs` → passes; demonstrated it FAILS on a temporary `^1.2.0` revert.
- `pnpm --filter @takazudo/zudo-doc test` → 857 passed.
- `pnpm check` → no errors.
- Showcase build → 337 pages, guard never trips on the real wired context.
- `pnpm install` clean; regenerated lockfile committed.