### PR TITLE
fix(showcase): start Changelog category collapsed

### DIFF
--- a/packages/zudo-doc/src/home-page/__tests__/home-page.test.tsx
+++ b/packages/zudo-doc/src/home-page/__tests__/home-page.test.tsx
@@ -29,6 +29,25 @@ import type { ChromeContext } from "../../factory-context/index.js";
 import { makeFakeChromeContext } from "../../__tests__/fixtures/fake-chrome-context.js";
 
 const EMPTY_TREE: DocNavNode[] = [];
+const CHANGELOG_TREE: DocNavNode[] = [
+  {
+    slug: "changelog",
+    label: "Release notes",
+    position: 0,
+    href: "/docs/changelog",
+    hasPage: true,
+    children: [
+      {
+        slug: "changelog/1.0.0",
+        label: "1.0.0",
+        position: 0,
+        href: "/docs/changelog/1.0.0",
+        hasPage: true,
+        children: [],
+      },
+    ],
+  },
+];
 
 function makeProps(overrides: Partial<HomePageViewProps> = {}): HomePageViewProps {
   return {
@@ -108,6 +127,31 @@ describe("createHomePageView — SiteTreeNav island", () => {
     const html = render(<HomePageView {...makeProps()} />);
 
     expect(html).toContain('data-zfb-island="SiteTreeNav"');
+  });
+
+  it("forwards the explicit initial-collapse slugs to SiteTreeNav", () => {
+    const ctx = makeFakeChromeContext();
+    const HomePageView = createHomePageView(ctx);
+    const html = render(
+      <HomePageView
+        {...makeProps({
+          tree: CHANGELOG_TREE,
+          initiallyCollapsedCategorySlugs: ["changelog"],
+        })}
+      />,
+    );
+
+    expect(html).toContain('aria-expanded="false" aria-label="Expand Release notes"');
+    expect(html).not.toContain('href="/docs/changelog/1.0.0"');
+  });
+
+  it("keeps the existing expanded default when no initial-collapse slugs are provided", () => {
+    const ctx = makeFakeChromeContext();
+    const HomePageView = createHomePageView(ctx);
+    const html = render(<HomePageView {...makeProps({ tree: CHANGELOG_TREE })} />);
+
+    expect(html).toContain('aria-expanded="true" aria-label="Collapse Release notes"');
+    expect(html).toContain('href="/docs/changelog/1.0.0"');
   });
 });
 

--- a/packages/zudo-doc/src/home-page/index.tsx
+++ b/packages/zudo-doc/src/home-page/index.tsx
@@ -71,6 +71,8 @@ export interface HomePageViewProps {
   tree: DocNavNode[];
   /** Ordered category prefixes, passed through to `SiteTreeNav`. */
   categoryOrder: string[];
+  /** Root-category slugs that should start collapsed in `SiteTreeNav`. */
+  initiallyCollapsedCategorySlugs?: string[];
   /** Unique tag count for the current locale — gates the "all tags" section
    *  together with `settings.docTags`. */
   tagCount: number;
@@ -119,6 +121,7 @@ export function createHomePageView<S extends Settings = Settings>(
     extras,
     tree,
     categoryOrder,
+    initiallyCollapsedCategorySlugs,
     tagCount,
     wide,
   }: HomePageViewProps): JSX.Element {
@@ -195,6 +198,7 @@ export function createHomePageView<S extends Settings = Settings>(
               tree={tree as unknown as SidebarNavNode[]}
               categoryOrder={categoryOrder}
               categoryIgnore={["inbox", "develop"]}
+              initiallyCollapsedCategorySlugs={initiallyCollapsedCategorySlugs}
             />
           ),
         }) as unknown as VNode}

--- a/packages/zudo-doc/src/site-tree-nav-island/__tests__/site-tree-nav-ssg.test.tsx
+++ b/packages/zudo-doc/src/site-tree-nav-island/__tests__/site-tree-nav-ssg.test.tsx
@@ -33,9 +33,26 @@ const SAMPLE_TREE: SidebarNavNode[] = [
     ],
   },
   {
+    slug: "changelog",
+    label: "Release notes",
+    position: 1,
+    href: "/docs/changelog",
+    hasPage: true,
+    children: [
+      {
+        slug: "changelog/1.0.0",
+        label: "1.0.0",
+        position: 0,
+        href: "/docs/changelog/1.0.0",
+        hasPage: true,
+        children: [],
+      },
+    ],
+  },
+  {
     slug: "reference",
     label: "Reference",
-    position: 1,
+    position: 2,
     href: "/docs/reference",
     hasPage: true,
     children: [],
@@ -63,6 +80,27 @@ describe("SiteTreeNav — SSG HTML presence", () => {
   it("renders child node href in static HTML", () => {
     const html = render(<SiteTreeNav tree={SAMPLE_TREE} />);
     expect(html).toContain('href="/docs/guides/getting-started"');
+  });
+
+  it("starts only explicitly selected root-category slugs collapsed", () => {
+    const html = render(
+      <SiteTreeNav
+        tree={SAMPLE_TREE}
+        initiallyCollapsedCategorySlugs={["changelog"]}
+      />,
+    );
+
+    expect(html).toContain('aria-expanded="false" aria-label="Expand Release notes"');
+    expect(html).not.toContain('href="/docs/changelog/1.0.0"');
+    expect(html).toContain('aria-expanded="true" aria-label="Collapse Guides"');
+    expect(html).toContain('href="/docs/guides/getting-started"');
+  });
+
+  it("keeps all categories expanded by default without inferring from labels", () => {
+    const html = render(<SiteTreeNav tree={SAMPLE_TREE} />);
+
+    expect(html).toContain('aria-expanded="true" aria-label="Collapse Release notes"');
+    expect(html).toContain('href="/docs/changelog/1.0.0"');
   });
 
   it("renders the data-site-nav attribute in static HTML", () => {

--- a/packages/zudo-doc/src/site-tree-nav-island/__tests__/site-tree-nav-state.test.ts
+++ b/packages/zudo-doc/src/site-tree-nav-island/__tests__/site-tree-nav-state.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import {
+  initialCategoryOpenState,
+  toggleCategoryOpenState,
+} from "../state.js";
+
+describe("SiteTreeNav category state", () => {
+  it("starts expanded unless the category is explicitly collapsed", () => {
+    expect(initialCategoryOpenState(false)).toBe(true);
+    expect(initialCategoryOpenState(true)).toBe(false);
+  });
+
+  it("allows an initially collapsed category to expand and collapse again", () => {
+    const initial = initialCategoryOpenState(true);
+    const expanded = toggleCategoryOpenState(initial);
+
+    expect(expanded).toBe(true);
+    expect(toggleCategoryOpenState(expanded)).toBe(false);
+  });
+});

--- a/packages/zudo-doc/src/site-tree-nav-island/index.tsx
+++ b/packages/zudo-doc/src/site-tree-nav-island/index.tsx
@@ -8,6 +8,7 @@ import { useState } from "preact/hooks";
 import type { SidebarNavNode } from "../sidebar/types.js";
 import { INDENT, connectorLeft, ConnectorLines, CategoryLinkIcon } from "../tree-nav-shared/index.js";
 import { ChevronRight } from "../icons/index.js";
+import { initialCategoryOpenState, toggleCategoryOpenState } from "./state.js";
 
 // site-tree-nav uses wider padding than the narrow sidebar
 const SITE_BASE_PAD = "clamp(0.5rem, 0.8vw, 1rem)";
@@ -39,6 +40,8 @@ export interface SiteTreeNavProps {
   ariaLabel?: string;
   categoryOrder?: string[];
   categoryIgnore?: string[];
+  /** Root-category slugs that should start collapsed. */
+  initiallyCollapsedCategorySlugs?: string[];
 }
 
 export function SiteTreeNav({
@@ -46,6 +49,7 @@ export function SiteTreeNav({
   ariaLabel = "Site index",
   categoryOrder,
   categoryIgnore,
+  initiallyCollapsedCategorySlugs,
 }: SiteTreeNavProps) {
   let processedTree = tree;
   if (categoryIgnore) {
@@ -55,6 +59,7 @@ export function SiteTreeNav({
   if (categoryOrder) {
     processedTree = reorderTree(processedTree, categoryOrder);
   }
+  const initiallyCollapsed = new Set(initiallyCollapsedCategorySlugs);
   return (
     <nav
       aria-label={ariaLabel}
@@ -67,7 +72,12 @@ export function SiteTreeNav({
       {processedTree.map((node) => (
         <div key={node.slug} className="min-w-0 border border-muted pl-hsp-sm py-vsp-2xs">
           {node.children.length > 0 ? (
-            <CategoryNode node={node} depth={0} isLast={true} />
+            <CategoryNode
+              node={node}
+              depth={0}
+              isLast={true}
+              initiallyCollapsed={initiallyCollapsed.has(node.slug)}
+            />
           ) : (
             <LeafNode node={node} depth={0} isLast={true} />
           )}
@@ -107,13 +117,15 @@ function CategoryNode({
   node,
   depth,
   isLast,
+  initiallyCollapsed = false,
 }: {
   node: SidebarNavNode;
   depth: number;
   isLast: boolean;
+  initiallyCollapsed?: boolean;
 }) {
-  const [open, setOpen] = useState(true);
-  const toggle = () => setOpen((prev) => !prev);
+  const [open, setOpen] = useState(() => initialCategoryOpenState(initiallyCollapsed));
+  const toggle = () => setOpen(toggleCategoryOpenState);
   const paddingLeft = padLeft(depth);
 
   return (

--- a/packages/zudo-doc/src/site-tree-nav-island/state.ts
+++ b/packages/zudo-doc/src/site-tree-nav-island/state.ts
@@ -1,0 +1,9 @@
+/** Derive the one-time open state used when a category mounts. */
+export function initialCategoryOpenState(initiallyCollapsed: boolean): boolean {
+  return !initiallyCollapsed;
+}
+
+/** Toggle a mounted category without coupling later state to its initial input. */
+export function toggleCategoryOpenState(open: boolean): boolean {
+  return !open;
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -36,6 +36,7 @@ export default function IndexPage(): JSX.Element {
       locale={locale}
       tree={tree}
       categoryOrder={categoryOrder}
+      initiallyCollapsedCategorySlugs={["changelog"]}
       tagCount={tagCount}
       // Showcase opts into the wide layout so the category grid fills the
       // viewport (better readability for the multi-column sitemap). Downstream


### PR DESCRIPTION
Parent: #2756
Implements: #2758

## Summary

- add an explicit root-category initial-collapse input to `SiteTreeNav`
- thread the input through `HomePageView` and configure only showcase `changelog`
- preserve toggle/accessibility behavior and all other category defaults

## Validation

- `pnpm --filter @takazudo/zudo-doc build`
- `pnpm --filter @takazudo/zudo-doc test` (1,253 passed)
- package and pages typechecks
- desktop and narrow deterministic browser verification

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786741464&installation_id=130359969&pr_number=2785&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2785&signature=7a5a59e5b1166ef47396fca5e1bfaf4cbd3187ea07941eaf1c5c87915a842581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->