### PR TITLE
Fix default header chrome background

### DIFF
--- a/packages/zudo-doc/src/__tests__/features-css.test.ts
+++ b/packages/zudo-doc/src/__tests__/features-css.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CSS_SOURCE = resolve(__dirname, "../features.css");
+const css = readFileSync(CSS_SOURCE, "utf8");
+
+describe("src/features.css source contract", () => {
+  it("keeps the default header on an opaque surface layer", () => {
+    expect(css).toContain("header[data-header]");
+    expect(css).toContain("background-color: var(--color-surface, var(--color-bg));");
+  });
+
+  it("keeps the default header above scrolling page content", () => {
+    expect(css).toContain("z-index: var(--z-index-toolbar, 20);");
+  });
+});

--- a/packages/zudo-doc/src/features.css
+++ b/packages/zudo-doc/src/features.css
@@ -14,6 +14,7 @@
  *   --spacing-{hsp-sm,hsp-2xs,hsp-lg,hsp-md,hsp-xl,vsp-xs,vsp-2xs,vsp-md,
  *              icon-sm}
  *   --z-index-local-1
+ *   --z-index-toolbar
  *   --radius-{DEFAULT,lg}
  *   --font-{mono,sans}
  *   --text-{small,caption}
@@ -27,6 +28,15 @@
  * All of these are defined by the project's @theme block (which is a
  * pre-condition before @importing this file).
  * ─────────────────────────────────────────────────────────────────────────── */
+
+/* ========================================
+ * Shared chrome defaults
+ * ======================================== */
+
+header[data-header] {
+  background-color: var(--color-surface, var(--color-bg));
+  z-index: var(--z-index-toolbar, 20);
+}
 
 /* ========================================
  * Code block buttons (copy + word wrap)


### PR DESCRIPTION
Closes #2678.

## Screenshot Requirement Contract
Expected: The site header has an opaque page-matching background in dark mode. Main page content, hero imagery/text, and long document trees are visually covered by the header when they scroll underneath it.
Forbidden: Any underlying page content remains readable through the header bar; top hero/logo content overlaps the nav area; long menu/tree labels show through the header or header-adjacent controls.
Unknown: Whether a translucent/glass header is desired in other themes. This fix assumes the header should use the current theme background rather than transparency.
Viewport: Desktop screenshot width around 1140px, including home page and document/navigation views.

## Summary
- Add a package-shipped `header[data-header]` chrome fallback in `features.css` so the default sticky header always paints an opaque surface and keeps toolbar z-index even if utility generation misses the relevant classes.
- Update the feature stylesheet token contract for `--z-index-toolbar`.
- Add a source-contract test covering the header background and z-index rules.

## Verification
- `pnpm --filter @takazudo/zudo-doc build`
- `pnpm --filter @takazudo/zudo-doc test`
- `pnpm build`
- Local preview at `http://localhost:4321`, viewport `1140x1074`, dark mode: checked `/` at top, `/` after scroll, and `/docs/claude-md/root/` after scroll. Header computed `backgroundColor` is opaque OKLCH, `zIndex` is `20`, `position` is `sticky`, and hit-testing inside the header returns header descendants.

## Notes
- `pnpm build` still reports the existing `DesignTokenPanelBootstrap` island marker collision warning; the build succeeds and this PR does not touch that surface.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786266232&installation_id=130359969&pr_number=2679&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2679&signature=551c4d8bc0d6383087f26b20a8993c9bf016fb2d516caf07520ae94f1a043e88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
