### PR TITLE
Deflake subprocess unit tests + boundary-aware claude-resources excludeDirs

### DIFF
--- a/packages/create-zudo-doc/templates/features/claudeResources/files/src/integrations/claude-resources/__tests__/generate.test.ts
+++ b/packages/create-zudo-doc/templates/features/claudeResources/files/src/integrations/claude-resources/__tests__/generate.test.ts
@@ -636,6 +636,25 @@ describe("generateClaudeResourcesDocs", () => {
       expect(result.claudemd).toBe(1);
       expect(fs.existsSync(path.join(docsDir, "claude-md", "dist--nested.mdx"))).toBe(false);
     });
+
+    it("still excludes docsDir contents when docsDir carries a trailing separator", () => {
+      // path.join preserves a trailing separator on a single argument, so the
+      // docsDir exclude entry keeps it — the boundary compare must not break.
+      fs.writeFileSync(
+        path.join(docsDir, "CLAUDE.md"),
+        "# decoy inside docsDir — should be excluded",
+      );
+
+      const result = generateClaudeResourcesDocs({
+        claudeDir,
+        projectRoot: tmpDir,
+        docsDir: docsDir + path.sep,
+      });
+
+      // Only root/CLAUDE.md (from the fixture) — docs/CLAUDE.md is excluded.
+      expect(result.claudemd).toBe(1);
+      expect(fs.existsSync(path.join(docsDir, "claude-md", "docs.mdx"))).toBe(false);
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/create-zudo-doc/templates/features/claudeResources/files/src/integrations/claude-resources/__tests__/generate.test.ts
+++ b/packages/create-zudo-doc/templates/features/claudeResources/files/src/integrations/claude-resources/__tests__/generate.test.ts
@@ -576,6 +576,69 @@ describe("generateClaudeResourcesDocs", () => {
   });
 
   // ---------------------------------------------------------------------------
+  // excludeDirs boundary matching (#2561)
+  // ---------------------------------------------------------------------------
+
+  describe("excludeDirs boundary matching", () => {
+    it("discovers CLAUDE.md in a prefix-colliding sibling of an excluded dir (dist-extra vs dist)", () => {
+      fs.mkdirSync(path.join(tmpDir, "dist-extra"), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, "dist-extra", "CLAUDE.md"),
+        "# dist-extra instructions",
+      );
+
+      const result = generateClaudeResourcesDocs({
+        claudeDir,
+        projectRoot: tmpDir,
+        docsDir,
+      });
+
+      // root/CLAUDE.md (from the fixture) + dist-extra/CLAUDE.md
+      expect(result.claudemd).toBe(2);
+      const decoyPage = path.join(docsDir, "claude-md", "dist-extra.mdx");
+      expect(fs.existsSync(decoyPage)).toBe(true);
+      expect(fs.readFileSync(decoyPage, "utf8")).toContain("dist-extra instructions");
+    });
+
+    it("still excludes CLAUDE.md directly inside the excluded dist directory", () => {
+      fs.mkdirSync(path.join(tmpDir, "dist"), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, "dist", "CLAUDE.md"),
+        "# dist instructions — should be excluded",
+      );
+
+      const result = generateClaudeResourcesDocs({
+        claudeDir,
+        projectRoot: tmpDir,
+        docsDir,
+      });
+
+      // Only root/CLAUDE.md (from the fixture) — dist/CLAUDE.md is excluded.
+      expect(result.claudemd).toBe(1);
+      expect(fs.existsSync(path.join(docsDir, "claude-md", "dist.mdx"))).toBe(false);
+    });
+
+    it("still excludes nested CLAUDE.md files under the excluded dist directory (exact-match boundary holds)", () => {
+      fs.mkdirSync(path.join(tmpDir, "dist", "nested"), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, "dist", "nested", "CLAUDE.md"),
+        "# nested dist instructions — should be excluded",
+      );
+
+      const result = generateClaudeResourcesDocs({
+        claudeDir,
+        projectRoot: tmpDir,
+        docsDir,
+      });
+
+      // Only root/CLAUDE.md (from the fixture) — the whole dist/ subtree,
+      // including nested dirs, is excluded once the top-level dist match hits.
+      expect(result.claudemd).toBe(1);
+      expect(fs.existsSync(path.join(docsDir, "claude-md", "dist--nested.mdx"))).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // CLAUDE.md repo-relative link downgrade (#2411, Class B)
   // ---------------------------------------------------------------------------
 

--- a/packages/create-zudo-doc/templates/features/claudeResources/files/src/integrations/claude-resources/generate.ts
+++ b/packages/create-zudo-doc/templates/features/claudeResources/files/src/integrations/claude-resources/generate.ts
@@ -218,7 +218,9 @@ function findClaudeMdFiles(dir: string, excludeDirs: string[]): string[] {
     if (item === "node_modules") continue;
     if (item.startsWith(".")) continue;
     const itemPath = path.join(dir, item);
-    if (excludeDirs.some((d) => itemPath.startsWith(d))) continue;
+    // Path-segment-boundary-aware: a raw startsWith(d) would also match a
+    // sibling like "dist-extra" against an excluded "dist" (#2561).
+    if (excludeDirs.some((d) => itemPath === d || itemPath.startsWith(d + path.sep))) continue;
 
     // lstat (not stat) so symlinks aren't followed — a symlinked dir can point
     // back into the project (e.g. e2e fixtures linking to packages/) or out to

--- a/packages/create-zudo-doc/templates/features/claudeResources/files/src/integrations/claude-resources/generate.ts
+++ b/packages/create-zudo-doc/templates/features/claudeResources/files/src/integrations/claude-resources/generate.ts
@@ -214,13 +214,19 @@ function findClaudeMdFiles(dir: string, excludeDirs: string[]): string[] {
   const results: string[] = [];
   if (!fs.existsSync(dir)) return results;
 
+  // Strip trailing separators (path.join preserves one on e.g. "docs/") so the
+  // boundary compare below stays exact for such entries too.
+  const excludes = excludeDirs.map((d) =>
+    d.endsWith(path.sep) ? d.slice(0, -path.sep.length) : d,
+  );
+
   for (const item of fs.readdirSync(dir)) {
     if (item === "node_modules") continue;
     if (item.startsWith(".")) continue;
     const itemPath = path.join(dir, item);
     // Path-segment-boundary-aware: a raw startsWith(d) would also match a
     // sibling like "dist-extra" against an excluded "dist" (#2561).
-    if (excludeDirs.some((d) => itemPath === d || itemPath.startsWith(d + path.sep))) continue;
+    if (excludes.some((d) => itemPath === d || itemPath.startsWith(d + path.sep))) continue;
 
     // lstat (not stat) so symlinks aren't followed — a symlinked dir can point
     // back into the project (e.g. e2e fixtures linking to packages/) or out to
@@ -233,7 +239,7 @@ function findClaudeMdFiles(dir: string, excludeDirs: string[]): string[] {
       continue;
     }
     if (stat.isDirectory()) {
-      results.push(...findClaudeMdFiles(itemPath, excludeDirs));
+      results.push(...findClaudeMdFiles(itemPath, excludes));
     } else if (stat.isFile() && item === "CLAUDE.md") {
       results.push(itemPath);
     }

--- a/packages/zudo-doc/src/integrations/claude-resources/__tests__/generate.test.ts
+++ b/packages/zudo-doc/src/integrations/claude-resources/__tests__/generate.test.ts
@@ -636,6 +636,25 @@ describe("generateClaudeResourcesDocs", () => {
       expect(result.claudemd).toBe(1);
       expect(fs.existsSync(path.join(docsDir, "claude-md", "dist--nested.mdx"))).toBe(false);
     });
+
+    it("still excludes docsDir contents when docsDir carries a trailing separator", () => {
+      // path.join preserves a trailing separator on a single argument, so the
+      // docsDir exclude entry keeps it — the boundary compare must not break.
+      fs.writeFileSync(
+        path.join(docsDir, "CLAUDE.md"),
+        "# decoy inside docsDir — should be excluded",
+      );
+
+      const result = generateClaudeResourcesDocs({
+        claudeDir,
+        projectRoot: tmpDir,
+        docsDir: docsDir + path.sep,
+      });
+
+      // Only root/CLAUDE.md (from the fixture) — docs/CLAUDE.md is excluded.
+      expect(result.claudemd).toBe(1);
+      expect(fs.existsSync(path.join(docsDir, "claude-md", "docs.mdx"))).toBe(false);
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/zudo-doc/src/integrations/claude-resources/__tests__/generate.test.ts
+++ b/packages/zudo-doc/src/integrations/claude-resources/__tests__/generate.test.ts
@@ -576,6 +576,69 @@ describe("generateClaudeResourcesDocs", () => {
   });
 
   // ---------------------------------------------------------------------------
+  // excludeDirs boundary matching (#2561)
+  // ---------------------------------------------------------------------------
+
+  describe("excludeDirs boundary matching", () => {
+    it("discovers CLAUDE.md in a prefix-colliding sibling of an excluded dir (dist-extra vs dist)", () => {
+      fs.mkdirSync(path.join(tmpDir, "dist-extra"), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, "dist-extra", "CLAUDE.md"),
+        "# dist-extra instructions",
+      );
+
+      const result = generateClaudeResourcesDocs({
+        claudeDir,
+        projectRoot: tmpDir,
+        docsDir,
+      });
+
+      // root/CLAUDE.md (from the fixture) + dist-extra/CLAUDE.md
+      expect(result.claudemd).toBe(2);
+      const decoyPage = path.join(docsDir, "claude-md", "dist-extra.mdx");
+      expect(fs.existsSync(decoyPage)).toBe(true);
+      expect(fs.readFileSync(decoyPage, "utf8")).toContain("dist-extra instructions");
+    });
+
+    it("still excludes CLAUDE.md directly inside the excluded dist directory", () => {
+      fs.mkdirSync(path.join(tmpDir, "dist"), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, "dist", "CLAUDE.md"),
+        "# dist instructions — should be excluded",
+      );
+
+      const result = generateClaudeResourcesDocs({
+        claudeDir,
+        projectRoot: tmpDir,
+        docsDir,
+      });
+
+      // Only root/CLAUDE.md (from the fixture) — dist/CLAUDE.md is excluded.
+      expect(result.claudemd).toBe(1);
+      expect(fs.existsSync(path.join(docsDir, "claude-md", "dist.mdx"))).toBe(false);
+    });
+
+    it("still excludes nested CLAUDE.md files under the excluded dist directory (exact-match boundary holds)", () => {
+      fs.mkdirSync(path.join(tmpDir, "dist", "nested"), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, "dist", "nested", "CLAUDE.md"),
+        "# nested dist instructions — should be excluded",
+      );
+
+      const result = generateClaudeResourcesDocs({
+        claudeDir,
+        projectRoot: tmpDir,
+        docsDir,
+      });
+
+      // Only root/CLAUDE.md (from the fixture) — the whole dist/ subtree,
+      // including nested dirs, is excluded once the top-level dist match hits.
+      expect(result.claudemd).toBe(1);
+      expect(fs.existsSync(path.join(docsDir, "claude-md", "dist--nested.mdx"))).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // CLAUDE.md repo-relative link downgrade (#2411, Class B)
   // ---------------------------------------------------------------------------
 

--- a/packages/zudo-doc/src/integrations/claude-resources/generate.ts
+++ b/packages/zudo-doc/src/integrations/claude-resources/generate.ts
@@ -218,7 +218,9 @@ function findClaudeMdFiles(dir: string, excludeDirs: string[]): string[] {
     if (item === "node_modules") continue;
     if (item.startsWith(".")) continue;
     const itemPath = path.join(dir, item);
-    if (excludeDirs.some((d) => itemPath.startsWith(d))) continue;
+    // Path-segment-boundary-aware: a raw startsWith(d) would also match a
+    // sibling like "dist-extra" against an excluded "dist" (#2561).
+    if (excludeDirs.some((d) => itemPath === d || itemPath.startsWith(d + path.sep))) continue;
 
     // lstat (not stat) so symlinks aren't followed — a symlinked dir can point
     // back into the project (e.g. e2e fixtures linking to packages/) or out to

--- a/packages/zudo-doc/src/integrations/claude-resources/generate.ts
+++ b/packages/zudo-doc/src/integrations/claude-resources/generate.ts
@@ -214,13 +214,19 @@ function findClaudeMdFiles(dir: string, excludeDirs: string[]): string[] {
   const results: string[] = [];
   if (!fs.existsSync(dir)) return results;
 
+  // Strip trailing separators (path.join preserves one on e.g. "docs/") so the
+  // boundary compare below stays exact for such entries too.
+  const excludes = excludeDirs.map((d) =>
+    d.endsWith(path.sep) ? d.slice(0, -path.sep.length) : d,
+  );
+
   for (const item of fs.readdirSync(dir)) {
     if (item === "node_modules") continue;
     if (item.startsWith(".")) continue;
     const itemPath = path.join(dir, item);
     // Path-segment-boundary-aware: a raw startsWith(d) would also match a
     // sibling like "dist-extra" against an excluded "dist" (#2561).
-    if (excludeDirs.some((d) => itemPath === d || itemPath.startsWith(d + path.sep))) continue;
+    if (excludes.some((d) => itemPath === d || itemPath.startsWith(d + path.sep))) continue;
 
     // lstat (not stat) so symlinks aren't followed — a symlinked dir can point
     // back into the project (e.g. e2e fixtures linking to packages/) or out to
@@ -233,7 +239,7 @@ function findClaudeMdFiles(dir: string, excludeDirs: string[]): string[] {
       continue;
     }
     if (stat.isDirectory()) {
-      results.push(...findClaudeMdFiles(itemPath, excludeDirs));
+      results.push(...findClaudeMdFiles(itemPath, excludes));
     } else if (stat.isFile() && item === "CLAUDE.md") {
       results.push(itemPath);
     }

--- a/scripts/__tests__/file-exam-issue.test.ts
+++ b/scripts/__tests__/file-exam-issue.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync, chmodSync, readFileSync, existsSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  chmodSync,
+  readFileSync,
+  existsSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -34,7 +42,7 @@ describe("file-exam-issue.sh", () => {
   beforeEach(() => {
     workDir = mkdtempSync(join(tmpdir(), "file-exam-issue-test-"));
     fakeBinDir = join(workDir, "bin");
-    execFileSync("mkdir", ["-p", fakeBinDir]);
+    mkdirSync(fakeBinDir, { recursive: true });
     const ghPath = join(fakeBinDir, "gh");
     writeFileSync(ghPath, FAKE_GH_SCRIPT);
     chmodSync(ghPath, 0o755);

--- a/scripts/__tests__/setup-doc-skill.test.ts
+++ b/scripts/__tests__/setup-doc-skill.test.ts
@@ -11,9 +11,11 @@ const TEST_SKILL_NAME = "test-wisdom";
 // The script uses `git worktree list | head -1` to get the main worktree path
 // so that symlinks survive worktree removal. In a worktree session this differs
 // from PROJECT_ROOT; in the main repo they are identical.
+// Module-level eval runs before vitest's per-test timeout applies, so this
+// needs its own explicit child-level timeout (#2563).
 const MAIN_WORKTREE_ROOT = execSync(
   "git worktree list | head -1 | awk '{print $1}'",
-  { cwd: PROJECT_ROOT, encoding: "utf-8" },
+  { cwd: PROJECT_ROOT, encoding: "utf-8", timeout: 30_000 },
 ).trim();
 
 /**

--- a/scripts/run-b4push.sh
+++ b/scripts/run-b4push.sh
@@ -265,7 +265,9 @@ fi
 # and root test jobs build it for the same reason. Building here also leaves
 # dist/safelist.css ready for the safelist check in step 17.
 step "Root unit tests (test:unit)"
-if (cd "$ROOT_DIR" && pnpm --filter @takazudo/zudo-doc build && pnpm test:unit); then
+# --maxWorkers=4 caps vitest parallelism for reliability under host CPU
+# contention over wall-clock, not speed (issue #2563).
+if (cd "$ROOT_DIR" && pnpm --filter @takazudo/zudo-doc build && pnpm test:unit --maxWorkers=4); then
   pass "Root unit tests passed"
 else
   fail "Root unit tests"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,10 +21,6 @@ export default defineConfig({
     },
   },
   test: {
-    include: [
-      "src/**/__tests__/**/*.test.ts",
-      "scripts/__tests__/**/*.test.ts",
-    ],
     server: {
       deps: {
         // Inline the zfb island runtime so vite transforms it through the
@@ -36,5 +32,29 @@ export default defineConfig({
         inline: [/@takazudo\/zfb/],
       },
     },
+    // Split into projects so scripts/__tests__ (subprocess-heavy) can get a
+    // longer per-test timeout without loosening the default for src/__tests__
+    // (pure unit tests). `extends: true` is required on both — vitest project
+    // configs do NOT inherit the root config by default, so without it the
+    // resolve.alias and server.deps.inline settings above would not apply.
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: "unit",
+          include: ["src/**/__tests__/**/*.test.ts"],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "scripts",
+          include: ["scripts/__tests__/**/*.test.ts"],
+          // Subprocess-heavy integration-flavored tests; 2x the largest 30s
+          // child budget for load headroom under host CPU contention (#2563).
+          testTimeout: 60_000,
+        },
+      },
+    ],
   },
 });


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2564

---

## Summary

- **Deflake `scripts/__tests__` under CPU load (#2565, from #2563):** subprocess-heavy root unit tests no longer ride vitest's 5s default timeout — they get a dedicated vitest project with a 60s per-test budget, and b4push's root-unit-tests step caps vitest workers to reduce self-inflicted contention.
- **Boundary-aware `excludeDirs` in claude-resources (#2566, from #2561):** `findClaudeMdFiles` no longer excludes prefix-colliding sibling dirs (`dist` exclude wrongly matching `dist-extra`), fixed identically in the package and the create-zudo-doc template copy.

## Changes

### Deflake (vitest + b4push)

- `vitest.config.ts`: split into `unit` (`src/**/__tests__`, default 5s timeout) and `scripts` (`scripts/__tests__`, `testTimeout: 60_000`) projects via `test.projects`, both with `extends: true` so the root react→preact aliases and `server.deps.inline` still apply; removed the root-level `test.include`.
- `scripts/__tests__/setup-doc-skill.test.ts`: added `timeout: 30_000` to the module-level `execSync` (module-eval code is not covered by vitest's testTimeout).
- `scripts/__tests__/file-exam-issue.test.ts`: replaced an untimed `execFileSync("mkdir", ...)` with `fs.mkdirSync(..., { recursive: true })`.
- `scripts/run-b4push.sh` (step 15): root unit tests now run `pnpm test:unit --maxWorkers=4` — reliability under host CPU contention over wall-clock (#2563). Plain `pnpm test:unit` is unchanged.

### excludeDirs boundary fix (claude-resources)

- `packages/zudo-doc/src/integrations/claude-resources/generate.ts`: exclude check is now `itemPath === d || itemPath.startsWith(d + path.sep)` with trailing-separator normalization of exclude entries (a `docsDir` like `"docs/"` produces a trailing-sep entry via `path.join`, which the boundary compare must still exclude).
- `packages/create-zudo-doc/templates/features/claudeResources/files/.../generate.ts`: identical fix (normalized parity guard enforced).
- Four new decoy unit tests in both `generate.test.ts` copies: `dist-extra/CLAUDE.md` sibling discovered; `dist/CLAUDE.md` and nested files still excluded; trailing-separator docsDir still excluded.

## Test Plan

- Root unit tests: 36 files / 1981 tests green; `--project scripts` runs the 9 subprocess-heavy files under the 60s budget.
- Package tests: 88 files / 995 tests green including the new decoy tests.
- `pnpm check:template-drift` green (claude-resources parity pair normalized-diff clean).
- `pnpm check:b4push-ci-parity` green (parity guard covers steps 1–13; the worker cap is step 15).
- Full CI on this PR: 20/20 checks passed.