### PR TITLE
Fix create-zudo-doc flags docs: tag-governance default and missing row

### DIFF
--- a/packages/create-zudo-doc/README.md
+++ b/packages/create-zudo-doc/README.md
@@ -72,7 +72,7 @@ Each feature has a `--[no-]<flag>` form. Passing `--feature` enables it; `--no-f
 | `--[no-]search` | Pagefind full-text search | on |
 | `--[no-]sidebar-filter` | Real-time sidebar filter | on |
 | `--[no-]image-enlarge` | Click-to-enlarge for oversized images | on |
-| `--[no-]tag-governance` | Vocabulary-aware tag audit + suggest scripts | on |
+| `--[no-]tag-governance` | Vocabulary-aware tag audit + suggest scripts | off |
 | `--[no-]claude-resources` | Auto-generate Claude Code docs (`CLAUDE.md`, `llms.txt`) | off |
 | `--[no-]claude-skills` | Ship zudo-doc Claude Code skills (design-system, translate, version-bump) | off |
 | `--[no-]design-token-panel` | Interactive panel for tweaking spacing, font, color tokens | off |
@@ -86,6 +86,7 @@ Each feature has a `--[no-]<flag>` form. Passing `--feature` enables it; `--no-f
 | `--[no-]tauri` | Tauri desktop app — Mode 1 offline reader | off |
 | `--[no-]tauri-dev` | Tauri dev wrapper — Mode 2 configurable dev wrapper | off |
 | `--[no-]footer-nav-group` | Navigation links in the footer | off |
+| `--[no-]dynamic-page-transition` | SPA-style page transition with history handling | on |
 | `--[no-]footer-copyright` | Copyright notice in the footer | on |
 | `--[no-]footer-taglist` | Grouped tag index in the footer (requires tag-governance) | off |
 | `--[no-]changelog` | Changelog page | off |

--- a/src/content/docs-ja/reference/create-zudo-doc.mdx
+++ b/src/content/docs-ja/reference/create-zudo-doc.mdx
@@ -82,9 +82,10 @@ zudo-doc が同梱するカラースキームは `Default Light` と `Default Da
 | `--[no-]tauri-dev` | Tauri 開発ラッパー（Mode 2）— 任意プロジェクト向けの設定可能なデスクトップ開発ラッパー | オフ |
 | `--[no-]footer-nav-group` | フッターのナビゲーションリンク | オフ |
 | `--[no-]image-enlarge` | マークダウン画像のクリック拡大表示 | オン |
+| `--[no-]dynamic-page-transition` | 履歴管理付きのSPA風ページ遷移 | オン |
 | `--[no-]footer-copyright` | フッターの著作権表示 | オン |
 | `--[no-]changelog` | 変更履歴ページ | オフ |
-| `--[no-]tag-governance` | 語彙対応タグ監査・サジェストスクリプト | オン |
+| `--[no-]tag-governance` | 語彙対応タグ監査・サジェストスクリプト | オフ |
 | `--[no-]doc-tags` | タグ別・タグ一覧の閲覧ルート（docs/tags/...） | オフ |
 | `--[no-]footer-taglist` | フッターのグループ化されたタグ一覧（tagGovernance が必要） | オフ |
 

--- a/src/content/docs/reference/create-zudo-doc.mdx
+++ b/src/content/docs/reference/create-zudo-doc.mdx
@@ -82,9 +82,10 @@ Customization happens one level deeper, through the `colorSchemes` escape-hatch 
 | `--[no-]tauri-dev` | Tauri dev wrapper (Mode 2) — configurable desktop dev wrapper for any project | off |
 | `--[no-]footer-nav-group` | Navigation links in the footer | off |
 | `--[no-]image-enlarge` | Click-to-enlarge for oversized markdown images | on |
+| `--[no-]dynamic-page-transition` | SPA-style page transition with history handling | on |
 | `--[no-]footer-copyright` | Copyright notice in the footer | on |
 | `--[no-]changelog` | Changelog page | off |
-| `--[no-]tag-governance` | Vocabulary-aware tag audit + suggest scripts | on |
+| `--[no-]tag-governance` | Vocabulary-aware tag audit + suggest scripts | off |
 | `--[no-]doc-tags` | Per-tag and tag-index browsing routes (docs/tags/...) | off |
 | `--[no-]footer-taglist` | Grouped tag index in the footer (requires tagGovernance) | off |
 


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2709
    - https://github.com/zudolab/zudo-doc/issues/2710

---

## Summary

Two doc inaccuracies found while reviewing #2708 (the `footerCopyright` default flip):

- `--[no-]tag-governance`'s "Default" column said **on** in all three flags tables (README, EN mdx, JA mdx), but `packages/create-zudo-doc/src/constants.ts` has `tagGovernance.default: false`.
- `--[no-]dynamic-page-transition` (which does default to `true`) was missing from all three tables entirely.

## Changes

- `packages/create-zudo-doc/README.md`, `src/content/docs/reference/create-zudo-doc.mdx`, `src/content/docs-ja/reference/create-zudo-doc.mdx`:
  - `tag-governance` default column: `on`/`オン` → `off`/`オフ`
  - Added a `--[no-]dynamic-page-transition` row (default `on`/`オン`), next to `image-enlarge`

Closes #2709
Closes #2710

## Test Plan

- [x] Visually verified table formatting/alignment against neighboring rows in all three files


---
_Generated by [Claude Code](https://claude.ai/code/session_01B1oQN1Ld4bG6uTxAqJyfky)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786406238&installation_id=130359969&pr_number=2711&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2711&signature=644124b6181d425e37e1dc61303f41aa7ecc1f98675db1c61c1d4069afffa4b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->