### PR TITLE
Bump zdtp 0.4.2 + surface the OKLCH color tweaker (#2477)

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     }
   },
   "dependencies": {
-    "@takazudo/zdtp": "0.4.1",
+    "@takazudo/zdtp": "0.4.2",
     "@takazudo/zfb": "0.1.0-next.72",
     "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.72",
     "@takazudo/zfb-runtime": "0.1.0-next.72",

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -584,7 +584,7 @@ describe("scaffold — designTokenPanel package.json wiring", () => {
     const pkg = await fs.readJson(
       projectPath("test-zdtp-deps", "package.json"),
     );
-    expect(pkg.dependencies["@takazudo/zdtp"]).toBe("0.4.1");
+    expect(pkg.dependencies["@takazudo/zdtp"]).toBe("0.4.2");
   });
 });
 

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -708,7 +708,7 @@ function generatePackageJson(choices: UserChoices) {
   if (choices.features.includes("designTokenPanel")) {
     // @takazudo/zdtp requires preact >= 10.29.1 — see the preact floor comment
     // above (~line 382) for why the floor is set there and the coupling this creates.
-    deps["@takazudo/zdtp"] = "0.4.1";
+    deps["@takazudo/zdtp"] = "0.4.2";
   }
 
   if (choices.features.includes("tagGovernance")) {

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -539,7 +539,7 @@
     "@takazudo/zfb": "^0.1.0-next.72",
     "@takazudo/zfb-runtime": "^0.1.0-next.72",
     "@takazudo/zudo-doc-history-server": "^2.1.1",
-    "@takazudo/zdtp": "^0.4.1",
+    "@takazudo/zdtp": "^0.4.2",
     "shiki": "^4.0.2",
     "zod": "^4.3.6",
     "katex": "^0.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
   .:
     dependencies:
       '@takazudo/zdtp':
-        specifier: 0.4.1
-        version: 0.4.1(preact@10.29.2)
+        specifier: 0.4.2
+        version: 0.4.2(preact@10.29.2)
       '@takazudo/zfb':
         specifier: 0.1.0-next.72
         version: 0.1.0-next.72
@@ -262,8 +262,8 @@ importers:
   packages/zudo-doc:
     dependencies:
       '@takazudo/zdtp':
-        specifier: ^0.4.1
-        version: 0.4.1(preact@10.29.2)
+        specifier: ^0.4.2
+        version: 0.4.2(preact@10.29.2)
       '@takazudo/zudo-doc-history-server':
         specifier: ^2.1.1
         version: 2.1.1
@@ -1376,8 +1376,8 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
 
-  '@takazudo/zdtp@0.4.1':
-    resolution: {integrity: sha512-Pn1jx1FdrOVIv2S08IfSwhF9VhvLEuVySCkY/BiOodPZihkqwZ4I4fl5vuxvM3BJX+0tVvRq9tIClgU4MmOPGQ==}
+  '@takazudo/zdtp@0.4.2':
+    resolution: {integrity: sha512-pii8L66REES2qbyK+cZDPHELgGvtFmQ1uNG5nwKhjhCIrhscUMWD9apVv7Nf+UIVK5411146pa/Ks68hGV6XHg==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
     peerDependencies:
@@ -4090,7 +4090,7 @@ snapshots:
       tailwindcss: 4.2.1
       vite: 7.3.5(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
 
-  '@takazudo/zdtp@0.4.1(preact@10.29.2)':
+  '@takazudo/zdtp@0.4.2(preact@10.29.2)':
     dependencies:
       culori: 4.0.2
       preact: 10.29.2

--- a/src/config/design-token-panel-config.ts
+++ b/src/config/design-token-panel-config.ts
@@ -192,7 +192,7 @@ function buildPaletteTier(): TierConfig {
       cssVar: `--zd-${i}`,
       label: `p${i}`,
       default: initial[i] ?? "#808080",
-      type: { kind: "color" },
+      type: { kind: "color", format: "oklch" },
     });
   }
   return {


### PR DESCRIPTION
Closes #2477

## Summary
zdtp 0.4.2 makes the reserved color tab honor `format: 'oklch'` (epic Takazudo/zudo-design-token-panel#434) and preserves OKLCH through seed/apply/persist (#435). Our palette is already oklch (from the migration #2471), so setting `format: 'oklch'` on the color tab's palette tier now routes its swatches through the **lossless OKLCH/HSL ColorField** (L/C/H/A sliders) while keeping the full cluster feature set (base roles, semantic→palette, scheme presets, secondary cluster).

This finally surfaces the improved color tweaker the original request was about.

## Changes
- Bump `@takazudo/zdtp` 0.4.1 → 0.4.2 in all pin-parity locations (root, `packages/zudo-doc` peer floor, `create-zudo-doc` scaffold + test).
- `format: 'oklch'` on the palette tier in `design-token-panel-config.ts`.
- create-zudo-doc template keeps native hex (downstream palettes are hex).

## Verified
- In-browser: palette swatches open the OKLCH ColorField (no native `<input type=color>`), live L/C/H/A editing works, 0 console errors.
- Local b4push: all automated steps green (typecheck, pin-parity, scaffold test 214, build, preview smoke 6/6).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2479"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785437616&installation_id=130359969&pr_number=2479&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2479&signature=811cbef7a649beaaaf4bdea9f673c8c4b4744f205d5a4f61f84546d3c62ddee6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->