### PR TITLE
fix(theme-packs): ledger DocPager selector over-matches NavCardGrid

### DIFF
--- a/packages/zudo-doc/src/theme-packs/ledger/pack.css
+++ b/packages/zudo-doc/src/theme-packs/ledger/pack.css
@@ -188,7 +188,7 @@ html[data-theme-pack="ledger"] .zd-doc-content-band:not([data-zd-wide]) .zd-cont
   max-width: 44rem;
 }
 html[data-theme-pack="ledger"] .zd-doc-content-band:not([data-zd-wide]) main nav[aria-label="Breadcrumb"],
-html[data-theme-pack="ledger"] .zd-doc-content-band:not([data-zd-wide]) .zd-content > nav:not([aria-label="Breadcrumb"]) {
+html[data-theme-pack="ledger"] .zd-doc-content-band:not([data-zd-wide]) .zd-content > nav:last-of-type:not([aria-label]) {
   max-width: 44rem;
 }
 
@@ -400,19 +400,19 @@ html[data-theme-pack="ledger"] .zd-content tbody tr:last-child td {
         The DocPager is a <nav> rendered as a direct child of
         <article class="zd-content">, with no aria-label (the breadcrumb nav
         carries one). ---- */
-html[data-theme-pack="ledger"] .zd-content > nav:not([aria-label="Breadcrumb"]) > a {
+html[data-theme-pack="ledger"] .zd-content > nav:last-of-type:not([aria-label]) > a {
   border-color: color-mix(in srgb, var(--zd-fg) 25%, transparent);
   border-radius: 0;
   background: transparent;
 }
-html[data-theme-pack="ledger"] .zd-content > nav:not([aria-label="Breadcrumb"]) > a:hover {
+html[data-theme-pack="ledger"] .zd-content > nav:last-of-type:not([aria-label]) > a:hover {
   background: color-mix(in srgb, var(--zd-accent) 5%, transparent);
 }
-html[data-theme-pack="ledger"] .zd-content > nav:not([aria-label="Breadcrumb"]) > a div {
+html[data-theme-pack="ledger"] .zd-content > nav:last-of-type:not([aria-label]) > a div {
   font-variant-caps: all-small-caps;
   letter-spacing: 0.12em;
 }
-html[data-theme-pack="ledger"] .zd-content > nav:not([aria-label="Breadcrumb"]) > a p {
+html[data-theme-pack="ledger"] .zd-content > nav:last-of-type:not([aria-label]) > a p {
   font-style: italic;
 }
 


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2862

---

## Summary

Auto-fix of a pre-existing bug found during the Theme Batch 2 deep-review (epic #2814).

The batch-1 `ledger` pack styled the DocPager with `.zd-content > nav:not([aria-label="Breadcrumb"])`, which also matched the **NavCardGrid** ("Child pages") nav — its `<a>` are direct children of a `.zd-content > nav` and its aria-label is "Child pages", not "Breadcrumb". So ledger's DocPager card styling (square hairline cards, small-caps labels, italic titles) and the band-width rule leaked onto the child-page cards on auto-index pages.

Switched all 5 occurrences to the batch-2 sibling idiom `.zd-content > nav:last-of-type:not([aria-label])`, which excludes both the breadcrumb and NavCardGrid and pins the DocPager (the last unlabelled nav). The identical fix was applied to `sumi` in #2860.

CSS-only, validator-legal (still attribute-scoped); all 11 packs pass the build-time validator.

Closes #2862

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2865"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786819044&installation_id=130359969&pr_number=2865&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2865&signature=5cd63087fa8f256d46ba3a0f3675c02474bffd6c9679b67d611522c2401dc36d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->