### PR TITLE
chore(deps): bump @takazudo/zdtp to 0.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     }
   },
   "dependencies": {
-    "@takazudo/zdtp": "0.4.2",
+    "@takazudo/zdtp": "0.4.3",
     "@takazudo/zfb": "0.1.0-next.76",
     "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.76",
     "@takazudo/zfb-runtime": "0.1.0-next.76",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
   .:
     dependencies:
       '@takazudo/zdtp':
-        specifier: 0.4.2
-        version: 0.4.2(preact@10.29.2)
+        specifier: 0.4.3
+        version: 0.4.3(preact@10.29.2)
       '@takazudo/zfb':
         specifier: 0.1.0-next.76
         version: 0.1.0-next.76
@@ -1381,6 +1381,13 @@ packages:
 
   '@takazudo/zdtp@0.4.2':
     resolution: {integrity: sha512-pii8L66REES2qbyK+cZDPHELgGvtFmQ1uNG5nwKhjhCIrhscUMWD9apVv7Nf+UIVK5411146pa/Ks68hGV6XHg==}
+    engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
+    hasBin: true
+    peerDependencies:
+      preact: ^10.29.1
+
+  '@takazudo/zdtp@0.4.3':
+    resolution: {integrity: sha512-ofPsqf9Ru4i/+8cIb83NqwypP3enod/jIgYXHfITl97i5EcsJmD7pUybpLdg3Uq1E7a6uvXpIMBr706LTnlfKg==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
     peerDependencies:
@@ -4090,6 +4097,11 @@ snapshots:
       vite: 7.3.5(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
 
   '@takazudo/zdtp@0.4.2(preact@10.29.2)':
+    dependencies:
+      culori: 4.0.2
+      preact: 10.29.2
+
+  '@takazudo/zdtp@0.4.3(preact@10.29.2)':
     dependencies:
       culori: 4.0.2
       preact: 10.29.2


### PR DESCRIPTION
## What

Bumps the doc site's `@takazudo/zdtp` dependency from `0.4.2` → **`0.4.3`** (latest published release), so the live design-token panel showcase tracks the current package version.

## Scope

- `package.json`: single-line dep bump (`0.4.2` → `0.4.3`).
- `pnpm-lock.yaml`: adds the `0.4.3` resolution for the site importer.
- The internal `packages/zudo-doc` dev range (`^0.4.2`) is **left untouched** — its published peer contract is unchanged, so `0.4.2` legitimately remains in the lockfile for that importer.

## Verification

- `pnpm check` (tsc `--noEmit`) — ✅ no errors
- `pnpm build` (`zfb build`) — ✅ 365 pages built

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785760540&installation_id=130359969&pr_number=2583&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2583&signature=a5bf3c4f517e57d69e5f5b1a280d33f4902fc62b91c27664a289455b4626f093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->