### PR TITLE
chore: bump zudo deps to next 77

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,9 +95,9 @@
   },
   "dependencies": {
     "@takazudo/zdtp": "0.4.5",
-    "@takazudo/zfb": "0.1.0-next.76",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.76",
-    "@takazudo/zfb-runtime": "0.1.0-next.76",
+    "@takazudo/zfb": "0.1.0-next.77",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.77",
+    "@takazudo/zfb-runtime": "0.1.0-next.77",
     "@takazudo/zudo-doc": "workspace:*",
     "diff": "^8.0.3",
     "gray-matter": "^4.0.3",

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -3801,9 +3801,12 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
    * consumer-facing change.
    * Bumped to 0.1.0-next.76: routine toolchain bump from next.75, in
    * lockstep with the root package.json pins. No consumer-facing change.
+   * Bumped to 0.1.0-next.77: router persistence/history fixes and runtime
+   * island remount support, in lockstep with the root package.json pins. No
+   * scaffold API change.
    * Generated package.json must pin all three.
    */
-  it("pins @takazudo/zfb at 0.1.0-next.76", async () => {
+  it("pins @takazudo/zfb at 0.1.0-next.77", async () => {
     const choices: UserChoices = {
       projectName: "test-pin-bump",
       defaultLang: "en",
@@ -3814,10 +3817,10 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
     };
     await scaffold(choices);
     const pkg = await fs.readJson(projectPath("test-pin-bump", "package.json"));
-    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.76");
-    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.76");
+    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.77");
+    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.77");
     expect(pkg.dependencies["@takazudo/zfb-adapter-cloudflare"]).toBe(
-      "0.1.0-next.76",
+      "0.1.0-next.77",
     );
   });
 });

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -616,13 +616,16 @@ function generatePackageJson(choices: UserChoices) {
     // class-candidate scanning through symlinked project trees
     // (zudolab/zudo-doc#2511), adopted in lockstep with the root package.json
     // pins. No consumer-facing / CLI change.
-    // next.76 (current pin): routine toolchain bump from next.75, adopted in
+    // next.76: routine toolchain bump from next.75, adopted in
     // lockstep with the root package.json pins. No consumer-facing / CLI change.
-    "@takazudo/zfb": "0.1.0-next.76",
-    "@takazudo/zfb-runtime": "0.1.0-next.76",
+    // next.77 (current pin): router persistence/history fixes and runtime
+    // island remount support, adopted in lockstep with the root package.json
+    // pins. No scaffold API change.
+    "@takazudo/zfb": "0.1.0-next.77",
+    "@takazudo/zfb-runtime": "0.1.0-next.77",
     // zfb-adapter-cloudflare — required for any route with `prerender = false`.
     // Pinned in lockstep with @takazudo/zfb.
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.76",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.77",
     // @takazudo/zudo-doc — published from this monorepo via
     // .github/workflows/publish-zudo-doc.yml. The pin here is bumped in
     // lockstep by scripts/release-create-zudo-doc.sh whenever zudo-doc's

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -558,8 +558,8 @@
   ],
   "peerDependencies": {
     "preact": "^10.29.1",
-    "@takazudo/zfb": "^0.1.0-next.76",
-    "@takazudo/zfb-runtime": "^0.1.0-next.76",
+    "@takazudo/zfb": "^0.1.0-next.77",
+    "@takazudo/zfb-runtime": "^0.1.0-next.77",
     "@takazudo/zudo-doc-history-server": "^3.0.0",
     "@takazudo/zdtp": "^0.4.5",
     "shiki": "^4.0.2",
@@ -602,8 +602,8 @@
     "typescript": "^5.0.0",
     "vitest": "^4.1.0",
     "zod": "^4.3.6",
-    "@takazudo/zfb": "0.1.0-next.76",
-    "@takazudo/zfb-runtime": "0.1.0-next.76",
+    "@takazudo/zfb": "0.1.0-next.77",
+    "@takazudo/zfb-runtime": "0.1.0-next.77",
     "@takazudo/zudo-doc-history-server": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,14 +30,14 @@ importers:
         specifier: 0.4.5
         version: 0.4.5(preact@10.29.2)
       '@takazudo/zfb':
-        specifier: 0.1.0-next.76
-        version: 0.1.0-next.76
+        specifier: 0.1.0-next.77
+        version: 0.1.0-next.77
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.76
-        version: 0.1.0-next.76
+        specifier: 0.1.0-next.77
+        version: 0.1.0-next.77
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.76
-        version: 0.1.0-next.76(@takazudo/zfb@0.1.0-next.76)
+        specifier: 0.1.0-next.77
+        version: 0.1.0-next.77(@takazudo/zfb@0.1.0-next.77)
       '@takazudo/zudo-doc':
         specifier: workspace:*
         version: link:packages/zudo-doc
@@ -287,11 +287,11 @@ importers:
         version: 1.1.1
     devDependencies:
       '@takazudo/zfb':
-        specifier: 0.1.0-next.76
-        version: 0.1.0-next.76
+        specifier: 0.1.0-next.77
+        version: 0.1.0-next.77
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.76
-        version: 0.1.0-next.76(@takazudo/zfb@0.1.0-next.76)
+        specifier: 0.1.0-next.77
+        version: 0.1.0-next.77(@takazudo/zfb@0.1.0-next.77)
       '@takazudo/zudo-doc-history-server':
         specifier: workspace:*
         version: link:../doc-history-server
@@ -1386,48 +1386,48 @@ packages:
     peerDependencies:
       preact: ^10.29.1
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.76':
-    resolution: {integrity: sha512-hcBbG23lismCVW9Caq4xfCKc3lVIAVvcs5N6ZdMlZRXELPt5GceQycAQ+Dc4CkSC+Sdvi4lt7rjzaTYMKjd95g==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.77':
+    resolution: {integrity: sha512-r7kGnlWq/vo8beHPnyOAeKSRk3UVvTYfHGN4pzlTo7hXP2Erd0g0rBmvNe2cDxEZqrhhm4NrAnCRlP0JE8A99w==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.76':
-    resolution: {integrity: sha512-fy7Ff0LGmPbpnLeZcTAzY3X4Hup4YkGYxboVMw7bKWq7AZr6DJ25rKSfGcGSOdQnPdrdFIXMoPkR/G3WBfWZdQ==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.77':
+    resolution: {integrity: sha512-4vHP3Ex8tVm33rPvFio86SdphSh75YAxR5HUcH/WI/cFNknamkRb/nTKvu9b8vUHKajIVPJNq6msyD4FFvGQ8Q==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.76':
-    resolution: {integrity: sha512-fq1KTz9WmPqTsRD/86iyKsvjaZVwO8NlhNcPxinKyFm8Z/QdD4U/mpPQuc57nV7Aor7zRfAVAK8EWgdngUCuSA==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.77':
+    resolution: {integrity: sha512-8MZFsBoTpq2xARNHYpXZE7K88KhznmMkOpOivMUcQXvuQalprAxA5lH9fG3CbkzmhUHuupH4ikJu9DqsYTRclQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.76':
-    resolution: {integrity: sha512-ZO2TAHXL18cGpQohFuje4oXjOC9CieJeDH93nMJyhphxI9lBy+AuyvfDeI1GTxOClRpH8pUqCluqvZsQRXuUHw==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.77':
+    resolution: {integrity: sha512-S+94+wK7upRzViMvwQ38tmgY2wo9h1ckY6kJwxh7AJQCR7FMVEHAlrF3d/xYBLk5zehiTsebe80/96ltL+t7Dg==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.76':
-    resolution: {integrity: sha512-P1O6b+edKagWCaTSGl56KD20WRpN9AKnVzDvIYpgHiKK4DYWUQzqbPcQ/4LJIppXgseaZNNfFr9IomHFX17ubQ==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.77':
+    resolution: {integrity: sha512-cTdn5JsYMrBevk5ggp4qbMbN6AkUgSjESohKeRlijIW0qMnHTUWdYzny/fbi63PoUkrYhJox4zp02bE+YEoeZg==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.76':
-    resolution: {integrity: sha512-k/3fsAjMNKucLO+kamspKB/W/x//9y/yJSuAZd52gnZdHWK2wMDxhu5akLjF5m2KpypvEBiYD6Wh3QmPVNw7lw==}
+  '@takazudo/zfb-runtime@0.1.0-next.77':
+    resolution: {integrity: sha512-rqmnAp3AGefmkQgchtqt46GYBfy4EKR1IDAzs9SNsCklu3M+30KdUJRJngFObiTwsehu57ebistRvd/MhzCqDA==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.76
+      '@takazudo/zfb': 0.1.0-next.77
       react: ^19.2.3
     peerDependenciesMeta:
       react:
         optional: true
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.76':
-    resolution: {integrity: sha512-qFwwExYsfYbrX0mr6lcCLnqQy10Vzogp9OGkEnJE65QI81OuiwO4XqdhlSuGZzqxsQ/G7DkgR0x4GcMvE8nfUw==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.77':
+    resolution: {integrity: sha512-C7BiOB9Ne6y/1AboAlJE7Y52xhXTRgi/qLvh3w4I7iDRbG0464WkX7ZCanabHOJ51U0wPNNr20xWlrROy35SQA==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.76':
-    resolution: {integrity: sha512-4k1Z0GPSuDIJw9pKzpJWVeLVKrUIOW2eTGA4/M/URj1zkBwo8KRtRFQ2jldBCjvdWkiz3nJK0MUNjwZJgq8bSA==}
+  '@takazudo/zfb@0.1.0-next.77':
+    resolution: {integrity: sha512-p0GHAWnz1ev+NLbmysN5SDk+3oDLWs+11ExHcTM/t9zTOF5L3LhsuGCslLYLV15hDj5CMP/DOJGPExYZZgL6sw==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
     peerDependencies:
@@ -4094,35 +4094,35 @@ snapshots:
       culori: 4.0.2
       preact: 10.29.2
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.76': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.77': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.76':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.77':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.76':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.77':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.76':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.77':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.76':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.77':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.76(@takazudo/zfb@0.1.0-next.76)':
+  '@takazudo/zfb-runtime@0.1.0-next.77(@takazudo/zfb@0.1.0-next.77)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.76
+      '@takazudo/zfb': 0.1.0-next.77
       hono: 4.12.25
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.76':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.77':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.76':
+  '@takazudo/zfb@0.1.0-next.77':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.76
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.76
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.76
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.76
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.76
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.77
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.77
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.77
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.77
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.77
 
   '@takazudo/zudo-design-token-lint@1.0.0(patch_hash=6a157fd850449b055cf64a8a7dd1faed5b1da9eebe6c81cca08488ac0de85182)':
     dependencies:


### PR DESCRIPTION
## Summary
- bump `@takazudo/zfb`, `@takazudo/zfb-runtime`, and `@takazudo/zfb-adapter-cloudflare` from `0.1.0-next.76` to `0.1.0-next.77`
- update `@takazudo/zudo-doc` peer/dev dependency pins for the same zfb family version
- keep `create-zudo-doc` scaffold pins and expectations in lockstep with the root pins
- refresh `pnpm-lock.yaml`

## Package Diff Review
- `@takazudo/zfb`: runtime island remount/persist support and stricter `GithubAutolinksConfig.repo` typing
- `@takazudo/zfb-runtime`: client-router persistence/history fixes and dynamic SSR route params passthrough
- `@takazudo/zfb-adapter-cloudflare`: package metadata/version only

Consumer source changes were limited to generated-project pin alignment. Local usage already omits `githubAutolinks` unless `githubAutolinksRepo` is present, and transition-persist wiring passed targeted smoke coverage.

## Verification
- `node $HOME/.claude/skills/dev-bump-zudo-deps/scripts/resolve-bumps.mjs`
- `pnpm install`
- `pnpm check`
- `pnpm test`
- `pnpm build`
- `pnpm check:pin-parity`
- `pnpm --filter ./packages/create-zudo-doc test`
- `E2E_FIXTURES=smoke pnpm exec playwright test e2e/smoke-vt-chrome-persist.spec.ts e2e/smoke-visual-vt-chrome-persist.spec.ts`
