### PR TITLE
fix(doc-history): auto-register DocHistory island under package-owned routes

### DIFF
--- a/.claude/skills/l-lessons-zfb-migration-parity/SKILL.md
+++ b/.claude/skills/l-lessons-zfb-migration-parity/SKILL.md
@@ -835,3 +835,32 @@ When testing an unpublished breaking `@takazudo/zudo-doc` version in a generated
 - GENSYNC wave: #2429
 - GENTEST wave: #2430
 - B4PUSH wave: #2431
+
+## 2026-07-01 — DocHistory island dead under package-owned routes (injected-path scanner reachability, #2480)
+
+### What we set out to do
+
+Fix a consumer-reported bug: with `settings.packageOwnedRoutes: true` + `settings.docHistory: true`, every doc page warned `island marker "DocHistory" … has no matching registry entry and will not hydrate` and the History button was dead (SSR sr-only fallback only).
+
+### Why it went wrong (root cause)
+
+zfb registers a client island only when its `"use client"` module is reachable from the scanned page/route import graph. The injected doc route builds chrome via `createChrome(routeCtx)` in `packages/zudo-doc/src/routes/_chrome.tsx` with **no** `hostBindings`, so the DocHistory slot resolved to the no-op `DocHistoryStub` — and, critically, **nothing statically imported the real `@takazudo/zudo-doc/doc-history` island** on the injected path. `DocHistoryArea` still emitted the `data-zfb-island-skip-ssr="DocHistory"` marker, so the marker existed with no matching registry entry → no hydration. The showcase masked it entirely because it keeps a `pages/docs/[[...slug]].tsx` stub that WINS over the injected route (Decision 6), and its host `pages/lib/_chrome.ts` already statically imports DocHistory — so `smoke-doc-history` e2e exercised the host path, never the injected one.
+
+### What worked instead
+
+Mirror the host adapter's documented "island-scanner contract" inside the injected shim: `routes/_chrome.tsx` **statically imports** `DocHistory` and threads it via `createChrome(routeCtx, { DocHistory })`. One seam fixes every injected doc route (all share `_chrome.tsx`). SSR output is byte-identical (skip-SSR island + `DocHistoryArea` gates on `settings.docHistory`), so the existing byte-parity hashes held. Proven with a build-based regression case (marker present + registry-miss warning absent + islands bundle registers DocHistory) plus a published-shape guard asserting the packed `routes-src/_chrome.tsx` carries the rewritten `@takazudo/zudo-doc/doc-history` import.
+
+### Watch for next time
+
+- **An island threaded as a stub-by-default host-binding is INVISIBLE to the injected route's scanner unless the real `"use client"` module is statically imported into the injected chrome graph.** Direct-imported package islands (BodyEndIslands, enlarge, search) are fine; the trap is any island whose default is a stub and whose real impl arrives via `hostBindings`. When adding such a slot, wire the real island into `routes/_chrome.tsx` too, not just the host `pages/lib/_chrome.ts`.
+- **The showcase's kept `pages/` stubs mask injected-route bugs.** Because user `pages/` wins over injected routes (Decision 6), the showcase never exercises the injected path for any URL it stubs. Regression coverage for package-owned routes must use an EMPTY-`pages/` build fixture (as `route-injection-build.test.ts` does), not the showcase e2e.
+- **The import MUST stay static.** A dynamic or type-only import stops zfb's island scanner from walking it — the same contract the host `_chrome.ts` header comment spells out.
+- **Static-importing an island drags its lazy deps into the bundle.** DocHistory's lazy `import("diff")` now rides into every `packageOwnedRoutes` build (matching the host path). `diff` is an optional peerDependency; document the requirement rather than trying to conditionally avoid the import (you can't keep scanner reachability AND drop the bundle when the feature is off).
+
+### References
+
+- Issue: #2480
+- Epic: #2486 / Sub: #2487
+- Fix seam: `packages/zudo-doc/src/routes/_chrome.tsx`
+- Regression: `packages/zudo-doc/src/__tests__/route-injection-build.test.ts` (Case DH + no-src published-shape guard)
+- ADR note: `packages/zudo-doc/docs/adr/route-injection-seam.md` ("Island registration under injected routes")

--- a/packages/zudo-doc/docs/adr/route-injection-seam.md
+++ b/packages/zudo-doc/docs/adr/route-injection-seam.md
@@ -155,3 +155,36 @@ while the stubs exist.
   green (descriptor is a bare specifier).
 - Dev rendering of injected routes remains a no-op until the upstream zfb dev
   pipeline lands; verify package routes via `zfb build`.
+
+### Island registration under injected routes (DocHistory) — #2480
+
+zfb registers a client island only when the `"use client"` module is reachable
+from the scanned page/route import graph. Most package islands (BodyEndIslands,
+SearchWidget, enlarge/mermaid) are imported directly by the package factories, so
+the injected route graph reaches them. **DocHistory is the exception**: it is a
+host-bound slot (`ctx.hostBindings.DocHistory`, default a no-op stub in
+`chrome/derive.tsx`), so nothing statically imported the real
+`@takazudo/zudo-doc/doc-history` island on the injected path. `DocHistoryArea`
+still emitted a `data-zfb-island-skip-ssr="DocHistory"` marker → the marker had
+**no matching registry entry** and the History button never hydrated under
+`packageOwnedRoutes: true` + `docHistory: true`.
+
+Fix (#2480): the injected chrome shim `routes/_chrome.tsx` **statically imports**
+the real `DocHistory` island and threads it via `createChrome(routeCtx, { DocHistory })`
+— the same "island-scanner contract" the host `pages/lib/_chrome.ts` documents.
+The import MUST stay static (a dynamic/type-only import stops zfb's scanner from
+walking it). SSR output is unchanged (the island is skip-SSR and `DocHistoryArea`
+gates on `settings.docHistory`), so no host `_register-islands.ts` re-export is
+needed — the package registers the island itself. Regression coverage:
+`__tests__/route-injection-build.test.ts` (Case DH + the published-shape guard in
+the no-src case).
+
+- **`diff` peer implication:** `DocHistory` carries a lazy `import("diff")`.
+  Statically importing it pulls `diff` into the injected chrome scan graph for
+  every `packageOwnedRoutes: true` project — identical to the pre-existing host
+  path. `diff` is already an **optional** `peerDependency` and generated projects
+  ship it; `docHistory: true` consumers need it regardless. A hand-assembled
+  `packageOwnedRoutes` consumer with `docHistory: false` and no `diff` may now
+  need `diff` resolvable at build. This is an accepted tradeoff — you cannot keep
+  the static import (required for scanner reachability) *and* avoid bundling
+  DocHistory when the feature is off.

--- a/packages/zudo-doc/src/__tests__/route-injection-build.test.ts
+++ b/packages/zudo-doc/src/__tests__/route-injection-build.test.ts
@@ -118,7 +118,7 @@ function setupFixture(options: { emptyPages?: boolean } = {}): string {
  * version that rejects `injectRoute` during builds; the local binary
  * (0.1.0-next.62+) supports build-time route injection.
  */
-function runZfbBuild(dir: string, outDir = "dist"): void {
+function runZfbBuild(dir: string, outDir = "dist"): string {
   const opts: ExecSyncOptions = {
     cwd: dir,
     env: {
@@ -131,7 +131,12 @@ function runZfbBuild(dir: string, outDir = "dist"): void {
     encoding: "utf-8",
   };
   try {
-    execSync(`./node_modules/.bin/zfb build --outdir ${outDir}`, opts);
+    // Merge stderr into stdout (2>&1) so the returned string carries BOTH streams.
+    // zfb emits the island-registry warning on a SUCCESSFUL build, so callers that
+    // assert on build diagnostics (the docHistory registration case) need stderr
+    // too — plain execSync would drop it on success. Existing callers ignore the
+    // return value, so widening void→string is backward-compatible.
+    return execSync(`./node_modules/.bin/zfb build --outdir ${outDir} 2>&1`, opts) as string;
   } catch (err) {
     const e = err as { stdout?: string; stderr?: string; message?: string };
     throw new Error(
@@ -284,6 +289,79 @@ describe("A2 islands-on: package route HTML carries island markers when flags ON
 });
 
 // ---------------------------------------------------------------------------
+// Case DH — doc-history island registration under package-owned routes
+//           (zudolab/zudo-doc#2480). With `docHistory: true`, the injected doc
+//           route emits a `data-zfb-island-skip-ssr="DocHistory"` marker, but the
+//           real DocHistory client island (`@takazudo/zudo-doc/doc-history`,
+//           `"use client"`) must be reachable from the injected route's scan
+//           graph so zfb REGISTERS a matching client binding — otherwise the
+//           marker has "no matching registry entry" and the History button never
+//           hydrates. `routes/_chrome.tsx` statically imports DocHistory and
+//           threads it via `createChrome(routeCtx, { DocHistory })` to close that
+//           gap. The showcase never caught this because it keeps a
+//           `pages/docs/[[...slug]].tsx` stub (wins per Decision 6) whose host
+//           chrome already imports DocHistory — so only the INJECTED path (empty
+//           `pages/`) exercises the bug, which is exactly what this case builds.
+// ---------------------------------------------------------------------------
+
+/** Flip `docHistory` ON in a fixture's settings.ts (it ships OFF) so the
+ *  route-context virtual module carries it true and the injected doc route
+ *  renders the DocHistoryArea (emitting the island marker). */
+function enableDocHistory(dir: string): void {
+  const settingsPath = join(dir, "src/config/settings.ts");
+  const src = readFileSync(settingsPath, "utf-8").replace(
+    /docHistory:\s*false/,
+    "docHistory: true",
+  );
+  writeFileSync(settingsPath, src);
+}
+
+/** Concatenate every emitted islands JS bundle (main + chunks) so a client
+ *  binding registration can be asserted regardless of chunk splitting. */
+function readIslandsBundles(dir: string): string {
+  const assetsDir = join(dir, "dist", "assets");
+  return readdirSync(assetsDir)
+    .filter((f) => /^islands.*\.js$/.test(f))
+    .map((f) => readFileSync(join(assetsDir, f), "utf-8"))
+    .join("\n");
+}
+
+describe("DH doc-history: injected doc route registers the DocHistory island (packageOwnedRoutes + docHistory)", () => {
+  let fixtureDir: string;
+  let buildOutput: string;
+
+  it("setup: fixture builds with docHistory enabled + empty pages/", { timeout: 180_000 }, () => {
+    fixtureDir = setupFixture({ emptyPages: true });
+    enableDocHistory(fixtureDir);
+    // Captures stdout+stderr — the registry-miss warning (asserted below) is
+    // emitted on a SUCCESSFUL build.
+    buildOutput = runZfbBuild(fixtureDir);
+  });
+
+  it("marker: injected /docs/getting-started/ HTML carries the DocHistory skip-ssr marker", () => {
+    const html = readBuiltHtml(fixtureDir, "docs/getting-started/index.html");
+    expect(html).toContain('data-zfb-island-skip-ssr="DocHistory"');
+  });
+
+  it("registry: build emits NO 'DocHistory … has no matching registry entry' warning", () => {
+    // The #2480 symptom: the marker is emitted but the real client island is
+    // never in the injected route's scan graph, so zfb warns and the button is
+    // dead. Assert NARROWLY on the co-occurrence (DocHistory + the registry-miss
+    // phrase), not on any warning, so unrelated warnings don't make this brittle.
+    const hasDocHistoryRegistryMiss =
+      buildOutput.includes("has no matching registry entry") &&
+      buildOutput.includes("DocHistory");
+    expect(hasDocHistoryRegistryMiss).toBe(false);
+  });
+
+  it("bundle: the emitted islands client bundle registers DocHistory (marker ↔ registry match ⇒ hydration)", () => {
+    // Marker present (above) + DocHistory in the client bundle = the marker has a
+    // matching registry entry, which is exactly what zfb's hydration requires.
+    expect(readIslandsBundles(fixtureDir)).toContain("DocHistory");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Case B — Precedence: stub wins when pages/404.tsx collides (Decision 6).
 // ---------------------------------------------------------------------------
 
@@ -401,6 +479,20 @@ describe("S1 no-src: published package (routes-src/, no src/) renders injected r
     expect(existsSync(join(pkgDest, "routes-src"))).toBe(true);
     expect(existsSync(join(pkgDest, "routes-src/docs-slug.tsx"))).toBe(true);
     expect(existsSync(join(pkgDest, "routes-src/locale-docs-slug.tsx"))).toBe(true);
+  });
+
+  // #2480 published-shape guard: the injected chrome must statically import the
+  // real DocHistory island so zfb registers it under packageOwnedRoutes. In the
+  // PUBLISHED tree the parent-relative `../doc-history/index.js` is rewritten to
+  // the bare package subpath by copy-routes-src.mjs — prove the rewrite landed in
+  // the packed output, not only in the in-repo `src/` shape.
+  it("registration: published routes-src/_chrome.tsx imports the real DocHistory island (rewritten specifier)", () => {
+    const chromeSrc = readFileSync(join(pkgDest, "routes-src/_chrome.tsx"), "utf-8");
+    expect(chromeSrc).toContain('from "@takazudo/zudo-doc/doc-history"');
+    // …and threads it into the chrome builder (not left as a dead import).
+    expect(chromeSrc).toMatch(/createChrome\(routeCtx,\s*\{/);
+    // No residual parent-relative form survived the rewrite.
+    expect(chromeSrc).not.toContain('from "../doc-history');
   });
 
   it("setup: build succeeds from the published package (no src/)", { timeout: 180_000 }, () => {

--- a/packages/zudo-doc/src/routes/_chrome.tsx
+++ b/packages/zudo-doc/src/routes/_chrome.tsx
@@ -4,17 +4,33 @@
 // The chrome wiring was PROMOTED to the public, shared
 // `createChrome(context, hostBindings)` builder
 // (`@takazudo/zudo-doc/chrome`, CTX #2423). This module is now just the seam
-// that calls it ONCE with the reconstructed route context and NO host bindings
-// — so every host-bound slot resolves to its package-default stub and the
-// injected package-routes render is byte-identical to before. The host
-// (HOSTCOLLAPSE wave) will call `createChrome` directly with real bindings.
+// that calls it ONCE with the reconstructed route context and the single
+// DocHistory host binding needed for island registration (see below) — every
+// OTHER host-bound slot resolves to its package-default stub, so the injected
+// package-routes render stays byte-identical. The host (HOSTCOLLAPSE wave) will
+// call `createChrome` directly with its full real bindings.
 
 import { routeCtx } from "./_context.js";
 import { createChrome } from "../chrome/index.js";
+import { DocHistory } from "../doc-history/index.js";
+import type { ChromeHostBindings } from "../factory-context/index.js";
 import type { DocNavNode } from "./_docs-helpers.js";
 
-// Empty host bindings → package-default stubs (byte-identical injected path).
-const chrome = createChrome(routeCtx);
+// Island-scanner contract (load-bearing): the injected doc routes reach the real
+// DocHistory client island ONLY through this static import → `createChrome`
+// hostBindings chain (docs-slug.tsx → _chrome.tsx → DocHistory). Without it,
+// `deriveDocHistorySlot` falls back to the no-op stub, the SSR marker
+// `data-zfb-island-skip-ssr="DocHistory"` has no matching registry entry, and the
+// History button never hydrates under `packageOwnedRoutes` (zudolab/zudo-doc#2480).
+// The import MUST stay static — a dynamic/type-only import stops zfb's island
+// scanner from walking it. SSR output is unchanged: `DocHistoryArea` gates on
+// `settings.docHistory` and the island is skip-SSR, so binding the real component
+// vs the stub is byte-identical. Mirrors the host's `pages/lib/_chrome.ts`.
+// (The narrow real-island props signature isn't assignable to the structural
+// `FactoryComponent`, so cast — same as the host.)
+const chrome = createChrome(routeCtx, {
+  DocHistory: DocHistory as unknown as ChromeHostBindings["DocHistory"],
+});
 
 export const {
   composeMetaTitle,


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2487
    - https://github.com/zudolab/zudo-doc/issues/2486 (epic)
    - https://github.com/zudolab/zudo-doc/issues/2480 (source)

---

## Summary

Fixes #2480. Under `packageOwnedRoutes: true` + `docHistory: true`, the package-injected doc route's DocHistory island never hydrated — the build warned `island marker "DocHistory" … has no matching registry entry and will not hydrate` on every doc page and the History button was dead (SSR sr-only fallback only).

**Root cause:** the injected chrome shim `packages/zudo-doc/src/routes/_chrome.tsx` called `createChrome(routeCtx)` with no `hostBindings` and never statically imported the real `@takazudo/zudo-doc/doc-history` (`"use client"`) island, so zfb's island scanner never registered a `"DocHistory"` client binding. The showcase masked this because it keeps a `pages/docs/[[...slug]].tsx` stub that wins over the injected route (ADR Decision 6) and whose host `pages/lib/_chrome.ts` already statically imports DocHistory (the documented "island-scanner contract"). Only an empty-`pages/` consumer hits the injected path.

## Changes

- **`packages/zudo-doc/src/routes/_chrome.tsx`** — statically import `DocHistory` and thread it via `createChrome(routeCtx, { DocHistory })`, mirroring the host adapter. One seam fixes every injected doc route (all share this barrel). SSR output is byte-identical: the island is skip-SSR and `DocHistoryArea` gates on `settings.docHistory`, so binding the real component vs the stub changes nothing in the HTML — it only makes the real client island reachable so the existing marker registers and hydrates. No host `_register-islands.ts` is needed.
- **`packages/zudo-doc/src/__tests__/route-injection-build.test.ts`** — new Case DH: builds a `packageOwnedRoutes:true` + `docHistory:true` + empty-`pages/` fixture and asserts the injected doc page carries `data-zfb-island-skip-ssr="DocHistory"`, the build emits **no** `DocHistory`+`has no matching registry entry` warning, and the islands bundle registers `DocHistory`. Plus a published-shape guard in the no-src case asserting the packed `routes-src/_chrome.tsx` carries the rewritten `@takazudo/zudo-doc/doc-history` import. `runZfbBuild` now returns combined stdout+stderr so the warning can be asserted.
- **`packages/zudo-doc/docs/adr/route-injection-seam.md`** — documents the island-registration fix and the `diff` peer implication.
- **`.claude/skills/l-lessons-zfb-migration-parity/SKILL.md`** — "Watch for next time" entry on stub-by-default host-binding islands being invisible to the injected-route scanner.

## Test Plan

- `pnpm --filter @takazudo/zudo-doc build` succeeds; `check-routes-src.mjs` passes (rewritten import, 0 residual `../`).
- `vitest run route-injection-build.test.ts` — 26/26 pass, including Case DH, the published-shape guard, and the **unchanged** byte-parity SHA fingerprints (`docHistory:false` output is byte-identical).
- Package `typecheck` + root `pnpm check` (tsc) — no errors.
- Reproduced the bug (warning present without the fix) and confirmed it's gone with the fix.

Closes #2480