### PR TITLE
polish: refine generated headers and showcase navigation

### DIFF
--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -685,7 +685,7 @@ describe("scaffold — zfb.config.ts content shape (integration with generateZfb
   // function unit test against generateZfbConfig() directly). These tests
   // only check that scaffold() writes exactly what that function returns,
   // plus the top-level shape guarantees the locked spec calls out.
-  it("barebone emits a near-empty zudoDoc({...}) — only siteName + always-different nav/header fields", async () => {
+  it("barebone emits a near-empty zudoDoc({...}) without an inert GitHub header item", async () => {
     await scaffold(baseChoices);
     const config = await fs.readFile(projectPath("test-doc", "zfb.config.ts"), "utf-8");
     expect(config).toMatch(/^import \{ defineConfig \} from "zfb\/config";$/m);
@@ -693,6 +693,8 @@ describe("scaffold — zfb.config.ts content shape (integration with generateZfb
     expect(config).toContain("export default defineConfig(");
     expect(config).toContain("zudoDoc({");
     expect(config).toContain('siteName: "Test Doc"');
+    expect(config).not.toContain('component: "github-link"');
+    expect(config).not.toContain("headerRightItems:");
     // Highlighting is package-preset-owned. The generated project delegates to
     // zudoDoc() and must not freeze an inline/dual-theme renderer config.
     for (const token of [
@@ -718,6 +720,20 @@ describe("scaffold — zfb.config.ts content shape (integration with generateZfb
     ]) {
       expect(config).not.toContain(token);
     }
+  });
+
+  it("scaffolds the GitHub header item when a usable GitHub URL is configured", async () => {
+    await scaffold({
+      ...baseChoices,
+      projectName: "test-github-header",
+      githubUrl: "  https://github.com/x/y  ",
+    });
+    const config = await fs.readFile(
+      projectPath("test-github-header", "zfb.config.ts"),
+      "utf-8",
+    );
+    expect(config).toContain('githubUrl: "https://github.com/x/y"');
+    expect(config).toContain('component: "github-link"');
   });
 
   it("emits findInPage: true when tauri is selected (#2690 — rides the tauri feature, package-owned island)", async () => {

--- a/packages/create-zudo-doc/src/__tests__/zfb-config-gen.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/zfb-config-gen.test.ts
@@ -85,20 +85,19 @@ describe("generateZfbConfig — siteName always emitted", () => {
 });
 
 describe("generateZfbConfig — diff-from-defaults (near-empty case)", () => {
-  it("emits ONLY siteName + the always-different headerNav/headerRightItems when every other choice matches the package default", () => {
+  it("emits ONLY siteName + the always-different headerNav when every other choice matches the package default", () => {
     // packageDefaultChoices resolves colorMode/colorScheme to the exact
     // DEFAULT_MIRROR values, so both are diffed away. headerNav always gets
-    // a "Getting Started" entry (default mirror is []) and headerRightItems
-    // always gets a github-link entry (default mirror is just theme-toggle)
-    // — both are therefore always emitted, even in the "everything default"
-    // case. No other field should appear.
+    // a "Getting Started" entry (default mirror is []). With no GitHub URL,
+    // headerRightItems is just theme-toggle and therefore matches the default
+    // mirror. No other field should appear.
     const result = generateZfbConfig(packageDefaultChoices);
     const bodyMatch = result.match(/zudoDoc\(\{([\s\S]*)\}\),/);
     expect(bodyMatch).not.toBeNull();
     const fieldNames = [...bodyMatch![1]!.matchAll(/^\s{4}(\w+):/gm)].map(
       (m) => m[1],
     );
-    expect(fieldNames).toEqual(["siteName", "headerNav", "headerRightItems"]);
+    expect(fieldNames).toEqual(["siteName", "headerNav"]);
     expect(result).not.toContain("colorMode");
     expect(result).not.toContain("colorScheme:");
   });
@@ -250,11 +249,12 @@ describe("generateZfbConfig — designTokenPanel headerRightItems trigger", () =
       features: ["designTokenPanel"],
     });
     expect(result).toContain('trigger: "design-token-panel"');
-    // Trigger must appear before github-link (order matters — it's the
-    // first pushed item in the default-fallback builder).
+    // Trigger remains the first item in the default builder. With no GitHub
+    // URL, the inert github-link is omitted.
     expect(result.indexOf('trigger: "design-token-panel"')).toBeLessThan(
-      result.indexOf('component: "github-link"'),
+      result.indexOf('component: "theme-toggle"'),
     );
+    expect(result).not.toContain('component: "github-link"');
   });
 
   it("omits the trigger when disabled", () => {
@@ -387,15 +387,22 @@ describe("generateZfbConfig — headerRightItems override", () => {
   it("emits a user-supplied headerRightItems array verbatim", () => {
     const result = generateZfbConfig({
       ...baseChoices,
+      features: ["search", "i18n"],
       headerRightItems: [
-        { type: "component", component: "theme-toggle" },
+        { type: "component", component: "github-link" },
         { type: "trigger", trigger: "ai-chat" },
       ],
     });
+    const githubIndex = result.indexOf('component: "github-link"');
+    const aiChatIndex = result.indexOf('trigger: "ai-chat"');
+    expect(githubIndex).toBeGreaterThan(-1);
     expect(result).toContain('trigger: "ai-chat"');
-    // The default-fallback github-link item must NOT appear — the override
-    // replaces the whole array.
-    expect(result).not.toContain('component: "github-link"');
+    expect(githubIndex).toBeLessThan(aiChatIndex);
+    // No URL is configured, but explicit items are preserved. Feature-based
+    // defaults are not added to the override.
+    expect(result).not.toContain('component: "theme-toggle"');
+    expect(result).not.toContain('component: "search"');
+    expect(result).not.toContain('component: "language-switcher"');
   });
 
   it("honors an explicit empty array (user wants no header-right items)", () => {
@@ -403,7 +410,7 @@ describe("generateZfbConfig — headerRightItems override", () => {
     expect(result).toContain("headerRightItems: []");
   });
 
-  it("strips a design-token-panel trigger from the override when the feature is off", () => {
+  it("does not filter a design-token-panel trigger from an explicit override when the feature is off", () => {
     const result = generateZfbConfig({
       ...baseChoices,
       headerRightItems: [
@@ -412,9 +419,32 @@ describe("generateZfbConfig — headerRightItems override", () => {
         { type: "component", component: "github-link" },
       ],
     });
-    expect(result).not.toContain("design-token-panel");
+    expect(result).toContain('trigger: "design-token-panel"');
     expect(result).toContain('component: "theme-toggle"');
     expect(result).toContain('component: "github-link"');
+  });
+
+  it("keeps the remaining default items in order around a URL-backed github-link", () => {
+    const result = generateZfbConfig({
+      ...baseChoices,
+      githubUrl: "https://github.com/x/y",
+      features: ["designTokenPanel", "versioning", "search", "i18n"],
+    });
+    const headerRightItems = result.match(
+      /headerRightItems: \[([\s\S]*?)\n    \],/,
+    );
+    expect(headerRightItems).not.toBeNull();
+    const itemNames = [
+      ...headerRightItems![1]!.matchAll(/(?:trigger|component): "([^"]+)"/g),
+    ].map((match) => match[1]);
+    expect(itemNames).toEqual([
+      "design-token-panel",
+      "version-switcher",
+      "github-link",
+      "theme-toggle",
+      "search",
+      "language-switcher",
+    ]);
   });
 });
 
@@ -467,15 +497,30 @@ describe("generateZfbConfig — misc scalar fields", () => {
     expect(result).toContain("cjkFriendly: true");
   });
 
-  it("emits githubUrl as a string when set, omits when blank", () => {
+  it("emits a trimmed githubUrl and default github-link when set", () => {
     const withUrl = generateZfbConfig({
       ...baseChoices,
-      githubUrl: "https://github.com/x/y",
+      githubUrl: "  https://github.com/x/y  ",
     });
     expect(withUrl).toContain('githubUrl: "https://github.com/x/y"');
+    expect(withUrl).toContain('component: "github-link"');
+    expect(withUrl.indexOf('component: "github-link"')).toBeLessThan(
+      withUrl.indexOf('component: "theme-toggle"'),
+    );
+  });
 
-    const blank = generateZfbConfig({ ...baseChoices, githubUrl: "" });
-    expect(blank).not.toContain("githubUrl");
+  it.each([
+    ["omitted", undefined],
+    ["false", false],
+    ["empty", ""],
+    ["whitespace-only", "  \t  "],
+  ])("omits githubUrl and the default github-link when %s", (_label, githubUrl) => {
+    const result = generateZfbConfig({
+      ...baseChoices,
+      githubUrl: githubUrl as UserChoices["githubUrl"],
+    });
+    expect(result).not.toContain("githubUrl");
+    expect(result).not.toContain('component: "github-link"');
   });
 });
 

--- a/packages/create-zudo-doc/src/zfb-config-gen.ts
+++ b/packages/create-zudo-doc/src/zfb-config-gen.ts
@@ -184,7 +184,8 @@ function buildDesiredConfig(choices: UserChoices): Record<string, unknown> {
   // ── Misc site fields ──────────────────────────────────────────────────
   desired.minifyHtml = choices.minifyHtml ?? true;
   desired.noindex = choices.features.includes("noindex");
-  const rawGithubUrl = (choices.githubUrl ?? "").trim();
+  const rawGithubUrl =
+    typeof choices.githubUrl === "string" ? choices.githubUrl.trim() : "";
   desired.githubUrl = rawGithubUrl ? rawGithubUrl : false;
   desired.cjkFriendly = choices.cjkFriendly ?? false;
 
@@ -320,16 +321,8 @@ function buildDesiredConfig(choices: UserChoices): Record<string, unknown> {
   desired.headerNav = headerNav;
 
   if (choices.headerRightItems !== undefined) {
-    // User-supplied override (including empty array) — emit verbatim, minus
-    // a defensive strip of "design-token-panel" when the feature is off.
-    desired.headerRightItems = choices.headerRightItems.filter(
-      (item) =>
-        !(
-          item.type === "trigger" &&
-          item.trigger === "design-token-panel" &&
-          !choices.features.includes("designTokenPanel")
-        ),
-    );
+    // User-supplied override (including empty array) — emit verbatim.
+    desired.headerRightItems = choices.headerRightItems;
   } else {
     const items: Array<Record<string, unknown>> = [];
     if (choices.features.includes("designTokenPanel")) {
@@ -338,7 +331,9 @@ function buildDesiredConfig(choices: UserChoices): Record<string, unknown> {
     if (choices.features.includes("versioning")) {
       items.push({ type: "component", component: "version-switcher" });
     }
-    items.push({ type: "component", component: "github-link" });
+    if (rawGithubUrl) {
+      items.push({ type: "component", component: "github-link" });
+    }
     items.push({ type: "component", component: "theme-toggle" });
     if (choices.features.includes("search")) {
       items.push({ type: "component", component: "search" });

--- a/packages/zudo-doc/src/home-page/__tests__/home-page.test.tsx
+++ b/packages/zudo-doc/src/home-page/__tests__/home-page.test.tsx
@@ -29,6 +29,25 @@ import type { ChromeContext } from "../../factory-context/index.js";
 import { makeFakeChromeContext } from "../../__tests__/fixtures/fake-chrome-context.js";
 
 const EMPTY_TREE: DocNavNode[] = [];
+const CHANGELOG_TREE: DocNavNode[] = [
+  {
+    slug: "changelog",
+    label: "Release notes",
+    position: 0,
+    href: "/docs/changelog",
+    hasPage: true,
+    children: [
+      {
+        slug: "changelog/1.0.0",
+        label: "1.0.0",
+        position: 0,
+        href: "/docs/changelog/1.0.0",
+        hasPage: true,
+        children: [],
+      },
+    ],
+  },
+];
 
 function makeProps(overrides: Partial<HomePageViewProps> = {}): HomePageViewProps {
   return {
@@ -108,6 +127,31 @@ describe("createHomePageView — SiteTreeNav island", () => {
     const html = render(<HomePageView {...makeProps()} />);
 
     expect(html).toContain('data-zfb-island="SiteTreeNav"');
+  });
+
+  it("forwards the explicit initial-collapse slugs to SiteTreeNav", () => {
+    const ctx = makeFakeChromeContext();
+    const HomePageView = createHomePageView(ctx);
+    const html = render(
+      <HomePageView
+        {...makeProps({
+          tree: CHANGELOG_TREE,
+          initiallyCollapsedCategorySlugs: ["changelog"],
+        })}
+      />,
+    );
+
+    expect(html).toContain('aria-expanded="false" aria-label="Expand Release notes"');
+    expect(html).not.toContain('href="/docs/changelog/1.0.0"');
+  });
+
+  it("keeps the existing expanded default when no initial-collapse slugs are provided", () => {
+    const ctx = makeFakeChromeContext();
+    const HomePageView = createHomePageView(ctx);
+    const html = render(<HomePageView {...makeProps({ tree: CHANGELOG_TREE })} />);
+
+    expect(html).toContain('aria-expanded="true" aria-label="Collapse Release notes"');
+    expect(html).toContain('href="/docs/changelog/1.0.0"');
   });
 });
 

--- a/packages/zudo-doc/src/home-page/index.tsx
+++ b/packages/zudo-doc/src/home-page/index.tsx
@@ -71,6 +71,8 @@ export interface HomePageViewProps {
   tree: DocNavNode[];
   /** Ordered category prefixes, passed through to `SiteTreeNav`. */
   categoryOrder: string[];
+  /** Root-category slugs that should start collapsed in `SiteTreeNav`. */
+  initiallyCollapsedCategorySlugs?: string[];
   /** Unique tag count for the current locale — gates the "all tags" section
    *  together with `settings.docTags`. */
   tagCount: number;
@@ -119,6 +121,7 @@ export function createHomePageView<S extends Settings = Settings>(
     extras,
     tree,
     categoryOrder,
+    initiallyCollapsedCategorySlugs,
     tagCount,
     wide,
   }: HomePageViewProps): JSX.Element {
@@ -195,6 +198,7 @@ export function createHomePageView<S extends Settings = Settings>(
               tree={tree as unknown as SidebarNavNode[]}
               categoryOrder={categoryOrder}
               categoryIgnore={["inbox", "develop"]}
+              initiallyCollapsedCategorySlugs={initiallyCollapsedCategorySlugs}
             />
           ),
         }) as unknown as VNode}

--- a/packages/zudo-doc/src/site-tree-nav-island/__tests__/site-tree-nav-ssg.test.tsx
+++ b/packages/zudo-doc/src/site-tree-nav-island/__tests__/site-tree-nav-ssg.test.tsx
@@ -33,9 +33,26 @@ const SAMPLE_TREE: SidebarNavNode[] = [
     ],
   },
   {
+    slug: "changelog",
+    label: "Release notes",
+    position: 1,
+    href: "/docs/changelog",
+    hasPage: true,
+    children: [
+      {
+        slug: "changelog/1.0.0",
+        label: "1.0.0",
+        position: 0,
+        href: "/docs/changelog/1.0.0",
+        hasPage: true,
+        children: [],
+      },
+    ],
+  },
+  {
     slug: "reference",
     label: "Reference",
-    position: 1,
+    position: 2,
     href: "/docs/reference",
     hasPage: true,
     children: [],
@@ -63,6 +80,27 @@ describe("SiteTreeNav — SSG HTML presence", () => {
   it("renders child node href in static HTML", () => {
     const html = render(<SiteTreeNav tree={SAMPLE_TREE} />);
     expect(html).toContain('href="/docs/guides/getting-started"');
+  });
+
+  it("starts only explicitly selected root-category slugs collapsed", () => {
+    const html = render(
+      <SiteTreeNav
+        tree={SAMPLE_TREE}
+        initiallyCollapsedCategorySlugs={["changelog"]}
+      />,
+    );
+
+    expect(html).toContain('aria-expanded="false" aria-label="Expand Release notes"');
+    expect(html).not.toContain('href="/docs/changelog/1.0.0"');
+    expect(html).toContain('aria-expanded="true" aria-label="Collapse Guides"');
+    expect(html).toContain('href="/docs/guides/getting-started"');
+  });
+
+  it("keeps all categories expanded by default without inferring from labels", () => {
+    const html = render(<SiteTreeNav tree={SAMPLE_TREE} />);
+
+    expect(html).toContain('aria-expanded="true" aria-label="Collapse Release notes"');
+    expect(html).toContain('href="/docs/changelog/1.0.0"');
   });
 
   it("renders the data-site-nav attribute in static HTML", () => {

--- a/packages/zudo-doc/src/site-tree-nav-island/__tests__/site-tree-nav-state.test.ts
+++ b/packages/zudo-doc/src/site-tree-nav-island/__tests__/site-tree-nav-state.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import {
+  initialCategoryOpenState,
+  toggleCategoryOpenState,
+} from "../state.js";
+
+describe("SiteTreeNav category state", () => {
+  it("starts expanded unless the category is explicitly collapsed", () => {
+    expect(initialCategoryOpenState(false)).toBe(true);
+    expect(initialCategoryOpenState(true)).toBe(false);
+  });
+
+  it("allows an initially collapsed category to expand and collapse again", () => {
+    const initial = initialCategoryOpenState(true);
+    const expanded = toggleCategoryOpenState(initial);
+
+    expect(expanded).toBe(true);
+    expect(toggleCategoryOpenState(expanded)).toBe(false);
+  });
+});

--- a/packages/zudo-doc/src/site-tree-nav-island/index.tsx
+++ b/packages/zudo-doc/src/site-tree-nav-island/index.tsx
@@ -8,6 +8,7 @@ import { useState } from "preact/hooks";
 import type { SidebarNavNode } from "../sidebar/types.js";
 import { INDENT, connectorLeft, ConnectorLines, CategoryLinkIcon } from "../tree-nav-shared/index.js";
 import { ChevronRight } from "../icons/index.js";
+import { initialCategoryOpenState, toggleCategoryOpenState } from "./state.js";
 
 // site-tree-nav uses wider padding than the narrow sidebar
 const SITE_BASE_PAD = "clamp(0.5rem, 0.8vw, 1rem)";
@@ -39,6 +40,8 @@ export interface SiteTreeNavProps {
   ariaLabel?: string;
   categoryOrder?: string[];
   categoryIgnore?: string[];
+  /** Root-category slugs that should start collapsed. */
+  initiallyCollapsedCategorySlugs?: string[];
 }
 
 export function SiteTreeNav({
@@ -46,6 +49,7 @@ export function SiteTreeNav({
   ariaLabel = "Site index",
   categoryOrder,
   categoryIgnore,
+  initiallyCollapsedCategorySlugs,
 }: SiteTreeNavProps) {
   let processedTree = tree;
   if (categoryIgnore) {
@@ -55,6 +59,7 @@ export function SiteTreeNav({
   if (categoryOrder) {
     processedTree = reorderTree(processedTree, categoryOrder);
   }
+  const initiallyCollapsed = new Set(initiallyCollapsedCategorySlugs);
   return (
     <nav
       aria-label={ariaLabel}
@@ -67,7 +72,12 @@ export function SiteTreeNav({
       {processedTree.map((node) => (
         <div key={node.slug} className="min-w-0 border border-muted pl-hsp-sm py-vsp-2xs">
           {node.children.length > 0 ? (
-            <CategoryNode node={node} depth={0} isLast={true} />
+            <CategoryNode
+              node={node}
+              depth={0}
+              isLast={true}
+              initiallyCollapsed={initiallyCollapsed.has(node.slug)}
+            />
           ) : (
             <LeafNode node={node} depth={0} isLast={true} />
           )}
@@ -107,13 +117,15 @@ function CategoryNode({
   node,
   depth,
   isLast,
+  initiallyCollapsed = false,
 }: {
   node: SidebarNavNode;
   depth: number;
   isLast: boolean;
+  initiallyCollapsed?: boolean;
 }) {
-  const [open, setOpen] = useState(true);
-  const toggle = () => setOpen((prev) => !prev);
+  const [open, setOpen] = useState(() => initialCategoryOpenState(initiallyCollapsed));
+  const toggle = () => setOpen(toggleCategoryOpenState);
   const paddingLeft = padLeft(depth);
 
   return (

--- a/packages/zudo-doc/src/site-tree-nav-island/state.ts
+++ b/packages/zudo-doc/src/site-tree-nav-island/state.ts
@@ -1,0 +1,9 @@
+/** Derive the one-time open state used when a category mounts. */
+export function initialCategoryOpenState(initiallyCollapsed: boolean): boolean {
+  return !initiallyCollapsed;
+}
+
+/** Toggle a mounted category without coupling later state to its initial input. */
+export function toggleCategoryOpenState(open: boolean): boolean {
+  return !open;
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -36,6 +36,7 @@ export default function IndexPage(): JSX.Element {
       locale={locale}
       tree={tree}
       categoryOrder={categoryOrder}
+      initiallyCollapsedCategorySlugs={["changelog"]}
       tagCount={tagCount}
       // Showcase opts into the wide layout so the category grid fills the
       // viewport (better readability for the multi-column sitemap). Downstream


### PR DESCRIPTION
Parent epic: #2756
Super-epic: #2754

## Summary

- omit the generator-created GitHub header item when no usable GitHub URL is configured
- start the showcase home-page Changelog category collapsed through an explicit slug-scoped navigation input
- preserve explicit header overrides, category toggle behavior, and all other category defaults

## Topics

- #2784 implements #2757 for generator defaults and focused scaffold coverage
- #2785 implements #2758 for the SiteTreeNav/HomePageView seam and showcase-only configuration

## Validation

- `pnpm --filter create-zudo-doc test` (505 passed)
- `pnpm --filter create-zudo-doc typecheck`
- `pnpm --filter create-zudo-doc build`
- `pnpm --filter @takazudo/zudo-doc build`
- `pnpm --filter @takazudo/zudo-doc test` (1,253 passed)
- `pnpm --filter @takazudo/zudo-doc typecheck`
- `pnpm check:pages`
- production build (378 pages)
- deterministic browser verification at 1140 × 1073 and 390 × 844: collapsed first render, expansion, accessibility state, reload reset, other categories unchanged, and no document overflow
