### PR TITLE
fix(i18n-version): re-wire persisted-header VersionSwitcher menu across SPA navigation

### DIFF
--- a/e2e/versioning-vt-chrome-persist.spec.ts
+++ b/e2e/versioning-vt-chrome-persist.spec.ts
@@ -127,3 +127,80 @@ test.describe("VT Chrome Persist: version-switcher state on versioned routes", (
     ).toMatch(/1\.0/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// #2553: the persisted header's version-switcher MENU (anchor hrefs, active
+// row, trigger label) must be recomputed from the live pathname on
+// zfb:after-swap — not just the toggle open/close behaviour. These assert the
+// stale-menu regression that the tests above deliberately left uncovered.
+//
+// The fixture emits slashless hrefs (trailingSlash off), so href assertions
+// tolerate an optional trailing slash.
+// ---------------------------------------------------------------------------
+test.describe("VT Chrome Persist: version-switcher menu re-wire (#2553)", () => {
+  test("menu anchor hrefs re-wire after a same-version SPA swap", async ({ page }) => {
+    await page.goto(VERSIONED_PAGE, { waitUntil: "domcontentloaded" });
+
+    // Scope to the persisted-header switcher (the only one carrying the
+    // re-wire config); the inline breadcrumb switcher lives in <main> and is
+    // re-rendered fresh on every swap, so it is intentionally not re-wired.
+    const sw = page.getByRole("banner").locator("[data-version-rewire]");
+    await expect(sw, "header version-switcher must opt into SPA re-wire").toBeAttached();
+
+    const latestAnchor = sw.locator("[data-version-latest]");
+    const v1Anchor = sw.locator('[data-version-slug="1.0"]');
+
+    // Baseline: on the getting-started page the menu points there.
+    await expect(v1Anchor).toHaveAttribute("href", /\/v\/1\.0\/docs\/getting-started\/?$/);
+    await expect(latestAnchor).toHaveAttribute("href", /^\/docs\/getting-started\/?$/);
+
+    // Tag the switcher DOM node so we can prove it persisted (a re-wire) rather
+    // than being re-rendered by the router.
+    await sw.evaluate((el) => el.setAttribute("data-persist-marker", "v1"));
+
+    const swapFired = await spaClick(page, VERSIONED_PAGE_2);
+    expect(swapFired, "zfb:after-swap should fire for the same-version SPA swap").toBe(true);
+    await page.waitForURL(/\/v\/1\.0\/docs\/installation\/?$/);
+
+    // Same DOM node → header genuinely persisted, so the hrefs below only
+    // update because of the client re-wire (they would be stale pre-fix).
+    await expect(
+      sw,
+      "the header switcher must be the same persisted DOM node after the swap",
+    ).toHaveAttribute("data-persist-marker", "v1");
+
+    await expect(v1Anchor).toHaveAttribute("href", /\/v\/1\.0\/docs\/installation\/?$/);
+    await expect(latestAnchor).toHaveAttribute("href", /^\/docs\/installation\/?$/);
+  });
+
+  test("active row + trigger label re-wire on a cross-version SPA swap", async ({ page }) => {
+    await page.goto(VERSIONED_PAGE, { waitUntil: "domcontentloaded" });
+
+    const sw = page.getByRole("banner").locator("[data-version-rewire]");
+    await expect(sw).toBeAttached();
+
+    const triggerLabel = sw.locator("[data-version-trigger-label]");
+    const latestAnchor = sw.locator("[data-version-latest]");
+    const v1Anchor = sw.locator('[data-version-slug="1.0"]');
+
+    // Baseline on the versioned page: label "1.0.0", the 1.0 row is active.
+    await expect(triggerLabel).toHaveText(/1\.0/);
+    await expect(v1Anchor).toHaveAttribute("aria-current", "page");
+
+    await sw.evaluate((el) => el.setAttribute("data-persist-marker", "vc"));
+
+    // SPA-navigate to the latest page via the switcher's own "Latest" menu
+    // link — a cross-version swap under the shared header-en persist key.
+    const swapFired = await spaClick(page, LATEST_PAGE);
+    expect(swapFired, "zfb:after-swap should fire for the cross-version SPA swap").toBe(true);
+    await page.waitForURL(/\/docs\/getting-started\/?$/);
+
+    await expect(sw).toHaveAttribute("data-persist-marker", "vc");
+
+    // Post-nav the active row + label must follow the latest page (would stay
+    // stale on "1.0.0" pre-fix).
+    await expect(triggerLabel).toHaveText(/Latest/);
+    await expect(latestAnchor).toHaveAttribute("aria-current", "page");
+    await expect(v1Anchor).not.toHaveAttribute("aria-current", "page");
+  });
+});

--- a/packages/zudo-doc/src/header-with-defaults/index.tsx
+++ b/packages/zudo-doc/src/header-with-defaults/index.tsx
@@ -193,6 +193,15 @@ export function createHeaderWithDefaults<S extends Settings = Settings>(
           versionUrls={versionUrls}
           labels={labels}
           idSuffix="header"
+          // Persisted-header re-wire (#2553): the menu's per-page hrefs / active
+          // row / trigger label are recomputed from the live pathname on
+          // zfb:after-swap, mirroring the LanguageSwitcher config above.
+          rewireConfig={{
+            base: settings.base.replace(/\/+$/, ""),
+            defaultLocale,
+            trailingSlash: settings.trailingSlash,
+            currentLocale: lang,
+          }}
         />
       ) as unknown as VNode;
     }

--- a/packages/zudo-doc/src/header/header.tsx
+++ b/packages/zudo-doc/src/header/header.tsx
@@ -46,6 +46,7 @@ import {
 } from "./nav-active.js";
 import { NAV_OVERFLOW_SCRIPT } from "./nav-overflow-script.js";
 import { LANGUAGE_SWITCHER_INIT_SCRIPT } from "../i18n-version/language-switcher.js";
+import { VERSION_SWITCHER_REWIRE_SCRIPT } from "../i18n-version/version-switcher.js";
 import type {
   HeaderNavItem,
   HeaderRightItem,
@@ -254,6 +255,7 @@ export function Header(props: HeaderProps): JSX.Element {
     headerRightItems,
     colorModeEnabled,
     hasLocales,
+    hasVersions,
     githubRepoUrl,
     githubLabel,
     urlHelpers,
@@ -280,8 +282,12 @@ export function Header(props: HeaderProps): JSX.Element {
       // AFTER_NAVIGATE_EVENT or URL derivation:
       //   - ThemeToggle: re-applies from localStorage on AFTER_NAVIGATE_EVENT
       //     (color-scheme-provider.tsx bootstrap script, #1546 verified (a))
-      //   - VersionSwitcher: VERSION_SWITCHER_INIT_SCRIPT re-wires toggle on
-      //     AFTER_NAVIGATE_EVENT (version-switcher.tsx:340, verified (a))
+      //   - VersionSwitcher: its menu hrefs, active row, and trigger label ARE
+      //     per-page (derived from currentSlug/currentVersion), so within a
+      //     same-locale persist window they WOULD go stale. VERSION_SWITCHER_INIT_SCRIPT
+      //     re-binds the dropdown toggle on AFTER_NAVIGATE_EVENT, and
+      //     VERSION_SWITCHER_REWIRE_SCRIPT recomputes the menu from
+      //     window.location on the same event (zudolab/zudo-doc#2553).
       //   - Search: <site-search> custom element re-registers on
       //     AFTER_NAVIGATE_EVENT (_search-widget-script.ts:184, verified (a))
       //   - SidebarToggle (mobile): closes on AFTER_NAVIGATE_EVENT
@@ -376,6 +382,15 @@ export function Header(props: HeaderProps): JSX.Element {
         // listener once; idempotent across re-execution.
         <script
           dangerouslySetInnerHTML={{ __html: LANGUAGE_SWITCHER_INIT_SCRIPT }}
+        />
+      ) : null}
+      {hasVersions ? (
+        // Keeps the persisted header's version-switcher menu hrefs / active row /
+        // trigger label tracking the current page across same-locale SPA
+        // navigation (#2553). Registers a document-level AFTER_NAVIGATE_EVENT
+        // listener once; idempotent across re-execution.
+        <script
+          dangerouslySetInnerHTML={{ __html: VERSION_SWITCHER_REWIRE_SCRIPT }}
         />
       ) : null}
     </header>

--- a/packages/zudo-doc/src/i18n-version/__tests__/version-switcher.test.tsx
+++ b/packages/zudo-doc/src/i18n-version/__tests__/version-switcher.test.tsx
@@ -6,10 +6,17 @@ import type { ComponentChildren, VNode } from "preact";
 import {
   VersionSwitcher,
   VERSION_SWITCHER_INIT_SCRIPT,
+  VERSION_SWITCHER_REWIRE_SCRIPT,
   VERSION_SWITCHER_VISIBILITY_STYLE,
+  computeVersionSwitcherState,
 } from "../version-switcher.js";
-import type { VersionEntry, VersionSwitcherLabels } from "../types.js";
+import type {
+  VersionEntry,
+  VersionSwitcherLabels,
+} from "../types.js";
+import type { VersionSwitcherRewireConfig } from "../version-switcher.js";
 import { AFTER_NAVIGATE_EVENT } from "../../transitions/page-events.js";
+import { makeUrlHelpers } from "../../url-helpers/index.js";
 
 type AnyVNode = VNode<{ children?: ComponentChildren; [key: string]: unknown }>;
 
@@ -224,5 +231,221 @@ describe("VersionSwitcher", () => {
     // bundle: it would force `display:none` on any wrapping element
     // a consumer chose, regardless of intent.
     expect(VERSION_SWITCHER_VISIBILITY_STYLE).not.toContain("*:has(");
+  });
+
+  it("emits data-* rewire config + anchor markers when rewireConfig is provided", () => {
+    const html = serialize(
+      <VersionSwitcher
+        versions={versions}
+        currentVersion="v1"
+        latestUrl="/docs/intro/"
+        versionsPageUrl="/docs/versions/"
+        versionUrls={versionUrls}
+        labels={labels}
+        idSuffix="header"
+        rewireConfig={{
+          base: "",
+          defaultLocale: "en",
+          trailingSlash: true,
+          currentLocale: "en",
+        }}
+      />,
+    );
+    expect(html).toContain("data-version-rewire");
+    expect(html).toContain('data-default-locale="en"');
+    expect(html).toContain('data-trailing-slash="true"');
+    expect(html).toContain('data-current-locale="en"');
+    expect(html).toContain("data-version-latest");
+    expect(html).toContain("data-version-trigger-label");
+    expect(html).toContain('data-version-slug="v1"');
+    expect(html).toContain('data-version-slug="v2"');
+  });
+
+  it("omits rewire markers for a static render (no rewireConfig)", () => {
+    const html = serialize(
+      <VersionSwitcher
+        versions={versions}
+        latestUrl="/docs/intro/"
+        versionsPageUrl="/docs/versions/"
+        versionUrls={versionUrls}
+        labels={labels}
+      />,
+    );
+    expect(html).not.toContain("data-version-rewire");
+    expect(html).not.toContain("data-version-latest");
+    expect(html).not.toContain("data-version-slug");
+    expect(html).not.toContain("data-version-trigger-label");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SPA re-wire (#2553): the client transform must reproduce the SSR-baked
+// header menu (latestUrl / versionUrls / active version) exactly, so a
+// persisted header's version switcher stays correct after same-locale
+// navigation. This pins computeVersionSwitcherState to the header factory's
+// URL logic (createHeaderWithDefaults's latestUrl/versionUrls block, in turn
+// makeUrlHelpers' docsUrl / versionedDocsUrl / withBase).
+// ---------------------------------------------------------------------------
+describe("computeVersionSwitcherState (client re-wire) matches SSR header menu", () => {
+  const i18n = {
+    defaultLocale: "en",
+    locales: ["en", "ja"],
+    getLocaleLabel: (c: string) => c.toUpperCase(),
+  };
+
+  const versionSlugs = ["1.0", "2.0"];
+
+  /**
+   * Reproduce the exact per-page menu the header factory builds
+   * (header-with-defaults/index.tsx) from (currentSlug, currentVersion, lang).
+   */
+  function ssrHeaderMenu(
+    helpers: ReturnType<typeof makeUrlHelpers>,
+    lang: string,
+    currentSlug: string | undefined,
+    currentVersion: string | undefined,
+  ) {
+    const isNonDefaultLocale = lang !== i18n.defaultLocale;
+    const versionsPageUrl = helpers.withBase(
+      isNonDefaultLocale ? `/${lang}/docs/versions` : "/docs/versions",
+    );
+    const latestUrl =
+      currentSlug != null ? helpers.docsUrl(currentSlug, lang) : versionsPageUrl;
+    const versionUrls: Record<string, string> = {};
+    for (const v of versionSlugs) {
+      versionUrls[v] =
+        currentSlug != null
+          ? helpers.versionedDocsUrl(currentSlug, v, lang)
+          : versionsPageUrl;
+    }
+    return { latestUrl, versionUrls, activeVersion: currentVersion ?? null };
+  }
+
+  const cases: Array<{
+    label: string;
+    base: string;
+    trailingSlash: boolean;
+    lang: string;
+    // A doc page carries currentSlug; the /docs/versions listing + non-doc
+    // pages pass currentSlug undefined (all links collapse to versionsPageUrl).
+    currentSlug: string | undefined;
+    currentVersion: string | undefined;
+    // How the SSR router builds this page's own pathname.
+    pathnameFor: (h: ReturnType<typeof makeUrlHelpers>) => string;
+  }> = [
+    {
+      label: "latest, default locale, deep slug",
+      base: "/",
+      trailingSlash: true,
+      lang: "en",
+      currentSlug: "guides/getting-started",
+      currentVersion: undefined,
+      pathnameFor: (h) => h.docsUrl("guides/getting-started", "en"),
+    },
+    {
+      label: "versioned, default locale",
+      base: "/",
+      trailingSlash: true,
+      lang: "en",
+      currentSlug: "getting-started",
+      currentVersion: "1.0",
+      pathnameFor: (h) => h.versionedDocsUrl("getting-started", "1.0", "en"),
+    },
+    {
+      label: "versioned, non-default locale",
+      base: "/",
+      trailingSlash: true,
+      lang: "ja",
+      currentSlug: "guide/intro",
+      currentVersion: "2.0",
+      pathnameFor: (h) => h.versionedDocsUrl("guide/intro", "2.0", "ja"),
+    },
+    {
+      label: "latest, non-default locale, docs root (empty slug)",
+      base: "/",
+      trailingSlash: true,
+      lang: "ja",
+      currentSlug: "",
+      currentVersion: undefined,
+      pathnameFor: (h) => h.docsUrl("", "ja"),
+    },
+    {
+      label: "versions index, default locale (no currentSlug)",
+      base: "/",
+      trailingSlash: true,
+      lang: "en",
+      currentSlug: undefined,
+      currentVersion: undefined,
+      pathnameFor: (h) => h.withBase("/docs/versions"),
+    },
+    {
+      label: "versions index, non-default locale (no currentSlug)",
+      base: "/",
+      trailingSlash: true,
+      lang: "ja",
+      currentSlug: undefined,
+      currentVersion: undefined,
+      pathnameFor: (h) => h.withBase("/ja/docs/versions"),
+    },
+    {
+      label: "with base prefix, versioned",
+      base: "/app",
+      trailingSlash: true,
+      lang: "en",
+      currentSlug: "x",
+      currentVersion: "2.0",
+      pathnameFor: (h) => h.versionedDocsUrl("x", "2.0", "en"),
+    },
+    {
+      label: "trailingSlash off, latest",
+      base: "/",
+      trailingSlash: false,
+      lang: "en",
+      currentSlug: "x",
+      currentVersion: undefined,
+      pathnameFor: (h) => h.docsUrl("x", "en"),
+    },
+  ];
+
+  for (const tc of cases) {
+    it(`reproduces SSR menu: ${tc.label}`, () => {
+      const helpers = makeUrlHelpers(
+        {
+          base: tc.base,
+          trailingSlash: tc.trailingSlash,
+          siteUrl: "",
+          defaultLocaleOnlyPrefixes: [],
+        },
+        i18n,
+      );
+      const pathname = tc.pathnameFor(helpers);
+      const ssr = ssrHeaderMenu(helpers, tc.lang, tc.currentSlug, tc.currentVersion);
+
+      const config: VersionSwitcherRewireConfig = {
+        base: tc.base.replace(/\/+$/, ""),
+        defaultLocale: i18n.defaultLocale,
+        trailingSlash: tc.trailingSlash,
+        currentLocale: tc.lang,
+      };
+      const client = computeVersionSwitcherState(pathname, config, versionSlugs);
+
+      expect(client.latestHref, `${tc.label} → latest`).toBe(ssr.latestUrl);
+      for (const v of versionSlugs) {
+        expect(client.versionHrefs[v], `${tc.label} → ${v}`).toBe(ssr.versionUrls[v]);
+      }
+      expect(client.activeVersion, `${tc.label} → active`).toBe(ssr.activeVersion);
+    });
+  }
+});
+
+describe("VERSION_SWITCHER_REWIRE_SCRIPT", () => {
+  it("is non-empty, rebinds on after-navigate, embeds the state fn, and is idempotent", () => {
+    expect(VERSION_SWITCHER_REWIRE_SCRIPT.length).toBeGreaterThan(0);
+    expect(VERSION_SWITCHER_REWIRE_SCRIPT).toContain(JSON.stringify(AFTER_NAVIGATE_EVENT));
+    expect(VERSION_SWITCHER_REWIRE_SCRIPT).toContain("data-version-rewire");
+    expect(VERSION_SWITCHER_REWIRE_SCRIPT).toContain("computeVersionSwitcherState");
+    expect(VERSION_SWITCHER_REWIRE_SCRIPT).toContain("window.location.pathname");
+    // idempotency guard (single document-level listener per page lifetime)
+    expect(VERSION_SWITCHER_REWIRE_SCRIPT).toContain("__zdVersionSwitcherRewire");
   });
 });

--- a/packages/zudo-doc/src/i18n-version/index.ts
+++ b/packages/zudo-doc/src/i18n-version/index.ts
@@ -30,9 +30,15 @@ export type {
 export {
   VersionSwitcher,
   VERSION_SWITCHER_INIT_SCRIPT,
+  VERSION_SWITCHER_REWIRE_SCRIPT,
   VERSION_SWITCHER_VISIBILITY_STYLE,
+  computeVersionSwitcherState,
 } from "./version-switcher.js";
-export type { VersionSwitcherProps } from "./version-switcher.js";
+export type {
+  VersionSwitcherProps,
+  VersionSwitcherRewireConfig,
+  VersionSwitcherState,
+} from "./version-switcher.js";
 
 export { VersionBanner } from "./version-banner.js";
 export type { VersionBannerProps, VersionBannerLabels } from "./version-banner.js";

--- a/packages/zudo-doc/src/i18n-version/version-switcher.tsx
+++ b/packages/zudo-doc/src/i18n-version/version-switcher.tsx
@@ -110,6 +110,150 @@ export interface VersionSwitcherProps {
    * unique.
    */
   idSuffix?: string;
+
+  /**
+   * When provided, the switcher container emits `data-version-rewire` plus its
+   * config as `data-*`, and the menu anchors / trigger label carry the marker
+   * attributes {@link VERSION_SWITCHER_REWIRE_SCRIPT} needs. This lets the
+   * script recompute the per-page menu hrefs + active state + trigger label
+   * from the live pathname after a same-locale SPA navigation — the header is
+   * persisted (`data-zfb-transition-persist="header-${lang}"`), so its SSR menu
+   * values would otherwise go stale (zudolab/zudo-doc#2553).
+   *
+   * Omit for a static / no-JS render, e.g. the inline breadcrumb switcher,
+   * which lives in swapped content and is re-rendered fresh on every swap.
+   */
+  rewireConfig?: VersionSwitcherRewireConfig;
+}
+
+/**
+ * The minimal project config the client re-wire needs to reproduce the header
+ * factory's per-page menu URLs from the live pathname. Emitted as `data-*`
+ * attributes on the switcher container so {@link VERSION_SWITCHER_REWIRE_SCRIPT}
+ * can read it without any serialized props.
+ */
+export interface VersionSwitcherRewireConfig {
+  /** Normalized site base with no trailing slash (`""` for a root site). */
+  base: string;
+  /** The project's default locale (rendered without a locale prefix). */
+  defaultLocale: string;
+  /** Whether the project appends trailing slashes to page URLs. */
+  trailingSlash: boolean;
+  /**
+   * The active locale code — constant within a `header-${lang}` persist window,
+   * so it can be read once from the SSR container rather than re-derived.
+   */
+  currentLocale: string;
+}
+
+/** The re-computed per-page menu state {@link computeVersionSwitcherState} returns. */
+export interface VersionSwitcherState {
+  /** Href for the "Latest" entry, matching the SSR `latestUrl`. */
+  latestHref: string;
+  /** version slug → href for that version of the current page (SSR `versionUrls`). */
+  versionHrefs: Record<string, string>;
+  /** Active version slug, or `null` when the current page is on "latest". */
+  activeVersion: string | null;
+}
+
+/**
+ * Client-side re-computation of the version-switcher's per-page menu state from
+ * the *current* pathname. This is a self-contained port of the header factory's
+ * URL logic (`createHeaderWithDefaults`'s `latestUrl` / `versionUrls` block, in
+ * turn `docsUrl` / `versionedDocsUrl` / `withBase` from `url-helpers`). It MUST
+ * stay behaviourally identical to that SSR path — pinned by the drift-guard test
+ * in `__tests__/version-switcher.test.tsx`, which asserts equality against the
+ * real `makeUrlHelpers` output across a case table.
+ *
+ * It is deliberately self-contained (no references to module-scope helpers)
+ * because {@link VERSION_SWITCHER_REWIRE_SCRIPT} embeds it verbatim via
+ * `.toString()`, so it must be valid as a standalone function in the browser.
+ *
+ * The `/docs/versions` listing is a standalone package route (`currentSlug`
+ * `undefined` on the SSR side), so — like the SSR factory — every menu href
+ * there collapses to `versionsPageUrl`; the exact-path check below mirrors that.
+ */
+export function computeVersionSwitcherState(
+  pathname: string,
+  config: VersionSwitcherRewireConfig,
+  versionSlugs: string[],
+): VersionSwitcherState {
+  const normalizedBase = config.base;
+  const defaultLocale = config.defaultLocale;
+  const currentLocale = config.currentLocale;
+  const trailingSlash = config.trailingSlash;
+
+  const stripBase = (path: string): string => {
+    if (normalizedBase === "") return path;
+    if (path === normalizedBase) return "/";
+    return path.indexOf(normalizedBase + "/") === 0
+      ? path.slice(normalizedBase.length)
+      : path;
+  };
+
+  const applyTrailingSlash = (url: string): string => {
+    if (!trailingSlash) return url;
+    if (url.charAt(url.length - 1) === "/") return url;
+    const suffixIdx = url.search(/[?#]/);
+    const pathPart = suffixIdx >= 0 ? url.slice(0, suffixIdx) : url;
+    const suffix = suffixIdx >= 0 ? url.slice(suffixIdx) : "";
+    if (pathPart.charAt(pathPart.length - 1) === "/") return url;
+    const segments = pathPart.split("/");
+    const lastSegment = segments[segments.length - 1] || "";
+    if (/\.[a-zA-Z]\w*$/.test(lastSegment)) return url;
+    return pathPart + "/" + suffix;
+  };
+
+  const withBase = (path: string): string => {
+    const raw =
+      normalizedBase === ""
+        ? path
+        : normalizedBase + (path.charAt(0) === "/" ? path : "/" + path);
+    return applyTrailingSlash(raw);
+  };
+
+  const versionsPageUrl = withBase(
+    currentLocale === defaultLocale
+      ? "/docs/versions"
+      : "/" + currentLocale + "/docs/versions",
+  );
+
+  const stripped = stripBase(pathname);
+  const versionMatch = stripped.match(/^\/v\/([^/]+)(\/.*|$)/);
+  const rest = versionMatch ? versionMatch[2] || "/" : stripped;
+
+  let localeStripped = rest;
+  if (currentLocale !== defaultLocale) {
+    localeStripped = rest.replace(
+      new RegExp("^/" + currentLocale + "(?:/|$)"),
+      "/",
+    );
+  }
+  // A page carries a `currentSlug` (and thus per-page menu URLs) iff it is one
+  // of the doc-collection catch-all routes — every `/docs/...` path EXCEPT the
+  // standalone `/docs/versions` listing, which has no `currentSlug`.
+  const isVersionsIndex =
+    localeStripped === "/docs/versions" || localeStripped === "/docs/versions/";
+  const isDocPage = /^\/docs(\/|$)/.test(localeStripped) && !isVersionsIndex;
+  const activeVersion = isDocPage && versionMatch ? versionMatch[1] || null : null;
+
+  const versionHrefs: Record<string, string> = {};
+  let latestHref: string;
+  if (isDocPage) {
+    latestHref = withBase(rest);
+    for (let i = 0; i < versionSlugs.length; i++) {
+      const slug = versionSlugs[i];
+      if (slug) versionHrefs[slug] = withBase("/v/" + slug + rest);
+    }
+  } else {
+    latestHref = versionsPageUrl;
+    for (let i = 0; i < versionSlugs.length; i++) {
+      const slug = versionSlugs[i];
+      if (slug) versionHrefs[slug] = versionsPageUrl;
+    }
+  }
+
+  return { latestHref, versionHrefs, activeVersion };
 }
 
 /** Concatenate Tailwind class strings, dropping falsy entries. */
@@ -189,6 +333,7 @@ export function VersionSwitcher(props: VersionSwitcherProps): VNode {
     unavailableVersions,
     labels,
     idSuffix = "",
+    rewireConfig,
   } = props;
 
   const menuId = `version-menu${idSuffix ? `-${idSuffix}` : ""}`;
@@ -197,8 +342,22 @@ export function VersionSwitcher(props: VersionSwitcherProps): VNode {
     ? labels.latest
     : (versions.find((v) => v.slug === currentVersion)?.label ?? currentVersion);
 
+  // Config attributes + anchor markers drive the SPA re-wire script; omitted
+  // when no config is supplied so static / inline callers render exactly as
+  // before (zudolab/zudo-doc#2553).
+  const rewire = rewireConfig != null;
+  const rewireAttrs = rewireConfig
+    ? {
+        "data-version-rewire": true,
+        "data-base": rewireConfig.base,
+        "data-default-locale": rewireConfig.defaultLocale,
+        "data-trailing-slash": String(rewireConfig.trailingSlash),
+        "data-current-locale": rewireConfig.currentLocale,
+      }
+    : {};
+
   return (
-    <div class="version-switcher relative" data-version-switcher>
+    <div class="version-switcher relative" data-version-switcher {...rewireAttrs}>
       <button
         type="button"
         class="flex items-center gap-hsp-2xs border border-muted rounded px-hsp-sm py-vsp-3xs text-small text-muted hover:border-accent hover:text-accent transition-colors cursor-pointer whitespace-nowrap"
@@ -207,7 +366,12 @@ export function VersionSwitcher(props: VersionSwitcherProps): VNode {
         data-version-toggle
       >
         <span class="text-caption">{labels.switcher}:</span>
-        <span class="font-medium">{triggerLabel}</span>
+        <span
+          class="font-medium"
+          data-version-trigger-label={rewire ? true : undefined}
+        >
+          {triggerLabel}
+        </span>
         <ChevronDownIcon />
       </button>
 
@@ -224,6 +388,7 @@ export function VersionSwitcher(props: VersionSwitcherProps): VNode {
               "block px-hsp-md py-vsp-2xs text-small hover:bg-accent/10 hover:underline focus-visible:underline",
               isLatest ? "font-bold text-accent" : "text-fg",
             )}
+            data-version-latest={rewire ? true : undefined}
           >
             {labels.latest}
           </a>
@@ -246,6 +411,7 @@ export function VersionSwitcher(props: VersionSwitcherProps): VNode {
                     "block px-hsp-md py-vsp-2xs text-small hover:bg-accent/10 hover:underline focus-visible:underline",
                     isActive ? "font-bold text-accent" : "text-fg",
                   )}
+                  data-version-slug={rewire ? v.slug : undefined}
                 >
                   {v.label}
                 </a>
@@ -256,6 +422,7 @@ export function VersionSwitcher(props: VersionSwitcherProps): VNode {
                   tabindex={-1}
                   class="block px-hsp-md py-vsp-2xs text-small text-muted/50 cursor-not-allowed pointer-events-none"
                   title={labels.unavailable}
+                  data-version-slug={rewire ? v.slug : undefined}
                 >
                   {v.label}
                 </a>
@@ -324,6 +491,76 @@ toggle.focus();
 }
 initVersionSwitcher();
 document.addEventListener(${JSON.stringify(AFTER_NAVIGATE_EVENT)},initVersionSwitcher);
+})();`;
+
+/**
+ * Inline script that keeps the switcher's per-page menu correct inside a
+ * persisted header. Mounted once wherever a header renders a re-wireable
+ * VersionSwitcher (see `header.tsx`, gated on `hasVersions`), it recomputes each
+ * menu anchor's href, the active row, and the trigger label from the live
+ * pathname on first load and on `zfb:after-swap` — the same rebind-on-navigate
+ * contract `LANGUAGE_SWITCHER_INIT_SCRIPT` uses (zudolab/zudo-doc#2553).
+ *
+ * It only touches switchers carrying `data-version-rewire` (emitted when a
+ * {@link VersionSwitcherRewireConfig} is passed), so the inline breadcrumb
+ * switcher — re-rendered fresh on every swap — is left alone.
+ *
+ * `window[FLAG]` makes it idempotent: the tag may re-execute on a hard reload or
+ * a cross-locale header repaint, but the listener registers exactly once per
+ * page lifetime.
+ */
+export const VERSION_SWITCHER_REWIRE_SCRIPT = `(function(){
+var FLAG="__zdVersionSwitcherRewire";
+if(window[FLAG])return;
+window[FLAG]=true;
+var computeVersionSwitcherState=${computeVersionSwitcherState.toString()};
+function setActive(a,active){
+a.classList.toggle("font-bold",active);
+a.classList.toggle("text-accent",active);
+a.classList.toggle("text-fg",!active);
+if(active){a.setAttribute("aria-current","page");}else{a.removeAttribute("aria-current");}
+}
+function rewire(){
+var containers=document.querySelectorAll("[data-version-rewire]");
+for(var i=0;i<containers.length;i++){
+var c=containers[i];
+var config={base:c.getAttribute("data-base")||"",defaultLocale:c.getAttribute("data-default-locale")||"",trailingSlash:c.getAttribute("data-trailing-slash")==="true",currentLocale:c.getAttribute("data-current-locale")||""};
+var versionAnchors=c.querySelectorAll("[data-version-slug]");
+var slugs=[];
+for(var j=0;j<versionAnchors.length;j++){
+var s=versionAnchors[j].getAttribute("data-version-slug");
+if(s)slugs.push(s);
+}
+var state=computeVersionSwitcherState(window.location.pathname,config,slugs);
+var latest=c.querySelector("[data-version-latest]");
+if(latest){
+latest.setAttribute("href",state.latestHref);
+setActive(latest,state.activeVersion===null);
+}
+for(var k=0;k<versionAnchors.length;k++){
+var a=versionAnchors[k];
+var slug=a.getAttribute("data-version-slug");
+if(!slug)continue;
+var href=state.versionHrefs[slug];
+if(href!=null)a.setAttribute("href",href);
+if(!a.hasAttribute("aria-disabled"))setActive(a,state.activeVersion===slug);
+}
+var label=c.querySelector("[data-version-trigger-label]");
+if(label){
+if(state.activeVersion===null){
+if(latest)label.textContent=latest.textContent;
+}else{
+var activeLabel=null;
+for(var m=0;m<versionAnchors.length;m++){
+if(versionAnchors[m].getAttribute("data-version-slug")===state.activeVersion){activeLabel=versionAnchors[m].textContent;break;}
+}
+label.textContent=activeLabel!=null?activeLabel:state.activeVersion;
+}
+}
+}
+}
+rewire();
+document.addEventListener(${JSON.stringify(AFTER_NAVIGATE_EVENT)},rewire);
 })();`;
 
 // Re-export the data types so consumers can import everything they need


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2553

---

## Summary

The header is persisted across same-locale SPA / view-transition navigations (`data-zfb-transition-persist="header-${lang}"`). #2551 fixed the **LanguageSwitcher** the same way; the header **VersionSwitcher** had the same latent staleness — its menu anchor hrefs, active row, and trigger label are per-page SSR values (derived from `currentSlug`/`currentVersion`), but `VERSION_SWITCHER_INIT_SCRIPT` only rebinds the dropdown open/close behaviour on `zfb:after-swap`; it never recomputed the menu. So after a same-locale navigation the version menu could point at the previous page's versioned URLs / show a stale label.

Latent on the showcase because versions are not enabled there.

## Changes

- **`i18n-version/version-switcher.tsx`**
  - `computeVersionSwitcherState(pathname, config, versionSlugs)` — a self-contained port of the header factory's `latestUrl`/`versionUrls` logic (in turn `docsUrl`/`versionedDocsUrl`/`withBase`). Returns `{ latestHref, versionHrefs, activeVersion }`. The standalone `/docs/versions` listing has no `currentSlug`, so — like SSR — every menu href there collapses to `versionsPageUrl`; the client mirrors that exact-path case.
  - `VERSION_SWITCHER_REWIRE_SCRIPT` — embeds the state fn via `.toString()`; on load and on `zfb:after-swap` it recomputes each anchor's href, toggles the active row (`aria-current` + `font-bold text-accent`/`text-fg`), and updates the trigger label from `window.location.pathname`. Idempotent via a `window` flag (single document-level listener).
  - New optional `rewireConfig` prop → emits `data-version-rewire` + config `data-*` + anchor markers (`data-version-latest`, `data-version-slug`, `data-version-trigger-label`) only when provided. Static / inline callers (the breadcrumb switcher, re-rendered fresh on every swap) are unchanged.
- **`header-with-defaults/index.tsx`** — pass `rewireConfig` (base / defaultLocale / trailingSlash / currentLocale) to the header `<VersionSwitcher>`, mirroring the LanguageSwitcher config.
- **`header/header.tsx`** — mount `VERSION_SWITCHER_REWIRE_SCRIPT` once, gated on `hasVersions` (next to the `hasLocales` language-switcher script); refreshed the persist-analysis comment.
- **`i18n-version/index.ts`** — export the new symbols + types.

## Test Plan

- **Drift-guard unit test** (`version-switcher.test.tsx`): `computeVersionSwitcherState` is pinned to the real `makeUrlHelpers` SSR output across a case table — latest / versioned, default & non-default locale, docs-root empty slug, versions-index (no `currentSlug`), base prefix, `trailingSlash` off. Plus rewire-marker emission/omission + script-shape assertions.
- **e2e** (`versioning-vt-chrome-persist.spec.ts`, versioning fixture): a same-version doc→doc SPA swap re-wires the menu hrefs, and a cross-version swap re-wires the active row + trigger label — both asserted against a **persisted** header DOM node (stale pre-fix, correct post-fix).
- Full package unit suite (986) + `pnpm check` + template-drift all green.

Fixes #2553.