### PR TITLE
fix(i18n): keep header language switcher hrefs correct across SPA navigation

### DIFF
--- a/e2e/fixtures/i18n/src/config/settings.ts
+++ b/e2e/fixtures/i18n/src/config/settings.ts
@@ -1,5 +1,6 @@
 import type {
   HeaderNavItem,
+  HeaderRightItem,
   ColorModeConfig,
   LocaleConfig,
   MetaTagsConfig,
@@ -47,5 +48,10 @@ export const settings = {
     },
     { label: "Guides", path: "/docs/guides", categoryMatch: "guides" },
   ] satisfies HeaderNavItem[] as HeaderNavItem[],
+  // Render the desktop header language switcher so the #2551 SPA-nav re-wire
+  // regression (i18n-vt-chrome-persist.spec.ts) can exercise it.
+  headerRightItems: [
+    { type: "component", component: "language-switcher" },
+  ] satisfies HeaderRightItem[] as HeaderRightItem[],
   packageOwnedRoutes: true,
 };

--- a/e2e/i18n-vt-chrome-persist.spec.ts
+++ b/e2e/i18n-vt-chrome-persist.spec.ts
@@ -194,3 +194,95 @@ test.describe("VT Chrome Persist: locale-toggle clickability post-EN→JA (W7A)"
     ).not.toContain("/ja/");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Test 6: language switcher href stays correct across SAME-locale SPA nav
+// (#2551 — the persisted header's switcher hrefs must not go stale)
+// ---------------------------------------------------------------------------
+test.describe("VT Chrome Persist: language switcher href after same-locale nav (#2551)", () => {
+  test("EN switcher link tracks the current page after a same-locale JA→JA swap", async ({
+    page,
+  }) => {
+    // Hard-load a JA page. The persisted header (persistKey header-ja) survives
+    // subsequent same-locale navigations, so its switcher hrefs must be
+    // re-wired on zfb:after-swap rather than left frozen at this page.
+    await page.goto("/ja/docs/getting-started/", { waitUntil: "domcontentloaded" });
+    await waitForSidebarNav(page);
+
+    // Normalize trailing slash so the assertion is agnostic to the fixture's
+    // trailingSlash setting — the exact-page path is what matters here.
+    const norm = (s: string | null) => (s ?? "").replace(/\/$/, "");
+    // Target the desktop header switcher specifically (the `[data-language-switcher]`
+    // container is the #2551 re-wire surface), not the mobile sidebar-footer switcher.
+    const enHref = async () =>
+      norm(
+        await page.evaluate(
+          () =>
+            document
+              .querySelector<HTMLAnchorElement>(
+                'header [data-language-switcher] a[lang="en"]',
+              )
+              ?.getAttribute("href") ?? null,
+        ),
+      );
+
+    // On the JA getting-started page, EN points at the EN equivalent.
+    expect(await enHref(), "initial EN switcher href on the JA getting-started page").toBe(
+      "/docs/getting-started",
+    );
+
+    // Tag the header node so we can prove it is the SAME (persisted) node after
+    // the same-locale swap — i.e. the fix is a re-wire, not a re-render.
+    await page.evaluate(() => {
+      const header = document.querySelector("header");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      if (header) (header as any).__sameLocaleMarker__ = 2551;
+    });
+
+    // Same-locale SPA navigation to a different JA section via the header nav.
+    const swapFired = await spaClick(page, "/ja/docs/guides/");
+    expect(swapFired, "same-locale JA→JA swap should fire zfb:after-swap").toBe(true);
+    await page.waitForURL((url) => url.pathname.includes("/ja/docs/guides"), {
+      timeout: 5000,
+    });
+
+    const post = await page.evaluate(() => {
+      const header = document.querySelector("header");
+      return {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        markerPreserved: (header as any)?.__sameLocaleMarker__ === 2551,
+        enHref:
+          document
+            .querySelector<HTMLAnchorElement>(
+              'header [data-language-switcher] a[lang="en"]',
+            )
+            ?.getAttribute("href") ?? null,
+      };
+    });
+
+    // Same-locale nav preserves the header DOM node (persist), so this really
+    // exercises the stale-href path the re-wire script fixes.
+    expect(
+      post.markerPreserved,
+      "header node should be preserved across same-locale nav (persisted header)",
+    ).toBe(true);
+
+    // The load-bearing assertion (#2551): the EN link now points at the CURRENT
+    // page's EN equivalent, not the stale getting-started target.
+    expect(
+      norm(post.enHref),
+      "EN switcher href must track the current JA page after same-locale nav",
+    ).toBe("/docs/guides");
+
+    // And clicking it actually lands on that exact EN page.
+    const enSwap = await spaClick(page, "/docs/guides/");
+    expect(enSwap, "clicking the re-wired EN link should fire an SPA swap").toBe(true);
+    await page.waitForURL((url) => /\/docs\/guides\/?$/.test(url.pathname), {
+      timeout: 5000,
+    });
+    expect(page.url(), "should land on the exact EN equivalent page").toContain(
+      "/docs/guides/",
+    );
+    expect(page.url()).not.toContain("/ja/");
+  });
+});

--- a/packages/zudo-doc/src/header-with-defaults/index.tsx
+++ b/packages/zudo-doc/src/header-with-defaults/index.tsx
@@ -48,6 +48,10 @@ export interface HeaderVersionEntry {
 /** Settings subset read by {@link createHeaderWithDefaults}. */
 export interface HeaderWithDefaultsSettings {
   siteName: string;
+  /** Site base path — fed to the language-switcher SPA re-wire config. */
+  base: string;
+  /** Trailing-slash policy — fed to the language-switcher SPA re-wire config. */
+  trailingSlash: boolean;
   headerNav: Array<{
     label: string;
     labelKey?: string;
@@ -197,6 +201,12 @@ export function createHeaderWithDefaults<S extends Settings = Settings>(
       localeLinks != null ? (
         <LanguageSwitcher
           links={localeLinks}
+          config={{
+            base: settings.base.replace(/\/+$/, ""),
+            defaultLocale,
+            trailingSlash: settings.trailingSlash,
+          }}
+          currentLocale={lang}
         />
       ) as unknown as VNode : undefined;
 

--- a/packages/zudo-doc/src/header/header.tsx
+++ b/packages/zudo-doc/src/header/header.tsx
@@ -45,6 +45,7 @@ import {
   pathForMatch,
 } from "./nav-active.js";
 import { NAV_OVERFLOW_SCRIPT } from "./nav-overflow-script.js";
+import { LANGUAGE_SWITCHER_INIT_SCRIPT } from "../i18n-version/language-switcher.js";
 import type {
   HeaderNavItem,
   HeaderRightItem,
@@ -290,9 +291,12 @@ export function Header(props: HeaderProps): JSX.Element {
       //     Island re-hydrates with correct nodes on mount)
       //   - Header nav + aria-current: NAV_OVERFLOW_SCRIPT re-runs on
       //     AFTER_NAVIGATE_EVENT (nav-overflow-script.ts:198, verified (a))
-      //   - LanguageSwitcher: SSR'd locale links are locale-static within
-      //     a same-locale persist window — no per-page fields go stale
-      //     (verified (a) — locale does not change during same-locale nav)
+      //   - LanguageSwitcher: its target hrefs ARE per-page (the equivalent
+      //     page in each other locale), so within a same-locale persist window
+      //     they WOULD go stale — the locale is constant but the path is not.
+      //     LANGUAGE_SWITCHER_INIT_SCRIPT recomputes each anchor's href from
+      //     window.location on AFTER_NAVIGATE_EVENT, same as the controls above
+      //     (zudolab/zudo-doc#2551).
       // Omit persistKey to fall back to the old repaint-on-every-swap path.
       data-zfb-transition-persist={persistKey}
     >
@@ -365,6 +369,15 @@ export function Header(props: HeaderProps): JSX.Element {
       </div>
 
       <script dangerouslySetInnerHTML={{ __html: NAV_OVERFLOW_SCRIPT }} />
+      {hasLocales ? (
+        // Keeps the persisted header's language-switcher hrefs pointing at the
+        // current page's equivalent in each other locale across same-locale SPA
+        // navigation (#2551). Registers a document-level AFTER_NAVIGATE_EVENT
+        // listener once; idempotent across re-execution.
+        <script
+          dangerouslySetInnerHTML={{ __html: LANGUAGE_SWITCHER_INIT_SCRIPT }}
+        />
+      ) : null}
     </header>
   );
 }

--- a/packages/zudo-doc/src/i18n-version/__tests__/language-switcher.test.tsx
+++ b/packages/zudo-doc/src/i18n-version/__tests__/language-switcher.test.tsx
@@ -3,8 +3,14 @@
 
 import { describe, expect, it } from "vitest";
 import type { ComponentChildren, VNode } from "preact";
-import { LanguageSwitcher } from "../language-switcher.js";
+import {
+  LanguageSwitcher,
+  LANGUAGE_SWITCHER_INIT_SCRIPT,
+  switchLocaleHref,
+} from "../language-switcher.js";
 import type { LocaleLink } from "../types.js";
+import { makeUrlHelpers } from "../../url-helpers/index.js";
+import { AFTER_NAVIGATE_EVENT } from "../../transitions/index.js";
 
 // Minimal VNode → HTML serializer (mirrors the helper used in
 // breadcrumb.test.tsx — kept inline so the test runs without a render
@@ -96,5 +102,99 @@ describe("LanguageSwitcher", () => {
     // Two separators for three links.
     const slashCount = (html.match(/<span class="text-muted">\/<\/span>/g) ?? []).length;
     expect(slashCount).toBe(2);
+  });
+
+  it("emits data-* config on the container when config is provided", () => {
+    const html = serialize(
+      <LanguageSwitcher
+        links={enJa}
+        config={{ base: "", defaultLocale: "en", trailingSlash: true }}
+        currentLocale="ja"
+      />,
+    );
+    expect(html).toContain("data-language-switcher");
+    expect(html).toContain('data-current-locale="ja"');
+    expect(html).toContain('data-default-locale="en"');
+    expect(html).toContain('data-trailing-slash="true"');
+  });
+
+  it("omits config attributes for a static render (no config)", () => {
+    const html = serialize(<LanguageSwitcher links={enJa} />);
+    expect(html).not.toContain("data-language-switcher");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SPA re-wire (#2551): the client transform must reproduce the SSR-baked
+// hrefs exactly, so a persisted header's switcher stays correct after
+// same-locale navigation.
+// ---------------------------------------------------------------------------
+describe("switchLocaleHref (client re-wire) matches SSR buildLocaleLinks", () => {
+  const i18n = {
+    defaultLocale: "en",
+    locales: ["en", "ja", "de"],
+    getLocaleLabel: (c: string) => c.toUpperCase(),
+  };
+
+  const cases: Array<{
+    label: string;
+    base: string;
+    trailingSlash: boolean;
+    pathname: string;
+    currentLang: string;
+  }> = [
+    { label: "non-default → default (ja deep page)", base: "/", trailingSlash: true, pathname: "/ja/docs/guides/sidebar-filter/", currentLang: "ja" },
+    { label: "default → non-default (en deep page)", base: "/", trailingSlash: true, pathname: "/docs/guides/sidebar-filter/", currentLang: "en" },
+    { label: "locale index (ja root)", base: "/", trailingSlash: true, pathname: "/ja/docs/", currentLang: "ja" },
+    { label: "versioned non-default", base: "/", trailingSlash: true, pathname: "/v/1.0/ja/docs/intro/", currentLang: "ja" },
+    { label: "versioned default", base: "/", trailingSlash: true, pathname: "/v/1.0/docs/intro/", currentLang: "en" },
+    { label: "with base prefix", base: "/app", trailingSlash: true, pathname: "/app/ja/docs/x/", currentLang: "ja" },
+    { label: "trailingSlash off", base: "/", trailingSlash: false, pathname: "/ja/docs/x", currentLang: "ja" },
+  ];
+
+  for (const tc of cases) {
+    it(`reproduces SSR hrefs: ${tc.label}`, () => {
+      const helpers = makeUrlHelpers(
+        { base: tc.base, trailingSlash: tc.trailingSlash, siteUrl: "", defaultLocaleOnlyPrefixes: [] },
+        i18n,
+      );
+      const config = {
+        base: tc.base.replace(/\/+$/, ""),
+        defaultLocale: "en",
+        trailingSlash: tc.trailingSlash,
+      };
+      const links = helpers.buildLocaleLinks(tc.pathname, tc.currentLang);
+      // Need >1 rendered link so there are inactive anchors to re-wire.
+      expect(links.length).toBeGreaterThan(1);
+      for (const link of links) {
+        if (link.active) continue;
+        expect(
+          switchLocaleHref(tc.pathname, config, tc.currentLang, link.code),
+          `${tc.label} → ${link.code}`,
+        ).toBe(link.href);
+      }
+    });
+  }
+
+  it("default-locale-only pages render one (active) link — nothing to re-wire", () => {
+    const helpers = makeUrlHelpers(
+      { base: "/", trailingSlash: true, siteUrl: "", defaultLocaleOnlyPrefixes: ["/docs/versions/"] },
+      i18n,
+    );
+    const links = helpers.buildLocaleLinks("/ja/docs/versions/", "ja");
+    expect(links.length).toBe(1);
+    expect(links[0]?.active).toBe(true);
+  });
+});
+
+describe("LANGUAGE_SWITCHER_INIT_SCRIPT", () => {
+  it("is non-empty, rebinds on after-navigate, and is idempotent", () => {
+    expect(LANGUAGE_SWITCHER_INIT_SCRIPT.length).toBeGreaterThan(0);
+    expect(LANGUAGE_SWITCHER_INIT_SCRIPT).toContain(JSON.stringify(AFTER_NAVIGATE_EVENT));
+    expect(LANGUAGE_SWITCHER_INIT_SCRIPT).toContain("data-language-switcher");
+    expect(LANGUAGE_SWITCHER_INIT_SCRIPT).toContain("switchLocaleHref");
+    expect(LANGUAGE_SWITCHER_INIT_SCRIPT).toContain("window.location.pathname");
+    // idempotency guard (single document-level listener per page lifetime)
+    expect(LANGUAGE_SWITCHER_INIT_SCRIPT).toContain("__zdLanguageSwitcherInit");
   });
 });

--- a/packages/zudo-doc/src/i18n-version/index.ts
+++ b/packages/zudo-doc/src/i18n-version/index.ts
@@ -17,8 +17,15 @@
 // layout's body-end scripts slot) — it idempotently re-binds after
 // View Transitions navigation.
 
-export { LanguageSwitcher } from "./language-switcher.js";
-export type { LanguageSwitcherProps } from "./language-switcher.js";
+export {
+  LanguageSwitcher,
+  LANGUAGE_SWITCHER_INIT_SCRIPT,
+  switchLocaleHref,
+} from "./language-switcher.js";
+export type {
+  LanguageSwitcherProps,
+  LanguageSwitcherConfig,
+} from "./language-switcher.js";
 
 export {
   VersionSwitcher,

--- a/packages/zudo-doc/src/i18n-version/language-switcher.tsx
+++ b/packages/zudo-doc/src/i18n-version/language-switcher.tsx
@@ -16,10 +16,137 @@
 //     keep `class` to match adjacent files like breadcrumb.tsx).
 //   * The Astro template's top-level guard (`localeLinks.length > 1 &&`)
 //     becomes an early `return null`.
+//
+// SPA re-wire (#2551): the header is persisted across same-locale SPA
+// navigations (`data-zfb-transition-persist="header-${lang}"`), so the
+// SSR-baked switcher hrefs — which are *per-page* targets — would go stale
+// after a client-side navigation. Like VersionSwitcher / ThemeToggle /
+// Search / the header nav, the switcher now ships an init script
+// (`LANGUAGE_SWITCHER_INIT_SCRIPT`) that recomputes each anchor's href from
+// `window.location.pathname` on load and on `zfb:after-swap`.
 
 import type { VNode } from "preact";
 import { Fragment } from "preact";
 import type { LocaleLink } from "./types.js";
+import { AFTER_NAVIGATE_EVENT } from "../transitions/index.js";
+
+/**
+ * The minimal project config the client re-wire needs to reproduce
+ * `getPathForLocale`'s output from the live pathname. Emitted as `data-*`
+ * attributes on the switcher container so {@link LANGUAGE_SWITCHER_INIT_SCRIPT}
+ * can read it without any serialized props.
+ */
+export interface LanguageSwitcherConfig {
+  /** Normalized site base with no trailing slash (`""` for a root site). */
+  base: string;
+  /** The project's default locale (rendered without a locale prefix). */
+  defaultLocale: string;
+  /** Whether the project appends trailing slashes to page URLs. */
+  trailingSlash: boolean;
+}
+
+/**
+ * Client-side re-computation of a locale-switched href from the *current*
+ * pathname. This is a self-contained port of `getPathForLocale` (+ its
+ * `stripBase` / version-prefix split / `withBase` / `applyTrailingSlash`
+ * dependencies) from `url-helpers`. It MUST stay behaviourally identical to
+ * that function — pinned by the drift-guard test in
+ * `__tests__/language-switcher.test.tsx`, which asserts equality against the
+ * real `buildLocaleLinks` output across a case table.
+ *
+ * It is deliberately self-contained (no references to module-scope helpers)
+ * because {@link LANGUAGE_SWITCHER_INIT_SCRIPT} embeds it verbatim via
+ * `.toString()`, so it must be valid as a standalone function in the browser.
+ */
+export function switchLocaleHref(
+  pathname: string,
+  config: LanguageSwitcherConfig,
+  currentLang: string,
+  targetLang: string,
+): string {
+  const normalizedBase = config.base;
+  const defaultLocale = config.defaultLocale;
+  const trailingSlash = config.trailingSlash;
+
+  const stripBase = (path: string): string => {
+    if (normalizedBase === "") return path;
+    if (path === normalizedBase) return "/";
+    return path.indexOf(normalizedBase + "/") === 0
+      ? path.slice(normalizedBase.length)
+      : path;
+  };
+
+  const applyTrailingSlash = (url: string): string => {
+    if (!trailingSlash) return url;
+    if (url.charAt(url.length - 1) === "/") return url;
+    const suffixIdx = url.search(/[?#]/);
+    const pathPart = suffixIdx >= 0 ? url.slice(0, suffixIdx) : url;
+    const suffix = suffixIdx >= 0 ? url.slice(suffixIdx) : "";
+    if (pathPart.charAt(pathPart.length - 1) === "/") return url;
+    const segments = pathPart.split("/");
+    const lastSegment = segments[segments.length - 1] || "";
+    if (/\.[a-zA-Z]\w*$/.test(lastSegment)) return url;
+    return pathPart + "/" + suffix;
+  };
+
+  const withBase = (path: string): string => {
+    const raw =
+      normalizedBase === ""
+        ? path
+        : normalizedBase + (path.charAt(0) === "/" ? path : "/" + path);
+    return applyTrailingSlash(raw);
+  };
+
+  const stripped = stripBase(pathname);
+  const versionMatch = stripped.match(/^(\/v\/[^/]+)(\/.*|$)/);
+  const versionPrefix = versionMatch ? versionMatch[1] || "" : "";
+  let relativePath = versionMatch ? versionMatch[2] || "/" : stripped;
+  if (currentLang !== defaultLocale) {
+    relativePath = relativePath.replace(
+      new RegExp("^/" + currentLang + "(?:/|$)"),
+      "/",
+    );
+  }
+  if (targetLang !== defaultLocale) {
+    relativePath = "/" + targetLang + relativePath;
+  }
+  return withBase(versionPrefix + relativePath);
+}
+
+/**
+ * Inline init script that keeps the switcher's per-page hrefs correct inside a
+ * persisted header. Mounted once wherever a header is rendered (see
+ * `header.tsx`), it registers a document-level `zfb:after-swap` listener on
+ * first load and re-runs {@link switchLocaleHref} against the live pathname —
+ * the same rebind-on-navigate contract `VERSION_SWITCHER_INIT_SCRIPT` uses.
+ *
+ * `window[FLAG]` makes it idempotent: the tag may re-execute on a hard reload
+ * or a cross-locale header repaint, but the listener is registered exactly
+ * once per page lifetime.
+ */
+export const LANGUAGE_SWITCHER_INIT_SCRIPT = `(function(){
+var FLAG="__zdLanguageSwitcherInit";
+if(window[FLAG])return;
+window[FLAG]=true;
+var switchLocaleHref=${switchLocaleHref.toString()};
+function rewire(){
+var containers=document.querySelectorAll("[data-language-switcher]");
+for(var i=0;i<containers.length;i++){
+var c=containers[i];
+var config={base:c.getAttribute("data-base")||"",defaultLocale:c.getAttribute("data-default-locale")||"",trailingSlash:c.getAttribute("data-trailing-slash")==="true"};
+var currentLang=c.getAttribute("data-current-locale")||config.defaultLocale;
+var anchors=c.querySelectorAll("a[lang]");
+for(var j=0;j<anchors.length;j++){
+var a=anchors[j];
+var target=a.getAttribute("lang");
+if(!target)continue;
+a.setAttribute("href",switchLocaleHref(window.location.pathname,config,currentLang,target));
+}
+}
+}
+rewire();
+document.addEventListener(${JSON.stringify(AFTER_NAVIGATE_EVENT)},rewire);
+})();`;
 
 export interface LanguageSwitcherProps {
   /**
@@ -28,6 +155,19 @@ export interface LanguageSwitcherProps {
    * `buildLocaleLinks(currentPath, currentLang)` helper before passing.
    */
   links: LocaleLink[];
+  /**
+   * When provided, the switcher container emits `data-*` config so
+   * {@link LANGUAGE_SWITCHER_INIT_SCRIPT} can re-compute each anchor's href
+   * from the live pathname after a same-locale SPA navigation (the header is
+   * persisted, so SSR hrefs would otherwise go stale). Omit for a purely
+   * static / no-JS render.
+   */
+  config?: LanguageSwitcherConfig;
+  /**
+   * The active locale code, recorded as `data-current-locale` so the re-wire
+   * script knows which locale segment to strip. Only read when `config` is set.
+   */
+  currentLocale?: string;
 }
 
 /**
@@ -37,11 +177,27 @@ export interface LanguageSwitcherProps {
  * template's `localeLinks.length > 1 &&` guard so call-sites can mount
  * the component unconditionally).
  */
-export function LanguageSwitcher({ links }: LanguageSwitcherProps): VNode | null {
+export function LanguageSwitcher({
+  links,
+  config,
+  currentLocale,
+}: LanguageSwitcherProps): VNode | null {
   if (links.length <= 1) return null;
 
+  // Config attributes drive the SPA re-wire script; omitted when no config
+  // is supplied so static callers render exactly as before.
+  const rewireAttrs = config
+    ? {
+        "data-language-switcher": true,
+        "data-base": config.base,
+        "data-default-locale": config.defaultLocale,
+        "data-trailing-slash": String(config.trailingSlash),
+        "data-current-locale": currentLocale ?? config.defaultLocale,
+      }
+    : {};
+
   return (
-    <div class="flex items-center gap-x-hsp-xs text-small">
+    <div class="flex items-center gap-x-hsp-xs text-small" {...rewireAttrs}>
       {links.map((link, i) => (
         // Fragment is keyed via the locale code so the reconciler keeps
         // the active/inactive nodes paired correctly across re-renders


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2551
    - https://github.com/zudolab/zudo-doc/issues/2550 (epic)

---

## Summary

The header language switcher navigated to the **wrong page** when switching locale after in-site navigation. On `/ja/docs/guides/sidebar-filter/`, switching to EN should land on `/docs/guides/sidebar-filter/` but it went to a stale target (e.g. the page where you first entered the locale).

**Root cause:** the `<header>` is persisted across same-locale SPA / view-transition navigations (`data-zfb-transition-persist="header-${lang}"`), so the header DOM is reused, not re-rendered. The `LanguageSwitcher` was a pure SSR component with **no client script**, so its per-page target hrefs (the equivalent page in each other locale) went stale after client-side navigation. Every other persisted control (VersionSwitcher, ThemeToggle, Search, nav aria-current) already re-wires on `zfb:after-swap` — the switcher did not.

## Changes

- **`LANGUAGE_SWITCHER_INIT_SCRIPT`** (`i18n-version/language-switcher.tsx`) — modelled on `VERSION_SWITCHER_INIT_SCRIPT`. On load and on `zfb:after-swap`, recomputes each switcher anchor's `href` from `window.location.pathname`. Registers a single document-level listener (idempotent `window` flag), mounted once inside the header (gated on `hasLocales`).
- **`switchLocaleHref`** — a self-contained port of `getPathForLocale` (base normalization, `/v/{version}` prefix, locale strip/add, trailing-slash), embedded into the script via `.toString()` so there is a single source of truth. Pinned to the real SSR output by a **drift-guard unit test** across a case table (default↔non-default, versioned, base-prefix, trailing-slash on/off).
- The switcher emits its config (`base` / `defaultLocale` / `trailingSlash` / `currentLocale`) as `data-*` attributes; `header-with-defaults` passes it. Static/no-JS render is unchanged when no config is supplied.
- Corrected the now-inaccurate persist comment in `header.tsx` (it claimed switcher links were "locale-static — no per-page fields go stale").

## Test Plan

- **Unit** (`i18n-version/__tests__/language-switcher.test.tsx`): drift-guard (client transform === `buildLocaleLinks` across 7 cases), script-structure (rebinds on `zfb:after-swap`, idempotent), config-attribute emission. 15/15 pass.
- **E2E** (`e2e/i18n-vt-chrome-persist.spec.ts`, new Test 6): hard-load a JA page → same-locale SPA nav to another JA page → assert the persisted header's EN switcher href tracks the current page and clicking it lands there. **Confirmed fails on main, passes with the fix.** The i18n fixture now renders the header switcher so the desktop surface is exercised.
- `pnpm check` (typecheck) ✓, `pnpm check:template-drift` ✓.

## Follow-up

- #2553 — `VersionSwitcher` menu hrefs have the same latent staleness (deferred; versions not enabled on the showcase).