### PR TITLE
[HtmlPreview Embed] fullHeight, external resources, preflight opt-out, showResources

### DIFF
--- a/packages/create-zudo-doc/templates/features/tauri/files/src-tauri/tauri.conf.json
+++ b/packages/create-zudo-doc/templates/features/tauri/files/src-tauri/tauri.conf.json
@@ -10,7 +10,7 @@
   "app": {
     "windows": [],
     "security": {
-      "csp": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data:; font-src 'self' data: https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; script-src 'self' 'unsafe-inline' https://esm.sh; connect-src 'self' https://esm.sh https://cdn.jsdelivr.net"
+      "csp": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data:; font-src 'self' data: https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; script-src 'self' 'unsafe-inline' https://esm.sh https://cdn.jsdelivr.net; connect-src 'self' https://esm.sh https://cdn.jsdelivr.net"
     }
   },
   "bundle": {

--- a/packages/zudo-doc/src/html-preview-wrapper/__tests__/build-srcdoc.test.ts
+++ b/packages/zudo-doc/src/html-preview-wrapper/__tests__/build-srcdoc.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { buildSrcdoc } from "../html-preview.js";
+
+describe("buildSrcdoc — fullHeight", () => {
+  it("omits the fullHeight style when fullHeight is unset", () => {
+    const srcdoc = buildSrcdoc("<div>hi</div>");
+    expect(srcdoc).not.toContain("html,body{height:100%}");
+  });
+
+  it("omits the fullHeight style when fullHeight is false", () => {
+    const srcdoc = buildSrcdoc(
+      "<div>hi</div>",
+      undefined,
+      undefined,
+      undefined,
+      false,
+    );
+    expect(srcdoc).not.toContain("html,body{height:100%}");
+  });
+
+  it("injects the fullHeight style after preflight, before head/css", () => {
+    const srcdoc = buildSrcdoc(
+      "<div>hi</div>",
+      "body{color:red}",
+      "<link rel='stylesheet' href='x.css'>",
+      undefined,
+      true,
+    );
+
+    const preflightIdx = srcdoc.indexOf("*,\n::after");
+    const fullHeightIdx = srcdoc.indexOf(
+      "<style>html,body{height:100%}</style>",
+    );
+    const headIdx = srcdoc.indexOf("<link rel='stylesheet' href='x.css'>");
+    const cssIdx = srcdoc.indexOf("<style>body{color:red}</style>");
+
+    expect(preflightIdx).toBeGreaterThan(-1);
+    expect(fullHeightIdx).toBeGreaterThan(-1);
+    expect(headIdx).toBeGreaterThan(-1);
+    expect(cssIdx).toBeGreaterThan(-1);
+
+    // Injection order contract: preflight -> fullHeight style -> head -> css
+    expect(fullHeightIdx).toBeGreaterThan(preflightIdx);
+    expect(headIdx).toBeGreaterThan(fullHeightIdx);
+    expect(cssIdx).toBeGreaterThan(headIdx);
+  });
+});

--- a/packages/zudo-doc/src/html-preview-wrapper/__tests__/build-srcdoc.test.ts
+++ b/packages/zudo-doc/src/html-preview-wrapper/__tests__/build-srcdoc.test.ts
@@ -45,3 +45,112 @@ describe("buildSrcdoc — fullHeight", () => {
     expect(cssIdx).toBeGreaterThan(headIdx);
   });
 });
+
+describe("buildSrcdoc — externalStyles / externalScripts / preflight", () => {
+  it("emits externalStyles as <link> tags, in order, AFTER preflight/fullHeight and BEFORE head/css", () => {
+    const srcdoc = buildSrcdoc(
+      "<div>hi</div>",
+      "body{color:red}",
+      "<meta name='x' content='y'>",
+      undefined,
+      true,
+      ["https://example.com/a.css", "https://example.com/b.css"],
+    );
+
+    const preflightIdx = srcdoc.indexOf("*,\n::after");
+    const fullHeightIdx = srcdoc.indexOf(
+      "<style>html,body{height:100%}</style>",
+    );
+    const styleAIdx = srcdoc.indexOf(
+      '<link rel="stylesheet" href="https://example.com/a.css">',
+    );
+    const styleBIdx = srcdoc.indexOf(
+      '<link rel="stylesheet" href="https://example.com/b.css">',
+    );
+    const headIdx = srcdoc.indexOf("<meta name='x' content='y'>");
+    const cssIdx = srcdoc.indexOf("<style>body{color:red}</style>");
+
+    expect(preflightIdx).toBeGreaterThan(-1);
+    expect(fullHeightIdx).toBeGreaterThan(-1);
+    expect(styleAIdx).toBeGreaterThan(-1);
+    expect(styleBIdx).toBeGreaterThan(-1);
+    expect(headIdx).toBeGreaterThan(-1);
+    expect(cssIdx).toBeGreaterThan(-1);
+
+    // Full epic-wide order: preflight -> fullHeight -> externalStyles -> head -> css
+    expect(fullHeightIdx).toBeGreaterThan(preflightIdx);
+    expect(styleAIdx).toBeGreaterThan(fullHeightIdx);
+    expect(styleBIdx).toBeGreaterThan(styleAIdx);
+    expect(headIdx).toBeGreaterThan(styleBIdx);
+    expect(cssIdx).toBeGreaterThan(headIdx);
+  });
+
+  it("emits externalScripts as <script src> tags", () => {
+    const srcdoc = buildSrcdoc(
+      "<div>hi</div>",
+      undefined,
+      undefined,
+      undefined,
+      false,
+      undefined,
+      ["https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"],
+    );
+    expect(srcdoc).toContain(
+      '<script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>',
+    );
+  });
+
+  it("includes the preflight reset by default (preflight omitted)", () => {
+    const srcdoc = buildSrcdoc("<div>hi</div>");
+    expect(srcdoc).toContain("*,\n::after");
+  });
+
+  it("includes the preflight reset when preflight is explicitly true", () => {
+    const srcdoc = buildSrcdoc(
+      "<div>hi</div>",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true,
+    );
+    expect(srcdoc).toContain("*,\n::after");
+  });
+
+  it("omits the preflight reset entirely when preflight is false", () => {
+    const srcdoc = buildSrcdoc(
+      "<div>hi</div>",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      false,
+    );
+    expect(srcdoc).not.toContain("*,\n::after");
+    expect(srcdoc).not.toContain("<style>" + "\n*,\n::after");
+  });
+
+  it("preflight: false does not affect fullHeight/externalStyles/head/css emission", () => {
+    const srcdoc = buildSrcdoc(
+      "<div>hi</div>",
+      "body{color:red}",
+      "<meta name='x'>",
+      undefined,
+      true,
+      ["https://example.com/a.css"],
+      undefined,
+      false,
+    );
+    expect(srcdoc).not.toContain("*,\n::after");
+    expect(srcdoc).toContain("<style>html,body{height:100%}</style>");
+    expect(srcdoc).toContain(
+      '<link rel="stylesheet" href="https://example.com/a.css">',
+    );
+    expect(srcdoc).toContain("<meta name='x'>");
+    expect(srcdoc).toContain("<style>body{color:red}</style>");
+  });
+});

--- a/packages/zudo-doc/src/html-preview-wrapper/__tests__/code-panel-resources.test.tsx
+++ b/packages/zudo-doc/src/html-preview-wrapper/__tests__/code-panel-resources.test.tsx
@@ -1,0 +1,97 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+/**
+ * showResources code-panel placement (#2914).
+ *
+ * externalStyles/externalScripts are excluded from the visible "HTML" code
+ * panel by default and only surfaced — as literal <link>/<script src> lines
+ * at the TOP of the panel — when showResources is true. This is independent
+ * of the iframe's srcdoc attribute, which always carries the resources
+ * regardless of showResources (showResources only controls what appears in
+ * the human-visible code panel, not what actually loads in the preview) — so
+ * these tests scope their assertions to the code-panel segment of the
+ * render() output, not the whole string.
+ *
+ * SSR (no hydration) means HighlightedCode falls back to a plain
+ * <pre><code> block, so the dedented source text is present verbatim.
+ * preact-render-to-string escapes `<` to `&lt;` and `"` to `&quot;` in text
+ * content but leaves `>` literal — see the exact escaping asserted below.
+ */
+
+import { describe, expect, it } from "vitest";
+import { render } from "preact-render-to-string";
+import { HtmlPreview } from "../html-preview.js";
+
+// The code panel starts at the "HTML" block label and ends at the first
+// </pre> (the primary/always-present HTML panel is always emitted first).
+function extractHtmlCodePanel(rendered: string): string {
+  const labelIdx = rendered.indexOf(">HTML</span>");
+  expect(labelIdx).toBeGreaterThan(-1);
+  const closeIdx = rendered.indexOf("</pre>", labelIdx);
+  expect(closeIdx).toBeGreaterThan(-1);
+  return rendered.slice(labelIdx, closeIdx);
+}
+
+describe("HtmlPreview — showResources code-panel placement", () => {
+  it("excludes externalStyles/externalScripts from the HTML code panel by default", () => {
+    const rendered = render(
+      <HtmlPreview
+        html="<div>hi</div>"
+        defaultOpen
+        externalStyles={["https://example.com/a.css"]}
+        externalScripts={[
+          "https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4",
+        ]}
+      />,
+    );
+    const panel = extractHtmlCodePanel(rendered);
+
+    expect(panel).not.toContain("https://example.com/a.css");
+    expect(panel).not.toContain(
+      "https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4",
+    );
+    expect(panel).toContain("&lt;div>hi&lt;/div>");
+  });
+
+  it("renders literal <link>/<script src> lines at the TOP of the HTML code panel when showResources is true", () => {
+    const rendered = render(
+      <HtmlPreview
+        html="<div>hi</div>"
+        defaultOpen
+        showResources
+        externalStyles={["https://example.com/a.css"]}
+        externalScripts={[
+          "https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4",
+        ]}
+      />,
+    );
+    const panel = extractHtmlCodePanel(rendered);
+
+    const linkIdx = panel.indexOf(
+      '&lt;link rel=&quot;stylesheet&quot; href=&quot;https://example.com/a.css&quot;>',
+    );
+    const scriptIdx = panel.indexOf(
+      '&lt;script src=&quot;https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4&quot;>&lt;/script>',
+    );
+    const htmlBodyIdx = panel.indexOf("&lt;div>hi&lt;/div>");
+
+    expect(linkIdx).toBeGreaterThan(-1);
+    expect(scriptIdx).toBeGreaterThan(-1);
+    expect(htmlBodyIdx).toBeGreaterThan(-1);
+
+    // "TOP of the HTML code block" — resource lines precede the author html.
+    expect(linkIdx).toBeLessThan(htmlBodyIdx);
+    expect(scriptIdx).toBeLessThan(htmlBodyIdx);
+  });
+
+  it("adds no resource lines when showResources is true but no external resources are set", () => {
+    const rendered = render(
+      <HtmlPreview html="<div>hi</div>" defaultOpen showResources />,
+    );
+    const panel = extractHtmlCodePanel(rendered);
+
+    expect(panel).toContain("&lt;div>hi&lt;/div>");
+    expect(panel).not.toContain("rel=&quot;stylesheet&quot;");
+    expect(panel).not.toContain("&lt;script");
+  });
+});

--- a/packages/zudo-doc/src/html-preview-wrapper/__tests__/resolve-sandbox.test.ts
+++ b/packages/zudo-doc/src/html-preview-wrapper/__tests__/resolve-sandbox.test.ts
@@ -17,6 +17,23 @@ describe("containsScript", () => {
   it("is false when head has markup but no script tag", () => {
     expect(containsScript("<link rel='stylesheet'>", undefined)).toBe(false);
   });
+
+  it("is true when externalScripts alone is non-empty", () => {
+    expect(
+      containsScript(undefined, undefined, [
+        "https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4",
+      ]),
+    ).toBe(true);
+  });
+
+  it("is false when externalScripts is an empty array", () => {
+    expect(containsScript(undefined, undefined, [])).toBe(false);
+  });
+
+  it("is false when externalScripts is omitted (back-compat, two-arg call)", () => {
+    expect(containsScript(undefined, undefined)).toBe(false);
+    expect(containsScript("<link rel='stylesheet'>", undefined)).toBe(false);
+  });
 });
 
 describe("resolveSandbox — default (no explicit prop)", () => {
@@ -45,5 +62,47 @@ describe("resolveSandbox — explicit override", () => {
   it("honors the empty string (maximally restrictive) — not nullish, no fallback", () => {
     expect(resolveSandbox("", true)).toBe("");
     expect(resolveSandbox("", false)).toBe("");
+  });
+});
+
+describe("resolveSandbox — flips to script-allowing on externalScripts alone", () => {
+  it("mirrors HtmlPreview's hasScripts derivation: externalScripts with no head/js", () => {
+    const hasScripts = containsScript(undefined, undefined, [
+      "https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4",
+    ]);
+    expect(hasScripts).toBe(true);
+    expect(resolveSandbox(undefined, hasScripts)).toBe(
+      "allow-scripts allow-same-origin",
+    );
+  });
+});
+
+// HtmlPreview derives `syncDelay` as `containsScript(head, js, externalScripts)
+// ? 300 : 0` — the exact same hasScripts boolean that feeds resolveSandbox
+// (see html-preview.tsx). This is a distinct assertion on that derivation
+// (not just the sandbox flip above), pinned per #2914's acceptance criteria.
+function deriveSyncDelay(
+  head: string | undefined,
+  js: string | undefined,
+  externalScripts: string[] | undefined,
+): number {
+  return containsScript(head, js, externalScripts) ? 300 : 0;
+}
+
+describe("syncDelay auto-derivation — fires on externalScripts alone", () => {
+  it("is 0 when there are no scripts at all", () => {
+    expect(deriveSyncDelay(undefined, undefined, undefined)).toBe(0);
+  });
+
+  it("is 300 when only externalScripts is set (no head, no js)", () => {
+    expect(
+      deriveSyncDelay(undefined, undefined, [
+        "https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4",
+      ]),
+    ).toBe(300);
+  });
+
+  it("stays 300 when js is set (unaffected back-compat baseline)", () => {
+    expect(deriveSyncDelay(undefined, "console.log(1)", undefined)).toBe(300);
   });
 });

--- a/packages/zudo-doc/src/html-preview-wrapper/html-preview-wrapper.tsx
+++ b/packages/zudo-doc/src/html-preview-wrapper/html-preview-wrapper.tsx
@@ -75,6 +75,38 @@ export interface HtmlPreviewWrapperProps {
    * `height`. See `HtmlPreviewProps.sandbox` for details.
    */
   sandbox?: string;
+
+  /**
+   * External stylesheet URLs, forwarded to `<HtmlPreview>` as-is. Per-usage
+   * only (v1) — deliberately NOT part of `HtmlPreviewGlobalConfig`, so there
+   * is no site-wide equivalent to merge. Loaded client-side at view time
+   * (a network dependency at render), not build-bundled. See
+   * `HtmlPreviewProps.externalStyles` for details.
+   */
+  externalStyles?: string[];
+  /**
+   * External script URLs, forwarded to `<HtmlPreview>` as-is. Presence
+   * flips the sandbox/`syncDelay` derivation to script-allowing exactly
+   * like `js`. Per-usage only (v1) — deliberately NOT part of
+   * `HtmlPreviewGlobalConfig`. See `HtmlPreviewProps.externalScripts` for
+   * details.
+   */
+  externalScripts?: string[];
+  /**
+   * Forwarded to `<HtmlPreview>`. When false, skips the injected preflight
+   * reset — useful when a framework loaded via `externalStyles`/
+   * `externalScripts` ships its own reset.
+   *
+   * @default true
+   */
+  preflight?: boolean;
+  /**
+   * Forwarded to `<HtmlPreview>`. When true, surfaces `externalStyles`/
+   * `externalScripts` as literal lines at the top of the "HTML" code panel.
+   *
+   * @default false
+   */
+  showResources?: boolean;
 }
 
 /**
@@ -118,6 +150,10 @@ export function HtmlPreviewWrapperInner(
     defaultOpen,
     fullHeight,
     sandbox,
+    externalStyles,
+    externalScripts,
+    preflight,
+    showResources,
   } = props;
 
   const mergedHead =
@@ -141,6 +177,10 @@ export function HtmlPreviewWrapperInner(
       componentCss={css}
       componentHead={head}
       componentJs={js}
+      externalStyles={externalStyles}
+      externalScripts={externalScripts}
+      preflight={preflight}
+      showResources={showResources}
     />
   );
 }

--- a/packages/zudo-doc/src/html-preview-wrapper/html-preview-wrapper.tsx
+++ b/packages/zudo-doc/src/html-preview-wrapper/html-preview-wrapper.tsx
@@ -52,6 +52,15 @@ export interface HtmlPreviewWrapperProps {
   height?: number;
   /** When true, the code section is expanded by default. */
   defaultOpen?: boolean;
+  /**
+   * Forwarded to `<HtmlPreview>`. When true, makes the preview document's
+   * `html`/`body` stretch to 100% height. Interacts with auto-height — pair
+   * with an explicit `height` prop. See `HtmlPreviewProps.fullHeight` for
+   * details.
+   *
+   * @default false
+   */
+  fullHeight?: boolean;
 
   /**
    * iframe `sandbox` attribute value, forwarded to `<HtmlPreview>`. Omit to
@@ -107,6 +116,7 @@ export function HtmlPreviewWrapperInner(
     title,
     height,
     defaultOpen,
+    fullHeight,
     sandbox,
   } = props;
 
@@ -126,6 +136,7 @@ export function HtmlPreviewWrapperInner(
       title={title}
       height={height}
       defaultOpen={defaultOpen}
+      fullHeight={fullHeight}
       sandbox={sandbox}
       componentCss={css}
       componentHead={head}

--- a/packages/zudo-doc/src/html-preview-wrapper/html-preview.tsx
+++ b/packages/zudo-doc/src/html-preview-wrapper/html-preview.tsx
@@ -16,6 +16,23 @@ export interface HtmlPreviewProps {
   height?: number;
   defaultOpen?: boolean;
   /**
+   * When true, injects `<style>html,body{height:100%}</style>` into the
+   * preview document so the preview's content can stretch to fill the
+   * iframe (e.g. a flex/grid layout that relies on `height: 100%` reaching
+   * the viewport).
+   *
+   * ⚠️ **Interacts with auto-height — pair with an explicit
+   * {@link HtmlPreviewProps.height}.** Auto-height measures
+   * `iframe.contentDocument.body.scrollHeight` and resizes the iframe to
+   * fit; `fullHeight` makes the body's height derive FROM the iframe's own
+   * height instead, which creates a feedback loop when the iframe height is
+   * itself derived from the body. This component does not attempt to
+   * detect or break that loop — always set `height` alongside `fullHeight`.
+   *
+   * @default false
+   */
+  fullHeight?: boolean;
+  /**
    * iframe `sandbox` attribute value. When omitted, defaults to the value
    * computed from the preview content (`allow-scripts allow-same-origin`
    * when scripts are present, `allow-same-origin` otherwise — see
@@ -78,11 +95,18 @@ export function resolveSandbox(
   );
 }
 
-function buildSrcdoc(
+// Injection order contract (epic-wide): preflight -> fullHeight style ->
+// externalStyles links -> head -> author css / js. Keep the fullHeight
+// style immediately after preflight so later Wave-2 props (externalStyles,
+// etc.) can insert cleanly between it and `head` without reordering this.
+const fullHeightStyle = "<style>html,body{height:100%}</style>";
+
+export function buildSrcdoc(
   html: string,
   css?: string,
   head?: string,
   js?: string,
+  fullHeight?: boolean,
 ): string {
   return `<!doctype html>
 <html>
@@ -90,6 +114,7 @@ function buildSrcdoc(
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <style>${preflightCss}</style>
+${fullHeight ? fullHeightStyle : ""}
 ${head ?? ""}
 ${css ? `<style>${css}</style>` : ""}
 </head>
@@ -119,14 +144,15 @@ export function HtmlPreview({
   title,
   height,
   defaultOpen,
+  fullHeight,
   sandbox,
   componentCss,
   componentHead,
   componentJs,
 }: HtmlPreviewProps): VNode {
   const srcdoc = useMemo(
-    () => buildSrcdoc(html, css, head, js),
-    [html, css, head, js],
+    () => buildSrcdoc(html, css, head, js, fullHeight),
+    [html, css, head, js, fullHeight],
   );
   const hasScripts = containsScript(head, js);
   const syncDelay = hasScripts ? 300 : 0;

--- a/packages/zudo-doc/src/html-preview-wrapper/html-preview.tsx
+++ b/packages/zudo-doc/src/html-preview-wrapper/html-preview.tsx
@@ -59,11 +59,63 @@ export interface HtmlPreviewProps {
   componentHead?: string;
   /** Per-component js for code block display (before global merge) */
   componentJs?: string;
+  /**
+   * External stylesheet URLs, emitted as `<link rel="stylesheet" href="...">`
+   * tags in the srcdoc head — injected AFTER the preflight/fullHeight styles
+   * and BEFORE {@link HtmlPreviewProps.head}/{@link HtmlPreviewProps.css}, so
+   * author styles can still override them.
+   *
+   * Per-usage only (v1) — there is no site-wide `globalConfig` equivalent.
+   *
+   * ⚠️ Loaded **client-side at view time** (a network dependency at render),
+   * not build-bundled — the preview may show unstyled content until the
+   * stylesheet(s) finish loading.
+   *
+   * @default undefined
+   */
+  externalStyles?: string[];
+  /**
+   * External script URLs, emitted as `<script src="...">` tags in the
+   * srcdoc head. Presence flips the sandbox/`syncDelay` derivation to
+   * script-allowing exactly like an inline {@link HtmlPreviewProps.js} — see
+   * {@link containsScript} / {@link resolveSandbox}.
+   *
+   * Per-usage only (v1) — there is no site-wide `globalConfig` equivalent.
+   *
+   * ⚠️ Loaded **client-side at view time** (a network dependency at render),
+   * not build-bundled.
+   *
+   * @default undefined
+   */
+  externalScripts?: string[];
+  /**
+   * When false, skips the injected Tailwind-preflight `<style>` reset.
+   * Useful when a framework loaded via {@link HtmlPreviewProps.externalStyles}
+   * or {@link HtmlPreviewProps.externalScripts} ships its own reset and would
+   * otherwise be double-applied.
+   *
+   * @default true
+   */
+  preflight?: boolean;
+  /**
+   * When true, renders {@link HtmlPreviewProps.externalStyles} and
+   * {@link HtmlPreviewProps.externalScripts} as literal `<link>`/`<script
+   * src>` lines at the top of the "HTML" code panel. Excluded by default so
+   * CDN plumbing doesn't clutter the visible lesson code.
+   *
+   * @default false
+   */
+  showResources?: boolean;
 }
 
-export function containsScript(head?: string, js?: string): boolean {
+export function containsScript(
+  head?: string,
+  js?: string,
+  externalScripts?: string[],
+): boolean {
   if (js) return true;
   if (head && /<script/i.test(head)) return true;
+  if (externalScripts && externalScripts.length > 0) return true;
   return false;
 }
 
@@ -96,9 +148,9 @@ export function resolveSandbox(
 }
 
 // Injection order contract (epic-wide): preflight -> fullHeight style ->
-// externalStyles links -> head -> author css / js. Keep the fullHeight
-// style immediately after preflight so later Wave-2 props (externalStyles,
-// etc.) can insert cleanly between it and `head` without reordering this.
+// externalStyles links -> externalScripts tags -> head -> author css / js.
+// Keep the fullHeight style immediately after preflight so `externalStyles`
+// can insert cleanly between it and `head` without reordering this.
 const fullHeightStyle = "<style>html,body{height:100%}</style>";
 
 export function buildSrcdoc(
@@ -107,14 +159,26 @@ export function buildSrcdoc(
   head?: string,
   js?: string,
   fullHeight?: boolean,
+  externalStyles?: string[],
+  externalScripts?: string[],
+  preflight?: boolean,
 ): string {
+  const includePreflight = preflight ?? true;
+  const externalStylesHtml = (externalStyles ?? [])
+    .map((href) => `<link rel="stylesheet" href="${href}">`)
+    .join("\n");
+  const externalScriptsHtml = (externalScripts ?? [])
+    .map((src) => `<script src="${src}"></script>`)
+    .join("\n");
   return `<!doctype html>
 <html>
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<style>${preflightCss}</style>
+${includePreflight ? `<style>${preflightCss}</style>` : ""}
 ${fullHeight ? fullHeightStyle : ""}
+${externalStylesHtml}
+${externalScriptsHtml}
 ${head ?? ""}
 ${css ? `<style>${css}</style>` : ""}
 </head>
@@ -149,18 +213,45 @@ export function HtmlPreview({
   componentCss,
   componentHead,
   componentJs,
+  externalStyles,
+  externalScripts,
+  preflight,
+  showResources,
 }: HtmlPreviewProps): VNode {
   const srcdoc = useMemo(
-    () => buildSrcdoc(html, css, head, js, fullHeight),
-    [html, css, head, js, fullHeight],
+    () =>
+      buildSrcdoc(
+        html,
+        css,
+        head,
+        js,
+        fullHeight,
+        externalStyles,
+        externalScripts,
+        preflight,
+      ),
+    [html, css, head, js, fullHeight, externalStyles, externalScripts, preflight],
   );
-  const hasScripts = containsScript(head, js);
+  const hasScripts = containsScript(head, js, externalScripts);
   const syncDelay = hasScripts ? 300 : 0;
   const sandboxValue = resolveSandbox(sandbox, hasScripts);
 
-  const codeBlocks = useMemo(
-    () => [
-      { language: "html", title: "HTML", code: dedent(html) },
+  const codeBlocks = useMemo(() => {
+    const resourceLines = showResources
+      ? [
+          ...(externalStyles ?? []).map(
+            (href) => `<link rel="stylesheet" href="${href}">`,
+          ),
+          ...(externalScripts ?? []).map(
+            (src) => `<script src="${src}"></script>`,
+          ),
+        ]
+      : [];
+    const htmlCode = resourceLines.length
+      ? `${resourceLines.join("\n")}\n\n${dedent(html)}`
+      : dedent(html);
+    return [
+      { language: "html", title: "HTML", code: htmlCode },
       ...(componentCss
         ? [{ language: "css", title: "CSS", code: dedent(componentCss) }]
         : []),
@@ -176,9 +267,16 @@ export function HtmlPreview({
             },
           ]
         : []),
-    ],
-    [html, componentCss, componentHead, componentJs],
-  );
+    ];
+  }, [
+    html,
+    componentCss,
+    componentHead,
+    componentJs,
+    showResources,
+    externalStyles,
+    externalScripts,
+  ]);
 
   return (
     <PreviewBase

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -81,8 +81,12 @@ the two CDNs the content genuinely uses, `object-src 'none'`,
 
 - `script-src … https://esm.sh` — Mermaid is loaded at runtime via
   `import("https://esm.sh/mermaid@11…")` (`packages/zudo-doc/src/code-syntax/mermaid-init-script.ts`).
-- `style-src` / `font-src … https://cdn.jsdelivr.net` — KaTeX CSS + fonts are
-  pulled from jsDelivr when a page uses math (`packages/zudo-doc/src/head/doc-head.tsx`).
+- `script-src` / `style-src` / `font-src … https://cdn.jsdelivr.net` — KaTeX CSS
+  + fonts are pulled from jsDelivr when a page uses math
+  (`packages/zudo-doc/src/head/doc-head.tsx`); `script-src` also covers the
+  `HtmlPreview` `externalScripts`/`externalStyles` demo on the
+  `components/html-preview` doc page (e.g. the `@tailwindcss/browser` CDN
+  recipe), since a `srcdoc` iframe inherits its parent document's CSP.
 - `'unsafe-inline'` on `script-src`/`style-src` — the site relies on inline
   pre-paint scripts (sidebar/theme/page-loading) and inline `style=` attributes.
   Exfiltration is still blocked by `connect-src`/`img-src`/`default-src`.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -10,7 +10,7 @@
   "app": {
     "windows": [],
     "security": {
-      "csp": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data:; font-src 'self' data: https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; script-src 'self' 'unsafe-inline' https://esm.sh; connect-src 'self' https://esm.sh https://cdn.jsdelivr.net"
+      "csp": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data:; font-src 'self' data: https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; script-src 'self' 'unsafe-inline' https://esm.sh https://cdn.jsdelivr.net; connect-src 'self' https://esm.sh https://cdn.jsdelivr.net"
     }
   },
   "bundle": {

--- a/src/content/docs-ja/components/html-preview.mdx
+++ b/src/content/docs-ja/components/html-preview.mdx
@@ -142,6 +142,48 @@ sidebar_position: 9
   `}
 />
 
+## 高さ100%
+
+`fullHeight` プロップを使うと、プレビュードキュメントの `html`/`body` を iframe いっぱいに広げられます。`height: 100%` がビューポートまで届くレイアウト（利用可能なスペースを埋めるフレックスカラムなど）に便利です。
+
+:::warning[明示的な `height` と併用する]
+`fullHeight` は高さ自動調整の仕組みと干渉します — 高さ自動調整は iframe の body を計測して iframe の高さをそれに合わせますが、`fullHeight` は逆に body の高さを iframe 側から導出させます。両方を組み合わせると、安定した解決策のないフィードバックループが発生します。`fullHeight` を使うときは必ず明示的な `height` も指定してください。
+:::
+
+<HtmlPreview
+  title="高さ100%のフレックスカラム"
+  height={200}
+  fullHeight
+  html={`
+    <div class="fill">
+      <header>ヘッダー</header>
+      <main>メイン（残りのスペースを埋める）</main>
+      <footer>フッター</footer>
+    </div>
+  `}
+  css={`
+    .fill {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+      font-family: system-ui, sans-serif;
+      color: #fff;
+      text-align: center;
+    }
+    .fill header, .fill footer {
+      padding: 8px;
+      background: #334155;
+    }
+    .fill main {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #64748b;
+    }
+  `}
+/>
+
 ## 外部リソース
 
 CSS フレームワーク、Web フォント、スクリプトなどの外部リソースをプレビューに読み込めます。`zfb.config.ts` でグローバルに設定するか、コンポーネントのプロップで個別に指定します。
@@ -233,6 +275,7 @@ export default defineConfig(
 | `title` | string | `undefined` | プレビューヘッダーバーに表示するタイトル |
 | `height` | number | auto | iframe の固定高さ（ピクセル）。省略時はコンテンツに合わせて自動調整 |
 | `defaultOpen` | boolean | `false` | ソースコードパネルをデフォルトで展開表示する |
+| `fullHeight` | boolean | `false` | プレビュードキュメントの `html`/`body` を高さ100%まで広げる。高さ自動調整と干渉するため、必ず明示的な `height` と併用する |
 | `sandbox` | string | auto | iframe の `sandbox` 属性。省略時は計算済みのデフォルト（スクリプトありなら `allow-scripts allow-same-origin`、なしなら `allow-same-origin`）。信頼できないコンテンツにはより厳しい値を指定 — ただし `allow-same-origin` を外すと高さ自動調整が無効になるため `height` も併せて指定する |
 
 ## サポートされている言語

--- a/src/content/docs-ja/components/html-preview.mdx
+++ b/src/content/docs-ja/components/html-preview.mdx
@@ -244,9 +244,65 @@ export default defineConfig(
 />
 ````
 
+### 外部スタイルシートとスクリプト
+
+`head` と `js` は文字列ベースのプロップで、常に可視の「Head」/「JS」コードブロックとして表示され、プレビューには preflight リセット（すべてのプレビューに注入される Tailwind v4 の CSS リセット）が常に上乗せで適用され、独自リセットを持つフレームワークでもスキップする手段がありません。`externalStyles`・`externalScripts`・`preflight`・`showResources` は、CDN リソース（CSS フレームワーク、Web フォント、`@tailwindcss/browser`・Bootstrap・htmx のようなスクリプト）向けに、コードパネルを意識した構造化された代替手段を提供します。
+
+- **`externalStyles`** — スタイルシート URL の配列。`<link rel="stylesheet" href="...">` タグとして出力されます。author の `css` より**前に**読み込まれるため、`css` でフレームワークを上書きできます。
+- **`externalScripts`** — スクリプト URL の配列。`<script src="...">` タグとして出力されます。インラインの `js` プロップと同じサンドボックス／`syncDelay` の導出ロジックを通るため、プレビューは自動的に `sandbox="allow-scripts allow-same-origin"` と 300ms の高さ再同期ディレイを得ます。
+- **`preflight`** — `false` を指定すると、注入される preflight リセットを完全にスキップします。Tailwind のように独自のベーススタイルを持つフレームワーク向けです。
+- **`showResources`** — 両方の配列は（`head`/`js` と異なり）**デフォルトでは可視のコードパネルから除外されます**。読者に読み込まれているリソースを示したい場合は `true` を指定すると、「HTML」パネルの先頭に `<link>`/`<script src>` の生の行として表示されます。
+
+これら4つのプロップは**コンポーネント単位のみ**です — `head`/`css`/`js` と異なり、`zfb.config.ts` のグローバル `htmlPreview` 設定には含まれません。
+
+:::warning[外部リソースはクライアントサイドで読み込まれ、ビルド時には読み込まれない]
+`externalStyles`/`externalScripts` は、**プレビューの iframe が描画されるときに**ブラウザが行うネットワークリクエストであり、ビルド時にバンドルされるアセットではありません。リソースの読み込み中はプレビューが一瞬スタイル未適用の状態で表示されることがあり、そのURLでリソースが利用可能であり続けることに依存します。
+:::
+
+`@tailwindcss/browser` は独自のリセットを持つため `preflight={false}` を指定する、Tailwind CDN の1行デモ:
+
+<HtmlPreview
+  title="Tailwind CDN"
+  externalScripts={["https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"]}
+  preflight={false}
+  html={`
+    <div class="flex gap-4 p-6 bg-slate-100">
+      <div class="px-4 py-2 bg-blue-500 text-white rounded-lg font-sans">Tailwind</div>
+      <div class="px-4 py-2 bg-emerald-500 text-white rounded-lg font-sans">via CDN</div>
+    </div>
+  `}
+/>
+
+````mdx
+<HtmlPreview
+  title="Tailwind CDN"
+  externalScripts={["https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"]}
+  preflight={false}
+  html={`
+    <div class="flex gap-4 p-6 bg-slate-100">
+      <div class="px-4 py-2 bg-blue-500 text-white rounded-lg font-sans">Tailwind</div>
+      <div class="px-4 py-2 bg-emerald-500 text-white rounded-lg font-sans">via CDN</div>
+    </div>
+  `}
+/>
+````
+
+`showResources` を指定すると、CDN の URL が非表示ではなく「HTML」コードパネルの先頭に生の行として表示されます:
+
+<HtmlPreview
+  title="Tailwind CDN（リソースを表示）"
+  showResources
+  externalScripts={["https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"]}
+  preflight={false}
+  defaultOpen
+  html={`
+    <div class="px-4 py-2 bg-violet-500 text-white rounded-lg font-sans w-fit">コードを開くとCDNの行が見えます</div>
+  `}
+/>
+
 ## セキュリティと `sandbox` プロップ
 
-プレビューは分離された `<iframe srcdoc>` 内に描画されます。その `sandbox` 属性は、プレビューにスクリプトが含まれる場合（`js` プロップまたは `head` 内の `<script>`）は `allow-scripts allow-same-origin`、含まれない場合は `allow-same-origin` を**デフォルト**とします。
+プレビューは分離された `<iframe srcdoc>` 内に描画されます。その `sandbox` 属性は、プレビューにスクリプトが含まれる場合（`js` プロップ、`head` 内の `<script>`、または空でない `externalScripts`）は `allow-scripts allow-same-origin`、含まれない場合は `allow-same-origin` を**デフォルト**とします。
 
 :::danger[信頼の前提]
 `allow-scripts` と `allow-same-origin` を組み合わせると、**iframe のサンドボックスは実質的に無効化されます** — プレビュー内のスクリプトが親ページのオリジンを共有し、親ドキュメントにアクセスできます。zudo-doc がこのデフォルトを採用しているのは、プレビューの内容が**作成者が信頼できる MDX** であるためで、また `allow-same-origin` が高さの自動計測を可能にしているためです。
@@ -277,6 +333,10 @@ export default defineConfig(
 | `defaultOpen` | boolean | `false` | ソースコードパネルをデフォルトで展開表示する |
 | `fullHeight` | boolean | `false` | プレビュードキュメントの `html`/`body` を高さ100%まで広げる。高さ自動調整と干渉するため、必ず明示的な `height` と併用する |
 | `sandbox` | string | auto | iframe の `sandbox` 属性。省略時は計算済みのデフォルト（スクリプトありなら `allow-scripts allow-same-origin`、なしなら `allow-same-origin`）。信頼できないコンテンツにはより厳しい値を指定 — ただし `allow-same-origin` を外すと高さ自動調整が無効になるため `height` も併せて指定する |
+| `externalStyles` | string[] | `undefined` | 外部スタイルシート URL。`head`/`css` より前に `<link rel="stylesheet">` として挿入される。コンポーネント単位のみ — ビルドバンドルされず、表示時にクライアントサイドで読み込まれる |
+| `externalScripts` | string[] | `undefined` | 外部スクリプト URL。`<script src>` として挿入される。`js` と同様にサンドボックス／`syncDelay` の導出を切り替える。コンポーネント単位のみ — ビルドバンドルされず、表示時にクライアントサイドで読み込まれる |
+| `preflight` | boolean | `true` | `false` を指定すると、注入される preflight リセットをスキップする — `externalStyles`/`externalScripts` で読み込む独自リセットを持つフレームワーク向け |
+| `showResources` | boolean | `false` | `externalStyles`/`externalScripts` を「HTML」コードパネルの先頭に生の行として表示する。デフォルトではパネルから除外される |
 
 ## サポートされている言語
 
@@ -295,3 +355,5 @@ export default defineConfig(
 - `htmlPreview` 設定フィールドのグローバルリソースは、コンポーネント単位のプロップの前に挿入されます。
 - `html`、`css`、`js` プロップはインデント付きのテンプレートリテラルに対応しています。先頭の空白はソースコード表示時に自動的に除去されます。
 - クライアントサイドのハイドレーションはコンポーネントラッパーにより自動的に処理されるため、MDX 内で `client:load` ディレクティブを付ける必要はありません。
+- `externalStyles`/`externalScripts` は表示時にクライアントサイドで読み込まれます — プレビュー iframe が描画されるときにブラウザが行うネットワークリクエストであり、ビルド時にバンドルされるアセットではありません。上記の[外部スタイルシートとスクリプト](#外部リソース-外部スタイルシートとスクリプト)を参照。
+- srcdoc への挿入順序: preflight リセット（`preflight={false}` でない限り）→ `fullHeight` スタイル → `externalStyles` → `head` → `css`。

--- a/src/content/docs/components/html-preview.mdx
+++ b/src/content/docs/components/html-preview.mdx
@@ -142,6 +142,48 @@ Use the `height` prop to set a fixed iframe height instead of auto-sizing.
   `}
 />
 
+## Full Height
+
+Use the `fullHeight` prop to make the preview document's `html`/`body` stretch to fill the iframe — useful for layouts that rely on `height: 100%` reaching the viewport (e.g. a flex column that fills the available space).
+
+:::warning[Pair with an explicit `height`]
+`fullHeight` interacts with the auto-height mechanism: auto-height measures the iframe body and resizes the iframe to fit, but `fullHeight` makes the body's height derive *from* the iframe instead — combining the two creates a feedback loop with no stable resolution. Always set an explicit `height` alongside `fullHeight`.
+:::
+
+<HtmlPreview
+  title="Full Height Flex Column"
+  height={200}
+  fullHeight
+  html={`
+    <div class="fill">
+      <header>Header</header>
+      <main>Main (fills remaining space)</main>
+      <footer>Footer</footer>
+    </div>
+  `}
+  css={`
+    .fill {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+      font-family: system-ui, sans-serif;
+      color: #fff;
+      text-align: center;
+    }
+    .fill header, .fill footer {
+      padding: 8px;
+      background: #334155;
+    }
+    .fill main {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #64748b;
+    }
+  `}
+/>
+
 ## External Resources
 
 You can inject external resources (CSS frameworks, webfonts, scripts) into previews. Configure globally via `zfb.config.ts` or per-component via props.
@@ -233,6 +275,7 @@ Removing `allow-same-origin` gives the iframe an opaque origin, which blocks the
 | `title` | string | `undefined` | Title displayed in the preview header bar |
 | `height` | number | auto | Fixed iframe height in pixels. When omitted, height auto-adjusts to content |
 | `defaultOpen` | boolean | `false` | Show the source code panel expanded by default |
+| `fullHeight` | boolean | `false` | Makes the preview document's `html`/`body` stretch to 100% height. Interacts with auto-height — always pair with an explicit `height` |
 | `sandbox` | string | auto | iframe `sandbox` attribute. Omit for the computed default (`allow-scripts allow-same-origin` with scripts, `allow-same-origin` without). Pass a stricter value for untrusted content — but disables auto-height when `allow-same-origin` is dropped, so set `height` too |
 
 ## Supported Languages

--- a/src/content/docs/components/html-preview.mdx
+++ b/src/content/docs/components/html-preview.mdx
@@ -244,9 +244,65 @@ Use `head` and `js` props to add resources to individual previews. These are mer
 />
 ````
 
+### External Stylesheets & Scripts
+
+`head` and `js` are stringly-typed and always render into a visible "Head"/"JS" code block, and the preflight reset (Tailwind v4 CSS reset injected into every preview) is always applied on top — no way to skip it for a framework that ships its own. `externalStyles`, `externalScripts`, `preflight`, and `showResources` give CDN resources (a CSS framework, webfont, or script like `@tailwindcss/browser`, Bootstrap, or htmx) a structured, code-panel-aware alternative:
+
+- **`externalStyles`** — array of stylesheet URLs, emitted as `<link rel="stylesheet" href="...">` tags. Loaded **before** the author `css`, so `css` can still override the framework.
+- **`externalScripts`** — array of script URLs, emitted as `<script src="...">` tags. Flows through the same sandbox/`syncDelay` derivation as an inline `js` prop — the preview automatically gets `sandbox="allow-scripts allow-same-origin"` and the 300ms height re-sync delay.
+- **`preflight`** — set to `false` to skip the injected preflight reset entirely, for a framework (like Tailwind) that ships its own base styles.
+- **`showResources`** — both arrays are **excluded from the visible code panel by default** (unlike `head`/`js`); set to `true` to surface them as literal `<link>`/`<script src>` lines at the top of the "HTML" panel when it's pedagogically useful to show the reader what's loaded.
+
+These four props are **per-usage only** — unlike `head`/`css`/`js`, they are not part of the global `htmlPreview` configuration in `zfb.config.ts`.
+
+:::warning[External resources load client-side, not at build time]
+`externalStyles`/`externalScripts` are network requests the browser makes **when the preview iframe renders**, not assets bundled at build time. The preview may briefly show unstyled/unstyled content while the resource loads, and it depends on the resource staying available at that URL.
+:::
+
+A one-line Tailwind CDN demo, using `preflight={false}` since `@tailwindcss/browser` ships its own reset:
+
+<HtmlPreview
+  title="Tailwind CDN"
+  externalScripts={["https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"]}
+  preflight={false}
+  html={`
+    <div class="flex gap-4 p-6 bg-slate-100">
+      <div class="px-4 py-2 bg-blue-500 text-white rounded-lg font-sans">Tailwind</div>
+      <div class="px-4 py-2 bg-emerald-500 text-white rounded-lg font-sans">via CDN</div>
+    </div>
+  `}
+/>
+
+````mdx
+<HtmlPreview
+  title="Tailwind CDN"
+  externalScripts={["https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"]}
+  preflight={false}
+  html={`
+    <div class="flex gap-4 p-6 bg-slate-100">
+      <div class="px-4 py-2 bg-blue-500 text-white rounded-lg font-sans">Tailwind</div>
+      <div class="px-4 py-2 bg-emerald-500 text-white rounded-lg font-sans">via CDN</div>
+    </div>
+  `}
+/>
+````
+
+With `showResources`, the CDN URL is shown as a literal line at the top of the "HTML" code panel instead of being hidden:
+
+<HtmlPreview
+  title="Tailwind CDN (resources visible)"
+  showResources
+  externalScripts={["https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"]}
+  preflight={false}
+  defaultOpen
+  html={`
+    <div class="px-4 py-2 bg-violet-500 text-white rounded-lg font-sans w-fit">Show code to see the CDN line</div>
+  `}
+/>
+
 ## Security & the `sandbox` prop
 
-Previews render inside an isolated `<iframe srcdoc>`. Its `sandbox` attribute **defaults** to `allow-scripts allow-same-origin` when the preview contains scripts (a `js` prop or a `<script>` in `head`), and `allow-same-origin` otherwise.
+Previews render inside an isolated `<iframe srcdoc>`. Its `sandbox` attribute **defaults** to `allow-scripts allow-same-origin` when the preview contains scripts (a `js` prop, a `<script>` in `head`, or a non-empty `externalScripts`), and `allow-same-origin` otherwise.
 
 :::danger[Trust assumption]
 `allow-scripts` + `allow-same-origin` together **void the iframe sandbox** — scripts inside the preview share the parent page's origin and can reach the parent document. zudo-doc keeps this default because preview content is **author-trusted MDX**, and `allow-same-origin` is what powers the auto-height measurement.
@@ -277,6 +333,10 @@ Removing `allow-same-origin` gives the iframe an opaque origin, which blocks the
 | `defaultOpen` | boolean | `false` | Show the source code panel expanded by default |
 | `fullHeight` | boolean | `false` | Makes the preview document's `html`/`body` stretch to 100% height. Interacts with auto-height — always pair with an explicit `height` |
 | `sandbox` | string | auto | iframe `sandbox` attribute. Omit for the computed default (`allow-scripts allow-same-origin` with scripts, `allow-same-origin` without). Pass a stricter value for untrusted content — but disables auto-height when `allow-same-origin` is dropped, so set `height` too |
+| `externalStyles` | string[] | `undefined` | External stylesheet URLs, injected as `<link rel="stylesheet">` before `head`/`css`. Per-usage only — loads client-side at view time, not build-bundled |
+| `externalScripts` | string[] | `undefined` | External script URLs, injected as `<script src>`. Flips the sandbox/`syncDelay` derivation the same as `js`. Per-usage only — loads client-side at view time, not build-bundled |
+| `preflight` | boolean | `true` | Set to `false` to skip the injected preflight reset — for a framework (loaded via `externalStyles`/`externalScripts`) that ships its own |
+| `showResources` | boolean | `false` | Surfaces `externalStyles`/`externalScripts` as literal lines at the top of the "HTML" code panel. Excluded from the panel by default |
 
 ## Supported Languages
 
@@ -295,3 +355,5 @@ Unsupported languages fall back to plain text (no highlighting). This is a small
 - Global resources from the `htmlPreview` config field are injected before per-component props.
 - The `html`, `css`, and `js` props support template literals with indentation. Leading whitespace is automatically stripped (dedented) in the source code display.
 - Client-side hydration is handled automatically by the component wrapper — no `client:load` directive needed in MDX.
+- `externalStyles`/`externalScripts` load client-side at view time — they are network requests the browser makes when the preview iframe renders, not assets bundled at build time. See [External Stylesheets & Scripts](#external-resources-external-stylesheets-scripts) above.
+- Injection order in the srcdoc: preflight reset (unless `preflight={false}`) → `fullHeight` style → `externalStyles` → `head` → `css`.


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2912
- parent PR
    - https://github.com/zudolab/zudo-doc/pull/2903

---

## Summary

Epic-PR for the **HtmlPreview Embed** epic (#2912), part of super-epic #2902. Adds per-usage embed props to `HtmlPreview` (v1: per-usage only — no `HtmlPreviewGlobalConfig` additions). Targets super base `base/sweep-260718`; super-PR (#2903) merges the batch into `main`.

## Changes

- **#2913 — `fullHeight` opt-in prop.** Injects `<style>html,body{height:100%}</style>` immediately after the preflight style and before author CSS. `buildSrcdoc` exported for unit testing. EN+JA docs document the fullHeight × auto-height feedback-loop interaction and require pairing with an explicit `height` (the demo does).
- **#2914 — external resources + preflight opt-out + showResources.** `externalStyles` (→ `<link>` after preflight/fullHeight, before author CSS), `externalScripts` (→ `<script src>`; flips sandbox derivation and the 300ms `syncDelay` auto-derive like inline `js`, via an appended `containsScript` param — `(head, js)` order frozen for back-compat), `preflight` (default true; false skips the reset), `showResources` (default false; true renders literal `<link>`/`<script src>` lines at the top of the HTML code panel). `head` back-compat preserved. EN+JA docs add the four props, the client-side-load/network-dependency caveat, and the Tailwind-CDN demo. The Tauri offline reader's CSP `script-src` gains `cdn.jsdelivr.net` (a `srcdoc` iframe inherits the parent CSP, so the CDN demo needs it there).
- **#2915 — confirm pass (PASS).** Browser verification on EN+JA `/docs/components/html-preview/`: fullHeight stable at 200px (no feedback loop), Tailwind-CDN renders (real `oklch` blue-500 computed), `preflight:false` omits the reset, `showResources` show/hide correct, no regressions, 0 console errors.

## Injection order contract
preflight → fullHeight style → externalStyles links → `head` → author css / js.

## Review
`/codex-review` on the full epic diff: no actionable regressions.