### PR TITLE
Enable zfb HTML minify by default

### DIFF
--- a/.github/actions/css-shape-smoke-gate/action.yml
+++ b/.github/actions/css-shape-smoke-gate/action.yml
@@ -25,7 +25,7 @@ runs:
         # hashed styles-<hash>.css before that asset has propagated, so an immediate
         # curl 404s. --retry-all-errors retries HTTP 4xx too (plain --retry does not).
         # Propagation race, not a real failure (#2236).
-        CSS_PATH=$(curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors "$DEPLOY_URL/" | grep -oE 'href="[^"]*assets/styles-[^"]*\.css"' | head -1 | sed 's/href="//;s/"$//')
+        CSS_PATH=$(curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors "$DEPLOY_URL/" | grep -oE "href=[\"']?[^\"' >]*assets/styles-[^\"' >]*\.css" | head -1 | sed -E "s/^href=[\"']?//")
         [ -n "$CSS_PATH" ] || { echo "::error::no CSS link found in $DEPLOY_URL/"; exit 1; }
         curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors "${DEPLOY_URL}${CSS_PATH}" -o /tmp/deployed-css.css
 

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -278,9 +278,9 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       # Guardrail: assert that the deployed HTML has root-relative asset URLs
-      # (stylesheet href and islands script src). If zfb silently drops the
-      # `base` threading in a future version this step goes red before the
-      # broken production site reaches users.
+      # (stylesheet href and islands script src, quoted or minified-unquoted).
+      # If zfb silently drops the `base` threading in a future version this
+      # step goes red before the broken production site reaches users.
       - name: Verify production site has root asset URLs
         run: |
           set -euo pipefail
@@ -289,9 +289,9 @@ jobs:
           HTML=$(curl -fsSL "$PROD_URL")
           # Use here-strings (not echo|grep) so grep -q exiting early on a
           # match cannot SIGPIPE upstream echo + flip pipefail.
-          grep -qE 'href="/assets/' <<<"$HTML" \
+          grep -qE "href=[\"']?/assets/" <<<"$HTML" \
             || { echo "::error::Production HTML missing root stylesheet href"; exit 1; }
-          grep -qE 'src="/assets/' <<<"$HTML" \
+          grep -qE "src=[\"']?/assets/" <<<"$HTML" \
             || { echo "::error::Production HTML missing root islands script src"; exit 1; }
           echo "OK: production site has root asset URLs"
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -755,9 +755,9 @@ jobs:
           HTML=$(curl -fsSL "$PREVIEW_URL")
           # Use here-strings (not echo|grep) so grep -q exiting early on a
           # match cannot SIGPIPE upstream echo + flip pipefail.
-          grep -qE 'href="/assets/' <<<"$HTML" \
+          grep -qE "href=[\"']?/assets/" <<<"$HTML" \
             || { echo "::error::Preview HTML missing root stylesheet href"; exit 1; }
-          grep -qE 'src="/assets/' <<<"$HTML" \
+          grep -qE "src=[\"']?/assets/" <<<"$HTML" \
             || { echo "::error::Preview HTML missing root islands script src"; exit 1; }
           echo "OK: deployed PR preview has root asset URLs"
 

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -306,9 +306,9 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       # Guardrail: assert that the deployed HTML has root-relative asset URLs
-      # (href="/assets/", src="/assets/"). With base="/" the build emits
-      # root-prefixed paths — this step catches any regression where zfb
-      # silently drops the base threading (epic #1386 / #1389).
+      # (href=/assets/ or href="/assets/", likewise for src). With base="/"
+      # the build emits root-prefixed paths — this step catches any regression
+      # where zfb silently drops the base threading (epic #1386 / #1389).
       - name: Verify deployed preview has root asset URLs
         run: |
           set -euo pipefail
@@ -317,9 +317,9 @@ jobs:
           HTML=$(curl -fsSL "$PREVIEW_URL")
           # Use here-strings (not echo|grep) so grep -q exiting early on a
           # match cannot SIGPIPE upstream echo + flip pipefail.
-          grep -qE 'href="/assets/' <<<"$HTML" \
+          grep -qE "href=[\"']?/assets/" <<<"$HTML" \
             || { echo "::error::Preview HTML missing root stylesheet href (expected href=\"/assets/...)"; exit 1; }
-          grep -qE 'src="/assets/' <<<"$HTML" \
+          grep -qE "src=[\"']?/assets/" <<<"$HTML" \
             || { echo "::error::Preview HTML missing root islands script src (expected src=\"/assets/...)"; exit 1; }
           echo "OK: deployed preview has root asset URLs"
 

--- a/e2e/fixtures/i18n/src/config/settings.ts
+++ b/e2e/fixtures/i18n/src/config/settings.ts
@@ -12,6 +12,7 @@ export const settings = {
   siteName: "i18n Test",
   siteDescription: "Test fixture for i18n E2E tests" as string,
   base: "/",
+  minifyHtml: true as boolean,
   docsDir: "src/content/docs",
   defaultLocale: "en" as const,
   locales: {

--- a/e2e/fixtures/sidebar/src/config/settings.ts
+++ b/e2e/fixtures/sidebar/src/config/settings.ts
@@ -11,6 +11,7 @@ export const settings = {
   siteName: "Sidebar Test",
   siteDescription: "Test fixture for sidebar E2E tests" as string,
   base: "/",
+  minifyHtml: true as boolean,
   docsDir: "src/content/docs",
   defaultLocale: "en" as const,
   locales: {} satisfies Record<string, LocaleConfig>,

--- a/e2e/fixtures/smoke/src/config/settings.ts
+++ b/e2e/fixtures/smoke/src/config/settings.ts
@@ -15,6 +15,7 @@ export const settings = {
   siteName: "Smoke Test",
   siteDescription: "Test fixture for smoke E2E tests" as string,
   base: "/",
+  minifyHtml: true as boolean,
   docsDir: "src/content/docs",
   defaultLocale: "en" as const,
   locales: {} satisfies Record<string, LocaleConfig>,

--- a/e2e/fixtures/theme/src/config/settings.ts
+++ b/e2e/fixtures/theme/src/config/settings.ts
@@ -17,6 +17,7 @@ export const settings = {
   siteName: "Theme Test",
   siteDescription: "Test fixture for theme toggle E2E tests" as string,
   base: "/",
+  minifyHtml: true as boolean,
   docsDir: "src/content/docs",
   defaultLocale: "en" as const,
   locales: {} satisfies Record<string, LocaleConfig>,

--- a/e2e/fixtures/versioning/src/config/settings.ts
+++ b/e2e/fixtures/versioning/src/config/settings.ts
@@ -13,6 +13,7 @@ export const settings = {
   siteName: "Versioning Test",
   siteDescription: "Test fixture for versioning E2E tests" as string,
   base: "/",
+  minifyHtml: true as boolean,
   docsDir: "src/content/docs",
   defaultLocale: "en" as const,
   locales: {} satisfies Record<string, LocaleConfig>,

--- a/e2e/html-assertions.ts
+++ b/e2e/html-assertions.ts
@@ -1,0 +1,130 @@
+import { expect } from "@playwright/test";
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function canBeUnquoted(value: string): boolean {
+  return !/[\s"'`=<>]/.test(value);
+}
+
+export function attrSource(name: string, value: string): string {
+  const attrName = escapeRegExp(name);
+  const attrValue = escapeRegExp(value);
+  const quotedValue = `"${attrValue}"|'${attrValue}'`;
+  const valueSource = canBeUnquoted(value)
+    ? `${quotedValue}|${attrValue}`
+    : quotedValue;
+  return `\\b${attrName}\\s*=\\s*(?:${valueSource})(?=[\\s>/])`;
+}
+
+export function classAttrSource(className: string): string {
+  const klass = escapeRegExp(className);
+  return [
+    "\\bclass\\s*=\\s*(?:",
+    `"[^"]*\\b${klass}\\b[^"]*"`,
+    `|'[^']*\\b${klass}\\b[^']*'`,
+    `|[^\\s>]*\\b${klass}\\b[^\\s>]*`,
+    ")(?=[\\s>/])",
+  ].join("");
+}
+
+export function booleanAttrSource(name: string): string {
+  const attrName = escapeRegExp(name);
+  return `\\b${attrName}(?:\\s*=\\s*(?:"[^"]*"|'[^']*'|[^\\s>]+))?(?=[\\s>/])`;
+}
+
+export function attrPattern(name: string, value: string): RegExp {
+  return new RegExp(attrSource(name, value));
+}
+
+export function expectHtmlAttr(
+  html: string,
+  name: string,
+  value: string,
+): void {
+  expect(html).toMatch(attrPattern(name, value));
+}
+
+export function tagWithAttrPattern(
+  tagName: string,
+  name: string,
+  value: string,
+): RegExp {
+  return new RegExp(
+    `<${escapeRegExp(tagName)}\\b(?=[^>]*${attrSource(name, value)})[^>]*>`,
+  );
+}
+
+export function expectHtmlTagWithAttr(
+  html: string,
+  tagName: string,
+  name: string,
+  value: string,
+): void {
+  expect(html).toMatch(tagWithAttrPattern(tagName, name, value));
+}
+
+export function expectHtmlTagWithAttrs(
+  html: string,
+  tagName: string,
+  attrs: Array<[name: string, value: string]>,
+): void {
+  const lookaheads = attrs
+    .map(([name, value]) => `(?=[^>]*${attrSource(name, value)})`)
+    .join("");
+  expect(html).toMatch(
+    new RegExp(`<${escapeRegExp(tagName)}\\b${lookaheads}[^>]*>`),
+  );
+}
+
+export function expectHtmlClass(html: string, className: string): void {
+  expect(html).toMatch(new RegExp(classAttrSource(className)));
+}
+
+export function tagWithClassPattern(
+  tagName: string,
+  className: string,
+): RegExp {
+  return new RegExp(
+    `<${escapeRegExp(tagName)}\\b(?=[^>]*${classAttrSource(className)})[^>]*>`,
+  );
+}
+
+export function expectHtmlTagWithClass(
+  html: string,
+  tagName: string,
+  className: string,
+): void {
+  expect(html).toMatch(tagWithClassPattern(tagName, className));
+}
+
+export function getAttrValue(tagHtml: string, name: string): string | null {
+  const match = tagHtml.match(
+    new RegExp(
+      `\\b${escapeRegExp(name)}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s>]+))`,
+    ),
+  );
+  return match?.[1] ?? match?.[2] ?? match?.[3] ?? null;
+}
+
+export function findTagWithAttr(
+  html: string,
+  tagName: string,
+  name: string,
+  value: string,
+): string | null {
+  return html.match(tagWithAttrPattern(tagName, name, value))?.[0] ?? null;
+}
+
+export function expectHtmlLink(
+  html: string,
+  href: string,
+  text: string,
+): void {
+  expect(html).toMatch(
+    new RegExp(
+      `<a\\b(?=[^>]*${attrSource("href", href)})[^>]*>${escapeRegExp(text)}</a>`,
+    ),
+  );
+}

--- a/e2e/smoke-404.spec.ts
+++ b/e2e/smoke-404.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { expectHtmlAttr, expectHtmlTagWithAttrs } from "./html-assertions";
 import { readDistFile } from "./smoke-dist-helper";
 
 test.describe("404 page: renders correctly", () => {
@@ -18,13 +19,16 @@ test.describe("404 page: renders correctly", () => {
   });
 
   test("contains a link back to home", () => {
-    expect(html).toContain('href="/"');
+    expectHtmlAttr(html, "href", "/");
   });
 
   test("has noindex robots meta tag", () => {
     // Match `noindex` as the leading directive; the renderer emits the
     // full `noindex, nofollow` form so we drop the literal closing quote
     // (matches the same prefix-only shape used in smoke-seo.spec.ts).
-    expect(html).toContain('<meta name="robots" content="noindex');
+    expectHtmlTagWithAttrs(html, "meta", [
+      ["name", "robots"],
+      ["content", "noindex, nofollow"],
+    ]);
   });
 });

--- a/e2e/smoke-admonitions.spec.ts
+++ b/e2e/smoke-admonitions.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { expectHtmlAttr } from "./html-assertions";
 import { readDistFile } from "./smoke-dist-helper";
 
 /**
@@ -56,10 +57,10 @@ test.describe("Admonitions: directive syntax renders correctly", () => {
 
   test("admonition HTML structure is present", () => {
     // Each admonition type should produce a data-admonition attribute
-    expect(html).toContain('data-admonition="note"');
-    expect(html).toContain('data-admonition="tip"');
-    expect(html).toContain('data-admonition="info"');
-    expect(html).toContain('data-admonition="warning"');
-    expect(html).toContain('data-admonition="danger"');
+    expectHtmlAttr(html, "data-admonition", "note");
+    expectHtmlAttr(html, "data-admonition", "tip");
+    expectHtmlAttr(html, "data-admonition", "info");
+    expectHtmlAttr(html, "data-admonition", "warning");
+    expectHtmlAttr(html, "data-admonition", "danger");
   });
 });

--- a/e2e/smoke-breadcrumbs.spec.ts
+++ b/e2e/smoke-breadcrumbs.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { expectHtmlAttr } from "./html-assertions";
 import { readDistFile } from "./smoke-dist-helper";
 
 test.describe("Breadcrumbs: navigation trail renders correctly", () => {
@@ -10,7 +11,7 @@ test.describe("Breadcrumbs: navigation trail renders correctly", () => {
 
   test("breadcrumb nav element exists with correct aria-label", () => {
     expect(html).toContain('<nav');
-    expect(html).toContain('aria-label="Breadcrumb"');
+    expectHtmlAttr(html, "aria-label", "Breadcrumb");
   });
 
   test("breadcrumb trail contains Guides link", () => {
@@ -24,7 +25,7 @@ test.describe("Breadcrumbs: navigation trail renders correctly", () => {
 
   test("home icon link is present", () => {
     // The first breadcrumb item is a home icon link pointing to "/"
-    expect(html).toContain('href="/"');
+    expectHtmlAttr(html, "href", "/");
     // It contains an SVG with the house icon path
     expect(html).toContain("M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3");
   });

--- a/e2e/smoke-directives.spec.ts
+++ b/e2e/smoke-directives.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { expectHtmlAttr } from "./html-assertions";
 import { readDistFile } from "./smoke-dist-helper";
 
 /**
@@ -34,12 +35,12 @@ test.describe("Directives map: ::: syntax renders correctly", () => {
   test(":::note[Custom Title] renders with data-admonition and title text", () => {
     // Verifies that the directives map resolves `note` → Note component and
     // that titleFromLabel defaults true so the bracketed label becomes the title.
-    expect(html).toContain('data-admonition="note"');
+    expectHtmlAttr(html, "data-admonition", "note");
     expect(html).toContain("Custom Title");
   });
 
   test(":::caution renders with data-admonition", () => {
-    expect(html).toContain('data-admonition="caution"');
+    expectHtmlAttr(html, "data-admonition", "caution");
   });
 
   test(":::details renders as a <details> element, not a data-admonition", () => {

--- a/e2e/smoke-edit-link.spec.ts
+++ b/e2e/smoke-edit-link.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { expectHtmlAttr } from "./html-assertions";
 import { readDistFile } from "./smoke-dist-helper";
 
 /**
@@ -23,11 +24,11 @@ test.describe("View source link: renders correctly", () => {
   });
 
   test("view-source link opens in a new tab", () => {
-    expect(html).toContain('target="_blank"');
+    expectHtmlAttr(html, "target", "_blank");
   });
 
   test("view-source link has noopener noreferrer rel attribute", () => {
-    expect(html).toContain('rel="noopener noreferrer"');
+    expectHtmlAttr(html, "rel", "noopener noreferrer");
   });
 
   test("view-source link text is 'View source on GitHub'", () => {

--- a/e2e/smoke-frontmatter-preview.spec.ts
+++ b/e2e/smoke-frontmatter-preview.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { expectHtmlAttr } from "./html-assertions";
 import { readDistFile } from "./smoke-dist-helper";
 
 /**
@@ -23,18 +24,18 @@ import { readDistFile } from "./smoke-dist-helper";
 test.describe("Frontmatter Preview: rendered-vs-hidden behavior", () => {
   test("system-only frontmatter → block absent", () => {
     const html = readDistFile("docs/getting-started/index.html");
-    expect(html).not.toContain('data-testid="frontmatter-preview"');
+    expect(html).not.toMatch(/data-testid\s*=\s*["']?frontmatter-preview/);
   });
 
   test("custom frontmatter → block visible with correct rows", () => {
     const html = readDistFile("docs/guides/frontmatter-preview-test/index.html");
 
     // Block must be present
-    expect(html).toContain('data-testid="frontmatter-preview"');
+    expectHtmlAttr(html, "data-testid", "frontmatter-preview");
 
     // Scope row assertions to the block's <tbody> — the page also has a
     // prose paragraph mentioning "author"/"status" outside the block.
-    const blockStart = html.indexOf('data-testid="frontmatter-preview"');
+    const blockStart = html.search(/data-testid\s*=\s*["']?frontmatter-preview/);
     const tbodyStart = html.indexOf("<tbody>", blockStart);
     const tbodyEnd = html.indexOf("</tbody>", tbodyStart);
     const tbody = html.slice(tbodyStart, tbodyEnd);
@@ -52,6 +53,6 @@ test.describe("Frontmatter Preview: rendered-vs-hidden behavior", () => {
 
   test("auto-index category page → block absent", () => {
     const html = readDistFile("docs/auto-index-category/index.html");
-    expect(html).not.toContain('data-testid="frontmatter-preview"');
+    expect(html).not.toMatch(/data-testid\s*=\s*["']?frontmatter-preview/);
   });
 });

--- a/e2e/smoke-header-dropdown.spec.ts
+++ b/e2e/smoke-header-dropdown.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "./fixtures";
+import { expectHtmlAttr, getAttrValue } from "./html-assertions";
 import { readDistFile } from "./smoke-dist-helper";
 
 /**
@@ -12,19 +13,18 @@ test.describe("Header dropdown navigation (static)", () => {
   test("dropdown markup is present in built HTML", () => {
     const html = readDistFile("docs/getting-started/index.html");
     expect(html).toContain("data-nav-item-dropdown");
-    expect(html).toContain('aria-haspopup="true"');
-    expect(html).toContain('aria-expanded="false"');
+    expectHtmlAttr(html, "aria-haspopup", "true");
+    expectHtmlAttr(html, "aria-expanded", "false");
   });
 
   test("dropdown trigger has correct label and href", () => {
     const html = readDistFile("docs/getting-started/index.html");
     // The dropdown trigger link should contain "Learn" and point to /docs/guides
-    const dropdownMatch = html.match(
-      /data-nav-item-dropdown[\s\S]*?<a[^>]*href="([^"]*)"[^>]*>([\s\S]*?)<\/a>/,
-    );
-    expect(dropdownMatch).toBeTruthy();
-    expect(dropdownMatch![1]).toContain("/docs/guides");
-    expect(dropdownMatch![2]).toContain("Learn");
+    const dropdownHtml = html.slice(html.indexOf("data-nav-item-dropdown"));
+    const anchorMatch = dropdownHtml.match(/<a\b[^>]*>([\s\S]*?)<\/a>/);
+    expect(anchorMatch).toBeTruthy();
+    expect(getAttrValue(anchorMatch![0], "href")).toContain("/docs/guides");
+    expect(anchorMatch![1]).toContain("Learn");
   });
 
   test("dropdown panel contains child links", () => {

--- a/e2e/smoke-html-preview.spec.ts
+++ b/e2e/smoke-html-preview.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "./fixtures";
+import { expectHtmlAttr } from "./html-assertions";
 import { readDistFile } from "./smoke-dist-helper";
 
 /**
@@ -29,9 +30,9 @@ test.describe("HtmlPreview: SSG shape", () => {
 
   test("iframes carry the resolveSandbox contract sandbox attributes", () => {
     // No-script preview: allow-same-origin (kept for auto-height measurement).
-    expect(html).toContain('sandbox="allow-same-origin"');
+    expectHtmlAttr(html, "sandbox", "allow-same-origin");
     // Script-bearing preview: allow-scripts allow-same-origin.
-    expect(html).toContain('sandbox="allow-scripts allow-same-origin"');
+    expectHtmlAttr(html, "sandbox", "allow-scripts allow-same-origin");
   });
 });
 

--- a/e2e/smoke-image-enlarge.spec.ts
+++ b/e2e/smoke-image-enlarge.spec.ts
@@ -1,4 +1,11 @@
 import { test, expect, type Page } from "@playwright/test";
+import {
+  attrSource,
+  booleanAttrSource,
+  classAttrSource,
+  expectHtmlClass,
+  findTagWithAttr,
+} from "./html-assertions";
 import { readDistFile } from "./smoke-dist-helper";
 
 const PAGE = "/docs/guides/image-enlarge-test";
@@ -45,32 +52,49 @@ test.describe("Image Enlarge: static HTML structure", () => {
   });
 
   test("oversized image is wrapped in figure.zd-enlargeable", () => {
-    expect(html).toContain('class="zd-enlargeable"');
+    expectHtmlClass(html, "zd-enlargeable");
   });
 
   test("hidden enlarge button follows img inside figure", () => {
-    expect(html).toMatch(/class="zd-enlarge-btn"[^>]*hidden|hidden[^>]*class="zd-enlarge-btn"/);
+    expect(html).toMatch(
+      new RegExp(
+        `<button\\b(?=[^>]*${classAttrSource("zd-enlarge-btn")})(?=[^>]*${booleanAttrSource("hidden")})[^>]*>`,
+      ),
+    );
   });
 
   test("opt-out: figure.zd-enlargeable does NOT wrap the opt-out image", () => {
-    expect(html).not.toMatch(/class="zd-enlargeable"[^<]*<img[^>]*alt="opt-out"/);
+    expect(html).not.toMatch(
+      new RegExp(
+        `<figure\\b(?=[^>]*${classAttrSource("zd-enlargeable")})[^>]*>[\\s\\S]*?<img\\b(?=[^>]*${attrSource("alt", "opt-out")})[\\s\\S]*?</figure>`,
+      ),
+    );
   });
 
   test("opt-out: no zd-enlarge-btn follows the opt-out image", () => {
-    const optoutSection = html.match(/<img[^>]*alt="opt-out"[^>]*>[\s\S]{0,200}/);
-    expect(optoutSection).not.toBeNull();
-    expect(optoutSection![0]).not.toContain("zd-enlarge-btn");
+    const optoutImg = findTagWithAttr(html, "img", "alt", "opt-out");
+    expect(optoutImg).not.toBeNull();
+    const optoutSection = html.slice(html.indexOf(optoutImg!), html.indexOf(optoutImg!) + 200);
+    expect(optoutSection).not.toContain("zd-enlarge-btn");
   });
 
   test("opt-out: img tag for opt-out image has NO title attribute (plugin stripped it)", () => {
-    const imgTag = html.match(/<img[^>]*alt="opt-out"[^>]*>/)?.[0] ?? "";
+    const imgTag = findTagWithAttr(html, "img", "alt", "opt-out") ?? "";
     expect(imgTag).toBeTruthy();
     expect(imgTag).not.toContain("title=");
   });
 
   test("inline image inside paragraph is NOT wrapped in figure", () => {
-    expect(html).toMatch(/<p[^>]*>[^<]*<img[^>]*alt="inline image"[^>]*>[^<]*<\/p>/);
-    expect(html).not.toMatch(/class="zd-enlargeable"[^<]*<img[^>]*alt="inline image"/);
+    expect(html).toMatch(
+      new RegExp(
+        `<p\\b[^>]*>[^<]*<img\\b(?=[^>]*${attrSource("alt", "inline image")})[^>]*>[^<]*</p>`,
+      ),
+    );
+    expect(html).not.toMatch(
+      new RegExp(
+        `<figure\\b(?=[^>]*${classAttrSource("zd-enlargeable")})[^>]*>[\\s\\S]*?<img\\b(?=[^>]*${attrSource("alt", "inline image")})[\\s\\S]*?</figure>`,
+      ),
+    );
   });
 
   test("page has exactly one zd-enlarge-dialog element", () => {

--- a/e2e/smoke-loading-overlay.spec.ts
+++ b/e2e/smoke-loading-overlay.spec.ts
@@ -15,6 +15,7 @@
  */
 
 import { test, expect } from "@playwright/test";
+import { expectHtmlAttr, expectHtmlClass } from "./html-assertions";
 import { readDistFile } from "./smoke-dist-helper";
 
 const PAGE_LOADING_OVERLAY_ID = "page-loading-overlay";
@@ -32,9 +33,9 @@ test.describe("Loading overlay: SSG shape", () => {
   });
 
   test("overlay element is present in built HTML", () => {
-    expect(html).toContain(`id="${PAGE_LOADING_OVERLAY_ID}"`);
-    expect(html).toContain('class="page-loading-overlay"');
-    expect(html).toContain('aria-hidden="true"');
+    expectHtmlAttr(html, "id", PAGE_LOADING_OVERLAY_ID);
+    expectHtmlClass(html, "page-loading-overlay");
+    expectHtmlAttr(html, "aria-hidden", "true");
   });
 
   test("bootstrap script is present with nav-event listeners", () => {
@@ -81,8 +82,8 @@ test.describe("Loading overlay: package-owned route (404)", () => {
   });
 
   test("overlay element is present on the package-owned 404 route", () => {
-    expect(html).toContain(`id="${PAGE_LOADING_OVERLAY_ID}"`);
-    expect(html).toContain('class="page-loading-overlay"');
+    expectHtmlAttr(html, "id", PAGE_LOADING_OVERLAY_ID);
+    expectHtmlClass(html, "page-loading-overlay");
   });
 
   test("nav-lifecycle bootstrap is present on the 404 route", () => {
@@ -117,4 +118,3 @@ test(
     expect(pointerEvents).toBe("none");
   },
 );
-

--- a/e2e/smoke-markdown-features.spec.ts
+++ b/e2e/smoke-markdown-features.spec.ts
@@ -1,4 +1,9 @@
 import { test, expect } from "@playwright/test";
+import {
+  expectHtmlLink,
+  expectHtmlTagWithAttr,
+  expectHtmlTagWithClass,
+} from "./html-assertions";
 import { readDistFile } from "./smoke-dist-helper";
 
 /**
@@ -40,15 +45,11 @@ test.describe("Markdown links: resolveMarkdownLinks + stripMdExt", () => {
   });
 
   test("markdown-syntax link to a sibling .mdx file resolves to its real route", () => {
-    expect(html).toContain(
-      '<a href="/docs/guides/page-1/" class="text-accent underline hover:text-accent-hover">Sibling page</a>',
-    );
+    expectHtmlLink(html, "/docs/guides/page-1/", "Sibling page");
   });
 
   test("markdown-syntax link with an anchor resolves and keeps the anchor", () => {
-    expect(html).toContain(
-      '<a href="/docs/guides/page-1/#section" class="text-accent underline hover:text-accent-hover">With anchor</a>',
-    );
+    expectHtmlLink(html, "/docs/guides/page-1/#section", "With anchor");
   });
 
   test("markdown-syntax link with a query string resolves AND keeps the query string (the retired JS bug does not reproduce in production)", () => {
@@ -57,36 +58,30 @@ test.describe("Markdown links: resolveMarkdownLinks + stripMdExt", () => {
     // live regression: the JS regex /\.mdx?(#.*)?$/ never matched query
     // strings, so `./other.md?foo=bar` stayed unrewritten there. The Rust
     // pipeline resolves the link to its real route AND preserves `?foo=bar`.
-    expect(html).toContain(
-      '<a href="/docs/guides/page-1/?foo=bar" class="text-accent underline hover:text-accent-hover">With query</a>',
-    );
+    expectHtmlLink(html, "/docs/guides/page-1/?foo=bar", "With query");
   });
 
   test("markdown-syntax link with both an anchor and a query string resolves correctly", () => {
-    expect(html).toContain(
-      '<a href="/docs/guides/page-1/?foo=bar#section" class="text-accent underline hover:text-accent-hover">With anchor and query</a>',
+    expectHtmlLink(
+      html,
+      "/docs/guides/page-1/?foo=bar#section",
+      "With anchor and query",
     );
   });
 
   test("external .md link is left untouched", () => {
-    expect(html).toContain(
-      '<a href="https://example.com/foo.md" class="text-accent underline hover:text-accent-hover">External</a>',
-    );
+    expectHtmlLink(html, "https://example.com/foo.md", "External");
   });
 
   test("mailto link is left untouched", () => {
-    expect(html).toContain(
-      '<a href="mailto:hi@example.com" class="text-accent underline hover:text-accent-hover">Mailto</a>',
-    );
+    expectHtmlLink(html, "mailto:hi@example.com", "Mailto");
   });
 
   test("pure in-page anchor link is left untouched", () => {
-    expect(html).toContain(
-      '<a href="#section" class="text-accent underline hover:text-accent-hover">Anchor only</a>',
-    );
+    expectHtmlLink(html, "#section", "Anchor only");
   });
 
-  test("a JSX-authored raw <a> is emitted byte-for-byte (not a markdown link node, so resolveMarkdownLinks/stripMdExt never see it)", () => {
+  test("a JSX-authored raw <a> keeps its authored href (not a markdown link node, so resolveMarkdownLinks/stripMdExt never see it)", () => {
     // Documents a genuine divergence from the JS pipeline: the JS driver
     // parses raw HTML via rehype-raw into the same hast tree markdown
     // links flow through, so rehypeStripMdExtension touches BOTH forms
@@ -94,8 +89,10 @@ test.describe("Markdown links: resolveMarkdownLinks + stripMdExt", () => {
     // the production MDX pipeline, JSX-authored <a> compiles straight to
     // JSX and never becomes a markdown mdast link node, so neither
     // resolveMarkdownLinks nor StripMdExtensionPlugin process it.
-    expect(html).toContain(
-      '<a href="./page-1.md?foo=bar" class="text-accent underline hover:text-accent-hover">raw JSX anchor, left exactly as authored</a>',
+    expectHtmlLink(
+      html,
+      "./page-1.md?foo=bar",
+      "raw JSX anchor, left exactly as authored",
     );
   });
 });
@@ -119,13 +116,13 @@ test.describe("Tables: GFM table rendering", () => {
 
   test("table cells render inline marks (code, bold) correctly", () => {
     expect(html).toContain("<td><code>key</code></td>");
-    expect(html).toContain('<td>An <strong class="font-bold text-fg">important</strong> value</td>');
+    expect(html).toMatch(/<td>An <strong\b[^>]*>important<\/strong> value<\/td>/);
+    expectHtmlTagWithClass(html, "strong", "font-bold");
+    expectHtmlTagWithClass(html, "strong", "text-fg");
   });
 
   test("table cells render links, resolved the same as prose links", () => {
-    expect(html).toContain(
-      '<a href="/docs/guides/page-1/" class="text-accent underline hover:text-accent-hover">Writing Docs</a>',
-    );
+    expectHtmlLink(html, "/docs/guides/page-1/", "Writing Docs");
   });
 
   test("no raw GFM table pipe syntax remains in output", () => {
@@ -151,25 +148,25 @@ test.describe("CJK-friendly: emphasis markers adjacent to CJK characters", () =>
   // by Pipeline::with_defaults(), on regardless of the setting being unset).
 
   test("Japanese: bold marker immediately adjacent to kanji parses as emphasis", () => {
-    expect(html).toContain('これは<strong class="font-bold text-fg">重要</strong>な機能です。');
+    expect(html).toMatch(/これは<strong\b[^>]*>重要<\/strong>な機能です。/);
   });
 
   test("Chinese: bold marker immediately adjacent to hanzi parses as emphasis", () => {
-    expect(html).toContain('中文<strong class="font-bold text-fg">强调</strong>测试。');
+    expect(html).toMatch(/中文<strong\b[^>]*>强调<\/strong>测试。/);
   });
 
   test("Korean: bold marker adjacent to hangul parses as emphasis", () => {
-    expect(html).toContain('한국어 <strong class="font-bold text-fg">강조</strong> 테스트.');
+    expect(html).toMatch(/한국어 <strong\b[^>]*>강조<\/strong> 테스트\./);
   });
 
   test("ASCII baseline (ordinary CommonMark emphasis between English words) is unaffected", () => {
-    expect(html).toContain(
-      'this is <strong class="font-bold text-fg">bold</strong> between English words',
+    expect(html).toMatch(
+      /this is <strong\b[^>]*>bold<\/strong> between English words/,
     );
   });
 
   test("mixed CJK + ASCII line renders emphasis correctly on both sides", () => {
-    expect(html).toContain('日本語の <strong class="font-bold text-fg">bold</strong> とテキスト。');
+    expect(html).toMatch(/日本語の <strong\b[^>]*>bold<\/strong> とテキスト。/);
   });
 
   test("no literal, unparsed ** markers remain in the article content", () => {
@@ -204,18 +201,26 @@ test.describe("Math: KaTeX rendering via <MathBlock>", () => {
   });
 
   test("inline math renders a KaTeX span with the correct source annotation", () => {
-    expect(html).toContain('<span class="math math-inline"><span class="katex">');
-    expect(html).toContain('<annotation encoding="application/x-tex">E = mc^2</annotation>');
+    expectHtmlTagWithClass(html, "span", "math-inline");
+    expectHtmlTagWithClass(html, "span", "katex");
+    expectHtmlTagWithAttr(html, "annotation", "encoding", "application/x-tex");
+    expect(html).toContain(">E = mc^2</annotation>");
   });
 
   test("block math renders a KaTeX display div with the correct source annotation", () => {
-    expect(html).toContain('<div class="math math-display">');
+    expectHtmlTagWithClass(html, "div", "math-display");
+    expectHtmlTagWithAttr(html, "annotation", "encoding", "application/x-tex");
     expect(html).toContain(
-      '<annotation encoding="application/x-tex">\\int_0^{\\infty} e^{-x^2} \\, dx = \\frac{\\sqrt{\\pi}}{2}</annotation>',
+      ">\\int_0^{\\infty} e^{-x^2} \\, dx = \\frac{\\sqrt{\\pi}}{2}</annotation>",
     );
   });
 
   test("KaTeX MathML fallback is present for accessibility", () => {
-    expect(html).toContain('<math xmlns="http://www.w3.org/1998/Math/MathML">');
+    expectHtmlTagWithAttr(
+      html,
+      "math",
+      "xmlns",
+      "http://www.w3.org/1998/Math/MathML",
+    );
   });
 });

--- a/e2e/smoke-preset-generator.spec.ts
+++ b/e2e/smoke-preset-generator.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "./fixtures";
+import { expectHtmlAttr, expectHtmlClass } from "./html-assertions";
 import { readDistFile } from "./smoke-dist-helper";
 
 /**
@@ -25,11 +26,11 @@ test.describe("PresetGenerator: SSR fallback shape", () => {
   });
 
   test("SSR emits the skip-ssr island marker for PresetGenerator", () => {
-    expect(html).toContain('data-zfb-island-skip-ssr="PresetGenerator"');
+    expectHtmlAttr(html, "data-zfb-island-skip-ssr", "PresetGenerator");
   });
 
   test("SSR fallback renders the static section-heading shell", () => {
-    expect(html).toContain('class="zd-preset-gen-fallback"');
+    expectHtmlClass(html, "zd-preset-gen-fallback");
     expect(html).toContain("Project Name");
     expect(html).toContain("Header right items");
   });

--- a/e2e/smoke-seo.spec.ts
+++ b/e2e/smoke-seo.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { expectHtmlTagWithAttr, expectHtmlTagWithAttrs } from "./html-assertions";
 import { readDistFile } from "./smoke-dist-helper";
 
 test.describe("SEO: meta tags render correctly", () => {
@@ -9,34 +10,43 @@ test.describe("SEO: meta tags render correctly", () => {
 
   test("og:title meta tag is present with correct content", () => {
     const html = readDistFile("docs/guides/page-1/index.html");
-    // Tolerate either HTML (`>`) or XHTML/self-closing (`/>`) closing form so
-    // the assertion stays valid regardless of how the renderer emits void tags.
-    expect(html).toMatch(
-      /<meta property="og:title" content="Writing Docs \| Smoke Test"\s*\/?>/,
-    );
+    expectHtmlTagWithAttrs(html, "meta", [
+      ["property", "og:title"],
+      ["content", "Writing Docs | Smoke Test"],
+    ]);
   });
 
   test("robots meta tag includes noindex", () => {
     const html = readDistFile("docs/guides/page-1/index.html");
-    expect(html).toContain('<meta name="robots" content="noindex');
+    expectHtmlTagWithAttrs(html, "meta", [
+      ["name", "robots"],
+      ["content", "noindex, nofollow"],
+    ]);
   });
 
   test("og:description meta tag renders from frontmatter description", () => {
     const html = readDistFile("docs/guides/code-blocks-test/index.html");
-    expect(html).toContain(
-      'content="A page for testing code blocks, tabs, details, and mermaid diagrams."',
+    expectHtmlTagWithAttr(
+      html,
+      "meta",
+      "content",
+      "A page for testing code blocks, tabs, details, and mermaid diagrams.",
     );
   });
 
   test("og:type meta tag is present with value website", () => {
     const html = readDistFile("docs/guides/page-1/index.html");
-    expect(html).toMatch(/<meta property="og:type" content="website"\s*\/?>/);
+    expectHtmlTagWithAttrs(html, "meta", [
+      ["property", "og:type"],
+      ["content", "website"],
+    ]);
   });
 
   test("og:site_name meta tag is present with correct site name", () => {
     const html = readDistFile("docs/guides/page-1/index.html");
-    expect(html).toMatch(
-      /<meta property="og:site_name" content="Smoke Test"\s*\/?>/,
-    );
+    expectHtmlTagWithAttrs(html, "meta", [
+      ["property", "og:site_name"],
+      ["content", "Smoke Test"],
+    ]);
   });
 });

--- a/e2e/smoke-tabs-html.spec.ts
+++ b/e2e/smoke-tabs-html.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { expectHtmlAttr } from "./html-assertions";
 import { readDistFile } from "./smoke-dist-helper";
 
 test.describe("Tabs component: HTML structure renders correctly", () => {
@@ -17,14 +18,14 @@ test.describe("Tabs component: HTML structure renders correctly", () => {
   });
 
   test("data-tab-value attributes present for js, py, and rust", () => {
-    expect(html).toContain('data-tab-value="js"');
-    expect(html).toContain('data-tab-value="py"');
-    expect(html).toContain('data-tab-value="rust"');
+    expectHtmlAttr(html, "data-tab-value", "js");
+    expectHtmlAttr(html, "data-tab-value", "py");
+    expectHtmlAttr(html, "data-tab-value", "rust");
   });
 
   test("data-tab-label attributes present for JavaScript, Python, and Rust", () => {
-    expect(html).toContain('data-tab-label="JavaScript"');
-    expect(html).toContain('data-tab-label="Python"');
-    expect(html).toContain('data-tab-label="Rust"');
+    expectHtmlAttr(html, "data-tab-label", "JavaScript");
+    expectHtmlAttr(html, "data-tab-label", "Python");
+    expectHtmlAttr(html, "data-tab-label", "Rust");
   });
 });

--- a/e2e/smoke-toc-markup.spec.ts
+++ b/e2e/smoke-toc-markup.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { attrSource, classAttrSource } from "./html-assertions";
 import { readDistFile } from "./smoke-dist-helper";
 
 /**
@@ -62,8 +63,10 @@ test.describe("TOC: desktop table of contents markup", () => {
   test("h3 list items have ml-hsp-lg class", () => {
     // Mirrors the original browser test's spot check: the "Prerequisites"
     // h3 link's parent <li> carries the indent class.
-    expect(toc).toContain(
-      '<li class="ml-hsp-lg"><a href="#getting-started-prerequisites"',
+    expect(toc).toMatch(
+      new RegExp(
+        `<li\\b(?=[^>]*${classAttrSource("ml-hsp-lg")})[^>]*>\\s*<a\\b(?=[^>]*${attrSource("href", "#getting-started-prerequisites")})`,
+      ),
     );
   });
 });

--- a/e2e/smoke-toc.spec.ts
+++ b/e2e/smoke-toc.spec.ts
@@ -32,10 +32,16 @@ test.describe("TOC: desktop table of contents", () => {
     const tocNav = page.locator('[aria-label="Table of contents"]');
     await expect(tocNav).toBeVisible({ timeout: 5000 });
 
-    // Scroll to the Introduction heading to ensure it enters the active zone.
-    // The scroll spy uses a debounce and position-based detection, so we need
-    // the heading to be near the top of the viewport.
-    await page.locator("#introduction").scrollIntoViewIfNeeded();
+    // Scroll the Introduction heading to the top of the viewport so it enters
+    // the scroll spy's active zone (top < viewportHeight / 2). Do not use
+    // scrollIntoViewIfNeeded(): the heading can already be visible but still
+    // sit below the active threshold after production HTML minification.
+    await page.evaluate(() => {
+      const el = document.getElementById("introduction");
+      if (el) {
+        el.scrollIntoView({ behavior: "instant", block: "start" });
+      }
+    });
 
     // Wait for the scroll spy debounce (200ms) to settle and mark a heading active
     const activeLink = tocNav.locator('a[aria-current="true"]');
@@ -50,8 +56,13 @@ test.describe("TOC: desktop table of contents", () => {
     const tocNav = page.locator('[aria-label="Table of contents"]');
     await expect(tocNav).toBeVisible({ timeout: 5000 });
 
-    // Scroll to Introduction first to activate scroll spy
-    await page.locator("#introduction").scrollIntoViewIfNeeded();
+    // Scroll to Introduction first to activate scroll spy.
+    await page.evaluate(() => {
+      const el = document.getElementById("introduction");
+      if (el) {
+        el.scrollIntoView({ behavior: "instant", block: "start" });
+      }
+    });
     const activeLink = tocNav.locator('a[aria-current="true"]');
     await expect(activeLink).toHaveCount(1, { timeout: 5000 });
 

--- a/e2e/versioning.spec.ts
+++ b/e2e/versioning.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "./fixtures";
 import { makeDistReader } from "./dist-helper";
+import { classAttrSource, expectHtmlAttr } from "./html-assertions";
 
 /**
  * E2E tests for documentation versioning feature.
@@ -122,13 +123,13 @@ test.describe("Versioning: versioned pages", () => {
     // proxy for the browser's toBeVisible() here.
     const banner = extractVersionBanner(html);
     expect(banner).not.toBeNull();
-    expect(banner).not.toMatch(/class="[^"]*\bhidden\b/);
+    expect(banner).not.toMatch(new RegExp(classAttrSource("hidden")));
   });
 
   test("version banner contains link to latest", () => {
     const banner = extractVersionBanner(html);
     expect(banner).not.toBeNull();
-    expect(banner).toContain('href="/docs/getting-started"');
+    expectHtmlAttr(banner!, "href", "/docs/getting-started");
     // Should NOT contain /v/1.0 — it links to the latest version
     expect(banner).not.toContain("/v/1.0");
   });

--- a/package.json
+++ b/package.json
@@ -95,9 +95,9 @@
   },
   "dependencies": {
     "@takazudo/zdtp": "0.4.5",
-    "@takazudo/zfb": "0.1.0-next.77",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.77",
-    "@takazudo/zfb-runtime": "0.1.0-next.77",
+    "@takazudo/zfb": "0.1.0-next.78",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.78",
+    "@takazudo/zfb-runtime": "0.1.0-next.78",
     "@takazudo/zudo-doc": "workspace:*",
     "diff": "^8.0.3",
     "gray-matter": "^4.0.3",

--- a/packages/create-zudo-doc/src/__tests__/preset.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/preset.test.ts
@@ -19,6 +19,23 @@ describe("presetToChoices — cjkFriendly", () => {
   });
 });
 
+describe("presetToChoices — minifyHtml", () => {
+  it("forwards minifyHtml: true", () => {
+    const choices = presetToChoices({ minifyHtml: true });
+    expect(choices.minifyHtml).toBe(true);
+  });
+
+  it("forwards minifyHtml: false", () => {
+    const choices = presetToChoices({ minifyHtml: false });
+    expect(choices.minifyHtml).toBe(false);
+  });
+
+  it("leaves minifyHtml undefined when omitted", () => {
+    const choices = presetToChoices({});
+    expect(choices.minifyHtml).toBeUndefined();
+  });
+});
+
 describe("validatePreset — cjkFriendly", () => {
   it("accepts boolean true", () => {
     expect(validatePreset({ cjkFriendly: true })).toBeNull();
@@ -31,6 +48,22 @@ describe("validatePreset — cjkFriendly", () => {
   it("rejects non-boolean values", () => {
     expect(validatePreset({ cjkFriendly: "yes" })).toMatch(
       /cjkFriendly.*must be a boolean/,
+    );
+  });
+});
+
+describe("validatePreset — minifyHtml", () => {
+  it("accepts boolean true", () => {
+    expect(validatePreset({ minifyHtml: true })).toBeNull();
+  });
+
+  it("accepts boolean false", () => {
+    expect(validatePreset({ minifyHtml: false })).toBeNull();
+  });
+
+  it("rejects non-boolean values", () => {
+    expect(validatePreset({ minifyHtml: "yes" })).toMatch(
+      /minifyHtml.*must be a boolean/,
     );
   });
 });

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -652,8 +652,8 @@ describe("scaffold — designTokenPanel package.json wiring", () => {
 });
 
 describe("scaffold — generated settings.ts content", () => {
-  // 5 of the tests below (cjkFriendly default, packageOwnedRoutes,
-  // tagPlacement, toc depth defaults, headingIdStrategy default) all
+  // 6 of the tests below (cjkFriendly default, minifyHtml default,
+  // packageOwnedRoutes, tagPlacement, toc depth defaults, headingIdStrategy default) all
   // scaffold the identical bare `search`-only config (only projectName
   // differed) — scaffold that config once in beforeAll instead of 5 times
   // (#2531 — dedupe scaffold() calls). The other tests in this describe
@@ -752,6 +752,32 @@ describe("scaffold — generated settings.ts content", () => {
       "utf-8",
     );
     expect(content).toContain("cjkFriendly: false");
+  });
+
+  it("minifyHtml: defaults to true when not specified", async () => {
+    const content = await fs.readFile(
+      sharedProjectPath("test-cjk-default", "src/config/settings.ts"),
+      "utf-8",
+    );
+    expect(content).toContain("minifyHtml: true");
+  });
+
+  it("minifyHtml: false from preset emits false in generated settings.ts", async () => {
+    const choices: UserChoices = {
+      projectName: "test-minify-html-off",
+      defaultLang: "en",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: ["search"],
+      minifyHtml: false,
+      packageManager: "pnpm",
+    };
+    await scaffold(choices);
+    const content = await fs.readFile(
+      projectPath("test-minify-html-off", "src/config/settings.ts"),
+      "utf-8",
+    );
+    expect(content).toContain("minifyHtml: false");
   });
 
   it("cjkFriendly: true flows through from preset into generated settings.ts", async () => {
@@ -2784,7 +2810,8 @@ describe("scaffold — zfb.config.ts shape (topic-config-generators)", () => {
 
     it("zfb.config.ts uses zudoDocPreset (S5b — collections/plugins/markdown delegated to preset)", async () => {
       // S5b (#2329): the thin preset-based shape delegates collections, plugins,
-      // markdown features, codeHighlight, resolveMarkdownLinks, and trailingSlash
+      // markdown features, codeHighlight, resolveMarkdownLinks, trailingSlash,
+      // and minifyHtml
       // to zudoDocPreset() from @takazudo/zudo-doc/preset. The generated config
       // spreads the result and keeps only the host-owned shell fields.
       // S5 (#2408): translations + colorSchemes forwarded unconditionally so
@@ -3802,11 +3829,12 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
    * Bumped to 0.1.0-next.76: routine toolchain bump from next.75, in
    * lockstep with the root package.json pins. No consumer-facing change.
    * Bumped to 0.1.0-next.77: router persistence/history fixes and runtime
-   * island remount support, in lockstep with the root package.json pins. No
-   * scaffold API change.
+   * island remount support, in lockstep with the root package.json pins.
+   * Bumped to 0.1.0-next.78: zfb production HTML minification support, wired
+   * through settings.minifyHtml as zudo-doc's default-on option.
    * Generated package.json must pin all three.
    */
-  it("pins @takazudo/zfb at 0.1.0-next.77", async () => {
+  it("pins @takazudo/zfb at 0.1.0-next.78", async () => {
     const choices: UserChoices = {
       projectName: "test-pin-bump",
       defaultLang: "en",
@@ -3817,10 +3845,10 @@ describe("scaffold — zfb next.30 pin bump (PR #1910)", () => {
     };
     await scaffold(choices);
     const pkg = await fs.readJson(projectPath("test-pin-bump", "package.json"));
-    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.77");
-    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.77");
+    expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.78");
+    expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.78");
     expect(pkg.dependencies["@takazudo/zfb-adapter-cloudflare"]).toBe(
-      "0.1.0-next.77",
+      "0.1.0-next.78",
     );
   });
 });

--- a/packages/create-zudo-doc/src/__tests__/zfb-config-gen.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/zfb-config-gen.test.ts
@@ -14,7 +14,7 @@ const baseChoices: UserChoices = {
 describe("generateZfbConfig", () => {
   // S5b (#2329): collapsed to the thin preset-based shape — all collection
   // wiring, plugin descriptors, markdown features, codeHighlight,
-  // resolveMarkdownLinks, and trailingSlash are now delegated to
+  // resolveMarkdownLinks, trailingSlash, and minifyHtml are now delegated to
   // `zudoDocPreset()` from `@takazudo/zudo-doc/preset`. The generated config
   // spreads the preset result into `defineConfig` and keeps only the
   // project-owned shell fields (framework, port, tailwind, base).
@@ -61,6 +61,7 @@ describe("generateZfbConfig", () => {
     expect(result).not.toContain("resolveMarkdownLinks: {");
     expect(result).not.toContain("stripMdExt:");
     expect(result).not.toContain("trailingSlash: settings.trailingSlash,");
+    expect(result).not.toContain("minifyHtml: settings.minifyHtml,");
 
     // migration guards: generated package.json must never include Astro deps
     expect(result).not.toContain("astro/config");

--- a/packages/create-zudo-doc/src/preset.ts
+++ b/packages/create-zudo-doc/src/preset.ts
@@ -70,6 +70,7 @@ export interface PresetJson {
   features?: string[];
   githubUrl?: string;
   cjkFriendly?: boolean;
+  minifyHtml?: boolean;
   packageManager?: "pnpm" | "npm" | "yarn" | "bun";
   headerRightItems?: PresetHeaderRightItem[];
   metaTags?: PresetMetaTagsConfig;
@@ -135,6 +136,9 @@ export function validatePreset(json: unknown): string | null {
   }
   if (p.cjkFriendly !== undefined && typeof p.cjkFriendly !== "boolean") {
     return `"cjkFriendly" must be a boolean in preset`;
+  }
+  if (p.minifyHtml !== undefined && typeof p.minifyHtml !== "boolean") {
+    return `"minifyHtml" must be a boolean in preset`;
   }
   if (p.headerRightItems !== undefined) {
     if (!Array.isArray(p.headerRightItems)) {
@@ -238,6 +242,7 @@ export function presetToChoices(json: PresetJson): PartialChoices {
   if (json.packageManager) choices.packageManager = json.packageManager;
   if (json.githubUrl !== undefined) choices.githubUrl = json.githubUrl;
   if (json.cjkFriendly !== undefined) choices.cjkFriendly = json.cjkFriendly;
+  if (json.minifyHtml !== undefined) choices.minifyHtml = json.minifyHtml;
   if (json.headerRightItems !== undefined) {
     choices.headerRightItems = json.headerRightItems;
   }

--- a/packages/create-zudo-doc/src/prompts.ts
+++ b/packages/create-zudo-doc/src/prompts.ts
@@ -26,6 +26,9 @@ export interface UserChoices {
   // Enable remark-cjk-friendly plugin (intelligent spacing around CJK text).
   // Preset-only for now — no interactive prompt.
   cjkFriendly?: boolean;
+  // Minify production HTML output. Preset-only for now; generated projects
+  // default to true and can flip src/config/settings.ts later.
+  minifyHtml?: boolean;
   // Package manager
   packageManager: "pnpm" | "npm" | "yarn" | "bun";
   // Header-right items override. Preset-only — no interactive prompt because
@@ -53,6 +56,7 @@ export interface PartialChoices {
   explicitlyDisabledFeatures?: string[];
   githubUrl?: string;
   cjkFriendly?: boolean;
+  minifyHtml?: boolean;
   packageManager?: "pnpm" | "npm" | "yarn" | "bun";
   headerRightItems?: PresetHeaderRightItem[];
   // Meta tags config. Preset-only — no interactive prompt.
@@ -252,6 +256,7 @@ export async function runPrompts(
     explicitlyDisabledFeatures: prefilled.explicitlyDisabledFeatures,
     githubUrl,
     cjkFriendly: prefilled.cjkFriendly,
+    minifyHtml: prefilled.minifyHtml,
     packageManager,
     headerRightItems: prefilled.headerRightItems,
     metaTags: prefilled.metaTags,

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -618,14 +618,15 @@ function generatePackageJson(choices: UserChoices) {
     // pins. No consumer-facing / CLI change.
     // next.76: routine toolchain bump from next.75, adopted in
     // lockstep with the root package.json pins. No consumer-facing / CLI change.
-    // next.77 (current pin): router persistence/history fixes and runtime
-    // island remount support, adopted in lockstep with the root package.json
-    // pins. No scaffold API change.
-    "@takazudo/zfb": "0.1.0-next.77",
-    "@takazudo/zfb-runtime": "0.1.0-next.77",
+    // next.77: router persistence/history fixes and runtime island remount
+    // support, adopted in lockstep with the root package.json pins. No
+    // scaffold API change. next.78 (current pin): production HTML minification
+    // support via minifyHtml, adopted as a zudo-doc default through settings.
+    "@takazudo/zfb": "0.1.0-next.78",
+    "@takazudo/zfb-runtime": "0.1.0-next.78",
     // zfb-adapter-cloudflare — required for any route with `prerender = false`.
     // Pinned in lockstep with @takazudo/zfb.
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.77",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.78",
     // @takazudo/zudo-doc — published from this monorepo via
     // .github/workflows/publish-zudo-doc.yml. The pin here is bumped in
     // lockstep by scripts/release-create-zudo-doc.sh whenever zudo-doc's

--- a/packages/create-zudo-doc/src/settings-gen.ts
+++ b/packages/create-zudo-doc/src/settings-gen.ts
@@ -70,6 +70,7 @@ export function generateSettingsFile(choices: UserChoices): string {
   lines.push(`  siteDescription: "" as string,`);
   lines.push(`  base: "/",`);
   lines.push(`  trailingSlash: false as boolean,`);
+  lines.push(`  minifyHtml: ${choices.minifyHtml ?? true} as boolean,`);
   lines.push(`  noindex: ${choices.features.includes("noindex")} as boolean,`);
   lines.push(`  editUrl: false as string | false,`);
   const rawGithubUrl = (choices.githubUrl ?? "").trim();

--- a/packages/create-zudo-doc/src/zfb-config-gen.ts
+++ b/packages/create-zudo-doc/src/zfb-config-gen.ts
@@ -5,8 +5,8 @@ import type { UserChoices } from "./prompts.js";
  *
  * S5b (#2329): collapsed to the thin preset-based shape that mirrors the
  * showcase `zfb.config.ts` after S5a. All collection wiring, plugin
- * descriptors, markdown features, codeHighlight, resolveMarkdownLinks, and
- * trailingSlash are now owned by `zudoDocPreset()` in
+ * descriptors, markdown features, codeHighlight, resolveMarkdownLinks,
+ * trailingSlash, and minifyHtml are now owned by `zudoDocPreset()` in
  * `@takazudo/zudo-doc/preset`. The generated config spreads the preset
  * result into `defineConfig` and keeps only the project-owned shell fields
  * (`framework`, `port`, `tailwind`, `base`).

--- a/packages/create-zudo-doc/templates/base/zfb-shim.d.ts
+++ b/packages/create-zudo-doc/templates/base/zfb-shim.d.ts
@@ -153,6 +153,11 @@ declare module "zfb/config" {
      */
     trailingSlash?: boolean;
     /**
+     * Minify production HTML output from `zfb build`.
+     * Mirrors `Config::minify_html` in crates/zfb/src/config.rs.
+     */
+    minifyHtml?: boolean;
+    /**
      * Markdown / MDX pipeline options. Mirrors `Config::markdown` →
      * `MarkdownConfig` in crates/zfb/src/config.rs. zfb next.12 moved the
      * former-Core features under `markdown.features` and next.13 ships the

--- a/packages/zudo-doc/API.md
+++ b/packages/zudo-doc/API.md
@@ -272,6 +272,7 @@ These fields are the stable contract. The snapshot guard locks this set.
 | `siteDescription` | `string` | Default site description |
 | `base` | `string` | Base URL path prefix |
 | `trailingSlash` | `boolean` | Whether to add trailing slashes to URLs |
+| `minifyHtml?` | `boolean` | Minify production HTML output from `zfb build`; defaults to `true` when omitted |
 | `docsDir` | `string` | Path to English docs content directory |
 | `defaultLocale` | `string` | Default locale code (e.g. `"en"`) |
 | `locales` | `Record<string, LocaleConfig>` | Locale configuration map |

--- a/packages/zudo-doc/CLAUDE.md
+++ b/packages/zudo-doc/CLAUDE.md
@@ -122,7 +122,7 @@ unchanged). `buildNavTree(entries, lang, categoryMeta, { buildHref })` in
 `src/preset.ts` (exported as `@takazudo/zudo-doc/preset`) returns the zfb config
 fragment every project used to hand-write in `zfb.config.ts` — collections loop,
 `markdown.features`, dual-theme `codeHighlight`, `resolveMarkdownLinks`,
-`stripMdExt`, `trailingSlash`, and the integration `plugins` array. The host
+`stripMdExt`, `trailingSlash`, `minifyHtml`, and the integration `plugins` array. The host
 spreads it into `defineConfig` and keeps only the shell fields it still owns
 (`framework`, `port`, `tailwind`, `bundle`, `base`, `adapter`).
 

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -558,9 +558,9 @@
   ],
   "peerDependencies": {
     "preact": "^10.29.1",
-    "@takazudo/zfb": "^0.1.0-next.77",
-    "@takazudo/zfb-runtime": "^0.1.0-next.77",
-    "@takazudo/zudo-doc-history-server": "^3.0.0",
+    "@takazudo/zfb": "^0.1.0-next.78",
+    "@takazudo/zfb-runtime": "^0.1.0-next.78",
+    "@takazudo/zudo-doc-history-server": "^3.1.0",
     "@takazudo/zdtp": "^0.4.5",
     "shiki": "^4.0.2",
     "zod": "^4.3.6",
@@ -602,8 +602,8 @@
     "typescript": "^5.0.0",
     "vitest": "^4.1.0",
     "zod": "^4.3.6",
-    "@takazudo/zfb": "0.1.0-next.77",
-    "@takazudo/zfb-runtime": "0.1.0-next.77",
+    "@takazudo/zfb": "0.1.0-next.78",
+    "@takazudo/zfb-runtime": "0.1.0-next.78",
     "@takazudo/zudo-doc-history-server": "workspace:*"
   }
 }

--- a/packages/zudo-doc/src/__tests__/fixtures/route-injection-i18n/zfb-shim.d.ts
+++ b/packages/zudo-doc/src/__tests__/fixtures/route-injection-i18n/zfb-shim.d.ts
@@ -153,6 +153,11 @@ declare module "zfb/config" {
      */
     trailingSlash?: boolean;
     /**
+     * Minify production HTML output from `zfb build`.
+     * Mirrors `Config::minify_html` in crates/zfb/src/config.rs.
+     */
+    minifyHtml?: boolean;
+    /**
      * Markdown / MDX pipeline options. Mirrors `Config::markdown` →
      * `MarkdownConfig` in crates/zfb/src/config.rs. zfb next.12 moved the
      * former-Core features under `markdown.features` and next.13 ships the

--- a/packages/zudo-doc/src/__tests__/fixtures/route-injection/zfb-shim.d.ts
+++ b/packages/zudo-doc/src/__tests__/fixtures/route-injection/zfb-shim.d.ts
@@ -153,6 +153,11 @@ declare module "zfb/config" {
      */
     trailingSlash?: boolean;
     /**
+     * Minify production HTML output from `zfb build`.
+     * Mirrors `Config::minify_html` in crates/zfb/src/config.rs.
+     */
+    minifyHtml?: boolean;
+    /**
      * Markdown / MDX pipeline options. Mirrors `Config::markdown` →
      * `MarkdownConfig` in crates/zfb/src/config.rs. zfb next.12 moved the
      * former-Core features under `markdown.features` and next.13 ships the

--- a/packages/zudo-doc/src/__tests__/preset.test.ts
+++ b/packages/zudo-doc/src/__tests__/preset.test.ts
@@ -183,7 +183,7 @@ describe("preset eval-graph is node-builtin-free (--platform=neutral)", () => {
 // ───────────────────────────────────────────────────────────────────────────
 // Behavioral parity — the returned fragment reproduces the hand-written
 // `zfb.config.ts` pipeline (collections loop, plugins, markdown.features,
-// codeHighlight, resolveMarkdownLinks, stripMdExt, trailingSlash).
+// codeHighlight, resolveMarkdownLinks, stripMdExt, trailingSlash, minifyHtml).
 // ───────────────────────────────────────────────────────────────────────────
 
 // A fixture mirroring the showcase `settings` shape (the subset the preset
@@ -197,6 +197,7 @@ const fixtureSettings: PresetSettings = {
   siteDescription: "Documentation base framework.",
   siteUrl: "https://zudo-doc.takazudomodular.com",
   trailingSlash: true,
+  minifyHtml: true,
   mermaid: true,
   onBrokenMarkdownLinks: "warn",
   headingIdStrategy: "hierarchical",
@@ -577,7 +578,7 @@ describe("zudoDocPreset markdown.features", () => {
 });
 
 describe("zudoDocPreset top-level pipeline fields", () => {
-  it("emits dual-theme codeHighlight, stripMdExt, and trailingSlash", () => {
+  it("emits dual-theme codeHighlight, stripMdExt, trailingSlash, and minifyHtml", () => {
     const r = preset();
     expect(r.codeHighlight).toEqual({
       themeLight: "base16-ocean.light",
@@ -585,6 +586,7 @@ describe("zudoDocPreset top-level pipeline fields", () => {
     });
     expect(r.stripMdExt).toBe(true);
     expect(r.trailingSlash).toBe(true);
+    expect(r.minifyHtml).toBe(true);
   });
 
   it("mirrors settings.trailingSlash", () => {
@@ -594,6 +596,25 @@ describe("zudoDocPreset top-level pipeline fields", () => {
       directiveVocabulary: fixtureDirectives,
     });
     expect(r.trailingSlash).toBe(false);
+  });
+
+  it("defaults minifyHtml to true when the setting is omitted", () => {
+    const { minifyHtml: _omitted, ...settingsWithoutMinifyHtml } = fixtureSettings;
+    const r = zudoDocPreset({
+      settings: settingsWithoutMinifyHtml,
+      buildDocsSchema: buildFixtureSchema,
+      directiveVocabulary: fixtureDirectives,
+    });
+    expect(r.minifyHtml).toBe(true);
+  });
+
+  it("mirrors settings.minifyHtml when explicitly false", () => {
+    const r = zudoDocPreset({
+      settings: { ...fixtureSettings, minifyHtml: false },
+      buildDocsSchema: buildFixtureSchema,
+      directiveVocabulary: fixtureDirectives,
+    });
+    expect(r.minifyHtml).toBe(false);
   });
 
   it("builds resolveMarkdownLinks dirs for docs + locales + versions", () => {

--- a/packages/zudo-doc/src/__tests__/public-api-snapshot.test.ts
+++ b/packages/zudo-doc/src/__tests__/public-api-snapshot.test.ts
@@ -223,6 +223,7 @@ describe("Settings public field set snapshot", () => {
         "siteDescription",
         "base",
         "trailingSlash",
+        "minifyHtml",
         "docsDir",
         "defaultLocale",
         "locales",

--- a/packages/zudo-doc/src/code-syntax/__tests__/mermaid-init.test.tsx
+++ b/packages/zudo-doc/src/code-syntax/__tests__/mermaid-init.test.tsx
@@ -212,10 +212,68 @@ describe("MERMAID_INIT_SCRIPT", () => {
   // node.
   it("caches the diagram source into data-mermaid-src before running", () => {
     expect(MERMAID_INIT_SCRIPT).toContain("data-mermaid-src");
+    expect(MERMAID_INIT_SCRIPT).toContain("normalizeCollapsedMermaidSource");
     // Must cache via textContent (decoded) — NOT innerHTML, which would
     // re-encode entities and corrupt `-->` / `&` diagrams.
     expect(MERMAID_INIT_SCRIPT).toContain("el.textContent");
     expect(MERMAID_INIT_SCRIPT).not.toContain("el.innerHTML");
+  });
+
+  it("leaves authored multiline mermaid source unchanged", () => {
+    const fn = extractNormalizeCollapsedMermaidSource(MERMAID_INIT_SCRIPT);
+    const source = "graph LR\n  A[Start] --> B[Process]\n  B --> C[End]";
+    expect(fn(source)).toBe(source);
+  });
+
+  it("restores statement boundaries for minified flowchart source", () => {
+    const fn = extractNormalizeCollapsedMermaidSource(MERMAID_INIT_SCRIPT);
+    expect(
+      fn("graph LR A[Start] --> B[Process] B --> C[End]"),
+    ).toBe("graph LR\nA[Start] --> B[Process];\nB --> C[End]");
+  });
+
+  it("restores statement boundaries for minified flowchart source with labels", () => {
+    const fn = extractNormalizeCollapsedMermaidSource(MERMAID_INIT_SCRIPT);
+    expect(
+      fn(
+        "graph LR A[Start] --> B{Decision} B -->|Yes| C[Action] B -->|No| D[Other Action] C --> E[End] D --> E",
+      ),
+    ).toBe(
+      "graph LR\nA[Start] --> B{Decision};\nB -->|Yes| C[Action];\nB -->|No| D[Other Action];\nC --> E[End];\nD --> E",
+    );
+  });
+
+  it("restores statement boundaries for minified sequence diagrams", () => {
+    const fn = extractNormalizeCollapsedMermaidSource(MERMAID_INIT_SCRIPT);
+    expect(
+      fn(
+        "sequenceDiagram participant User participant App participant API User->>App: Click button App->>API: Fetch data API-->>App: JSON response App-->>User: Render result",
+      ),
+    ).toBe(
+      "sequenceDiagram\nparticipant User;\nparticipant App;\nparticipant API;\nUser->>App: Click button;\nApp->>API: Fetch data;\nAPI-->>App: JSON response;\nApp-->>User: Render result",
+    );
+  });
+
+  it("restores statement boundaries for minified state diagrams", () => {
+    const fn = extractNormalizeCollapsedMermaidSource(MERMAID_INIT_SCRIPT);
+    expect(
+      fn(
+        "stateDiagram-v2 [*] --> Draft Draft --> Review : Submit Review --> Published : Approve Review --> Draft : Request Changes Published --> Archived : Archive Archived --> [*]",
+      ),
+    ).toBe(
+      "stateDiagram-v2\n[*] --> Draft;\nDraft --> Review : Submit;\nReview --> Published : Approve;\nReview --> Draft : Request Changes;\nPublished --> Archived : Archive;\nArchived --> [*]",
+    );
+  });
+
+  it("restores statement boundaries for minified subgraph flowcharts", () => {
+    const fn = extractNormalizeCollapsedMermaidSource(MERMAID_INIT_SCRIPT);
+    expect(
+      fn(
+        "flowchart TB subgraph Build A[MDX source] --> B[Mermaid pass] B --> C[Wrapper div] end subgraph Runtime C --> D[Client island] D --> E[Rendered SVG] E --> F[Enlarge button] end F --> G((Dialog\\n+ / - / pan))",
+      ),
+    ).toBe(
+      "flowchart TB\nsubgraph Build;\nA[MDX source] --> B[Mermaid pass];\nB --> C[Wrapper div];\nend;\nsubgraph Runtime;\nC --> D[Client island];\nD --> E[Rendered SVG];\nE --> F[Enlarge button];\nend;\nF --> G((Dialog\\n+ / - / pan))",
+    );
   });
 
   it("reinitMermaid restores the cached source and removes data-processed", () => {
@@ -413,6 +471,23 @@ function extractHasThemeStateChanged(
   return new Function(
     `${tokens[0]}\n${fn[0]}\nreturn hasThemeStateChanged;`,
   )() as (prev: ThemeSnapshot | undefined, next: ThemeSnapshot) => boolean;
+}
+
+function extractNormalizeCollapsedMermaidSource(
+  script: string,
+): (raw: string) => string {
+  const match = script.match(
+    /function\s+normalizeCollapsedMermaidSource\s*\([^)]*\)\s*\{[\s\S]*?\n\s{2}\}/,
+  );
+  if (!match) {
+    throw new Error(
+      "normalizeCollapsedMermaidSource not found in MERMAID_INIT_SCRIPT",
+    );
+  }
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  return new Function(
+    `${match[0]}\nreturn normalizeCollapsedMermaidSource;`,
+  )() as (raw: string) => string;
 }
 
 // zudolab/zudo-doc#2474 — OKLCH migration: resolveColor must handle the

--- a/packages/zudo-doc/src/code-syntax/mermaid-init-script.ts
+++ b/packages/zudo-doc/src/code-syntax/mermaid-init-script.ts
@@ -255,6 +255,49 @@ export function buildMermaidInitScript(cdnUrl: string): string {
     return false;
   }
 
+  /**
+   * zfb 0.1.0-next.78's HTML minifier collapses text inside
+   * <div data-mermaid>, but Mermaid's DSL uses line/statement boundaries
+   * as syntax. Only repair single-line sources; already-multiline source
+   * keeps its authored layout.
+   */
+  function normalizeCollapsedMermaidSource(raw) {
+    var source = (raw || "").replace(/\\r\\n?/g, "\\n");
+    if (source.indexOf("\\n") !== -1) return source;
+    source = source.replace(/^\\s+|\\s+$/g, "").replace(/\\s+/g, " ");
+    if (!source) return source;
+
+    var out = source
+      .replace(/^(graph|flowchart)\\s+(TB|TD|BT|RL|LR)\\s+/i, "$1 $2\\n")
+      .replace(/^(sequenceDiagram|stateDiagram(?:-v2)?|classDiagram|erDiagram|journey|gantt|gitGraph|mindmap|timeline|quadrantChart|requirementDiagram)\\s+/i, "$1\\n");
+
+    if (/^(graph|flowchart)\\b/i.test(out)) {
+      out = out
+        .replace(/\\bend\\s+subgraph\\b/gi, "end;\\nsubgraph")
+        .replace(/\\bsubgraph\\s+([A-Za-z0-9_-]+)\\s+(?=(?:[A-Za-z0-9_][\\w-]*|\\[\\*\\])[\\[{(]?)/gi, "subgraph $1;\\n")
+        .replace(/([\\]\\)\\}])\\s+\\bend\\b/gi, "$1;\\nend")
+        .replace(/\\bend\\s+((?:[A-Za-z0-9_][\\w-]*|\\[\\*\\])\\s*(?:[-=.xo<~]+|--?>))/gi, "end;\\n$1")
+        .replace(/([\\]\\)\\}])\\s+((?:[A-Za-z0-9_][\\w-]*|\\[\\*\\])\\s*(?:[-=.xo<~]+|--?>))/g, "$1;\\n$2");
+    } else if (/^sequenceDiagram\\b/i.test(out)) {
+      out = out
+        .replace(/\\s+(create\\s+(?:participant|actor)|participant|actor)\\s+/gi, ";\\n$1 ")
+        .replace(/\\s+([A-Za-z][\\w.-]*\\s*(?:-+>>\\+?|-+>\\+?|-+\\)\\+?|-+x\\+?))/g, ";\\n$1")
+        .replace(/\\s+(Note\\s+(?:left|right|over)\\s+of\\s+)/gi, ";\\n$1")
+        .replace(/\\s+(loop|alt|else|opt|par|and|rect|critical|break|end)\\b/gi, ";\\n$1");
+    } else if (/^stateDiagram(?:-v2)?\\b/i.test(out)) {
+      out = out.replace(
+        /([A-Za-z0-9_*\\]\\)\\}])\\s+((?:\\[\\*\\]|[A-Za-z0-9_][\\w-]*)\\s*--?>)/g,
+        "$1;\\n$2",
+      );
+    }
+
+    return out
+      .replace(/\\n\\s*;\\s*\\n/g, "\\n")
+      .replace(/^(sequenceDiagram|stateDiagram(?:-v2)?);\\n/i, "$1\\n")
+      .replace(/;{2,}/g, ";")
+      .replace(/^\\s+|\\s+$/g, "");
+  }
+
   async function initMermaid() {
     var els = document.querySelectorAll("[data-mermaid]:not([data-mermaid-rendered])");
     if (els.length === 0) return;
@@ -359,8 +402,10 @@ export function buildMermaidInitScript(cdnUrl: string): string {
       // Only set when absent so repeated reinits keep the ORIGINAL
       // source (zudolab/zudo-doc#2181).
       els.forEach(function (el) {
+        var source = normalizeCollapsedMermaidSource(el.textContent);
+        el.textContent = source;
         if (!el.hasAttribute("data-mermaid-src")) {
-          el.setAttribute("data-mermaid-src", el.textContent);
+          el.setAttribute("data-mermaid-src", source);
         }
       });
       await mermaid.run({ nodes: Array.from(els) });

--- a/packages/zudo-doc/src/preset.ts
+++ b/packages/zudo-doc/src/preset.ts
@@ -4,7 +4,7 @@
  * `zudoDocPreset()` returns the zfb config fragment that every zudo-doc
  * project previously hand-wrote in its `zfb.config.ts` (collections loop,
  * markdown.features, dual-theme codeHighlight, resolveMarkdownLinks,
- * stripMdExt, trailingSlash, and the integration plugins array). The host
+ * stripMdExt, trailingSlash, minifyHtml, and the integration plugins array). The host
  * config spreads this fragment into `defineConfig` and supplies only the
  * project-specific shell fields it still owns (`framework`, `port`,
  * `tailwind`, `bundle`, `base`, `adapter`).
@@ -86,6 +86,7 @@ export interface PresetSettings {
   siteDescription: string;
   siteUrl: string;
   trailingSlash: boolean;
+  minifyHtml?: boolean;
   mermaid: boolean;
   onBrokenMarkdownLinks: "warn" | "error" | "ignore";
   headingIdStrategy: "flat" | "hierarchical";
@@ -240,6 +241,7 @@ export interface ZudoDocPresetResult {
   resolveMarkdownLinks: PresetResolveMarkdownLinks;
   stripMdExt: boolean;
   trailingSlash: boolean;
+  minifyHtml: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -296,6 +298,7 @@ export function zudoDocPreset({
     // `[label](./other.mdx)` references resolve to the rendered route URL.
     stripMdExt: true,
     trailingSlash: settings.trailingSlash,
+    minifyHtml: settings.minifyHtml ?? true,
   };
 }
 

--- a/packages/zudo-doc/src/settings.ts
+++ b/packages/zudo-doc/src/settings.ts
@@ -275,6 +275,8 @@ export interface Settings {
   siteDescription: string;
   base: string;
   trailingSlash: boolean;
+  /** Minify production HTML output from `zfb build`. Defaults to `true` when omitted. */
+  minifyHtml?: boolean;
   docsDir: string;
   defaultLocale: string;
   locales: Record<string, LocaleConfig>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,14 +30,14 @@ importers:
         specifier: 0.4.5
         version: 0.4.5(preact@10.29.2)
       '@takazudo/zfb':
-        specifier: 0.1.0-next.77
-        version: 0.1.0-next.77
+        specifier: 0.1.0-next.78
+        version: 0.1.0-next.78
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.77
-        version: 0.1.0-next.77
+        specifier: 0.1.0-next.78
+        version: 0.1.0-next.78
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.77
-        version: 0.1.0-next.77(@takazudo/zfb@0.1.0-next.77)
+        specifier: 0.1.0-next.78
+        version: 0.1.0-next.78(@takazudo/zfb@0.1.0-next.78)
       '@takazudo/zudo-doc':
         specifier: workspace:*
         version: link:packages/zudo-doc
@@ -287,11 +287,11 @@ importers:
         version: 1.1.1
     devDependencies:
       '@takazudo/zfb':
-        specifier: 0.1.0-next.77
-        version: 0.1.0-next.77
+        specifier: 0.1.0-next.78
+        version: 0.1.0-next.78
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.77
-        version: 0.1.0-next.77(@takazudo/zfb@0.1.0-next.77)
+        specifier: 0.1.0-next.78
+        version: 0.1.0-next.78(@takazudo/zfb@0.1.0-next.78)
       '@takazudo/zudo-doc-history-server':
         specifier: workspace:*
         version: link:../doc-history-server
@@ -1386,48 +1386,48 @@ packages:
     peerDependencies:
       preact: ^10.29.1
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.77':
-    resolution: {integrity: sha512-r7kGnlWq/vo8beHPnyOAeKSRk3UVvTYfHGN4pzlTo7hXP2Erd0g0rBmvNe2cDxEZqrhhm4NrAnCRlP0JE8A99w==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.78':
+    resolution: {integrity: sha512-g9KyrzOEN0NTmJi7GqR9Q6mal1O4H5ja+2JhKKHzk2CiGwUBAuNNzH0pJvfwcc15K0wm6aIC2VcUx5iRUzhMjQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.77':
-    resolution: {integrity: sha512-4vHP3Ex8tVm33rPvFio86SdphSh75YAxR5HUcH/WI/cFNknamkRb/nTKvu9b8vUHKajIVPJNq6msyD4FFvGQ8Q==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.78':
+    resolution: {integrity: sha512-F1VsKrilKgF0qEAtO7JQyi5PO50jGHep3UGzPKFfrSDlMzbfh6hiKeNp0SMekeKE0tuTfIXVDZqFLP06nGVf6Q==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.77':
-    resolution: {integrity: sha512-8MZFsBoTpq2xARNHYpXZE7K88KhznmMkOpOivMUcQXvuQalprAxA5lH9fG3CbkzmhUHuupH4ikJu9DqsYTRclQ==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.78':
+    resolution: {integrity: sha512-JtE4CfUY6gqdzMiuP6q4JuFW0GVVqqjL1vFjY/uFVroelTmwiSgjSAyeI6G+kUnhJDbG8F2m0eGjd9mEh5rAlQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.77':
-    resolution: {integrity: sha512-S+94+wK7upRzViMvwQ38tmgY2wo9h1ckY6kJwxh7AJQCR7FMVEHAlrF3d/xYBLk5zehiTsebe80/96ltL+t7Dg==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.78':
+    resolution: {integrity: sha512-YgVgdBYk1/LgsmhJIHqlPeTItV10BkooVnbs3UTmPYvKMu8vrOsrfqLcw60tF5dx6hZxXtWX+a2Jv6dCc/F28g==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.77':
-    resolution: {integrity: sha512-cTdn5JsYMrBevk5ggp4qbMbN6AkUgSjESohKeRlijIW0qMnHTUWdYzny/fbi63PoUkrYhJox4zp02bE+YEoeZg==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.78':
+    resolution: {integrity: sha512-JS4vJBunnc5s9LSghl55Pvs/nDToFnPVmOMbOS6Mgq/8T1dEsoDe0wP8288xxXTv8RbxJk2YJ0eg9JLxxeATMQ==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.77':
-    resolution: {integrity: sha512-rqmnAp3AGefmkQgchtqt46GYBfy4EKR1IDAzs9SNsCklu3M+30KdUJRJngFObiTwsehu57ebistRvd/MhzCqDA==}
+  '@takazudo/zfb-runtime@0.1.0-next.78':
+    resolution: {integrity: sha512-YG8py9ce0dfpCzv5rinUYFCUVeZalpyaaL53aSo1diQASEbT7Wh3gOEdHdF6+1fB8UHlukQlBaVdW7Z9pQ+iTA==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.77
+      '@takazudo/zfb': 0.1.0-next.78
       react: ^19.2.3
     peerDependenciesMeta:
       react:
         optional: true
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.77':
-    resolution: {integrity: sha512-C7BiOB9Ne6y/1AboAlJE7Y52xhXTRgi/qLvh3w4I7iDRbG0464WkX7ZCanabHOJ51U0wPNNr20xWlrROy35SQA==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.78':
+    resolution: {integrity: sha512-yy2lD2eRMQQ7g23JJYBPacCyqBvjyWGhwb/sndCXlixUBVI1rga3ZA7MbVNfAuOGmN0Ak3BCFAeM3TCKBILuHg==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.77':
-    resolution: {integrity: sha512-p0GHAWnz1ev+NLbmysN5SDk+3oDLWs+11ExHcTM/t9zTOF5L3LhsuGCslLYLV15hDj5CMP/DOJGPExYZZgL6sw==}
+  '@takazudo/zfb@0.1.0-next.78':
+    resolution: {integrity: sha512-wwY1sLCKZznq/aNidOO0oYbw5f/gy+jRVqC5ntbTH2CdVl9EdjnuRBCuEAb2qSUHYOKaeYUDbevUMmqP5E5Zyw==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
     peerDependencies:
@@ -4094,35 +4094,35 @@ snapshots:
       culori: 4.0.2
       preact: 10.29.2
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.77': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.78': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.77':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.78':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.77':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.78':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.77':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.78':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.77':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.78':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.77(@takazudo/zfb@0.1.0-next.77)':
+  '@takazudo/zfb-runtime@0.1.0-next.78(@takazudo/zfb@0.1.0-next.78)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.77
+      '@takazudo/zfb': 0.1.0-next.78
       hono: 4.12.25
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.77':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.78':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.77':
+  '@takazudo/zfb@0.1.0-next.78':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.77
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.77
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.77
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.77
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.77
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.78
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.78
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.78
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.78
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.78
 
   '@takazudo/zudo-design-token-lint@1.0.0(patch_hash=6a157fd850449b055cf64a8a7dd1faed5b1da9eebe6c81cca08488ac0de85182)':
     dependencies:

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -42,6 +42,7 @@ export const settings = {
   siteDescription: "Documentation base framework built with zfb, MDX, and Tailwind CSS v4." as string,
   base: "/",
   trailingSlash: true as boolean,
+  minifyHtml: true as boolean,
   docsDir: "src/content/docs",
   defaultLocale: "en" as const,
   locales: {

--- a/src/content/docs-ja/guides/configuration.mdx
+++ b/src/content/docs-ja/guides/configuration.mdx
@@ -23,6 +23,7 @@ export const settings = {
   siteDescription: "Documentation base framework...",
   base: "/",
   trailingSlash: true,
+  minifyHtml: true,
   docsDir: "src/content/docs",
   locales: {
     ja: { label: "JA", dir: "src/content/docs-ja" },
@@ -136,6 +137,16 @@ trailingSlash: true,
 このドキュメントの以前のバージョンでは`/_astro/`と`/_image`もリダイレクト除外対象として記載されていました。これらはAstro時代のレガシーパスであり、zfbはこれらのプレフィックスを出力しません。既存のキャッシュ済みリンクとの後方互換性のためにリダイレクトスキップリストに残されています。
 
 </Note>
+
+### minifyHtml
+
+`zfb build`が生成する`.html`ファイルをminifyするかどうかを制御します。
+
+デフォルト：zudo-docプロジェクトでは`true`です。ビルド出力のHTMLを読みやすい形でデバッグしたい場合は`false`に設定します。
+
+```ts
+minifyHtml: true,
+```
 
 ### onBrokenMarkdownLinks
 

--- a/src/content/docs/guides/configuration.mdx
+++ b/src/content/docs/guides/configuration.mdx
@@ -23,6 +23,7 @@ export const settings = {
   siteDescription: "Documentation base framework...",
   base: "/",
   trailingSlash: true,
+  minifyHtml: true,
   docsDir: "src/content/docs",
   locales: {
     ja: { label: "JA", dir: "src/content/docs-ja" },
@@ -136,6 +137,16 @@ When enabled, the dev server automatically redirects URLs without a trailing sla
 Earlier versions of this doc referenced `/_astro/` and `/_image` as additional redirect exclusions. Those are legacy Astro-era paths; zfb does not emit them. They are preserved in the redirect skip-list only for backward compatibility with existing cached links.
 
 </Note>
+
+### minifyHtml
+
+Controls whether `zfb build` minifies generated `.html` files.
+
+Default: `true` in zudo-doc projects. Set it to `false` if you need readable production HTML while debugging build output.
+
+```ts
+minifyHtml: true,
+```
 
 ### onBrokenMarkdownLinks
 

--- a/zfb-shim.d.ts
+++ b/zfb-shim.d.ts
@@ -153,6 +153,11 @@ declare module "zfb/config" {
      */
     trailingSlash?: boolean;
     /**
+     * Minify production HTML output from `zfb build`.
+     * Mirrors `Config::minify_html` in crates/zfb/src/config.rs.
+     */
+    minifyHtml?: boolean;
+    /**
      * Markdown / MDX pipeline options. Mirrors `Config::markdown` →
      * `MarkdownConfig` in crates/zfb/src/config.rs. zfb next.12 moved the
      * former-Core features under `markdown.features` and next.13 ships the


### PR DESCRIPTION
## Summary
- Bump the zfb toolchain to `0.1.0-next.78` and enable the new `settings.minifyHtml` option by default in zudo-doc.
- Thread `minifyHtml` through `zudoDocPreset()`, create-zudo-doc prompts/scaffolding/config generation, fixtures, zfb shims, and EN/JA configuration docs.
- Update deploy and CSS smoke guards to accept minified HTML attribute output, including unquoted asset URLs.
- Harden static E2E HTML assertions for quoted, single-quoted, and unquoted attributes produced by the minifier.
- Preserve Mermaid rendering under minified HTML by normalizing collapsed diagram text before `mermaid.run()` and caching the normalized source.

## Verification
- `pnpm b4push`
- `pnpm check`
- `pnpm test`
- `pnpm build`
- `E2E_FORCE_REBUILD=1 E2E_FIXTURES=smoke bash e2e/setup-fixtures.sh`
- `E2E_FIXTURES=smoke npx playwright test e2e/smoke-mermaid-render.spec.ts e2e/smoke-mermaid-enlarge.spec.ts e2e/smoke-mermaid-spa.spec.ts e2e/smoke-toc.spec.ts --project smoke --grep-invert '@flaky|@local-only|@verification'`
- `E2E_FIXTURES=smoke,versioning pnpm test:e2e:ci`
- Preview-render check for Mermaid pages at `/docs/markdown-features/mermaid/` and `/docs/components/mermaid-diagrams/`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786093105&installation_id=130359969&pr_number=2646&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2646&signature=c5c29eb81f52f176cef018925b13a25bbdf8aeff458ae632ae9bb1e7b9c95e60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
