### PR TITLE
chore(deps): bump @takazudo/zfb stack to 0.1.0-next.76

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,9 +91,9 @@
   },
   "dependencies": {
     "@takazudo/zdtp": "0.4.2",
-    "@takazudo/zfb": "0.1.0-next.75",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.75",
-    "@takazudo/zfb-runtime": "0.1.0-next.75",
+    "@takazudo/zfb": "0.1.0-next.76",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.76",
+    "@takazudo/zfb-runtime": "0.1.0-next.76",
     "@takazudo/zudo-doc": "workspace:*",
     "diff": "^8.0.3",
     "gray-matter": "^4.0.3",

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -3777,12 +3777,11 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
    * Bumped to 0.1.0-next.74: routine upstream prerelease adoption (next.74,
    * next.73 skipped) in lockstep with the root package.json pins. No
    * consumer-facing change.
-   * Bumped to 0.1.0-next.75: toolchain bump restoring Tailwind class-candidate
-   * scanning through symlinked project trees (zudolab/zudo-doc#2511), in
+   * Bumped to 0.1.0-next.76: routine toolchain bump from next.75, in
    * lockstep with the root package.json pins. No consumer-facing change.
    * Generated package.json must pin all three.
    */
-  it("pins @takazudo/zfb at 0.1.0-next.75", async () => {
+  it("pins @takazudo/zfb at 0.1.0-next.76", async () => {
     const choices: UserChoices = {
       projectName: "test-pin-bump",
       defaultLang: "en",
@@ -3793,10 +3792,10 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
     };
     await scaffold(choices);
     const pkg = await fs.readJson(projectPath("test-pin-bump", "package.json"));
-    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.75");
-    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.75");
+    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.76");
+    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.76");
     expect(pkg.dependencies["@takazudo/zfb-adapter-cloudflare"]).toBe(
-      "0.1.0-next.75",
+      "0.1.0-next.76",
     );
   });
 });

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -607,15 +607,17 @@ function generatePackageJson(choices: UserChoices) {
     // next.74: routine toolchain bump from next.72 (next.73
     // skipped), adopted in lockstep with the root package.json pins. No
     // consumer-facing / CLI change.
-    // next.75 (current pin): toolchain bump from next.74 restoring Tailwind
+    // next.75: toolchain bump from next.74 restoring Tailwind
     // class-candidate scanning through symlinked project trees
     // (zudolab/zudo-doc#2511), adopted in lockstep with the root package.json
     // pins. No consumer-facing / CLI change.
-    "@takazudo/zfb": "0.1.0-next.75",
-    "@takazudo/zfb-runtime": "0.1.0-next.75",
+    // next.76 (current pin): routine toolchain bump from next.75, adopted in
+    // lockstep with the root package.json pins. No consumer-facing / CLI change.
+    "@takazudo/zfb": "0.1.0-next.76",
+    "@takazudo/zfb-runtime": "0.1.0-next.76",
     // zfb-adapter-cloudflare — required for any route with `prerender = false`.
     // Pinned in lockstep with @takazudo/zfb.
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.75",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.76",
     // @takazudo/zudo-doc — published from this monorepo via
     // .github/workflows/publish-zudo-doc.yml. The pin here is bumped in
     // lockstep by scripts/release-create-zudo-doc.sh whenever zudo-doc's

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -549,8 +549,8 @@
   ],
   "peerDependencies": {
     "preact": "^10.29.1",
-    "@takazudo/zfb": "^0.1.0-next.75",
-    "@takazudo/zfb-runtime": "^0.1.0-next.75",
+    "@takazudo/zfb": "^0.1.0-next.76",
+    "@takazudo/zfb-runtime": "^0.1.0-next.76",
     "@takazudo/zudo-doc-history-server": "^2.2.1",
     "@takazudo/zdtp": "^0.4.2",
     "shiki": "^4.0.2",
@@ -593,8 +593,8 @@
     "typescript": "^5.0.0",
     "vitest": "^4.1.0",
     "zod": "^4.3.6",
-    "@takazudo/zfb": "0.1.0-next.75",
-    "@takazudo/zfb-runtime": "0.1.0-next.75",
+    "@takazudo/zfb": "0.1.0-next.76",
+    "@takazudo/zfb-runtime": "0.1.0-next.76",
     "@takazudo/zudo-doc-history-server": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,14 +30,14 @@ importers:
         specifier: 0.4.2
         version: 0.4.2(preact@10.29.2)
       '@takazudo/zfb':
-        specifier: 0.1.0-next.75
-        version: 0.1.0-next.75
+        specifier: 0.1.0-next.76
+        version: 0.1.0-next.76
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.75
-        version: 0.1.0-next.75
+        specifier: 0.1.0-next.76
+        version: 0.1.0-next.76
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.75
-        version: 0.1.0-next.75(@takazudo/zfb@0.1.0-next.75)
+        specifier: 0.1.0-next.76
+        version: 0.1.0-next.76(@takazudo/zfb@0.1.0-next.76)
       '@takazudo/zudo-doc':
         specifier: workspace:*
         version: link:packages/zudo-doc
@@ -284,11 +284,11 @@ importers:
         version: 1.1.1
     devDependencies:
       '@takazudo/zfb':
-        specifier: 0.1.0-next.75
-        version: 0.1.0-next.75
+        specifier: 0.1.0-next.76
+        version: 0.1.0-next.76
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.75
-        version: 0.1.0-next.75(@takazudo/zfb@0.1.0-next.75)
+        specifier: 0.1.0-next.76
+        version: 0.1.0-next.76(@takazudo/zfb@0.1.0-next.76)
       '@takazudo/zudo-doc-history-server':
         specifier: workspace:*
         version: link:../doc-history-server
@@ -1383,48 +1383,48 @@ packages:
     peerDependencies:
       preact: ^10.29.1
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.75':
-    resolution: {integrity: sha512-IgMWfhrW7dkzY0dn5rzh8itjVrpScxY0A71dtISmvtVxqerJx5KcAy3qF6FXTUkGzDX+/9L8DJzJb0K1Xzsa9g==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.76':
+    resolution: {integrity: sha512-hcBbG23lismCVW9Caq4xfCKc3lVIAVvcs5N6ZdMlZRXELPt5GceQycAQ+Dc4CkSC+Sdvi4lt7rjzaTYMKjd95g==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.75':
-    resolution: {integrity: sha512-N3lQ+ArGP5NjMBBkLlT5ihbIzPxtpAQpeKV9gu7WjqjE6PaW57qRY6zaXZNN2NV2P8BHCV3gIVIEy34mBO3S6g==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.76':
+    resolution: {integrity: sha512-fy7Ff0LGmPbpnLeZcTAzY3X4Hup4YkGYxboVMw7bKWq7AZr6DJ25rKSfGcGSOdQnPdrdFIXMoPkR/G3WBfWZdQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.75':
-    resolution: {integrity: sha512-jVR8La4e2iHAnReN5NuxvGTuK9O9so0ByE2oJYLFJWw3iLfRVivVhIEuNlzv/A/hS7Xg4uwU9DrjvtXbNxdckw==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.76':
+    resolution: {integrity: sha512-fq1KTz9WmPqTsRD/86iyKsvjaZVwO8NlhNcPxinKyFm8Z/QdD4U/mpPQuc57nV7Aor7zRfAVAK8EWgdngUCuSA==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.75':
-    resolution: {integrity: sha512-Gta4oVcF1wrfNDSGGl48Hgxlu/V4dQTUlPqjJiH7Yk5DZbMgyktTUSYSFCO+ddPc/Eqt03JepyXj9FOLQ3T7jQ==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.76':
+    resolution: {integrity: sha512-ZO2TAHXL18cGpQohFuje4oXjOC9CieJeDH93nMJyhphxI9lBy+AuyvfDeI1GTxOClRpH8pUqCluqvZsQRXuUHw==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.75':
-    resolution: {integrity: sha512-b/ilV+9fy2WGzqfX+BvWEvqg3XYHBjuJcfjhNeEk2NCW9zovWtDbALGRCBQqm4XVA/0FWKPsYm0hPyOVq/RqOg==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.76':
+    resolution: {integrity: sha512-P1O6b+edKagWCaTSGl56KD20WRpN9AKnVzDvIYpgHiKK4DYWUQzqbPcQ/4LJIppXgseaZNNfFr9IomHFX17ubQ==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.75':
-    resolution: {integrity: sha512-7mFfwGn8y4KcYfOHHwQ2lTes/aOjPKU0FYc7xf0c6fg8YIYooMCDDcxEKlOFCpD6DFk4hRI/dbs8sOYu2DzXSg==}
+  '@takazudo/zfb-runtime@0.1.0-next.76':
+    resolution: {integrity: sha512-k/3fsAjMNKucLO+kamspKB/W/x//9y/yJSuAZd52gnZdHWK2wMDxhu5akLjF5m2KpypvEBiYD6Wh3QmPVNw7lw==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.75
+      '@takazudo/zfb': 0.1.0-next.76
       react: ^19.2.3
     peerDependenciesMeta:
       react:
         optional: true
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.75':
-    resolution: {integrity: sha512-obBtHSEm8KDAXgpyX4z3vKzHyja1vp770PYIkh6SE8xnqYiuG0af02ptf5D5rZ/eDDWoEv1K3OvdzWlh8gxW0g==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.76':
+    resolution: {integrity: sha512-qFwwExYsfYbrX0mr6lcCLnqQy10Vzogp9OGkEnJE65QI81OuiwO4XqdhlSuGZzqxsQ/G7DkgR0x4GcMvE8nfUw==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.75':
-    resolution: {integrity: sha512-ANQ/MXedYUh6ZOYAzE7MWsK3u5WnHXg3au7nPHcW2wJKlU/yO8hA9WPB5duCsIwYXAQIOPHQ+5MkYf6MJhwSIw==}
+  '@takazudo/zfb@0.1.0-next.76':
+    resolution: {integrity: sha512-4k1Z0GPSuDIJw9pKzpJWVeLVKrUIOW2eTGA4/M/URj1zkBwo8KRtRFQ2jldBCjvdWkiz3nJK0MUNjwZJgq8bSA==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
     peerDependencies:
@@ -4091,35 +4091,35 @@ snapshots:
       culori: 4.0.2
       preact: 10.29.2
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.75': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.76': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.75':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.76':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.75':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.76':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.75':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.76':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.75':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.76':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.75(@takazudo/zfb@0.1.0-next.75)':
+  '@takazudo/zfb-runtime@0.1.0-next.76(@takazudo/zfb@0.1.0-next.76)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.75
+      '@takazudo/zfb': 0.1.0-next.76
       hono: 4.12.25
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.75':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.76':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.75':
+  '@takazudo/zfb@0.1.0-next.76':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.75
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.75
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.75
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.75
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.75
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.76
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.76
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.76
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.76
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.76
 
   '@takazudo/zudo-design-token-lint@1.0.0(patch_hash=6a157fd850449b055cf64a8a7dd1faed5b1da9eebe6c81cca08488ac0de85182)':
     dependencies:


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2556
    - https://github.com/zudolab/zudo-doc/issues/2555 (epic)

---

## Summary

Bump the `@takazudo/zfb` family from `0.1.0-next.75` → `0.1.0-next.76` across every pin location, in lockstep. `@takazudo/zdtp` is already at `latest` `0.4.2` and is untouched.

Recon of the npm metadata showed a clean bump (no added/removed deps; only the platform-binary `optionalDependencies` moved), and the full local gate confirmed no host-side code update was required.

## Changes

- **Root `package.json`** — `@takazudo/zfb`, `@takazudo/zfb-runtime`, `@takazudo/zfb-adapter-cloudflare` → `0.1.0-next.76` (exact).
- **`packages/zudo-doc/package.json`** — `devDependencies` (zfb, zfb-runtime) exact `.76`; `peerDependencies` (zfb, zfb-runtime) `^0.1.0-next.76`.
- **`packages/create-zudo-doc/src/scaffold.ts`** — scaffold pins for all three zfb packages → `.76`; pin-history comment updated.
- **`packages/create-zudo-doc/src/__tests__/scaffold.test.ts`** — all three `.toBe(...)` pin assertions (incl. the line-wrapped adapter one), the test title, and the comment block → `.76`.
- **`pnpm-lock.yaml`** — regenerated.

## Test Plan

- `pnpm check:pin-parity` — ✅ 4 external + 2 internal + 4 workspace-package + 2 first-party peer-floor fields verified at `.76` (zdtp `0.4.2`).
- `pnpm check` (typecheck) — ✅ 3 collections + tsc, no errors.
- `pnpm test` — ✅ 1981 root + 376 create-zudo-doc + 986 packages/zudo-doc + doc-history/md-plugins/search-worker; all green.
- `pnpm build` — ✅ 358 pages built with the `.76` pipeline + `.76` cloudflare adapter worker.

Closes #2556.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPtmBBBRMH6H9D2zLyUuy8)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785686156&installation_id=130359969&pr_number=2557&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2557&signature=5cc531ebedbb316e628ac8fa81c7ce7be6e2a32fc6862c2d170dcd20df7ae3c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->