### PR TITLE
fix(release): relax pin-parity first-party peer floor to satisfies-based (unblock lockstep release)

### DIFF
--- a/.claude/skills/l-make-release/SKILL.md
+++ b/.claude/skills/l-make-release/SKILL.md
@@ -214,6 +214,18 @@ pnpm b4push
 
 Fix any failures and recommit before proceeding. Do not tag until b4push is fully green.
 
+> **Do NOT bump the `@takazudo/zudo-doc-history-server` peer floor.** The release
+> script intentionally leaves `packages/zudo-doc/package.json`
+> `peerDependencies["@takazudo/zudo-doc-history-server"]` alone. That floor names
+> an **already-published** version (the showcase resolves the peer from the npm
+> registry under `--frozen-lockfile`), so raising it to the in-flight release
+> version makes the lockfile unresolvable and deadlocks CI **and** the publish
+> workflows. The floor lags by design and is adopted *after* publish via
+> `/l-bump-deps`. The pin-parity guard uses satisfies-semantics for this peer, so a
+> same-major lag (e.g. floor `^2.0.1` at release `2.1.0`) **passes** and only emits
+> a non-fatal advisory — do not "fix" that advisory by editing the floor here. See
+> RELEASE.md → "First-party peer floor (publish-lag)".
+
 ## Step 5 — Commit
 
 Stage and commit all changed files:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -126,6 +126,35 @@ maintain the order above for any that do change.
 
 ---
 
+## First-party peer floor (publish-lag)
+
+`packages/zudo-doc/package.json` declares `@takazudo/zudo-doc-history-server` as a
+**peerDependency** with a caret floor (e.g. `^2.0.1`). The showcase resolves this
+peer from the **npm registry** (not a workspace link), and every install — local,
+CI, and the publish workflows — runs `pnpm install --frozen-lockfile`. So the floor
+can only ever name an **already-published** version.
+
+**Do NOT bump this floor to the in-flight release version during a release.** The
+release script (`scripts/release-create-zudo-doc.sh`) deliberately does **not**
+touch it: bumping it to the version being released (not yet on npm) makes the frozen
+lockfile unresolvable and deadlocks both main CI and the publish workflows.
+
+Instead the floor **lags by design** and is adopted *after* the version publishes,
+through the normal dependency-bump cycle (`/l-bump-deps`) — exactly like the zfb /
+zdtp pins. A lagging same-major floor is correct: `^2.0.1` is satisfied by a
+`@takazudo/zudo-doc@2.1.0` install.
+
+The pin-parity guard (`scripts/check-pin-parity.mjs`) enforces this with
+**satisfies-semantics** for the lockstep peer: it fails only when the floor would
+**exclude** the root version (a cross-major drift like `^1.x` at root `2.x`, or a
+floor above root like `^2.2.0` at root `2.1.0`), and prints a non-fatal advisory
+when a valid floor lags. A clean linear release therefore needs no interleaving:
+
+> bump versions + scaffold pins → `pnpm b4push` → commit → push → main CI green →
+> tag → publish all three in publish-order.
+
+---
+
 ## Tag namespaces and Draft Release model
 
 Each package has its own tag namespace and its own publish workflow. Publishing a

--- a/scripts/__tests__/check-pin-parity.test.ts
+++ b/scripts/__tests__/check-pin-parity.test.ts
@@ -60,6 +60,15 @@ describe("satisfiesCaret", () => {
     expect(satisfiesCaret("2.1.0", "~2.1.0")).toBeNull();
     expect(satisfiesCaret("2.1.0", ">=2.0.0")).toBeNull();
   });
+
+  it("compares a prerelease root on its core triple (intentional — avoids the publish-lag deadlock)", () => {
+    // Strict npm semantics would say `^2.1.0` excludes `2.2.0-next.1`; this guard
+    // deliberately compares cores so a prerelease release isn't forced to name an
+    // unpublished prerelease in the floor. See satisfiesCaret() docs / RELEASE.md.
+    expect(satisfiesCaret("2.2.0-next.1", "^2.1.0")).toBe(true);
+    // Cross-major staleness is still caught even for a prerelease root.
+    expect(satisfiesCaret("2.0.0-next.1", "^1.5.0")).toBe(false);
+  });
 });
 
 describe("evaluateFirstPartyPeer — lockstep (satisfies)", () => {

--- a/scripts/__tests__/check-pin-parity.test.ts
+++ b/scripts/__tests__/check-pin-parity.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  parseSemverCore,
+  satisfiesCaret,
+  evaluateFirstPartyPeer,
+} from "../check-pin-parity.mjs";
+
+describe("parseSemverCore", () => {
+  it("parses a plain version", () => {
+    expect(parseSemverCore("2.1.0")).toEqual({ major: 2, minor: 1, patch: 0 });
+  });
+
+  it("tolerates a leading caret", () => {
+    expect(parseSemverCore("^2.0.1")).toEqual({ major: 2, minor: 0, patch: 1 });
+  });
+
+  it("drops prerelease / build suffixes", () => {
+    expect(parseSemverCore("0.1.0-next.71")).toEqual({
+      major: 0,
+      minor: 1,
+      patch: 0,
+    });
+  });
+
+  it("returns null for unparseable input", () => {
+    expect(parseSemverCore("latest")).toBeNull();
+    expect(parseSemverCore("2.1")).toBeNull();
+    expect(parseSemverCore(undefined as unknown as string)).toBeNull();
+  });
+});
+
+describe("satisfiesCaret", () => {
+  it("accepts a same-major lagging floor (the publish-lag case)", () => {
+    expect(satisfiesCaret("2.1.0", "^2.0.1")).toBe(true);
+  });
+
+  it("accepts an exact-match floor", () => {
+    expect(satisfiesCaret("2.1.0", "^2.1.0")).toBe(true);
+  });
+
+  it("rejects a cross-major stale floor (#2381 / #2445)", () => {
+    // 2.0.1 is NOT within ^1.2.0 (caret on major 1 stops below 2.0.0).
+    expect(satisfiesCaret("2.0.1", "^1.2.0")).toBe(false);
+  });
+
+  it("rejects a floor above the root version", () => {
+    expect(satisfiesCaret("2.1.0", "^2.2.0")).toBe(false);
+  });
+
+  it("honors 0.x caret semantics", () => {
+    expect(satisfiesCaret("0.4.5", "^0.4.1")).toBe(true);
+    expect(satisfiesCaret("0.5.0", "^0.4.1")).toBe(false);
+    expect(satisfiesCaret("0.0.4", "^0.0.4")).toBe(true);
+    expect(satisfiesCaret("0.0.5", "^0.0.4")).toBe(false);
+  });
+
+  it("returns null for non-caret range forms (loud failure upstream)", () => {
+    expect(satisfiesCaret("2.1.0", "2.1.0")).toBeNull();
+    expect(satisfiesCaret("2.1.0", "~2.1.0")).toBeNull();
+    expect(satisfiesCaret("2.1.0", ">=2.0.0")).toBeNull();
+  });
+});
+
+describe("evaluateFirstPartyPeer — lockstep (satisfies)", () => {
+  const base = {
+    pkg: "@takazudo/zudo-doc-history-server",
+    sourceKind: "lockstep (root version)",
+    comparison: "satisfies" as const,
+  };
+
+  it("(a) PASSES when the floor lags but still includes the root version", () => {
+    const res = evaluateFirstPartyPeer({
+      ...base,
+      sourceValue: "2.1.0",
+      actualPeer: "^2.0.1",
+    });
+    expect(res.ok).toBe(true);
+    // A lagging-but-valid floor emits a non-fatal advisory nudging a bump.
+    expect(res.advisory).toBeTruthy();
+  });
+
+  it("(b) PASSES on an exact match with no advisory", () => {
+    const res = evaluateFirstPartyPeer({
+      ...base,
+      sourceValue: "2.1.0",
+      actualPeer: "^2.1.0",
+    });
+    expect(res.ok).toBe(true);
+    expect(res.advisory).toBeUndefined();
+  });
+
+  it("(c) FAILS on a cross-major stale floor", () => {
+    const res = evaluateFirstPartyPeer({
+      ...base,
+      sourceValue: "2.0.1",
+      actualPeer: "^1.2.0",
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("(d) FAILS when the floor is above the root version", () => {
+    const res = evaluateFirstPartyPeer({
+      ...base,
+      sourceValue: "2.1.0",
+      actualPeer: "^2.2.0",
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("FAILS loudly on an unrecognizable (non-caret) floor", () => {
+    const res = evaluateFirstPartyPeer({
+      ...base,
+      sourceValue: "2.1.0",
+      actualPeer: "~2.0.1",
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("FAILS when the floor is missing", () => {
+    const res = evaluateFirstPartyPeer({
+      ...base,
+      sourceValue: "2.1.0",
+      actualPeer: undefined,
+    });
+    expect(res.ok).toBe(false);
+    expect(res.actual).toBe("(missing)");
+  });
+});
+
+describe("evaluateFirstPartyPeer — pinned (exact)", () => {
+  const base = {
+    pkg: "@takazudo/zdtp",
+    sourceKind: 'pinned (root dependencies["@takazudo/zdtp"])',
+    comparison: "exact" as const,
+  };
+
+  it("(e) PASSES only on exact equality", () => {
+    expect(
+      evaluateFirstPartyPeer({ ...base, sourceValue: "0.4.1", actualPeer: "^0.4.1" }).ok,
+    ).toBe(true);
+  });
+
+  it("(e) FAILS a lagging floor even though it would satisfy — pinned stays strict", () => {
+    const res = evaluateFirstPartyPeer({
+      ...base,
+      sourceValue: "0.4.1",
+      actualPeer: "^0.4.0",
+    });
+    expect(res.ok).toBe(false);
+  });
+});

--- a/scripts/check-pin-parity.mjs
+++ b/scripts/check-pin-parity.mjs
@@ -163,10 +163,10 @@ function readScaffoldPin(scaffoldSrc, pkgName) {
 /**
  * Parse the core "MAJOR.MINOR.PATCH" of a version or caret range into numeric
  * parts. A single leading `^` is tolerated; a `-prerelease` / `+build` suffix is
- * dropped (the lockstep first-party peers compared here are clean releases — the
- * prerelease zfb pins go through a different, exact block). Returns null when the
- * three numeric segments can't be read, so callers fail loudly rather than
- * silently mis-judging an unexpected range form.
+ * deliberately dropped — see satisfiesCaret() for why this guard compares on the
+ * core triple rather than applying strict npm prerelease semantics. Returns null
+ * when the three numeric segments can't be read, so callers fail loudly rather
+ * than silently mis-judging an unexpected range form.
  */
 export function parseSemverCore(value) {
   if (typeof value !== "string") return null;
@@ -185,6 +185,16 @@ export function parseSemverCore(value) {
  *   ^0.0.C       → >=0.0.C  <0.0.(C+1)
  * Returns null when `caretRange` isn't a caret range or either side can't be
  * parsed (callers treat null as a loud failure, never a silent pass).
+ *
+ * Prerelease handling is INTENTIONALLY non-strict: comparison is on the core
+ * MAJOR.MINOR.PATCH triple, ignoring any `-prerelease` identifier. Strict npm
+ * semantics ("a prerelease only satisfies a range whose comparator carries a
+ * matching prerelease tag") would, for a prerelease lockstep root like
+ * `2.2.0-next.1`, demand the floor name that very prerelease — which is NOT yet
+ * published and would reintroduce the publish-lag deadlock this check exists to
+ * avoid (see RELEASE.md "publish-lag"). Core comparison still catches the case
+ * this guard cares about — cross-major staleness — e.g. `2.0.0-next.1` vs
+ * `^1.5.0` parses to core `2.0.0`, which is excluded by `^1.x` → fail.
  */
 export function satisfiesCaret(version, caretRange) {
   if (typeof caretRange !== "string" || !caretRange.trim().startsWith("^")) {

--- a/scripts/check-pin-parity.mjs
+++ b/scripts/check-pin-parity.mjs
@@ -31,7 +31,7 @@
 //   - .github/workflows/pr-checks.yml (own lightweight job)
 
 import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { dirname, resolve } from "node:path";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -86,16 +86,31 @@ const ZUDO_DOC_ZFB_PACKAGES = ["@takazudo/zfb", "@takazudo/zfb-runtime"];
 // Insurance: both sources are exact strings today (no leading ^/~). The check
 // below rejects a future ranged source value that would produce a malformed `^^…`
 // expected peer, making the breakage loud rather than silently wrong.
+// `comparison` selects how the actual floor is judged against the source value:
+//   "satisfies" — the root version must fall WITHIN the declared floor range.
+//                 A floor is only stale when it EXCLUDES the root version. This
+//                 permits a benign same-major lag (^2.0.1 at root 2.1.0), which
+//                 the lockstep release REQUIRES: the showcase resolves this peer
+//                 from the npm registry under --frozen-lockfile, so the floor can
+//                 only point at an already-published version and is bumped
+//                 post-publish via the /l-bump-deps cycle (see RELEASE.md
+//                 "publish-lag"). Demanding exact `^<root>` here deadlocked the
+//                 release (the in-flight version isn't on npm yet).
+//   "exact"     — floor must equal `^<sourceValue>`. Used for the pinned (not
+//                 lockstep) zdtp peer: it's an external dep that is always
+//                 already published, so there is no bootstrap reason to lag it.
 const FIRST_PARTY_PEER_CHECKS = [
   {
     pkg: "@takazudo/zudo-doc-history-server",
     sourceKind: "lockstep (root version)",
+    comparison: "satisfies",
     // Released at the same lockstep version as the root package.
     getSource: (rootPkg) => rootPkg.version,
   },
   {
     pkg: "@takazudo/zdtp",
     sourceKind: 'pinned (root dependencies["@takazudo/zdtp"])',
+    comparison: "exact",
     // External dependency pinned in root dependencies — NOT lockstep.
     getSource: (rootPkg) => rootPkg.dependencies?.["@takazudo/zdtp"],
   },
@@ -143,6 +158,127 @@ function readScaffoldPin(scaffoldSrc, pkgName) {
   );
   const constMatch = scaffoldSrc.match(constRe);
   return constMatch ? constMatch[1] : null;
+}
+
+/**
+ * Parse the core "MAJOR.MINOR.PATCH" of a version or caret range into numeric
+ * parts. A single leading `^` is tolerated; a `-prerelease` / `+build` suffix is
+ * dropped (the lockstep first-party peers compared here are clean releases — the
+ * prerelease zfb pins go through a different, exact block). Returns null when the
+ * three numeric segments can't be read, so callers fail loudly rather than
+ * silently mis-judging an unexpected range form.
+ */
+export function parseSemverCore(value) {
+  if (typeof value !== "string") return null;
+  const core = value.trim().replace(/^\^/, "").split(/[-+]/, 1)[0];
+  const m = core.match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!m) return null;
+  return { major: Number(m[1]), minor: Number(m[2]), patch: Number(m[3]) };
+}
+
+/**
+ * Does `version` fall within the caret range `caretRange` (e.g. "^2.0.1")?
+ * Implements npm caret semantics without pulling in `semver` (this guard ships
+ * dependency-free — it imports only node builtins):
+ *   ^A.B.C, A>0  → >=A.B.C  <(A+1).0.0
+ *   ^0.B.C, B>0  → >=0.B.C  <0.(B+1).0
+ *   ^0.0.C       → >=0.0.C  <0.0.(C+1)
+ * Returns null when `caretRange` isn't a caret range or either side can't be
+ * parsed (callers treat null as a loud failure, never a silent pass).
+ */
+export function satisfiesCaret(version, caretRange) {
+  if (typeof caretRange !== "string" || !caretRange.trim().startsWith("^")) {
+    return null;
+  }
+  const v = parseSemverCore(version);
+  const lo = parseSemverCore(caretRange);
+  if (!v || !lo) return null;
+  const cmp = (a, b) =>
+    a.major - b.major || a.minor - b.minor || a.patch - b.patch;
+  if (cmp(v, lo) < 0) return false; // below the floor
+  let hi;
+  if (lo.major > 0) hi = { major: lo.major + 1, minor: 0, patch: 0 };
+  else if (lo.minor > 0) hi = { major: 0, minor: lo.minor + 1, patch: 0 };
+  else hi = { major: 0, minor: 0, patch: lo.patch + 1 };
+  return cmp(v, hi) < 0;
+}
+
+/**
+ * @typedef {Object} PeerEvalResult
+ * @property {boolean} ok          Whether the floor is acceptable.
+ * @property {string}  expected    The canonical/expected floor for messaging.
+ * @property {string}  actual      The actual floor (or "(missing)").
+ * @property {string}  [reason]    Failure explanation (present when !ok).
+ * @property {string}  [advisory]  Non-fatal note emitted when a valid
+ *                                 `satisfies` floor lags the root version.
+ */
+
+/**
+ * Evaluate one first-party peer floor against its source-of-truth version.
+ * See FIRST_PARTY_PEER_CHECKS for the `comparison` modes.
+ *
+ * @param {Object} args
+ * @param {string} args.pkg
+ * @param {string} args.sourceKind
+ * @param {string} args.sourceValue   Exact version (no leading ^/~).
+ * @param {"satisfies"|"exact"} args.comparison
+ * @param {string|undefined|null} args.actualPeer
+ * @returns {PeerEvalResult}
+ */
+export function evaluateFirstPartyPeer({
+  pkg,
+  sourceKind,
+  sourceValue,
+  comparison,
+  actualPeer,
+}) {
+  const expectedPeer = `^${sourceValue}`;
+  const actual = actualPeer ?? "(missing)";
+
+  if (actualPeer === undefined || actualPeer === null) {
+    return {
+      ok: false,
+      expected: expectedPeer,
+      actual,
+      reason: `Missing first-party peer floor for ${pkg} (${sourceKind})`,
+    };
+  }
+
+  if (comparison === "exact") {
+    if (actualPeer !== expectedPeer) {
+      return {
+        ok: false,
+        expected: expectedPeer,
+        actual,
+        reason: `First-party peer floor drift — ${sourceKind} requires exactly ${expectedPeer}`,
+      };
+    }
+    return { ok: true, expected: expectedPeer, actual };
+  }
+
+  // comparison === "satisfies": the root version must fall within the floor range.
+  const includesRoot = satisfiesCaret(sourceValue, actualPeer);
+  if (includesRoot === null) {
+    return {
+      ok: false,
+      expected: `a caret range that includes ${sourceValue} (e.g. ${expectedPeer})`,
+      actual,
+      reason: `First-party peer floor ${actual} is not a recognizable caret range — cannot verify it includes the current ${sourceKind} ${sourceValue}`,
+    };
+  }
+  if (!includesRoot) {
+    return {
+      ok: false,
+      expected: `a range that includes ${sourceValue} (e.g. ${expectedPeer})`,
+      actual,
+      reason: `First-party peer floor stale — ${actual} does NOT include the current ${sourceKind} ${sourceValue} (#2381 / #2445)`,
+    };
+  }
+  const result = { ok: true, expected: expectedPeer, actual };
+  if (actualPeer !== expectedPeer) {
+    result.advisory = `${pkg} peer floor ${actual} lags the lockstep version ${sourceValue} (still valid — root is within range). Bump it to ${expectedPeer} when convenient, e.g. via /l-bump-deps after the version publishes.`;
+  }
+  return result;
 }
 
 function main() {
@@ -273,10 +409,19 @@ function main() {
   }
 
   // ── First-party peer floors in packages/zudo-doc peerDependencies ────────────
-  // Guards the recurrence class from #2381 / #2445: the zfb ZUDO_DOC_ZFB_PACKAGES
-  // loop above only covers the zfb pair; these two first-party peers were unguarded
-  // and went stale on the 2.0.1 major bump. This block catches the same pattern.
-  for (const { pkg, sourceKind, getSource } of FIRST_PARTY_PEER_CHECKS) {
+  // Guards the recurrence class from #2381 / #2445: a first-party peer floor that
+  // EXCLUDES the lockstep root version (e.g. ^1.x left behind on a 2.x major bump).
+  // The lockstep peer (history-server) is judged with satisfies-semantics — a
+  // benign same-major lag is allowed (see evaluateFirstPartyPeer + RELEASE.md
+  // "publish-lag"); the pinned peer (zdtp) stays exact.
+  const firstPartyAdvisories = [];
+  const firstPartyOk = [];
+  for (const {
+    pkg,
+    sourceKind,
+    getSource,
+    comparison,
+  } of FIRST_PARTY_PEER_CHECKS) {
     const sourceValue = getSource(rootPkg);
 
     if (!sourceValue) {
@@ -292,10 +437,8 @@ function main() {
       continue;
     }
 
-    // Insurance: assert source is an exact string with no leading ^/~.
-    // Today both lockstep (root version) and pinned (root dependencies) sources
-    // are bare version strings. A future change that makes one a range would
-    // produce a malformed `^^…` expected peer — fail loudly instead.
+    // Insurance: the source-of-truth must be an exact version string with no
+    // leading ^/~ — otherwise `^${sourceValue}` would be a malformed double-caret.
     if (/^[\^~]/.test(sourceValue)) {
       mismatches.push({
         pkg,
@@ -309,20 +452,33 @@ function main() {
       continue;
     }
 
-    const expectedPeer = `^${sourceValue}`;
-    const actualPeer = zudoDocPkg.peerDependencies?.[pkg];
-
-    if (actualPeer !== expectedPeer) {
+    const res = evaluateFirstPartyPeer({
+      pkg,
+      sourceKind,
+      sourceValue,
+      comparison,
+      actualPeer: zudoDocPkg.peerDependencies?.[pkg],
+    });
+    if (!res.ok) {
       mismatches.push({
         pkg,
-        reason: `First-party peer floor drift — stale floor will reject the current ${sourceKind} (#2381 / #2445)`,
-        expected: expectedPeer,
-        actual: actualPeer ?? "(missing)",
+        reason: res.reason,
+        expected: res.expected,
+        actual: res.actual,
         file: ZUDO_DOC_PKG_PATH,
         field: "peerDependencies",
         kind: "first-party-peer",
       });
+    } else {
+      firstPartyOk.push({ pkg, actual: res.actual, expected: res.expected });
+      if (res.advisory) firstPartyAdvisories.push(res.advisory);
     }
+  }
+
+  // Non-fatal advisories (e.g. a valid-but-lagging lockstep floor) — print
+  // regardless of overall pass/fail so the nudge isn't buried on a failing run.
+  for (const note of firstPartyAdvisories) {
+    console.log(`note: ${note}`);
   }
 
   if (mismatches.length === 0) {
@@ -347,10 +503,11 @@ function main() {
         `  packages/zudo-doc peerDependencies[${pkgName}] = ${zudoDocPkg.peerDependencies?.[pkgName]} (^${rootPin})`,
       );
     }
-    for (const { pkg, getSource } of FIRST_PARTY_PEER_CHECKS) {
-      const sourceValue = getSource(rootPkg);
+    for (const { pkg, actual, expected } of firstPartyOk) {
+      const how =
+        actual === expected ? `matched ${expected}` : `includes root (${expected})`;
       console.log(
-        `  packages/zudo-doc peerDependencies[${pkg}] = ${zudoDocPkg.peerDependencies?.[pkg]} (matched ^${sourceValue})`,
+        `  packages/zudo-doc peerDependencies[${pkg}] = ${actual} (${how})`,
       );
     }
     return 0;
@@ -394,10 +551,14 @@ function main() {
   console.error(`  - ${SCAFFOLD_TS_PATH}`);
   console.error(`  - ${ZUDO_DOC_PKG_PATH}`);
   console.error(
-    `      devDependencies must be exact-equal to root pins; peerDependencies must be ^<root pin>`,
+    `      devDependencies must be exact-equal to root pins; the lockstep peer floor must INCLUDE the root version (caret range), the pinned peer floor must be ^<root pin>`,
   );
   console.error("then re-run this check.");
   return 1;
 }
 
-process.exit(main());
+const invokedDirectly =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  process.exit(main());
+}


### PR DESCRIPTION
## Summary

The pin-parity guard's first-party peer-floor check (`scripts/check-pin-parity.mjs`) required the `@takazudo/zudo-doc-history-server` floor in `packages/zudo-doc/package.json` to **strictly equal** `^<root version>`. But the showcase resolves history-server from the npm **registry** under `--frozen-lockfile`, so the floor can only ever name an **already-published** version — and during a lockstep release the new version isn't on npm until the end. That made the demand unsatisfiable mid-release and **deadlocked both main CI and the publish workflows** (hit live during the 2.1.0 release; worked around there with a fragile interleaved publish).

The guard's own failure message said "stale floor will **reject** the current lockstep" — the *intended* semantic was satisfies-based, but it was implemented as strict equality. `^2.0.1` does **not** reject root `2.1.0` (2.1.0 satisfies `^2.0.1`); it's a benign same-major lag — the historical, working pattern, adopted post-publish via `/l-bump-deps`.

## Changes

- **`scripts/check-pin-parity.mjs`** — the lockstep first-party peer (history-server) is now judged with **satisfies-semantics**: the root version must fall within the floor's caret range. It fails only on genuine staleness — a cross-major drift (`^1.x` at root `2.x`, the #2381/#2445 case) or a floor above root (`^2.2.0` at root `2.1.0`) — and prints a **non-fatal advisory** when a valid floor lags. The pinned peer (zdtp, external/always-published) stays **exact**, selected via a new `comparison` field on `FIRST_PARTY_PEER_CHECKS`. The caret comparator is a small **dependency-free** inline implementation (the guard imports only node builtins). `main()` is now guarded behind an `import.meta`/`process.argv` check and the pure helpers are exported so they're unit-testable; CLI behavior is unchanged.
- **`scripts/__tests__/check-pin-parity.test.ts`** (new) — 19 cases: lag-passes, exact-passes, cross-major-fails, floor-above-fails, zdtp-stays-strict, 0.x caret rules, non-caret loud-fail, missing floor, and intentional prerelease core-comparison.
- **`RELEASE.md` + `.claude/skills/l-make-release/SKILL.md`** — document the **publish-lag**: the floor is bumped to adopt an *already-published* version (never the in-flight one), the release script deliberately doesn't touch it, and the linear release flow needs no interleaving.

## Test Plan

- `node scripts/check-pin-parity.mjs` → passes on the current tree.
- `pnpm exec vitest run scripts/__tests__/check-pin-parity.test.ts` → 19/19 pass (proves lag-passes / cross-major-fails / floor-above-fails / prerelease behavior).
- `pnpm check` (tsc) → clean.
- `pnpm b4push` (with `B4PUSH_SKIP_MANUAL_SMOKE=1`) → all 21 checks pass.

## Background

Surfaced during the create-zudo-doc **2.1.0** release. The new pin-parity first-party-peer-floor guard (added in #2455, *after* the prior release) conflicted with the lockstep publish-lag. Addressed by a codex review note: prerelease handling in the comparator is intentionally core-version-based to avoid reintroducing the deadlock for prerelease releases — documented in code + a test.