### PR TITLE
fix(create-zudo-doc): Node floor >=22 + document built-in MDX components (#2702, #2703)

### DIFF
--- a/packages/create-zudo-doc/package.json
+++ b/packages/create-zudo-doc/package.json
@@ -22,7 +22,7 @@
     "cli"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -1058,6 +1058,17 @@ describe("scaffold — CLAUDE.md generation", () => {
     expect(content).toContain("npm run build");
     expect(content).not.toContain("pnpm");
   });
+
+  it("documents the built-in MDX components the seed content uses (CategoryNav) (#2703)", async () => {
+    await scaffold(baseChoices);
+    const content = await fs.readFile(
+      projectPath("test-doc", "CLAUDE.md"),
+      "utf-8",
+    );
+    expect(content).toContain("### Built-in MDX components");
+    expect(content).toContain("CategoryNav");
+    expect(content).toContain("/docs/components/");
+  });
 });
 
 describe("scaffold — generated package.json", () => {
@@ -1070,6 +1081,38 @@ describe("scaffold — generated package.json", () => {
       preview: "zfb preview",
       check: "zfb check",
     });
+  });
+
+  it("emits engines.node >=22 to match zfb's Node floor (#2702)", async () => {
+    await scaffold(baseChoices);
+    const pkg = await fs.readJson(projectPath("test-doc", "package.json"));
+    expect(pkg.engines).toEqual({ node: ">=22" });
+  });
+
+  it("seeds the installation doc with the real Node floor (>=22), both locales (#2702)", async () => {
+    await scaffold({
+      ...baseChoices,
+      projectName: "test-node-floor",
+      features: ["i18n"],
+    });
+    const en = await fs.readFile(
+      projectPath(
+        "test-node-floor",
+        "src/content/docs/getting-started/installation.mdx",
+      ),
+      "utf-8",
+    );
+    expect(en).toContain("Node.js 22 or later");
+    expect(en).not.toContain("Node.js 18");
+    const ja = await fs.readFile(
+      projectPath(
+        "test-node-floor",
+        "src/content/docs-ja/getting-started/installation.mdx",
+      ),
+      "utf-8",
+    );
+    expect(ja).toContain("Node.js 22 以降");
+    expect(ja).not.toContain("Node.js 18");
   });
 
   it("does NOT include html-validate in devDependencies", async () => {

--- a/packages/create-zudo-doc/src/claude-md-gen.ts
+++ b/packages/create-zudo-doc/src/claude-md-gen.ts
@@ -102,6 +102,30 @@ export function generateCLAUDEFile(choices: UserChoices): string {
   );
   lines.push(``);
 
+  // Built-in MDX components. The seeded getting-started/index.mdx uses
+  // <CategoryNav>, a package-provided global — without this section a new user
+  // has no in-project pointer to what it is or which siblings exist (#2703).
+  lines.push(`### Built-in MDX components`);
+  lines.push(``);
+  lines.push(
+    `\`@takazudo/zudo-doc\` ships a few **globally-available MDX components** — usable in any \`.mdx\` file with **no import**. The seeded \`getting-started/index.mdx\` already uses one:`,
+  );
+  lines.push(``);
+  lines.push(
+    `- \`<CategoryNav category="..." />\` — a card-grid list of the pages in a docs category (this is the one seeded into \`getting-started/index.mdx\`).`,
+  );
+  lines.push(
+    `- \`<CategoryTreeNav category="..." />\` — the same listing as a compact nested tree, better for deeper hierarchies.`,
+  );
+  lines.push(
+    `- \`<SiteTreeNavDemo />\` — a full-site documentation tree (the MDX-available wrapper of the \`SiteTreeNav\` island).`,
+  );
+  lines.push(``);
+  lines.push(
+    `Admonitions (above), tabbed content (\`<Tabs>\` / \`<TabItem>\`, \`<CodeGroup>\`), and block math (\`<MathBlock>\`) work the same way — no import. Full reference: https://zudo-doc.takazudomodular.com/docs/components/`,
+  );
+  lines.push(``);
+
   // i18n section
   if (choices.features.includes("i18n")) {
     const secondaryLang = choices.defaultLang === "ja" ? "en" : "ja";

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -121,7 +121,7 @@ sidebar_position: 2
 
 ## Requirements
 
-- Node.js 18 or later
+- Node.js 22 or later
 - pnpm (recommended), npm, yarn, or bun
 
 ## Create a New Project
@@ -150,7 +150,7 @@ sidebar_position: 2
 
 ## 動作要件
 
-- Node.js 18 以降
+- Node.js 22 以降
 - pnpm（推奨）、npm、yarn、または bun
 
 ## 新しいプロジェクトを作成する
@@ -808,6 +808,9 @@ function generatePackageJson(choices: UserChoices) {
     version: "0.0.1",
     private: true,
     type: "module",
+    // @takazudo/zfb + @takazudo/zfb-runtime declare engines.node ">=22.0.0";
+    // emit the floor so `<pm> install` warns early on an unsupported Node.
+    engines: { node: ">=22" },
     scripts,
     dependencies: deps,
     devDependencies: devDeps,


### PR DESCRIPTION
## Summary

Sweeps two `create-zudo-doc` polish findings from the same fresh-scaffold walk-through (minimal-scaffold epic #2651) into one PR. Tracking epic: #2706.

### #2702 — Node version floor `>=22`

`@takazudo/zfb` and `@takazudo/zfb-runtime` declare `engines.node ">=22.0.0"`, but the generator understated it in three places, now all aligned to `>=22`:

- Seeded `installation.mdx` (EN + JA): "Node.js 18" → "Node.js 22".
- `generatePackageJson()` now emits `"engines": { "node": ">=22" }` — the generated `package.json` previously shipped no `engines` field, so `pnpm install` on Node 18/20 gave no early warning.
- `create-zudo-doc`'s own `engines.node`: `>=20` → `>=22`.

### #2703 — Document built-in MDX components

The seeded `getting-started/index.mdx` uses `<CategoryNav>`, but the generated per-project `CLAUDE.md` never documented it, leaving a new user no in-project pointer to what it is or which siblings exist. Adds a **Built-in MDX components** subsection to `claude-md-gen.ts` listing the globally-available (no-import) components — `CategoryNav` (seeded), `CategoryTreeNav`, `SiteTreeNavDemo` — plus tabbed content / math and a link to the `/docs/components/` reference.

> Accuracy note: `SiteTreeNav` itself is **not** MDX-available (it needs server-side data), so the MDX-available `SiteTreeNavDemo` wrapper is documented instead. The *optional* inline seed-content comment from #2703 was intentionally skipped to keep the seed file clean (minimal-scaffold ethos); the `CLAUDE.md` subsection is the discoverability fix.

## Tests

`create-zudo-doc` unit suite green (499 tests), including new regressions:

- `engines.node` equals `{ node: ">=22" }` in generated output.
- Seeded installation doc carries the `>=22` floor in both locales.
- Generated `CLAUDE.md` contains the "Built-in MDX components" subsection + `/docs/components/` pointer.

Closes #2702
Closes #2703

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoHMf1hfoZSzELguvSn6cQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoHMf1hfoZSzELguvSn6cQ)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786397040&installation_id=130359969&pr_number=2707&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2707&signature=047fcb5b65418e6da7342f8e2fd520c7a9a39557c7a60474d628e16ab62d45f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->