### PR TITLE
[Sweep Cleanups] Mermaid state-diagram fix + two nightly slow-test regressions

### DIFF
--- a/packages/create-zudo-doc/src/__tests__/chrome-bindings-build.slow.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/chrome-bindings-build.slow.test.ts
@@ -90,6 +90,15 @@ const componentSources: Record<PrimarySlot, string> = {
   )`,
 };
 
+// spawnSync captures raw stdout/stderr bytes. picocolors treats `CI=true`
+// (set by GitHub Actions, incl. the nightly slow-test run) as color support
+// even though the piped stream isn't a TTY, so the eject CLI's nested
+// pc.bold(...pc.green("✓")...) composition inserts an ANSI reset between "✓"
+// and " Ejected <component>" — breaking a plain substring check. Strip ANSI
+// once here so every assertion below tests human-visible text, not byte
+// adjacency (mirrors packages/zudo-doc/src/__tests__/eject.test.ts).
+const ANSI_ESCAPE = new RegExp(`${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`, "g");
+
 const TEMP_PREFIX = "create-zudo-doc-chrome-matrix-";
 const projectDirs = new Map<string, string>();
 let tempDir: string;
@@ -314,7 +323,7 @@ describe("generated chrome customization matrix", () => {
     const outputFor = (component: string): string => {
       const proof = ejectProofs.get(component)!;
       expect(proof.status).toBe(0);
-      return `${proof.stdout}\n${proof.stderr}`;
+      return `${proof.stdout}\n${proof.stderr}`.replace(ANSI_ESCAPE, "");
     };
     const headerOutput = outputFor("header");
     expect(headerOutput).toContain("WARNING: the ejected header copy is not wired");

--- a/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
+++ b/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
@@ -303,15 +303,29 @@ describe("A2 no-stub: injected routes render correct HTML (packageOwnedRoutes:tr
   //
   // To update: run `vitest run --update-snapshots`, inspect the diff, and
   // confirm the output delta is intentional before committing.
+  //
+  // 2026-07-18 re-baseline (zudolab/zudo-doc#2911): old-vs-new normalized-HTML
+  // diff confirmed every changed byte traces to already-merged, intentional
+  // output changes since the prior baseline (set at 27d95e578, compat-cleanup) —
+  //   - `<html data-theme-pack=default>` + the inlined FOUC-safe theme-pack
+  //     bootstrap `<script>` in `<head>` (theme-packs runtime switching engine,
+  //     #2822, base/theme-feature-core)
+  //   - `data-footer`, `data-doc-description`, `data-doc-pager` stable data-*
+  //     DOM hooks (#2873, base/theme-pack-hooks)
+  //   - `data-zd-mobile-sidebar` stable DOM hook on the mobile sidebar aside
+  //     (#2887, base/theme-nav-fonts chrome font seam + mobile hooks)
+  //   - the stateDiagram `;`→newline mermaid-init fix + its explanatory
+  //     comment (#2909, this epic's Wave-1 mermaid-semicolon-fix)
+  // No other bytes changed. See sub-issue #2911 for the full diff.
 
   it("parity: /404.html normalized-HTML sha256 is stable (stub-defaults path)", () => {
     const html = readBuiltHtml(fixtureDir, "404.html");
-    expect(sha256Html(html)).toMatchInlineSnapshot(`"94cb49dc62d8cf4aef6ea8a74ecce0f44f78868ed0b20edb157c0c26bc2bc3d2"`);
+    expect(sha256Html(html)).toMatchInlineSnapshot(`"b2328e098a65b1056ecd8b604dac7baaceed936b61be1caee2b03524119abdb6"`);
   });
 
   it("parity: /docs/getting-started/index.html normalized-HTML sha256 is stable (stub-defaults path)", () => {
     const html = readBuiltHtml(fixtureDir, "docs/getting-started/index.html");
-    expect(sha256Html(html)).toMatchInlineSnapshot(`"6bbdd7b2a66d3fe9bb735317461def9cfd1b7ff61f47c0e7cce543dafe153e25"`);
+    expect(sha256Html(html)).toMatchInlineSnapshot(`"e412483fcbf75cd0db3f71cacfb4b251d0bdb30337c6203a21af3e029ac3b04a"`);
   });
 });
 

--- a/packages/zudo-doc/src/code-syntax/__tests__/mermaid-init.test.tsx
+++ b/packages/zudo-doc/src/code-syntax/__tests__/mermaid-init.test.tsx
@@ -256,14 +256,20 @@ describe("MERMAID_INIT_SCRIPT", () => {
   });
 
   it("restores statement boundaries for minified state diagrams", () => {
+    // zudolab/zudo-doc#2909 — unlike flowchart/sequenceDiagram, mermaid
+    // does NOT treat `;` as a separator it strips from a stateDiagram
+    // state id: a trailing `;` glued onto "Draft" makes mermaid parse
+    // "Draft;" as a DISTINCT state, rendering both a spurious "Draft;"
+    // node and a floating ";" node. The repaired output must use
+    // newline-only separation for this branch, with no `;` token.
     const fn = extractNormalizeCollapsedMermaidSource(MERMAID_INIT_SCRIPT);
-    expect(
-      fn(
-        "stateDiagram-v2 [*] --> Draft Draft --> Review : Submit Review --> Published : Approve Review --> Draft : Request Changes Published --> Archived : Archive Archived --> [*]",
-      ),
-    ).toBe(
-      "stateDiagram-v2\n[*] --> Draft;\nDraft --> Review : Submit;\nReview --> Published : Approve;\nReview --> Draft : Request Changes;\nPublished --> Archived : Archive;\nArchived --> [*]",
+    const result = fn(
+      "stateDiagram-v2 [*] --> Draft Draft --> Review : Submit Review --> Published : Approve Review --> Draft : Request Changes Published --> Archived : Archive Archived --> [*]",
     );
+    expect(result).toBe(
+      "stateDiagram-v2\n[*] --> Draft\nDraft --> Review : Submit\nReview --> Published : Approve\nReview --> Draft : Request Changes\nPublished --> Archived : Archive\nArchived --> [*]",
+    );
+    expect(result).not.toContain(";");
   });
 
   it("restores statement boundaries for minified subgraph flowcharts", () => {

--- a/packages/zudo-doc/src/code-syntax/mermaid-init-script.ts
+++ b/packages/zudo-doc/src/code-syntax/mermaid-init-script.ts
@@ -276,9 +276,13 @@ export function buildMermaidInitScript(cdnUrl: string): string {
         .replace(/\\s+(Note\\s+(?:left|right|over)\\s+of\\s+)/gi, ";\\n$1")
         .replace(/\\s+(loop|alt|else|opt|par|and|rect|critical|break|end)\\b/gi, ";\\n$1");
     } else if (/^stateDiagram(?:-v2)?\\b/i.test(out)) {
+      // Newline only — unlike flowchart/sequenceDiagram, \`;\` is not a
+      // trailing separator mermaid strips from a stateDiagram state id;
+      // it parses "Draft;" as a state DISTINCT from "Draft", producing
+      // a spurious node (zudolab/zudo-doc#2909).
       out = out.replace(
         /([A-Za-z0-9_*\\]\\)\\}])\\s+((?:\\[\\*\\]|[A-Za-z0-9_][\\w-]*)\\s*--?>)/g,
-        "$1;\\n$2",
+        "$1\\n$2",
       );
     }
 


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2908
- parent PR
    - https://github.com/zudolab/zudo-doc/pull/2903

---

## Summary

Epic-PR for the **Sweep Cleanups** epic (#2908), part of super-epic #2902. Batches three independent, fully-diagnosed fixes. Targets the super-epic base `base/sweep-260718`; the super-PR (#2903) then merges the whole batch into `main`.

## Changes

- **#2909 — mermaid stateDiagram `;`-node fix.** `normalizeCollapsedMermaidSource`'s `stateDiagram(-v2)` branch re-expanded the HTML-minifier-collapsed one-line source with `"$1;\n$2"`, gluing a `;` onto state ids (`Draft;`), which mermaid parses as a distinct state — producing a spurious `Draft;` node and a floating `;` node. Changed that branch to newline-only separation (`"$1\n$2"`); flowchart/sequenceDiagram branches untouched (their `;` is valid). Updated the previously locked-in-broken unit fixture and added a `not.toContain(";")` guard. **Verified:** 44 unit tests pass; headless render of `/docs/components/mermaid-diagrams/` shows exactly 4 clean states (Draft, Review, Published, Archived) + start/end markers, no `;` node.

- **#2910 — create-zudo-doc eject-output slow-test.** Under `CI=true`, picocolors emits ANSI; the eject success line nests `pc.green` inside `pc.bold`, leaving a literal reset (`\x1b[39m`) between "✓" and " Ejected details", breaking a plain `toContain` substring check. Fixed at the test-capture level: strip ANSI once in the shared `outputFor()` helper (mirroring the existing `eject.test.ts` precedent). CLI output is correct as-is. **Verified:** passes with and without `CI=1`; no other slow-file test regressed.

- **#2911 — nightly route-injection parity snapshots.** The two normalized-HTML sha256 parity tests drifted due to intentional merged changes (theme-packs runtime engine, mobile chrome hooks, stable data-* hooks) plus this epic's Wave-1 mermaid init-script change. Produced an old-vs-new normalized-HTML diff (old ref `27d95e578` matched the stored snapshots byte-for-byte); every hunk maps to an intentional change. Re-baselined by hand-editing only the two snapshots (no `vitest -u`); documented the covered changes in a test comment. **Verified:** both parity tests pass; no other snapshot modified.

## Review

`/codex-review` on the full epic diff: no actionable regressions.