### PR TITLE
Fix create-zudo-doc skill symlinker packaging

### DIFF
--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -53,6 +53,14 @@ function packageSrcPath(...segments: string[]): string {
   );
 }
 
+function packageTemplatePath(...segments: string[]): string {
+  return path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../../templates",
+    ...segments,
+  );
+}
+
 describe("scaffold — minimal (no i18n, search only, single dark scheme)", () => {
   const choices: UserChoices = {
     projectName: "test-minimal",
@@ -1501,6 +1509,20 @@ describe("scaffold — changelog feature", () => {
 });
 
 describe("scaffold — skillSymlinker feature", () => {
+  it("keeps the packaged setup-doc-skill.sh template in sync with the root script", async () => {
+    const rootScript = path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "../../../../scripts/setup-doc-skill.sh",
+    );
+    const packagedScript = packageTemplatePath(
+      "base/scripts/setup-doc-skill.sh",
+    );
+
+    expect(await fs.readFile(packagedScript, "utf-8")).toBe(
+      await fs.readFile(rootScript, "utf-8"),
+    );
+  });
+
   it("copies setup-doc-skill.sh and adds npm script when enabled", async () => {
     const choices: UserChoices = {
       projectName: "test-symlinker-on",
@@ -1516,6 +1538,17 @@ describe("scaffold — skillSymlinker feature", () => {
         projectPath("test-symlinker-on", "scripts/setup-doc-skill.sh"),
       ),
     ).toBe(true);
+    expect(
+      await fs.readFile(
+        projectPath("test-symlinker-on", "scripts/setup-doc-skill.sh"),
+        "utf-8",
+      ),
+    ).toBe(
+      await fs.readFile(
+        packageTemplatePath("base/scripts/setup-doc-skill.sh"),
+        "utf-8",
+      ),
+    );
     const pkg = await fs.readJson(
       projectPath("test-symlinker-on", "package.json"),
     );

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -24,9 +24,9 @@ export { getSecondaryLang };
 export const ZUDO_DOC_PIN = "^3.1.0";
 
 /**
- * Files in `templates/base/**` that must never be copied into a generated
- * project. Each entry is matched against the path relative to `templates/base/`
- * (POSIX-style, forward slashes).
+ * Files in `templates/base/**` that must not be copied by the unconditional
+ * base mirror. Each entry is matched against the path relative to
+ * `templates/base/` (POSIX-style, forward slashes).
  *
  * W2 spec-lock Decision 5 (#1728) — `pages/api/**` is worker-only SSR
  * (uses `@takazudo/zfb-adapter-cloudflare`, `prerender = false`) and is
@@ -36,6 +36,7 @@ export const ZUDO_DOC_PIN = "^3.1.0";
  */
 const EXCLUDE_FROM_MIRROR: RegExp[] = [
   /^pages\/api(\/|$)/,
+  /^scripts\/setup-doc-skill\.sh$/,
 ];
 
 /**
@@ -226,7 +227,7 @@ export async function scaffold(choices: UserChoices): Promise<void> {
   const baseDir = path.join(templatesDir, "base");
   const featuresDir = path.join(templatesDir, "features");
 
-  // For skillSymlinker, we still need the monorepo root for the script
+  // Still needed for source-checkout-only assets such as Claude skills.
   const monorepoRoot = path.resolve(pkgRoot, "../..");
 
   await fs.ensureDir(targetDir);
@@ -242,11 +243,9 @@ export async function scaffold(choices: UserChoices): Promise<void> {
 
   // 2. Copy skill symlinker script when enabled
   if (choices.features.includes("skillSymlinker")) {
-    const scriptSrc = path.join(monorepoRoot, "scripts/setup-doc-skill.sh");
+    const scriptSrc = path.join(baseDir, "scripts/setup-doc-skill.sh");
     const scriptDest = path.join(targetDir, "scripts/setup-doc-skill.sh");
-    if (await fs.pathExists(scriptSrc)) {
-      await fs.copy(scriptSrc, scriptDest);
-    }
+    await fs.copy(scriptSrc, scriptDest);
   }
 
   // 2b. Copy user-facing Claude Code skills when enabled

--- a/packages/create-zudo-doc/templates/base/scripts/setup-doc-skill.sh
+++ b/packages/create-zudo-doc/templates/base/scripts/setup-doc-skill.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ── setup-doc-skill.sh ─────────────────────────────────
+# Creates an agent skill that exposes your zudo-doc
+# documentation as a knowledge base, then symlinks it into
+# the user-scope skills directory (~/.claude/skills/ and/or
+# ~/.codex/skills/).
+# ────────────────────────────────────────────────────────
+
+TARGET_MODE="auto"
+
+# Accept --silent (alias -y) for parity with the consuming-site convention:
+# scaffolded sites expose `setup:doc-skill-silent` = `bash scripts/setup-doc-skill.sh
+# --silent`. This script is already non-interactive (the skill name is deterministic
+# — see below), so the flag is a no-op here; it is consumed only so it is never
+# mistaken for the positional skill-name override (`$1`).
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --silent|-y) shift ;;
+    --target)
+      shift
+      if [ $# -eq 0 ]; then
+        echo "Error: --target requires one of: auto, claude, codex, both" >&2
+        exit 1
+      fi
+      TARGET_MODE="$1"
+      shift
+      ;;
+    --target=*)
+      TARGET_MODE="${1#--target=}"
+      shift
+      ;;
+    --) shift; break ;;
+    -*) echo "Error: unknown flag '$1'" >&2; exit 1 ;;
+    *) break ;;
+  esac
+done
+
+case "$TARGET_MODE" in
+  auto|claude|codex|both) ;;
+  *)
+    echo "Error: --target must be one of: auto, claude, codex, both" >&2
+    exit 1
+    ;;
+esac
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Read project name from package.json
+PROJECT_NAME=$(node -e "console.log(require('$ROOT_DIR/package.json').name || 'my-project')")
+DEFAULT_SKILL_NAME="${PROJECT_NAME}-wisdom"
+
+echo ""
+echo "=== zudo-doc Skill Setup ==="
+echo ""
+
+# Skill name is DETERMINISTIC: always `<projectName>-wisdom`. The scaffolded
+# .gitignore (emitted by create-zudo-doc) hard-codes this exact name, so the
+# generated skill directory must match it — an interactive prompt would let the
+# name drift from the gitignore entry and leave the skill showing as untracked
+# (zudolab/zudo-doc#2173). An explicit override is still allowed via the first
+# CLI arg or the SKILL_NAME env var (consumers who override must also update
+# their .gitignore), but never via an interactive prompt.
+SKILL_NAME="${1:-${SKILL_NAME:-$DEFAULT_SKILL_NAME}}"
+
+# Validate skill name (allow only alphanumeric, hyphens, underscores)
+if [[ ! "$SKILL_NAME" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+  echo "Error: Skill name may only contain letters, numbers, hyphens, and underscores."
+  exit 1
+fi
+
+# Resolve the main repo root (handles git worktrees correctly)
+# Use the main worktree path so symlinks survive worktree removal
+REPO_ROOT="$(git -C "$ROOT_DIR" worktree list | head -1 | awk '{print $1}')"
+
+DOCS_DIR="$ROOT_DIR/src/content/docs"
+
+# Validate docs directory exists
+if [ ! -d "$DOCS_DIR" ]; then
+  echo "Error: Documentation directory not found at $DOCS_DIR"
+  exit 1
+fi
+
+# Helper: replace a symlink or file at the given path
+ensure_symlink() {
+  local link_path="$1"
+  local target="$2"
+  if [ -L "$link_path" ] || [ -e "$link_path" ]; then
+    rm -rf "$link_path"
+  fi
+  ln -s "$target" "$link_path"
+}
+
+DOCS_JA_DIR="$ROOT_DIR/src/content/docs-ja"
+HAS_JA=""
+if [ -d "$DOCS_JA_DIR" ]; then
+  HAS_JA="true"
+fi
+
+# Discover top-level doc categories dynamically
+DOC_TREE=""
+for dir in "$DOCS_DIR"/*/; do
+  [ -d "$dir" ] || continue
+  dirname="$(basename "$dir")"
+  DOC_TREE="${DOC_TREE}- ${dirname}/
+"
+done
+
+resolve_targets() {
+  case "$TARGET_MODE" in
+    claude) echo "claude" ;;
+    codex) echo "codex" ;;
+    both) echo "claude codex" ;;
+    auto)
+      local has_claude=""
+      local has_codex=""
+      [ -d "$HOME/.claude" ] && has_claude="true"
+      [ -d "$HOME/.codex" ] && has_codex="true"
+
+      if [ "$has_claude" = "true" ] && [ "$has_codex" = "true" ]; then
+        echo "claude codex"
+      elif [ "$has_codex" = "true" ]; then
+        echo "codex"
+      else
+        # Preserve the historical default for fresh machines and test homes.
+        echo "claude"
+      fi
+      ;;
+  esac
+}
+
+generate_skill() {
+  local target="$1"
+  local project_skills_dir="$ROOT_DIR/.$target/skills"
+  local skill_dir="$project_skills_dir/$SKILL_NAME"
+  local global_skills_dir="$HOME/.$target/skills"
+  local assistant_label
+
+  case "$target" in
+    claude) assistant_label="Claude Code" ;;
+    codex) assistant_label="Codex" ;;
+    *) echo "Error: unknown target '$target'" >&2; exit 1 ;;
+  esac
+
+  mkdir -p "$skill_dir"
+
+  ensure_symlink "$skill_dir/docs" "$REPO_ROOT/src/content/docs"
+  echo "  [$target] Created docs symlink -> $REPO_ROOT/src/content/docs"
+
+  if [ "$HAS_JA" = "true" ]; then
+    ensure_symlink "$skill_dir/docs-ja" "$REPO_ROOT/src/content/docs-ja"
+    echo "  [$target] Created docs-ja symlink -> $REPO_ROOT/src/content/docs-ja"
+  fi
+
+  cat > "$skill_dir/SKILL.md" << SKILLEOF
+---
+name: $SKILL_NAME
+description: >-
+  Search and reference documentation from the $PROJECT_NAME project.
+  Use when answering questions about $PROJECT_NAME features, configuration,
+  components, or usage patterns.
+user-invocable: true
+argument-hint: "[-u|--update] [topic keyword, e.g., 'configuration', 'sidebar', 'i18n']"
+---
+
+# $PROJECT_NAME Documentation Reference
+
+Look up documentation from the $PROJECT_NAME project for $assistant_label.
+Documentation base path: \`src/content/docs\` (relative to repo root)
+
+## Mode Detection
+
+Parse the argument string for flags:
+
+- If args start with \`-u\` or \`--update\`: enter **Update mode** (see below)
+- Otherwise: enter **Lookup mode** (default)
+
+Strip the flag from the remaining argument to get the topic keyword.
+
+## Lookup Mode (default)
+
+1. Find the relevant article(s) from the \`docs/\` directory based on the topic
+2. Read ONLY the specific article(s) you need — do NOT load all articles at once
+3. Apply the information from the article when answering the user's question
+4. Mention the source article path so the user can find it for further reading
+
+## Update Mode (\`-u\` / \`--update\`)
+
+The user has new information and wants to add or update documentation in this repo.
+
+### Workflow
+
+1. **Understand the new info**: Ask the user what they learned or want to
+   document. The topic keyword (if provided) hints at the subject area.
+2. **Find existing docs**: Search the \`docs/\` directory for articles related to
+   the topic. Read them to understand what is already covered.
+3. **Decide create vs update**: If an existing article covers the topic, update
+   it. Otherwise, create a new \`.mdx\` file in the appropriate subdirectory.
+4. **Write the content**: Follow the doc-authoring rules in the root CLAUDE.md:
+   - Required frontmatter: \`title\` (string). Always set \`sidebar_position\`.
+     Optional: \`description\`, \`sidebar_label\`, \`tags\`, etc.
+   - Do NOT use \`# h1\` in content — the frontmatter \`title\` renders as h1.
+     Start with \`## h2\` headings.
+   - Use available MDX components (\`<Note>\`, \`<Tip>\`, \`<Info>\`, \`<Warning>\`,
+     \`<Danger>\`, \`<HtmlPreview>\`) where appropriate.
+   - For live demos, use \`<HtmlPreview>\` with \`js\`/\`displayJs\` props.
+   - Link to other docs using relative paths with \`.mdx\` extension.
+5. **Update Japanese docs**: Create or update the corresponding file under
+   \`docs-ja/\` mirroring the English directory structure. Keep code blocks,
+   Mermaid diagrams, and \`<HtmlPreview>\` blocks identical — only translate
+   surrounding prose. Exception: pages with \`generated: true\` skip translation.
+6. **Format**: Run \`pnpm format:md\` to format the new/changed MDX files.
+7. **Verify**: Run \`pnpm build\` to confirm the site builds correctly.
+
+## Documentation Structure
+
+The documentation is organized in MDX files under \`docs/\`:
+
+\`\`\`
+${DOC_TREE}\`\`\`
+
+Browse the \`docs/\` directory to discover available articles. Each \`.mdx\` file
+has YAML frontmatter with \`title\` and \`description\` fields that help identify
+the right article to read.
+SKILLEOF
+
+  if [ "$HAS_JA" = "true" ]; then
+    cat >> "$skill_dir/SKILL.md" << JAEOF
+
+## Japanese Documentation
+
+Japanese translations are available under \`docs-ja/\`. When the user is working
+in Japanese or asks for Japanese content, prefer articles from \`docs-ja/\`.
+JAEOF
+  fi
+
+  echo "  [$target] Generated SKILL.md"
+
+  mkdir -p "$global_skills_dir"
+  ensure_symlink "$global_skills_dir/$SKILL_NAME" "$skill_dir"
+
+  echo "  [$target] Project skill: $skill_dir"
+  echo "  [$target] Global symlink: $global_skills_dir/$SKILL_NAME"
+}
+
+read -r -a TARGETS <<< "$(resolve_targets)"
+echo "Target: $TARGET_MODE -> ${TARGETS[*]}"
+echo ""
+
+for target in "${TARGETS[@]}"; do
+  generate_skill "$target"
+done
+
+echo ""
+echo "Done! Skill '$SKILL_NAME' is ready."
+echo ""
+echo "Use --target claude, --target codex, or --target both to override auto-detection."
+echo "In Claude Code, use: /$SKILL_NAME <topic>"
+echo "In Codex, mention the skill by name when asking about this documentation."
+echo ""


### PR DESCRIPTION
Closes #2647.

## Summary
- Package `setup-doc-skill.sh` under `packages/create-zudo-doc/templates/base/scripts/` so it is included by the `create-zudo-doc` npm package.
- Copy the skill symlinker script from the package-owned template path instead of resolving the monorepo root at scaffold time.
- Keep the script gated behind the `skillSymlinker` feature by excluding it from the unconditional base template mirror.
- Add regression coverage that the packaged template stays in sync with the root script and that generated projects copy that packaged script.

## Test plan
- `pnpm --filter create-zudo-doc exec vitest run src/__tests__/scaffold.test.ts -t 'skillSymlinker'`
- `pnpm --filter create-zudo-doc build`
- `npm pack --dry-run --json` in `packages/create-zudo-doc` and verified `templates/base/scripts/setup-doc-skill.sh` is included with executable mode
- `git diff --check`

## Notes
- A broader `src/__tests__/scaffold.test.ts` run still requires prebuilt `packages/zudo-doc/routes-src` artifacts; this checkout cannot rebuild them because `packages/zudo-doc/node_modules` is absent (`tsup` is not installed there). The focused regression and package dry-run cover this issue's changed surface.
