### PR TITLE
feat: add typed primary chrome replacement slots

### DIFF
--- a/.template-drift-allowlist
+++ b/.template-drift-allowlist
@@ -71,17 +71,16 @@ pages/index.tsx
 # Both are self-contained doc-route stubs (#2653 Decision 4; locked form
 # #2660) — REQUIRED because the injected DYNAMIC `/docs/[[...slug]]` route
 # 404s in `zfb dev` (see each file's own header comment for the full
-# rationale). The template's copies use only the three sanctioned package
-# entrypoints (virtual:zudo-doc-route-context, @takazudo/zudo-doc/route-context,
-# @takazudo/zudo-doc/routes/_chrome's createChrome) with no fourth argument —
-# `createChrome(routeCtx)`. The showcase's copies additionally import
-# `virtual:zudo-doc-chrome-bindings` and call `createChrome(routeCtx,
-# chromeBindings)`, threading the showcase's real host-bound slots (search,
-# doc history, frontmatter renderers, PresetGenerator, MDX overrides — see
-# src/chrome-bindings.tsx) through the `chromeBindingsModule` host-callables
-# channel (ADR "Host-callables channel", #2501), plus locale-specific extra
-# fallback-tracking props on the [locale] variant. A project that sets its own
-# `chromeBindingsModule` diverges from the template the same way — this is
-# the documented escape hatch, not drift.
+# rationale). The template's copies use only the sanctioned package
+# entrypoints (virtual:zudo-doc-route-context,
+# virtual:zudo-doc-chrome-bindings, @takazudo/zudo-doc/route-context, and
+# @takazudo/zudo-doc/chrome's createChrome). Both template stubs now thread
+# `chromeBindings` unconditionally, matching the showcase's host-callables
+# channel: projects without a `chromeBindingsModule` receive the plugin's `{}`
+# fallback, while configured projects reach their MDX/chrome slots without a
+# manual stub edit (#2774). The whole files remain allowlisted because the
+# showcase carries project-specific typed page props, much fuller rationale
+# comments, and locale-specific fallback-tracking shapes; those differences
+# are intentional and independent of the bindings channel now shared by both.
 pages/docs/[[...slug]].tsx
 pages/[locale]/docs/[[...slug]].tsx

--- a/packages/create-zudo-doc/src/__tests__/chrome-bindings-build.slow.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/chrome-bindings-build.slow.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Generated-project chrome-bindings regression test (#2774 / source #2716).
+ *
+ * A self-contained `pages/docs/[[...slug]].tsx` route shadows the package's
+ * injected dynamic route. Before #2774 that stub called `createChrome()` with
+ * no host bindings, so a valid `chromeBindingsModule` never reached document
+ * MDX: custom tags such as `<MyBadge />` failed SSR even though the package's
+ * injected route consumed the same virtual module correctly.
+ *
+ * Keep this in the slow tier. The acceptance signal is a real scaffolded
+ * project build whose generated doc-route stub is left untouched: we add only
+ * the documented config/module/content inputs, then assert the bound component
+ * appears in emitted HTML.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import fs from "fs-extra";
+import os from "node:os";
+import path from "node:path";
+import { scaffold } from "../scaffold.js";
+import type { UserChoices } from "../prompts.js";
+import {
+  runOrThrow,
+  installScaffoldedDeps,
+  overrideWithLocalZudoDoc,
+} from "./slow-build-helpers.js";
+
+const TEMP_PREFIX = "create-zudo-doc-chrome-bindings-build-";
+const PROJECT_NAME = "chrome-bindings-build-test";
+
+const choices: UserChoices = {
+  projectName: PROJECT_NAME,
+  defaultLang: "en",
+  colorSchemeMode: "single",
+  singleScheme: "Default Dark",
+  // Keeping docHistory on proves its statically imported island survives the
+  // host-binding merge at the same time as the virtual mdxExtras binding.
+  features: ["docHistory"],
+  packageManager: "pnpm",
+};
+
+let tempDir: string;
+let projectDir: string;
+let originalCwd: string;
+
+beforeAll(async () => {
+  originalCwd = process.cwd();
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), TEMP_PREFIX));
+  process.chdir(tempDir);
+
+  await scaffold(choices);
+  projectDir = path.join(tempDir, PROJECT_NAME);
+
+  const configPath = path.join(projectDir, "zfb.config.ts");
+  const config = await fs.readFile(configPath, "utf-8");
+  await fs.writeFile(
+    configPath,
+    config.replace(
+      /siteName: ([^,]+),/,
+      'siteName: $1,\n    chromeBindingsModule: "./src/chrome-bindings.tsx",',
+    ),
+  );
+
+  await fs.writeFile(
+    path.join(projectDir, "src", "chrome-bindings.tsx"),
+    `/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+import { defineChromeBindings } from "@takazudo/zudo-doc/chrome-bindings";
+
+function MyBadge() {
+  return <span data-my-badge="reachable">Bound badge</span>;
+}
+
+export const chromeBindings = defineChromeBindings({
+  mdxExtras: { MyBadge },
+});
+`,
+  );
+
+  const docPath = path.join(
+    projectDir,
+    "src",
+    "content",
+    "docs",
+    "getting-started",
+    "introduction.mdx",
+  );
+  await fs.appendFile(docPath, "\n\n<MyBadge />\n");
+
+  installScaffoldedDeps(projectDir);
+  overrideWithLocalZudoDoc(projectDir);
+  runOrThrow("pnpm build", projectDir, { SKIP_DOC_HISTORY: "1" });
+}, 5 * 60 * 1000);
+
+afterAll(async () => {
+  process.chdir(originalCwd);
+  if (tempDir && (await fs.pathExists(tempDir))) {
+    await fs.remove(tempDir);
+  }
+});
+
+describe("generated chromeBindingsModule reaches the self-contained doc route", () => {
+  it("renders an mdxExtras MyBadge binding without editing the route stub", async () => {
+    const html = await fs.readFile(
+      path.join(
+        projectDir,
+        "dist",
+        "docs",
+        "getting-started",
+        "introduction",
+        "index.html",
+      ),
+      "utf-8",
+    );
+    expect(html).toMatch(/data-my-badge=(?:"reachable"|reachable)/);
+    expect(html).toContain("Bound badge");
+    expect(html).toMatch(
+      /data-zfb-island-skip-ssr=(?:"DocHistory"|DocHistory)/,
+    );
+  });
+});

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -218,7 +218,12 @@ describe("scaffold — i18n locale doc stub threads isFallback + per-locale cont
     expect(stub).toContain(
       'import { createChrome } from "@takazudo/zudo-doc/chrome";',
     );
-    expect(stub).toContain("const { renderDocPage } = createChrome(routeCtx);");
+    expect(stub).toContain(
+      'import { chromeBindings } from "virtual:zudo-doc-chrome-bindings";',
+    );
+    expect(stub).toContain(
+      "const { renderDocPage } = createChrome(routeCtx, chromeBindings);",
+    );
   });
 });
 
@@ -926,63 +931,68 @@ describe("scaffold — global.css", () => {
   });
 });
 
-describe("scaffold — the doc-route stub is patched (not duplicated) when docHistory is selected", () => {
-  it("statically imports DocHistory and threads it into createChrome", async () => {
-    await scaffold({
-      ...baseChoices,
-      projectName: "test-doc-history-stub",
-      features: ["docHistory"],
-    });
-    const stub = await fs.readFile(
-      projectPath("test-doc-history-stub", "pages/docs/[[...slug]].tsx"),
-      "utf-8",
-    );
-    expect(stub).toContain(
-      'import { DocHistory } from "@takazudo/zudo-doc/doc-history";',
-    );
-    expect(stub).toContain(
-      'import { defineChromeBindings } from "@takazudo/zudo-doc/chrome-bindings";',
-    );
-    expect(stub).toContain(
-      "createChrome(routeCtx, defineChromeBindings({ DocHistory }))",
-    );
-    // Only the DocHistory-specific widening cast is in scope here — the
-    // unrelated `routeContext as unknown as RouteContextPayload` cast earlier
-    // in the stub (base template, #2653) is a separate concern.
-    expect(stub).not.toContain("DocHistory as unknown as");
-  });
+describe("scaffold — every docHistory × i18n route stub threads chrome bindings", () => {
+  it.each([
+    { docHistory: false, i18n: false },
+    { docHistory: true, i18n: false },
+    { docHistory: false, i18n: true },
+    { docHistory: true, i18n: true },
+  ])(
+    "emits the exact merged binding shape for docHistory=$docHistory, i18n=$i18n",
+    async ({ docHistory, i18n }) => {
+      const projectName =
+        `test-bindings-dh-${docHistory ? "on" : "off"}` +
+        `-i18n-${i18n ? "on" : "off"}`;
+      const features: UserChoices["features"] = [
+        ...(docHistory ? ["docHistory"] : []),
+        ...(i18n ? ["i18n"] : []),
+      ];
+      await scaffold({ ...baseChoices, projectName, features });
 
-  it("also patches the i18n locale stub when both i18n and docHistory are selected", async () => {
-    await scaffold({
-      ...baseChoices,
-      projectName: "test-doc-history-i18n",
-      features: ["docHistory", "i18n"],
-    });
-    const stub = await fs.readFile(
-      projectPath(
-        "test-doc-history-i18n",
-        "pages/[locale]/docs/[[...slug]].tsx",
-      ),
-      "utf-8",
-    );
-    expect(stub).toContain(
-      'import { DocHistory } from "@takazudo/zudo-doc/doc-history";',
-    );
-  });
+      const stubPaths = [
+        "pages/docs/[[...slug]].tsx",
+        ...(i18n ? ["pages/[locale]/docs/[[...slug]].tsx"] : []),
+      ];
+      for (const stubPath of stubPaths) {
+        const stub = await fs.readFile(
+          projectPath(projectName, stubPath),
+          "utf-8",
+        );
+        expect(stub).toContain(
+          'import { chromeBindings } from "virtual:zudo-doc-chrome-bindings";',
+        );
 
-  it("leaves the stub unpatched when docHistory is off", async () => {
-    // The stub's own header comment explains the docHistory patch in prose
-    // (mentions "DocHistory" even when unpatched) — assert on the actual
-    // inserted import statement, not a bare substring match.
-    await scaffold(baseChoices);
-    const stub = await fs.readFile(
-      projectPath("test-doc", "pages/docs/[[...slug]].tsx"),
-      "utf-8",
-    );
-    expect(stub).not.toContain(
-      'import { DocHistory } from "@takazudo/zudo-doc/doc-history";',
-    );
-  });
+        const docHistoryImport =
+          'import { DocHistory } from "@takazudo/zudo-doc/doc-history";';
+        if (docHistory) {
+          // The real component stays statically reachable by zfb's island
+          // scanner, while the spread preserves every configured host slot.
+          expect(stub).toContain(docHistoryImport);
+          expect(stub).toContain(
+            'import { defineChromeBindings } from "@takazudo/zudo-doc/chrome-bindings";',
+          );
+          expect(stub).toContain(
+            `const { renderDocPage } = createChrome(routeCtx, {
+  ...chromeBindings,
+  ...defineChromeBindings({ DocHistory }),
+});`,
+          );
+          expect(stub).not.toContain("DocHistory as unknown as");
+        } else {
+          expect(stub).not.toContain(docHistoryImport);
+          expect(stub).toContain(
+            "const { renderDocPage } = createChrome(routeCtx, chromeBindings);",
+          );
+        }
+      }
+
+      expect(
+        await fs.pathExists(
+          projectPath(projectName, "pages/[locale]/docs/[[...slug]].tsx"),
+        ),
+      ).toBe(i18n);
+    },
+  );
 });
 
 describe("scaffold — bodyFootUtil auto-enables docHistory (#1795 behavior, re-targeted to zfb.config.ts)", () => {
@@ -1330,7 +1340,8 @@ describe("scaffold — settings-drift guard: generator-known fields must cover e
       port: "shell passthrough — dev/preview server port, not a scaffold prompt",
       adapter: "shell passthrough — deploy-target wiring, project-specific",
       bundle: "shell passthrough — raw esbuild bundler options",
-      chromeBindingsModule: "shell passthrough — host-callables wiring, hand-authored after scaffold",
+      chromeBindingsModule:
+        "shell passthrough — host-callables module path is hand-authored after scaffold; generated doc routes consume it automatically",
       designTokenPanelConfigModule: "shell passthrough — mirrors chromeBindingsModule's contract exactly (module-path wiring, hand-authored after scaffold)",
       // Fields with no CLI/prompt surface (yet) — hand-edit zfb.config.ts
       // after scaffold, or covered by a future sub-issue.

--- a/packages/create-zudo-doc/src/features/doc-history.ts
+++ b/packages/create-zudo-doc/src/features/doc-history.ts
@@ -15,14 +15,15 @@ import type { FeatureModule } from "../compose.js";
  *
  * What's left to wire: the self-contained doc-route stub(s)
  * (`pages/docs/[[...slug]].tsx`, and its i18n locale sibling when i18n is
- * also selected) call `createChrome(routeCtx)` with NO hostBindings — unlike
+ * also selected) always thread the host's `chromeBindings`. Unlike
  * `DesignTokenPanelBootstrap` (auto-defaulted at the chrome-derive seam,
  * #2658 gate-2 fix), `DocHistory`'s derive-level default is a deliberate
  * no-op stub (see `routes/_chrome.tsx`'s comment on why — its own island
  * needs the REAL host binding to hydrate). So when docHistory is selected,
  * this feature patches the stub(s) to statically import the real
- * `DocHistory` component and thread it through — the same #2480 chain
- * `routes/_chrome.tsx` uses for the package's own routes.
+ * `DocHistory` component and merge it over those bindings — preserving every
+ * configured host slot while maintaining the same #2480 scanner-reachability
+ * chain `routes/_chrome.tsx` uses for the package's own routes.
  */
 export const docHistoryFeature: FeatureModule = () => ({
   name: "docHistory",
@@ -50,8 +51,11 @@ ${importMarker}
 import { defineChromeBindings } from "@takazudo/zudo-doc/chrome-bindings";`,
       );
       content = content.replace(
-        `const { renderDocPage } = createChrome(routeCtx);`,
-        `const { renderDocPage } = createChrome(routeCtx, defineChromeBindings({ DocHistory }));`,
+        `const { renderDocPage } = createChrome(routeCtx, chromeBindings);`,
+        `const { renderDocPage } = createChrome(routeCtx, {
+  ...chromeBindings,
+  ...defineChromeBindings({ DocHistory }),
+});`,
       );
       await fs.writeFile(stubPath, content);
     }

--- a/packages/create-zudo-doc/templates/base/pages/docs/[[...slug]].tsx
+++ b/packages/create-zudo-doc/templates/base/pages/docs/[[...slug]].tsx
@@ -5,19 +5,23 @@
 // `zfb dev` (real pre-existing gap in zfb's dev-mode dynamic-route rendering,
 // distinct from the `/`-injection gap zfb#1227; empirically confirmed on
 // #2653). This stub reconstructs the doc route from scratch using ONLY the
-// three sanctioned package entrypoints — no `pages/lib`, no `@/config`:
+// sanctioned package entrypoints — no `pages/lib`, no `@/config`:
 //   1. the `virtual:zudo-doc-route-context` virtual module (serializable
 //      settings/translations/tagVocabulary/colorSchemes payload),
-//   2. `@takazudo/zudo-doc/route-context` (`createRouteContext`), and
-//   3. `@takazudo/zudo-doc/chrome` (`createChrome`).
+//   2. `@takazudo/zudo-doc/route-context` (`createRouteContext`),
+//   3. `@takazudo/zudo-doc/chrome` (`createChrome`), and
+//   4. `virtual:zudo-doc-chrome-bindings` (the host-callables channel).
+// The bindings import is unconditional: the routes plugin supplies an empty
+// object when `chromeBindingsModule` is unset, while configured projects get
+// their MDX/chrome bindings without editing this stub.
 // Makes `/docs/getting-started/` return 200 in BOTH `zfb dev` and `zfb build`
 // (see the "TM negative guard" case in route-injection-build.slow.test.ts for
 // the no-stub 404 proof this fixes).
 //
 // docHistory note: when the docHistory feature is selected, the generator
 // patches this file to statically import DocHistory from
-// "@takazudo/zudo-doc/doc-history" and pass it to createChrome's hostBindings
-// (second) argument via defineChromeBindings({ DocHistory }) —
+// "@takazudo/zudo-doc/doc-history" and merge it over chromeBindings in
+// createChrome's hostBindings (second) argument —
 // DocHistory's chrome-derive default is a no-op stub (unlike
 // DesignTokenPanelBootstrap, which the package auto-defaults), so without
 // that patch the doc-history button never hydrates on this route.
@@ -29,10 +33,11 @@ import {
   type RouteContextPayload,
 } from "@takazudo/zudo-doc/route-context";
 import { createChrome } from "@takazudo/zudo-doc/chrome";
+import { chromeBindings } from "virtual:zudo-doc-chrome-bindings";
 
 const ctx = routeContext as unknown as RouteContextPayload;
 const routeCtx = createRouteContext(ctx);
-const { renderDocPage } = createChrome(routeCtx);
+const { renderDocPage } = createChrome(routeCtx, chromeBindings);
 
 export const frontmatter = { title: "Docs" };
 

--- a/packages/create-zudo-doc/templates/features/i18n/files/pages/[locale]/docs/[[...slug]].tsx
+++ b/packages/create-zudo-doc/templates/features/i18n/files/pages/[locale]/docs/[[...slug]].tsx
@@ -2,8 +2,11 @@
 /** @jsxImportSource preact */
 // Locked manifest (#2653 Decision 4, i18n addendum): the locale-prefixed
 // counterpart of pages/docs/[[...slug]].tsx — required for the same reason
-// (injected DYNAMIC routes 404 in `zfb dev`). Self-contained: only the three
-// sanctioned package entrypoints — no `pages/lib`, no `@/config`. Mirrors
+// (injected DYNAMIC routes 404 in `zfb dev`). Self-contained: only the
+// sanctioned package entrypoints — no `pages/lib`, no `@/config`. The
+// `virtual:zudo-doc-chrome-bindings` import is unconditional, just like the
+// default-locale stub: the routes plugin supplies `{}` when no host module is
+// configured. Mirrors
 // the package's own `routes/locale-docs-slug.tsx` shape, rebuilt from the
 // route-context payload instead of the package-internal `_context.js`.
 //
@@ -28,10 +31,11 @@ import {
   type RouteContextPayload,
 } from "@takazudo/zudo-doc/route-context";
 import { createChrome } from "@takazudo/zudo-doc/chrome";
+import { chromeBindings } from "virtual:zudo-doc-chrome-bindings";
 
 const ctx = routeContext as unknown as RouteContextPayload;
 const routeCtx = createRouteContext(ctx);
-const { renderDocPage } = createChrome(routeCtx);
+const { renderDocPage } = createChrome(routeCtx, chromeBindings);
 
 export const frontmatter = { title: "Docs" };
 

--- a/packages/zudo-doc/API.md
+++ b/packages/zudo-doc/API.md
@@ -31,7 +31,7 @@ The full `package.json#exports` keyset is the contract. Any addition or removal 
 | `./preset` | `zudoDocPreset()` — zfb config preset factory (internal fragment builder; `./config` is the documented API) |
 | `./settings` | `Settings` / `PresetSettings` type definitions |
 | `./factory-context` | `FactoryContext` / `ChromeContext` / `RouteContext` / `ChromeHostBindings` — the full shared type surface for package factories and chrome wiring (types only, node-free) |
-| `./chrome-bindings` | `defineChromeBindings(input)` — compile-time-checked widening adapter that builds a host's `ChromeHostBindings` object from the narrower, call-site-precise `ChromeBindingsInput` type; use it instead of a raw object literal or an `as`/`as unknown as` cast on `ChromeHostBindings` (drift detection, #2674) |
+| `./chrome-bindings` | `defineChromeBindings(input)` — compile-time-checked widening adapter that builds a host's `ChromeHostBindings` object from the narrower, call-site-precise `ChromeBindingsInput` type; exports exact props for every component slot, including `HeaderSlotProps`, `FooterSlotProps`, `SidebarSlotProps`, `TocSlotProps`, `BreadcrumbSlotProps`, and `DocPagerSlotProps`; use it instead of a raw object literal or an `as`/`as unknown as` cast on `ChromeHostBindings` (drift detection, #2674) |
 | `./route-context` | `createRouteContext(payload, options?)` — reconstructs the full `RouteContext` callable surface from the serializable `RouteContextPayload`; also re-exports `RouteContext` / `RouteContextPayload` / `TagInfo` / `ContentBridge` types |
 | `./chrome` | `createChrome(context, hostBindings?)` — assembles a `ChromeContext` from a `RouteContext` + `ChromeHostBindings` (stub defaults) and wires all page-chrome factories; returns the `Chrome` surface |
 | `./eject` | `EJECTABLE` map + `eject()` function + `ZudoDocJson` type — ejectable component registry for the `zudo-doc eject` CLI |
@@ -47,6 +47,12 @@ behaviour byte-for-byte.
 
 | Slot | Default when absent |
 |---|---|
+| `Header` | The package `HeaderWithDefaults`; receives `HeaderSlotProps` |
+| `Footer` | The package `FooterWithDefaults`; receives `FooterSlotProps` |
+| `Sidebar` | The package `SidebarWithDefaults`; receives `SidebarSlotProps` |
+| `Toc` | The package desktop `Toc` island component; receives `TocSlotProps` |
+| `Breadcrumb` | The package `Breadcrumb`; receives `BreadcrumbSlotProps` |
+| `DocPager` | The package `DocPager`; receives `DocPagerSlotProps` |
 | `SearchWidget` | The package `SearchWidget` bound to the site base |
 | `docHistoryMeta` | `{}` (no Created/Updated block) |
 | `sidebarsConfig` | `{}` (auto-generated tree only) |

--- a/packages/zudo-doc/src/__tests__/chrome-bindings.test.ts
+++ b/packages/zudo-doc/src/__tests__/chrome-bindings.test.ts
@@ -25,8 +25,14 @@ const concreteSidebars: ShowcaseSidebars = { "!": [], guides: [] };
  * caller-side cast. If any stops compiling, the adapter has over-tightened.
  */
 export function _positiveCompileAssertions(): void {
-  // All 13 slots at once, with narrow/concrete real-world values.
+  // All slots at once, with narrow/concrete real-world values.
   defineChromeBindings({
+    Header: (props) => props.lang,
+    Footer: (props) => props.lang,
+    Sidebar: (props) => props.currentSlug,
+    Toc: (props) => props.headings.length,
+    Breadcrumb: (props) => props.items.length,
+    DocPager: (props) => props.locale,
     SearchWidget: (props) => props.searchLabel,
     BodyEndIslands: (props) => props.basePath,
     DocHistory: (props: { slug: string }) => props.slug, // reads a SUBSET of the passed props
@@ -56,6 +62,17 @@ export function _positiveCompileAssertions(): void {
 
   // A concrete typed sidebars object in `sidebarsConfig`.
   defineChromeBindings({ sidebarsConfig: concreteSidebars });
+
+  // Primary replacements may require every prop that the real call site
+  // always supplies, while reading only a subset is also safe.
+  defineChromeBindings({
+    Header: ({ lang }: { lang: string }) => lang,
+    Footer: ({ lang }: { lang: string }) => lang,
+    Sidebar: ({ currentSlug }: { currentSlug: string }) => currentSlug,
+    Toc: ({ title }: { title: string }) => title,
+    Breadcrumb: ({ items }: { items: unknown[] }) => items.length,
+    DocPager: ({ locale }: { locale: string }) => locale,
+  });
 
   // A real renderer in `frontmatterRenderers` (typed by its call-side contract),
   // and a loose `Record<string, unknown>` in `mdxExtras` (legitimately loose —
@@ -107,6 +124,36 @@ export function _negativeCompileAssertions(): void {
       // @ts-expect-error renderer requires `extra`, which the chrome never passes
       foo: (props: { value: unknown; extra: string }) => props.extra,
     },
+  });
+
+  // (6) each primary component rejects a required prop its call site never
+  // supplies. These guard the exact contracts independently so widening one
+  // slot cannot silently weaken the rest.
+  defineChromeBindings({
+    // @ts-expect-error Header never supplies `accountId`
+    Header: (props: { lang: string; accountId: string }) => props.accountId,
+  });
+  defineChromeBindings({
+    // @ts-expect-error Footer never supplies `legalNotice`
+    Footer: (props: { lang: string; legalNotice: string }) => props.legalNotice,
+  });
+  defineChromeBindings({
+    // @ts-expect-error Sidebar never supplies `expandedDepth`
+    Sidebar: (props: { currentSlug: string; expandedDepth: number }) =>
+      props.expandedDepth,
+  });
+  defineChromeBindings({
+    // @ts-expect-error Toc never supplies `activeSlug`
+    Toc: (props: { headings: unknown[]; title: string; activeSlug: string }) =>
+      props.activeSlug,
+  });
+  defineChromeBindings({
+    // @ts-expect-error Breadcrumb never supplies `homeLabel`
+    Breadcrumb: (props: { items: unknown[]; homeLabel: string }) => props.homeLabel,
+  });
+  defineChromeBindings({
+    // @ts-expect-error DocPager never supplies `pageCount`
+    DocPager: (props: { locale: string; pageCount: number }) => props.pageCount,
   });
 }
 

--- a/packages/zudo-doc/src/chrome-bindings.ts
+++ b/packages/zudo-doc/src/chrome-bindings.ts
@@ -33,6 +33,10 @@
 // `@takazudo/zudo-doc/chrome-bindings` (NOT folded into `./chrome`, which would
 // drag the whole `createChrome` tree into hosts that only want the helper).
 
+import type { ComponentChildren } from "preact";
+import type { BreadcrumbItem } from "./breadcrumb/index.js";
+import type { DocPageNavNode } from "./doc-page-shell/index.js";
+import type { HeadingItem } from "./toc/index.js";
 import type { ChromeHostBindings } from "./factory-context/index.js";
 
 // ===========================================================================
@@ -119,10 +123,62 @@ export interface FrontmatterRendererSlotProps {
   locale?: string;
 }
 
+/**
+ * Props supplied at every package `Header` replacement call site. `lang` is
+ * always present; the remaining fields are route-specific.
+ */
+export interface HeaderSlotProps {
+  lang: string;
+  currentPath?: string;
+  currentVersion?: string;
+  currentSlug?: string;
+  navSection?: string;
+}
+
+/** Props supplied at every package `Footer` replacement call site. */
+export interface FooterSlotProps {
+  lang: string;
+}
+
+/**
+ * Props supplied to the doc-route `Sidebar` replacement. Properties whose
+ * values may be absent remain present with `undefined`, matching the real JSX
+ * call site.
+ */
+export interface SidebarSlotProps {
+  currentSlug: string;
+  lang: string;
+  navSection: string | undefined;
+  currentVersion: string | undefined;
+  currentPath: string;
+}
+
+/** Props supplied to the desktop `Toc` replacement. */
+export interface TocSlotProps {
+  headings: readonly HeadingItem[];
+  title: string;
+}
+
+/**
+ * Props supplied to `Breadcrumb` replacements. All package call sites provide
+ * pre-built items; doc routes additionally provide the optional right slot.
+ */
+export interface BreadcrumbSlotProps {
+  items: BreadcrumbItem[];
+  rightSlot?: ComponentChildren;
+}
+
+/** Props supplied to the doc-route `DocPager` replacement. */
+export interface DocPagerSlotProps {
+  prev: DocPageNavNode | null;
+  next: DocPageNavNode | null;
+  locale: string;
+}
+
 // ===========================================================================
 // ChromeBindingsInput — the compile-time-checked input surface.
 //
-// Every one of the 13 `ChromeHostBindings` slots appears here, optional, typed
+// Every `ChromeHostBindings` slot appears here, optional, typed
 // to its call-side contract above. Component slots are `(props: Expected) =>
 // unknown` (accept the chrome's props, return anything renderable). Function
 // slots carry their real param + return contract. Data/record slots use the
@@ -140,6 +196,18 @@ export interface FrontmatterRendererSlotProps {
  * module header for the drift-detection rationale.
  */
 export interface ChromeBindingsInput {
+  /** Primary header replacement — see {@link HeaderSlotProps}. */
+  Header?: (props: HeaderSlotProps) => unknown;
+  /** Primary footer replacement — see {@link FooterSlotProps}. */
+  Footer?: (props: FooterSlotProps) => unknown;
+  /** Primary doc-sidebar replacement — see {@link SidebarSlotProps}. */
+  Sidebar?: (props: SidebarSlotProps) => unknown;
+  /** Primary desktop TOC replacement — see {@link TocSlotProps}. */
+  Toc?: (props: TocSlotProps) => unknown;
+  /** Primary breadcrumb replacement — see {@link BreadcrumbSlotProps}. */
+  Breadcrumb?: (props: BreadcrumbSlotProps) => unknown;
+  /** Primary previous/next pager replacement — see {@link DocPagerSlotProps}. */
+  DocPager?: (props: DocPagerSlotProps) => unknown;
   /** Header search widget — see {@link SearchWidgetSlotProps}. */
   SearchWidget?: (props: SearchWidgetSlotProps) => unknown;
   /** Body-end bootstrap islands — see {@link BodyEndIslandsSlotProps}. */

--- a/packages/zudo-doc/src/chrome/__tests__/primary-slots.test.tsx
+++ b/packages/zudo-doc/src/chrome/__tests__/primary-slots.test.tsx
@@ -1,0 +1,206 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { describe, expect, it } from "vitest";
+import { render } from "preact-render-to-string";
+import type { ComponentChildren } from "preact";
+import { defineChromeBindings } from "../../chrome-bindings.js";
+import type {
+  BreadcrumbSlotProps,
+  DocPagerSlotProps,
+  FooterSlotProps,
+  HeaderSlotProps,
+  SidebarSlotProps,
+  TocSlotProps,
+} from "../../chrome-bindings.js";
+import { createDocPageShell } from "../../doc-page-shell/index.js";
+import type { DocPageShellProps } from "../../doc-page-shell/index.js";
+import { createChrome } from "../index.js";
+import type { ChromeContext, RouteContext } from "../../factory-context/index.js";
+import { makeFakeChromeContext } from "../../__tests__/fixtures/fake-chrome-context.js";
+
+function shellProps(): DocPageShellProps {
+  return {
+    kind: "entry",
+    locale: "en",
+    slug: "guides/custom-chrome",
+    title: "Custom chrome",
+    description: "Slot placement proof",
+    breadcrumbs: [
+      { label: "Docs", href: "/docs" },
+      { label: "Custom chrome" },
+    ],
+    prev: {
+      slug: "guides/previous",
+      label: "Previous",
+      href: "/docs/guides/previous",
+      hasPage: true,
+      children: [],
+    },
+    next: null,
+    headings: [{ depth: 2, slug: "typed-slots", text: "Typed slots" }],
+    navSection: "guides",
+    sidebarPersistKey: "sidebar-en-guides",
+    currentPath: "/docs/guides/custom-chrome",
+    currentVersion: undefined,
+    versionSwitcher: <span data-version-switcher>latest</span>,
+    contentHeaderSlot: <h1 data-content-header>Custom chrome</h1>,
+    contentSlot: <div data-content>Body</div>,
+    docHistorySlot: <div data-history>History</div>,
+  };
+}
+
+describe("primary chrome replacement slots", () => {
+  it("renders all six replacements in their package chrome locations with exact props", () => {
+    const received: {
+      Header?: HeaderSlotProps;
+      Footer?: FooterSlotProps;
+      Sidebar?: SidebarSlotProps;
+      Toc?: TocSlotProps;
+      Breadcrumb?: BreadcrumbSlotProps;
+      DocPager?: DocPagerSlotProps;
+    } = {};
+
+    const hostBindings = defineChromeBindings({
+      Header: (props) => {
+        received.Header = props;
+        return <header data-slot="header" />;
+      },
+      Footer: (props) => {
+        received.Footer = props;
+        return <footer data-slot="footer" />;
+      },
+      Sidebar: (props) => {
+        received.Sidebar = props;
+        return <div data-slot="sidebar" />;
+      },
+      Toc: (props) => {
+        received.Toc = props;
+        return <nav data-slot="toc" />;
+      },
+      Breadcrumb: (props) => {
+        received.Breadcrumb = props;
+        return <nav data-slot="breadcrumb">{props.rightSlot as ComponentChildren}</nav>;
+      },
+      DocPager: (props) => {
+        received.DocPager = props;
+        return <nav data-slot="doc-pager" />;
+      },
+    });
+    const ctx = makeFakeChromeContext({
+      overrides: { hostBindings } as Partial<ChromeContext>,
+    });
+    const DocPageShell = createDocPageShell(ctx);
+    const html = render(<DocPageShell {...shellProps()} />);
+
+    const markers = [
+      'data-slot="header"',
+      'data-slot="sidebar"',
+      'data-slot="breadcrumb"',
+      "data-content",
+      'data-slot="doc-pager"',
+      "data-history",
+      'data-slot="toc"',
+      'data-slot="footer"',
+    ];
+    const positions = markers.map((marker) => html.indexOf(marker));
+    expect(positions.every((position) => position >= 0)).toBe(true);
+    expect(positions).toEqual([...positions].sort((a, b) => a - b));
+
+    expect(received.Header).toEqual({
+      lang: "en",
+      currentSlug: "guides/custom-chrome",
+      navSection: "guides",
+      currentVersion: undefined,
+      currentPath: "/docs/guides/custom-chrome",
+    });
+    expect(received.Footer).toEqual({ lang: "en" });
+    expect(received.Sidebar).toEqual({
+      currentSlug: "guides/custom-chrome",
+      lang: "en",
+      navSection: "guides",
+      currentVersion: undefined,
+      currentPath: "/docs/guides/custom-chrome",
+    });
+    expect(received.Toc).toEqual({
+      headings: [{ depth: 2, slug: "typed-slots", text: "Typed slots" }],
+      title: "On this page",
+    });
+    expect(received.Breadcrumb?.items).toEqual(shellProps().breadcrumbs);
+    expect(received.Breadcrumb?.rightSlot).toBeTruthy();
+    expect(received.DocPager).toEqual({
+      prev: shellProps().prev,
+      next: null,
+      locale: "en",
+    });
+  });
+
+  it("preserves package defaults for omitted slots in a partial binding object", () => {
+    const hostBindings = defineChromeBindings({
+      Header: ({ lang }) => <header data-slot="header-only">{lang}</header>,
+    });
+    const ctx = makeFakeChromeContext({
+      overrides: { hostBindings } as Partial<ChromeContext>,
+    });
+    const DocPageShell = createDocPageShell(ctx);
+    const html = render(<DocPageShell {...shellProps()} />);
+
+    expect(html).toContain('data-slot="header-only"');
+    expect(html).toContain('data-zfb-island="SidebarTree"');
+    expect(html).toContain('aria-label="Breadcrumb"');
+    expect(html).toContain('data-zfb-island="Toc"');
+    expect(html).toContain('class="mt-vsp-2xl grid grid-cols-2 gap-hsp-xl"');
+    expect(html).toContain("<footer");
+    expect(html).not.toContain('data-slot="footer"');
+  });
+
+  it("carries the same binding object through createChrome's package-route seam", () => {
+    const hostBindings = defineChromeBindings({
+      Header: () => <header data-route-slot="header" />,
+      Footer: () => <footer data-route-slot="footer" />,
+      Sidebar: () => <div data-route-slot="sidebar" />,
+      Toc: () => <nav data-route-slot="toc" />,
+      Breadcrumb: () => <nav data-route-slot="breadcrumb" />,
+      DocPager: () => <nav data-route-slot="doc-pager" />,
+    });
+    const fullContext = makeFakeChromeContext({
+      overrides: {
+        getNavSectionForSlug: () => "guides",
+      } as Partial<ChromeContext>,
+    });
+    const { components: _components, hostBindings: _defaults, ...routeFields } =
+      fullContext;
+    const chrome = createChrome(routeFields as RouteContext, hostBindings);
+    const vnode = chrome.renderDocPage(
+      {
+        kind: "entry",
+        entry: {
+          slug: "guides/custom-chrome",
+          id: "guides/custom-chrome",
+          collection: "docs",
+          data: { title: "Custom chrome" },
+          module_specifier: "guides/custom-chrome.mdx",
+          Content: () => <div data-route-content>Body</div>,
+        },
+        breadcrumbs: [{ label: "Custom chrome" }],
+        prev: null,
+        next: null,
+        headings: [{ depth: 2, slug: "typed-slots", text: "Typed slots" }],
+      } as unknown as Parameters<typeof chrome.renderDocPage>[0],
+      { locale: "en" },
+    );
+    const html = render(vnode);
+
+    for (const slot of [
+      "header",
+      "footer",
+      "sidebar",
+      "toc",
+      "breadcrumb",
+      "doc-pager",
+    ]) {
+      expect(html).toContain(`data-route-slot="${slot}"`);
+    }
+    expect(html).toContain("data-route-content");
+  });
+});

--- a/packages/zudo-doc/src/chrome/index.tsx
+++ b/packages/zudo-doc/src/chrome/index.tsx
@@ -31,9 +31,6 @@ import type {
 import type { Settings } from "../settings.js";
 
 import { createHeadWithDefaults } from "../head-with-defaults/index.js";
-import { createHeaderWithDefaults } from "../header-with-defaults/index.js";
-import { createFooterWithDefaults } from "../footer-with-defaults/index.js";
-import { createSidebarWithDefaults } from "../sidebar-with-defaults/index.js";
 import { createRenderDocPage } from "../doc-page-renderer/index.js";
 import { createVersionsPageView } from "../versions-page/index.js";
 import { createTagPages } from "../tag-pages/index.js";
@@ -43,6 +40,7 @@ import {
   deriveBodyEndIslands,
   deriveMdxComponents,
 } from "./derive.js";
+import { derivePrimaryChromeSlots } from "./primary-slots.js";
 
 /**
  * Build the wired page-chrome factories from a reconstructed route context plus
@@ -61,9 +59,11 @@ export function createChrome<S extends Settings = Settings>(
 
   const composeMetaTitle = deriveComposeMetaTitle(ctx);
   const HeadWithDefaults = createHeadWithDefaults(ctx);
-  const HeaderWithDefaults = createHeaderWithDefaults(ctx);
-  const FooterWithDefaults = createFooterWithDefaults(ctx);
-  const SidebarWithDefaults = createSidebarWithDefaults(ctx);
+  const {
+    Header: HeaderWithDefaults,
+    Footer: FooterWithDefaults,
+    Sidebar: SidebarWithDefaults,
+  } = derivePrimaryChromeSlots(ctx);
   const renderDocPage = createRenderDocPage(ctx);
   const VersionsPageView = createVersionsPageView(ctx);
   const { collectTagMapForLocale, TagDetailPageView, TagsIndexPageView } =

--- a/packages/zudo-doc/src/chrome/primary-slots.tsx
+++ b/packages/zudo-doc/src/chrome/primary-slots.tsx
@@ -1,0 +1,87 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+// Primary chrome replacement seam (#2775).
+//
+// Package-owned routes, self-contained scaffold routes, and the shared page
+// factories all arrive here with the same ChromeContext. This is the only
+// place that widens the structural ChromeHostBindings component values back to
+// their exact call-site contracts. Every absent slot keeps its statically
+// imported package implementation, preserving both default output and island
+// scanner reachability.
+
+import type { ComponentChildren } from "preact";
+import type { ChromeContext, FactoryComponent } from "../factory-context/index.js";
+import type {
+  BreadcrumbSlotProps,
+  DocPagerSlotProps,
+  FooterSlotProps,
+  HeaderSlotProps,
+  SidebarSlotProps,
+  TocSlotProps,
+} from "../chrome-bindings.js";
+import type { Settings } from "../settings.js";
+
+import { createHeaderWithDefaults } from "../header-with-defaults/index.js";
+import { createFooterWithDefaults } from "../footer-with-defaults/index.js";
+import { createSidebarWithDefaults } from "../sidebar-with-defaults/index.js";
+import { Toc } from "../toc/index.js";
+import { Breadcrumb } from "../breadcrumb/index.js";
+import { createDocPager } from "../doc-pager/index.js";
+
+type PrimarySlot<P> = (props: P) => ComponentChildren;
+
+/**
+ * Recover one exact call-site component type from the deliberately wide
+ * `FactoryComponent` storage boundary. Hosts built with `defineChromeBindings`
+ * have already proved this assignment safe; keeping the cast here prevents
+ * route factories from inventing their own override logic.
+ */
+function resolvePrimarySlot<P>(
+  replacement: FactoryComponent | undefined,
+  createPackageDefault: () => PrimarySlot<P>,
+): PrimarySlot<P> {
+  return replacement
+    ? (replacement as unknown as PrimarySlot<P>)
+    : createPackageDefault();
+}
+
+/**
+ * Resolve all six primary chrome components through one binding object.
+ * Accessors keep package defaults lazy: a home view that only reads Header and
+ * Footer does not construct the doc-only Sidebar or DocPager factories.
+ */
+export function derivePrimaryChromeSlots<S extends Settings = Settings>(
+  ctx: ChromeContext<S>,
+) {
+  return {
+    get Header() {
+      return resolvePrimarySlot<HeaderSlotProps>(ctx.hostBindings.Header, () =>
+        createHeaderWithDefaults(ctx),
+      );
+    },
+    get Footer() {
+      return resolvePrimarySlot<FooterSlotProps>(ctx.hostBindings.Footer, () =>
+        createFooterWithDefaults(ctx),
+      );
+    },
+    get Sidebar() {
+      return resolvePrimarySlot<SidebarSlotProps>(ctx.hostBindings.Sidebar, () =>
+        createSidebarWithDefaults(ctx),
+      );
+    },
+    get Toc() {
+      return resolvePrimarySlot<TocSlotProps>(ctx.hostBindings.Toc, () => Toc);
+    },
+    get Breadcrumb() {
+      return resolvePrimarySlot<BreadcrumbSlotProps>(
+        ctx.hostBindings.Breadcrumb,
+        () => Breadcrumb,
+      );
+    },
+    get DocPager() {
+      return resolvePrimarySlot<DocPagerSlotProps>(ctx.hostBindings.DocPager, () =>
+        createDocPager(ctx),
+      );
+    },
+  };
+}

--- a/packages/zudo-doc/src/doc-page-shell/index.tsx
+++ b/packages/zudo-doc/src/doc-page-shell/index.tsx
@@ -17,8 +17,7 @@
 import type { ComponentChildren, JSX, VNode } from "preact";
 import { Island } from "@takazudo/zfb";
 import { DocLayoutWithDefaults } from "../doclayout/index.js";
-import { Toc, MobileToc, getTocTitle } from "../toc/index.js";
-import { Breadcrumb } from "../breadcrumb/index.js";
+import { MobileToc, getTocTitle } from "../toc/index.js";
 import { NavCardGrid } from "../nav-indexing/index.js";
 import type { VersionBannerLabels } from "../i18n-version/index.js";
 import type { ChromeContext } from "../factory-context/index.js";
@@ -28,12 +27,9 @@ import {
   createSidebarVisibilityPrepaint,
 } from "../sidebar-prepaint/index.js";
 import { createHeadWithDefaults } from "../head-with-defaults/index.js";
-import { createSidebarWithDefaults } from "../sidebar-with-defaults/index.js";
-import { createHeaderWithDefaults } from "../header-with-defaults/index.js";
-import { createFooterWithDefaults } from "../footer-with-defaults/index.js";
 import { createDocBodyEnd } from "../doc-body-end/index.js";
-import { createDocPager } from "../doc-pager/index.js";
 import { deriveComposeMetaTitle } from "../chrome/derive.js";
+import { derivePrimaryChromeSlots } from "../chrome/primary-slots.js";
 import { assertChromeContext } from "../chrome/assert-chrome-context.js";
 
 /** A heading item for the TOC. */
@@ -186,9 +182,14 @@ export function createDocPageShell<S extends Settings = Settings>(
   const settings = ctx.settings as unknown as DocPageShellSettings;
   const composeMetaTitle = deriveComposeMetaTitle(ctx);
   const HeadWithDefaults = createHeadWithDefaults(ctx);
-  const SidebarWithDefaults = createSidebarWithDefaults(ctx);
-  const HeaderWithDefaults = createHeaderWithDefaults(ctx);
-  const FooterWithDefaults = createFooterWithDefaults(ctx);
+  const {
+    Header: HeaderWithDefaults,
+    Footer: FooterWithDefaults,
+    Sidebar: SidebarWithDefaults,
+    Toc,
+    Breadcrumb,
+    DocPager,
+  } = derivePrimaryChromeSlots(ctx);
   const sidebarToggleEnabled = Boolean(
     (ctx.settings as { sidebarToggle?: boolean }).sidebarToggle,
   );
@@ -201,8 +202,6 @@ export function createDocPageShell<S extends Settings = Settings>(
     sidebarToggle: sidebarToggleEnabled,
   });
   const DocBodyEnd = createDocBodyEnd(ctx);
-  const DocPager = createDocPager(ctx);
-
   /**
    * Render shell shared by all 4 doc-route page components.
    */

--- a/packages/zudo-doc/src/factory-context/index.ts
+++ b/packages/zudo-doc/src/factory-context/index.ts
@@ -245,6 +245,18 @@ export interface RouteContext<S = Settings>
  * (HOSTCOLLAPSE wave) later passes the real bindings.
  */
 export interface ChromeHostBindings {
+  /** Primary header chrome. Default: the package HeaderWithDefaults component. */
+  Header?: FactoryComponent;
+  /** Primary footer chrome. Default: the package FooterWithDefaults component. */
+  Footer?: FactoryComponent;
+  /** Primary doc sidebar chrome. Default: the package SidebarWithDefaults component. */
+  Sidebar?: FactoryComponent;
+  /** Primary desktop table of contents. Default: the package Toc component. */
+  Toc?: FactoryComponent;
+  /** Primary breadcrumb trail. Default: the package Breadcrumb component. */
+  Breadcrumb?: FactoryComponent;
+  /** Primary previous/next document pager. Default: the package DocPager component. */
+  DocPager?: FactoryComponent;
   /** Header search widget. Default: the package SearchWidget bound to the site base. */
   SearchWidget?: FactoryComponent;
   /** Per-page git-history meta manifest. Default: `{}` (no Created/Updated block). */

--- a/packages/zudo-doc/src/home-page/index.tsx
+++ b/packages/zudo-doc/src/home-page/index.tsx
@@ -39,9 +39,8 @@ import type { DocNavNode } from "../doc-page-props/index.js";
 import type { ChromeContext } from "../factory-context/index.js";
 import type { Settings } from "../settings.js";
 import { createHeadWithDefaults } from "../head-with-defaults/index.js";
-import { createHeaderWithDefaults } from "../header-with-defaults/index.js";
-import { createFooterWithDefaults } from "../footer-with-defaults/index.js";
 import { deriveComposeMetaTitle, deriveBodyEndIslands } from "../chrome/derive.js";
+import { derivePrimaryChromeSlots } from "../chrome/primary-slots.js";
 import { assertChromeContext } from "../chrome/assert-chrome-context.js";
 
 export { prepareHomeData } from "./prepare-home-data.js";
@@ -110,8 +109,8 @@ export function createHomePageView<S extends Settings = Settings>(
   const defaultLocale = ctx.defaultLocale;
   const composeMetaTitle = deriveComposeMetaTitle(ctx);
   const HeadWithDefaults = createHeadWithDefaults(ctx);
-  const HeaderWithDefaults = createHeaderWithDefaults(ctx);
-  const FooterWithDefaults = createFooterWithDefaults(ctx);
+  const { Header: HeaderWithDefaults, Footer: FooterWithDefaults } =
+    derivePrimaryChromeSlots(ctx);
   const BodyEndIslands = deriveBodyEndIslands(ctx);
   const homeExtras = ctx.hostBindings.homeExtras;
 

--- a/packages/zudo-doc/src/tag-pages/index.tsx
+++ b/packages/zudo-doc/src/tag-pages/index.tsx
@@ -28,7 +28,6 @@
 
 import type { ComponentChildren, JSX } from "preact";
 import { DocLayoutWithDefaults } from "../doclayout/index.js";
-import { Breadcrumb } from "../breadcrumb/index.js";
 import type { BreadcrumbItem } from "../breadcrumb/index.js";
 import { DocCardGrid, TagNav } from "../nav-indexing/index.js";
 import type { TagItem, TagNavLabels } from "../nav-indexing/index.js";
@@ -38,10 +37,9 @@ import { toRouteSlug } from "../slug/index.js";
 import type { ChromeContext } from "../factory-context/index.js";
 import type { Settings } from "../settings.js";
 import { createHeadWithDefaults } from "../head-with-defaults/index.js";
-import { createHeaderWithDefaults } from "../header-with-defaults/index.js";
-import { createFooterWithDefaults } from "../footer-with-defaults/index.js";
 import { createDocHistoryArea } from "../doc-history-area/index.js";
 import { deriveComposeMetaTitle, deriveBodyEndIslands } from "../chrome/derive.js";
+import { derivePrimaryChromeSlots } from "../chrome/primary-slots.js";
 import { assertChromeContext } from "../chrome/assert-chrome-context.js";
 import type { DocPageEntry } from "../doc-page-props/index.js";
 
@@ -70,8 +68,8 @@ export interface TagPagesSettings {
 /** Host-supplied component bindings injected into the tag-pages factory. */
 export interface TagPagesComponents {
   HeadWithDefaults: (props: { title: string }) => JSX.Element;
-  HeaderWithDefaults: (props: { lang?: string; currentPath?: string }) => JSX.Element;
-  FooterWithDefaults: (props: { lang?: string }) => JSX.Element;
+  HeaderWithDefaults: (props: { lang: string; currentPath?: string }) => JSX.Element;
+  FooterWithDefaults: (props: { lang: string }) => JSX.Element;
   BodyEndIslands: (props: { basePath: string }) => JSX.Element;
   DocHistoryArea: (props: { slug: string; locale: string }) => JSX.Element | null;
 }
@@ -154,12 +152,11 @@ export function createTagPages<S extends Settings = Settings>(
   const stableDocs = ctx.stableDocs;
   const isDefaultLocaleOnlyPath = ctx.isDefaultLocaleOnlyPath;
   const HeadWithDefaults = createHeadWithDefaults(ctx) as TagPagesComponents["HeadWithDefaults"];
-  const HeaderWithDefaults = createHeaderWithDefaults(
-    ctx,
-  ) as TagPagesComponents["HeaderWithDefaults"];
-  const FooterWithDefaults = createFooterWithDefaults(
-    ctx,
-  ) as TagPagesComponents["FooterWithDefaults"];
+  const {
+    Header: HeaderWithDefaults,
+    Footer: FooterWithDefaults,
+    Breadcrumb,
+  } = derivePrimaryChromeSlots(ctx);
   const BodyEndIslands = deriveBodyEndIslands(ctx) as TagPagesComponents["BodyEndIslands"];
   const DocHistoryArea = createDocHistoryArea(ctx) as TagPagesComponents["DocHistoryArea"];
 

--- a/packages/zudo-doc/src/versions-page/index.tsx
+++ b/packages/zudo-doc/src/versions-page/index.tsx
@@ -15,9 +15,8 @@ import type { VersionPageEntry, VersionsPageLabels } from "../nav-indexing/index
 import type { ChromeContext } from "../factory-context/index.js";
 import type { Settings } from "../settings.js";
 import { createHeadWithDefaults } from "../head-with-defaults/index.js";
-import { createHeaderWithDefaults } from "../header-with-defaults/index.js";
-import { createFooterWithDefaults } from "../footer-with-defaults/index.js";
 import { deriveComposeMetaTitle, deriveBodyEndIslands } from "../chrome/derive.js";
+import { derivePrimaryChromeSlots } from "../chrome/primary-slots.js";
 import { assertChromeContext } from "../chrome/assert-chrome-context.js";
 
 // ---------------------------------------------------------------------------
@@ -42,8 +41,8 @@ export interface VersionsPageSettings {
 /** Host-supplied component bindings injected into the versions page factory. */
 export interface VersionsPageComponents {
   HeadWithDefaults: (props: { title: string }) => JSX.Element;
-  HeaderWithDefaults: (props: { lang?: string; currentPath?: string }) => JSX.Element;
-  FooterWithDefaults: (props: { lang?: string }) => JSX.Element;
+  HeaderWithDefaults: (props: { lang: string; currentPath?: string }) => JSX.Element;
+  FooterWithDefaults: (props: { lang: string }) => JSX.Element;
   BodyEndIslands: (props: { basePath: string }) => JSX.Element;
 }
 
@@ -86,12 +85,8 @@ export function createVersionsPageView<S extends Settings = Settings>(
   const withBase = ctx.withBase;
   const composeMetaTitle = deriveComposeMetaTitle(ctx);
   const HeadWithDefaults = createHeadWithDefaults(ctx) as VersionsPageComponents["HeadWithDefaults"];
-  const HeaderWithDefaults = createHeaderWithDefaults(
-    ctx,
-  ) as VersionsPageComponents["HeaderWithDefaults"];
-  const FooterWithDefaults = createFooterWithDefaults(
-    ctx,
-  ) as VersionsPageComponents["FooterWithDefaults"];
+  const { Header: HeaderWithDefaults, Footer: FooterWithDefaults } =
+    derivePrimaryChromeSlots(ctx);
   const BodyEndIslands = deriveBodyEndIslands(ctx) as VersionsPageComponents["BodyEndIslands"];
 
   /** Versions index page for one locale. Lists the latest version and any past


### PR DESCRIPTION
Parent epic: #2773

Adds typed replacement slots for Header, Footer, Sidebar, Toc, Breadcrumb, and DocPager with lazy shared resolution and exact public props.

Closes #2775

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786756603&installation_id=130359969&pr_number=2802&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2802&signature=1032e8bf0cf01d3f4b4a29f197be4ed29338f376e879be395fb68b683fde1246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->