### PR TITLE
fix(theme-packs): onyx focus-visible outline gate

### DIFF
--- a/packages/zudo-doc/src/theme-packs/onyx/meta.json
+++ b/packages/zudo-doc/src/theme-packs/onyx/meta.json
@@ -4,7 +4,7 @@
   "name": "Onyx",
   "description": "Luxury noir — jet black, champagne serif headings, and a single gold hairline accent. Watch-brand restraint.",
   "mode": "dark",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "fonts": {
     "sans": "Jost",
     "mono": "IBM Plex Mono",

--- a/packages/zudo-doc/src/theme-packs/onyx/pack.css
+++ b/packages/zudo-doc/src/theme-packs/onyx/pack.css
@@ -452,10 +452,15 @@ html[data-theme-pack="onyx"] footer[data-footer] > div > div:last-child:not(:fir
    the `data-switcher-card` hook (#2873). */
 html[data-theme-pack="onyx"] div[data-switcher-card] {
   border: 1px solid color-mix(in oklch, var(--zd-accent) 55%, transparent);
-  outline: 1px solid color-mix(in oklch, var(--zd-accent) 22%, transparent);
-  outline-offset: 4px;
   border-radius: 0;
   box-shadow: 0 18px 44px -10px rgb(0 0 0 / 0.55);
+}
+/* decorative gold rule only while NOT keyboard-focused — an unconditional
+   outline would beat the layered focus-visible utility and hide the focus
+   ring (#2883) */
+html[data-theme-pack="onyx"] div[data-switcher-card]:not(:focus-visible) {
+  outline: 1px solid color-mix(in oklch, var(--zd-accent) 22%, transparent);
+  outline-offset: 4px;
 }
 html[data-theme-pack="onyx"] div[data-switcher-card] p[aria-live="polite"] {
   font-family: var(--font-display);
@@ -469,10 +474,14 @@ html[data-theme-pack="onyx"] div[data-switcher-card] p[aria-live="polite"] {
    role/aria-label hook doesn't match this <dialog>) */
 html[data-theme-pack="onyx"] dialog[aria-labelledby="zd-theme-pack-dialog-title"] {
   border: 1px solid color-mix(in oklch, var(--zd-accent) 55%, transparent);
-  outline: 1px solid color-mix(in oklch, var(--zd-accent) 22%, transparent);
-  outline-offset: 4px;
   border-radius: 0;
   box-shadow: 0 18px 44px -10px rgb(0 0 0 / 0.55);
+}
+/* same focus-visible gate as the flyout card (#2883) */
+html[data-theme-pack="onyx"]
+  dialog[aria-labelledby="zd-theme-pack-dialog-title"]:not(:focus-visible) {
+  outline: 1px solid color-mix(in oklch, var(--zd-accent) 22%, transparent);
+  outline-offset: 4px;
 }
 html[data-theme-pack="onyx"] dialog[aria-labelledby="zd-theme-pack-dialog-title"] button {
   border-radius: 0;


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2883

---

## Summary
- Gates onyx's decorative gold `outline` on the switcher flyout card and browse-all dialog behind `:not(:focus-visible)`, so the layered Tailwind `focus-visible:outline-accent` keyboard-focus ring can render again (the unlayered pack rule previously always won)
- Bumps onyx `meta.json` to `1.0.2` (CSS change → `?v=` cache buster)
- Beacon's pager `a:hover` outline (noted in the issue) assessed and left as-is: it is itself a 3px accent ring, so focus indication is never lost — matches the issue's own "probably fine" judgment

## Test Plan
- `pnpm --filter @takazudo/zudo-doc test` green (1538, incl. the pack validator suite)
- Codex review of the diff: clean

Raised by #2880's child agent as an unrelated finding; auto-fixed by the /x-wt-teams `-fix` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786842753&installation_id=130359969&pr_number=2884&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2884&signature=c39d92a4f5475d9976a317ff6debae99bdfee3939102ef90d4b811fd751b3a6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->