### PR TITLE
feat: thread chrome bindings through scaffold routes

### DIFF
--- a/.template-drift-allowlist
+++ b/.template-drift-allowlist
@@ -71,17 +71,16 @@ pages/index.tsx
 # Both are self-contained doc-route stubs (#2653 Decision 4; locked form
 # #2660) — REQUIRED because the injected DYNAMIC `/docs/[[...slug]]` route
 # 404s in `zfb dev` (see each file's own header comment for the full
-# rationale). The template's copies use only the three sanctioned package
-# entrypoints (virtual:zudo-doc-route-context, @takazudo/zudo-doc/route-context,
-# @takazudo/zudo-doc/routes/_chrome's createChrome) with no fourth argument —
-# `createChrome(routeCtx)`. The showcase's copies additionally import
-# `virtual:zudo-doc-chrome-bindings` and call `createChrome(routeCtx,
-# chromeBindings)`, threading the showcase's real host-bound slots (search,
-# doc history, frontmatter renderers, PresetGenerator, MDX overrides — see
-# src/chrome-bindings.tsx) through the `chromeBindingsModule` host-callables
-# channel (ADR "Host-callables channel", #2501), plus locale-specific extra
-# fallback-tracking props on the [locale] variant. A project that sets its own
-# `chromeBindingsModule` diverges from the template the same way — this is
-# the documented escape hatch, not drift.
+# rationale). The template's copies use only the sanctioned package
+# entrypoints (virtual:zudo-doc-route-context,
+# virtual:zudo-doc-chrome-bindings, @takazudo/zudo-doc/route-context, and
+# @takazudo/zudo-doc/chrome's createChrome). Both template stubs now thread
+# `chromeBindings` unconditionally, matching the showcase's host-callables
+# channel: projects without a `chromeBindingsModule` receive the plugin's `{}`
+# fallback, while configured projects reach their MDX/chrome slots without a
+# manual stub edit (#2774). The whole files remain allowlisted because the
+# showcase carries project-specific typed page props, much fuller rationale
+# comments, and locale-specific fallback-tracking shapes; those differences
+# are intentional and independent of the bindings channel now shared by both.
 pages/docs/[[...slug]].tsx
 pages/[locale]/docs/[[...slug]].tsx

--- a/packages/create-zudo-doc/src/__tests__/chrome-bindings-build.slow.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/chrome-bindings-build.slow.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Generated-project chrome-bindings regression test (#2774 / source #2716).
+ *
+ * A self-contained `pages/docs/[[...slug]].tsx` route shadows the package's
+ * injected dynamic route. Before #2774 that stub called `createChrome()` with
+ * no host bindings, so a valid `chromeBindingsModule` never reached document
+ * MDX: custom tags such as `<MyBadge />` failed SSR even though the package's
+ * injected route consumed the same virtual module correctly.
+ *
+ * Keep this in the slow tier. The acceptance signal is a real scaffolded
+ * project build whose generated doc-route stub is left untouched: we add only
+ * the documented config/module/content inputs, then assert the bound component
+ * appears in emitted HTML.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import fs from "fs-extra";
+import os from "node:os";
+import path from "node:path";
+import { scaffold } from "../scaffold.js";
+import type { UserChoices } from "../prompts.js";
+import {
+  runOrThrow,
+  installScaffoldedDeps,
+  overrideWithLocalZudoDoc,
+} from "./slow-build-helpers.js";
+
+const TEMP_PREFIX = "create-zudo-doc-chrome-bindings-build-";
+const PROJECT_NAME = "chrome-bindings-build-test";
+
+const choices: UserChoices = {
+  projectName: PROJECT_NAME,
+  defaultLang: "en",
+  colorSchemeMode: "single",
+  singleScheme: "Default Dark",
+  // Keeping docHistory on proves its statically imported island survives the
+  // host-binding merge at the same time as the virtual mdxExtras binding.
+  features: ["docHistory"],
+  packageManager: "pnpm",
+};
+
+let tempDir: string;
+let projectDir: string;
+let originalCwd: string;
+
+beforeAll(async () => {
+  originalCwd = process.cwd();
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), TEMP_PREFIX));
+  process.chdir(tempDir);
+
+  await scaffold(choices);
+  projectDir = path.join(tempDir, PROJECT_NAME);
+
+  const configPath = path.join(projectDir, "zfb.config.ts");
+  const config = await fs.readFile(configPath, "utf-8");
+  await fs.writeFile(
+    configPath,
+    config.replace(
+      /siteName: ([^,]+),/,
+      'siteName: $1,\n    chromeBindingsModule: "./src/chrome-bindings.tsx",',
+    ),
+  );
+
+  await fs.writeFile(
+    path.join(projectDir, "src", "chrome-bindings.tsx"),
+    `/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+import { defineChromeBindings } from "@takazudo/zudo-doc/chrome-bindings";
+
+function MyBadge() {
+  return <span data-my-badge="reachable">Bound badge</span>;
+}
+
+export const chromeBindings = defineChromeBindings({
+  mdxExtras: { MyBadge },
+});
+`,
+  );
+
+  const docPath = path.join(
+    projectDir,
+    "src",
+    "content",
+    "docs",
+    "getting-started",
+    "introduction.mdx",
+  );
+  await fs.appendFile(docPath, "\n\n<MyBadge />\n");
+
+  installScaffoldedDeps(projectDir);
+  overrideWithLocalZudoDoc(projectDir);
+  runOrThrow("pnpm build", projectDir, { SKIP_DOC_HISTORY: "1" });
+}, 5 * 60 * 1000);
+
+afterAll(async () => {
+  process.chdir(originalCwd);
+  if (tempDir && (await fs.pathExists(tempDir))) {
+    await fs.remove(tempDir);
+  }
+});
+
+describe("generated chromeBindingsModule reaches the self-contained doc route", () => {
+  it("renders an mdxExtras MyBadge binding without editing the route stub", async () => {
+    const html = await fs.readFile(
+      path.join(
+        projectDir,
+        "dist",
+        "docs",
+        "getting-started",
+        "introduction",
+        "index.html",
+      ),
+      "utf-8",
+    );
+    expect(html).toMatch(/data-my-badge=(?:"reachable"|reachable)/);
+    expect(html).toContain("Bound badge");
+    expect(html).toMatch(
+      /data-zfb-island-skip-ssr=(?:"DocHistory"|DocHistory)/,
+    );
+  });
+});

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -218,7 +218,12 @@ describe("scaffold — i18n locale doc stub threads isFallback + per-locale cont
     expect(stub).toContain(
       'import { createChrome } from "@takazudo/zudo-doc/chrome";',
     );
-    expect(stub).toContain("const { renderDocPage } = createChrome(routeCtx);");
+    expect(stub).toContain(
+      'import { chromeBindings } from "virtual:zudo-doc-chrome-bindings";',
+    );
+    expect(stub).toContain(
+      "const { renderDocPage } = createChrome(routeCtx, chromeBindings);",
+    );
   });
 });
 
@@ -926,63 +931,68 @@ describe("scaffold — global.css", () => {
   });
 });
 
-describe("scaffold — the doc-route stub is patched (not duplicated) when docHistory is selected", () => {
-  it("statically imports DocHistory and threads it into createChrome", async () => {
-    await scaffold({
-      ...baseChoices,
-      projectName: "test-doc-history-stub",
-      features: ["docHistory"],
-    });
-    const stub = await fs.readFile(
-      projectPath("test-doc-history-stub", "pages/docs/[[...slug]].tsx"),
-      "utf-8",
-    );
-    expect(stub).toContain(
-      'import { DocHistory } from "@takazudo/zudo-doc/doc-history";',
-    );
-    expect(stub).toContain(
-      'import { defineChromeBindings } from "@takazudo/zudo-doc/chrome-bindings";',
-    );
-    expect(stub).toContain(
-      "createChrome(routeCtx, defineChromeBindings({ DocHistory }))",
-    );
-    // Only the DocHistory-specific widening cast is in scope here — the
-    // unrelated `routeContext as unknown as RouteContextPayload` cast earlier
-    // in the stub (base template, #2653) is a separate concern.
-    expect(stub).not.toContain("DocHistory as unknown as");
-  });
+describe("scaffold — every docHistory × i18n route stub threads chrome bindings", () => {
+  it.each([
+    { docHistory: false, i18n: false },
+    { docHistory: true, i18n: false },
+    { docHistory: false, i18n: true },
+    { docHistory: true, i18n: true },
+  ])(
+    "emits the exact merged binding shape for docHistory=$docHistory, i18n=$i18n",
+    async ({ docHistory, i18n }) => {
+      const projectName =
+        `test-bindings-dh-${docHistory ? "on" : "off"}` +
+        `-i18n-${i18n ? "on" : "off"}`;
+      const features: UserChoices["features"] = [
+        ...(docHistory ? ["docHistory"] : []),
+        ...(i18n ? ["i18n"] : []),
+      ];
+      await scaffold({ ...baseChoices, projectName, features });
 
-  it("also patches the i18n locale stub when both i18n and docHistory are selected", async () => {
-    await scaffold({
-      ...baseChoices,
-      projectName: "test-doc-history-i18n",
-      features: ["docHistory", "i18n"],
-    });
-    const stub = await fs.readFile(
-      projectPath(
-        "test-doc-history-i18n",
-        "pages/[locale]/docs/[[...slug]].tsx",
-      ),
-      "utf-8",
-    );
-    expect(stub).toContain(
-      'import { DocHistory } from "@takazudo/zudo-doc/doc-history";',
-    );
-  });
+      const stubPaths = [
+        "pages/docs/[[...slug]].tsx",
+        ...(i18n ? ["pages/[locale]/docs/[[...slug]].tsx"] : []),
+      ];
+      for (const stubPath of stubPaths) {
+        const stub = await fs.readFile(
+          projectPath(projectName, stubPath),
+          "utf-8",
+        );
+        expect(stub).toContain(
+          'import { chromeBindings } from "virtual:zudo-doc-chrome-bindings";',
+        );
 
-  it("leaves the stub unpatched when docHistory is off", async () => {
-    // The stub's own header comment explains the docHistory patch in prose
-    // (mentions "DocHistory" even when unpatched) — assert on the actual
-    // inserted import statement, not a bare substring match.
-    await scaffold(baseChoices);
-    const stub = await fs.readFile(
-      projectPath("test-doc", "pages/docs/[[...slug]].tsx"),
-      "utf-8",
-    );
-    expect(stub).not.toContain(
-      'import { DocHistory } from "@takazudo/zudo-doc/doc-history";',
-    );
-  });
+        const docHistoryImport =
+          'import { DocHistory } from "@takazudo/zudo-doc/doc-history";';
+        if (docHistory) {
+          // The real component stays statically reachable by zfb's island
+          // scanner, while the spread preserves every configured host slot.
+          expect(stub).toContain(docHistoryImport);
+          expect(stub).toContain(
+            'import { defineChromeBindings } from "@takazudo/zudo-doc/chrome-bindings";',
+          );
+          expect(stub).toContain(
+            `const { renderDocPage } = createChrome(routeCtx, {
+  ...chromeBindings,
+  ...defineChromeBindings({ DocHistory }),
+});`,
+          );
+          expect(stub).not.toContain("DocHistory as unknown as");
+        } else {
+          expect(stub).not.toContain(docHistoryImport);
+          expect(stub).toContain(
+            "const { renderDocPage } = createChrome(routeCtx, chromeBindings);",
+          );
+        }
+      }
+
+      expect(
+        await fs.pathExists(
+          projectPath(projectName, "pages/[locale]/docs/[[...slug]].tsx"),
+        ),
+      ).toBe(i18n);
+    },
+  );
 });
 
 describe("scaffold — bodyFootUtil auto-enables docHistory (#1795 behavior, re-targeted to zfb.config.ts)", () => {
@@ -1330,7 +1340,8 @@ describe("scaffold — settings-drift guard: generator-known fields must cover e
       port: "shell passthrough — dev/preview server port, not a scaffold prompt",
       adapter: "shell passthrough — deploy-target wiring, project-specific",
       bundle: "shell passthrough — raw esbuild bundler options",
-      chromeBindingsModule: "shell passthrough — host-callables wiring, hand-authored after scaffold",
+      chromeBindingsModule:
+        "shell passthrough — host-callables module path is hand-authored after scaffold; generated doc routes consume it automatically",
       designTokenPanelConfigModule: "shell passthrough — mirrors chromeBindingsModule's contract exactly (module-path wiring, hand-authored after scaffold)",
       // Fields with no CLI/prompt surface (yet) — hand-edit zfb.config.ts
       // after scaffold, or covered by a future sub-issue.

--- a/packages/create-zudo-doc/src/features/doc-history.ts
+++ b/packages/create-zudo-doc/src/features/doc-history.ts
@@ -15,14 +15,15 @@ import type { FeatureModule } from "../compose.js";
  *
  * What's left to wire: the self-contained doc-route stub(s)
  * (`pages/docs/[[...slug]].tsx`, and its i18n locale sibling when i18n is
- * also selected) call `createChrome(routeCtx)` with NO hostBindings — unlike
+ * also selected) always thread the host's `chromeBindings`. Unlike
  * `DesignTokenPanelBootstrap` (auto-defaulted at the chrome-derive seam,
  * #2658 gate-2 fix), `DocHistory`'s derive-level default is a deliberate
  * no-op stub (see `routes/_chrome.tsx`'s comment on why — its own island
  * needs the REAL host binding to hydrate). So when docHistory is selected,
  * this feature patches the stub(s) to statically import the real
- * `DocHistory` component and thread it through — the same #2480 chain
- * `routes/_chrome.tsx` uses for the package's own routes.
+ * `DocHistory` component and merge it over those bindings — preserving every
+ * configured host slot while maintaining the same #2480 scanner-reachability
+ * chain `routes/_chrome.tsx` uses for the package's own routes.
  */
 export const docHistoryFeature: FeatureModule = () => ({
   name: "docHistory",
@@ -50,8 +51,11 @@ ${importMarker}
 import { defineChromeBindings } from "@takazudo/zudo-doc/chrome-bindings";`,
       );
       content = content.replace(
-        `const { renderDocPage } = createChrome(routeCtx);`,
-        `const { renderDocPage } = createChrome(routeCtx, defineChromeBindings({ DocHistory }));`,
+        `const { renderDocPage } = createChrome(routeCtx, chromeBindings);`,
+        `const { renderDocPage } = createChrome(routeCtx, {
+  ...chromeBindings,
+  ...defineChromeBindings({ DocHistory }),
+});`,
       );
       await fs.writeFile(stubPath, content);
     }

--- a/packages/create-zudo-doc/templates/base/pages/docs/[[...slug]].tsx
+++ b/packages/create-zudo-doc/templates/base/pages/docs/[[...slug]].tsx
@@ -5,19 +5,23 @@
 // `zfb dev` (real pre-existing gap in zfb's dev-mode dynamic-route rendering,
 // distinct from the `/`-injection gap zfb#1227; empirically confirmed on
 // #2653). This stub reconstructs the doc route from scratch using ONLY the
-// three sanctioned package entrypoints — no `pages/lib`, no `@/config`:
+// sanctioned package entrypoints — no `pages/lib`, no `@/config`:
 //   1. the `virtual:zudo-doc-route-context` virtual module (serializable
 //      settings/translations/tagVocabulary/colorSchemes payload),
-//   2. `@takazudo/zudo-doc/route-context` (`createRouteContext`), and
-//   3. `@takazudo/zudo-doc/chrome` (`createChrome`).
+//   2. `@takazudo/zudo-doc/route-context` (`createRouteContext`),
+//   3. `@takazudo/zudo-doc/chrome` (`createChrome`), and
+//   4. `virtual:zudo-doc-chrome-bindings` (the host-callables channel).
+// The bindings import is unconditional: the routes plugin supplies an empty
+// object when `chromeBindingsModule` is unset, while configured projects get
+// their MDX/chrome bindings without editing this stub.
 // Makes `/docs/getting-started/` return 200 in BOTH `zfb dev` and `zfb build`
 // (see the "TM negative guard" case in route-injection-build.slow.test.ts for
 // the no-stub 404 proof this fixes).
 //
 // docHistory note: when the docHistory feature is selected, the generator
 // patches this file to statically import DocHistory from
-// "@takazudo/zudo-doc/doc-history" and pass it to createChrome's hostBindings
-// (second) argument via defineChromeBindings({ DocHistory }) —
+// "@takazudo/zudo-doc/doc-history" and merge it over chromeBindings in
+// createChrome's hostBindings (second) argument —
 // DocHistory's chrome-derive default is a no-op stub (unlike
 // DesignTokenPanelBootstrap, which the package auto-defaults), so without
 // that patch the doc-history button never hydrates on this route.
@@ -29,10 +33,11 @@ import {
   type RouteContextPayload,
 } from "@takazudo/zudo-doc/route-context";
 import { createChrome } from "@takazudo/zudo-doc/chrome";
+import { chromeBindings } from "virtual:zudo-doc-chrome-bindings";
 
 const ctx = routeContext as unknown as RouteContextPayload;
 const routeCtx = createRouteContext(ctx);
-const { renderDocPage } = createChrome(routeCtx);
+const { renderDocPage } = createChrome(routeCtx, chromeBindings);
 
 export const frontmatter = { title: "Docs" };
 

--- a/packages/create-zudo-doc/templates/features/i18n/files/pages/[locale]/docs/[[...slug]].tsx
+++ b/packages/create-zudo-doc/templates/features/i18n/files/pages/[locale]/docs/[[...slug]].tsx
@@ -2,8 +2,11 @@
 /** @jsxImportSource preact */
 // Locked manifest (#2653 Decision 4, i18n addendum): the locale-prefixed
 // counterpart of pages/docs/[[...slug]].tsx — required for the same reason
-// (injected DYNAMIC routes 404 in `zfb dev`). Self-contained: only the three
-// sanctioned package entrypoints — no `pages/lib`, no `@/config`. Mirrors
+// (injected DYNAMIC routes 404 in `zfb dev`). Self-contained: only the
+// sanctioned package entrypoints — no `pages/lib`, no `@/config`. The
+// `virtual:zudo-doc-chrome-bindings` import is unconditional, just like the
+// default-locale stub: the routes plugin supplies `{}` when no host module is
+// configured. Mirrors
 // the package's own `routes/locale-docs-slug.tsx` shape, rebuilt from the
 // route-context payload instead of the package-internal `_context.js`.
 //
@@ -28,10 +31,11 @@ import {
   type RouteContextPayload,
 } from "@takazudo/zudo-doc/route-context";
 import { createChrome } from "@takazudo/zudo-doc/chrome";
+import { chromeBindings } from "virtual:zudo-doc-chrome-bindings";
 
 const ctx = routeContext as unknown as RouteContextPayload;
 const routeCtx = createRouteContext(ctx);
-const { renderDocPage } = createChrome(routeCtx);
+const { renderDocPage } = createChrome(routeCtx, chromeBindings);
 
 export const frontmatter = { title: "Docs" };
 


### PR DESCRIPTION
Parent epic: #2773

Threads virtual chrome bindings through every generated scaffold route, preserves static DocHistory precedence, and proves all scaffold shapes remain synchronized.

Closes #2774

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786756601&installation_id=130359969&pr_number=2801&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2801&signature=32180768c33f7fce4748d1e035ffd2d69f4c8d39be796c508114f44810ad6b91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->