### PR TITLE
fix(create-zudo-doc): omit inert GitHub header item

### DIFF
--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -685,7 +685,7 @@ describe("scaffold — zfb.config.ts content shape (integration with generateZfb
   // function unit test against generateZfbConfig() directly). These tests
   // only check that scaffold() writes exactly what that function returns,
   // plus the top-level shape guarantees the locked spec calls out.
-  it("barebone emits a near-empty zudoDoc({...}) — only siteName + always-different nav/header fields", async () => {
+  it("barebone emits a near-empty zudoDoc({...}) without an inert GitHub header item", async () => {
     await scaffold(baseChoices);
     const config = await fs.readFile(projectPath("test-doc", "zfb.config.ts"), "utf-8");
     expect(config).toMatch(/^import \{ defineConfig \} from "zfb\/config";$/m);
@@ -693,6 +693,8 @@ describe("scaffold — zfb.config.ts content shape (integration with generateZfb
     expect(config).toContain("export default defineConfig(");
     expect(config).toContain("zudoDoc({");
     expect(config).toContain('siteName: "Test Doc"');
+    expect(config).not.toContain('component: "github-link"');
+    expect(config).not.toContain("headerRightItems:");
     // Highlighting is package-preset-owned. The generated project delegates to
     // zudoDoc() and must not freeze an inline/dual-theme renderer config.
     for (const token of [
@@ -718,6 +720,20 @@ describe("scaffold — zfb.config.ts content shape (integration with generateZfb
     ]) {
       expect(config).not.toContain(token);
     }
+  });
+
+  it("scaffolds the GitHub header item when a usable GitHub URL is configured", async () => {
+    await scaffold({
+      ...baseChoices,
+      projectName: "test-github-header",
+      githubUrl: "  https://github.com/x/y  ",
+    });
+    const config = await fs.readFile(
+      projectPath("test-github-header", "zfb.config.ts"),
+      "utf-8",
+    );
+    expect(config).toContain('githubUrl: "https://github.com/x/y"');
+    expect(config).toContain('component: "github-link"');
   });
 
   it("emits findInPage: true when tauri is selected (#2690 — rides the tauri feature, package-owned island)", async () => {

--- a/packages/create-zudo-doc/src/__tests__/zfb-config-gen.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/zfb-config-gen.test.ts
@@ -85,20 +85,19 @@ describe("generateZfbConfig — siteName always emitted", () => {
 });
 
 describe("generateZfbConfig — diff-from-defaults (near-empty case)", () => {
-  it("emits ONLY siteName + the always-different headerNav/headerRightItems when every other choice matches the package default", () => {
+  it("emits ONLY siteName + the always-different headerNav when every other choice matches the package default", () => {
     // packageDefaultChoices resolves colorMode/colorScheme to the exact
     // DEFAULT_MIRROR values, so both are diffed away. headerNav always gets
-    // a "Getting Started" entry (default mirror is []) and headerRightItems
-    // always gets a github-link entry (default mirror is just theme-toggle)
-    // — both are therefore always emitted, even in the "everything default"
-    // case. No other field should appear.
+    // a "Getting Started" entry (default mirror is []). With no GitHub URL,
+    // headerRightItems is just theme-toggle and therefore matches the default
+    // mirror. No other field should appear.
     const result = generateZfbConfig(packageDefaultChoices);
     const bodyMatch = result.match(/zudoDoc\(\{([\s\S]*)\}\),/);
     expect(bodyMatch).not.toBeNull();
     const fieldNames = [...bodyMatch![1]!.matchAll(/^\s{4}(\w+):/gm)].map(
       (m) => m[1],
     );
-    expect(fieldNames).toEqual(["siteName", "headerNav", "headerRightItems"]);
+    expect(fieldNames).toEqual(["siteName", "headerNav"]);
     expect(result).not.toContain("colorMode");
     expect(result).not.toContain("colorScheme:");
   });
@@ -250,11 +249,12 @@ describe("generateZfbConfig — designTokenPanel headerRightItems trigger", () =
       features: ["designTokenPanel"],
     });
     expect(result).toContain('trigger: "design-token-panel"');
-    // Trigger must appear before github-link (order matters — it's the
-    // first pushed item in the default-fallback builder).
+    // Trigger remains the first item in the default builder. With no GitHub
+    // URL, the inert github-link is omitted.
     expect(result.indexOf('trigger: "design-token-panel"')).toBeLessThan(
-      result.indexOf('component: "github-link"'),
+      result.indexOf('component: "theme-toggle"'),
     );
+    expect(result).not.toContain('component: "github-link"');
   });
 
   it("omits the trigger when disabled", () => {
@@ -387,15 +387,22 @@ describe("generateZfbConfig — headerRightItems override", () => {
   it("emits a user-supplied headerRightItems array verbatim", () => {
     const result = generateZfbConfig({
       ...baseChoices,
+      features: ["search", "i18n"],
       headerRightItems: [
-        { type: "component", component: "theme-toggle" },
+        { type: "component", component: "github-link" },
         { type: "trigger", trigger: "ai-chat" },
       ],
     });
+    const githubIndex = result.indexOf('component: "github-link"');
+    const aiChatIndex = result.indexOf('trigger: "ai-chat"');
+    expect(githubIndex).toBeGreaterThan(-1);
     expect(result).toContain('trigger: "ai-chat"');
-    // The default-fallback github-link item must NOT appear — the override
-    // replaces the whole array.
-    expect(result).not.toContain('component: "github-link"');
+    expect(githubIndex).toBeLessThan(aiChatIndex);
+    // No URL is configured, but explicit items are preserved. Feature-based
+    // defaults are not added to the override.
+    expect(result).not.toContain('component: "theme-toggle"');
+    expect(result).not.toContain('component: "search"');
+    expect(result).not.toContain('component: "language-switcher"');
   });
 
   it("honors an explicit empty array (user wants no header-right items)", () => {
@@ -403,7 +410,7 @@ describe("generateZfbConfig — headerRightItems override", () => {
     expect(result).toContain("headerRightItems: []");
   });
 
-  it("strips a design-token-panel trigger from the override when the feature is off", () => {
+  it("does not filter a design-token-panel trigger from an explicit override when the feature is off", () => {
     const result = generateZfbConfig({
       ...baseChoices,
       headerRightItems: [
@@ -412,9 +419,32 @@ describe("generateZfbConfig — headerRightItems override", () => {
         { type: "component", component: "github-link" },
       ],
     });
-    expect(result).not.toContain("design-token-panel");
+    expect(result).toContain('trigger: "design-token-panel"');
     expect(result).toContain('component: "theme-toggle"');
     expect(result).toContain('component: "github-link"');
+  });
+
+  it("keeps the remaining default items in order around a URL-backed github-link", () => {
+    const result = generateZfbConfig({
+      ...baseChoices,
+      githubUrl: "https://github.com/x/y",
+      features: ["designTokenPanel", "versioning", "search", "i18n"],
+    });
+    const headerRightItems = result.match(
+      /headerRightItems: \[([\s\S]*?)\n    \],/,
+    );
+    expect(headerRightItems).not.toBeNull();
+    const itemNames = [
+      ...headerRightItems![1]!.matchAll(/(?:trigger|component): "([^"]+)"/g),
+    ].map((match) => match[1]);
+    expect(itemNames).toEqual([
+      "design-token-panel",
+      "version-switcher",
+      "github-link",
+      "theme-toggle",
+      "search",
+      "language-switcher",
+    ]);
   });
 });
 
@@ -467,15 +497,30 @@ describe("generateZfbConfig — misc scalar fields", () => {
     expect(result).toContain("cjkFriendly: true");
   });
 
-  it("emits githubUrl as a string when set, omits when blank", () => {
+  it("emits a trimmed githubUrl and default github-link when set", () => {
     const withUrl = generateZfbConfig({
       ...baseChoices,
-      githubUrl: "https://github.com/x/y",
+      githubUrl: "  https://github.com/x/y  ",
     });
     expect(withUrl).toContain('githubUrl: "https://github.com/x/y"');
+    expect(withUrl).toContain('component: "github-link"');
+    expect(withUrl.indexOf('component: "github-link"')).toBeLessThan(
+      withUrl.indexOf('component: "theme-toggle"'),
+    );
+  });
 
-    const blank = generateZfbConfig({ ...baseChoices, githubUrl: "" });
-    expect(blank).not.toContain("githubUrl");
+  it.each([
+    ["omitted", undefined],
+    ["false", false],
+    ["empty", ""],
+    ["whitespace-only", "  \t  "],
+  ])("omits githubUrl and the default github-link when %s", (_label, githubUrl) => {
+    const result = generateZfbConfig({
+      ...baseChoices,
+      githubUrl: githubUrl as UserChoices["githubUrl"],
+    });
+    expect(result).not.toContain("githubUrl");
+    expect(result).not.toContain('component: "github-link"');
   });
 });
 

--- a/packages/create-zudo-doc/src/zfb-config-gen.ts
+++ b/packages/create-zudo-doc/src/zfb-config-gen.ts
@@ -184,7 +184,8 @@ function buildDesiredConfig(choices: UserChoices): Record<string, unknown> {
   // ── Misc site fields ──────────────────────────────────────────────────
   desired.minifyHtml = choices.minifyHtml ?? true;
   desired.noindex = choices.features.includes("noindex");
-  const rawGithubUrl = (choices.githubUrl ?? "").trim();
+  const rawGithubUrl =
+    typeof choices.githubUrl === "string" ? choices.githubUrl.trim() : "";
   desired.githubUrl = rawGithubUrl ? rawGithubUrl : false;
   desired.cjkFriendly = choices.cjkFriendly ?? false;
 
@@ -320,16 +321,8 @@ function buildDesiredConfig(choices: UserChoices): Record<string, unknown> {
   desired.headerNav = headerNav;
 
   if (choices.headerRightItems !== undefined) {
-    // User-supplied override (including empty array) — emit verbatim, minus
-    // a defensive strip of "design-token-panel" when the feature is off.
-    desired.headerRightItems = choices.headerRightItems.filter(
-      (item) =>
-        !(
-          item.type === "trigger" &&
-          item.trigger === "design-token-panel" &&
-          !choices.features.includes("designTokenPanel")
-        ),
-    );
+    // User-supplied override (including empty array) — emit verbatim.
+    desired.headerRightItems = choices.headerRightItems;
   } else {
     const items: Array<Record<string, unknown>> = [];
     if (choices.features.includes("designTokenPanel")) {
@@ -338,7 +331,9 @@ function buildDesiredConfig(choices: UserChoices): Record<string, unknown> {
     if (choices.features.includes("versioning")) {
       items.push({ type: "component", component: "version-switcher" });
     }
-    items.push({ type: "component", component: "github-link" });
+    if (rawGithubUrl) {
+      items.push({ type: "component", component: "github-link" });
+    }
     items.push({ type: "component", component: "theme-toggle" });
     if (choices.features.includes("search")) {
       items.push({ type: "component", component: "search" });


### PR DESCRIPTION
Parent: #2756
Implements: #2757

## Summary

- gate the generator-created `github-link` on a normalized non-empty GitHub URL
- preserve explicit `headerRightItems` exactly, including explicit GitHub or design-token entries
- cover false, omitted, empty, whitespace-only, URL-backed, and explicit-override cases

## Validation

- `pnpm --filter create-zudo-doc test` (505 passed)
- `pnpm --filter create-zudo-doc typecheck`
- `pnpm --filter create-zudo-doc build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786741464&installation_id=130359969&pr_number=2784&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2784&signature=5c801955a3cd96a72f7965bdb472d4ba10e321ea07d5142fa03de2af09cd724f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->