### PR TITLE
agent-fix: test-strategy-sweep follow-up fixes (#2546, #2547, #2548)

### DIFF
--- a/packages/search-worker/vitest.config.ts
+++ b/packages/search-worker/vitest.config.ts
@@ -3,5 +3,10 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["src/__tests__/**/*.test.ts"],
+    // These suites run concurrently with the other package suites under
+    // `pnpm test:packages`; the default 5000ms intermittently times out under
+    // CPU/IO contention (zudolab/zudo-doc#2547) even though each test is fast
+    // in isolation. Raise the ceiling so contention doesn't cause false flakes.
+    testTimeout: 20000,
   },
 });

--- a/scripts/check-package-safelist.mjs
+++ b/scripts/check-package-safelist.mjs
@@ -20,7 +20,7 @@
 // Run `pnpm --filter @takazudo/zudo-doc build` first if missing.
 //
 // Wired into:
-//   - scripts/run-b4push.sh (after package build step — step 10)
+//   - scripts/run-b4push.sh (after the package-build step)
 //   - .github/workflows/pr-checks.yml (after pnpm install + package build)
 
 import { readFileSync, readdirSync, existsSync } from "node:fs";

--- a/scripts/parity-diff.mjs
+++ b/scripts/parity-diff.mjs
@@ -235,15 +235,25 @@ async function diff() {
   }
 
   // ── 2. Route list diff ────────────────────────────────────────────────────
-  const addedRoutes = routeList.filter((r) => !baselineRoutes.includes(r));
-  const removedRoutes = baselineRoutes.filter((r) => !routeList.includes(r));
-  if (addedRoutes.length > 0 || removedRoutes.length > 0) {
-    hasChanges = true;
-    console.log(`\n[parity-diff] ROUTE LIST DIFF:`);
-    for (const r of addedRoutes) console.log(`  + ${r}`);
-    for (const r of removedRoutes) console.log(`  - ${r}`);
+  // baselineRoutes is null when the baseline was generated from a dist/ that
+  // lacked dist/__zfb/routes.json (buildRouteList returns null → written as
+  // `null`). Skip the section loudly instead of throwing on `.filter` (#2546).
+  if (baselineRoutes == null) {
+    console.warn(
+      `[parity-diff] Route list: SKIP — baseline route-list.json is null ` +
+        `(baseline was generated without dist/__zfb/routes.json). Regenerate the baseline from a real build.`,
+    );
   } else {
-    console.log(`[parity-diff] Route list: PASS — ${routeList.length} routes unchanged`);
+    const addedRoutes = routeList.filter((r) => !baselineRoutes.includes(r));
+    const removedRoutes = baselineRoutes.filter((r) => !routeList.includes(r));
+    if (addedRoutes.length > 0 || removedRoutes.length > 0) {
+      hasChanges = true;
+      console.log(`\n[parity-diff] ROUTE LIST DIFF:`);
+      for (const r of addedRoutes) console.log(`  + ${r}`);
+      for (const r of removedRoutes) console.log(`  - ${r}`);
+    } else {
+      console.log(`[parity-diff] Route list: PASS — ${routeList.length} routes unchanged`);
+    }
   }
 
   // ── 3. Asset manifest diff ────────────────────────────────────────────────


### PR DESCRIPTION
Auto-fix of three `agent-found` issues raised during the test-strategy-sweep epic (#2525). All three are small, low-risk test/CI-infra fixes bundled into one PR.

- Closes #2546 — guard null baseline route-list in `parity-diff.mjs` `diff()` (warn + skip instead of `TypeError`)
- Closes #2547 — raise `testTimeout` in search-worker vitest config to absorb parallel `pnpm test:packages` contention
- Closes #2548 — drop stale b4push step number from `check-package-safelist.mjs` header comment

## Verification
- null-baseline path now warns instead of throwing (behavioral test)
- search-worker 44/44 pass
- `pnpm check` typecheck clean

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) during `/x-wt-teams` Step 15.5 auto-fix

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785616411&installation_id=130359969&pr_number=2549&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2549&signature=a15fd3005f3ee1e7125b3dd28de21cb4014db36f5ff4ec25be7604d7a056bfb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->