### PR TITLE
fix: chromeBindingsModule directory-path guard + ADR status note (#2520, #2521)

### DIFF
--- a/packages/zudo-doc/docs/adr/route-injection-seam.md
+++ b/packages/zudo-doc/docs/adr/route-injection-seam.md
@@ -114,6 +114,9 @@ pattern once, not one per concrete value (matching how the current stubs work).
 
 ### 4. The dormant `settings.packageOwnedRoutes` gate
 
+> **Status update (#2518):** default-on since #2404 — the "dormant" framing
+> below is historical.
+
 Add `settings.packageOwnedRoutes?: boolean` (default **false**) to the package
 `PresetSettings` and the showcase `src/config/settings.ts`. `buildPlugins()` adds
 the routes-plugin descriptor **only when true**. Decision: **internal/advanced —

--- a/packages/zudo-doc/src/__tests__/route-injection-build.test.ts
+++ b/packages/zudo-doc/src/__tests__/route-injection-build.test.ts
@@ -439,6 +439,17 @@ function enableEmptyChromeBindingsModule(dir: string): void {
   writeFileSync(settingsPath, src);
 }
 
+/** Point `chromeBindingsModule` at a directory (the project root) — used by
+ *  the directory-path error case (#2520). */
+function enableDirectoryChromeBindingsModule(dir: string): void {
+  const settingsPath = join(dir, "src/config/settings.ts");
+  const src = readFileSync(settingsPath, "utf-8").replace(
+    /packageOwnedRoutes:\s*true,/,
+    'packageOwnedRoutes: true,\n  chromeBindingsModule: ".",',
+  );
+  writeFileSync(settingsPath, src);
+}
+
 describe("CB chrome-bindings: chromeBindingsModule wires host bindings into createChrome on injected routes", () => {
   let fixtureDir: string;
 
@@ -537,6 +548,24 @@ describe("CB chrome-bindings empty: build fails loudly when chromeBindingsModule
     expect(thrown).toBeDefined();
     expect(thrown!.message).toContain("chromeBindingsModule");
     expect(thrown!.message).toContain("empty string");
+  });
+});
+
+describe("CB chrome-bindings directory: build fails loudly when chromeBindingsModule points at a directory", () => {
+  it("setup: build throws an error naming chromeBindingsModule and the directory condition", { timeout: 180_000 }, () => {
+    const fixtureDir = setupFixture({ emptyPages: true });
+    enableDirectoryChromeBindingsModule(fixtureDir);
+
+    let thrown: Error | undefined;
+    try {
+      runZfbBuild(fixtureDir);
+    } catch (err) {
+      thrown = err as Error;
+    }
+
+    expect(thrown).toBeDefined();
+    expect(thrown!.message).toContain("chromeBindingsModule");
+    expect(thrown!.message).toContain("directory, not a module file");
   });
 });
 

--- a/packages/zudo-doc/src/plugins/routes.ts
+++ b/packages/zudo-doc/src/plugins/routes.ts
@@ -54,7 +54,7 @@
 // sibling `doc-history.ts` for the standalone-module rationale.
 
 import { createRequire } from "node:module";
-import { existsSync, cpSync, rmSync, mkdirSync } from "node:fs";
+import { existsSync, statSync, cpSync, rmSync, mkdirSync } from "node:fs";
 import { dirname, basename, join } from "node:path";
 import { definePlugin, type ZfbSetupContext } from "@takazudo/zfb/plugins";
 
@@ -237,6 +237,16 @@ const plugin = definePlugin({
           `zudo-doc: settings.chromeBindingsModule is set to "${chromeBindingsModule}", ` +
             `which resolves to "${resolved}" — that file does not exist. Create it (must ` +
             `export a named \`chromeBindings: ChromeHostBindings\`) or remove the setting.`,
+        );
+      }
+      // A directory-valued path (e.g. "." or "./src") passes existsSync above
+      // (directories exist too) and would otherwise sail through to the
+      // bundler, which fails later with a confusing non-loud error (#2520).
+      if (!statSync(resolved).isFile()) {
+        throw new Error(
+          `zudo-doc: settings.chromeBindingsModule is set to "${chromeBindingsModule}", ` +
+            `which resolves to "${resolved}" — that path is a directory, not a module file. ` +
+            `Point it at a module file (e.g. "./src/chrome-bindings.tsx") or remove the setting.`,
         );
       }
       chromeBindingsAbsPath = resolved;

--- a/packages/zudo-doc/src/settings.ts
+++ b/packages/zudo-doc/src/settings.ts
@@ -355,6 +355,8 @@ export interface Settings {
    * - Present but the resolved file does not exist → the build fails loudly
    *   at plugin setup, naming the resolved absolute path (never a silent
    *   empty fallback).
+   * - Present but the resolved path is a directory (e.g. `"."` or `"./src"`)
+   *   → the build fails loudly at plugin setup, naming the resolved path.
    *
    * Only the PATH travels through `settings` (a string is serializable data,
    * consistent with the ADR's "virtual module = serializable data only"


### PR DESCRIPTION
## Summary

Two small follow-ups from the Issue Sweep epic (#2516):

- **Fixes #2520** — `settings.chromeBindingsModule` accepted a directory-valued path (e.g. `"."` or `"./src"`): it passed the existing `existsSync(resolved)` guard in `packages/zudo-doc/src/plugins/routes.ts` (directories exist too) and only failed later with a confusing bundler error. Added a `statSync(resolved).isFile()` check right after the existing existsSync guard, throwing the same loud, path-naming error style as the missing-file case. Mirrored the new behavior into the `chromeBindingsModule` JSDoc bullet list in `packages/zudo-doc/src/settings.ts`, and added a fixture test in `route-injection-build.test.ts` modeled on the existing empty-string case.
- **Fixes #2521** — `packages/zudo-doc/docs/adr/route-injection-seam.md` still described `packageOwnedRoutes` as "dormant" even though it's been default-on since #2404 (per #2518). Added a short status-update blockquote near that section instead of rewriting the ADR body.

## Test plan

- [x] `pnpm --filter @takazudo/zudo-doc build` — succeeds
- [x] `pnpm --filter @takazudo/zudo-doc test` — 81 files / 934 tests pass (including the new directory-path fixture test)
- [x] `pnpm check` — no errors
- [x] `cd packages/zudo-doc && pnpm run typecheck` — no errors


---
_Generated by [Claude Code](https://claude.ai/code/session_01BXwSiChYD1iabBx6MPZfyQ)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785593613&installation_id=130359969&pr_number=2524&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2524&signature=07b20eca565a4902d6ee2d3e8f6dfe3ae1f8bae01764dd8ca28404ae28765435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->