### PR TITLE
feat(claude-resources): add scanRoot to decouple CLAUDE.md scan root from output base

### DIFF
--- a/e2e/fixtures/i18n/src/config/settings.ts
+++ b/e2e/fixtures/i18n/src/config/settings.ts
@@ -35,7 +35,7 @@ export const settings = {
   math: false,
   docHistory: false,
   dynamicPageTransition: true as boolean,
-  claudeResources: false as { claudeDir: string; projectRoot?: string } | false,
+  claudeResources: false as { claudeDir: string; projectRoot?: string; scanRoot?: string } | false,
   defaultLocaleOnlyPrefixes: [] as string[],
   tocMinDepth: 2 as number,
   tocMaxDepth: 4 as number,

--- a/e2e/fixtures/sidebar/src/config/settings.ts
+++ b/e2e/fixtures/sidebar/src/config/settings.ts
@@ -39,7 +39,7 @@ export const settings = {
   docTags: false,
   math: false,
   docHistory: false,
-  claudeResources: false as { claudeDir: string; projectRoot?: string } | false,
+  claudeResources: false as { claudeDir: string; projectRoot?: string; scanRoot?: string } | false,
   defaultLocaleOnlyPrefixes: [] as string[],
   tocMinDepth: 2 as number,
   tocMaxDepth: 4 as number,

--- a/e2e/fixtures/smoke/src/config/settings.ts
+++ b/e2e/fixtures/smoke/src/config/settings.ts
@@ -51,7 +51,7 @@ export const settings = {
   htmlPreview: {
     css: `.global-test { border: 3px solid rgb(255, 0, 0); }`,
   } as HtmlPreviewConfig | undefined,
-  claudeResources: false as { claudeDir: string; projectRoot?: string } | false,
+  claudeResources: false as { claudeDir: string; projectRoot?: string; scanRoot?: string } | false,
   defaultLocaleOnlyPrefixes: [] as string[],
   tocMinDepth: 2 as number,
   tocMaxDepth: 4 as number,

--- a/e2e/fixtures/theme/src/config/settings.ts
+++ b/e2e/fixtures/theme/src/config/settings.ts
@@ -38,7 +38,7 @@ export const settings = {
   designTokenPanel: true as boolean,
   dynamicPageTransition: true as boolean,
   docHistory: false,
-  claudeResources: false as { claudeDir: string; projectRoot?: string } | false,
+  claudeResources: false as { claudeDir: string; projectRoot?: string; scanRoot?: string } | false,
   defaultLocaleOnlyPrefixes: [] as string[],
   tocMinDepth: 2 as number,
   tocMaxDepth: 4 as number,

--- a/e2e/fixtures/versioning/src/config/settings.ts
+++ b/e2e/fixtures/versioning/src/config/settings.ts
@@ -42,7 +42,7 @@ export const settings = {
       banner: "unmaintained",
     },
   ] satisfies VersionConfig[] as VersionConfig[] | false,
-  claudeResources: false as { claudeDir: string; projectRoot?: string } | false,
+  claudeResources: false as { claudeDir: string; projectRoot?: string; scanRoot?: string } | false,
   defaultLocaleOnlyPrefixes: [] as string[],
   tocMinDepth: 2 as number,
   tocMaxDepth: 4 as number,

--- a/packages/create-zudo-doc/src/settings-gen.ts
+++ b/packages/create-zudo-doc/src/settings-gen.ts
@@ -245,11 +245,11 @@ export function generateSettingsFile(choices: UserChoices): string {
     lines.push(`  claudeResources: {`);
     lines.push(`    claudeDir: ".claude",`);
     lines.push(
-      `  } as { claudeDir: string; projectRoot?: string } | false,`,
+      `  } as { claudeDir: string; projectRoot?: string; scanRoot?: string } | false,`,
     );
   } else {
     lines.push(
-      `  claudeResources: false as { claudeDir: string; projectRoot?: string } | false,`,
+      `  claudeResources: false as { claudeDir: string; projectRoot?: string; scanRoot?: string } | false,`,
     );
   }
 

--- a/packages/zudo-doc/API.md
+++ b/packages/zudo-doc/API.md
@@ -310,7 +310,7 @@ These fields are the stable contract. The snapshot guard locks this set.
 | `bodyFootUtilArea` | `BodyFootUtilAreaConfig \| false` | Body footer utility area config |
 | `htmlPreview` | `HtmlPreviewConfig \| undefined` | HTML preview sandbox config |
 | `versions` | `VersionConfig[] \| false` | Multi-version config |
-| `claudeResources` | `{ claudeDir: string; projectRoot?: string } \| false` | Claude resources generation config |
+| `claudeResources` | `{ claudeDir: string; projectRoot?: string; scanRoot?: string } \| false` | Claude resources generation config (`scanRoot` — CLAUDE.md discovery root, defaults to `projectRoot`; #2558) |
 | `defaultLocaleOnlyPrefixes` | `string[]` | URL prefixes that only render for the default locale |
 | `footer` | `FooterConfig \| false` | Footer config |
 | `headerNav` | `HeaderNavItem[]` | Header navigation items |

--- a/packages/zudo-doc/src/integrations/claude-resources/README.md
+++ b/packages/zudo-doc/src/integrations/claude-resources/README.md
@@ -23,9 +23,27 @@ import {
 
 | Field | Type | Default | Notes |
 | --- | --- | --- | --- |
-| `claudeDir` | `string` | required | Path to `.claude/`. Resolved against `projectRoot` when relative. |
-| `projectRoot` | `string` | `process.cwd()` | Search root for `CLAUDE.md` discovery and the anchor for relative paths. |
+| `claudeDir` | `string` | required | Path to `.claude/` (source of commands/skills/agents). Resolved against `projectRoot` when relative. |
+| `projectRoot` | `string` | `process.cwd()` | Anchor for the relative `claudeDir`, `docsDir`, and `scanRoot` paths, and the default value of `scanRoot`. |
+| `scanRoot` | `string` | `projectRoot` | Root for **`CLAUDE.md` discovery** and the base for generated pages' relative-path titles/slugs. Resolved against `projectRoot` when relative (absolute allowed). Governs `CLAUDE.md` discovery **only** — commands/skills/agents always come from `claudeDir`. |
 | `docsDir` | `string` | `src/content/docs` | Output directory for generated MDX. Resolved against `projectRoot` when relative. |
+
+#### Anchor precedence
+
+All three relative inputs (`claudeDir`, `docsDir`, `scanRoot`) resolve against `projectRoot`. `scanRoot` then becomes the walk / relative-path base for `CLAUDE.md` discovery, decoupled from the output base (`docsDir`). When `scanRoot` is unset it equals `projectRoot`, so single-root projects behave exactly as before.
+
+#### Subdirectory-monorepo doc sites (`scanRoot`)
+
+When the doc site lives in a **subdirectory** of the repo but should surface `CLAUDE.md` files from the repo root and sibling packages, set `scanRoot` to widen discovery without moving the generated output out of the doc package:
+
+```ts
+// settings.claudeResources — doc site in <repo>/docs-site, .claude at repo root
+claudeResources: { claudeDir: "../.claude", scanRoot: ".." }
+```
+
+- Output still lands in the doc site's own `docsDir` (anchored to `projectRoot`, which in the preset/plugin path defaults to `ctx.projectRoot` — the doc-site root). Omitting `projectRoot` as above is the most robust form; the imperative `runClaudeResourcesPreStep` runner instead defaults `projectRoot` to `process.cwd()`.
+- `scanRoot: ".."` makes the `CLAUDE.md` walk start at the repo root, so repo-root and sibling-package `CLAUDE.md` files are discovered and titled relative to the repo root (e.g. `/CLAUDE.md`, `/app/CLAUDE.md`).
+- Note: with `scanRoot` at the repo root the discovery walk's exclude list (`.git`, `node_modules`, `dist`, `out`, `public`, `worktrees`, `__inbox`, `test-results`, `e2e/fixtures`, and the `docsDir` itself) re-anchors there, so a per-subdirectory build output in another package is no longer excluded from the walk. In practice this is negligible — only files literally named `CLAUDE.md` are collected and dotdirs/`node_modules` are always skipped — but repo-wide scanning is heavier and will surface sibling-package `CLAUDE.md` files, which is the intended aggregation.
 
 ## Registration in zfb.config.ts
 

--- a/packages/zudo-doc/src/integrations/claude-resources/__tests__/index.test.ts
+++ b/packages/zudo-doc/src/integrations/claude-resources/__tests__/index.test.ts
@@ -131,16 +131,20 @@ describe("runClaudeResourcesPreStep — scanRoot decoupling", () => {
     expect(counts.commands).toBe(1);
   });
 
-  it("(e) does not re-scan its own output when scanRoot and output overlap", () => {
+  it("(e) excludes its own output dir from the scan even when it lives under scanRoot", () => {
     const first = runClaudeResourcesPreStep({
       claudeDir,
       projectRoot: docsSite,
       scanRoot: repoRoot,
     });
-    const firstTitles = claudeMdTitles();
+    expect(first.claudemd).toBe(3);
 
-    // Re-run: the generated pages live under scanRoot (docs-site/src/content/docs)
-    // but are excluded from the walk, so the result is stable — no feedback loop.
+    // Drop a decoy file literally named CLAUDE.md INSIDE the output dir (which
+    // lives under scanRoot). It must NOT be collected — the walk excludes
+    // docsDir — so generated output can never feed back into the next run.
+    // Without the docsDir exclude this decoy would push the count to 4.
+    fs.writeFileSync(path.join(outDir, "CLAUDE.md"), "# Decoy\n\nShould be excluded.");
+
     const second = runClaudeResourcesPreStep({
       claudeDir,
       projectRoot: docsSite,
@@ -148,7 +152,10 @@ describe("runClaudeResourcesPreStep — scanRoot decoupling", () => {
     });
 
     expect(second.claudemd).toBe(3);
-    expect(second.claudemd).toBe(first.claudemd);
-    expect(claudeMdTitles()).toEqual(firstTitles);
+    expect(claudeMdTitles()).toEqual([
+      "/CLAUDE.md",
+      "/app/CLAUDE.md",
+      "/docs-site/CLAUDE.md",
+    ]);
   });
 });

--- a/packages/zudo-doc/src/integrations/claude-resources/__tests__/index.test.ts
+++ b/packages/zudo-doc/src/integrations/claude-resources/__tests__/index.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import matter from "gray-matter";
+import { runClaudeResourcesPreStep } from "../index.js";
+
+// Exercises the imperative runner `runClaudeResourcesPreStep` — in particular
+// the `scanRoot` option that decouples CLAUDE.md discovery from the generated-
+// output base (#2558). The fixture models a subdirectory-monorepo doc site:
+//
+//   REPO_ROOT/
+//   ├─ CLAUDE.md                 (repo-root guidance)
+//   ├─ app/CLAUDE.md             (sibling-package guidance)
+//   ├─ .claude/commands/…        (commands source — follows claudeDir, not scanRoot)
+//   └─ docs-site/
+//      ├─ CLAUDE.md              (the doc package's own guidance)
+//      └─ src/content/docs/      (output base — docsDir default)
+
+let repoRoot: string;
+let docsSite: string;
+let claudeDir: string;
+let outDir: string;
+
+function createMonorepoFixture() {
+  repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "claude-res-runner-"));
+  docsSite = path.join(repoRoot, "docs-site");
+  claudeDir = path.join(repoRoot, ".claude");
+  outDir = path.join(docsSite, "src", "content", "docs");
+
+  fs.mkdirSync(docsSite, { recursive: true });
+  fs.mkdirSync(outDir, { recursive: true });
+
+  // Three CLAUDE.md files at different depths.
+  fs.writeFileSync(path.join(repoRoot, "CLAUDE.md"), "# Repo root\n\nRoot guidance.");
+  fs.mkdirSync(path.join(repoRoot, "app"), { recursive: true });
+  fs.writeFileSync(path.join(repoRoot, "app", "CLAUDE.md"), "# App\n\nApp guidance.");
+  fs.writeFileSync(path.join(docsSite, "CLAUDE.md"), "# Docs site\n\nDoc-site guidance.");
+
+  // A command so we can assert claudeDir-sourced resources are unaffected by scanRoot.
+  const commandsDir = path.join(claudeDir, "commands");
+  fs.mkdirSync(commandsDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(commandsDir, "test-cmd.md"),
+    '---\ndescription: "A test command"\n---\n\nBody.',
+  );
+}
+
+/** Titles of the generated claude-md pages (frontmatter `title` = `/relPath`). */
+function claudeMdTitles(): string[] {
+  const dir = path.join(outDir, "claude-md");
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith(".mdx") && f !== "index.mdx")
+    .map((f) => matter(fs.readFileSync(path.join(dir, f), "utf8")).data.title as string)
+    .sort();
+}
+
+describe("runClaudeResourcesPreStep — scanRoot decoupling", () => {
+  beforeEach(() => {
+    createMonorepoFixture();
+  });
+
+  afterEach(() => {
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it("(a) writes output under projectRoot's docsDir while scanning from scanRoot", () => {
+    const counts = runClaudeResourcesPreStep({
+      claudeDir,
+      projectRoot: docsSite,
+      scanRoot: repoRoot,
+    });
+
+    // Output base = projectRoot (docs-site), NOT scanRoot (repo root).
+    expect(fs.existsSync(path.join(outDir, "claude-md"))).toBe(true);
+    expect(fs.existsSync(path.join(repoRoot, "src", "content", "docs"))).toBe(false);
+
+    // Scan root = scanRoot: all three CLAUDE.md files discovered.
+    expect(counts.claudemd).toBe(3);
+    // claudeDir-sourced resources are independent of scanRoot.
+    expect(counts.commands).toBe(1);
+  });
+
+  it("(b)+(c) discovers repo-wide CLAUDE.md and titles them relative to scanRoot", () => {
+    runClaudeResourcesPreStep({ claudeDir, projectRoot: docsSite, scanRoot: repoRoot });
+
+    // Slugs are file-named; titles are `/relPath` relative to scanRoot.
+    expect(fs.existsSync(path.join(outDir, "claude-md", "root.mdx"))).toBe(true);
+    expect(fs.existsSync(path.join(outDir, "claude-md", "app.mdx"))).toBe(true);
+    expect(fs.existsSync(path.join(outDir, "claude-md", "docs-site.mdx"))).toBe(true);
+
+    expect(claudeMdTitles()).toEqual([
+      "/CLAUDE.md",
+      "/app/CLAUDE.md",
+      "/docs-site/CLAUDE.md",
+    ]);
+  });
+
+  it("resolves a relative scanRoot against projectRoot", () => {
+    const counts = runClaudeResourcesPreStep({
+      claudeDir,
+      projectRoot: docsSite,
+      scanRoot: "..", // relative to projectRoot (docs-site) => repo root
+    });
+
+    expect(counts.claudemd).toBe(3);
+    expect(claudeMdTitles()).toEqual([
+      "/CLAUDE.md",
+      "/app/CLAUDE.md",
+      "/docs-site/CLAUDE.md",
+    ]);
+  });
+
+  it("(d) backward compat: unset scanRoot confines discovery to projectRoot", () => {
+    const counts = runClaudeResourcesPreStep({
+      claudeDir,
+      projectRoot: docsSite,
+      // scanRoot omitted => defaults to projectRoot (docs-site)
+    });
+
+    // Only the doc-site's own CLAUDE.md is found; repo-root and app are outside.
+    expect(counts.claudemd).toBe(1);
+    expect(fs.existsSync(path.join(outDir, "claude-md", "root.mdx"))).toBe(true);
+    expect(fs.existsSync(path.join(outDir, "claude-md", "app.mdx"))).toBe(false);
+    expect(fs.existsSync(path.join(outDir, "claude-md", "docs-site.mdx"))).toBe(false);
+    // The doc-site CLAUDE.md is now "root" (relPath base = projectRoot).
+    expect(claudeMdTitles()).toEqual(["/CLAUDE.md"]);
+    // claudeDir still resolved independently.
+    expect(counts.commands).toBe(1);
+  });
+
+  it("(e) does not re-scan its own output when scanRoot and output overlap", () => {
+    const first = runClaudeResourcesPreStep({
+      claudeDir,
+      projectRoot: docsSite,
+      scanRoot: repoRoot,
+    });
+    const firstTitles = claudeMdTitles();
+
+    // Re-run: the generated pages live under scanRoot (docs-site/src/content/docs)
+    // but are excluded from the walk, so the result is stable — no feedback loop.
+    const second = runClaudeResourcesPreStep({
+      claudeDir,
+      projectRoot: docsSite,
+      scanRoot: repoRoot,
+    });
+
+    expect(second.claudemd).toBe(3);
+    expect(second.claudemd).toBe(first.claudemd);
+    expect(claudeMdTitles()).toEqual(firstTitles);
+  });
+});

--- a/packages/zudo-doc/src/integrations/claude-resources/index.ts
+++ b/packages/zudo-doc/src/integrations/claude-resources/index.ts
@@ -43,10 +43,27 @@ export interface ClaudeResourcesPluginOptions {
    */
   claudeDir: string;
   /**
-   * Project root used both as the search root for `CLAUDE.md` discovery
-   * and to anchor relative paths. Defaults to `process.cwd()`.
+   * Anchor for resolving the relative `claudeDir`, `docsDir`, and `scanRoot`
+   * paths, and the default value of `scanRoot`. Defaults to `process.cwd()`.
+   *
+   * Note: this does NOT itself decide where `CLAUDE.md` discovery walks — that
+   * is `scanRoot` (which defaults to this). Set `scanRoot` to widen discovery
+   * (e.g. a subdirectory doc site scanning its repo root) without moving the
+   * output base, which stays anchored here.
    */
   projectRoot?: string;
+  /**
+   * Root for `CLAUDE.md` discovery and the base for the generated pages'
+   * relative-path titles/slugs. Defaults to `projectRoot`. Resolved against
+   * `projectRoot` when relative (absolute allowed).
+   *
+   * Scope: governs `CLAUDE.md` discovery ONLY. Commands, skills, and agents
+   * always come from `claudeDir` and are unaffected by `scanRoot`. Decoupling
+   * this from `projectRoot` lets a doc site in a repo subdirectory scan
+   * repo-wide `CLAUDE.md` files while still writing generated pages into its
+   * own content collection (see #2558).
+   */
+  scanRoot?: string;
   /**
    * Output directory for generated MDX pages, resolved against
    * `projectRoot` when relative. Defaults to `src/content/docs` to
@@ -86,12 +103,24 @@ export function runClaudeResourcesPreStep(
   const claudeDir = path.isAbsolute(options.claudeDir)
     ? options.claudeDir
     : path.resolve(projectRoot, options.claudeDir);
+  // scanRoot decouples CLAUDE.md discovery (and the generated pages' relPath
+  // base) from the output base. Defaults to projectRoot, so an unset scanRoot
+  // reproduces the pre-#2558 behaviour byte-for-byte.
+  const scanRoot =
+    options.scanRoot === undefined
+      ? projectRoot
+      : path.isAbsolute(options.scanRoot)
+        ? options.scanRoot
+        : path.resolve(projectRoot, options.scanRoot);
   const docsDirInput = options.docsDir ?? "src/content/docs";
   const docsDir = path.isAbsolute(docsDirInput)
     ? docsDirInput
     : path.resolve(projectRoot, docsDirInput);
 
-  return generateClaudeResourcesDocs({ claudeDir, projectRoot, docsDir });
+  // The generator's `projectRoot` param IS the CLAUDE.md scan root + relPath
+  // base (it never touches output — output is always `docsDir`), so pass the
+  // resolved scanRoot there while docsDir stays anchored to the real projectRoot.
+  return generateClaudeResourcesDocs({ claudeDir, projectRoot: scanRoot, docsDir });
 }
 
 export {

--- a/packages/zudo-doc/src/plugins/claude-resources.ts
+++ b/packages/zudo-doc/src/plugins/claude-resources.ts
@@ -27,11 +27,13 @@ const plugin: ZfbPlugin = {
       );
     }
     const projectRootOpt = ctx.options["projectRoot"];
+    const scanRootOpt = ctx.options["scanRoot"];
     const docsDirOpt = ctx.options["docsDir"];
     const result = await runClaudeResourcesPreStep({
       claudeDir,
       projectRoot:
         typeof projectRootOpt === "string" ? projectRootOpt : ctx.projectRoot,
+      scanRoot: typeof scanRootOpt === "string" ? scanRootOpt : undefined,
       docsDir: typeof docsDirOpt === "string" ? docsDirOpt : "src/content/docs",
     });
     // Surface a one-line summary so build logs make the generation

--- a/packages/zudo-doc/src/preset.ts
+++ b/packages/zudo-doc/src/preset.ts
@@ -58,6 +58,11 @@ export interface PresetVersionConfig {
 export interface PresetClaudeResourcesConfig {
   claudeDir: string;
   projectRoot?: string;
+  /**
+   * Root for `CLAUDE.md` discovery; defaults to `projectRoot`. Decouples
+   * repo-wide scanning from the output base for subdirectory doc sites (#2558).
+   */
+  scanRoot?: string;
 }
 
 /**
@@ -509,6 +514,7 @@ function buildPlugins(
             options: {
               claudeDir: settings.claudeResources.claudeDir,
               projectRoot: settings.claudeResources.projectRoot,
+              scanRoot: settings.claudeResources.scanRoot,
               docsDir: settings.docsDir,
             },
           },

--- a/packages/zudo-doc/src/settings.ts
+++ b/packages/zudo-doc/src/settings.ts
@@ -313,7 +313,7 @@ export interface Settings {
   bodyFootUtilArea: BodyFootUtilAreaConfig | false;
   htmlPreview: HtmlPreviewConfig | undefined;
   versions: VersionConfig[] | false;
-  claudeResources: { claudeDir: string; projectRoot?: string } | false;
+  claudeResources: { claudeDir: string; projectRoot?: string; scanRoot?: string } | false;
   defaultLocaleOnlyPrefixes: string[];
   footer: FooterConfig | false;
   headerNav: HeaderNavItem[];

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -209,7 +209,7 @@ export const settings = {
   ] satisfies VersionConfig[] as VersionConfig[] | false,
   claudeResources: {
     claudeDir: ".claude",
-  } as { claudeDir: string; projectRoot?: string } | false,
+  } as { claudeDir: string; projectRoot?: string; scanRoot?: string } | false,
   defaultLocaleOnlyPrefixes: [
     "/docs/claude-md/",
     "/docs/claude-skills/",


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2560
    - https://github.com/zudolab/zudo-doc/issues/2559 (epic)

---

## Summary

Resolves #2560 (epic #2559, supersedes #2558). The `claudeResources` integration's single `projectRoot` conflated two independent concerns — the **CLAUDE.md discovery/scan root** and the **generated-output base** — which want opposite values when a doc site lives in a repo **subdirectory**. This adds an optional **`scanRoot`** option (defaulting to `projectRoot`) that governs CLAUDE.md discovery + relPath base only, so a subdirectory doc site can scan repo-wide `CLAUDE.md` files while writing generated pages into its own content collection. Unset `scanRoot` is **byte-identical** to prior behavior.

Key insight: the low-level generator (`generate.ts`) already uses its `projectRoot` param solely as the scan root + relPath base (never for output), so it is **unchanged** — the runner simply passes the resolved `scanRoot` there while `docsDir` stays anchored to the real `projectRoot`.

## Changes

- **`integrations/claude-resources/index.ts`** — add `scanRoot?` to `ClaudeResourcesPluginOptions`; resolve it in `runClaudeResourcesPreStep` (undefined → `projectRoot`; absolute → as-is; relative → against `projectRoot`) and pass it as the generator's `projectRoot`.
- **`plugins/claude-resources.ts`**, **`preset.ts`** (+ `PresetClaudeResourcesConfig`) — thread `scanRoot` through the zfb plugin and preset.
- **`settings.ts`** (package) + **`src/config/settings.ts`** (host) + **`create-zudo-doc/settings-gen.ts`** + **`API.md`** — widen the `claudeResources` type to include `scanRoot?`; 5 e2e fixture casts synced.
- **`integrations/claude-resources/README.md`** — document the option, anchor precedence, and the subdirectory-monorepo example (incl. the `excludeDirs` re-anchoring note).
- **New `__tests__/index.test.ts`** — covers decoupled discovery/output, relative `scanRoot` resolution, backward-compat confinement (unset), and the `docsDir` self-rescan exclude (decoy `CLAUDE.md`).

## Test Plan

- `pnpm --filter @takazudo/zudo-doc test` — 991 pass (incl. new runner test 5/5)
- `pnpm test:packages` — create-zudo-doc 376, doc-history 71, md-plugins 80, search-worker 44 — all green
- `pnpm check` — typecheck clean
- `pnpm check:template-drift`, `pnpm check:fixture-settings-drift` — both pass

Follow-up (out of scope, pre-existing): #2561 — non-boundary-aware `startsWith` in the discovery exclude check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01393aVfX285gRjUWFbLHAko)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785691391&installation_id=130359969&pr_number=2562&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2562&signature=96c01bee089f9067518152d6edec48efe22fe3ae3afba9786055f6fd98befeaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->