### PR TITLE
Default footerCopyright feature to on in create-zudo-doc CLI

### DIFF
--- a/.claude/skills/l-generator-cli-tester/SKILL.md
+++ b/.claude/skills/l-generator-cli-tester/SKILL.md
@@ -90,13 +90,13 @@ Set `REPO_ROOT` to the repository root (absolute path). Run the generator from w
 
 ### CLI Commands per Pattern
 
-**barebone** — every flag with a `default: true` in `constants.ts` (`search`, `sidebarFilter`, `imageEnlarge`, `dynamicPageTransition`) must be EXPLICITLY turned off, or `--yes` fills it in as ON:
+**barebone** — every flag with a `default: true` in `constants.ts` (`search`, `sidebarFilter`, `imageEnlarge`, `dynamicPageTransition`, `footerCopyright`) must be EXPLICITLY turned off, or `--yes` fills it in as ON:
 
 ```bash
 cd __inbox/generator-test-barebone && \
   node $REPO_ROOT/packages/create-zudo-doc/dist/index.js test-project --yes \
   --no-search --no-sidebar-filter --no-i18n --no-claude-resources \
-  --no-image-enlarge --no-dynamic-page-transition --no-tag-governance \
+  --no-image-enlarge --no-dynamic-page-transition --no-footer-copyright --no-tag-governance \
   --color-scheme-mode single --scheme "Default Dark" --no-install
 ```
 
@@ -525,7 +525,7 @@ Provide a clear pass/fail report:
 ## Important Notes
 
 - Always `cd` back to the repo root between major steps (use absolute paths)
-- The `--yes` flag auto-fills all unspecified options with defaults. Feature defaults with `--yes`: search=true, sidebarFilter=true, imageEnlarge=true, dynamicPageTransition=true, tagGovernance=false, i18n=false, claudeResources=false, designTokenPanel=false (all other features false)
+- The `--yes` flag auto-fills all unspecified options with defaults. Feature defaults with `--yes`: search=true, sidebarFilter=true, imageEnlarge=true, dynamicPageTransition=true, footerCopyright=true, tagGovernance=false, i18n=false, claudeResources=false, designTokenPanel=false (all other features false)
 - Use `--no-install` with CLI to prevent auto-install, then install manually for better error visibility
 - `sidebarFilter` has zero structural effect in the minimal manifest (no TODO, no strip step needed — it never had a file or field to remove)
 - The dev server smoke test uses `pnpm dev` (generated projects have a single `dev` script)

--- a/.claude/skills/l-generator-cli-tester/SKILL.md
+++ b/.claude/skills/l-generator-cli-tester/SKILL.md
@@ -102,10 +102,11 @@ cd __inbox/generator-test-barebone && \
 
 > This exact invocation is the one verified against the locked 12-file
 > manifest in `packages/create-zudo-doc/src/__tests__/scaffold.test.ts`
-> (`BAREBONE_MANIFEST`) — do not drop `--no-dynamic-page-transition` or
-> `--no-image-enlarge`; both default to `true` and, while they don't add any
-> files, dropping them would emit extra fields into `zfb.config.ts` and
-> defeat the "everything OFF" premise of this pattern.
+> (`BAREBONE_MANIFEST`) — do not drop `--no-dynamic-page-transition`,
+> `--no-image-enlarge`, or `--no-footer-copyright`; all three default to
+> `true` and, while they don't add any files, dropping them would emit extra
+> fields into `zfb.config.ts` and defeat the "everything OFF" premise of this
+> pattern.
 
 **search:**
 
@@ -404,7 +405,11 @@ There is no more `src/config/settings.ts` to read in a fresh scaffold (except th
 
 **sidebar-filter:**
 
-- Identical to barebone's `zfb.config.ts` — no field this flag would set
+- `sidebarFilter` itself sets no field, but this pattern's CLI command doesn't
+  turn off `imageEnlarge` / `dynamicPageTransition` / `footerCopyright` (all
+  default to `true`), so — unlike barebone, which explicitly disables all
+  three — the generated `zfb.config.ts` additionally has `imageEnlarge: true`,
+  `dynamicPageTransition: true`, and a `footer: { copyright: "..." }` field
 
 **claude-resources:**
 

--- a/packages/create-zudo-doc/README.md
+++ b/packages/create-zudo-doc/README.md
@@ -86,7 +86,7 @@ Each feature has a `--[no-]<flag>` form. Passing `--feature` enables it; `--no-f
 | `--[no-]tauri` | Tauri desktop app — Mode 1 offline reader | off |
 | `--[no-]tauri-dev` | Tauri dev wrapper — Mode 2 configurable dev wrapper | off |
 | `--[no-]footer-nav-group` | Navigation links in the footer | off |
-| `--[no-]footer-copyright` | Copyright notice in the footer | off |
+| `--[no-]footer-copyright` | Copyright notice in the footer | on |
 | `--[no-]footer-taglist` | Grouped tag index in the footer (requires tag-governance) | off |
 | `--[no-]changelog` | Changelog page | off |
 

--- a/packages/create-zudo-doc/src/constants.ts
+++ b/packages/create-zudo-doc/src/constants.ts
@@ -172,7 +172,7 @@ export const FEATURES: Feature[] = [
     value: "footerCopyright",
     label: "Footer copyright",
     hint: "Copyright notice in the footer",
-    default: false,
+    default: true,
     cliFlag: "footer-copyright",
   },
   {

--- a/src/__tests__/preset-generator-logic.test.ts
+++ b/src/__tests__/preset-generator-logic.test.ts
@@ -280,7 +280,7 @@ describe("default generator state — regression: matches target JSON", () => {
       darkScheme: "Default Dark",
       defaultMode: "dark",
       respectPrefersColorScheme: true,
-      features: ["search", "sidebarFilter", "imageEnlarge", "dynamicPageTransition"],
+      features: ["search", "sidebarFilter", "imageEnlarge", "dynamicPageTransition", "footerCopyright"],
       cjkFriendly: true,
       packageManager: "pnpm",
       headerRightItems: [

--- a/src/content/docs-ja/reference/create-zudo-doc.mdx
+++ b/src/content/docs-ja/reference/create-zudo-doc.mdx
@@ -82,7 +82,7 @@ zudo-doc が同梱するカラースキームは `Default Light` と `Default Da
 | `--[no-]tauri-dev` | Tauri 開発ラッパー（Mode 2）— 任意プロジェクト向けの設定可能なデスクトップ開発ラッパー | オフ |
 | `--[no-]footer-nav-group` | フッターのナビゲーションリンク | オフ |
 | `--[no-]image-enlarge` | マークダウン画像のクリック拡大表示 | オン |
-| `--[no-]footer-copyright` | フッターの著作権表示 | オフ |
+| `--[no-]footer-copyright` | フッターの著作権表示 | オン |
 | `--[no-]changelog` | 変更履歴ページ | オフ |
 | `--[no-]tag-governance` | 語彙対応タグ監査・サジェストスクリプト | オン |
 | `--[no-]doc-tags` | タグ別・タグ一覧の閲覧ルート（docs/tags/...） | オフ |

--- a/src/content/docs/reference/create-zudo-doc.mdx
+++ b/src/content/docs/reference/create-zudo-doc.mdx
@@ -82,7 +82,7 @@ Customization happens one level deeper, through the `colorSchemes` escape-hatch 
 | `--[no-]tauri-dev` | Tauri dev wrapper (Mode 2) — configurable desktop dev wrapper for any project | off |
 | `--[no-]footer-nav-group` | Navigation links in the footer | off |
 | `--[no-]image-enlarge` | Click-to-enlarge for oversized markdown images | on |
-| `--[no-]footer-copyright` | Copyright notice in the footer | off |
+| `--[no-]footer-copyright` | Copyright notice in the footer | on |
 | `--[no-]changelog` | Changelog page | off |
 | `--[no-]tag-governance` | Vocabulary-aware tag audit + suggest scripts | on |
 | `--[no-]doc-tags` | Per-tag and tag-index browsing routes (docs/tags/...) | off |

--- a/src/lib/preset-generator-logic.ts
+++ b/src/lib/preset-generator-logic.ts
@@ -109,7 +109,7 @@ export const FEATURES = [
   { value: "footerNavGroup", label: "Footer nav group", cliFlag: "footer-nav-group", default: false, docPath: "/docs/guides/footer/" },
   { value: "imageEnlarge", label: "Image enlarge", cliFlag: "image-enlarge", default: true, docPath: "/docs/markdown-features/image-enlarge/" },
   { value: "dynamicPageTransition", label: "Dynamic page transition", cliFlag: "dynamic-page-transition", default: true, docPath: "/docs/guides/dynamic-page-transitions/" },
-  { value: "footerCopyright", label: "Footer copyright", cliFlag: "footer-copyright", default: false, docPath: "/docs/guides/footer/" },
+  { value: "footerCopyright", label: "Footer copyright", cliFlag: "footer-copyright", default: true, docPath: "/docs/guides/footer/" },
   { value: "changelog", label: "Changelog", cliFlag: "changelog", default: false, docPath: "/docs/guides/changelog/" },
   { value: "tagGovernance", label: "Tag governance", cliFlag: "tag-governance", default: false, docPath: "/docs/guides/tag-governance/" },
   { value: "docTags", label: "Doc tags pages", cliFlag: "doc-tags", default: false, docPath: "/docs/guides/tags/" },


### PR DESCRIPTION
## Summary

Flips the `footerCopyright` feature's default to pre-checked/on in the `create-zudo-doc` interactive CLI, matching the two attached screenshots (before: only Pagefind search, Sidebar filter, Image enlarge, Dynamic page transition checked; after: Footer copyright also checked).

## Changes

- `packages/create-zudo-doc/src/constants.ts` — `footerCopyright.default: false → true` (drives the interactive multiselect's pre-checked state and the `--yes`/`--preset` fill-in default)
- `src/lib/preset-generator-logic.ts` — mirrored `FEATURES` list used by the site's browser-based Preset Generator UI, kept in sync (same default flip)
- `src/__tests__/preset-generator-logic.test.ts` — updated the hardcoded default-features regression expectation to include `footerCopyright`
- `packages/create-zudo-doc/README.md`, `src/content/docs/reference/create-zudo-doc.mdx`, `src/content/docs-ja/reference/create-zudo-doc.mdx` — flags table default column `off → on` (EN/JA)
- `.claude/skills/l-generator-cli-tester/SKILL.md`:
  - barebone test invocation now explicitly passes `--no-footer-copyright` (since barebone means "everything off"), and its explanatory callout + `--yes` defaults prose updated to name all three always-on-by-default flags
  - fixed a stale "sidebar-filter's `zfb.config.ts` is identical to barebone's" claim, which was already inaccurate (`imageEnlarge`/`dynamicPageTransition` diverge too, since that pattern's command never disables them) and now also diverges on `footerCopyright` — found and verified empirically during review

This only changes the CLI's own default selection for **new** scaffolds — it does not touch `packages/zudo-doc/src/config.ts`'s `DEFAULT_SETTINGS` (the package-level default when a project's `zfb.config.ts` omits the field), which stays `false` for backward compatibility with existing projects.

Two unrelated pre-existing doc inaccuracies found during review were filed separately rather than fixed here: #2709 (tag-governance default mis-documented as "on") and #2710 (dynamic-page-transition flag missing from the flags tables).

## Test Plan

- [x] `vitest run` (root unit tests) — 725 passed
- [x] `packages/create-zudo-doc` package tests — 499 passed
- [x] 3-reviewer `/deep-review` pass (Sonnet) on the diff — one actionable finding (the stale sidebar-filter claim), fixed and verified empirically by generating both `barebone` and `sidebar-filter` test projects and diffing their `zfb.config.ts`
- [x] CI green (19/19 checks)
