### PR TITLE
fix(page-loading): mount PageLoadingOverlay on package-owned routes (#2484)

### DIFF
--- a/e2e/smoke-loading-overlay.spec.ts
+++ b/e2e/smoke-loading-overlay.spec.ts
@@ -62,6 +62,37 @@ test.describe("Loading overlay: SSG shape", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Package-owned route regression (zudolab/zudo-doc#2482).
+//
+// The smoke fixture runs `packageOwnedRoutes: true` + `dynamicPageTransition:
+// true`, so package-owned routes (e.g. `404`) render their body-end via the
+// package default `createBodyEndIslands` — NOT the host `_body-end-islands.tsx`.
+// Before #2482 that default never mounted `<PageLoadingOverlay/>`, so `404.html`
+// (and every pure package-owned page) shipped zero overlay markup while host doc
+// pages had it. The `docs/guides/page-1` case above is a host-rendered page and
+// did NOT catch this gap; `404.html` is the package-owned route that does.
+// ---------------------------------------------------------------------------
+
+test.describe("Loading overlay: package-owned route (404)", () => {
+  let html: string;
+
+  test.beforeAll(() => {
+    html = readDistFile("404.html");
+  });
+
+  test("overlay element is present on the package-owned 404 route", () => {
+    expect(html).toContain(`id="${PAGE_LOADING_OVERLAY_ID}"`);
+    expect(html).toContain('class="page-loading-overlay"');
+  });
+
+  test("nav-lifecycle bootstrap is present on the 404 route", () => {
+    expect(html).toContain("zfb:before-preparation");
+    expect(html).toContain("zfb:after-swap");
+    expect(html).toContain("data-zd-nav-pending");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // 3: pointer-events: none — browser assertion
 // ---------------------------------------------------------------------------
 

--- a/packages/zudo-doc/src/doc-body-end-islands/__tests__/body-end-islands.test.tsx
+++ b/packages/zudo-doc/src/doc-body-end-islands/__tests__/body-end-islands.test.tsx
@@ -13,6 +13,10 @@
  *      a feature-off route ships neither a dead marker nor a misleading
  *      landmark, zudolab/zudo-doc#2058).
  *   3. The three flags gate independently.
+ *   4. `dynamicPageTransition` ON emits the pure-SSR `<PageLoadingOverlay/>`
+ *      markup + self-wiring bootstrap; OFF omits it — the package-owned-routes
+ *      fix for zudolab/zudo-doc#2482 (the package default is the only body-end
+ *      mount under packageOwnedRoutes, so it must carry the overlay itself).
  *
  * The skip-ssr marker name is derived by zfb's `captureComponentName` from each
  * island's pinned `displayName` (AiChatModal / ImageEnlarge / MermaidEnlarge).
@@ -24,13 +28,24 @@ import { describe, expect, it } from "vitest";
 import { render } from "preact-render-to-string";
 import { createBodyEndIslands } from "../index.js";
 
-const ALL_ON = { aiAssistant: true, imageEnlarge: true, mermaid: true };
-const ALL_OFF = { aiAssistant: false, imageEnlarge: false, mermaid: false };
+const ALL_ON = {
+  aiAssistant: true,
+  imageEnlarge: true,
+  mermaid: true,
+  dynamicPageTransition: true,
+};
+const ALL_OFF = {
+  aiAssistant: false,
+  imageEnlarge: false,
+  mermaid: false,
+  dynamicPageTransition: false,
+};
 
 function renderIslands(settings: {
   aiAssistant: boolean;
   imageEnlarge: boolean;
   mermaid: boolean;
+  dynamicPageTransition: boolean;
 }): string {
   const BodyEndIslands = createBodyEndIslands({ settings });
   return render(<BodyEndIslands basePath="/" />);
@@ -80,6 +95,7 @@ describe("BodyEndIslands — flags gate independently", () => {
       aiAssistant: false,
       imageEnlarge: true,
       mermaid: false,
+      dynamicPageTransition: false,
     });
     expect(html).toContain('data-zfb-island-skip-ssr="ImageEnlarge"');
     expect(html).not.toContain('data-zfb-island-skip-ssr="AiChatModal"');
@@ -91,10 +107,74 @@ describe("BodyEndIslands — flags gate independently", () => {
       aiAssistant: true,
       imageEnlarge: false,
       mermaid: false,
+      dynamicPageTransition: false,
     });
     expect(html).toContain('data-zfb-island-skip-ssr="AiChatModal"');
     expect(html).toContain("AI Assistant");
     expect(html).not.toContain('data-zfb-island-skip-ssr="ImageEnlarge"');
     expect(html).not.toContain('data-zfb-island-skip-ssr="MermaidEnlarge"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PageLoadingOverlay gate (zudolab/zudo-doc#2482): under packageOwnedRoutes the
+// package default is the ONLY body-end mount, so it must emit the full-page
+// loading overlay (markup + self-wiring bootstrap script) when
+// `dynamicPageTransition` is on — mirroring the host mount in
+// `pages/lib/_body-end-islands.tsx`. Gated independently of the island flags.
+// ---------------------------------------------------------------------------
+
+describe("BodyEndIslands — page-loading overlay gates on dynamicPageTransition", () => {
+  const OVERLAY_ID = 'id="page-loading-overlay"';
+
+  it("dynamicPageTransition ON emits the overlay markup + nav-lifecycle bootstrap", () => {
+    const html = renderIslands({
+      aiAssistant: false,
+      imageEnlarge: false,
+      mermaid: false,
+      dynamicPageTransition: true,
+    });
+    expect(html).toContain(OVERLAY_ID);
+    expect(html).toContain('class="page-loading-overlay"');
+    // Self-wiring bootstrap: show on before-preparation, hide on after-swap,
+    // and flag the clicked nav link as pending.
+    expect(html).toContain("zfb:before-preparation");
+    expect(html).toContain("zfb:after-swap");
+    expect(html).toContain("data-zd-nav-pending");
+  });
+
+  it("dynamicPageTransition OFF omits the overlay entirely", () => {
+    const html = renderIslands({
+      aiAssistant: false,
+      imageEnlarge: false,
+      mermaid: false,
+      dynamicPageTransition: false,
+    });
+    expect(html).not.toContain(OVERLAY_ID);
+    expect(html).not.toContain('class="page-loading-overlay"');
+    expect(html).not.toContain("zfb:before-preparation");
+  });
+
+  it("gates independently of the island flags (overlay ON, islands OFF)", () => {
+    const html = renderIslands({
+      aiAssistant: false,
+      imageEnlarge: false,
+      mermaid: false,
+      dynamicPageTransition: true,
+    });
+    expect(html).toContain(OVERLAY_ID);
+    expect(html).not.toContain("data-zfb-island-skip-ssr");
+    expect(html).not.toContain("AI Assistant");
+  });
+
+  it("composes with an island flag (overlay ON + imageEnlarge ON)", () => {
+    const html = renderIslands({
+      aiAssistant: false,
+      imageEnlarge: true,
+      mermaid: false,
+      dynamicPageTransition: true,
+    });
+    expect(html).toContain(OVERLAY_ID);
+    expect(html).toContain('data-zfb-island-skip-ssr="ImageEnlarge"');
   });
 });

--- a/packages/zudo-doc/src/doc-body-end-islands/index.tsx
+++ b/packages/zudo-doc/src/doc-body-end-islands/index.tsx
@@ -12,13 +12,19 @@
 // the host's `pages/lib/_body-end-islands.tsx` from the serializable `settings`
 // flags the route-context virtual module already carries.
 //
-// SCOPE — package islands ONLY (gated on serializable settings):
-//   - aiAssistant  → `<h2 sr-only>AI Assistant</h2>` + skip-ssr AiChatModal
-//   - imageEnlarge → idle skip-ssr ImageEnlarge   (SSR dialog-shell fallback)
-//   - mermaid      → idle skip-ssr MermaidEnlarge (SSR dialog-shell fallback)
+// SCOPE — package islands + chrome (gated on serializable settings):
+//   - aiAssistant           → `<h2 sr-only>AI Assistant</h2>` + skip-ssr AiChatModal
+//   - imageEnlarge          → idle skip-ssr ImageEnlarge   (SSR dialog-shell fallback)
+//   - mermaid               → idle skip-ssr MermaidEnlarge (SSR dialog-shell fallback)
+//   - dynamicPageTransition → pure-SSR <PageLoadingOverlay/> (zudolab/zudo-doc#2482)
 // It deliberately OMITS the host-owned bootstraps that helper also wires
 // (`ClientRouterBootstrap`, `DesignTokenPanelBootstrap`): those import from
-// `@/components/*` and are NOT reconstructable from package settings.
+// `@/components/*` and are NOT reconstructable from package settings. The page-
+// loading overlay, by contrast, is a pure PACKAGE component (`../page-loading`)
+// with no host coupling, so it CAN be mounted here — and package-owned routes
+// already activate `<ClientRouter/>` via `enableClientRouter` on the same flag,
+// so the overlay only needed its markup mount (zudolab/zudo-doc#2482, the
+// package-owned-routes analog of the #1541 host-mount decision).
 //
 // WHY A FACTORY (and not a component that imports `settings` itself): this
 // module compiles to `dist/`, which a published consumer resolves INSIDE
@@ -43,6 +49,8 @@ import { Island } from "@takazudo/zfb";
 import { AiChatModal } from "../ai-chat-modal/index.js";
 import { ImageEnlarge, ImageEnlargeSsrFallback } from "../image-enlarge/index.js";
 import { MermaidEnlarge, MermaidEnlargeSsrFallback } from "../mermaid-enlarge/index.js";
+// Named export (`page-loading/index.ts` re-exports `{ default as PageLoadingOverlay }`).
+import { PageLoadingOverlay } from "../page-loading/index.js";
 
 /** Default sr-only label rendered as the AiChatModal SSR fallback. Mirrors the
  *  host helper's default verbatim so assistive tech can discover the chat
@@ -56,6 +64,9 @@ export interface BodyEndIslandsSettings {
   aiAssistant: boolean;
   imageEnlarge: boolean;
   mermaid: boolean;
+  /** Gates the pure-SSR `<PageLoadingOverlay/>` mount (zudolab/zudo-doc#2482),
+   *  mirroring the host gate and `enableClientRouter`'s on package-owned routes. */
+  dynamicPageTransition: boolean;
 }
 
 /** Dependencies injected by `_chrome.tsx` (carries the virtual-module settings). */
@@ -134,6 +145,16 @@ export function createBodyEndIslands(
 
     return (
       <>
+        {/* Pure SSR — no <Island> wrap. Gated on `settings.dynamicPageTransition`
+            (zudolab/zudo-doc#2482), mirroring the host mount in
+            `pages/lib/_body-end-islands.tsx`: package-owned routes had the overlay
+            CSS but nothing mounted its markup, so SPA transitions showed no
+            loading spinner. The overlay self-wires its show/hide on
+            zfb:before-preparation / zfb:after-swap via an inline bootstrap script
+            and is intentionally not hydrated. No ClientRouterBootstrap needed
+            here — package routes already activate <ClientRouter/> through
+            `enableClientRouter` on this same flag. */}
+        {settings.dynamicPageTransition ? <PageLoadingOverlay /> : null}
         {aiAssistant}
         {imageEnlarge}
         {mermaidEnlarge}

--- a/packages/zudo-doc/src/doc-body-end-islands/index.tsx
+++ b/packages/zudo-doc/src/doc-body-end-islands/index.tsx
@@ -65,8 +65,12 @@ export interface BodyEndIslandsSettings {
   imageEnlarge: boolean;
   mermaid: boolean;
   /** Gates the pure-SSR `<PageLoadingOverlay/>` mount (zudolab/zudo-doc#2482),
-   *  mirroring the host gate and `enableClientRouter`'s on package-owned routes. */
-  dynamicPageTransition: boolean;
+   *  mirroring the host gate and `enableClientRouter`'s on package-owned routes.
+   *  Optional so adding it is NOT a breaking change for external callers that
+   *  construct this documented subset — this is an exported package subpath API.
+   *  `undefined` is treated as `false` (no overlay) at the mount site, preserving
+   *  pre-#2482 behavior; internal callers always pass the full `Settings`. */
+  dynamicPageTransition?: boolean;
 }
 
 /** Dependencies injected by `_chrome.tsx` (carries the virtual-module settings). */


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2484
    - https://github.com/zudolab/zudo-doc/issues/2483 (epic)

---

## Summary

Fixes #2482. Under `settings.packageOwnedRoutes: true` the host has no `pages/lib/_body-end-islands.tsx`, so body-end is owned by the package default `createBodyEndIslands`, which rendered AiChat / ImageEnlarge / MermaidEnlarge but **never** mounted `<PageLoadingOverlay/>` nor read `settings.dynamicPageTransition`. Package-owned route pages (404 / tags / versions) therefore emitted **zero** `id="page-loading-overlay"` markup even with `dynamicPageTransition: true`, so SPA transitions showed no loading overlay/spinner.

The fix mounts the overlay in the package default, gated on `settings.dynamicPageTransition` — pure SSR, no `<Island>` wrap — mirroring the host mount in `pages/lib/_body-end-islands.tsx` and the `enableClientRouter` gate already applied on package-owned routes. `PageLoadingOverlay` is a pure package component (no host coupling), unlike the deliberately-omitted `ClientRouterBootstrap`; and package routes already activate `<ClientRouter/>` via `enableClientRouter`, so only the overlay markup needed mounting.

## Changes

- `packages/zudo-doc/src/doc-body-end-islands/index.tsx` — import `PageLoadingOverlay` (named export) and mount it gated on `settings.dynamicPageTransition`; add the flag to the exported `BodyEndIslandsSettings` subset as **optional** (backward-compatible for external callers; `undefined` → no overlay).
- `packages/zudo-doc/src/doc-body-end-islands/__tests__/body-end-islands.test.tsx` — unit cases for the overlay gate (ON emits markup + `zfb:before-preparation`/`zfb:after-swap`/`data-zd-nav-pending` bootstrap; OFF omits it; gates independently of the island flags).
- `e2e/smoke-loading-overlay.spec.ts` — assertion that the package-owned `404` route (smoke fixture runs `packageOwnedRoutes: true` + `dynamicPageTransition: true`) now carries the overlay.

## Test Plan

- `pnpm --filter @takazudo/zudo-doc test` — 882 pass (incl. new overlay-gate cases).
- `pnpm check` — clean.
- `pnpm build` (showcase) — `grep -rl 'id="page-loading-overlay"' dist --include='*.html' | wc -l` = **342/342** (was 319/342); the previously-overlay-less 404 / tags / versions + `ja/` mirrors now carry it.
- E2E: new smoke `404.html` assertion runs in CI.

## Notes

- **No host change** and **no settings field added** (`dynamicPageTransition` already exists) — no create-zudo-doc generator sync needed. Package source is the single source of truth; no template drift.
- External npm consumers (e.g. the zfb docs site on `@takazudo/zudo-doc@2.1.2`) receive the overlay after a subsequent `/l-make-release` — a human-run follow-up, tracked on epic #2483.