### PR TITLE
[Compatibility Cleanup][Sub] Remove legacy Syntect markup support

### DIFF
--- a/e2e/smoke-smart-break.spec.ts
+++ b/e2e/smoke-smart-break.spec.ts
@@ -213,20 +213,18 @@ test.describe("smart-break: visual wrapping on narrow viewports", () => {
 // --------------------------------------------------------------------------
 
 test.describe("smart-break: regression guards", () => {
-  test("fenced code blocks render unwrapped (smart-break skips Shiki output)", async ({
+  test("fenced code blocks render unwrapped (smart-break skips highlighted output)", async ({
     page,
   }) => {
     await page.setViewportSize(NARROW);
     await page.goto(TEST_PAGE, { waitUntil: "load" });
 
-    const pre = page
-      .locator('main :is(pre.hi-root, pre[class*="syntect-"])')
-      .first();
+    const pre = page.locator("main pre.hi-root").first();
     await expect(pre).toBeVisible();
 
     // The pre may show a horizontal scrollbar (overflow-x: auto) — the
     // content is wider than the visible box but stays on one physical line.
-    // If smart-break had polluted Shiki spans with <wbr>, the long line
+    // If smart-break had polluted highlighted spans with <wbr>, the long line
     // would wrap instead of overflowing, and scrollWidth would equal
     // clientWidth.
     const { scrollWidth, clientWidth, wbrInsideCode } = await pre.evaluate(

--- a/packages/zudo-doc/src/__tests__/features-css.test.ts
+++ b/packages/zudo-doc/src/__tests__/features-css.test.ts
@@ -31,20 +31,19 @@ describe("src/features.css source contract", () => {
     expect(css).toContain("z-index: var(--z-index-toolbar, 20);");
   });
 
-  it("styles both highlighted block shapes without matching every pre", () => {
-    const highlightedPre = ':is(pre.hi-root, pre[class*="syntect-"])';
+  it("styles current highlighted blocks without matching every pre", () => {
+    const highlightedPre = "pre.hi-root";
 
     expect(css).toContain(
       `${highlightedPre} [data-line-highlight="true"]`,
     );
     expect(css).toContain(`${highlightedPre} .line .highlighted-word`);
     expect(css).toContain(`.code-block-container ${highlightedPre}`);
-    expect(css).not.toContain('pre[class^="syntect-"]');
+    expect(css).not.toContain("syntect-");
   });
 
   it("applies word wrapping to highlighted blocks and raw tab fallbacks", () => {
-    const enhanceablePre =
-      ':is(pre.hi-root, pre[class*="syntect-"], .tab-panel pre)';
+    const enhanceablePre = ":is(pre.hi-root, .tab-panel pre)";
 
     expect(css).toContain(`${enhanceablePre}.word-wrap {`);
     expect(css).toContain(`${enhanceablePre}.word-wrap code {`);
@@ -95,7 +94,8 @@ describe("src/features.css source contract", () => {
   });
 
   it("keeps Shiki compatibility colors scoped away from class output", () => {
-    expect(css).toContain('[data-theme] pre[class*="syntect-"] span');
+    expect(css).toContain("[data-theme] .shiki span");
+    expect(css).toContain("[data-theme] .shiki {");
     expect(css).toContain("color: light-dark(var(--shiki-light)");
     expect(css).not.toMatch(
       /\[data-theme\][^{]*hi-root[^{]*\{[^}]*--shiki-/s,

--- a/packages/zudo-doc/src/code-syntax/__tests__/code-block-enhancer.test.tsx
+++ b/packages/zudo-doc/src/code-syntax/__tests__/code-block-enhancer.test.tsx
@@ -62,14 +62,10 @@ describe("CODE_BLOCK_ENHANCER_SCRIPT", () => {
     expect(CODE_BLOCK_ENHANCER_SCRIPT.trimEnd()).toMatch(/\)\(\);$/);
   });
 
-  it("targets current and future highlighted pre elements", () => {
-    expect(HIGHLIGHTED_CODE_BLOCK_SELECTOR).toBe(
-      ':is(pre.hi-root, pre[class*="syntect-"])',
-    );
-    expect(CODE_BLOCK_ENHANCER_SELECTOR).toContain("pre.hi-root");
-    expect(CODE_BLOCK_ENHANCER_SELECTOR).toContain(
-      'pre[class*="syntect-"]',
-    );
+  it("targets current highlighted pre elements only", () => {
+    expect(HIGHLIGHTED_CODE_BLOCK_SELECTOR).toBe("pre.hi-root");
+    expect(CODE_BLOCK_ENHANCER_SELECTOR).not.toContain("syntect-");
+    expect(CODE_BLOCK_ENHANCER_SCRIPT).not.toContain("syntect-");
   });
 
   it("also targets bare <pre> inside tab panels", () => {

--- a/packages/zudo-doc/src/code-syntax/code-block-enhancer-script.ts
+++ b/packages/zudo-doc/src/code-syntax/code-block-enhancer-script.ts
@@ -24,9 +24,8 @@ import {
   BEFORE_NAVIGATE_EVENT,
 } from "../transitions/page-events.js";
 
-/** Highlighted block shapes emitted by current Syntect and future class mode. */
-export const HIGHLIGHTED_CODE_BLOCK_SELECTOR =
-  ':is(pre.hi-root, pre[class*="syntect-"])';
+/** Highlighted blocks emitted by the current class-mode highlighter. */
+export const HIGHLIGHTED_CODE_BLOCK_SELECTOR = "pre.hi-root";
 
 /** Highlighted blocks plus the intentional raw-code fallback inside tabs. */
 export const CODE_BLOCK_ENHANCER_SELECTOR = `${HIGHLIGHTED_CODE_BLOCK_SELECTOR}, .tab-panel pre`;
@@ -42,11 +41,9 @@ export const CODE_BLOCK_ENHANCER_SCRIPT = `(function () {
   });
 
   function enhanceCodeBlocks() {
-    // Selector covers three shapes:
+    // Selector covers two shapes:
     //   1. pre.hi-root from the class-mode highlighter.
-    //   2. pre.syntect-... from the legacy syntect highlighter (the class
-    //      may be merged with other classes).
-    //   3. bare pre inside .tab-panel (TabItem) wrappers where some
+    //   2. bare pre inside .tab-panel (TabItem) wrappers where some
     //      pipelines emit class-less pre elements.
     // No backticks in this comment: this whole script body lives inside
     // a template literal in the host .ts module, so an inline backtick

--- a/packages/zudo-doc/src/code-syntax/code-block-enhancer.tsx
+++ b/packages/zudo-doc/src/code-syntax/code-block-enhancer.tsx
@@ -22,8 +22,8 @@ import { CODE_BLOCK_ENHANCER_SCRIPT } from "./code-block-enhancer-script.js";
  * and emits the code-block enhancer init script via `dangerouslySetInnerHTML`.
  *
  * The script:
- * - Wraps each highlighted `<pre>` (`.hi-root` or legacy `.syntect-*`) and
- *   raw tab-panel fallback in a `.code-block-wrapper` container.
+ * - Wraps each highlighted `<pre>` (`.hi-root`) and raw tab-panel fallback in
+ *   a `.code-block-wrapper` container.
  * - Adds a copy-to-clipboard button and a word-wrap toggle button.
  * - Observes resize events to hide the wrap button when content fits.
  * - Handles before-navigate cleanup and after-navigate re-init for View

--- a/packages/zudo-doc/src/code-syntax/index.ts
+++ b/packages/zudo-doc/src/code-syntax/index.ts
@@ -2,9 +2,8 @@
 //
 // Three JSX ports of the code/syntax Astro components:
 //
-//   CodeBlockEnhancer — wraps highlighted blocks (`.hi-root` or legacy
-//                       `.syntect-*`) with copy + word-wrap buttons. Include
-//                       once in the layout.
+//   CodeBlockEnhancer — wraps highlighted `.hi-root` blocks with copy +
+//                       word-wrap buttons. Include once in the layout.
 //
 //   MermaidInit       — lazily renders [data-mermaid] diagrams and re-renders
 //                       on color scheme changes. Include once in the layout.

--- a/packages/zudo-doc/src/doclayout/doc-layout-with-defaults.tsx
+++ b/packages/zudo-doc/src/doclayout/doc-layout-with-defaults.tsx
@@ -408,9 +408,9 @@ export function DocLayoutWithDefaults(
         bodyEndScripts={
           bodyEndScripts ?? (
             // Default body-end scripts:
-            //   - CodeBlockEnhancer wraps every highlighted <pre> (`.hi-root`
-            //     or legacy `.syntect-*`) with copy + word-wrap controls and
-            //     emits an SR-announce live region for clipboard feedback.
+            //   - CodeBlockEnhancer wraps every highlighted <pre> (`.hi-root`)
+            //     with copy + word-wrap controls and emits an SR-announce live
+            //     region for clipboard feedback.
             //     Idempotent on pages with no fenced code.
             //   - TabsInit activates the correct tab panel and wires click
             //     handlers for <Tabs> components.

--- a/packages/zudo-doc/src/features.css
+++ b/packages/zudo-doc/src/features.css
@@ -48,11 +48,11 @@ header[data-header] {
   position: relative;
 }
 
-:is(pre.hi-root, pre[class*="syntect-"], .tab-panel pre).word-wrap {
+:is(pre.hi-root, .tab-panel pre).word-wrap {
   overflow-x: hidden;
 }
 
-:is(pre.hi-root, pre[class*="syntect-"], .tab-panel pre).word-wrap code {
+:is(pre.hi-root, .tab-panel pre).word-wrap code {
   white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
@@ -179,14 +179,11 @@ header[data-header] {
   --zfb-hi-hd: var(--zd-syntax-keyword);
 }
 
-/* HTML Preview remains on Shiki until #2742. Its dual-theme variables, plus
- * legacy syntect-dual output supplied by downstream content, continue to
- * resolve through color-scheme. These selectors intentionally exclude
- * `.hi-root`, whose colors come from the semantic bridge above. */
+/* HTML Preview remains on Shiki until #2742. Its dual-theme variables resolve
+ * through color-scheme. These selectors intentionally exclude `.hi-root`,
+ * whose colors come from the semantic bridge above. */
 [data-theme] .shiki,
-[data-theme] .shiki span,
-[data-theme] pre[class*="syntect-"],
-[data-theme] pre[class*="syntect-"] span {
+[data-theme] .shiki span {
   color: light-dark(var(--shiki-light), var(--shiki-dark));
   font-style: light-dark(
     var(--shiki-light-font-style, inherit),
@@ -199,8 +196,7 @@ header[data-header] {
  * painting them per-span would lay an opaque base background over the
  * translucent line-/word-highlight backgrounds that sit on the enclosing
  * .line span (see .line.highlighted below). */
-[data-theme] .shiki,
-[data-theme] pre[class*="syntect-"] {
+[data-theme] .shiki {
   background-color: light-dark(var(--shiki-light-bg), var(--shiki-dark-bg));
 }
 
@@ -228,13 +224,13 @@ header[data-header] {
  * zfb emits data-line-highlight="true" on the <span class="line"> element
  * (verified empirically at next.13). The .highlighted class form is kept for
  * forward-compat in case a future zfb version emits both. */
-:is(pre.hi-root, pre[class*="syntect-"]) .line.highlighted,
-:is(pre.hi-root, pre[class*="syntect-"]) [data-line-highlight="true"] {
+pre.hi-root .line.highlighted,
+pre.hi-root [data-line-highlight="true"] {
   background-color: color-mix(in srgb, var(--color-accent) 15%, transparent);
 }
 
 /* Word highlighting via /word/ meta syntax */
-:is(pre.hi-root, pre[class*="syntect-"]) .line .highlighted-word {
+pre.hi-root .line .highlighted-word {
   background-color: color-mix(in srgb, var(--color-accent) 25%, transparent);
   border-bottom: 1px solid var(--color-accent);
 }
@@ -258,7 +254,7 @@ header[data-header] {
   padding: var(--spacing-vsp-2xs) var(--spacing-hsp-lg);
 }
 
-.code-block-container :is(pre.hi-root, pre[class*="syntect-"]) {
+.code-block-container pre.hi-root {
   margin-top: 0 !important;
   border-top-left-radius: 0;
   border-top-right-radius: 0;
@@ -269,10 +265,10 @@ header[data-header] {
  *
  * zfb's :::code-group emits <CodeGroup tabs={[...]}> with one
  * <pre data-lang="…">{RAW text}</pre> child per fence. These <pre> elements
- * are NOT syntect-highlighted (the Rust pipeline doesn't highlight inside
- * code-group fences), so they get no `.syntect-*` class. Apply explicit
- * code-block visual treatment via tokens to match the syntect-highlighted
- * code blocks surrounding them.
+ * are NOT syntax-highlighted (the Rust pipeline doesn't highlight inside
+ * code-group fences), so they get no `.hi-root` class. Apply explicit
+ * code-block visual treatment via tokens to match the highlighted code blocks
+ * surrounding them.
  * ======================================== */
 
 .code-group-panel pre[data-lang] {


### PR DESCRIPTION
Parent epic: #2759

Closes #2766

Removes repository-owned Syntect markup selectors while preserving current zfb/Shiki behavior. Verified and merged into the epic integration branch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786750512&installation_id=130359969&pr_number=2793&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2793&signature=b735b84301ef7c8bebee161749568fed8d1a17ec1ff9d1624d9fd80d62360c20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->