### PR TITLE
Theme Pack Hooks: stable DOM hooks, ADR/authoring-doc hardening, 20-pack retarget + restored styling

### DIFF
--- a/packages/zudo-doc/docs/adr/theme-packs.md
+++ b/packages/zudo-doc/docs/adr/theme-packs.md
@@ -451,15 +451,30 @@ Rules:
    `.zd-doc-content-band`, `.zd-content`, `[data-admonition]` (+ variant
    values) and `.admonition-title::before` (icon overrides allowed),
    `pre.hi-root` / `.hi-*` token classes, `nav[data-zd-toc]`,
-   `a[data-nav-active]`, `body`. NEVER select on Tailwind utility class
-   names (not a contract surface) and never reintroduce Tailwind default
-   palette tokens.
+   `a[data-nav-active]`, `body`, `footer[data-footer]`,
+   `nav[data-doc-pager]`, `p[data-doc-description]`,
+   `[data-theme-pack-switcher]`, `[data-switcher-card]`,
+   `[data-switcher-launcher]`. The TOC's active-item hook is
+   `nav[data-zd-toc] a[aria-current="true"]` — there is no `.toc-active`
+   class; the `aria-current` state IS the contract. NEVER select on
+   Tailwind utility class names (not a contract surface) and never
+   reintroduce Tailwind default palette tokens. **Custom-chrome caveat:**
+   a replacement supplied via `defineChromeBindings` (e.g. a custom
+   `Footer` or `DocPager`) must emit these same stable hooks to retain
+   shipped-pack styling — packs select on `[data-footer]`/
+   `[data-doc-pager]`, not on component structure.
 6. **`!important` is forbidden**, with one enumerated exception: defeating
-   SSR-inlined styles — today exactly one exists, the h2 gradient rule
-   (`style="border-image:linear-gradient(…)"` emitted by the h2 content
-   component). A pack replacing the h2 rule uses
-   `html[data-theme-pack="x"] .zd-content h2 { border-image: none !important; … }`.
-   (A follow-up may tokenize that seam; until then this is the allowlist.)
+   SSR-inlined styles — the h2/h3/h4 heading-rule gradient. All three
+   heading components (`packages/zudo-doc/src/content/heading-h2.tsx`,
+   `heading-h3.tsx`, `heading-h4.tsx`) SSR-inline a
+   `style="border-image:linear-gradient(…)"` rule on their respective
+   element; a pack restyling any of the three bars uses the same
+   carve-out, e.g.
+   `html[data-theme-pack="x"] .zd-content h2 { border-image: none !important; … }`
+   (the same pattern applies to `h3`/`h4`). The validator allowlists by CSS
+   property (`border-image`), not by selector or heading level, so all
+   three already pass. (A follow-up may tokenize that seam; until then
+   this is the allowlist.)
 7. **Validator (build-time, #2819)** enforces: slug regex + directory-name
    parity; meta schema; `pack.css` present and non-empty for every
    non-`default` slug (and absent for `default`); every rule scoped under

--- a/packages/zudo-doc/docs/theme-pack-authoring.md
+++ b/packages/zudo-doc/docs/theme-pack-authoring.md
@@ -19,31 +19,35 @@ The tree below is not reconstructed from memory or from the old prototype bundle
   <aside id="desktop-sidebar"><!-- SidebarTree island --></aside>
 
   <div class="zd-sidebar-content-wrapper">
-    <div class="zd-doc-content-band">
-      <main>
-        <nav aria-label="Breadcrumb">…</nav>
-        <!-- MobileToc island (xl:hidden) -->
+    <div class="flex min-h-[calc(100vh-3.5rem)] justify-center">
+      <div class="zd-doc-content-band">
+        <main>
+          <nav aria-label="Breadcrumb">…</nav>
+          <!-- MobileToc island (xl:hidden) -->
 
-        <article class="zd-content max-w-none">
-          <h1>Test Page</h1>
-          <p data-doc-description>A test description.</p>
-          <!-- MDX content -->
-          <nav data-doc-pager>
-            <a href="/docs/a"><!-- prev card --></a>
-            <a href="/docs/b"><!-- next card --></a>
-          </nav>
-        </article>
-      </main>
+          <article class="zd-content max-w-none">
+            <h1>Test Page</h1>
+            <p data-doc-description>A test description.</p>
+            <!-- MDX content -->
+            <nav data-doc-pager>
+              <a href="/docs/a"><!-- prev card --></a>
+              <a href="/docs/b"><!-- next card --></a>
+            </nav>
+            <!-- docHistorySlot (DocHistoryArea) — AFTER the pager, still
+                 inside article.zd-content, when docHistory is enabled -->
+          </article>
+        </main>
 
-      <!-- Toc island (hidden xl:flex) -->
-      <nav aria-label="Table of contents" data-zd-toc>
-        <ul>
-          <li><a href="#h2-a">H2 A</a></li>
-          <li class="ml-hsp-lg">
-            <a href="#h3-a" aria-current="true">H3 A</a>
-          </li>
-        </ul>
-      </nav>
+        <!-- Toc island (hidden xl:flex) -->
+        <nav aria-label="Table of contents" data-zd-toc>
+          <ul>
+            <li><a href="#h2-a">H2 A</a></li>
+            <li class="ml-hsp-lg">
+              <a href="#h3-a">H3 A</a>
+            </li>
+          </ul>
+        </nav>
+      </div>
     </div>
 
     <footer data-footer>
@@ -55,12 +59,12 @@ The tree below is not reconstructed from memory or from the old prototype bundle
 
 Key structural facts a pack author needs, all confirmed against the render above:
 
-- **`nav[data-doc-pager]` is a direct child of `article.zd-content`** — the last element inside the article, after the MDX content. It is NOT a sibling of the article (the old tokens-dump.md skeleton showed it outside — that was wrong).
-- **`footer[data-footer]`** sits at the very end of `.zd-sidebar-content-wrapper`, a sibling of `.zd-doc-content-band` (main + TOC) — outside `article.zd-content` and outside `<main>`.
-- **`p[data-doc-description]`** on the entry-page path is the first element inside `article.zd-content` after `<h1>` (before `DocMetainfoArea`/`DocTagsArea` when those are present — see below).
-- **TOC active state has no dedicated class.** `nav[data-zd-toc] a[aria-current="true"]` is the only signal a currently-active heading link carries; an inactive link has no `aria-current` attribute at all (not `aria-current="false"`). In pure SSR output no link is ever marked active — activation is client-only (scroll-spy), so this hook only fires after hydration.
+- **`nav[data-doc-pager]` is a direct child of `article.zd-content`**, after the MDX content — but it is not necessarily the article's *last* child: when `docHistory` is enabled, `docHistorySlot` (`DocHistoryArea`) renders immediately after it, still inside the article. Do not rely on `:last-child`/`:last-of-type` for the pager. The pager is NOT a sibling of the article (the old tokens-dump.md skeleton showed it outside — that was wrong).
+- **`footer[data-footer]`** is a direct child of `.zd-sidebar-content-wrapper`, but NOT a sibling of `.zd-doc-content-band` directly — an intermediate centering `<div class="flex min-h-[…] justify-center">` sits between `.zd-sidebar-content-wrapper` and `.zd-doc-content-band` (see the tree above). The footer is a sibling of that intermediate wrapper, not of the content band itself. A sibling/adjacency selector built against `.zd-doc-content-band` will not match the footer.
+- **`p[data-doc-description]`** on the entry-page path renders AFTER `<h1>` and after any `docContentHeaderExtras`/`DocMetainfoArea`/`DocTagsArea`/fallback-notice content — see the expanded article order below. It is not the element immediately following `<h1>` whenever any of those optional slots are present.
+- **TOC active state has no dedicated class.** `nav[data-zd-toc] a[aria-current="true"]` is the only signal a currently-active heading link carries; an inactive link has no `aria-current` attribute at all (not `aria-current="false"`). The skeleton above is literal SSR output, where `aria-current` never appears on any link — `useActiveHeading` initializes with no active id and only sets one from a client-side scroll-spy effect that runs after hydration. Expect `aria-current="true"` to show up only when inspecting a hydrated page in a real browser, never in a raw SSR/build HTML diff.
 
-The full entry-page article, with `DocMetainfoArea`/tags/frontmatter-preview slots present, is (in order):
+The full entry-page article, with every optional slot present, in ACTUAL order:
 
 ```html
 <article class="zd-content max-w-none">
@@ -73,6 +77,7 @@ The full entry-page article, with `DocMetainfoArea`/tags/frontmatter-preview slo
   <!-- FrontmatterPreview table, only when custom frontmatter keys exist -->
   <!-- MDX <Content /> -->
   <nav data-doc-pager>…</nav>
+  <!-- docHistorySlot (DocHistoryArea), when docHistory is enabled -->
 </article>
 ```
 

--- a/packages/zudo-doc/docs/theme-pack-authoring.md
+++ b/packages/zudo-doc/docs/theme-pack-authoring.md
@@ -1,0 +1,184 @@
+# Authoring a theme pack
+
+A durable reference for anyone writing or restyling a `packages/zudo-doc/src/theme-packs/<slug>/pack.css`. It replaces the old `_temp-resource/2812-theme-prototypes/tokens-dump.md` §6a skeleton, which was deleted along with the rest of `_temp-resource/2812-theme-prototypes/` when the Theme Finalize epic merged (zudolab/zudo-doc#2856) — and which was wrong in one important way anyway (it showed the pager living outside `article.zd-content`; it does not — see (a) below).
+
+For the full architecture decision record — `meta.json` schema, asset emission, the runtime swap algorithm, zdtp persistence, font policy, and the build-time validator — see [`docs/adr/theme-packs.md`](./adr/theme-packs.md). This document only covers what an individual pack author needs while writing `pack.css`.
+
+## (a) Real rendered markup skeleton
+
+The tree below is not reconstructed from memory or from the old prototype bundle — it is the literal output of `preact-render-to-string` rendering the real `createDocPageShell` factory (with real `Header`, `Sidebar`, `Toc`, `DocPager`, `Footer`, `DocContentHeader` components, via `derivePrimaryChromeSlots`) against a fake-but-complete `ChromeContext`, the same harness pattern used by `packages/zudo-doc/src/doc-page-shell/__tests__/data-doc-description.test.tsx`. Classes are trimmed to the ones relevant to structure; the full class lists are longer in the real build.
+
+### Regular entry doc page
+
+```html
+<body>
+  <header data-header>
+    <!-- data-header-logo, data-header-nav, data-header-right also present -->
+  </header>
+
+  <aside id="desktop-sidebar"><!-- SidebarTree island --></aside>
+
+  <div class="zd-sidebar-content-wrapper">
+    <div class="zd-doc-content-band">
+      <main>
+        <nav aria-label="Breadcrumb">…</nav>
+        <!-- MobileToc island (xl:hidden) -->
+
+        <article class="zd-content max-w-none">
+          <h1>Test Page</h1>
+          <p data-doc-description>A test description.</p>
+          <!-- MDX content -->
+          <nav data-doc-pager>
+            <a href="/docs/a"><!-- prev card --></a>
+            <a href="/docs/b"><!-- next card --></a>
+          </nav>
+        </article>
+      </main>
+
+      <!-- Toc island (hidden xl:flex) -->
+      <nav aria-label="Table of contents" data-zd-toc>
+        <ul>
+          <li><a href="#h2-a">H2 A</a></li>
+          <li class="ml-hsp-lg">
+            <a href="#h3-a" aria-current="true">H3 A</a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+
+    <footer data-footer>
+      <!-- link columns / tag columns / copyright -->
+    </footer>
+  </div>
+</body>
+```
+
+Key structural facts a pack author needs, all confirmed against the render above:
+
+- **`nav[data-doc-pager]` is a direct child of `article.zd-content`** — the last element inside the article, after the MDX content. It is NOT a sibling of the article (the old tokens-dump.md skeleton showed it outside — that was wrong).
+- **`footer[data-footer]`** sits at the very end of `.zd-sidebar-content-wrapper`, a sibling of `.zd-doc-content-band` (main + TOC) — outside `article.zd-content` and outside `<main>`.
+- **`p[data-doc-description]`** on the entry-page path is the first element inside `article.zd-content` after `<h1>` (before `DocMetainfoArea`/`DocTagsArea` when those are present — see below).
+- **TOC active state has no dedicated class.** `nav[data-zd-toc] a[aria-current="true"]` is the only signal a currently-active heading link carries; an inactive link has no `aria-current` attribute at all (not `aria-current="false"`). In pure SSR output no link is ever marked active — activation is client-only (scroll-spy), so this hook only fires after hydration.
+
+The full entry-page article, with `DocMetainfoArea`/tags/frontmatter-preview slots present, is (in order):
+
+```html
+<article class="zd-content max-w-none">
+  <h1>…</h1>
+  <!-- docContentHeaderExtras host-binding slot, if set -->
+  <!-- DocMetainfoArea (Created/Updated/Author), hidden on versioned pages -->
+  <!-- DocTagsArea (tag chips), hidden on versioned pages -->
+  <!-- fallback notice, locale-fallback pages only -->
+  <p data-doc-description>…</p>
+  <!-- FrontmatterPreview table, only when custom frontmatter keys exist -->
+  <!-- MDX <Content /> -->
+  <nav data-doc-pager>…</nav>
+</article>
+```
+
+### Auto-index category page (no `index.mdx`)
+
+Same outer chrome (header/sidebar/footer/TOC unaffected); the article body differs — no pager, no `DocContentHeader`:
+
+```html
+<article class="zd-content max-w-none">
+  <h1>Category Label</h1>
+  <!-- metainfoSlot (DocMetainfoArea), if configured -->
+  <p data-doc-description>Category description.</p>
+  <!-- NavCardGrid of child pages -->
+</article>
+```
+
+`p[data-doc-description]` is emitted from a **second, independent code path** here (`doc-page-shell`'s own auto-index branch, not `doc-content-header`) — a pack selecting on this hook automatically covers both emitters since the attribute and class are identical, but if you are instrumenting/testing selectors, know there are two source sites.
+
+### Theme pack switcher flyout
+
+The switcher island (`ThemePackSwitcher`) renders CLOSED on the server — no card markup in SSR output. Its full closed→open shape (from `packages/zudo-doc/src/theme-pack-switcher/index.tsx`, the source, not a prototype):
+
+```html
+<div class="fixed right-hsp-lg bottom-hsp-lg z-popover …" data-theme-pack-switcher>
+  <!-- only present while open (client-toggled) -->
+  <div role="dialog" aria-label="Theme pack switcher" data-switcher-card>
+    <p>Pack name</p>
+    <button aria-label="Browse all theme packs">…</button>
+    <button aria-label="Close theme pack switcher">…</button>
+    <span>Light|Dark badge</span>
+    <p>Pack description</p>
+    <button aria-label="Previous theme pack">Prev</button>
+    <button aria-label="Next theme pack">Next</button>
+  </div>
+
+  <button aria-haspopup="dialog" aria-expanded="false|true" data-switcher-launcher>
+    <!-- palette icon -->
+  </button>
+
+  <!-- browse-all dialog mount point (ThemePackDialogSlot), separate component -->
+</div>
+```
+
+`[data-theme-pack-switcher]` is the always-present root (present even while closed, launcher-only); `[data-switcher-card]` only exists in the DOM while the card is open; `[data-switcher-launcher]` is the always-present round button.
+
+## (b) Stable DOM hooks — full table
+
+The complete extras-authoring surface (ADR Decision 6, rule 5). Select ONLY on these — never on Tailwind utility class names, and never on component internal structure:
+
+| Hook | What it is | When to use |
+|---|---|---|
+| `header[data-header]` | The site header `<header>` element | Restyling the header bar itself (background, border, height) |
+| `[data-header-logo]` | The header's site-name/logo link | Logo text/branding |
+| `[data-header-nav]` | The header's top-level nav `<nav>` | Nav bar layout |
+| `[data-nav-item]` | Individual header nav item wrapper | Per-item nav styling |
+| `#desktop-sidebar` | The desktop `<aside>` sidebar container | Sidebar background/border/width |
+| `.zd-sidebar-content-wrapper` | Wrapper that shifts content right of the sidebar | Content-area left-margin geometry |
+| `.zd-doc-content-band` | Flex row containing `<main>` + TOC | Content band width/gap |
+| `.zd-content` | The `<article>` MDX content root | Prose typography extras (beyond `content.css`) |
+| `[data-admonition]` (+ variant values) | Admonition (callout) blocks | Admonition backgrounds/borders/icons |
+| `.admonition-title::before` | Admonition title icon | Icon overrides (allowed) |
+| `pre.hi-root` / `.hi-*` | Code-fence syntax highlighting root + token classes | Code block colors/spacing |
+| `nav[data-zd-toc]` | The right-rail table of contents `<nav>` | TOC panel styling |
+| `nav[data-zd-toc] a[aria-current="true"]` | The currently-active TOC entry | Active-item highlight — there is no `.toc-active` class; `aria-current` IS the contract |
+| `a[data-nav-active]` | Sidebar's active nav item | Active sidebar-item highlight |
+| `body` | The document body | Global background/base color |
+| `footer[data-footer]` | The page footer `<footer>` | Footer background/border/link colors |
+| `nav[data-doc-pager]` | Prev/Next pagination `<nav>` (inside `article.zd-content`, see (a)) | Pager card styling |
+| `p[data-doc-description]` | The doc-page description paragraph (both emitters, see (a)) | Description text styling |
+| `[data-theme-pack-switcher]` | The switcher flyout's root `<div>` | Positioning/z-index overrides of the whole flyout |
+| `[data-switcher-card]` | The switcher's open card (present only while open) | Card background/border/shadow |
+| `[data-switcher-launcher]` | The switcher's round launcher button | Launcher button styling |
+
+## (c) The `!important` carve-out — heading border-image gradients
+
+`!important` is **forbidden** everywhere else in a pack. The one enumerated exception exists because `h2`/`h3`/`h4` SSR-inline a `border-image` rule directly on the element (`packages/zudo-doc/src/content/heading-h2.tsx`, `heading-h3.tsx`, `heading-h4.tsx`), and an inline `style` attribute beats any stylesheet rule regardless of specificity — the only way to override it from `pack.css` is `!important`:
+
+```css
+html[data-theme-pack="x"] .zd-content h2 {
+  border-image: none !important;
+  border-bottom: 2px solid var(--zd-accent);
+}
+/* same pattern applies to h3 and h4 */
+```
+
+The build-time validator allowlists this **by CSS property** (`border-image`), not by selector or heading level — so all three headings already pass. Do not use `!important` for anything else; the validator rejects it.
+
+## (d) Pack-versioning rule
+
+Every `pack.css` change that should reach already-visited browsers **requires a `meta.json` version bump**. `meta.version` drives the `?v=` cache-busting query string on the stylesheet URL — `buildPackCssUrl` in `packages/zudo-doc/src/theme-pack-switcher/theme-pack-sync.ts`:
+
+```ts
+export function buildPackCssUrl(base: string, slug: string, version: string): string {
+  return `${base}theme-packs/${slug}/pack.css?v=${version}`;
+}
+```
+
+Both the pre-paint bootstrap script and the runtime switch engine read the version from the inlined pack registry, not from a live fetch. A `pack.css` edit shipped **without** bumping `meta.json`'s `version` field can serve a stale cached copy of the stylesheet to a returning visitor whose browser already cached the old `?v=` URL. Bump the version on every content change to `pack.css`, however small.
+
+## (e) Custom-chrome caveat
+
+Packs select on the **stable hooks** (table (b)), not on any particular component's internal markup structure. If a downstream project replaces `Footer` or `DocPager` via `defineChromeBindings` (or any other primary chrome slot — `Header`, `Sidebar`, `Toc`, `Breadcrumb`), the **replacement component must emit the same hooks** (`footer[data-footer]`, `nav[data-doc-pager]`, etc.) to keep the shipped pack's styling working. A custom `Footer` that drops `data-footer` silently loses every pack rule scoped to `footer[data-footer]` — there is no fallback or warning; the pack rule simply never matches.
+
+## (f) Authoring workflow notes
+
+- **Verify selectors against real rendered output — never against prototypes or memory.** The old `_temp-resource/2812-theme-prototypes/` bundle (deleted, zudolab/zudo-doc#2856) was a static HTML reference that drifted from the real components and got the pager placement wrong (#2858). This document's skeleton in (a) was produced by SSR-rendering the actual `createDocPageShell` factory through `preact-render-to-string`, the same harness the package's own regression tests use — not hand-written or copied from a mockup. If you're unsure whether a hook still matches reality, render the real component the same way (see any `__tests__/*.test.tsx` file next to the component you care about for the pattern) or run a full `pnpm build` and inspect `dist/`.
+- **Every rule must be scoped** under `html[data-theme-pack="<slug>"]` (ADR Decision 6, rule 3) — this is what makes the pack swap atomic and lets the validator prove an inactive pack never leaks styles.
+- **Override `--zd-*` semantic roles, not `--color-*` Tailwind aliases**, and always via `light-dark()` for both modes (ADR Decision 6, rules 1–2).
+- For the full decision record — `meta.json` schema, asset emission paths, the runtime swap algorithm and its atomicity guarantee, zdtp per-pack persistence, font-loading policy (self-hosted OFL only, `local()` forbidden), and everything the build-time validator enforces — read [`docs/adr/theme-packs.md`](./adr/theme-packs.md). That document is the source of truth; this one is the pack-author's cheat sheet distilled from it.

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -598,16 +598,16 @@
     "CHANGELOG.md"
   ],
   "peerDependencies": {
-    "preact": "^10.29.1",
+    "@takazudo/zdtp": "^0.4.9",
     "@takazudo/zfb": "^0.1.0-next.87",
     "@takazudo/zfb-md-wasm": "^0.1.0-next.87",
     "@takazudo/zfb-runtime": "^0.1.0-next.87",
     "@takazudo/zudo-doc-history-server": "^3.3.0",
-    "@takazudo/zdtp": "^0.4.9",
-    "shiki": "^4.0.2",
-    "zod": "^4.3.6",
+    "diff": "^8.0.0",
     "katex": "^0.16.0",
-    "diff": "^8.0.0"
+    "preact": "^10.29.1",
+    "shiki": "^4.0.2",
+    "zod": "^4.3.6"
   },
   "peerDependenciesMeta": {
     "@takazudo/zudo-doc-history-server": {
@@ -640,22 +640,23 @@
     "tsx": "^4.21.0"
   },
   "devDependencies": {
+    "@takazudo/zfb": "0.1.0-next.87",
+    "@takazudo/zfb-md-wasm": "0.1.0-next.87",
+    "@takazudo/zfb-runtime": "0.1.0-next.87",
+    "@takazudo/zudo-doc-history-server": "workspace:*",
     "@types/fs-extra": "^11.0.4",
     "@types/minimist": "^1.2.5",
     "@types/node": "^25.3.5",
     "@types/pluralize": "^0.0.33",
     "@types/string-similarity": "^4.0.2",
     "cross-env": "^7.0.3",
+    "happy-dom": "^20.10.6",
     "preact": "^10.29.1",
     "preact-render-to-string": "^6.6.6",
     "shiki": "^4.0.2",
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
     "vitest": "^4.1.0",
-    "zod": "^4.3.6",
-    "@takazudo/zfb": "0.1.0-next.87",
-    "@takazudo/zfb-md-wasm": "0.1.0-next.87",
-    "@takazudo/zfb-runtime": "0.1.0-next.87",
-    "@takazudo/zudo-doc-history-server": "workspace:*"
+    "zod": "^4.3.6"
   }
 }

--- a/packages/zudo-doc/src/doc-content-header/__tests__/doc-content-header.test.tsx
+++ b/packages/zudo-doc/src/doc-content-header/__tests__/doc-content-header.test.tsx
@@ -132,3 +132,29 @@ describe("createDocContentHeader — docContentHeaderExtras seam", () => {
     ]);
   });
 });
+
+describe("createDocContentHeader — data-doc-description hook (zudolab/zudo-doc#2873)", () => {
+  it("emits data-doc-description on the description <p> when a description is set", () => {
+    const ctx = makeFakeChromeContext({ overrides: { hostBindings: {} } as Partial<ChromeContext> });
+    const DocContentHeader = createDocContentHeader(ctx);
+    const out = render(
+      <DocContentHeader
+        entry={makeEntry({ description: "A test description." })}
+        slug="test-page"
+        locale="en"
+      />,
+    );
+
+    expect(out).toMatch(/<p[^>]*data-doc-description[^>]*>A test description\.<\/p>/);
+  });
+
+  it("omits the <p> entirely when no description is set (no stray hook)", () => {
+    const ctx = makeFakeChromeContext({ overrides: { hostBindings: {} } as Partial<ChromeContext> });
+    const DocContentHeader = createDocContentHeader(ctx);
+    const out = render(
+      <DocContentHeader entry={makeEntry()} slug="test-page" locale="en" />,
+    );
+
+    expect(out).not.toContain("data-doc-description");
+  });
+});

--- a/packages/zudo-doc/src/doc-content-header/index.tsx
+++ b/packages/zudo-doc/src/doc-content-header/index.tsx
@@ -170,7 +170,7 @@ export function createDocContentHeader<S extends Settings = Settings>(
         )}
 
         {entry.data.description && (
-          <p class="mb-vsp-lg text-title text-muted">
+          <p class="mb-vsp-lg text-title text-muted" data-doc-description>
             {entry.data.description}
           </p>
         )}

--- a/packages/zudo-doc/src/doc-page-shell/__tests__/data-doc-description.test.tsx
+++ b/packages/zudo-doc/src/doc-page-shell/__tests__/data-doc-description.test.tsx
@@ -1,0 +1,64 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+/**
+ * Stable DOM hook regression test (zudolab/zudo-doc#2873).
+ *
+ * `data-doc-description` is emitted on TWO description `<p>` sites: the
+ * regular entry-page emitter (`doc-content-header`, covered separately) and
+ * this factory's own auto-index branch (a category page with no
+ * `index.mdx`). Only the latter is exercised here — the two emitters render
+ * from different code paths, so each needs its own explicit coverage.
+ */
+
+import { describe, expect, it } from "vitest";
+import { render } from "preact-render-to-string";
+import { createDocPageShell } from "../index.js";
+import { makeFakeChromeContext } from "../../__tests__/fixtures/fake-chrome-context.js";
+
+const BASE_PROPS = {
+  locale: "en",
+  slug: "cat",
+  breadcrumbs: [],
+  prev: null,
+  next: null,
+  headings: [],
+  navSection: undefined,
+  sidebarPersistKey: undefined,
+  currentPath: "/docs/cat",
+  versionSwitcher: null,
+};
+
+describe("createDocPageShell — auto-index data-doc-description hook", () => {
+  it("emits data-doc-description on the auto-index description <p>", () => {
+    const ctx = makeFakeChromeContext();
+    const DocPageShell = createDocPageShell(ctx);
+    const html = render(
+      <DocPageShell
+        {...BASE_PROPS}
+        kind="autoIndex"
+        title="Cat"
+        description="Cat description text"
+        autoIndexLabel="Cat"
+        autoIndexChildren={[]}
+      />,
+    );
+
+    expect(html).toMatch(/<p[^>]*data-doc-description[^>]*>Cat description text<\/p>/);
+  });
+
+  it("omits the <p> entirely when no description is set (no stray hook)", () => {
+    const ctx = makeFakeChromeContext();
+    const DocPageShell = createDocPageShell(ctx);
+    const html = render(
+      <DocPageShell
+        {...BASE_PROPS}
+        kind="autoIndex"
+        title="Cat"
+        autoIndexLabel="Cat"
+        autoIndexChildren={[]}
+      />,
+    );
+
+    expect(html).not.toContain("data-doc-description");
+  });
+});

--- a/packages/zudo-doc/src/doc-page-shell/index.tsx
+++ b/packages/zudo-doc/src/doc-page-shell/index.tsx
@@ -335,7 +335,7 @@ export function createDocPageShell<S extends Settings = Settings>(
             {metainfoSlot}
 
             {description && (
-              <p class="mb-vsp-lg text-title text-muted">{description}</p>
+              <p class="mb-vsp-lg text-title text-muted" data-doc-description>{description}</p>
             )}
             <NavCardGrid children={autoIndexChildren ?? []} />
           </>

--- a/packages/zudo-doc/src/doc-pager/__tests__/doc-pager.test.tsx
+++ b/packages/zudo-doc/src/doc-pager/__tests__/doc-pager.test.tsx
@@ -1,0 +1,32 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+// SSR-shape test for the DocPager's `data-doc-pager` stable DOM hook
+// (zudolab/zudo-doc#2873 — theme packs select `[data-doc-pager]` instead of
+// relying on the bare `<nav>` structure).
+
+import { describe, expect, it } from "vitest";
+import { render } from "preact-render-to-string";
+import { createDocPager } from "../index.js";
+import { makeFakeChromeContext } from "../../__tests__/fixtures/fake-chrome-context.js";
+
+describe("createDocPager — data-doc-pager hook", () => {
+  it("renders data-doc-pager on the <nav>, with both prev/next present", () => {
+    const ctx = makeFakeChromeContext();
+    const DocPager = createDocPager(ctx);
+    const html = render(
+      <DocPager
+        prev={{ href: "/docs/a", label: "A" }}
+        next={{ href: "/docs/b", label: "B" }}
+        locale="en"
+      />,
+    );
+    expect(html).toMatch(/<nav[^>]*data-doc-pager[^>]*>/);
+  });
+
+  it("renders data-doc-pager on the <nav> even when prev/next are both absent", () => {
+    const ctx = makeFakeChromeContext();
+    const DocPager = createDocPager(ctx);
+    const html = render(<DocPager prev={null} next={null} locale="en" />);
+    expect(html).toMatch(/<nav[^>]*data-doc-pager[^>]*>/);
+  });
+});

--- a/packages/zudo-doc/src/doc-pager/index.tsx
+++ b/packages/zudo-doc/src/doc-pager/index.tsx
@@ -50,7 +50,7 @@ export function createDocPager<S extends Settings = Settings>(
    */
   function DocPager({ prev, next, locale }: DocPagerProps): JSX.Element {
     return (
-      <nav class="mt-vsp-2xl grid grid-cols-2 gap-hsp-xl">
+      <nav class="mt-vsp-2xl grid grid-cols-2 gap-hsp-xl" data-doc-pager>
         {prev ? (
           <a
             href={prev.href}

--- a/packages/zudo-doc/src/footer/__tests__/footer.test.tsx
+++ b/packages/zudo-doc/src/footer/__tests__/footer.test.tsx
@@ -1,0 +1,22 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+// SSR-shape test for the Footer shell's `data-footer` stable DOM hook
+// (zudolab/zudo-doc#2873 — theme packs select `[data-footer]` instead of
+// relying on the `<footer>` tag/structure alone).
+
+import { describe, expect, it } from "vitest";
+import { render } from "preact-render-to-string";
+import { Footer } from "../footer.js";
+
+describe("Footer — data-footer hook", () => {
+  it("renders data-footer on the <footer> element (no columns/copyright)", () => {
+    const html = render(<Footer />);
+    expect(html).toMatch(/<footer[^>]*data-footer[^>]*>/);
+  });
+
+  it("still renders data-footer when a persistKey is set (attribute co-exists with data-zfb-transition-persist)", () => {
+    const html = render(<Footer persistKey="footer-en" />);
+    expect(html).toMatch(/<footer[^>]*data-footer[^>]*>/);
+    expect(html).toContain('data-zfb-transition-persist="footer-en"');
+  });
+});

--- a/packages/zudo-doc/src/footer/footer.tsx
+++ b/packages/zudo-doc/src/footer/footer.tsx
@@ -87,6 +87,7 @@ export function Footer(props: FooterProps): VNode {
   return (
     <footer
       class="border-t border-muted bg-surface"
+      data-footer
       // Strategy B: locale-keyed persist (zudolab/zudo-doc#1546).
       // The footer's locale-aware bits (link labels, copyright) are SSR'd
       // per locale; a locale-keyed persist key (`footer-en`, `footer-ja`)

--- a/packages/zudo-doc/src/theme-pack-dialog/index.tsx
+++ b/packages/zudo-doc/src/theme-pack-dialog/index.tsx
@@ -49,8 +49,10 @@ type RegistryState = "idle" | "loading" | "loaded" | "error";
 const COLOR_SCHEME_CHANGED_EVENT = "color-scheme-changed";
 
 /** Stable selector for the flyout's ALWAYS-mounted round launcher button
- *  (`theme-pack-switcher/index.tsx`) — see the focus-restore note below. */
-const LAUNCHER_SELECTOR = '[aria-label="Theme pack switcher"]';
+ *  (`theme-pack-switcher/index.tsx`) — see the focus-restore note below.
+ *  Strictly more precise than the prior `[aria-label="Theme pack switcher"]`
+ *  selector: that aria-label value also matches the flyout card (#2873). */
+const LAUNCHER_SELECTOR = "[data-switcher-launcher]";
 
 export function ThemePackDialog({ open, onClose, order, active, base }: ThemePackDialogProps) {
   const [registryState, setRegistryState] = useState<RegistryState>("idle");

--- a/packages/zudo-doc/src/theme-pack-switcher/__tests__/theme-pack-switcher-interaction.test.tsx
+++ b/packages/zudo-doc/src/theme-pack-switcher/__tests__/theme-pack-switcher-interaction.test.tsx
@@ -1,0 +1,114 @@
+/** @vitest-environment happy-dom */
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+// Real-DOM interaction tests for the ThemePackSwitcher stable DOM hooks
+// (zudolab/zudo-doc#2873 acceptance criteria):
+//
+//   - opening the flyout card must expose `data-switcher-card` (the card is
+//     NOT rendered while closed, so the SSR-closed snapshot in
+//     theme-pack-switcher-ssr.test.tsx cannot see it — this needs a real
+//     mount + click).
+//   - closing the browse-all dialog (rendered inside this same island's tree
+//     via the ThemePackDialogSlot seam) must restore focus to the launcher,
+//     proving the `LAUNCHER_SELECTOR` retarget to `[data-switcher-launcher]`
+//     (theme-pack-dialog/index.tsx) resolves the right element.
+//
+// This is the one spot in the package that needs a real DOM (`happy-dom`,
+// declared per-file via the `@vitest-environment` pragma above) — every
+// other test in this package runs in vitest's default plain-Node
+// environment. `order` here carries only the "default" pack so
+// `hasBrowsablePacks` is false (theme-pack-dialog/index.tsx) and the dialog's
+// lazy registry fetch never fires — keeping this a pure DOM-interaction test
+// with no network mocking required.
+
+import { afterEach, describe, expect, it } from "vitest";
+import { render } from "preact";
+import { act } from "preact/test-utils";
+import { ThemePackSwitcher, type ThemePackSwitcherProps } from "../index.js";
+
+const PROPS: ThemePackSwitcherProps = {
+  active: "default",
+  order: [
+    { slug: "default", name: "Default", mode: "light", description: "The stock zudo-doc look." },
+  ],
+  base: "/",
+};
+
+// The dialog's focus-restore reads `document.querySelector(LAUNCHER_SELECTOR)`
+// against the WHOLE document (theme-pack-dialog/index.tsx), not scoped to a
+// container — so a leftover mounted switcher from a prior test would shadow
+// the current test's own launcher. Track + unmount/remove after every test.
+let mounted: HTMLDivElement | null = null;
+
+function mount(props: ThemePackSwitcherProps): HTMLDivElement {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  act(() => {
+    render(<ThemePackSwitcher {...props} />, container);
+  });
+  mounted = container;
+  return container;
+}
+
+afterEach(() => {
+  if (mounted) {
+    act(() => {
+      render(null, mounted!);
+    });
+    mounted.remove();
+    mounted = null;
+  }
+});
+
+describe("ThemePackSwitcher — real-DOM interaction", () => {
+  it("clicking the launcher opens the card and exposes data-switcher-card", () => {
+    const container = mount(PROPS);
+
+    expect(container.querySelector("[data-switcher-card]")).toBeNull();
+
+    const launcher = container.querySelector<HTMLButtonElement>("[data-switcher-launcher]");
+    expect(launcher).not.toBeNull();
+
+    act(() => {
+      launcher!.click();
+    });
+
+    const card = container.querySelector("[data-switcher-card]");
+    expect(card).not.toBeNull();
+    expect(card).toHaveProperty("tagName", "DIV");
+  });
+
+  it("closing the browse-all dialog restores focus to [data-switcher-launcher]", () => {
+    const container = mount(PROPS);
+
+    const launcher = container.querySelector<HTMLButtonElement>("[data-switcher-launcher]");
+    expect(launcher).not.toBeNull();
+
+    // Open the flyout card, then the browse-all dialog (mirrors openDialog()
+    // in theme-pack-switcher/index.tsx: opening the dialog closes the card).
+    act(() => {
+      launcher!.click();
+    });
+    const gridButton = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Browse all theme packs"]',
+    );
+    expect(gridButton).not.toBeNull();
+    act(() => {
+      gridButton!.click();
+    });
+
+    const dialog = container.querySelector<HTMLDialogElement>("dialog");
+    expect(dialog).not.toBeNull();
+    expect(dialog!.open).toBe(true);
+    // The flyout card is unmounted once the dialog takes over.
+    expect(container.querySelector("[data-switcher-card]")).toBeNull();
+
+    // Native close (Esc key or dialog.close()) — useModalDialog listens for
+    // the dialog's own "close" event to restore focus.
+    act(() => {
+      dialog!.close();
+    });
+
+    expect(document.activeElement).toBe(launcher);
+  });
+});

--- a/packages/zudo-doc/src/theme-pack-switcher/__tests__/theme-pack-switcher-ssr.test.tsx
+++ b/packages/zudo-doc/src/theme-pack-switcher/__tests__/theme-pack-switcher-ssr.test.tsx
@@ -35,8 +35,16 @@ describe("ThemePackSwitcher — SSR shape", () => {
     expect(html).toContain('aria-expanded="false"');
   });
 
+  it("renders stable DOM hooks: data-theme-pack-switcher on the root, data-switcher-launcher on the launcher (zudolab/zudo-doc#2873)", () => {
+    expect(html).toMatch(/<div[^>]*data-theme-pack-switcher[^>]*>/);
+    expect(html).toMatch(
+      /<button[^>]*aria-label="Theme pack switcher"[^>]*data-switcher-launcher[^>]*>/,
+    );
+  });
+
   it("renders NO card content while closed (the card is toggled client-side)", () => {
     expect(html).not.toContain('role="dialog"');
+    expect(html).not.toContain("data-switcher-card");
     expect(html).not.toContain("Foundry");
     expect(html).not.toContain("Industrial dark pack.");
     // Matched by aria-label rather than the raw "Prev"/"Next" substrings:

--- a/packages/zudo-doc/src/theme-pack-switcher/index.tsx
+++ b/packages/zudo-doc/src/theme-pack-switcher/index.tsx
@@ -211,13 +211,17 @@ export function ThemePackSwitcher({ active, order, base }: ThemePackSwitcherProp
   }
 
   return (
-    <div class="fixed right-hsp-lg bottom-hsp-lg z-popover flex flex-col items-end gap-vsp-2xs">
+    <div
+      class="fixed right-hsp-lg bottom-hsp-lg z-popover flex flex-col items-end gap-vsp-2xs"
+      data-theme-pack-switcher
+    >
       {open ? (
         <div
           ref={cardRef}
           tabIndex={-1}
           role="dialog"
           aria-label="Theme pack switcher"
+          data-switcher-card
           class="flex w-72 max-w-[calc(100vw-2rem)] flex-col gap-vsp-2xs rounded-lg border border-muted bg-surface p-hsp-lg shadow-lg focus-visible:outline-2 focus-visible:outline-accent"
         >
           <div class="flex items-start justify-between gap-hsp-sm">
@@ -287,6 +291,7 @@ export function ThemePackSwitcher({ active, order, base }: ThemePackSwitcherProp
         aria-expanded={open}
         aria-label="Theme pack switcher"
         title="Theme packs"
+        data-switcher-launcher
         onClick={() => setOpen(!open)}
         class="flex h-10 w-10 items-center justify-center rounded-full border border-muted bg-surface text-fg shadow-lg transition-colors hover:text-accent focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2"
       >

--- a/packages/zudo-doc/src/theme-packs-registry/__tests__/validator.test.ts
+++ b/packages/zudo-doc/src/theme-packs-registry/__tests__/validator.test.ts
@@ -186,7 +186,11 @@ describe("validateThemePack", () => {
         cssContent: `html[data-theme-pack="foundry"] .zd-content h2 { color: red !important; }`,
       }),
     );
-    expect(disallowed.issues.some((i) => i.rule === "important-allowlist")).toBe(true);
+    const importantIssues = disallowed.issues.filter((i) => i.rule === "important-allowlist");
+    expect(importantIssues).toHaveLength(1);
+    expect(importantIssues[0]?.message).toContain(
+      "the h2–h4 heading-rule gradient carve-out, Decision 6.6",
+    );
 
     const allowed = validateThemePack(
       baseInput({

--- a/packages/zudo-doc/src/theme-packs-registry/validator.ts
+++ b/packages/zudo-doc/src/theme-packs-registry/validator.ts
@@ -10,8 +10,8 @@
 // `html[data-theme-pack="<slug>"]`; the known-custom-property-name manifest;
 // preview swatches are plain resolved colors; `fonts.loaded` ⇄ `@font-face`
 // parity; `OFL.txt` presence when font files ship; the commercial-typeface
-// denylist; the `!important` allowlist (the h2 `border-image` carve-out
-// only); no `color-scheme:` declarations; no `[data-theme]` selectors. A
+// denylist; the `!important` allowlist (the h2–h4 heading-rule
+// `border-image` carve-out); no `color-scheme:` declarations; no `[data-theme]` selectors. A
 // total-payload-size overage is a WARNING, not an error (Decision 6.7's
 // soft ~250 KB budget).
 
@@ -223,7 +223,7 @@ function checkImportantAllowlist(cssContent: string, issues: ThemePackValidation
       issues.push({
         rule: "important-allowlist",
         severity: "error",
-        message: `"!important" is only allowed on a "border-image" declaration (the h2 gradient carve-out, Decision 6.6) — found on "${prop}"`,
+        message: `"!important" is only allowed on a "border-image" declaration (the h2–h4 heading-rule gradient carve-out, Decision 6.6) — found on "${prop}"`,
       });
     }
   }

--- a/packages/zudo-doc/src/theme-packs/beacon/meta.json
+++ b/packages/zudo-doc/src/theme-packs/beacon/meta.json
@@ -4,7 +4,7 @@
   "name": "Beacon",
   "description": "WCAG-AAA high contrast — 7:1+ ink everywhere, 3px focus rings, always-underlined links. Clarity as beauty.",
   "mode": "light",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "fonts": {
     "sans": "Atkinson Hyperlegible",
     "mono": "Atkinson Hyperlegible Mono",

--- a/packages/zudo-doc/src/theme-packs/beacon/pack.css
+++ b/packages/zudo-doc/src/theme-packs/beacon/pack.css
@@ -40,23 +40,22 @@
      comma list of fully-prefixed branches (the validator checks
      every comma-separated branch for the scope prefix, so the
      comma-bearing :where() argument list can't be used)
-   - `.lead`             → `.zd-content > p:first-of-type` (the
-                           description paragraph DocContentHeader
-                           renders as the article's first direct-child
-                           <p>; fails soft on pages without one)
-   - `.doc-pager`        → `.zd-content > nav:last-of-type:not([aria-label]) > a`
-                           (the DocPager is the article's last
-                           unlabelled direct-child nav whose children
-                           are bare <a> cards; breadcrumb and
-                           NavCardGrid navs carry aria-labels)
+   - `.lead`             → `.zd-content > p[data-doc-description]`
+                           (the description paragraph DocContentHeader
+                           renders now carries a stable data-doc-description
+                           hook; fails soft on pages without one, #2876)
+   - `.doc-pager`        → `.zd-content > nav[data-doc-pager] > a`
+                           (the DocPager nav now carries a stable
+                           data-doc-pager hook, #2876)
    - `.pager-title`      → the pager card's <p> (its only <p>)
-   - `footer[data-footer]` → `.zd-sidebar-content-wrapper > footer`
-                           (no data-footer attribute in the real DOM)
-   - `.tp-flyout`        → `div[role="dialog"][aria-label="Theme pack
-                           switcher"]` (the ledger/nocturne precedent).
-                           The launcher button and `.tp-btn` controls
-                           have NO stable hook — intentionally NOT
-                           ported.
+   - `footer[data-footer]` → ships literally now — the real footer
+                           carries the stable data-footer hook (#2876)
+   - `.tp-flyout`        → `div[data-switcher-card]` (the flyout card
+                           now carries a stable data-switcher-card
+                           hook, #2876). The launcher button and
+                           `.tp-btn` controls carry a data-switcher-launcher
+                           hook too, but their styling is intentionally
+                           NOT ported.
    - `.hdr-search` / `.hdr-icon-btn` / `.toc-title` / `.sb-group > p`
                            — prototype-mock markup with no stable
                            hook; NOT ported.
@@ -244,7 +243,7 @@ html[data-theme-pack="beacon"] [data-nav-item],
 html[data-theme-pack="beacon"] aside a,
 html[data-theme-pack="beacon"] main nav[aria-label="Breadcrumb"] a,
 html[data-theme-pack="beacon"] nav[data-zd-toc] a,
-html[data-theme-pack="beacon"] .zd-sidebar-content-wrapper > footer a {
+html[data-theme-pack="beacon"] footer[data-footer] a {
   text-decoration: underline;
   text-underline-offset: 0.2em;
 }
@@ -266,7 +265,7 @@ html[data-theme-pack="beacon"] aside a,
 html[data-theme-pack="beacon"] a[data-nav-active] {
   border-radius: 0;
 }
-html[data-theme-pack="beacon"] .zd-sidebar-content-wrapper > footer {
+html[data-theme-pack="beacon"] footer[data-footer] {
   border-top: 3px solid var(--zd-fg);
 }
 
@@ -274,7 +273,7 @@ html[data-theme-pack="beacon"] .zd-sidebar-content-wrapper > footer {
 html[data-theme-pack="beacon"] .zd-content h1 {
   font-size: 3rem;
 }
-html[data-theme-pack="beacon"] .zd-content > p:first-of-type {
+html[data-theme-pack="beacon"] .zd-content > p[data-doc-description] {
   font-size: 1.3rem;
 }
 /* h2: a 4px ink rule. The SSR-inlined
@@ -412,16 +411,16 @@ html[data-theme-pack="beacon"] nav[data-zd-toc] ul {
    language. The DocPager is the article's LAST unlabelled
    direct-child nav (breadcrumb and NavCardGrid navs carry
    aria-labels). */
-html[data-theme-pack="beacon"] .zd-content > nav:last-of-type:not([aria-label]) > a {
+html[data-theme-pack="beacon"] .zd-content > nav[data-doc-pager] > a {
   border: 2px solid var(--zd-fg);
   border-radius: 0;
 }
-html[data-theme-pack="beacon"] .zd-content > nav:last-of-type:not([aria-label]) > a:hover {
+html[data-theme-pack="beacon"] .zd-content > nav[data-doc-pager] > a:hover {
   border-color: var(--zd-accent);
   outline: 3px solid var(--zd-accent);
   outline-offset: 0;
 }
-html[data-theme-pack="beacon"] .zd-content > nav:last-of-type:not([aria-label]) > a p {
+html[data-theme-pack="beacon"] .zd-content > nav[data-doc-pager] > a p {
   font-weight: 700;
   text-decoration: underline;
   text-decoration-thickness: 2px;
@@ -429,14 +428,14 @@ html[data-theme-pack="beacon"] .zd-content > nav:last-of-type:not([aria-label]) 
 }
 
 /* theme-pack flyout: square, 3px-framed, hard offset shadow (the
-   launcher button has no stable hook) */
-html[data-theme-pack="beacon"] div[role="dialog"][aria-label="Theme pack switcher"] {
+   launcher button's styling is intentionally not ported) */
+html[data-theme-pack="beacon"] div[data-switcher-card] {
   border: 3px solid var(--zd-fg);
   border-radius: 0;
   box-shadow: 6px 6px 0 0 color-mix(in srgb, var(--zd-fg) 18%, transparent);
 }
 html[data-theme-pack="beacon"]
-  div[role="dialog"][aria-label="Theme pack switcher"]
+  div[data-switcher-card]
   p[aria-live="polite"]::before {
   content: "◉ ";
   color: var(--zd-accent);

--- a/packages/zudo-doc/src/theme-packs/broadsheet/meta.json
+++ b/packages/zudo-doc/src/theme-packs/broadsheet/meta.json
@@ -4,7 +4,7 @@
   "name": "Broadsheet",
   "description": "Newspaper editorial — Playfair masthead, Oxford ink rules, a red drop cap, and a night-edition dark mode.",
   "mode": "light",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "fonts": {
     "sans": "Source Serif 4",
     "mono": "Courier Prime",

--- a/packages/zudo-doc/src/theme-packs/broadsheet/pack.css
+++ b/packages/zudo-doc/src/theme-packs/broadsheet/pack.css
@@ -33,9 +33,11 @@
                           data-doc-pager hook, #2876)
    - `footer[data-footer]` → ships literally now — the real footer
                           carries the stable data-footer hook (#2876)
-   - the theme-switcher flyout has NO stable hook ported — its
-     classified-ad double frame is intentionally NOT ported (see pack
-     notes).
+   - `.tp-flyout`       → `div[data-switcher-card]` (the flyout card
+                          now carries a stable data-switcher-card
+                          hook, #2873) — its classified-ad double
+                          frame, originally left unported for lack of
+                          a hook, ships now (#2880).
    ============================================================ */
 
 /* ---- Playfair Display — masthead / headlines / pull quotes / drop
@@ -414,4 +416,33 @@ html[data-theme-pack="broadsheet"] .zd-content > nav[data-doc-pager] a p {
 html[data-theme-pack="broadsheet"] footer[data-footer] {
   border-top: 3px solid var(--zd-fg);
   box-shadow: 0 -6px 0 -5px var(--zd-fg);
+}
+
+/* switcher flyout: a classified-ad box — square, inner ink hairline
+   with an offset outer rule (the prototype's double frame, restored in
+   #2880 against the stable data-switcher-card hook, #2873). The outer
+   rule + 3px paper gap are drawn as box-shadow rings, NOT `outline`,
+   so the card's keyboard focus-visible accent outline keeps working
+   (an unlayered pack `outline` would silently override that utility);
+   the rings also replace the default elevation shadow — print floats
+   nothing. */
+html[data-theme-pack="broadsheet"] div[data-switcher-card] {
+  border-radius: 0;
+  border: 1px solid var(--zd-fg);
+  box-shadow:
+    0 0 0 3px var(--zd-surface),
+    0 0 0 4px var(--zd-fg);
+}
+/* the ad's head: pack name set in the Playfair display face (the
+   p[aria-live="polite"] hook is the live pack-name line — the onyx/
+   ledger/nocturne precedent) */
+html[data-theme-pack="broadsheet"] div[data-switcher-card] p[aria-live="polite"] {
+  font-family: var(--font-display);
+  font-weight: 900;
+}
+/* print is square — the card's internal controls and the mode badge
+   drop their rounding too */
+html[data-theme-pack="broadsheet"] div[data-switcher-card] button,
+html[data-theme-pack="broadsheet"] div[data-switcher-card] > span {
+  border-radius: 0;
 }

--- a/packages/zudo-doc/src/theme-packs/broadsheet/pack.css
+++ b/packages/zudo-doc/src/theme-packs/broadsheet/pack.css
@@ -16,21 +16,26 @@
 
    Prototype-selector adaptations against the REAL DOM (tokens-dump
    §6 + component sources), noted inline where they matter:
-   - `.lead`            → `.zd-content > p:first-of-type` (the
-                          description paragraph DocContentHeader emits)
-   - `.lead + p`        → `.zd-content > p:first-of-type + p`
+   - `.lead`            → `.zd-content > p[data-doc-description]` (the
+                          description paragraph DocContentHeader emits
+                          now carries a stable data-doc-description
+                          hook, #2876)
+   - `.lead + p`        → `.zd-content > p[data-doc-description] + p`
+                          — a description-less page now gets neither
+                          the deck nor the drop cap (the old
+                          `.zd-content > p:first-of-type` fallback
+                          mis-styled body text there — intended fix,
+                          #2876)
    - `.toc-title`       → no desktop TOC heading exists (#1655); the
                           double head-rule moves onto the TOC's <ul>
-   - `.doc-pager`       → `.zd-content > nav:not([aria-label])` (the
-                          DocPager nav is a direct child of the
-                          article and is the only unlabelled nav there;
-                          NavCardGrid carries aria-label="Child pages")
-   - `footer[data-footer]` → `.zd-sidebar-content-wrapper > footer`
-                          (no data-footer attribute in the real DOM;
-                          the footer is a direct child of the wrapper
-                          hook — doc-layout.tsx)
-   - the theme-switcher flyout has NO stable hook — its classified-ad
-     double frame is intentionally NOT ported (see pack notes).
+   - `.doc-pager`       → `.zd-content > nav[data-doc-pager]` (the
+                          DocPager nav now carries a stable
+                          data-doc-pager hook, #2876)
+   - `footer[data-footer]` → ships literally now — the real footer
+                          carries the stable data-footer hook (#2876)
+   - the theme-switcher flyout has NO stable hook ported — its
+     classified-ad double frame is intentionally NOT ported (see pack
+     notes).
    ============================================================ */
 
 /* ---- Playfair Display — masthead / headlines / pull quotes / drop
@@ -214,27 +219,26 @@ html[data-theme-pack="broadsheet"] .zd-content h1 {
   margin-bottom: 1rem;
 }
 
-/* the deck: italic standfirst under the headline. The prototype's
-   `.lead` is the description paragraph DocContentHeader renders as the
-   FIRST direct-child <p> of the article (metainfo/tags render as divs,
-   so p:first-of-type is the deck on every page with a description).
-   Known limit: the description is optional frontmatter — on a page
-   without one (~4% of the showcase corpus) the first BODY paragraph
-   takes the standfirst styling instead (reads as an emphasized opening
-   paragraph) and the drop cap below lands on the second paragraph.
-   CSS alone can't tell the two apart; a stable hook on the emitted
-   description paragraph would fix this properly (follow-up). */
-html[data-theme-pack="broadsheet"] .zd-content > p:first-of-type {
+/* the deck: italic standfirst under the headline. The description
+   paragraph DocContentHeader renders now carries a stable
+   data-doc-description hook (#2876), so the deck only ever styles the
+   real description — not the first body paragraph. Behavior change,
+   intended fix: on a page without a description (~4% of the showcase
+   corpus) NEITHER the deck NOR the drop cap below is drawn, rather
+   than the old fallback mis-styling the first body paragraph as a
+   standfirst. */
+html[data-theme-pack="broadsheet"] .zd-content > p[data-doc-description] {
   font-style: italic;
   line-height: 1.5;
 }
 
 /* signature move #1 — red Playfair drop cap opening the first body
-   paragraph (prototype `.lead + p`). Fails safe: on a page whose body
-   doesn't open with a paragraph right after the deck (or with a
-   frontmatter-preview table between them) no cap is drawn, rather than
-   capping a random mid-article paragraph. */
-html[data-theme-pack="broadsheet"] .zd-content > p:first-of-type + p::first-letter {
+   paragraph immediately after the description. Fails safe: on a page
+   without a description, or whose body doesn't open with a paragraph
+   right after it (or with a frontmatter-preview table between them),
+   no cap is drawn, rather than capping a random mid-article
+   paragraph. */
+html[data-theme-pack="broadsheet"] .zd-content > p[data-doc-description] + p::first-letter {
   float: left;
   font-family: var(--font-display);
   font-weight: 900;
@@ -382,36 +386,32 @@ html[data-theme-pack="broadsheet"] nav[data-zd-toc] ul {
   padding-top: 0.5rem;
 }
 
-/* pager: classified-corner cards under a closing double rule. DocPager
-   renders after the MDX content on every regular doc page, so it is
-   always the article's LAST direct-child nav; the :not([aria-label])
-   guard excludes NavCardGrid ("Child pages") on auto-index pages, and
-   :last-of-type excludes an unlabelled <CategoryNav> used mid-content
-   (its nav also ships without an aria-label — review finding). */
-html[data-theme-pack="broadsheet"] .zd-content > nav:last-of-type:not([aria-label]) {
+/* pager: classified-corner cards under a closing double rule. The
+   DocPager nav now carries a stable data-doc-pager hook (#2876). */
+html[data-theme-pack="broadsheet"] .zd-content > nav[data-doc-pager] {
   border-top: 4px double color-mix(in oklch, var(--zd-fg) 70%, transparent);
   padding-top: 1.25rem;
 }
-html[data-theme-pack="broadsheet"] .zd-content > nav:last-of-type:not([aria-label]) a {
+html[data-theme-pack="broadsheet"] .zd-content > nav[data-doc-pager] a {
   border-radius: 0;
   border-color: color-mix(in oklch, var(--zd-fg) 50%, transparent);
 }
-html[data-theme-pack="broadsheet"] .zd-content > nav:last-of-type:not([aria-label]) a:hover {
+html[data-theme-pack="broadsheet"] .zd-content > nav[data-doc-pager] a:hover {
   border-color: var(--zd-accent);
 }
-html[data-theme-pack="broadsheet"] .zd-content > nav:last-of-type:not([aria-label]) a > div {
+html[data-theme-pack="broadsheet"] .zd-content > nav[data-doc-pager] a > div {
   text-transform: uppercase;
   font-size: 0.68rem;
   letter-spacing: 0.12em;
 }
-html[data-theme-pack="broadsheet"] .zd-content > nav:last-of-type:not([aria-label]) a p {
+html[data-theme-pack="broadsheet"] .zd-content > nav[data-doc-pager] a p {
   font-family: var(--font-display);
   font-weight: 700;
 }
 
 /* colophon footer under its own thick-thin Oxford rule (the real
-   footer has no data-footer hook; it is the wrapper's direct child) */
-html[data-theme-pack="broadsheet"] .zd-sidebar-content-wrapper > footer {
+   footer now carries the stable data-footer hook, #2876) */
+html[data-theme-pack="broadsheet"] footer[data-footer] {
   border-top: 3px solid var(--zd-fg);
   box-shadow: 0 -6px 0 -5px var(--zd-fg);
 }

--- a/packages/zudo-doc/src/theme-packs/brutalist/meta.json
+++ b/packages/zudo-doc/src/theme-packs/brutalist/meta.json
@@ -4,7 +4,7 @@
   "name": "Brutalist",
   "description": "Raw concrete web — stark black on white, 4px slab borders, zero radius, hazard-orange tape. Structure you can see.",
   "mode": "light",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "fonts": {
     "sans": "Space Grotesk",
     "mono": "IBM Plex Mono",

--- a/packages/zudo-doc/src/theme-packs/brutalist/pack.css
+++ b/packages/zudo-doc/src/theme-packs/brutalist/pack.css
@@ -42,25 +42,24 @@
    - `.crumb-current`    → `nav[aria-label="Breadcrumb"] li > span`
                            (the current page is the only <span>
                            directly inside a breadcrumb <li>).
-   - `.doc-pager`        → `.zd-content > nav:last-of-type:not([aria-label]) > a`
-                           (the DocPager is the article's last
-                           unlabelled direct-child nav whose children
-                           are bare <a> cards — the nocturne/ledger
-                           precedent); label = `> a div`, title =
-                           `> a p`.
+   - `.doc-pager`        → `.zd-content > nav[data-doc-pager] > a`
+                           (the DocPager nav now carries a stable
+                           data-doc-pager hook, #2876); label =
+                           `> a div`, title = `> a p`.
    - `.toc-active`       → the real TOC active entry already carries
                            the inverted `bg-fg text-bg` fill
                            (toc.tsx aria-current) — the pack only
                            bolds it.
-   - `footer[data-footer]` → `.zd-sidebar-content-wrapper > footer`
-                           (no data-footer attribute in the real DOM);
+   - `footer[data-footer]` → ships literally now — the real footer
+                           carries the stable data-footer hook (#2876);
                            the mock's `.footer-copy` has no hook, so
                            only the 4px signage rule is ported.
-   - `.tp-flyout`        → `div[role="dialog"][aria-label="Theme pack
-                           switcher"]`; its title is
+   - `.tp-flyout`        → `div[data-switcher-card]`; its title is
                            `p[aria-live="polite"]`. The launcher
-                           button and control buttons have NO stable
-                           hooks — intentionally NOT ported.
+                           button carries a data-switcher-launcher
+                           hook too, but its styling and the other
+                           control buttons are intentionally NOT
+                           ported.
    - the prototype's `--bru-tape` / `--bru-hot` helper properties are
      not part of the token manifest; their values are inlined at each
      use site (tape = repeating -45deg #ff5c00/fg 10px stripes; hot =
@@ -473,32 +472,31 @@ html[data-theme-pack="brutalist"] [data-admonition="warning"] .admonition-title:
   content: "▲ ";
 }
 
-/* pager: slab cards, full inversion on hover. The DocPager is the
-   article's LAST unlabelled direct-child nav (breadcrumb and
-   NavCardGrid navs carry aria-labels). */
-html[data-theme-pack="brutalist"] .zd-content > nav:last-of-type:not([aria-label]) > a {
+/* pager: slab cards, full inversion on hover. The DocPager nav now
+   carries a stable data-doc-pager hook (#2876). */
+html[data-theme-pack="brutalist"] .zd-content > nav[data-doc-pager] > a {
   border: 4px solid var(--zd-fg);
   border-radius: 0;
 }
 html[data-theme-pack="brutalist"]
   .zd-content
-  > nav:last-of-type:not([aria-label])
+  > nav[data-doc-pager]
   > a:hover {
   border-color: var(--zd-fg);
   background-color: var(--zd-fg);
 }
-html[data-theme-pack="brutalist"] .zd-content > nav:last-of-type:not([aria-label]) > a div {
+html[data-theme-pack="brutalist"] .zd-content > nav[data-doc-pager] > a div {
   font-family: var(--font-mono);
   font-size: 0.66rem;
   text-transform: uppercase;
   letter-spacing: 0.1em;
 }
-html[data-theme-pack="brutalist"] .zd-content > nav:last-of-type:not([aria-label]) > a p {
+html[data-theme-pack="brutalist"] .zd-content > nav[data-doc-pager] > a p {
   font-weight: 700;
 }
-html[data-theme-pack="brutalist"] .zd-content > nav:last-of-type:not([aria-label]) > a:hover div,
-html[data-theme-pack="brutalist"] .zd-content > nav:last-of-type:not([aria-label]) > a:hover p,
-html[data-theme-pack="brutalist"] .zd-content > nav:last-of-type:not([aria-label]) > a:hover svg {
+html[data-theme-pack="brutalist"] .zd-content > nav[data-doc-pager] > a:hover div,
+html[data-theme-pack="brutalist"] .zd-content > nav[data-doc-pager] > a:hover p,
+html[data-theme-pack="brutalist"] .zd-content > nav[data-doc-pager] > a:hover svg {
   color: var(--zd-bg);
 }
 
@@ -511,22 +509,23 @@ html[data-theme-pack="brutalist"] nav[data-zd-toc] a[aria-current="true"] {
   font-weight: 700;
 }
 
-/* footer: signage strip (the real footer has no data-footer hook;
-   it is the wrapper's direct child) */
-html[data-theme-pack="brutalist"] .zd-sidebar-content-wrapper > footer {
+/* footer: signage strip (the real footer now carries the stable
+   data-footer hook, #2876) */
+html[data-theme-pack="brutalist"] footer[data-footer] {
   border-top: 4px solid var(--zd-fg);
   background-color: var(--zd-bg);
 }
 
 /* theme-pack flyout: a shadowless 4px crate with a hazard-tape lid
-   (the launcher button and control buttons have no stable hooks) */
-html[data-theme-pack="brutalist"] div[role="dialog"][aria-label="Theme pack switcher"] {
+   (the launcher button and control buttons keep their styling
+   intentionally NOT ported) */
+html[data-theme-pack="brutalist"] div[data-switcher-card] {
   border: 4px solid var(--zd-fg);
   border-radius: 0;
   box-shadow: none;
 }
 html[data-theme-pack="brutalist"]
-  div[role="dialog"][aria-label="Theme pack switcher"]::before {
+  div[data-switcher-card]::before {
   content: "";
   height: 6px;
   margin: calc(-1 * var(--spacing-hsp-lg, 1rem)) calc(-1 * var(--spacing-hsp-lg, 1rem)) 0;
@@ -537,7 +536,7 @@ html[data-theme-pack="brutalist"]
   );
 }
 html[data-theme-pack="brutalist"]
-  div[role="dialog"][aria-label="Theme pack switcher"]
+  div[data-switcher-card]
   p[aria-live="polite"] {
   font-family: var(--font-display);
   font-weight: 400;

--- a/packages/zudo-doc/src/theme-packs/drift/meta.json
+++ b/packages/zudo-doc/src/theme-packs/drift/meta.json
@@ -4,7 +4,7 @@
   "name": "Drift",
   "description": "Floaty slate-blue comfort dark for long reading — soft glows in place of borders, gentle elevation, relaxed Plex type.",
   "mode": "dark",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "fonts": {
     "sans": "IBM Plex Sans",
     "mono": "IBM Plex Mono",

--- a/packages/zudo-doc/src/theme-packs/drift/pack.css
+++ b/packages/zudo-doc/src/theme-packs/drift/pack.css
@@ -26,17 +26,17 @@
    - `.toc-active`       → `nav[data-zd-toc] a[aria-current="true"]`
                            (toc/toc.tsx marks the active entry with
                            aria-current, not a mock class)
-   - `.doc-pager`        → `.zd-content > nav:last-of-type:not([aria-label]) > a`
-                           (the DocPager nav is the article's last
-                           unlabelled direct-child nav; the :not
-                           guard excludes NavCardGrid's labelled
-                           "Child pages" nav — see #2862)
-   - `footer[data-footer]` → `.zd-sidebar-content-wrapper > footer`
-                           (no data-footer attribute in the real DOM)
+   - `.doc-pager`        → `.zd-content > nav[data-doc-pager] > a`
+                           (the DocPager nav now carries a stable
+                           data-doc-pager hook, #2876)
+   - `footer[data-footer]` → ships literally now — the real footer
+                           carries the stable data-footer hook (#2876)
    - `.hdr-search` / `.hdr-icon-btn` — prototype-mock markup with no
      stable hook; their pill/glow styling is NOT ported.
-   - the theme-switcher flyout + launcher have NO stable hook —
-     intentionally NOT ported.
+   - the theme-switcher flyout + launcher carry stable hooks now
+     ([data-switcher-card] / [data-switcher-launcher]) but their
+     styling is intentionally NOT ported — no visual intent to
+     preserve there.
    - the prototype's `--drift-hairline` / `--drift-shadow` /
      `--drift-halo` helper properties are not part of the token
      manifest, so their light-dark() values are inlined at each use
@@ -409,9 +409,8 @@ html[data-theme-pack="drift"] .zd-content hr {
 }
 
 /* pager cards: levitating panels — glow ring, lift on hover. The
-   DocPager is the article's LAST unlabelled direct-child nav
-   (breadcrumb and NavCardGrid navs carry aria-labels). */
-html[data-theme-pack="drift"] .zd-content > nav:last-of-type:not([aria-label]) > a {
+   DocPager nav now carries a stable data-doc-pager hook (#2876). */
+html[data-theme-pack="drift"] .zd-content > nav[data-doc-pager] > a {
   border-color: transparent;
   border-radius: 14px;
   background: color-mix(in oklch, var(--zd-surface) 72%, var(--zd-bg));
@@ -422,7 +421,7 @@ html[data-theme-pack="drift"] .zd-content > nav:last-of-type:not([aria-label]) >
     box-shadow 0.25s,
     transform 0.25s;
 }
-html[data-theme-pack="drift"] .zd-content > nav:last-of-type:not([aria-label]) > a:hover {
+html[data-theme-pack="drift"] .zd-content > nav[data-doc-pager] > a:hover {
   border-color: transparent;
   transform: translateY(-2px);
   box-shadow:
@@ -467,8 +466,8 @@ html[data-theme-pack="drift"] main nav[aria-label="Breadcrumb"] a:hover {
 }
 
 /* footer: dissolves upward, hairline + settling gradient (the real
-   footer has no data-footer hook; it is the wrapper's direct child) */
-html[data-theme-pack="drift"] .zd-sidebar-content-wrapper > footer {
+   footer now carries the stable data-footer hook, #2876) */
+html[data-theme-pack="drift"] footer[data-footer] {
   border-top-color: transparent;
   box-shadow: 0 -1px 0 light-dark(oklch(0.45 0.04 248 / 0.17), oklch(0.78 0.04 240 / 0.13));
   background: linear-gradient(

--- a/packages/zudo-doc/src/theme-packs/fjord/meta.json
+++ b/packages/zudo-doc/src/theme-packs/fjord/meta.json
@@ -4,7 +4,7 @@
   "name": "Fjord",
   "description": "Polar-night blue under a faint aurora — frost-cyan accents, icy borders, snow-white text. Cold nordic calm.",
   "mode": "dark",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "fonts": {
     "sans": "Inter",
     "mono": "JetBrains Mono",

--- a/packages/zudo-doc/src/theme-packs/fjord/pack.css
+++ b/packages/zudo-doc/src/theme-packs/fjord/pack.css
@@ -23,17 +23,14 @@
    - `.toc-active`      → `nav[data-zd-toc] a[aria-current="true"]`
                           (toc/toc.tsx marks the active entry with
                           aria-current, not a mock class)
-   - `.doc-pager`       → `.zd-content > nav:last-of-type:not([aria-label]) > a`
-                          (DocPager is the article's last unlabelled
-                          direct-child nav; the child combinator keeps
-                          NavCardGrid/CategoryNav card anchors — which
-                          sit one level deeper — out of the match)
-   - `footer[data-footer]` → `.zd-sidebar-content-wrapper > footer`
-                          (no data-footer attribute in the real DOM)
-   - `.tp-flyout`       → `div[role="dialog"][aria-label="Theme pack switcher"]`
-                          (the real flyout's stable hook — the ledger
-                          precedent); the aurora cap rides its top
-                          border via border-image
+   - `.doc-pager`       → `.zd-content > nav[data-doc-pager] > a`
+                          (the DocPager nav now carries a stable
+                          data-doc-pager hook, #2876)
+   - `footer[data-footer]` → ships literally now — the real footer
+                          carries the stable data-footer hook (#2876)
+   - `.tp-flyout`       → `div[data-switcher-card]` (the flyout's
+                          stable hook, #2876); the aurora cap rides
+                          its top border via border-image
    - `.hdr-search` / `.sb-group > p` — prototype-mock markup with no
      stable hook; their frost styling is NOT ported.
    - the prototype's `--fjord-*` helper properties (ice-border,
@@ -332,22 +329,21 @@ html[data-theme-pack="fjord"] nav[data-zd-toc] a[aria-current="true"] {
   box-shadow: inset 2px 0 0 var(--zd-accent);
 }
 
-/* pager cards: translucent ice, cold glow on hover. The DocPager is
-   the article's LAST unlabelled direct-child nav; the > a child
-   combinator keeps NavCardGrid/CategoryNav anchors out. */
-html[data-theme-pack="fjord"] .zd-content > nav:last-of-type:not([aria-label]) > a {
+/* pager cards: translucent ice, cold glow on hover. The DocPager nav
+   now carries a stable data-doc-pager hook (#2876). */
+html[data-theme-pack="fjord"] .zd-content > nav[data-doc-pager] > a {
   border-radius: 0;
   border-color: light-dark(oklch(0.79 0.038 220 / 0.9), oklch(0.56 0.055 220 / 0.4));
   background: color-mix(in oklch, var(--zd-surface) 55%, transparent);
 }
-html[data-theme-pack="fjord"] .zd-content > nav:last-of-type:not([aria-label]) > a:hover {
+html[data-theme-pack="fjord"] .zd-content > nav[data-doc-pager] > a:hover {
   border-color: color-mix(in oklch, var(--zd-accent) 70%, transparent);
   box-shadow: 0 0 22px -8px color-mix(in oklch, var(--zd-accent) 50%, transparent);
 }
 
-/* footer: icy top rule, faint frost drift (the real footer has no
-   data-footer hook; it is the wrapper's direct child) */
-html[data-theme-pack="fjord"] .zd-sidebar-content-wrapper > footer {
+/* footer: icy top rule, faint frost drift (the real footer now
+   carries the stable data-footer hook, #2876) */
+html[data-theme-pack="fjord"] footer[data-footer] {
   border-top-color: light-dark(oklch(0.79 0.038 220 / 0.9), oklch(0.56 0.055 220 / 0.4));
   background: linear-gradient(
     180deg,
@@ -360,7 +356,7 @@ html[data-theme-pack="fjord"] .zd-sidebar-content-wrapper > footer {
    painted as a top-anchored background gradient (the hearth h2
    technique) so the icy 1px border keeps its own color on all four
    sides */
-html[data-theme-pack="fjord"] div[role="dialog"][aria-label="Theme pack switcher"] {
+html[data-theme-pack="fjord"] div[data-switcher-card] {
   border-color: light-dark(oklch(0.79 0.038 220 / 0.9), oklch(0.56 0.055 220 / 0.4));
   background-color: color-mix(in oklch, var(--zd-surface) 90%, transparent);
   background-image: linear-gradient(

--- a/packages/zudo-doc/src/theme-packs/foundry/meta.json
+++ b/packages/zudo-doc/src/theme-packs/foundry/meta.json
@@ -4,7 +4,7 @@
   "name": "Foundry",
   "description": "GitHub-neutral baseline — white paper, near-black ink, Primer-blue links, quiet gray rules. Restraint, perfected.",
   "mode": "light",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "fonts": {
     "sans": "Inter",
     "mono": "System",

--- a/packages/zudo-doc/src/theme-packs/foundry/pack.css
+++ b/packages/zudo-doc/src/theme-packs/foundry/pack.css
@@ -10,6 +10,11 @@
    the validator prove a pack can never leak styles while inactive
    (Decision 6.7). The two @font-face blocks are the sole exception
    (at-rules can't be selector-scoped).
+
+   Prototype-selector adaptation against the REAL DOM:
+   - `.doc-pager a`     → `.zd-content > nav[data-doc-pager] > a` (the
+                          DocPager nav carries a stable data-doc-pager
+                          hook, #2873; hover wash restored in #2880)
    ============================================================ */
 
 @font-face {
@@ -186,9 +191,12 @@ html[data-theme-pack="foundry"] .zd-content tbody tr:nth-child(even) {
   background-color: var(--zd-code-bg);
 }
 
-/* pager cards: the prototype's hover wash is intentionally NOT ported. A
-   stable hook now exists (.zd-content > nav[data-doc-pager]), but foundry has
-   never carried a live pager rule (it was dropped in the #2828 parity pass
-   before the hook existed) — restoring it is a separate Wave-3 sub-issue, not
-   this retarget. The default hover:border-accent blue border cue already
-   carries the affordance. */
+/* pager cards: quiet gray hover wash under the default blue-border cue —
+   the prototype's `.doc-pager a:hover` treatment, dropped in the #2828
+   parity pass because `.zd-content > nav` over-matched NavCardGrid, and
+   restored (#2880) against the stable data-doc-pager hook (#2873). 8% muted
+   — one notch softer than the 14% nav/sidebar washes, since the pager card
+   is a much larger surface. */
+html[data-theme-pack="foundry"] .zd-content > nav[data-doc-pager] > a:hover {
+  background: color-mix(in srgb, var(--zd-muted) 8%, transparent);
+}

--- a/packages/zudo-doc/src/theme-packs/foundry/pack.css
+++ b/packages/zudo-doc/src/theme-packs/foundry/pack.css
@@ -89,13 +89,13 @@ html[data-theme-pack="foundry"] {
 html[data-theme-pack="foundry"] .zd-content a:hover {
   text-decoration: underline;
 }
-/* footer: quiet links, underline only on intent. The real footer carries no
-   data-footer hook (that was prototype-mock markup) — it is the sole <footer>
-   inside the stable .zd-sidebar-content-wrapper (doclayout/doc-layout.tsx). */
-html[data-theme-pack="foundry"] .zd-sidebar-content-wrapper footer a {
+/* footer: quiet links, underline only on intent. footer[data-footer] is the
+   stable hook (footer/footer.tsx) — the sole <footer> inside
+   .zd-sidebar-content-wrapper (doclayout/doc-layout.tsx). */
+html[data-theme-pack="foundry"] footer[data-footer] a {
   text-decoration: none;
 }
-html[data-theme-pack="foundry"] .zd-sidebar-content-wrapper footer a:hover {
+html[data-theme-pack="foundry"] footer[data-footer] a:hover {
   text-decoration: underline;
 }
 
@@ -186,8 +186,9 @@ html[data-theme-pack="foundry"] .zd-content tbody tr:nth-child(even) {
   background-color: var(--zd-code-bg);
 }
 
-/* pager cards: the prototype's hover wash is intentionally NOT ported — the
-   DocPager <nav> has no stable hook (.doc-pager was prototype-mock markup),
-   and any structural selector (.zd-content > nav) also catches NavCardGrid /
-   CategoryNav navs in the same position. The default hover:border-accent
-   blue border cue already carries the affordance. */
+/* pager cards: the prototype's hover wash is intentionally NOT ported. A
+   stable hook now exists (.zd-content > nav[data-doc-pager]), but foundry has
+   never carried a live pager rule (it was dropped in the #2828 parity pass
+   before the hook existed) — restoring it is a separate Wave-3 sub-issue, not
+   this retarget. The default hover:border-accent blue border cue already
+   carries the affordance. */

--- a/packages/zudo-doc/src/theme-packs/futura-editorial/meta.json
+++ b/packages/zudo-doc/src/theme-packs/futura-editorial/meta.json
@@ -4,7 +4,7 @@
   "name": "Futura Editorial",
   "description": "Normal-weight geometric Futura headings over Noto Sans body — clean white, near-black ink, one restrained red accent.",
   "mode": "light",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "fonts": {
     "sans": "Noto Sans",
     "mono": "Space Mono",

--- a/packages/zudo-doc/src/theme-packs/futura-editorial/pack.css
+++ b/packages/zudo-doc/src/theme-packs/futura-editorial/pack.css
@@ -21,11 +21,10 @@
 
    Prototype-selector adaptations against the REAL DOM (tokens-dump
    §6 + component sources), noted inline where they matter:
-   - `.lead`         → `.zd-content > p:first-of-type` (the description
-                       paragraph DocContentHeader emits — broadsheet's
-                       adaptation, same known limit: on a page without a
-                       frontmatter description the first BODY paragraph
-                       takes the deck styling instead)
+   - `.lead`         → `p[data-doc-description]` (the description
+                       paragraph DocContentHeader/DocPageShell emit —
+                       stable hook, kept anchored under the structural
+                       `.zd-content >` chain)
    - `.sb-group > p` → the static group heads don't exist in the real
                        SidebarTree island; not ported. The active link
                        already renders the prototype's ink fill (the
@@ -33,16 +32,16 @@
    - `.toc-title`    → no desktop TOC heading exists (#1655), and the
                        prototype's `.toc-active` ink fill IS the stock
                        active style — the TOC needs no extras at all.
-   - `.doc-pager`    → `.zd-content > nav:last-of-type:not([aria-label])`
-                       (DocPager is the article's last direct-child nav
-                       and ships no aria-label; the :not guard excludes
-                       NavCardGrid's "Child pages" nav).
-   - `footer[data-footer]` → `.zd-sidebar-content-wrapper > footer` (no
-                       data-footer attribute in the real DOM). The
-                       prototype's uppercase colophon line has no stable
-                       hook and is intentionally not ported.
-   - the theme-switcher flyout has NO stable hook — its square-card
-     print-offset shadow is intentionally NOT ported.
+   - `.doc-pager`    → `.zd-content > nav[data-doc-pager]` (stable hook
+                       on the DocPager <nav>, kept anchored under the
+                       structural `.zd-content >` chain).
+   - `footer[data-footer]` → `footer[data-footer]` (stable hook on the
+                       sole <footer> inside .zd-sidebar-content-wrapper).
+                       The prototype's uppercase colophon line has no
+                       stable hook and is intentionally not ported.
+   - the theme-switcher flyout has stable hooks now ([data-switcher-card]
+     / [data-switcher-launcher]), but this pack styles neither — its
+     square-card print-offset shadow is intentionally NOT ported.
 
    Fonts: latin subsets only (all three families) to stay well inside
    the ~250 KB payload budget — a stray latin-ext glyph falls back to
@@ -206,7 +205,7 @@ html[data-theme-pack="futura-editorial"] .zd-content h1::before {
 
 /* the deck: display-face standfirst under the headline (prototype
    `.lead` — see the adaptation note in the header comment) */
-html[data-theme-pack="futura-editorial"] .zd-content > p:first-of-type {
+html[data-theme-pack="futura-editorial"] .zd-content > p[data-doc-description] {
   font-family: var(--font-display);
   font-weight: 400;
   font-size: 1.3rem;
@@ -290,25 +289,25 @@ html[data-theme-pack="futura-editorial"] .zd-content th {
 
 /* pager: square folio cards, ink border on hover, uppercase display
    labels (DocPager selector — see the header adaptation note) */
-html[data-theme-pack="futura-editorial"] .zd-content > nav:last-of-type:not([aria-label]) a {
+html[data-theme-pack="futura-editorial"] .zd-content > nav[data-doc-pager] a {
   border-radius: 0;
 }
-html[data-theme-pack="futura-editorial"] .zd-content > nav:last-of-type:not([aria-label]) a:hover {
+html[data-theme-pack="futura-editorial"] .zd-content > nav[data-doc-pager] a:hover {
   border-color: var(--zd-fg);
 }
-html[data-theme-pack="futura-editorial"] .zd-content > nav:last-of-type:not([aria-label]) a > div {
+html[data-theme-pack="futura-editorial"] .zd-content > nav[data-doc-pager] a > div {
   font-family: var(--font-display);
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.12em;
   font-size: 0.68rem;
 }
-html[data-theme-pack="futura-editorial"] .zd-content > nav:last-of-type:not([aria-label]) a p {
+html[data-theme-pack="futura-editorial"] .zd-content > nav[data-doc-pager] a p {
   font-family: var(--font-display);
   font-weight: 500;
 }
 
 /* footer: colophon under a solid ink hairline */
-html[data-theme-pack="futura-editorial"] .zd-sidebar-content-wrapper > footer {
+html[data-theme-pack="futura-editorial"] footer[data-footer] {
   border-top: 1px solid var(--zd-fg);
 }

--- a/packages/zudo-doc/src/theme-packs/hearth/meta.json
+++ b/packages/zudo-doc/src/theme-packs/hearth/meta.json
@@ -4,7 +4,7 @@
   "name": "Hearth",
   "description": "Warm cream & brick-red fireside docs — Fraunces headings, amber code blocks, ember-glow dark mode.",
   "mode": "light",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "fonts": {
     "sans": "Nunito",
     "mono": "Spline Sans Mono",

--- a/packages/zudo-doc/src/theme-packs/hearth/pack.css
+++ b/packages/zudo-doc/src/theme-packs/hearth/pack.css
@@ -23,17 +23,17 @@
    - `.toc-active`       → `nav[data-zd-toc] a[aria-current="true"]`
                            (toc/toc.tsx marks the active entry with
                            aria-current, not a mock class)
-   - `.doc-pager`        → `.zd-content > nav:last-of-type:not([aria-label])`
-                           (the DocPager nav is the article's last
-                           unlabelled direct-child nav; breadcrumb and
-                           NavCardGrid navs carry aria-labels)
-   - `footer[data-footer]` → `.zd-sidebar-content-wrapper > footer`
-                           (no data-footer attribute in the real DOM)
+   - `.doc-pager`        → `.zd-content > nav[data-doc-pager]` (stable
+                           hook on the DocPager nav, kept anchored under
+                           the structural `.zd-content >` chain)
+   - `footer[data-footer]` → `footer[data-footer]` (stable hook on the
+                           sole <footer> inside .zd-sidebar-content-wrapper)
    - `.hdr-search` / `.hdr-icon-btn` / `.sb-group > p` — prototype-mock
      markup with no stable hook; their rounded/brick styling is NOT
      ported.
-   - the theme-switcher flyout + glowing-coal launcher have NO stable
-     hook — intentionally NOT ported.
+   - the theme-switcher flyout + glowing-coal launcher have stable hooks
+     now ([data-switcher-card] / [data-switcher-launcher]), but this pack
+     styles neither — intentionally NOT ported.
    - the prototype's `--hearth-shadow` / `--hearth-line` helper
      properties are not part of the token manifest, so their
      light-dark() values are inlined at each use site below.
@@ -336,10 +336,9 @@ html[data-theme-pack="hearth"] .zd-content hr {
   );
 }
 
-/* pager: cushioned cards that lift toward the fire. The DocPager is
-   the article's LAST unlabelled direct-child nav (breadcrumb and
-   NavCardGrid navs carry aria-labels). */
-html[data-theme-pack="hearth"] .zd-content > nav:last-of-type:not([aria-label]) a {
+/* pager: cushioned cards that lift toward the fire. DocPager carries the
+   stable data-doc-pager hook. */
+html[data-theme-pack="hearth"] .zd-content > nav[data-doc-pager] a {
   background: var(--zd-surface);
   border-radius: 12px;
   border-color: light-dark(oklch(0.85 0.042 76), oklch(0.335 0.034 48));
@@ -349,7 +348,7 @@ html[data-theme-pack="hearth"] .zd-content > nav:last-of-type:not([aria-label]) 
     border-color 0.18s ease,
     transform 0.18s ease;
 }
-html[data-theme-pack="hearth"] .zd-content > nav:last-of-type:not([aria-label]) a:hover {
+html[data-theme-pack="hearth"] .zd-content > nav[data-doc-pager] a:hover {
   border-color: color-mix(in oklch, var(--zd-accent) 60%, transparent);
   box-shadow: 0 12px 26px -14px light-dark(oklch(0.42 0.09 45 / 0.2), oklch(0.05 0.01 45 / 0.6));
   transform: translateY(-1px);
@@ -376,12 +375,11 @@ html[data-theme-pack="hearth"] nav[data-zd-toc] a[aria-current="true"] {
   box-shadow: 0 3px 10px -4px light-dark(oklch(0.42 0.09 45 / 0.2), oklch(0.05 0.01 45 / 0.6));
 }
 
-/* breadcrumb + footer warmth (the real footer has no data-footer
-   hook; it is the wrapper's direct child) */
+/* breadcrumb + footer warmth (footer carries the stable data-footer hook) */
 html[data-theme-pack="hearth"] main nav[aria-label="Breadcrumb"] a:hover {
   color: var(--zd-accent);
 }
-html[data-theme-pack="hearth"] .zd-sidebar-content-wrapper > footer {
+html[data-theme-pack="hearth"] footer[data-footer] {
   background-color: light-dark(oklch(0.936 0.026 80), oklch(0.196 0.02 45));
   border-top-color: light-dark(oklch(0.85 0.042 76), oklch(0.335 0.034 48));
 }

--- a/packages/zudo-doc/src/theme-packs/hollow/meta.json
+++ b/packages/zudo-doc/src/theme-packs/hollow/meta.json
@@ -4,7 +4,7 @@
   "name": "Hollow",
   "description": "Dark violet space — neon pink headings, violet links, a quiet starfield, and razor-square midnight chrome.",
   "mode": "dark",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "fonts": {
     "sans": "Space Grotesk",
     "mono": "Space Mono",

--- a/packages/zudo-doc/src/theme-packs/hollow/pack.css
+++ b/packages/zudo-doc/src/theme-packs/hollow/pack.css
@@ -36,19 +36,19 @@
      razor-square shape is carried by --zdc-admonition-radius /
      --zdc-card-radius plus explicit border-radius: 0 on the
      remaining rounded surfaces.
-   - `.doc-pager` → `.zd-content > nav:last-of-type:not([aria-label])`
-     (the DocPager nav is the article's last unlabelled direct-child
-     nav; breadcrumb and NavCardGrid navs carry aria-labels — the
-     `> a` child combinator keeps NavCardGrid card links out).
+   - `.doc-pager` → `.zd-content > nav[data-doc-pager]` (stable hook on
+     the DocPager nav, kept anchored under the structural
+     `.zd-content >` chain — the `> a` child combinator keeps
+     NavCardGrid card links out).
    - `.toc-active` → `nav[data-zd-toc] a[aria-current="true"]`
      (toc/toc.tsx marks the active entry with aria-current).
-   - `footer[data-footer]` → `.zd-sidebar-content-wrapper footer`
-     (no data-footer attribute in the real DOM).
+   - `footer[data-footer]` → `footer[data-footer]` (stable hook on the
+     sole <footer> inside .zd-sidebar-content-wrapper).
    - `.sb-group a[data-nav-active]` → `a[data-nav-active]` (the
      real active link already paints --zdc-nav-active-indicator-color
      as its fill with bg-token text — only the token + weight land).
    - the flyout/launcher mock classes → the switcher's stable
-     role/aria-label handles (the swissgrid precedent).
+     [data-switcher-card] / [data-switcher-launcher] hooks.
    - `.zd-content .lead` — prototype-mock class with no stable
      hook; NOT ported.
    ============================================================ */
@@ -356,13 +356,12 @@ html[data-theme-pack="hollow"] nav[data-zd-toc] a[aria-current="true"] {
 }
 
 /* ---- pager: square translucent cards that glow pink on hover.
-        The DocPager is the article's LAST unlabelled direct-child
-        nav (breadcrumb and NavCardGrid navs carry aria-labels). ---- */
-html[data-theme-pack="hollow"] .zd-content > nav:last-of-type:not([aria-label]) > a {
+        DocPager carries the stable data-doc-pager hook. ---- */
+html[data-theme-pack="hollow"] .zd-content > nav[data-doc-pager] > a {
   background: color-mix(in srgb, var(--zd-surface) 60%, transparent);
   border-radius: 0;
 }
-html[data-theme-pack="hollow"] .zd-content > nav:last-of-type:not([aria-label]) > a:hover {
+html[data-theme-pack="hollow"] .zd-content > nav[data-doc-pager] > a:hover {
   border-color: light-dark(oklch(0.52 0.2 350), oklch(0.78 0.17 348));
   box-shadow: 0 0 16px -6px
     color-mix(
@@ -372,17 +371,16 @@ html[data-theme-pack="hollow"] .zd-content > nav:last-of-type:not([aria-label]) 
     );
 }
 
-/* footer: calm panel, violet hairline (the real footer has no
-   data-footer hook; it lives inside the wrapper) */
-html[data-theme-pack="hollow"] .zd-sidebar-content-wrapper footer {
+/* footer: calm panel, violet hairline (footer carries the stable
+   data-footer hook) */
+html[data-theme-pack="hollow"] footer[data-footer] {
   border-top-color: color-mix(in oklch, var(--zd-accent) 26%, transparent);
 }
 
 /* ---- theme-pack switcher: the pack's own card — square, neon
-        pink top edge, violet halo (the flyout/launcher carry no
-        dedicated hook classes; their accessible names are the
-        stable handle) ---- */
-html[data-theme-pack="hollow"] div[role="dialog"][aria-label="Theme pack switcher"] {
+        pink top edge, violet halo. Both the flyout card and the
+        launcher button carry stable [data-switcher-*] hooks. ---- */
+html[data-theme-pack="hollow"] div[data-switcher-card] {
   border-radius: 0;
   border-color: color-mix(in oklch, var(--zd-accent) 45%, transparent);
   border-top: 2px solid light-dark(oklch(0.52 0.2 350), oklch(0.78 0.17 348));
@@ -390,20 +388,20 @@ html[data-theme-pack="hollow"] div[role="dialog"][aria-label="Theme pack switche
     0 0 24px -8px color-mix(in oklch, var(--zd-accent) 55%, transparent),
     0 18px 50px -12px oklch(0.2 0.1 300 / 0.55);
 }
-html[data-theme-pack="hollow"] div[role="dialog"][aria-label="Theme pack switcher"] span {
+html[data-theme-pack="hollow"] div[data-switcher-card] span {
   border-radius: 0;
 }
-html[data-theme-pack="hollow"] div[role="dialog"][aria-label="Theme pack switcher"] button {
+html[data-theme-pack="hollow"] div[data-switcher-card] button {
   border-radius: 0;
 }
-html[data-theme-pack="hollow"] div[role="dialog"][aria-label="Theme pack switcher"] button:hover {
+html[data-theme-pack="hollow"] div[data-switcher-card] button:hover {
   border-color: light-dark(oklch(0.52 0.2 350), oklch(0.78 0.17 348));
   color: light-dark(oklch(0.52 0.2 350), oklch(0.78 0.17 348));
 }
-html[data-theme-pack="hollow"] button[aria-haspopup="dialog"][aria-label="Theme pack switcher"] {
+html[data-theme-pack="hollow"] button[data-switcher-launcher] {
   border-radius: 0;
 }
-html[data-theme-pack="hollow"] button[aria-haspopup="dialog"][aria-label="Theme pack switcher"]:hover {
+html[data-theme-pack="hollow"] button[data-switcher-launcher]:hover {
   color: light-dark(oklch(0.52 0.2 350), oklch(0.78 0.17 348));
   border-color: light-dark(oklch(0.52 0.2 350), oklch(0.78 0.17 348));
   box-shadow: 0 0 18px -4px

--- a/packages/zudo-doc/src/theme-packs/ledger/meta.json
+++ b/packages/zudo-doc/src/theme-packs/ledger/meta.json
@@ -4,7 +4,7 @@
   "name": "Ledger",
   "description": "Cream academic serif in the Tufte tradition — warm paper, ink prose, oxblood links, hairline rules, quiet code.",
   "mode": "light",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "fonts": {
     "sans": "Crimson Pro",
     "mono": "IBM Plex Mono",

--- a/packages/zudo-doc/src/theme-packs/ledger/pack.css
+++ b/packages/zudo-doc/src/theme-packs/ledger/pack.css
@@ -188,7 +188,7 @@ html[data-theme-pack="ledger"] .zd-doc-content-band:not([data-zd-wide]) .zd-cont
   max-width: 44rem;
 }
 html[data-theme-pack="ledger"] .zd-doc-content-band:not([data-zd-wide]) main nav[aria-label="Breadcrumb"],
-html[data-theme-pack="ledger"] .zd-doc-content-band:not([data-zd-wide]) .zd-content > nav:last-of-type:not([aria-label]) {
+html[data-theme-pack="ledger"] .zd-doc-content-band:not([data-zd-wide]) .zd-content > nav[data-doc-pager] {
   max-width: 44rem;
 }
 
@@ -397,22 +397,20 @@ html[data-theme-pack="ledger"] .zd-content tbody tr:last-child td {
 }
 
 /* ---- pager: square hairline cards, small-caps labels, italic titles.
-        The DocPager is a <nav> rendered as a direct child of
-        <article class="zd-content">, with no aria-label (the breadcrumb nav
-        carries one). ---- */
-html[data-theme-pack="ledger"] .zd-content > nav:last-of-type:not([aria-label]) > a {
+        DocPager carries the stable data-doc-pager hook. ---- */
+html[data-theme-pack="ledger"] .zd-content > nav[data-doc-pager] > a {
   border-color: color-mix(in srgb, var(--zd-fg) 25%, transparent);
   border-radius: 0;
   background: transparent;
 }
-html[data-theme-pack="ledger"] .zd-content > nav:last-of-type:not([aria-label]) > a:hover {
+html[data-theme-pack="ledger"] .zd-content > nav[data-doc-pager] > a:hover {
   background: color-mix(in srgb, var(--zd-accent) 5%, transparent);
 }
-html[data-theme-pack="ledger"] .zd-content > nav:last-of-type:not([aria-label]) > a div {
+html[data-theme-pack="ledger"] .zd-content > nav[data-doc-pager] > a div {
   font-variant-caps: all-small-caps;
   letter-spacing: 0.12em;
 }
-html[data-theme-pack="ledger"] .zd-content > nav:last-of-type:not([aria-label]) > a p {
+html[data-theme-pack="ledger"] .zd-content > nav[data-doc-pager] > a p {
   font-style: italic;
 }
 
@@ -440,25 +438,25 @@ html[data-theme-pack="ledger"] nav[data-zd-toc] a[aria-current="true"] {
 }
 
 /* ---- footer: the closing double rule of the ledger ---- */
-html[data-theme-pack="ledger"] .zd-sidebar-content-wrapper > footer {
+html[data-theme-pack="ledger"] footer[data-footer] {
   border-top: 3px double color-mix(in srgb, var(--zd-fg) 45%, transparent);
 }
 /* italicize the copyright line only when it coexists with link/tag columns
    (`:not(:first-child)` keeps a columns-only footer's grid — which is then
    the sole child — out of this positional rule). */
-html[data-theme-pack="ledger"] .zd-sidebar-content-wrapper > footer > div > div:last-child:not(:first-child) {
+html[data-theme-pack="ledger"] footer[data-footer] > div > div:last-child:not(:first-child) {
   font-style: italic;
 }
 
 /* ---- theme-pack flyout: a catalogue card — oxblood double rule at its
         head, square corners, roman italic title ---- */
-html[data-theme-pack="ledger"] div[role="dialog"][aria-label="Theme pack switcher"] {
+html[data-theme-pack="ledger"] div[data-switcher-card] {
   border: 1px solid color-mix(in srgb, var(--zd-fg) 30%, transparent);
   border-top: 4px double var(--zd-accent);
   border-radius: 0;
   box-shadow: 0 16px 40px -18px light-dark(rgb(60 30 10 / 0.4), rgb(0 0 0 / 0.7));
 }
-html[data-theme-pack="ledger"] div[role="dialog"][aria-label="Theme pack switcher"] p[aria-live="polite"] {
+html[data-theme-pack="ledger"] div[data-switcher-card] p[aria-live="polite"] {
   font-style: italic;
   font-weight: 500;
   font-size: 1.2rem;

--- a/packages/zudo-doc/src/theme-packs/manuscript/meta.json
+++ b/packages/zudo-doc/src/theme-packs/manuscript/meta.json
@@ -4,7 +4,7 @@
   "name": "Manuscript",
   "description": "A quiet Garamond book page — warm paper, soft ink, sepia rubrication, small-caps subheads, fleuron section marks.",
   "mode": "light",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "fonts": {
     "sans": "EB Garamond",
     "mono": "Courier Prime",

--- a/packages/zudo-doc/src/theme-packs/manuscript/pack.css
+++ b/packages/zudo-doc/src/theme-packs/manuscript/pack.css
@@ -332,21 +332,26 @@ html[data-theme-pack="manuscript"] .zd-content code:not(pre code) {
   border-radius: 0;
 }
 
-/* pager: colophon cards. The DocPager <nav> is the article's only direct
-   nav child (doc-page-shell renders it inside .zd-content); the prototype's
-   .doc-pager/.pager-label/.pager-title classes don't exist in the real DOM. */
-html[data-theme-pack="manuscript"] .zd-content > nav a {
+/* pager: colophon cards, targeted at the DocPager's `data-doc-pager` hook
+   (#2873). The prior broad `.zd-content > nav a` form matched EVERY direct-
+   child nav's descendant <a> — including NavCardGrid's `aria-label="Child
+   pages"` grid on auto-index pages, which picked up the colophon-card
+   framing by accident (no NavCardGrid-specific intent was ever documented
+   here). The `[data-doc-pager]` hook scopes this to the pager only; the
+   prototype's .doc-pager/.pager-label/.pager-title classes don't exist in
+   the real DOM. */
+html[data-theme-pack="manuscript"] .zd-content > nav[data-doc-pager] a {
   border-radius: 0;
   border-color: color-mix(in oklch, var(--zd-fg) 25%, transparent);
 }
-html[data-theme-pack="manuscript"] .zd-content > nav a:hover {
+html[data-theme-pack="manuscript"] .zd-content > nav[data-doc-pager] a:hover {
   border-color: var(--zd-accent);
 }
-html[data-theme-pack="manuscript"] .zd-content > nav a > div {
+html[data-theme-pack="manuscript"] .zd-content > nav[data-doc-pager] a > div {
   font-variant-caps: small-caps;
   letter-spacing: 0.08em;
 }
-html[data-theme-pack="manuscript"] .zd-content > nav a > p {
+html[data-theme-pack="manuscript"] .zd-content > nav[data-doc-pager] a > p {
   font-style: italic;
 }
 
@@ -354,13 +359,13 @@ html[data-theme-pack="manuscript"] .zd-content > nav a > p {
    (the prototype's .footer-copy class does not exist in the real DOM). The
    :not(:has(ul)) guard keeps the ornament off the link/tag column grid when
    a footer configures columns but no copyright — the grid's div always
-   contains <ul> lists, the copyright block never does. */
-html[data-theme-pack="manuscript"] .zd-sidebar-content-wrapper footer {
+   contains <ul> lists, the copyright block never does. Targets the
+   `data-footer` hook (#2873) instead of the wrapper-descendant form. */
+html[data-theme-pack="manuscript"] footer[data-footer] {
   border-top: 3px double color-mix(in oklch, var(--zd-fg) 50%, transparent);
 }
 html[data-theme-pack="manuscript"]
-  .zd-sidebar-content-wrapper
-  footer
+  footer[data-footer]
   > div
   > div:last-child:not(:has(ul))::before {
   content: "❦";

--- a/packages/zudo-doc/src/theme-packs/matcha/meta.json
+++ b/packages/zudo-doc/src/theme-packs/matcha/meta.json
@@ -4,7 +4,7 @@
   "name": "Matcha",
   "description": "Green tea ceremony — deep matcha on warm cream, mincho headings, zen whitespace, tea-foam surfaces in both modes.",
   "mode": "light",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "fonts": {
     "sans": "Zen Kaku Gothic New",
     "mono": "M PLUS 1 Code",

--- a/packages/zudo-doc/src/theme-packs/matcha/pack.css
+++ b/packages/zudo-doc/src/theme-packs/matcha/pack.css
@@ -21,18 +21,22 @@
 
    Prototype-selector adaptations against the REAL DOM (tokens-dump
    §6 + component sources), noted inline where they matter:
-   - `.lead`         → `.zd-content > p:first-of-type` (the
-                       description paragraph DocContentHeader emits)
+   - `.lead`         → `p[data-doc-description]` (#2873 stable hook on
+                       the description paragraph DocContentHeader
+                       emits; only renders when the page has a
+                       frontmatter description — no longer falls back
+                       onto the opening body paragraph)
    - `.toc-active`   → `nav[data-zd-toc] a[aria-current="true"]`
-   - `.doc-pager`    → `.zd-content > nav:last-of-type:not([aria-label])`
-                       (DocPager is the article's last direct-child
-                       nav and ships no aria-label; NavCardGrid
-                       carries aria-label="Child pages")
-   - `footer[data-footer]` → `.zd-sidebar-content-wrapper > footer`
+   - `.doc-pager`    → `.zd-content > nav[data-doc-pager]` (#2873
+                       stable hook on the DocPager nav)
+   - `footer[data-footer]` → `footer[data-footer]` (#2873 stable hook;
+                       the wrapper-descendant form is no longer needed)
    - the h2 chashaku-scoop rule → a background-image gradient after
      `border-image: none !important` clears the SSR-inlined default
-   - the theme-switcher flyout ("the presented bowl") has NO stable
-     hook — its matcha lip is intentionally NOT ported.
+   - the theme-switcher flyout ("the presented bowl") now HAS stable
+     hooks (`[data-switcher-card]` / `[data-switcher-launcher]`,
+     #2873); its matcha lip remains intentionally NOT ported — an
+     unchanged design decision, not a selector gap.
    ============================================================ */
 
 /* ---- Zen Kaku Gothic New — the reading face (static 400 + 500;
@@ -186,13 +190,11 @@ html[data-theme-pack="matcha"] .zd-content {
   line-height: 1.9;
 }
 
-/* the lead: mincho standfirst under the ceremony title. The
-   prototype's `.lead` is the description paragraph DocContentHeader
-   renders as the FIRST direct-child <p> of the article. Known limit
-   (same as broadsheet): on a page without a frontmatter description
-   the first body paragraph takes the mincho styling instead — reads
-   as an emphasized opening line, fails safe. */
-html[data-theme-pack="matcha"] .zd-content > p:first-of-type {
+/* the lead: mincho standfirst under the ceremony title. Targets the
+   `data-doc-description` hook (#2873) — the description paragraph
+   DocContentHeader renders. Only present when the page has a
+   frontmatter description; pages without one simply render no lead. */
+html[data-theme-pack="matcha"] .zd-content > p[data-doc-description] {
   font-family: var(--font-display);
   line-height: 1.75;
 }
@@ -374,12 +376,10 @@ html[data-theme-pack="matcha"] nav[data-zd-toc] a[aria-current="true"] {
   color: var(--zd-bg);
 }
 
-/* pager: tea-foam cards, mincho titles, whispered labels. DocPager is
-   the article's LAST direct-child nav and ships no aria-label; the
-   :not([aria-label]) guard excludes NavCardGrid ("Child pages") and
-   :last-of-type excludes an unlabelled mid-content CategoryNav
-   (broadsheet's reviewed selector). */
-html[data-theme-pack="matcha"] .zd-content > nav:last-of-type:not([aria-label]) > a {
+/* pager: tea-foam cards, mincho titles, whispered labels. Targets the
+   DocPager's `data-doc-pager` hook (#2873) directly instead of the
+   positional :last-of-type:not([aria-label]) guard. */
+html[data-theme-pack="matcha"] .zd-content > nav[data-doc-pager] > a {
   background: var(--zd-surface);
   border-color: color-mix(in oklch, var(--zd-muted) 30%, transparent);
   border-radius: 0;
@@ -388,22 +388,22 @@ html[data-theme-pack="matcha"] .zd-content > nav:last-of-type:not([aria-label]) 
     border-color 0.18s ease,
     background-color 0.18s ease;
 }
-html[data-theme-pack="matcha"] .zd-content > nav:last-of-type:not([aria-label]) > a:hover {
+html[data-theme-pack="matcha"] .zd-content > nav[data-doc-pager] > a:hover {
   background: color-mix(in srgb, var(--zd-accent) 6%, var(--zd-surface));
   border-color: var(--zd-accent);
 }
-html[data-theme-pack="matcha"] .zd-content > nav:last-of-type:not([aria-label]) > a > div {
+html[data-theme-pack="matcha"] .zd-content > nav[data-doc-pager] > a > div {
   text-transform: uppercase;
   font-size: 0.72rem;
   letter-spacing: 0.1em;
 }
-html[data-theme-pack="matcha"] .zd-content > nav:last-of-type:not([aria-label]) > a p {
+html[data-theme-pack="matcha"] .zd-content > nav[data-doc-pager] > a p {
   font-family: var(--font-display);
   font-weight: 600;
 }
 
-/* footer: the room's far wall under a matcha hairline (the real
-   footer has no data-footer hook; it is the wrapper's direct child) */
-html[data-theme-pack="matcha"] .zd-sidebar-content-wrapper > footer {
+/* footer: the room's far wall under a matcha hairline. Targets the
+   `data-footer` hook (#2873) directly. */
+html[data-theme-pack="matcha"] footer[data-footer] {
   border-top-color: color-mix(in oklch, var(--zd-accent) 26%, transparent);
 }

--- a/packages/zudo-doc/src/theme-packs/nocturne/meta.json
+++ b/packages/zudo-doc/src/theme-packs/nocturne/meta.json
@@ -4,7 +4,7 @@
   "name": "Nocturne",
   "description": "Purple midnight — velvet aubergine depths, lavender links, and muted gold hairlines. Elegant, never neon.",
   "mode": "dark",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "fonts": {
     "sans": "Manrope",
     "mono": "IBM Plex Mono",

--- a/packages/zudo-doc/src/theme-packs/nocturne/pack.css
+++ b/packages/zudo-doc/src/theme-packs/nocturne/pack.css
@@ -27,32 +27,29 @@
                            `a[data-nav-active]` (gilded active marker;
                            the gold spine is an inset box-shadow so the
                            nested tree's own padding never shifts)
-   - `.lead`             → `.zd-content > p:first-of-type` (the
-                           description paragraph DocContentHeader
-                           renders as the article's first direct-child
-                           <p>; on a page without a frontmatter
-                           description the first body paragraph takes
-                           this styling — reads as an emphasized
-                           opening line, fails soft)
+   - `.lead`             → `p[data-doc-description]` (#2873 stable
+                           hook on the description paragraph
+                           DocContentHeader renders; only present when
+                           the page has a frontmatter description — no
+                           longer falls back onto the first body
+                           paragraph)
    - `.toc-active`       → `nav[data-zd-toc] a[aria-current="true"]`
                            (toc/toc.tsx marks the active entry with
                            aria-current, not a mock class)
-   - `.doc-pager`        → `.zd-content > nav:last-of-type:not([aria-label]) > a`
-                           (the DocPager is the article's last
-                           unlabelled direct-child nav whose children
-                           are bare <a> cards; breadcrumb and
-                           NavCardGrid navs carry aria-labels, and
-                           list-structured navs never match `> a`)
-   - `footer[data-footer]` → `.zd-sidebar-content-wrapper > footer`
-                           (no data-footer attribute in the real DOM)
+   - `.doc-pager`        → `.zd-content > nav[data-doc-pager] > a`
+                           (#2873 stable hook on the DocPager nav)
+   - `footer[data-footer]` → `footer[data-footer]` (#2873 stable hook;
+                           the wrapper-descendant form is no longer
+                           needed)
    - `.crumb-sep`        → the breadcrumb separators are inline SVG
                            chevrons inside the nav's <li>s; gilded via
                            `nav[aria-label="Breadcrumb"] li > svg`
-   - `.tp-flyout`        → `div[role="dialog"][aria-label="Theme pack
-                           switcher"]` (the ledger precedent); its
-                           title is `p[aria-live="polite"]`. The
-                           launcher button has NO stable hook —
-                           intentionally NOT ported.
+   - `.tp-flyout`        → `div[data-switcher-card]` (#2873 stable
+                           hook); its title is `p[aria-live="polite"]`.
+                           The launcher now has a stable hook too
+                           (`[data-switcher-launcher]`) but remains
+                           intentionally NOT ported — unchanged design
+                           decision.
    - `.hdr-search` / `.hdr-icon-btn` / `.sb-group > p` / `.toc-title`
                            — prototype-mock markup with no stable
                            hook; NOT ported.
@@ -302,8 +299,9 @@ html[data-theme-pack="nocturne"] .zd-content h1::after {
   );
 }
 
-/* the lead: an italic serif whisper under the title */
-html[data-theme-pack="nocturne"] .zd-content > p:first-of-type {
+/* the lead: an italic serif whisper under the title. Targets the
+   `data-doc-description` hook (#2873). */
+html[data-theme-pack="nocturne"] .zd-content > p[data-doc-description] {
   font-family: var(--font-display);
   font-style: italic;
   font-size: 1.4rem;
@@ -412,10 +410,9 @@ html[data-theme-pack="nocturne"] .zd-content td {
   border-bottom-color: color-mix(in oklch, var(--zd-muted) 22%, transparent);
 }
 
-/* pager: velvet cards, serif destinations, gilt on hover. The
-   DocPager is the article's LAST unlabelled direct-child nav
-   (breadcrumb and NavCardGrid navs carry aria-labels). */
-html[data-theme-pack="nocturne"] .zd-content > nav:last-of-type:not([aria-label]) > a {
+/* pager: velvet cards, serif destinations, gilt on hover. Targets the
+   DocPager's `data-doc-pager` hook (#2873) directly. */
+html[data-theme-pack="nocturne"] .zd-content > nav[data-doc-pager] > a {
   border-radius: 0;
   background-image: linear-gradient(
     150deg,
@@ -427,11 +424,11 @@ html[data-theme-pack="nocturne"] .zd-content > nav:last-of-type:not([aria-label]
     box-shadow 0.18s ease,
     border-color 0.18s ease;
 }
-html[data-theme-pack="nocturne"] .zd-content > nav:last-of-type:not([aria-label]) > a:hover {
+html[data-theme-pack="nocturne"] .zd-content > nav[data-doc-pager] > a:hover {
   border-color: light-dark(oklch(0.53 0.105 85 / 0.45), oklch(0.78 0.105 87 / 0.45));
   box-shadow: 0 12px 28px -18px light-dark(oklch(0.35 0.06 300 / 0.5), oklch(0 0 0 / 0.7));
 }
-html[data-theme-pack="nocturne"] .zd-content > nav:last-of-type:not([aria-label]) > a div {
+html[data-theme-pack="nocturne"] .zd-content > nav[data-doc-pager] > a div {
   text-transform: uppercase;
   letter-spacing: 0.12em;
   font-size: 0.66rem;
@@ -440,7 +437,7 @@ html[data-theme-pack="nocturne"] .zd-content > nav:last-of-type:not([aria-label]
      needs 4.5:1 there (gold L .53 → .46). */
   color: light-dark(oklch(0.46 0.105 85), oklch(0.78 0.105 87));
 }
-html[data-theme-pack="nocturne"] .zd-content > nav:last-of-type:not([aria-label]) > a p {
+html[data-theme-pack="nocturne"] .zd-content > nav[data-doc-pager] > a p {
   font-family: var(--font-display);
   font-weight: 600;
   font-size: 1.2rem;
@@ -466,9 +463,9 @@ html[data-theme-pack="nocturne"] nav[data-zd-toc] a[aria-current="true"] {
   border-left: 2px solid light-dark(oklch(0.53 0.105 85), oklch(0.78 0.105 87));
 }
 
-/* footer: dusk band above a soft gold hairline (the real footer has
-   no data-footer hook; it is the wrapper's direct child) */
-html[data-theme-pack="nocturne"] .zd-sidebar-content-wrapper > footer {
+/* footer: dusk band above a soft gold hairline. Targets the
+   `data-footer` hook (#2873) directly. */
+html[data-theme-pack="nocturne"] footer[data-footer] {
   border-top-color: light-dark(oklch(0.53 0.105 85 / 0.26), oklch(0.78 0.105 87 / 0.26));
   background-image: linear-gradient(
     to bottom,
@@ -478,8 +475,10 @@ html[data-theme-pack="nocturne"] .zd-sidebar-content-wrapper > footer {
 }
 
 /* theme-pack flyout: a jewel box — velvet glow, gold hairline frame,
-   serif title (the launcher button has no stable hook) */
-html[data-theme-pack="nocturne"] div[role="dialog"][aria-label="Theme pack switcher"] {
+   serif title. Targets the `data-switcher-card` hook (#2873); the
+   launcher button now has a stable hook too but remains intentionally
+   NOT ported. */
+html[data-theme-pack="nocturne"] div[data-switcher-card] {
   border: 1px solid light-dark(oklch(0.53 0.105 85 / 0.45), oklch(0.78 0.105 87 / 0.45));
   border-radius: 2px;
   background:
@@ -494,7 +493,7 @@ html[data-theme-pack="nocturne"] div[role="dialog"][aria-label="Theme pack switc
     0 22px 48px -16px light-dark(oklch(0.3 0.06 300 / 0.4), oklch(0 0 0 / 0.7));
 }
 html[data-theme-pack="nocturne"]
-  div[role="dialog"][aria-label="Theme pack switcher"]
+  div[data-switcher-card]
   p[aria-live="polite"] {
   font-family: var(--font-display);
   font-weight: 600;

--- a/packages/zudo-doc/src/theme-packs/observatory/meta.json
+++ b/packages/zudo-doc/src/theme-packs/observatory/meta.json
@@ -4,7 +4,7 @@
   "name": "Observatory",
   "description": "Night-sky atlas: star-field depth, constellation-line rules, nebula violet and comet gold over astronomer's navy.",
   "mode": "dark",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "fonts": {
     "sans": "Jost",
     "mono": "Space Mono",

--- a/packages/zudo-doc/src/theme-packs/observatory/pack.css
+++ b/packages/zudo-doc/src/theme-packs/observatory/pack.css
@@ -25,27 +25,26 @@
 
    Prototype-selector adaptations against the REAL DOM (tokens-dump
    §6 + component sources), noted inline where they matter:
-   - `.lead`             → `.zd-content > p:first-of-type` (the
-                           description paragraph DocContentHeader
-                           renders as the article's first direct-child
-                           <p>; fails soft on pages without one)
+   - `.lead`             → `p[data-doc-description]` (#2873 stable
+                           hook on the description paragraph
+                           DocContentHeader renders; only present when
+                           the page has a frontmatter description)
    - `.toc-active`       → `nav[data-zd-toc] a[aria-current="true"]`
                            (toc/toc.tsx marks the active entry with
                            aria-current, not a mock class)
-   - `.doc-pager`        → `.zd-content > nav:last-of-type:not([aria-label]) > a`
-                           (the DocPager is the article's last
-                           unlabelled direct-child nav whose children
-                           are bare <a> cards; breadcrumb and
-                           NavCardGrid navs carry aria-labels)
-   - `footer[data-footer]` → `.zd-sidebar-content-wrapper > footer`
-                           (no data-footer attribute in the real DOM)
+   - `.doc-pager`        → `.zd-content > nav[data-doc-pager] > a`
+                           (#2873 stable hook on the DocPager nav)
+   - `footer[data-footer]` → `footer[data-footer]` (#2873 stable hook;
+                           the wrapper-descendant form is no longer
+                           needed)
    - `.hdr-search` / `.hdr-icon-btn` / `.sb-group > p` / `.toc-title`
                            — prototype-mock markup with no stable
                            hook; NOT ported.
-   - `.tp-flyout`        → `div[role="dialog"][aria-label="Theme pack
-                           switcher"]`; its title is
-                           `p[aria-live="polite"]`. The launcher
-                           button has NO stable hook — NOT ported.
+   - `.tp-flyout`        → `div[data-switcher-card]` (#2873 stable
+                           hook); its title is `p[aria-live="polite"]`.
+                           The launcher now has a stable hook too but
+                           remains NOT ported (unchanged design
+                           decision).
    - the prototype's `--obs-*` helper properties are not part of the
      token manifest; their values are inlined at each use site:
        gold        = var(--zd-accent)
@@ -386,8 +385,9 @@ html[data-theme-pack="observatory"] .zd-content h1::after {
   );
 }
 
-/* the lead: a light-weight opening line under the title */
-html[data-theme-pack="observatory"] .zd-content > p:first-of-type {
+/* the lead: a light-weight opening line under the title. Targets the
+   `data-doc-description` hook (#2873). */
+html[data-theme-pack="observatory"] .zd-content > p[data-doc-description] {
   font-weight: 300;
 }
 
@@ -588,10 +588,9 @@ html[data-theme-pack="observatory"] nav[data-zd-toc] a[aria-current="true"] {
 }
 
 /* pager — constellation cards: glowing nodes pinned to opposite
-   corners; gilt frame and node-glow on hover. The DocPager is the
-   article's LAST unlabelled direct-child nav (breadcrumb and
-   NavCardGrid navs carry aria-labels). */
-html[data-theme-pack="observatory"] .zd-content > nav:last-of-type:not([aria-label]) > a {
+   corners; gilt frame and node-glow on hover. Targets the DocPager's
+   `data-doc-pager` hook (#2873) directly. */
+html[data-theme-pack="observatory"] .zd-content > nav[data-doc-pager] > a {
   border-radius: 0;
   border-color: light-dark(oklch(0.33 0.05 268 / 0.22), oklch(0.88 0.04 265 / 0.16));
   background-color: color-mix(in oklch, var(--zd-surface) 60%, transparent);
@@ -617,22 +616,21 @@ html[data-theme-pack="observatory"] .zd-content > nav:last-of-type:not([aria-lab
 }
 html[data-theme-pack="observatory"]
   .zd-content
-  > nav:last-of-type:not([aria-label])
+  > nav[data-doc-pager]
   > a:hover {
   border-color: color-mix(in oklch, var(--zd-accent) 65%, transparent);
   box-shadow: 0 0 16px -4px
     light-dark(oklch(0.52 0.11 80 / 0.35), oklch(0.86 0.13 88 / 0.55));
 }
-html[data-theme-pack="observatory"] .zd-content > nav:last-of-type:not([aria-label]) > a div {
+html[data-theme-pack="observatory"] .zd-content > nav[data-doc-pager] > a div {
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-size: 0.72rem;
 }
 
-/* footer — the horizon: gilt rule fading at both ends, last stars
-   (the real footer has no data-footer hook; it is the wrapper's
-   direct child) */
-html[data-theme-pack="observatory"] .zd-sidebar-content-wrapper > footer {
+/* footer — the horizon: gilt rule fading at both ends, last stars.
+   Targets the `data-footer` hook (#2873) directly. */
+html[data-theme-pack="observatory"] footer[data-footer] {
   border-image: linear-gradient(
       to right,
       transparent,
@@ -658,8 +656,9 @@ html[data-theme-pack="observatory"] .zd-sidebar-content-wrapper > footer {
 
 /* theme-pack flyout — a framed star chart: violet frame, nebula wash,
    its own stars, glowing gold nodes on opposing corners; Josefin
-   chart-label title (the launcher button has no stable hook) */
-html[data-theme-pack="observatory"] div[role="dialog"][aria-label="Theme pack switcher"] {
+   chart-label title. Targets the `data-switcher-card` hook (#2873);
+   the launcher now has a stable hook too but remains NOT ported. */
+html[data-theme-pack="observatory"] div[data-switcher-card] {
   /* the dialog is a static flex child of the fixed wrapper — anchor
      the corner-node pseudos to the card itself */
   position: relative;
@@ -696,9 +695,9 @@ html[data-theme-pack="observatory"] div[role="dialog"][aria-label="Theme pack sw
     0 0 22px -8px light-dark(oklch(0.52 0.11 80 / 0.35), oklch(0.86 0.13 88 / 0.55));
 }
 html[data-theme-pack="observatory"]
-  div[role="dialog"][aria-label="Theme pack switcher"]::before,
+  div[data-switcher-card]::before,
 html[data-theme-pack="observatory"]
-  div[role="dialog"][aria-label="Theme pack switcher"]::after {
+  div[data-switcher-card]::after {
   content: "";
   position: absolute;
   width: 5px;
@@ -709,17 +708,17 @@ html[data-theme-pack="observatory"]
   pointer-events: none;
 }
 html[data-theme-pack="observatory"]
-  div[role="dialog"][aria-label="Theme pack switcher"]::before {
+  div[data-switcher-card]::before {
   top: -2.5px;
   left: -2.5px;
 }
 html[data-theme-pack="observatory"]
-  div[role="dialog"][aria-label="Theme pack switcher"]::after {
+  div[data-switcher-card]::after {
   bottom: -2.5px;
   right: -2.5px;
 }
 html[data-theme-pack="observatory"]
-  div[role="dialog"][aria-label="Theme pack switcher"]
+  div[data-switcher-card]
   p[aria-live="polite"] {
   font-family: var(--font-display);
   font-weight: 300;

--- a/packages/zudo-doc/src/theme-packs/onyx/meta.json
+++ b/packages/zudo-doc/src/theme-packs/onyx/meta.json
@@ -4,7 +4,7 @@
   "name": "Onyx",
   "description": "Luxury noir — jet black, champagne serif headings, and a single gold hairline accent. Watch-brand restraint.",
   "mode": "dark",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "fonts": {
     "sans": "Jost",
     "mono": "IBM Plex Mono",

--- a/packages/zudo-doc/src/theme-packs/onyx/pack.css
+++ b/packages/zudo-doc/src/theme-packs/onyx/pack.css
@@ -24,30 +24,30 @@
 
    Prototype-selector adaptations against the REAL DOM (tokens-dump
    §6 + component sources), noted inline where they matter:
-   - `.lead`      → `.zd-content > p:first-of-type` (the description
-                    paragraph DocContentHeader emits — the shared
-                    adaptation, same known limit: on a page without a
-                    frontmatter description the first BODY paragraph
-                    takes the serif-italic lead voice; fails soft)
+   - `.lead`      → `p[data-doc-description]` (#2873 stable hook on
+                    the description paragraph DocContentHeader emits;
+                    only present when the page has a frontmatter
+                    description — no longer falls back onto the first
+                    BODY paragraph)
    - `.sb-group > p` gold group plaques → no stable hook exists for
      sidebar group headers in the real SidebarTree island; the gold
      treatment moves onto a[data-nav-active] (transparent ground,
      gold text, a 1px gold spine via inset box-shadow — the
      swissgrid idiom, no layout shift)
-   - `.doc-pager` → `.zd-content > nav:last-of-type:not([aria-label]) > a`
-     (the batch-2 idiom: `:last-of-type:not([aria-label])` excludes
-     BOTH the Breadcrumb and the NavCardGrid "Child pages" nav —
-     the ledger over-match fix)
+   - `.doc-pager` → `.zd-content > nav[data-doc-pager] > a` (#2873
+     stable hook on the DocPager nav — replaces the batch-2
+     `:last-of-type:not([aria-label])` positional idiom)
    - `.toc-title` / `a.toc-active` → no stable hooks (the real TOC
      renders no title element; the active entry is utility-classed).
      The TOC keeps its default fg-on-bg active treatment; only the
      spine border (a stable `nav[data-zd-toc] ul` hook) is tuned.
-   - `footer .footer-copy` → the ledger idiom:
-     `.zd-sidebar-content-wrapper > footer > div > div:last-child:not(:first-child)`
+   - `footer .footer-copy` → `footer[data-footer] > div >
+     div:last-child:not(:first-child)` (#2873 stable hook; the
+     wrapper-descendant form is no longer needed)
    - the flyout and launcher DO have stable hooks in the real
-     switcher island (`div[role="dialog"][aria-label="Theme pack
-     switcher"]`, `button[aria-label="Theme pack switcher"]`) — the
-     double gold frame and the gold-ringed crown are ported.
+     switcher island — `div[data-switcher-card]` and
+     `button[data-switcher-launcher]` (#2873) — the double gold frame
+     and the gold-ringed crown are ported.
    ============================================================ */
 
 /* ---- Cormorant Garamond — the champagne serif: display headings,
@@ -261,8 +261,9 @@ html[data-theme-pack="onyx"] .zd-content h1::after {
   margin-top: 1rem;
 }
 
-/* the lead: a maison line in serif italic (see adaptation note) */
-html[data-theme-pack="onyx"] .zd-content > p:first-of-type {
+/* the lead: a maison line in serif italic. Targets the
+   `data-doc-description` hook (#2873) — see adaptation note. */
+html[data-theme-pack="onyx"] .zd-content > p[data-doc-description] {
   font-family: var(--font-display);
   font-style: italic;
   font-size: 1.4rem;
@@ -405,23 +406,21 @@ html[data-theme-pack="onyx"] [data-admonition="caution"] .admonition-title::befo
 }
 
 /* pager: two presentation cards — square, gold inset ring on hover,
-   uppercase labels, serif titles. Target the LAST unlabelled nav under
-   .zd-content — the DocPager. `:last-of-type:not([aria-label])`
-   excludes BOTH the Breadcrumb and the NavCardGrid "Child pages" nav
-   (the ledger over-match fix). */
-html[data-theme-pack="onyx"] .zd-content > nav:last-of-type:not([aria-label]) > a {
+   uppercase labels, serif titles. Targets the DocPager's
+   `data-doc-pager` hook (#2873) directly. */
+html[data-theme-pack="onyx"] .zd-content > nav[data-doc-pager] > a {
   border-radius: 0;
   padding: 1rem 1.2rem;
 }
-html[data-theme-pack="onyx"] .zd-content > nav:last-of-type:not([aria-label]) > a:hover {
+html[data-theme-pack="onyx"] .zd-content > nav[data-doc-pager] > a:hover {
   box-shadow: inset 0 0 0 1px var(--zd-accent);
 }
-html[data-theme-pack="onyx"] .zd-content > nav:last-of-type:not([aria-label]) > a div {
+html[data-theme-pack="onyx"] .zd-content > nav[data-doc-pager] > a div {
   font-size: 0.62rem;
   text-transform: uppercase;
   letter-spacing: 0.22em;
 }
-html[data-theme-pack="onyx"] .zd-content > nav:last-of-type:not([aria-label]) > a p {
+html[data-theme-pack="onyx"] .zd-content > nav[data-doc-pager] > a p {
   font-family: var(--font-display);
   font-size: 1.25rem;
   font-weight: 600;
@@ -434,29 +433,31 @@ html[data-theme-pack="onyx"] nav[data-zd-toc] ul {
   border-left: 1px solid color-mix(in oklch, var(--zd-muted) 32%, transparent);
 }
 
-/* footer: an engraved copyright line under the closing gold hairline */
-html[data-theme-pack="onyx"] .zd-sidebar-content-wrapper > footer {
+/* footer: an engraved copyright line under the closing gold hairline.
+   Targets the `data-footer` hook (#2873) directly. */
+html[data-theme-pack="onyx"] footer[data-footer] {
   border-top: 1px solid color-mix(in oklch, var(--zd-accent) 30%, transparent);
 }
 /* italicize the copyright line only when it coexists with link/tag
    columns (the ledger idiom — `:not(:first-child)` keeps a columns-only
    footer's grid out of this positional rule) */
-html[data-theme-pack="onyx"] .zd-sidebar-content-wrapper > footer > div > div:last-child:not(:first-child) {
+html[data-theme-pack="onyx"] footer[data-footer] > div > div:last-child:not(:first-child) {
   font-family: var(--font-display);
   font-style: italic;
   font-size: 0.95rem;
   letter-spacing: 0.05em;
 }
 
-/* flyout: the jewelry box — double gold frame, serif title */
-html[data-theme-pack="onyx"] div[role="dialog"][aria-label="Theme pack switcher"] {
+/* flyout: the jewelry box — double gold frame, serif title. Targets
+   the `data-switcher-card` hook (#2873). */
+html[data-theme-pack="onyx"] div[data-switcher-card] {
   border: 1px solid color-mix(in oklch, var(--zd-accent) 55%, transparent);
   outline: 1px solid color-mix(in oklch, var(--zd-accent) 22%, transparent);
   outline-offset: 4px;
   border-radius: 0;
   box-shadow: 0 18px 44px -10px rgb(0 0 0 / 0.55);
 }
-html[data-theme-pack="onyx"] div[role="dialog"][aria-label="Theme pack switcher"] p[aria-live="polite"] {
+html[data-theme-pack="onyx"] div[data-switcher-card] p[aria-live="polite"] {
   font-family: var(--font-display);
   font-size: 1.45rem;
   font-weight: 600;
@@ -477,8 +478,9 @@ html[data-theme-pack="onyx"] dialog[aria-labelledby="zd-theme-pack-dialog-title"
   border-radius: 0;
 }
 
-/* launcher: the crown — the page's only circle, gold-ringed */
-html[data-theme-pack="onyx"] button[aria-haspopup="dialog"][aria-label="Theme pack switcher"] {
+/* launcher: the crown — the page's only circle, gold-ringed. Targets
+   the `data-switcher-launcher` hook (#2873). */
+html[data-theme-pack="onyx"] button[data-switcher-launcher] {
   border-color: color-mix(in oklch, var(--zd-accent) 60%, transparent);
   box-shadow:
     0 4px 14px -4px rgb(0 0 0 / 0.45),

--- a/packages/zudo-doc/src/theme-packs/phosphor/meta.json
+++ b/packages/zudo-doc/src/theme-packs/phosphor/meta.json
@@ -4,7 +4,7 @@
   "name": "Phosphor",
   "description": "Green CRT terminal — phosphor glow, scanlines, inverse-video nav, monospace everything.",
   "mode": "dark",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "fonts": {
     "sans": "JetBrains Mono",
     "mono": "JetBrains Mono",

--- a/packages/zudo-doc/src/theme-packs/phosphor/pack.css
+++ b/packages/zudo-doc/src/theme-packs/phosphor/pack.css
@@ -32,18 +32,23 @@
    - `.toc-active`       → `nav[data-zd-toc] a[aria-current="true"]`
                            (toc/toc.tsx marks the active entry with
                            aria-current, not a mock class)
-   - `.doc-pager`        → `.zd-content > nav:last-of-type:not([aria-label]) > a`
-                           (the DocPager is the article's last
-                           unlabelled direct-child nav; breadcrumb
-                           and NavCardGrid navs carry aria-labels)
-   - `footer[data-footer]` → `.zd-sidebar-content-wrapper > footer`
-                           (no data-footer attribute in the real
-                           DOM); the "── EOF ──" end-of-stream mark
-                           rides the footer's own ::after
-   - `.tp-flyout`        → `div[role="dialog"][aria-label="Theme pack
-                           switcher"]`; its title is
+   - `.doc-pager`        → `.zd-content > nav[data-doc-pager] > a`
+                           (retargeted onto the stable hook,
+                           zudolab/zudo-doc#2879 — was
+                           `.zd-content > nav:last-of-type:not([aria-label])`)
+   - `footer[data-footer]` → `footer[data-footer]` (retargeted onto the
+                           stable hook, zudolab/zudo-doc#2879 — was
+                           `.zd-sidebar-content-wrapper > footer`); the
+                           "── EOF ──" end-of-stream mark rides the
+                           footer's own ::after
+   - `.tp-flyout`        → `div[data-switcher-card]` (retargeted onto
+                           the stable hook, zudolab/zudo-doc#2879 — was
+                           `div[role="dialog"][aria-label="Theme pack
+                           switcher"]`); its title is
                            `p[aria-live="polite"]`. The launcher
-                           button has NO stable hook — NOT ported.
+                           (`button[data-switcher-launcher]`) has a
+                           stable hook now too but stays unstyled —
+                           pack choice, not a missing-hook limitation.
    - `.hdr-search` / `.sb-group > p` — prototype-mock markup with no
                            stable hook; NOT ported.
    - the prototype's `--phos-*` helper properties (glow, scanline,
@@ -411,16 +416,16 @@ html[data-theme-pack="phosphor"] .zd-content td {
 /* pager: bracketed jump targets — faint green fill, glow on hover.
    The DocPager is the article's LAST unlabelled direct-child nav
    (breadcrumb and NavCardGrid navs carry aria-labels). */
-html[data-theme-pack="phosphor"] .zd-content > nav:last-of-type:not([aria-label]) > a {
+html[data-theme-pack="phosphor"] .zd-content > nav[data-doc-pager] > a {
   border-radius: 0;
   background: color-mix(in srgb, var(--zd-accent) 4%, transparent);
 }
-html[data-theme-pack="phosphor"] .zd-content > nav:last-of-type:not([aria-label]) > a:hover {
+html[data-theme-pack="phosphor"] .zd-content > nav[data-doc-pager] > a:hover {
   box-shadow:
     0 0 14px light-dark(oklch(0.42 0.13 150 / 0.1), oklch(0.87 0.215 148 / 0.28)),
     inset 0 0 20px color-mix(in oklch, var(--zd-accent) 6%, transparent);
 }
-html[data-theme-pack="phosphor"] .zd-content > nav:last-of-type:not([aria-label]) > a div {
+html[data-theme-pack="phosphor"] .zd-content > nav[data-doc-pager] > a div {
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-size: 0.72rem;
@@ -442,12 +447,11 @@ html[data-theme-pack="phosphor"] nav[data-zd-toc] a[aria-current="true"] {
   text-shadow: none;
 }
 
-/* footer: end of stream (the real footer has no data-footer hook;
-   it is the wrapper's direct child) */
-html[data-theme-pack="phosphor"] .zd-sidebar-content-wrapper > footer {
+/* footer: end of stream */
+html[data-theme-pack="phosphor"] footer[data-footer] {
   border-top-color: color-mix(in oklch, var(--zd-accent) 40%, transparent);
 }
-html[data-theme-pack="phosphor"] .zd-sidebar-content-wrapper > footer::after {
+html[data-theme-pack="phosphor"] footer[data-footer]::after {
   content: "── EOF ──";
   display: block;
   text-align: center;
@@ -457,8 +461,9 @@ html[data-theme-pack="phosphor"] .zd-sidebar-content-wrapper > footer::after {
 }
 
 /* theme-pack flyout: a small terminal window with a glowing bezel
-   (the launcher button has no stable hook) */
-html[data-theme-pack="phosphor"] div[role="dialog"][aria-label="Theme pack switcher"] {
+   (the launcher is a stable hook now too but stays unstyled — pack
+   choice, not a missing-hook limitation) */
+html[data-theme-pack="phosphor"] div[data-switcher-card] {
   border: 1px solid color-mix(in oklch, var(--zd-accent) 55%, transparent);
   border-radius: 0;
   box-shadow:
@@ -466,7 +471,7 @@ html[data-theme-pack="phosphor"] div[role="dialog"][aria-label="Theme pack switc
     0 10px 30px -6px oklch(0 0 0 / 0.45);
 }
 html[data-theme-pack="phosphor"]
-  div[role="dialog"][aria-label="Theme pack switcher"]
+  div[data-switcher-card]
   p[aria-live="polite"] {
   font-family: var(--font-display);
   font-weight: 400;
@@ -475,7 +480,7 @@ html[data-theme-pack="phosphor"]
   text-shadow: 0 0 8px light-dark(oklch(0.42 0.13 150 / 0.22), oklch(0.87 0.215 148 / 0.55));
 }
 html[data-theme-pack="phosphor"]
-  div[role="dialog"][aria-label="Theme pack switcher"]
+  div[data-switcher-card]
   p[aria-live="polite"]::before {
   content: "$ ";
   color: var(--zd-muted);

--- a/packages/zudo-doc/src/theme-packs/solar/meta.json
+++ b/packages/zudo-doc/src/theme-packs/solar/meta.json
@@ -4,7 +4,7 @@
   "name": "Solar",
   "description": "Solarized precision — low-eyestrain paper tones, blue/cyan/orange accents, mono labels, technical calm in both modes.",
   "mode": "light",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "fonts": {
     "sans": "Source Sans 3",
     "mono": "Source Code Pro",

--- a/packages/zudo-doc/src/theme-packs/solar/pack.css
+++ b/packages/zudo-doc/src/theme-packs/solar/pack.css
@@ -33,17 +33,20 @@
                            aria-current, not a mock class); the
                            prototype's absolute ::before bar becomes
                            a border-left snug against the rail
-   - `.doc-pager`        → `.zd-content > nav:last-of-type:not([aria-label]) > a`
-                           (DocPager is the article's last unlabelled
-                           direct-child nav; the child combinator
-                           keeps NavCardGrid card anchors out)
+   - `.doc-pager`        → `.zd-content > nav[data-doc-pager] > a`
+                           (retargeted onto the stable hook,
+                           zudolab/zudo-doc#2879 — was
+                           `.zd-content > nav:last-of-type:not([aria-label])`)
    - `.crumb-current`    → `main nav[aria-label="Breadcrumb"] li > span`
                            (the current page is the only bare <span>
                            in the breadcrumb list)
-   - `footer[data-footer]` → `.zd-sidebar-content-wrapper > footer`
-                           (no data-footer attribute in the real DOM)
-   - `.tp-flyout`        → `div[role="dialog"][aria-label="Theme pack
-                           switcher"]`; the spectrum cap strip is a
+   - `footer[data-footer]` → `footer[data-footer]` (retargeted onto the
+                           stable hook, zudolab/zudo-doc#2879 — was
+                           `.zd-sidebar-content-wrapper > footer`)
+   - `.tp-flyout`        → `div[data-switcher-card]` (retargeted onto
+                           the stable hook, zudolab/zudo-doc#2879 — was
+                           `div[role="dialog"][aria-label="Theme pack
+                           switcher"]`); the spectrum cap strip is a
                            top-anchored background gradient (the
                            fjord/hearth technique) instead of the
                            prototype's ::before overlay
@@ -337,14 +340,14 @@ html[data-theme-pack="solar"] .zd-content tbody tr:hover td {
 /* pager: crisp cards, mono uppercase yellow micro-labels (the
    solarized-yellow terminal dialect), cyan hover wash. The DocPager
    is the article's LAST unlabelled direct-child nav. */
-html[data-theme-pack="solar"] .zd-content > nav:last-of-type:not([aria-label]) > a div {
+html[data-theme-pack="solar"] .zd-content > nav[data-doc-pager] > a div {
   font-family: var(--font-mono);
   font-size: 0.7rem;
   text-transform: uppercase;
   letter-spacing: 0.1em;
   color: light-dark(#876500, #be9000);
 }
-html[data-theme-pack="solar"] .zd-content > nav:last-of-type:not([aria-label]) > a:hover {
+html[data-theme-pack="solar"] .zd-content > nav[data-doc-pager] > a:hover {
   border-color: var(--zd-accent-hover);
   background: color-mix(in srgb, var(--zd-accent-hover) 7%, transparent);
 }
@@ -353,14 +356,14 @@ html[data-theme-pack="solar"] .zd-content > nav:last-of-type:not([aria-label]) >
 html[data-theme-pack="solar"] header[data-header] {
   border-bottom-color: light-dark(#ddd6c1, #0b4354);
 }
-html[data-theme-pack="solar"] .zd-sidebar-content-wrapper > footer {
+html[data-theme-pack="solar"] footer[data-footer] {
   border-top-color: light-dark(#ddd6c1, #0b4354);
 }
 
 /* theme-pack flyout: the solarized accent spectrum as a 3px cap
    strip — painted as a top-anchored background gradient (the fjord
    technique) so the hairline border keeps its own color */
-html[data-theme-pack="solar"] div[role="dialog"][aria-label="Theme pack switcher"] {
+html[data-theme-pack="solar"] div[data-switcher-card] {
   border-color: light-dark(#ddd6c1, #0e4250);
   background-color: var(--zd-surface);
   background-image: linear-gradient(90deg, #268bd2, #2aa198, #b58900, #cb4b16);
@@ -370,7 +373,7 @@ html[data-theme-pack="solar"] div[role="dialog"][aria-label="Theme pack switcher
   box-shadow: 0 12px 32px -8px light-dark(rgba(88, 110, 117, 0.35), rgba(0, 0, 0, 0.55));
 }
 html[data-theme-pack="solar"]
-  div[role="dialog"][aria-label="Theme pack switcher"]
+  div[data-switcher-card]
   p[aria-live="polite"] {
   color: light-dark(#073642, #eee8d5);
   font-weight: 600;

--- a/packages/zudo-doc/src/theme-packs/sumi/meta.json
+++ b/packages/zudo-doc/src/theme-packs/sumi/meta.json
@@ -4,7 +4,7 @@
   "name": "Sumi",
   "description": "Sumi-e ink on washi — bold mincho brush headings, deep black strokes, one vermillion hanko seal accent.",
   "mode": "light",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "fonts": {
     "sans": "Zen Kaku Gothic New",
     "mono": "IBM Plex Mono",

--- a/packages/zudo-doc/src/theme-packs/sumi/pack.css
+++ b/packages/zudo-doc/src/theme-packs/sumi/pack.css
@@ -36,13 +36,12 @@
      has no stable hook, the top-right corner belongs to the
      injected copy/wrap buttons, and a background pins to the
      scrollport instead of scrolling away with wide code)
-   - `.doc-pager` → `.zd-content > nav:not([aria-label="Breadcrumb"]) > a`
-     (the ledger idiom: DocPager is the only direct-child nav of the
-     article whose children are bare <a> cards; list-structured
-     CategoryNav / NavCardGrid never match the `> a` step)
-   - `footer[data-footer] .footer-copy::before` → the closing
-     artist's seal becomes ::after on the stable
-     `.zd-sidebar-content-wrapper > footer` hook
+   - `.doc-pager` → `.zd-content > nav[data-doc-pager] > a` (retargeted
+     onto the stable hook, zudolab/zudo-doc#2879 — was
+     `.zd-content > nav:last-of-type:not([aria-label]) > a`)
+   - the closing artist's seal becomes ::after on the stable
+     `footer[data-footer]` hook (retargeted from
+     `.zd-sidebar-content-wrapper > footer`, zudolab/zudo-doc#2879)
    - the square 印 launcher stamp and the flyout's stamp-shadow frame
      have NO stable hook — intentionally NOT ported (pack notes).
    ============================================================ */
@@ -370,12 +369,14 @@ html[data-theme-pack="sumi"] .zd-content h3::before {
   vertical-align: 0.12em;
 }
 
-/* the lead: subtitle in the brush hand. The prototype's `.lead` is the
-   description paragraph DocContentHeader renders as the FIRST direct-
-   child <p> of the article (broadsheet's adaptation + caveat: on a page
-   without a frontmatter description the first BODY paragraph takes this
-   styling instead — reads as an emphasized opening line, fails soft). */
-html[data-theme-pack="sumi"] .zd-content > p:first-of-type {
+/* the lead: subtitle in the brush hand — the description paragraph
+   DocContentHeader renders, retargeted onto the stable
+   `data-doc-description` hook (zudolab/zudo-doc#2879; was
+   `.zd-content > p:first-of-type`, which carried a broadsheet-style
+   soft fallback onto the first body paragraph on description-less
+   pages). Description-less pages now intentionally lose that fallback
+   deck — same rationale as broadsheet's own retarget. */
+html[data-theme-pack="sumi"] .zd-content > p[data-doc-description] {
   font-family: var(--font-display);
   font-weight: 600;
 }
@@ -460,21 +461,21 @@ html[data-theme-pack="sumi"] .zd-content th {
 }
 
 /* pager: square cards that stamp down on hover with a seal-red offset
-   shadow. Target the LAST unlabelled nav under .zd-content — the DocPager.
-   `:last-of-type:not([aria-label])` (the batch-2 sibling idiom) excludes BOTH
-   the Breadcrumb and the NavCardGrid ("Child pages") nav, whose <a> are also
-   direct children of a `.zd-content > nav` — a bare `:not([aria-label="Breadcrumb"])`
-   would wrongly stamp the child-page cards on auto-index pages. */
-html[data-theme-pack="sumi"] .zd-content > nav:last-of-type:not([aria-label]) > a {
+   shadow. Targets the stable `data-doc-pager` hook on the DocPager
+   <nav> (retargeted, zudolab/zudo-doc#2879 — was
+   `.zd-content > nav:last-of-type:not([aria-label])`, the sibling
+   idiom that excluded the Breadcrumb and NavCardGrid navs by
+   position/aria-label instead of a dedicated hook). */
+html[data-theme-pack="sumi"] .zd-content > nav[data-doc-pager] > a {
   border-radius: 0;
   border-color: color-mix(in srgb, var(--zd-fg) 45%, transparent);
 }
-html[data-theme-pack="sumi"] .zd-content > nav:last-of-type:not([aria-label]) > a:hover {
+html[data-theme-pack="sumi"] .zd-content > nav[data-doc-pager] > a:hover {
   border-color: var(--zd-fg);
   box-shadow: 4px 4px 0
     color-mix(in srgb, light-dark(#c2242f, #d9333f) 45%, transparent);
 }
-html[data-theme-pack="sumi"] .zd-content > nav:last-of-type:not([aria-label]) > a p {
+html[data-theme-pack="sumi"] .zd-content > nav[data-doc-pager] > a p {
   font-family: var(--font-display);
   font-weight: 700;
 }
@@ -486,12 +487,12 @@ html[data-theme-pack="sumi"] nav[data-zd-toc] ul {
 }
 
 /* footer: one decisive ink rule; the artist's seal closes the scroll
-   (the real footer has no data-footer hook — it is the wrapper's
-   direct child, and the seal renders ::after its content, centered) */
-html[data-theme-pack="sumi"] .zd-sidebar-content-wrapper > footer {
+   (targets the stable data-footer hook; the seal renders ::after its
+   content, centered) */
+html[data-theme-pack="sumi"] footer[data-footer] {
   border-top: 3px solid var(--zd-fg);
 }
-html[data-theme-pack="sumi"] .zd-sidebar-content-wrapper > footer::after {
+html[data-theme-pack="sumi"] footer[data-footer]::after {
   content: "";
   display: block;
   width: 0.55rem;

--- a/packages/zudo-doc/src/theme-packs/swissgrid/meta.json
+++ b/packages/zudo-doc/src/theme-packs/swissgrid/meta.json
@@ -4,7 +4,7 @@
   "name": "Swissgrid",
   "description": "International Typographic Style — grid discipline, black on white, one hot Swiss-red accent, oversized section numbers.",
   "mode": "light",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "fonts": {
     "sans": "Inter",
     "mono": "IBM Plex Mono",

--- a/packages/zudo-doc/src/theme-packs/swissgrid/pack.css
+++ b/packages/zudo-doc/src/theme-packs/swissgrid/pack.css
@@ -410,25 +410,29 @@ html[data-theme-pack="swissgrid"] .zd-content td {
 }
 
 /* ---- pager: square cards, hard red offset on hover ----
-   (DocPager renders as the direct-child <nav> of article.zd-content —
-   the prototype's ".doc-pager" class doesn't exist in the real DOM.
-   Inside each card: <div> = the small prev/next label row, <p> = the
-   destination title.) */
+   (Retargeted onto the stable `data-doc-pager` hook on the DocPager
+   <nav>, zudolab/zudo-doc#2879 — was the bare `.zd-content > nav`,
+   which had no exclusion for the NavCardGrid "Child pages" nav that
+   also renders as a `.zd-content > nav` on auto-index pages; this
+   pack's rules were accidentally stamping those child-page cards with
+   the pager's square-card treatment too. The hook-scoped selector
+   fixes that overreach. Inside each card: <div> = the small prev/next
+   label row, <p> = the destination title.) */
 
-html[data-theme-pack="swissgrid"] .zd-content > nav a {
+html[data-theme-pack="swissgrid"] .zd-content > nav[data-doc-pager] a {
   border: 1px solid var(--zd-fg);
   border-radius: 0;
 }
-html[data-theme-pack="swissgrid"] .zd-content > nav a:hover {
+html[data-theme-pack="swissgrid"] .zd-content > nav[data-doc-pager] a:hover {
   border-color: #ff0000;
   box-shadow: 4px 4px 0 0 #ff0000;
 }
-html[data-theme-pack="swissgrid"] .zd-content > nav a div {
+html[data-theme-pack="swissgrid"] .zd-content > nav[data-doc-pager] a div {
   text-transform: uppercase;
   font-size: 0.66rem;
   letter-spacing: 0.14em;
 }
-html[data-theme-pack="swissgrid"] .zd-content > nav a p {
+html[data-theme-pack="swissgrid"] .zd-content > nav[data-doc-pager] a p {
   font-weight: 700;
 }
 
@@ -451,49 +455,54 @@ html[data-theme-pack="swissgrid"] nav[data-zd-toc] a[aria-current="true"] {
   box-shadow: inset 3px 0 0 0 #ff0000;
 }
 
-/* ---- footer: heavy rule, ink links with red underlines ---- */
+/* ---- footer: heavy rule, ink links with red underlines ----
+   (Retargeted onto the stable data-footer hook, zudolab/zudo-doc#2879
+   — was `.zd-sidebar-content-wrapper footer`.) */
 
-html[data-theme-pack="swissgrid"] .zd-sidebar-content-wrapper footer {
+html[data-theme-pack="swissgrid"] footer[data-footer] {
   border-top: 4px solid var(--zd-fg);
 }
-html[data-theme-pack="swissgrid"] .zd-sidebar-content-wrapper footer a {
+html[data-theme-pack="swissgrid"] footer[data-footer] a {
   color: var(--zd-fg);
   text-decoration-color: #ff0000;
   text-decoration-thickness: 2px;
 }
-html[data-theme-pack="swissgrid"] .zd-sidebar-content-wrapper footer a:hover {
+html[data-theme-pack="swissgrid"] footer[data-footer] a:hover {
   color: var(--zd-accent);
 }
 
 /* ---- theme-pack switcher: square, black frame, hard red shadow ----
-   (The flyout card and launcher carry no dedicated hook classes; their
-   accessible names are the stable handle.) */
+   (Retargeted onto the stable data-switcher-card / data-switcher-launcher
+   hooks, zudolab/zudo-doc#2879 — was the flyout card/launcher's
+   accessible names, `div[role="dialog"][aria-label="Theme pack
+   switcher"]` and `button[aria-haspopup="dialog"][aria-label="Theme
+   pack switcher"]`.) */
 
-html[data-theme-pack="swissgrid"] div[role="dialog"][aria-label="Theme pack switcher"] {
+html[data-theme-pack="swissgrid"] div[data-switcher-card] {
   border: 2px solid var(--zd-fg);
   border-radius: 0;
   box-shadow: 10px 10px 0 0 #ff0000;
 }
-html[data-theme-pack="swissgrid"] div[role="dialog"][aria-label="Theme pack switcher"] span {
+html[data-theme-pack="swissgrid"] div[data-switcher-card] span {
   border-radius: 0;
 }
-html[data-theme-pack="swissgrid"] div[role="dialog"][aria-label="Theme pack switcher"] button {
+html[data-theme-pack="swissgrid"] div[data-switcher-card] button {
   border-radius: 0;
   border-color: var(--zd-fg);
   text-transform: uppercase;
   letter-spacing: 0.06em;
 }
-html[data-theme-pack="swissgrid"] div[role="dialog"][aria-label="Theme pack switcher"] button:hover {
+html[data-theme-pack="swissgrid"] div[data-switcher-card] button:hover {
   background-color: var(--zd-accent);
   border-color: var(--zd-accent);
   color: light-dark(#ffffff, #0c0c0c);
 }
-html[data-theme-pack="swissgrid"] button[aria-haspopup="dialog"][aria-label="Theme pack switcher"] {
+html[data-theme-pack="swissgrid"] button[data-switcher-launcher] {
   border-radius: 0;
   border: 2px solid var(--zd-fg);
   box-shadow: 5px 5px 0 0 #ff0000;
 }
-html[data-theme-pack="swissgrid"] button[aria-haspopup="dialog"][aria-label="Theme pack switcher"]:hover {
+html[data-theme-pack="swissgrid"] button[data-switcher-launcher]:hover {
   color: var(--zd-accent);
   border-color: var(--zd-accent);
 }

--- a/packages/zudo-doc/src/theme-packs/washi/meta.json
+++ b/packages/zudo-doc/src/theme-packs/washi/meta.json
@@ -4,7 +4,7 @@
   "name": "Washi",
   "description": "Warm washi paper, sumi ink, and ai-iro indigo seals — quiet Japanese stationery for calm documentation.",
   "mode": "light",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "fonts": {
     "sans": "Zen Kaku Gothic New",
     "mono": "M PLUS 1 Code",

--- a/packages/zudo-doc/src/theme-packs/washi/pack.css
+++ b/packages/zudo-doc/src/theme-packs/washi/pack.css
@@ -26,23 +26,31 @@
 
    Prototype-selector adaptations against the REAL DOM (tokens-dump
    §6 + component sources), noted inline where they matter:
-   - `.lead`            → `.zd-content > p:first-of-type` (the
-                          description paragraph DocContentHeader
-                          emits; broadsheet precedent + known limit)
+   - `.lead`            → `.zd-content > p[data-doc-description]`
+                          (retargeted onto the stable hook,
+                          zudolab/zudo-doc#2879 — was
+                          `.zd-content > p:first-of-type`, which fell
+                          back to the first body paragraph on
+                          description-less pages; that fallback deck
+                          is intentionally gone now, same rationale as
+                          broadsheet's own retarget)
    - `.sb-group > p::before` (sidebar group-label seal squares) →
                           NOT ported — sidebar group labels have no
                           stable hook; the sidebar keeps its
                           vertical-fiber sheet + accent hover
    - `.toc-active`      → `nav[data-zd-toc] a[aria-current="true"]`
-   - `.doc-pager`       → `.zd-content > nav:last-of-type:not([aria-label])`
-                          (DocPager is the article's last direct-child
-                          nav and ships no aria-label; the :not guard
-                          excludes NavCardGrid "Child pages")
-   - `footer[data-footer]` → `.zd-sidebar-content-wrapper > footer`
-                          (no data-footer attribute in the real DOM)
+   - `.doc-pager`       → `.zd-content > nav[data-doc-pager]`
+                          (retargeted onto the stable hook,
+                          zudolab/zudo-doc#2879 — was
+                          `.zd-content > nav:last-of-type:not([aria-label])`)
+   - `footer[data-footer]` → `footer[data-footer]` (retargeted onto the
+                          stable hook, zudolab/zudo-doc#2879 — was
+                          `.zd-sidebar-content-wrapper > footer`)
    - the theme-switcher flyout/launcher (the square indigo hanko
-     launcher + 和紙 stamp) has NO stable hook — intentionally NOT
-     ported (broadsheet precedent)
+     launcher + 和紙 stamp) — `[data-switcher-card]` /
+     `[data-switcher-launcher]` are stable hooks now too, but stay
+     unstyled — pack choice (broadsheet precedent), not a
+     missing-hook limitation
    - prototype `--radius`/`--radius-lg` were structural mock tokens,
      not part of the pack token contract — squareness lands via
      `--zdc-admonition-radius: 0`, `--zdc-card-radius: 0`, and
@@ -242,7 +250,7 @@ html[data-theme-pack="washi"] body {
 
 /* header and footer: single-fleck grain over the surface tone */
 html[data-theme-pack="washi"] header[data-header],
-html[data-theme-pack="washi"] .zd-sidebar-content-wrapper > footer {
+html[data-theme-pack="washi"] footer[data-footer] {
   background-image: radial-gradient(
     light-dark(rgb(101 78 42 / 0.04), rgb(214 205 180 / 0.028)) 1px,
     transparent 1.2px
@@ -288,13 +296,13 @@ html[data-theme-pack="washi"] .zd-content {
   letter-spacing: 0.01em;
 }
 
-/* the lead: mincho standfirst. The prototype's `.lead` is the
-   description paragraph DocContentHeader renders as the FIRST
-   direct-child <p> of the article. Known limit (broadsheet
-   precedent): the description is optional frontmatter — on a page
-   without one the first BODY paragraph takes the mincho voice
-   instead (reads as an emphasized opening paragraph, fails soft). */
-html[data-theme-pack="washi"] .zd-content > p:first-of-type {
+/* the lead: mincho standfirst — the description paragraph
+   DocContentHeader renders, targeted via the stable
+   `data-doc-description` hook. Description-less pages no longer get
+   a fallback deck (the prior `:first-of-type` selector fell back to
+   the first body paragraph; that soft-fail behavior is intentionally
+   gone, same rationale as broadsheet's own retarget). */
+html[data-theme-pack="washi"] .zd-content > p[data-doc-description] {
   font-family: var(--font-display);
   font-size: 1.2rem;
   line-height: 1.8;
@@ -454,7 +462,7 @@ html[data-theme-pack="washi"] nav[data-zd-toc] a[aria-current="true"] {
    an indigo binding edge in from the reading direction (prev = left
    card = left edge; next = right card = right edge — DocPager always
    renders two grid children, so :first/:last-child are stable) */
-html[data-theme-pack="washi"] .zd-content > nav:last-of-type:not([aria-label]) > a {
+html[data-theme-pack="washi"] .zd-content > nav[data-doc-pager] > a {
   background-color: var(--zd-surface);
   background-image: radial-gradient(
     light-dark(rgb(101 78 42 / 0.04), rgb(214 205 180 / 0.028)) 1px,
@@ -463,9 +471,9 @@ html[data-theme-pack="washi"] .zd-content > nav:last-of-type:not([aria-label]) >
   background-size: 11px 13px;
   border-radius: 0;
 }
-html[data-theme-pack="washi"] .zd-content > nav:last-of-type:not([aria-label]) > a:first-child:hover {
+html[data-theme-pack="washi"] .zd-content > nav[data-doc-pager] > a:first-child:hover {
   box-shadow: inset 3px 0 0 var(--zd-accent);
 }
-html[data-theme-pack="washi"] .zd-content > nav:last-of-type:not([aria-label]) > a:last-child:hover {
+html[data-theme-pack="washi"] .zd-content > nav[data-doc-pager] > a:last-child:hover {
   box-shadow: inset -3px 0 0 var(--zd-accent);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,7 +73,7 @@ importers:
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: 0.18.5
-        version: 0.18.5(@vitest/runner@4.1.0)(@vitest/snapshot@4.1.0)(vitest@4.1.0(@types/node@25.3.5)(msw@2.12.12(@types/node@25.3.5)(typescript@5.9.3))(vite@7.3.5(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))
+        version: 0.18.5(@cloudflare/workers-types@4.20260608.1)(@vitest/runner@4.1.0)(@vitest/snapshot@4.1.0)(vitest@4.1.0(@types/node@25.3.5)(happy-dom@20.10.6)(msw@2.12.12(@types/node@25.3.5)(typescript@5.9.3))(vite@7.3.5(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))
       '@cloudflare/workers-types':
         specifier: 4.20260608.1
         version: 4.20260608.1
@@ -112,7 +112,7 @@ importers:
         version: 4.0.2
       html-validate:
         specifier: ^10.15.0
-        version: 10.15.0(vitest@4.1.0(@types/node@25.3.5)(msw@2.12.12(@types/node@25.3.5)(typescript@5.9.3))(vite@7.3.5(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))
+        version: 10.15.0(vitest@4.1.0(@types/node@25.3.5)(happy-dom@20.10.6)(msw@2.12.12(@types/node@25.3.5)(typescript@5.9.3))(vite@7.3.5(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))
       lefthook:
         specifier: ^2.1.4
         version: 2.1.4
@@ -142,7 +142,7 @@ importers:
         version: 7.3.5(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@25.3.5)(msw@2.12.12(@types/node@25.3.5)(typescript@5.9.3))(vite@7.3.5(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+        version: 4.1.0(@types/node@25.3.5)(happy-dom@20.10.6)(msw@2.12.12(@types/node@25.3.5)(typescript@5.9.3))(vite@7.3.5(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
       wrangler:
         specifier: 4.85.0
         version: 4.85.0(@cloudflare/workers-types@4.20260608.1)
@@ -179,7 +179,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@22.19.15)(msw@2.12.12(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+        version: 4.1.0(@types/node@22.19.15)(happy-dom@20.10.6)(msw@2.12.12(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
 
   packages/doc-history-server:
     devDependencies:
@@ -197,7 +197,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@22.19.15)(msw@2.12.12(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+        version: 4.1.0(@types/node@22.19.15)(happy-dom@20.10.6)(msw@2.12.12(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
 
   packages/search-worker:
     dependencies:
@@ -213,7 +213,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@25.3.5)(msw@2.12.12(@types/node@25.3.5)(typescript@5.9.3))(vite@7.3.5(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+        version: 4.1.0(@types/node@25.3.5)(happy-dom@20.10.6)(msw@2.12.12(@types/node@25.3.5)(typescript@5.9.3))(vite@7.3.5(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
       wrangler:
         specifier: ^4.85.0
         version: 4.85.0(@cloudflare/workers-types@4.20260608.1)
@@ -284,6 +284,9 @@ importers:
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
+      happy-dom:
+        specifier: ^20.10.6
+        version: 20.10.6
       preact:
         specifier: ^10.29.1
         version: 10.29.2
@@ -301,7 +304,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@25.3.5)(msw@2.12.12(@types/node@25.3.5)(typescript@5.9.3))(vite@7.3.5(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+        version: 4.1.0(@types/node@25.3.5)(happy-dom@20.10.6)(msw@2.12.12(@types/node@25.3.5)(typescript@5.9.3))(vite@7.3.5(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1457,6 +1460,12 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
@@ -1542,6 +1551,10 @@ packages:
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
+
+  buffer-image-size@0.6.4:
+    resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
+    engines: {node: '>=4.0'}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -1848,6 +1861,10 @@ packages:
     resolution: {integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==}
     engines: {node: '>=10.13.0'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
 
@@ -1956,6 +1973,10 @@ packages:
 
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
+  happy-dom@20.10.6:
+    resolution: {integrity: sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==}
+    engines: {node: '>=20.0.0'}
 
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
@@ -2828,6 +2849,10 @@ packages:
       jsdom:
         optional: true
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -2966,15 +2991,15 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260710.1
 
-  '@cloudflare/vitest-pool-workers@0.18.5(@vitest/runner@4.1.0)(@vitest/snapshot@4.1.0)(vitest@4.1.0(@types/node@25.3.5)(msw@2.12.12(@types/node@25.3.5)(typescript@5.9.3))(vite@7.3.5(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))':
+  '@cloudflare/vitest-pool-workers@0.18.5(@cloudflare/workers-types@4.20260608.1)(@vitest/runner@4.1.0)(@vitest/snapshot@4.1.0)(vitest@4.1.0(@types/node@25.3.5)(happy-dom@20.10.6)(msw@2.12.12(@types/node@25.3.5)(typescript@5.9.3))(vite@7.3.5(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))':
     dependencies:
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
       cjs-module-lexer: 1.2.3
       esbuild: 0.28.1
       miniflare: 4.20260710.0
-      vitest: 4.1.0(@types/node@25.3.5)(msw@2.12.12(@types/node@25.3.5)(typescript@5.9.3))(vite@7.3.5(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
-      wrangler: 4.111.0
+      vitest: 4.1.0(@types/node@25.3.5)(happy-dom@20.10.6)(msw@2.12.12(@types/node@25.3.5)(typescript@5.9.3))(vite@7.3.5(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+      wrangler: 4.111.0(@cloudflare/workers-types@4.20260608.1)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
@@ -3876,6 +3901,12 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.3.5
+
   '@ungap/structured-clone@1.3.0': {}
 
   '@upsetjs/venn.js@2.0.0':
@@ -3974,6 +4005,10 @@ snapshots:
   brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
+
+  buffer-image-size@0.6.4:
+    dependencies:
+      '@types/node': 25.3.5
 
   bundle-require@5.1.0(esbuild@0.28.1):
     dependencies:
@@ -4272,6 +4307,8 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.0
 
+  entities@7.0.1: {}
+
   error-stack-parser-es@1.0.5: {}
 
   es-module-lexer@2.0.0: {}
@@ -4399,6 +4436,19 @@ snapshots:
 
   hachure-fill@0.5.2: {}
 
+  happy-dom@20.10.6:
+    dependencies:
+      '@types/node': 25.3.5
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      buffer-image-size: 0.6.4
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   hast-util-to-html@9.0.5:
     dependencies:
       '@types/hast': 3.0.4
@@ -4422,7 +4472,7 @@ snapshots:
 
   hono@4.12.25: {}
 
-  html-validate@10.15.0(vitest@4.1.0(@types/node@25.3.5)(msw@2.12.12(@types/node@25.3.5)(typescript@5.9.3))(vite@7.3.5(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))):
+  html-validate@10.15.0(vitest@4.1.0(@types/node@25.3.5)(happy-dom@20.10.6)(msw@2.12.12(@types/node@25.3.5)(typescript@5.9.3))(vite@7.3.5(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))):
     dependencies:
       '@html-validate/stylish': 5.2.0
       '@sidvind/better-ajv-errors': 5.0.0(ajv@8.20.0)
@@ -4433,7 +4483,7 @@ snapshots:
       prompts: 2.4.2
       semver: 7.7.4
     optionalDependencies:
-      vitest: 4.1.0(@types/node@25.3.5)(msw@2.12.12(@types/node@25.3.5)(typescript@5.9.3))(vite@7.3.5(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+      vitest: 4.1.0(@types/node@25.3.5)(happy-dom@20.10.6)(msw@2.12.12(@types/node@25.3.5)(typescript@5.9.3))(vite@7.3.5(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
 
   html-void-elements@3.0.0: {}
 
@@ -5261,7 +5311,7 @@ snapshots:
       lightningcss: 1.31.1
       tsx: 4.21.0
 
-  vitest@4.1.0(@types/node@22.19.15)(msw@2.12.12(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)):
+  vitest@4.1.0(@types/node@22.19.15)(happy-dom@20.10.6)(msw@2.12.12(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.0
       '@vitest/mocker': 4.1.0(msw@2.12.12(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
@@ -5285,10 +5335,11 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.15
+      happy-dom: 20.10.6
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.0(@types/node@25.3.5)(msw@2.12.12(@types/node@25.3.5)(typescript@5.9.3))(vite@7.3.5(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)):
+  vitest@4.1.0(@types/node@25.3.5)(happy-dom@20.10.6)(msw@2.12.12(@types/node@25.3.5)(typescript@5.9.3))(vite@7.3.5(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.0
       '@vitest/mocker': 4.1.0(msw@2.12.12(@types/node@25.3.5)(typescript@5.9.3))(vite@7.3.5(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
@@ -5312,8 +5363,11 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.3.5
+      happy-dom: 20.10.6
     transitivePeerDependencies:
       - msw
+
+  whatwg-mimetype@3.0.0: {}
 
   which@2.0.2:
     dependencies:
@@ -5344,7 +5398,7 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260710.1
       '@cloudflare/workerd-windows-64': 1.20260710.1
 
-  wrangler@4.111.0:
+  wrangler@4.111.0(@cloudflare/workers-types@4.20260608.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260710.1)
@@ -5355,22 +5409,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       workerd: 1.20260710.1
     optionalDependencies:
-      fsevents: 2.3.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
-  wrangler@4.85.0:
-    dependencies:
-      '@cloudflare/kv-asset-handler': 0.4.2
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260424.1)
-      blake3-wasm: 2.1.5
-      esbuild: 0.28.1
-      miniflare: 4.20260424.0
-      path-to-regexp: 6.3.0
-      unenv: 2.0.0-rc.24
-      workerd: 1.20260424.1
-    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260608.1
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2872

---

## Summary

- Adds first-class stable `data-*` DOM hooks to the four component surfaces theme packs previously reached via fragile structural/aria selectors: `data-footer`, `data-doc-pager`, `data-doc-description` (both emitters, incl. the auto-index branch), and `data-theme-pack-switcher` / `data-switcher-card` / `data-switcher-launcher` (#2873)
- Retargets all 20 shipped packs onto the new hooks, behavior-preserving, with every changed pack's `meta.json` bumped `1.0.0 → 1.0.1` to drive the `?v=` stylesheet cache buster (#2876–#2879)
- Restores the two styling features previously dropped for lack of hooks: foundry's pager hover wash and broadsheet's classified-ad flyout double frame (#2880)
- Hardens the durable docs: ADR 6.5 hook list + TOC `aria-current` contract + custom-chrome caveat, ADR 6.6 h2–h4 gradient reality + matching validator message, and a new `packages/zudo-doc/docs/theme-pack-authoring.md` authoring reference with a skeleton verified against real component SSR output (#2874, #2875)

## Changes

**Hooks (`packages/zudo-doc/src`)**
- `footer/footer.tsx` → `data-footer`; `doc-pager/index.tsx` → `data-doc-pager`; `doc-content-header/index.tsx` + `doc-page-shell/index.tsx` → `data-doc-description`; `theme-pack-switcher/index.tsx` → `data-theme-pack-switcher` / `data-switcher-card` / `data-switcher-launcher`
- `theme-pack-dialog/index.tsx`: `LAUNCHER_SELECTOR` retargeted from the aria-label lookup to `[data-switcher-launcher]` (strictly more precise for focus restore)
- Unit tests for every hook, incl. an explicit auto-index description test, a real-DOM switcher interaction test (new `happy-dom` devDep, per-file environment pragma), and a focus-restore assertion

**Pack retargets (all 20 `theme-packs/*/pack.css` + `meta.json`)**
- Switcher card/launcher, pager, footer, and description selectors moved onto the hooks with specificity-preserving anchor chains; header-comment selector maps updated
- Locked description outcomes applied: deck/lede rules → `p[data-doc-description]` (beacon, broadsheet, futura-editorial, matcha, nocturne, observatory, onyx, sumi, washi); manuscript deliberately keeps its `:first-of-type` illuminated initial
- Intentional behavior fixes (documented): broadsheet/sumi description-less pages no longer mis-style the first body paragraph; manuscript/swissgrid's broadest pager selectors no longer leak onto NavCardGrid

**Restored styling**
- foundry: pager hover wash (`--zd-muted` @8% under the existing hover border cue), `nav[data-doc-pager]`-scoped
- broadsheet: square classified-ad double ink frame on `[data-switcher-card]` (1px ink + 3px paper gap + 1px outer rule), focus-visible preserved via box-shadow rings

**Docs / validator**
- ADR `theme-packs.md` Decision 6.5 (full hook table + TOC aria-current contract + `defineChromeBindings` caveat) and 6.6 (h2–h4 heading-rule gradients); `theme-packs-registry/validator.ts` message + header comment updated with matching test
- New `docs/theme-pack-authoring.md` (skeleton, hook table, `!important` carve-out, pack-versioning rule, custom-chrome caveat, workflow notes). The planned tokens-dump §6a patch was moot — `_temp-resource/2812-theme-prototypes/` was already deleted on main by #2856/#2871

## Test Plan

- `pnpm test` green (root 797; `@takazudo/zudo-doc` 1538 incl. the 21-pack validator suite); `pnpm check` green; full `pnpm build` green (381 pages)
- Comment-stripped selector sweep across all 20 packs: zero live fragile selectors (aria-label switcher forms, un-hooked pager/footer forms)
- Cache-buster: `dist/theme-packs/index.json` reports 1.0.1 for all 20 changed packs
- In-browser spot-check (8 packs × light/dark, computed-style assertions + screenshots): footer/pager/switcher-card/description per the locked tables, both restored effects rendering per spec — full evidence on #2881

Full check evidence: https://github.com/zudolab/zudo-doc/issues/2881