### PR TITLE
fix(zudo-doc): correct non-existent _chrome-context.ts comment references (#2436)

### DIFF
--- a/packages/create-zudo-doc/templates/base/pages/lib/_chrome.ts
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_chrome.ts
@@ -58,7 +58,7 @@ import docHistoryMeta from "#doc-history-meta";
 
 // ---------------------------------------------------------------------------
 // Footer tag loader (host-side; moved verbatim from the former
-// _chrome-context.ts / _footer-with-defaults.tsx). Reads collections via
+// _footer-with-defaults.tsx). Reads collections via
 // stableDocs / memoizeDerived and aggregates tags per locale. Threaded as
 // hostBindings.loadTagsForLocale.
 // ---------------------------------------------------------------------------

--- a/packages/create-zudo-doc/templates/base/pages/lib/_doc-route-entries.ts
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_doc-route-entries.ts
@@ -1,6 +1,6 @@
 // Thin shim — the memoized doc-route-entry builder rides on the unified
 // ChromeContext now (epic Collapse Wiring Shells #2420, FACTORIES #2424).
-// `createRouteContext` (in _chrome-context.ts) assembles `buildDocRouteEntries`
+// `createRouteContext` (in _route-context.ts) assembles `buildDocRouteEntries`
 // as part of the route context; this module just re-exports it so the doc-route
 // page files keep importing it from here unchanged.
 

--- a/packages/create-zudo-doc/templates/base/pages/lib/_nav-source-docs.ts
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_nav-source-docs.ts
@@ -1,6 +1,6 @@
 // Thin shim — nav-source resolvers ride on the unified ChromeContext now
 // (epic Collapse Wiring Shells #2420, FACTORIES #2424). The reconstructed
-// `createRouteContext` (in _chrome-context.ts) builds the identity-stable
+// `createRouteContext` (in _route-context.ts) builds the identity-stable
 // nav-source API as part of the route context; this module just re-exports the
 // bindings so the existing call sites (route files, nav wrappers, _nav-data-prep,
 // route-enumerators) keep importing them from here unchanged.

--- a/packages/create-zudo-doc/templates/base/pages/lib/_route-context.ts
+++ b/packages/create-zudo-doc/templates/base/pages/lib/_route-context.ts
@@ -3,7 +3,7 @@
 // + route enumerators), built ONCE via the public `createRouteContext`
 // (epic Collapse Wiring Shells #2420, FACTORIES #2424).
 //
-// Kept SEPARATE from `_chrome-context.ts` so the data shells (`_nav-source-docs`
+// Kept SEPARATE from `_chrome.ts` so the data shells (`_nav-source-docs`
 // / `_doc-route-entries` / `route-enumerators`) — and the unit tests that import
 // them — depend ONLY on this lightweight module, NOT on the chrome host bindings
 // (which pull the build-time `#doc-history-meta` alias + island components that

--- a/pages/lib/_chrome.ts
+++ b/pages/lib/_chrome.ts
@@ -58,7 +58,7 @@ import docHistoryMeta from "#doc-history-meta";
 
 // ---------------------------------------------------------------------------
 // Footer tag loader (host-side; moved verbatim from the former
-// _chrome-context.ts / _footer-with-defaults.tsx). Reads collections via
+// _footer-with-defaults.tsx). Reads collections via
 // stableDocs / memoizeDerived and aggregates tags per locale. Threaded as
 // hostBindings.loadTagsForLocale.
 // ---------------------------------------------------------------------------

--- a/pages/lib/_doc-route-entries.ts
+++ b/pages/lib/_doc-route-entries.ts
@@ -1,6 +1,6 @@
 // Thin shim — the memoized doc-route-entry builder rides on the unified
 // ChromeContext now (epic Collapse Wiring Shells #2420, FACTORIES #2424).
-// `createRouteContext` (in _chrome-context.ts) assembles `buildDocRouteEntries`
+// `createRouteContext` (in _route-context.ts) assembles `buildDocRouteEntries`
 // as part of the route context; this module just re-exports it so the doc-route
 // page files keep importing it from here unchanged.
 

--- a/pages/lib/_nav-source-docs.ts
+++ b/pages/lib/_nav-source-docs.ts
@@ -1,6 +1,6 @@
 // Thin shim — nav-source resolvers ride on the unified ChromeContext now
 // (epic Collapse Wiring Shells #2420, FACTORIES #2424). The reconstructed
-// `createRouteContext` (in _chrome-context.ts) builds the identity-stable
+// `createRouteContext` (in _route-context.ts) builds the identity-stable
 // nav-source API as part of the route context; this module just re-exports the
 // bindings so the existing call sites (route files, nav wrappers, _nav-data-prep,
 // route-enumerators) keep importing them from here unchanged.

--- a/pages/lib/_route-context.ts
+++ b/pages/lib/_route-context.ts
@@ -3,7 +3,7 @@
 // + route enumerators), built ONCE via the public `createRouteContext`
 // (epic Collapse Wiring Shells #2420, FACTORIES #2424).
 //
-// Kept SEPARATE from `_chrome-context.ts` so the data shells (`_nav-source-docs`
+// Kept SEPARATE from `_chrome.ts` so the data shells (`_nav-source-docs`
 // / `_doc-route-entries` / `route-enumerators`) — and the unit tests that import
 // them — depend ONLY on this lightweight module, NOT on the chrome host bindings
 // (which pull the build-time `#doc-history-meta` alias + island components that


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2467
    - https://github.com/zudolab/zudo-doc/issues/2466 (epic)
    - https://github.com/zudolab/zudo-doc/issues/2436 (superseded source)

---

## Summary

Fixes #2436. Four `pages/lib/*` comment lines referenced a file `_chrome-context.ts` that the 2.0 scaffold never creates (`createChrome` is inline in `_chrome.ts`; `createRouteContext` is in `_route-context.ts`). Corrected in **both** the showcase `pages/lib/` and the `templates/base/pages/lib/` copies (byte-tracked by the template-drift gate, so both must match).

## Changes (comments-only — 8 comment-line swaps, 0 logic changes)

- `_doc-route-entries.ts`, `_nav-source-docs.ts`: `createRouteContext (in _chrome-context.ts)` → `(in _route-context.ts)` (where it actually lives).
- `_route-context.ts`: `Kept SEPARATE from \`_chrome-context.ts\`` → `_chrome.ts` — the chrome host-bindings module (NOT self-referential `_route-context.ts`, which the issue's literal sed would have produced).
- `_chrome.ts`: dropped the stale `_chrome-context.ts /` fragment (the footer tag loader's provenance is `_footer-with-defaults.tsx`).

## Test Plan

- `grep -rn '_chrome-context' --include='*.ts' --include='*.tsx'` (excl. node_modules/dist) → nothing remains.
- Showcase ↔ template copies byte-identical for all 4 files; `pnpm check:template-drift` → ✅ no drift.
- `pnpm check` (typecheck) → no errors.