### PR TITLE
Fix three post-2.5.0 bugs: sidebar hard-reload flash, nav defaultLocaleOnly 404 hrefs, overview dup

### DIFF
--- a/packages/create-zudo-doc/templates/features/claudeResources/files/src/integrations/claude-resources/__tests__/generate.test.ts
+++ b/packages/create-zudo-doc/templates/features/claudeResources/files/src/integrations/claude-resources/__tests__/generate.test.ts
@@ -147,6 +147,26 @@ describe("generateClaudeResourcesDocs", () => {
       expect(overview).toContain('<CategoryNav categories={');
     });
 
+    it("overview body has no prose line duplicating the frontmatter description", () => {
+      // Regression test for #2568: the body used to repeat the frontmatter
+      // `description` verbatim as a standalone prose line right below `---`.
+      generateClaudeResourcesDocs({
+        claudeDir,
+        projectRoot: tmpDir,
+        docsDir,
+      });
+
+      const overview = fs.readFileSync(
+        path.join(docsDir, "claude", "index.mdx"),
+        "utf8",
+      );
+      const parsed = matter(overview);
+      const description = parsed.data.description as string;
+      const bodyLines = parsed.content.split("\n");
+
+      expect(bodyLines).not.toContain(description);
+    });
+
     it("skill page has correct frontmatter", () => {
       generateClaudeResourcesDocs({
         claudeDir,

--- a/packages/create-zudo-doc/templates/features/claudeResources/files/src/integrations/claude-resources/generate.ts
+++ b/packages/create-zudo-doc/templates/features/claudeResources/files/src/integrations/claude-resources/generate.ts
@@ -706,8 +706,6 @@ sidebar_position: 899
 generated: true
 ---
 
-Claude Code configuration reference.
-
 ## Resources
 
 <CategoryNav categories={${categoriesAttr}} />

--- a/packages/zudo-doc/src/desktop-sidebar-toggle-island/__tests__/desktop-sidebar-toggle-ssg.test.tsx
+++ b/packages/zudo-doc/src/desktop-sidebar-toggle-island/__tests__/desktop-sidebar-toggle-ssg.test.tsx
@@ -43,16 +43,20 @@ describe("DesktopSidebarToggle — SSG HTML presence", () => {
   });
 });
 
-// Behaviour test for the mount-time reconcile (bug zudolab/zudo-doc#2571):
-// when localStorage has the collapsed preference, a freshly-mounted toggle
-// must reconcile to hidden on INITIAL LOAD — independent of the SPA
-// AFTER_NAVIGATE_EVENT. The package vitest config runs in a plain Node env
-// (no jsdom), so — mirroring the sibling ThemeToggle's color-scheme-sync
-// tests — the browser globals the mount effect touches are stubbed with
-// minimal fakes and the two helpers the effect uses (`readState` to reconcile
-// `visible`, `setDataAttribute` to apply `<html data-sidebar-hidden>`) are
-// exercised directly. No AFTER_NAVIGATE_EVENT is ever dispatched here, so the
-// reconcile is proven to happen on load alone.
+// Reconcile-helper contract (bug zudolab/zudo-doc#2571). The island's mount
+// effect reconciles the persisted preference on initial load via exactly two
+// helpers: `readState()` (reads localStorage → the `visible` value) and
+// `setDataAttribute(visible)` (applies/removes `<html data-sidebar-hidden>`).
+// These tests pin that helper contract — the units the mount effect composes.
+//
+// SCOPE NOTE (honest about what this does NOT cover): the package vitest runs
+// in a plain Node env (no jsdom/happy-dom), so these exercise the helpers
+// DIRECTLY — they do NOT mount the component or run its `useEffect`, and would
+// still pass if the mount effect itself were deleted. The load-bearing #2571
+// fix (the pre-paint `<script>` hoisted into `<head>` before `<aside>`) is
+// guarded end-to-end by `sidebar-prepaint/__tests__/sidebar-prepaint-ssg.test`;
+// the mount effect's actual firing is a browser-only behaviour outside this
+// node test env's reach.
 function makeFakeDocument() {
   const attrs = new Map<string, string>();
   return {
@@ -82,7 +86,7 @@ function makeFakeStorage() {
   };
 }
 
-describe("DesktopSidebarToggle — mount reconcile (hard-reload, no SPA nav)", () => {
+describe("DesktopSidebarToggle — reconcile helpers (readState / setDataAttribute)", () => {
   let fakeDocument: ReturnType<typeof makeFakeDocument>;
   let fakeStorage: ReturnType<typeof makeFakeStorage>;
 

--- a/packages/zudo-doc/src/desktop-sidebar-toggle-island/__tests__/desktop-sidebar-toggle-ssg.test.tsx
+++ b/packages/zudo-doc/src/desktop-sidebar-toggle-island/__tests__/desktop-sidebar-toggle-ssg.test.tsx
@@ -8,11 +8,16 @@
  * hidden states with the correct aria attributes.
  */
 
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { VNode } from "preact";
 import { render } from "preact-render-to-string";
 import { Island } from "@takazudo/zfb";
-import { DesktopSidebarToggle } from "../index.js";
+import {
+  DesktopSidebarToggle,
+  SIDEBAR_STORAGE_KEY,
+  readState,
+  setDataAttribute,
+} from "../index.js";
 
 describe("DesktopSidebarToggle — SSG HTML presence", () => {
   it("renders a button element in static HTML", () => {
@@ -35,6 +40,96 @@ describe("DesktopSidebarToggle — SSG HTML presence", () => {
   it("renders the transition-persist data attribute", () => {
     const html = render(<DesktopSidebarToggle />);
     expect(html).toContain('data-zfb-transition-persist="desktop-sidebar-toggle"');
+  });
+});
+
+// Behaviour test for the mount-time reconcile (bug zudolab/zudo-doc#2571):
+// when localStorage has the collapsed preference, a freshly-mounted toggle
+// must reconcile to hidden on INITIAL LOAD — independent of the SPA
+// AFTER_NAVIGATE_EVENT. The package vitest config runs in a plain Node env
+// (no jsdom), so — mirroring the sibling ThemeToggle's color-scheme-sync
+// tests — the browser globals the mount effect touches are stubbed with
+// minimal fakes and the two helpers the effect uses (`readState` to reconcile
+// `visible`, `setDataAttribute` to apply `<html data-sidebar-hidden>`) are
+// exercised directly. No AFTER_NAVIGATE_EVENT is ever dispatched here, so the
+// reconcile is proven to happen on load alone.
+function makeFakeDocument() {
+  const attrs = new Map<string, string>();
+  return {
+    documentElement: {
+      getAttribute: (name: string) => attrs.get(name) ?? null,
+      hasAttribute: (name: string) => attrs.has(name),
+      setAttribute: (name: string, value: string) => {
+        attrs.set(name, value);
+      },
+      removeAttribute: (name: string) => {
+        attrs.delete(name);
+      },
+    },
+  };
+}
+
+function makeFakeStorage() {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+  };
+}
+
+describe("DesktopSidebarToggle — mount reconcile (hard-reload, no SPA nav)", () => {
+  let fakeDocument: ReturnType<typeof makeFakeDocument>;
+  let fakeStorage: ReturnType<typeof makeFakeStorage>;
+
+  beforeEach(() => {
+    fakeDocument = makeFakeDocument();
+    fakeStorage = makeFakeStorage();
+    // `window` must be defined for readState() to consult localStorage
+    // (it short-circuits to `true` when window is undefined, i.e. during SSR).
+    vi.stubGlobal("window", new EventTarget());
+    vi.stubGlobal("document", fakeDocument);
+    vi.stubGlobal("localStorage", fakeStorage);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("reconciles to hidden when localStorage says 'false'", () => {
+    fakeStorage.setItem(SIDEBAR_STORAGE_KEY, "false");
+
+    // This is exactly what the island's mount effect computes on initial load.
+    const visible = readState();
+    expect(visible).toBe(false);
+
+    // ...and applies to <html> via setDataAttribute — no SPA nav involved.
+    setDataAttribute(visible);
+    expect(fakeDocument.documentElement.hasAttribute("data-sidebar-hidden")).toBe(
+      true,
+    );
+    expect(fakeDocument.documentElement.getAttribute("data-sidebar-hidden")).toBe(
+      "",
+    );
+  });
+
+  it("reconciles to visible (attribute removed) when no preference is stored", () => {
+    const visible = readState();
+    expect(visible).toBe(true);
+
+    setDataAttribute(visible);
+    expect(fakeDocument.documentElement.hasAttribute("data-sidebar-hidden")).toBe(
+      false,
+    );
+  });
+
+  it("treats an explicit 'true' preference as visible", () => {
+    fakeStorage.setItem(SIDEBAR_STORAGE_KEY, "true");
+    expect(readState()).toBe(true);
   });
 });
 

--- a/packages/zudo-doc/src/desktop-sidebar-toggle-island/index.tsx
+++ b/packages/zudo-doc/src/desktop-sidebar-toggle-island/index.tsx
@@ -8,7 +8,12 @@ import { AFTER_NAVIGATE_EVENT } from "../transitions/index.js";
 
 export const SIDEBAR_STORAGE_KEY = "zudo-doc-sidebar-visible";
 
-function readState(): boolean {
+// Exported for unit testing the mount-reconcile logic in a plain Node env
+// (no jsdom in the package vitest config) — the same convention the sibling
+// ThemeToggle uses via color-scheme-sync.ts. `readState` is the localStorage
+// reader the mount effect uses to reconcile `visible` on initial load;
+// `setDataAttribute` is the `<html data-sidebar-hidden>` writer.
+export function readState(): boolean {
   if (typeof window === "undefined") return true;
   try {
     return localStorage.getItem(SIDEBAR_STORAGE_KEY) !== "false";
@@ -17,7 +22,7 @@ function readState(): boolean {
   }
 }
 
-function setDataAttribute(isVisible: boolean) {
+export function setDataAttribute(isVisible: boolean) {
   if (isVisible) {
     document.documentElement.removeAttribute("data-sidebar-hidden");
   } else {

--- a/packages/zudo-doc/src/doc-page-shell/index.tsx
+++ b/packages/zudo-doc/src/doc-page-shell/index.tsx
@@ -23,7 +23,10 @@ import { NavCardGrid } from "../nav-indexing/index.js";
 import type { VersionBannerLabels } from "../i18n-version/index.js";
 import type { ChromeContext } from "../factory-context/index.js";
 import type { Settings } from "../settings.js";
-import { createSidebarPrepaint } from "../sidebar-prepaint/index.js";
+import {
+  createSidebarPrepaint,
+  createSidebarVisibilityPrepaint,
+} from "../sidebar-prepaint/index.js";
 import { createHeadWithDefaults } from "../head-with-defaults/index.js";
 import { createSidebarWithDefaults } from "../sidebar-with-defaults/index.js";
 import { createHeaderWithDefaults } from "../header-with-defaults/index.js";
@@ -184,8 +187,16 @@ export function createDocPageShell<S extends Settings = Settings>(
   const SidebarWithDefaults = createSidebarWithDefaults(ctx);
   const HeaderWithDefaults = createHeaderWithDefaults(ctx);
   const FooterWithDefaults = createFooterWithDefaults(ctx);
+  const sidebarToggleEnabled = Boolean(
+    (ctx.settings as { sidebarToggle?: boolean }).sidebarToggle,
+  );
   const SidebarPrepaint = createSidebarPrepaint({
-    sidebarToggle: Boolean((ctx.settings as { sidebarToggle?: boolean }).sidebarToggle),
+    sidebarToggle: sidebarToggleEnabled,
+  });
+  // Pre-paint visibility script — emitted into the page <head> (below) so it
+  // runs before the <aside> paints, killing the hard-reload flash (#2571).
+  const SidebarVisibilityPrepaint = createSidebarVisibilityPrepaint({
+    sidebarToggle: sidebarToggleEnabled,
   });
   const DocBodyEnd = createDocBodyEnd(ctx);
   const DocPager = createDocPager(ctx);
@@ -245,7 +256,15 @@ export function createDocPageShell<S extends Settings = Settings>(
       <DocLayoutWithDefaults
         title={composeMetaTitle(title)}
         description={settings.metaTags.description ? description : undefined}
-        head={<HeadWithDefaults title={title} description={description} canonical={canonical} />}
+        head={
+          <>
+            <HeadWithDefaults title={title} description={description} canonical={canonical} />
+            {/* Pre-paint sidebar-visibility restore — must sit in <head> so it
+                runs before the <aside> desktop sidebar is painted (#2571).
+                Gated identically to the afterSidebar toggle Island below. */}
+            <SidebarVisibilityPrepaint hideSidebar={hideSidebar} />
+          </>
+        }
         lang={locale}
         noindex={settings.noindex}
         hideSidebar={hideSidebar}

--- a/packages/zudo-doc/src/head-with-defaults/index.tsx
+++ b/packages/zudo-doc/src/head-with-defaults/index.tsx
@@ -141,8 +141,10 @@ export function createHeadWithDefaults<S extends Settings = Settings>(
         {/* Pre-paint inline script: restore persisted sidebar width to
             --zd-sidebar-w on :root before first paint, so a reload after
             drag-resizing the sidebar doesn't snap back to the CSS default
-            clamp() width. Mirrors the sibling sidebar-toggle restore
-            script emitted from the page's afterSidebar slot. */}
+            clamp() width. Mirrors the sibling sidebar-toggle visibility
+            restore script, which is likewise hoisted into <head> (emitted
+            from doc-page-shell's head slot via createSidebarVisibilityPrepaint,
+            zudolab/zudo-doc#2571). */}
         {settings.sidebarResizer && <script dangerouslySetInnerHTML={{ __html: SIDEBAR_RESIZER_RESTORE_SCRIPT }} />}
         {/* favicon set — withBase() handles the configured base path prefix */}
         <link rel="icon" href={withBase("/favicon.ico")} sizes="any" />

--- a/packages/zudo-doc/src/integrations/claude-resources/__tests__/generate.test.ts
+++ b/packages/zudo-doc/src/integrations/claude-resources/__tests__/generate.test.ts
@@ -147,6 +147,26 @@ describe("generateClaudeResourcesDocs", () => {
       expect(overview).toContain('<CategoryNav categories={');
     });
 
+    it("overview body has no prose line duplicating the frontmatter description", () => {
+      // Regression test for #2568: the body used to repeat the frontmatter
+      // `description` verbatim as a standalone prose line right below `---`.
+      generateClaudeResourcesDocs({
+        claudeDir,
+        projectRoot: tmpDir,
+        docsDir,
+      });
+
+      const overview = fs.readFileSync(
+        path.join(docsDir, "claude", "index.mdx"),
+        "utf8",
+      );
+      const parsed = matter(overview);
+      const description = parsed.data.description as string;
+      const bodyLines = parsed.content.split("\n");
+
+      expect(bodyLines).not.toContain(description);
+    });
+
     it("skill page has correct frontmatter", () => {
       generateClaudeResourcesDocs({
         claudeDir,

--- a/packages/zudo-doc/src/integrations/claude-resources/generate.ts
+++ b/packages/zudo-doc/src/integrations/claude-resources/generate.ts
@@ -706,8 +706,6 @@ sidebar_position: 899
 generated: true
 ---
 
-Claude Code configuration reference.
-
 ## Resources
 
 <CategoryNav categories={${categoriesAttr}} />

--- a/packages/zudo-doc/src/sidebar-prepaint/__tests__/sidebar-prepaint-ssg.test.tsx
+++ b/packages/zudo-doc/src/sidebar-prepaint/__tests__/sidebar-prepaint-ssg.test.tsx
@@ -1,0 +1,114 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+/**
+ * SSG tests for the sidebar-prepaint factories (bug zudolab/zudo-doc#2571).
+ *
+ * The load-bearing fix is a PLACEMENT change: the `data-sidebar-hidden`
+ * pre-paint `<script>` must be emitted in `<head>` — before the `<aside>`
+ * desktop sidebar is painted — instead of in the `afterSidebar` slot (which the
+ * doc layout renders AFTER the `<aside>`, so on a hard reload the expanded
+ * sidebar could paint first → flash). These tests assert against serialized
+ * HTML, since a real browser is out of scope for unit tests.
+ *
+ * Coverage:
+ *   1. createSidebarVisibilityPrepaint emits the pre-paint script (gated).
+ *   2. ORDERING: in a full <DocLayout> render the script sits inside <head>,
+ *      before the <aside id="desktop-sidebar"> element.
+ *   3. createSidebarPrepaint (afterSidebar) emits ONLY the toggle Island — the
+ *      pre-paint script is no longer duplicated there.
+ */
+
+import { describe, expect, it } from "vitest";
+import { render } from "preact-render-to-string";
+import {
+  createSidebarPrepaint,
+  createSidebarVisibilityPrepaint,
+} from "../index.js";
+import { DocLayout } from "../../doclayout/doc-layout.js";
+
+// Distinctive substrings of the pre-paint script body.
+const SCRIPT_STORAGE_READ = `localStorage.getItem("zudo-doc-sidebar-visible")`;
+const SCRIPT_SET_ATTR = `setAttribute('data-sidebar-hidden','')`;
+
+describe("createSidebarVisibilityPrepaint — head pre-paint script", () => {
+  it("emits the pre-paint script when sidebarToggle is on and the page shows a sidebar", () => {
+    const SidebarVisibilityPrepaint = createSidebarVisibilityPrepaint({
+      sidebarToggle: true,
+    });
+    const html = render(<SidebarVisibilityPrepaint hideSidebar={false} />);
+    expect(html).toContain("<script");
+    expect(html).toContain(SCRIPT_STORAGE_READ);
+    expect(html).toContain(SCRIPT_SET_ATTR);
+  });
+
+  it("emits nothing when the page hides the sidebar (hideSidebar)", () => {
+    const SidebarVisibilityPrepaint = createSidebarVisibilityPrepaint({
+      sidebarToggle: true,
+    });
+    const html = render(<SidebarVisibilityPrepaint hideSidebar={true} />);
+    expect(html).toBe("");
+  });
+
+  it("emits nothing when the sidebar toggle feature is disabled", () => {
+    const SidebarVisibilityPrepaint = createSidebarVisibilityPrepaint({
+      sidebarToggle: false,
+    });
+    const html = render(<SidebarVisibilityPrepaint hideSidebar={false} />);
+    expect(html).toBe("");
+  });
+});
+
+describe("sidebar-visibility pre-paint — placement/ordering in <head>", () => {
+  const SidebarVisibilityPrepaint = createSidebarVisibilityPrepaint({
+    sidebarToggle: true,
+  });
+
+  function renderLayout() {
+    return render(
+      <DocLayout
+        title="Placement Test"
+        // Router off keeps the head minimal; irrelevant to the pre-paint script.
+        enableClientRouter={false}
+        head={<SidebarVisibilityPrepaint hideSidebar={false} />}
+        header={<header>hdr</header>}
+        sidebar={<nav>nav</nav>}
+        main={<p>body</p>}
+      />,
+    );
+  }
+
+  it("renders the pre-paint script before the <aside> desktop sidebar", () => {
+    const html = renderLayout();
+
+    const scriptIdx = html.indexOf(SCRIPT_SET_ATTR);
+    const asideIdx = html.indexOf('<aside id="desktop-sidebar"');
+    const headCloseIdx = html.indexOf("</head>");
+
+    expect(scriptIdx).toBeGreaterThan(-1);
+    expect(asideIdx).toBeGreaterThan(-1);
+    // The script executes before the <aside> is parsed/painted — the whole
+    // point of the fix. Also confirm it lives inside <head> (before </head>).
+    expect(scriptIdx).toBeLessThan(asideIdx);
+    expect(scriptIdx).toBeLessThan(headCloseIdx);
+    expect(headCloseIdx).toBeLessThan(asideIdx);
+  });
+});
+
+describe("createSidebarPrepaint — afterSidebar slot (Island only)", () => {
+  it("emits the DesktopSidebarToggle island but NOT the pre-paint script", () => {
+    const SidebarPrepaint = createSidebarPrepaint({ sidebarToggle: true });
+    const html = render(<SidebarPrepaint hideSidebar={false} />);
+
+    // The interactive toggle island is still here...
+    expect(html).toContain('data-zfb-island="DesktopSidebarToggle"');
+    // ...but the pre-paint visibility script was hoisted to <head> and must
+    // not be duplicated in the body (that duplication was the pre-fix state).
+    expect(html).not.toContain(SCRIPT_SET_ATTR);
+  });
+
+  it("emits nothing when the page hides the sidebar", () => {
+    const SidebarPrepaint = createSidebarPrepaint({ sidebarToggle: true });
+    const html = render(<SidebarPrepaint hideSidebar={true} />);
+    expect(html).toBe("");
+  });
+});

--- a/packages/zudo-doc/src/sidebar-prepaint/__tests__/sidebar-prepaint-ssg.test.tsx
+++ b/packages/zudo-doc/src/sidebar-prepaint/__tests__/sidebar-prepaint-ssg.test.tsx
@@ -19,12 +19,15 @@
  */
 
 import { describe, expect, it } from "vitest";
+import type { VNode } from "preact";
 import { render } from "preact-render-to-string";
 import {
   createSidebarPrepaint,
   createSidebarVisibilityPrepaint,
 } from "../index.js";
 import { DocLayout } from "../../doclayout/doc-layout.js";
+import { createRenderDocPage } from "../../doc-page-renderer/index.js";
+import { makeFakeChromeContext } from "../../__tests__/fixtures/fake-chrome-context.js";
 
 // Distinctive substrings of the pre-paint script body.
 const SCRIPT_STORAGE_READ = `localStorage.getItem("zudo-doc-sidebar-visible")`;
@@ -89,6 +92,49 @@ describe("sidebar-visibility pre-paint — placement/ordering in <head>", () => 
     // The script executes before the <aside> is parsed/painted — the whole
     // point of the fix. Also confirm it lives inside <head> (before </head>).
     expect(scriptIdx).toBeLessThan(asideIdx);
+    expect(scriptIdx).toBeLessThan(headCloseIdx);
+    expect(headCloseIdx).toBeLessThan(asideIdx);
+  });
+});
+
+describe("doc-page-shell wiring — visibility script actually reaches <head>", () => {
+  // The ordering test above hardcodes the script into DocLayout's `head` prop, so
+  // it proves DocLayout's slot order but NOT that doc-page-shell wires the factory
+  // in. This renders the REAL shell (via createRenderDocPage + a fake ChromeContext
+  // with sidebarToggle on), so a regression that dropped <SidebarVisibilityPrepaint>
+  // from doc-page-shell's head slot (the actual #2571 fix site) is caught.
+  const ctx = makeFakeChromeContext({ settings: { sidebarToggle: true } });
+  const renderDocPage = createRenderDocPage(ctx);
+
+  it("emits the pre-paint script inside <head>, before the <aside> desktop sidebar", () => {
+    const vnode = renderDocPage(
+      {
+        kind: "entry",
+        entry: {
+          slug: "getting-started",
+          id: "getting-started",
+          collection: "docs",
+          data: { title: "Getting Started" },
+          module_specifier: "getting-started.mdx",
+          Content: () => null,
+        },
+        breadcrumbs: [],
+        prev: null,
+        next: null,
+        headings: [],
+      } as unknown as Parameters<typeof renderDocPage>[0],
+      { locale: "en" },
+    ) as VNode;
+
+    const html = render(vnode);
+    const scriptIdx = html.indexOf(SCRIPT_SET_ATTR);
+    const headCloseIdx = html.indexOf("</head>");
+    const asideIdx = html.indexOf('<aside id="desktop-sidebar"');
+
+    expect(scriptIdx).toBeGreaterThan(-1);
+    expect(headCloseIdx).toBeGreaterThan(-1);
+    expect(asideIdx).toBeGreaterThan(-1);
+    // Wired into <head> (before </head>) and therefore before the <aside>.
     expect(scriptIdx).toBeLessThan(headCloseIdx);
     expect(headCloseIdx).toBeLessThan(asideIdx);
   });

--- a/packages/zudo-doc/src/sidebar-prepaint/index.tsx
+++ b/packages/zudo-doc/src/sidebar-prepaint/index.tsx
@@ -1,19 +1,37 @@
 /** @jsxRuntime automatic */
 /** @jsxImportSource preact */
-// sidebar-prepaint — factory for the afterSidebar slot (epic #2344, S5).
+// sidebar-prepaint — factories for the sidebar-visibility feature (epic #2344, S5).
 //
-// The host's `pages/lib/_sidebar-prepaint.tsx` previously imported
-// `settings` and `DesktopSidebarToggle` from the package. Moving this
-// logic into the package allows the host stub to be a thin re-export.
+// This module owns TWO pieces of the desktop sidebar-toggle feature:
 //
-// Note: `DesktopSidebarToggle` is already a package-internal component
-// (from `@takazudo/zudo-doc/desktop-sidebar-toggle-island`). The factory
-// just needs to receive the `sidebarToggle` setting value and the
-// `Island` slot component so it never imports `@/config/settings`.
+//   1. createSidebarVisibilityPrepaint — the pre-paint inline `<script>` that
+//      restores the persisted "hidden" preference to `<html data-sidebar-hidden>`
+//      BEFORE first paint. It is emitted into the page `<head>` (see
+//      doc-page-shell's `head` slot) so it runs before the `<aside>` desktop
+//      sidebar is parsed/painted. Body-end / afterSidebar placement is too late:
+//      the browser can paint the expanded `<aside>` before an in-body script
+//      runs, producing a hard-reload flash (zudolab/zudo-doc#2571). This mirrors
+//      the sibling sidebar-RESIZER restore script, which is likewise hoisted
+//      into `<head>` (SIDEBAR_RESIZER_RESTORE_SCRIPT in head-with-defaults).
+//
+//   2. createSidebarPrepaint — the `afterSidebar` slot content: the
+//      `DesktopSidebarToggle` Island (the collapse/expand button). This stays in
+//      the body because it is an interactive island, not a pre-paint script.
+//
+// Both factories receive the `sidebarToggle` setting value and gate on the same
+// condition (`settings.sidebarToggle && !hideSidebar`) so the script and the
+// toggle button always appear together on exactly the pages that show a
+// collapsible sidebar. `DesktopSidebarToggle` is already a package-internal
+// component (from `@takazudo/zudo-doc/desktop-sidebar-toggle-island`); the
+// factories just need the setting value and the `Island` slot component so they
+// never import `@/config/settings`.
 
 import type { VNode, JSX } from "preact";
 import { Island } from "@takazudo/zfb";
-import { DesktopSidebarToggle } from "../desktop-sidebar-toggle-island/index.js";
+import {
+  DesktopSidebarToggle,
+  SIDEBAR_STORAGE_KEY,
+} from "../desktop-sidebar-toggle-island/index.js";
 
 export interface SidebarPrepaintProps {
   /**
@@ -23,9 +41,55 @@ export interface SidebarPrepaintProps {
   hideSidebar?: boolean;
 }
 
-/** Settings subset read by {@link createSidebarPrepaint}. */
+/** Settings subset read by the sidebar-prepaint factories. */
 export interface SidebarPrepaintSettings {
   sidebarToggle?: boolean;
+}
+
+/**
+ * Pre-paint inline script body: restore persisted sidebar visibility to
+ * `<html data-sidebar-hidden>` before first paint to avoid a hard-reload flash.
+ *
+ * A tiny synchronous IIFE that reads `localStorage[SIDEBAR_STORAGE_KEY]` and
+ * sets `data-sidebar-hidden` only when the stored value is exactly "false"
+ * (the collapsed preference) — the default (visible) needs no attribute and
+ * causes no layout shift. Silently no-ops in privacy / disabled-storage modes.
+ *
+ * The storage key is interpolated from `SIDEBAR_STORAGE_KEY` so it stays in
+ * sync with the island's reader; the `data-sidebar-hidden` attribute name is a
+ * literal here (the island's `setDataAttribute` hardcodes the same literal —
+ * keep the two in sync). Intended for `<head>` placement so it executes before
+ * the `<aside>` sidebar is painted.
+ */
+export const SIDEBAR_VISIBILITY_PREPAINT_SCRIPT = `(function(){try{if(localStorage.getItem(${JSON.stringify(
+  SIDEBAR_STORAGE_KEY,
+)})==='false'){document.documentElement.setAttribute('data-sidebar-hidden','');}}catch(e){}})();`;
+
+/**
+ * Create a `SidebarVisibilityPrepaint` component bound to the host's settings.
+ *
+ * Returns the pre-paint `<script>` (for the page `<head>`) when
+ * `settings.sidebarToggle` is enabled AND the page actually shows a sidebar;
+ * returns `undefined` when the toggle is disabled or the page hides the sidebar
+ * — the SAME gating as {@link createSidebarPrepaint}, so the head script and
+ * the afterSidebar toggle button always appear together.
+ */
+export function createSidebarVisibilityPrepaint(
+  settings: SidebarPrepaintSettings,
+): (props: SidebarPrepaintProps) => JSX.Element | undefined {
+  function SidebarVisibilityPrepaint({
+    hideSidebar,
+  }: SidebarPrepaintProps): JSX.Element | undefined {
+    if (!settings.sidebarToggle || hideSidebar) return undefined;
+
+    return (
+      <script
+        dangerouslySetInnerHTML={{ __html: SIDEBAR_VISIBILITY_PREPAINT_SCRIPT }}
+      />
+    );
+  }
+
+  return SidebarVisibilityPrepaint;
 }
 
 /**
@@ -40,10 +104,12 @@ export function createSidebarPrepaint(
   /**
    * The `afterSidebar` slot content shared by all 4 doc-route page components.
    *
-   * Returns the pre-paint localStorage script + `DesktopSidebarToggle` Island
-   * when `settings.sidebarToggle` is enabled AND the page actually shows a
-   * sidebar; returns `undefined` when the toggle is disabled or the page hides
-   * the sidebar.
+   * Returns the `DesktopSidebarToggle` Island when `settings.sidebarToggle` is
+   * enabled AND the page actually shows a sidebar; returns `undefined` when the
+   * toggle is disabled or the page hides the sidebar. The pre-paint
+   * visibility-restore `<script>` is NOT emitted here — it is hoisted into the
+   * page `<head>` via {@link createSidebarVisibilityPrepaint} so it runs before
+   * the `<aside>` paints (zudolab/zudo-doc#2571).
    */
   function SidebarPrepaint({
     hideSidebar,
@@ -52,14 +118,6 @@ export function createSidebarPrepaint(
 
     return (
       <>
-        {/* Pre-paint inline script: restore persisted sidebar visibility to
-            <html data-sidebar-hidden> before first paint to avoid flash.
-            Rendered only when the toggle is enabled and the page shows a
-            sidebar; the attribute is only set when localStorage says "false"
-            so the default (visible) needs no attribute and causes no layout shift. */}
-        <script dangerouslySetInnerHTML={{
-          __html: `(function(){try{if(localStorage.getItem('zudo-doc-sidebar-visible')==='false'){document.documentElement.setAttribute('data-sidebar-hidden','');}}catch(e){}})();`,
-        }} />
         {Island({
           when: "load",
           children: <DesktopSidebarToggle />,

--- a/packages/zudo-doc/src/sidebar-prepaint/index.tsx
+++ b/packages/zudo-doc/src/sidebar-prepaint/index.tsx
@@ -47,6 +47,20 @@ export interface SidebarPrepaintSettings {
 }
 
 /**
+ * Shared gate for BOTH sidebar-prepaint factories: the head pre-paint `<script>`
+ * and the `afterSidebar` toggle Island must appear on exactly the same pages, so
+ * they read the same predicate here rather than each inlining
+ * `settings.sidebarToggle && !hideSidebar` (a one-sided edit could otherwise let
+ * the script and the button desync — #2571).
+ */
+function sidebarPrepaintActive(
+  settings: SidebarPrepaintSettings,
+  hideSidebar?: boolean,
+): boolean {
+  return Boolean(settings.sidebarToggle) && !hideSidebar;
+}
+
+/**
  * Pre-paint inline script body: restore persisted sidebar visibility to
  * `<html data-sidebar-hidden>` before first paint to avoid a hard-reload flash.
  *
@@ -80,7 +94,7 @@ export function createSidebarVisibilityPrepaint(
   function SidebarVisibilityPrepaint({
     hideSidebar,
   }: SidebarPrepaintProps): JSX.Element | undefined {
-    if (!settings.sidebarToggle || hideSidebar) return undefined;
+    if (!sidebarPrepaintActive(settings, hideSidebar)) return undefined;
 
     return (
       <script
@@ -114,7 +128,7 @@ export function createSidebarPrepaint(
   function SidebarPrepaint({
     hideSidebar,
   }: SidebarPrepaintProps): JSX.Element | undefined {
-    if (!settings.sidebarToggle || hideSidebar) return undefined;
+    if (!sidebarPrepaintActive(settings, hideSidebar)) return undefined;
 
     return (
       <>

--- a/packages/zudo-doc/src/url-helpers/__tests__/url-helpers.test.ts
+++ b/packages/zudo-doc/src/url-helpers/__tests__/url-helpers.test.ts
@@ -55,6 +55,12 @@ describe("navHref", () => {
   it("undefined lang is treated as default locale", () => {
     expect(h.navHref("/docs/guides", undefined, "1.0")).toBe("/v/1.0/docs/guides/");
   });
+  it("defaultLocaleOnly path on a ja surface drops the locale prefix (#2569)", () => {
+    expect(h.navHref("/docs/claude-md/setup", "ja", undefined)).toBe("/docs/claude-md/setup/");
+  });
+  it("versioned defaultLocaleOnly path preserves the version and drops the locale (#2569)", () => {
+    expect(h.navHref("/docs/claude-md/setup", "ja", "1.0")).toBe("/v/1.0/docs/claude-md/setup/");
+  });
 });
 
 describe("getPathForLocale", () => {
@@ -101,6 +107,14 @@ describe("docsUrl / versionedDocsUrl / absoluteUrl / resolveHref", () => {
   it("docsUrl honors locale", () => {
     expect(h.docsUrl("guides", "en")).toBe("/docs/guides/");
     expect(h.docsUrl("guides", "ja")).toBe("/ja/docs/guides/");
+  });
+  it("docsUrl remints a defaultLocaleOnly slug to the default-locale URL on ja (#2569)", () => {
+    // defaultLocaleOnly docs only ship default-locale routes, so a ja nav surface
+    // must link into the default-locale space instead of minting a /ja 404 href.
+    expect(h.docsUrl("claude-md/setup", "ja")).toBe("/docs/claude-md/setup/");
+    // en and non-defaultLocaleOnly ja hrefs are unchanged.
+    expect(h.docsUrl("claude-md/setup", "en")).toBe("/docs/claude-md/setup/");
+    expect(h.docsUrl("guides/intro", "ja")).toBe("/ja/docs/guides/intro/");
   });
   it("versionedDocsUrl nests locale after version", () => {
     expect(h.versionedDocsUrl("guides", "1.0", "ja")).toBe("/v/1.0/ja/docs/guides/");

--- a/packages/zudo-doc/src/url-helpers/__tests__/url-helpers.test.ts
+++ b/packages/zudo-doc/src/url-helpers/__tests__/url-helpers.test.ts
@@ -119,6 +119,14 @@ describe("docsUrl / versionedDocsUrl / absoluteUrl / resolveHref", () => {
   it("versionedDocsUrl nests locale after version", () => {
     expect(h.versionedDocsUrl("guides", "1.0", "ja")).toBe("/v/1.0/ja/docs/guides/");
   });
+  it("versionedDocsUrl drops the locale for a defaultLocaleOnly slug but keeps the version (#2569)", () => {
+    // Mirrors docsUrl/navHref: a defaultLocaleOnly doc has no non-default-locale
+    // route, so a ja versioned surface must not mint /v/1.0/ja/docs/claude-md/... (404).
+    expect(h.versionedDocsUrl("claude-md/setup", "1.0", "ja")).toBe("/v/1.0/docs/claude-md/setup/");
+    // en and non-defaultLocaleOnly ja are unchanged.
+    expect(h.versionedDocsUrl("claude-md/setup", "1.0", "en")).toBe("/v/1.0/docs/claude-md/setup/");
+    expect(h.versionedDocsUrl("guides/intro", "1.0", "ja")).toBe("/v/1.0/ja/docs/guides/intro/");
+  });
   it("absoluteUrl joins siteUrl, undefined when empty", () => {
     expect(h.absoluteUrl("/docs/x/")).toBe("https://example.com/docs/x/");
     expect(helpers({ siteUrl: "" }).absoluteUrl("/docs/x/")).toBeUndefined();

--- a/packages/zudo-doc/src/url-helpers/index.ts
+++ b/packages/zudo-doc/src/url-helpers/index.ts
@@ -228,9 +228,19 @@ export function makeUrlHelpers(
 
   /** Build a versioned docs URL for the given slug, version, and lang. */
   function versionedDocsUrl(slug: string, versionSlug: string, lang: string = defaultLocale): string {
-    const path = lang === defaultLocale
-      ? `/v/${versionSlug}/docs/${slug}`
-      : `/v/${versionSlug}/${lang}/docs/${slug}`;
+    // A defaultLocaleOnly doc (settings.defaultLocaleOnlyPrefixes, #1592/#2569)
+    // has no non-default-locale route, so keep it in the default-locale URL
+    // space even on a non-default-locale surface — mirroring docsUrl/navHref.
+    // Matched on the plain `/docs/` shape (version prefix excluded), so the
+    // version is always preserved. (Currently unreachable for these docs because
+    // the versioned sidebar drops them via applyDefaultLocaleOnlyFilter, but the
+    // guard keeps every href seam consistent so a future caller can't mint a
+    // `/v/{ver}/{lang}/docs/...` 404.)
+    const localePrefixed =
+      lang !== defaultLocale && !isDefaultLocaleOnlyPath(`/docs/${slug}`);
+    const path = localePrefixed
+      ? `/v/${versionSlug}/${lang}/docs/${slug}`
+      : `/v/${versionSlug}/docs/${slug}`;
     return withBase(path);
   }
 

--- a/packages/zudo-doc/src/url-helpers/index.ts
+++ b/packages/zudo-doc/src/url-helpers/index.ts
@@ -116,7 +116,14 @@ export function makeUrlHelpers(
 
   /** Build a docs URL for the given slug and lang. */
   function docsUrl(slug: string, lang: string = defaultLocale): string {
-    const path = lang === defaultLocale ? `/docs/${slug}` : `/${lang}/docs/${slug}`;
+    const defaultPath = `/docs/${slug}`;
+    // defaultLocaleOnly docs (settings.defaultLocaleOnlyPrefixes, epic #1592) ship
+    // ONLY default-locale routes, so a non-default locale must still resolve into the
+    // default-locale URL space — a `/${lang}/docs/...` href would 404 (#2569).
+    const path =
+      lang === defaultLocale || isDefaultLocaleOnlyPath(defaultPath)
+        ? defaultPath
+        : `/${lang}/docs/${slug}`;
     return withBase(path);
   }
 
@@ -141,7 +148,13 @@ export function makeUrlHelpers(
     lang: string | undefined,
     currentVersion: string | undefined,
   ): string {
-    const isNonDefaultLocale = lang != null && lang !== defaultLocale;
+    // A defaultLocaleOnly path (settings.defaultLocaleOnlyPrefixes, #1592/#2569)
+    // has no non-default-locale route, so keep it in the default-locale URL space
+    // even on a non-default-locale surface. The version prefix is applied
+    // separately below, so this preserves `/v/{version}/docs/...`
+    // (isDefaultLocaleOnlyPath matches the plain `/docs/` shape only).
+    const isNonDefaultLocale =
+      lang != null && lang !== defaultLocale && !isDefaultLocaleOnlyPath(path);
     const versionPrefix = currentVersion ? `/v/${currentVersion}` : "";
     return withBase(
       isNonDefaultLocale


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2572

---

## Summary

Fixes three independent bugs from the **Zudo Doc Bug Triage** epic (#2572), all in the `@takazudo/zudo-doc` package. Planned via `/big-plan`, implemented in parallel worktrees via `/x-wt-teams`, then hardened by a 3-reviewer deep review.

| Sub-issue | Fix |
|---|---|
| #2573 (was #2568) | `claude-resources` `generateOverviewIndex` no longer emits a body prose line duplicating the frontmatter `description`; fixed in both the package copy and the byte-mirrored `create-zudo-doc` template, with a regression test in both. |
| #2574 (was #2569) | `docsUrl`/`navHref`/`versionedDocsUrl` are now `defaultLocaleOnly`-aware, so nav surfaces on a non-default locale link `defaultLocaleOnlyPrefixes` docs into the default-locale URL space instead of minting `/ja/docs/claude-md/...` 404s. Version prefixes preserved. |
| #2575 (was #2571) | The sidebar-visibility pre-paint `<script>` is hoisted from the `afterSidebar` slot into `<head>` (before `<aside>`), killing the hard-reload flash of a persisted-hidden sidebar. Mount-reconcile effect and SPA-nav handling unchanged. |

## Review hardening (deep-review, 3 Opus reviewers — 0 confirmed bugs)

- Extended the `defaultLocaleOnly` guard to `versionedDocsUrl` so no href seam can mint a versioned `/ja/...` 404.
- Extracted a shared `sidebarPrepaintActive()` gate so the head pre-paint script and the `afterSidebar` toggle Island can't desync.
- Strengthened the sidebar tests: added a real `doc-page-shell` render test proving the pre-paint script reaches `<head>` before `<aside>` (the actual fix site), and reframed the reconcile-helper test so it no longer overclaims to exercise the mount effect.

## Verification

- Full suite green: **1981 root unit + 1010 `@takazudo/zudo-doc` + 376 `create-zudo-doc` + 195 other package tests**, package build (tsup + `tsc`) clean.
- Playwright E2E runs in CI (not in local `pnpm test`).

## Notes

- All changes are package-internal (`dist/` is gitignored and rebuilt by the build). Downstream consumers receive these only after a `@takazudo/zudo-doc` version bump + republish — tracked in the epic as a post-merge follow-up.
- This was implemented on Claude Code on the web (limited env): the desktop sidebar's hard-reload behaviour is unit/build-verified but not visually confirmed in a real browser — flagging for a Mac visual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cp9azBMujXxa5S4E8NPk7i)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785714996&installation_id=130359969&pr_number=2576&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2576&signature=dd9edd760a518f079907ddc446208b5dd6e19b5b4329cb8f7744ecba6d1c9664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->