### PR TITLE
fix(worker): preserve preview URL deployments

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -713,32 +713,18 @@ jobs:
           # alias URL (subdomain starts with the alias) — not the per-version
           # hash URL — so smoke gates + PR comments hit a stable host.
           DEPLOY_LOG=$(mktemp)
-          set +e
+          # Cloudflare does not generate preview URLs for versions implementing
+          # Durable Objects. Upload an adapter-only entry to a separate preview
+          # service; production remains on worker-entry.ts with its DO binding.
+          PREVIEW_CONFIG=$(mktemp "$PWD/.wrangler-preview.XXXXXX.toml")
+          trap 'rm -f "$PREVIEW_CONFIG"' EXIT
+          node scripts/write-worker-preview-config.mjs "$PREVIEW_CONFIG"
           npx wrangler@4.85.0 versions upload \
+            --config "$PREVIEW_CONFIG" \
             --preview-alias "$ALIAS" \
             2>&1 | tee "$DEPLOY_LOG"
-          UPLOAD_STATUS=${PIPESTATUS[0]}
-          set -e
-          if [ "$UPLOAD_STATUS" -ne 0 ]; then
-            # New Durable Object migrations are atomic and Cloudflare rejects
-            # them from `versions upload`. For the one introducing preview,
-            # retry without the not-yet-created namespace; after production
-            # applies the migration, the normal upload above keeps the binding.
-            if ! grep -Eiq 'new.{0,80}migrations cannot be uploaded|cannot upload.{0,80}migration|migrations?.{0,120}(wrangler deploy|atomic|cannot be uploaded)' "$DEPLOY_LOG"; then
-              exit "$UPLOAD_STATUS"
-            fi
-            # Keep the generated config beside wrangler.toml: Wrangler resolves
-            # relative main/assets paths from the config file's directory.
-            PREVIEW_CONFIG=$(mktemp "$PWD/.wrangler-preview-bootstrap.XXXXXX.toml")
-            trap 'rm -f "$PREVIEW_CONFIG"' EXIT
-            node scripts/write-worker-preview-config.mjs "$PREVIEW_CONFIG"
-            npx wrangler@4.85.0 versions upload \
-              --config "$PREVIEW_CONFIG" \
-              --preview-alias "$ALIAS" \
-              2>&1 | tee "$DEPLOY_LOG"
-            rm -f "$PREVIEW_CONFIG"
-            trap - EXIT
-          fi
+          rm -f "$PREVIEW_CONFIG"
+          trap - EXIT
           DEPLOY_URL=$(grep -oE "https://${ALIAS}-[a-z0-9.-]+\.workers\.dev" "$DEPLOY_LOG" | head -1)
           if [ -z "$DEPLOY_URL" ]; then
             echo "::error::Failed to parse alias preview URL for '$ALIAS' from wrangler output"

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -285,33 +285,19 @@ jobs:
           # Parse it — not the per-version hash URL — so smoke gates and PR
           # comments always target the stable, predictable alias host.
           DEPLOY_LOG=$(mktemp)
-          set +e
+          # Cloudflare does not generate preview URLs for versions implementing
+          # Durable Objects. Upload an adapter-only entry to a separate preview
+          # service; production remains on worker-entry.ts with its DO binding.
+          PREVIEW_CONFIG=$(mktemp "$PWD/.wrangler-preview.XXXXXX.toml")
+          trap 'rm -f "$PREVIEW_CONFIG"' EXIT
+          node scripts/write-worker-preview-config.mjs "$PREVIEW_CONFIG"
           npx wrangler@4.85.0 versions upload \
+            --config "$PREVIEW_CONFIG" \
             --preview-alias="$SLUG" \
             --message="Preview: ${SLUG} @ ${GITHUB_SHA:0:7}" \
             2>&1 | tee "$DEPLOY_LOG"
-          UPLOAD_STATUS=${PIPESTATUS[0]}
-          set -e
-          if [ "$UPLOAD_STATUS" -ne 0 ]; then
-            # `versions upload` cannot introduce an atomic Durable Object
-            # migration. Retry only that known bootstrap failure without the
-            # not-yet-created namespace; all unrelated failures remain fatal.
-            if ! grep -Eiq 'new.{0,80}migrations cannot be uploaded|cannot upload.{0,80}migration|migrations?.{0,120}(wrangler deploy|atomic|cannot be uploaded)' "$DEPLOY_LOG"; then
-              exit "$UPLOAD_STATUS"
-            fi
-            # Keep the generated config beside wrangler.toml: Wrangler resolves
-            # relative main/assets paths from the config file's directory.
-            PREVIEW_CONFIG=$(mktemp "$PWD/.wrangler-preview-bootstrap.XXXXXX.toml")
-            trap 'rm -f "$PREVIEW_CONFIG"' EXIT
-            node scripts/write-worker-preview-config.mjs "$PREVIEW_CONFIG"
-            npx wrangler@4.85.0 versions upload \
-              --config "$PREVIEW_CONFIG" \
-              --preview-alias="$SLUG" \
-              --message="Preview bootstrap (no unapplied DO migration): ${SLUG} @ ${GITHUB_SHA:0:7}" \
-              2>&1 | tee "$DEPLOY_LOG"
-            rm -f "$PREVIEW_CONFIG"
-            trap - EXIT
-          fi
+          rm -f "$PREVIEW_CONFIG"
+          trap - EXIT
 
           # Match the stable alias URL: the subdomain starts with the slug
           # followed by a hyphen and the worker name (slug-zudo-doc), anchored

--- a/scripts/__tests__/worker-entry-config.test.ts
+++ b/scripts/__tests__/worker-entry-config.test.ts
@@ -3,7 +3,7 @@ import { resolve } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { withoutUnappliedDurableObjectMigration } from "../write-worker-preview-config.mjs";
+import { createPreviewWorkerConfig } from "../write-worker-preview-config.mjs";
 
 const ROOT = resolve(import.meta.dirname, "../..");
 const read = (path: string) => readFileSync(resolve(ROOT, path), "utf8");
@@ -46,15 +46,23 @@ describe("custom Worker deployment contract", () => {
     expect(entry).toContain('import adapterWorker from "./dist/_worker.js";');
     expect(entry).toMatch(/export default adapterWorker;\s*$/);
     expect(entry).not.toMatch(/export default \{/);
+
+    const previewEntry = read("worker-preview-entry.ts");
+    expect(previewEntry).toContain('import adapterWorker from "./dist/_worker.js";');
+    expect(previewEntry).toMatch(/export default adapterWorker;\s*$/);
+    expect(previewEntry).not.toContain("AiChatDailySpendCap");
   });
 
-  it("can omit only an unapplied migration from a bootstrap preview", () => {
+  it("uses an adapter-only service for preview URLs", () => {
     const config = read("wrangler.toml");
-    const previewConfig = withoutUnappliedDurableObjectMigration(config);
+    const previewConfig = createPreviewWorkerConfig(config);
 
     expect(previewConfig).not.toContain('name = "AI_CHAT_DAILY_SPEND_CAP"');
     expect(previewConfig).not.toContain('new_sqlite_classes = ["AiChatDailySpendCap"]');
-    expect(previewConfig).toContain('main = "./worker-entry.ts"');
+    expect(previewConfig).toContain('name = "zudo-doc-preview"');
+    expect(previewConfig).toContain('main = "./worker-preview-entry.ts"');
+    expect(previewConfig).not.toContain('name = "zudo-doc"\n');
+    expect(previewConfig).not.toContain('main = "./worker-entry.ts"');
     expect(previewConfig).toContain('[assets]\ndirectory = "./dist"');
     expect(previewConfig).toContain('binding = "RATE_LIMIT"');
     expect(previewConfig).toContain('pattern = "zudo-doc.takazudomodular.com"');
@@ -64,8 +72,11 @@ describe("custom Worker deployment contract", () => {
       ".github/workflows/preview-deploy.yml",
     ]) {
       const source = read(workflow);
-      expect(source).toContain('mktemp "$PWD/.wrangler-preview-bootstrap.XXXXXX.toml"');
+      expect(source).toContain('mktemp "$PWD/.wrangler-preview.XXXXXX.toml"');
+      expect(source).toContain('node scripts/write-worker-preview-config.mjs "$PREVIEW_CONFIG"');
+      expect(source).toContain('--config "$PREVIEW_CONFIG"');
       expect(source).not.toContain('$RUNNER_TEMP/wrangler-preview-bootstrap.toml');
+      expect(source).not.toContain("UPLOAD_STATUS");
     }
   });
 });

--- a/scripts/write-worker-preview-config.mjs
+++ b/scripts/write-worker-preview-config.mjs
@@ -4,8 +4,12 @@ import { pathToFileURL } from "node:url";
 
 const START = "# BEGIN AI_CHAT_DAILY_SPEND_CAP_BOOTSTRAP";
 const END = "# END AI_CHAT_DAILY_SPEND_CAP_BOOTSTRAP";
+const PRODUCTION_NAME = 'name = "zudo-doc"';
+const PREVIEW_NAME = 'name = "zudo-doc-preview"';
+const PRODUCTION_ENTRY = 'main = "./worker-entry.ts"';
+const PREVIEW_ENTRY = 'main = "./worker-preview-entry.ts"';
 
-export function withoutUnappliedDurableObjectMigration(source) {
+export function createPreviewWorkerConfig(source) {
   const start = source.indexOf(START);
   const end = source.indexOf(END);
 
@@ -17,7 +21,15 @@ export function withoutUnappliedDurableObjectMigration(source) {
   }
 
   const afterEnd = end + END.length;
-  return `${source.slice(0, start)}${source.slice(afterEnd).replace(/^\r?\n/, "")}`;
+  const withoutObject = `${source.slice(0, start)}${source.slice(afterEnd).replace(/^\r?\n/, "")}`;
+
+  if (!withoutObject.includes(PRODUCTION_NAME) || !withoutObject.includes(PRODUCTION_ENTRY)) {
+    throw new Error("wrangler.toml is missing the production Worker name or entry");
+  }
+
+  return withoutObject
+    .replace(PRODUCTION_NAME, PREVIEW_NAME)
+    .replace(PRODUCTION_ENTRY, PREVIEW_ENTRY);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
@@ -28,5 +40,5 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
 
   const root = resolve(import.meta.dirname, "..");
   const source = readFileSync(resolve(root, "wrangler.toml"), "utf8");
-  writeFileSync(outputPath, withoutUnappliedDurableObjectMigration(source));
+  writeFileSync(outputPath, createPreviewWorkerConfig(source));
 }

--- a/tsconfig.worker.json
+++ b/tsconfig.worker.json
@@ -3,6 +3,7 @@
   "extends": "./tsconfig.json",
   "include": [
     "worker-entry.ts",
+    "worker-preview-entry.ts",
     "generated-worker.d.ts",
     "worker-configuration.d.ts",
     "worker-tests/**/*.ts",

--- a/worker-preview-entry.ts
+++ b/worker-preview-entry.ts
@@ -1,0 +1,6 @@
+import adapterWorker from "./dist/_worker.js";
+
+// Cloudflare does not generate preview URLs for a Worker version that
+// implements a Durable Object. Preview uploads therefore use this adapter-only
+// entry on a separate service; production continues to use worker-entry.ts.
+export default adapterWorker;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -15,16 +15,15 @@ compatibility_flags = ["nodejs_compat"]
 # warns "Unexpected fields found in assets field" and silently ignores them).
 #
 # preview_urls enables *.workers.dev version-preview URLs for staging/preview
-# deploys (consumed by preview-deploy.yml / pr-checks.yml via
-# `wrangler versions upload --preview-alias`).
+# deploys. Cloudflare does not generate them for versions that implement a
+# Durable Object, so preview workflows generate an adapter-only config for the
+# separate zudo-doc-preview service. Production keeps this complete config.
 preview_urls = true
 workers_dev = false  # prevent serving on *.workers.dev prod route; previews use preview_urls above
 
-# A preview-version upload cannot introduce a Durable Object migration because
-# migrations are atomic. scripts/write-worker-preview-config.mjs removes this
-# marked bootstrap block only when a versions upload reports that exact
-# migration constraint; normal previews keep the binding after production has
-# applied the migration.
+# scripts/write-worker-preview-config.mjs removes this marked block and switches
+# to worker-preview-entry.ts for preview uploads. Cloudflare preview URLs cannot
+# be generated for a version that implements a Durable Object.
 # BEGIN AI_CHAT_DAILY_SPEND_CAP_BOOTSTRAP
 [[durable_objects.bindings]]
 name = "AI_CHAT_DAILY_SPEND_CAP"


### PR DESCRIPTION
Follow-up to #2807 after independent review. Cloudflare does not generate preview URLs for versions implementing Durable Objects, so preview workflows now upload an adapter-only entry to a separate preview service while production retains the Durable Object implementation and binding.

## Validation

- `pnpm exec tsc --noEmit -p tsconfig.worker.json`
- `pnpm exec vitest run scripts/__tests__/worker-entry-config.test.ts`
- generated preview config with `pnpm exec wrangler deploy --dry-run`

Refs #2780
