### PR TITLE
fix(e2e): clean stale copied fixture directories

### DIFF
--- a/e2e/setup-fixtures.sh
+++ b/e2e/setup-fixtures.sh
@@ -371,8 +371,10 @@ setup_fixture() {
 
   # ----- Copy top-level first-party dirs (pages/, plugins/) -----
   for dir in "${ROOT_COPIED_DIRS[@]}"; do
-    [ -e "$REPO_ROOT/$dir" ] || continue
+    # Clean first: a directory removed from the root must not leave a stale
+    # fixture copy (or dangling symlink) behind on the next setup run.
     rm -rf "$fixture_dir/$dir"
+    [ -e "$REPO_ROOT/$dir" ] || continue
     cp -RL "$REPO_ROOT/$dir" "$fixture_dir/$dir"
   done
 

--- a/scripts/__tests__/setup-fixtures.test.ts
+++ b/scripts/__tests__/setup-fixtures.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..", "..");
+const SETUP_FIXTURES = resolve(REPO_ROOT, "e2e", "setup-fixtures.sh");
+
+describe("e2e fixture setup", () => {
+  it("removes a stale copied root directory before a missing source short-circuits", () => {
+    const script = readFileSync(SETUP_FIXTURES, "utf8");
+    const copyLoopStart = script.indexOf("# ----- Copy top-level first-party dirs");
+    const copyLoopEnd = script.indexOf("# The theme fixture", copyLoopStart);
+    const copyLoop = script.slice(copyLoopStart, copyLoopEnd);
+    const cleanupIndex = copyLoop.indexOf('rm -rf "$fixture_dir/$dir"');
+    const sourceCheckIndex = copyLoop.indexOf('[ -e "$REPO_ROOT/$dir" ] || continue');
+
+    expect(copyLoopStart).toBeGreaterThanOrEqual(0);
+    expect(copyLoopEnd).toBeGreaterThan(copyLoopStart);
+    expect(cleanupIndex).toBeGreaterThanOrEqual(0);
+    expect(sourceCheckIndex).toBeGreaterThanOrEqual(0);
+    expect(cleanupIndex).toBeLessThan(sourceCheckIndex);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2749 by removing each copied fixture directory before checking whether its root source still exists. A removed root `plugins/` directory can no longer leave dangling links under ignored E2E fixtures.

## Validation

- `pnpm exec vitest run --project scripts scripts/__tests__/setup-fixtures.test.ts scripts/__tests__/zfb-md-wasm-release.test.ts scripts/__tests__/check-pin-parity.test.ts`
- `bash -n e2e/setup-fixtures.sh`
- `bash e2e/setup-fixtures.sh` verified all five fixtures have no stale `plugins` entry
- `SKIP_DOC_HISTORY=1 pnpm build` — 378 pages

## Scope

This is the standalone cleanup found while validating the zfb next.86 release. It does not modify zfb pins or the active highlighting worktree.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2750"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786722199&installation_id=130359969&pr_number=2750&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2750&signature=04fbb5f578f6a826e3b2c146f0be3e96bfe406063e1cf5e67bc7cb4a40fa9faa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->