### PR TITLE
[Nested Scaffold] Support scaffolding into a subdirectory of an existing repo

### DIFF
--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -825,10 +825,18 @@ describe("scaffold — package-injected routes are never emitted as project file
 });
 
 describe("scaffold — .gitignore base blocks", () => {
-  it("always ignores node_modules, dist, .zfb, .env*, and .zudo-doc/ build artifacts", async () => {
+  it("always ignores node_modules, dist, .zfb, .zfb-build/, .env*, and .zudo-doc/ build artifacts", async () => {
     await scaffold(baseChoices);
     const gitignore = await fs.readFile(projectPath("test-doc", ".gitignore"), "utf-8");
-    for (const line of ["node_modules", "dist", ".zfb", ".env", ".wrangler/", ".zudo-doc/"]) {
+    for (const line of [
+      "node_modules",
+      "dist",
+      ".zfb",
+      ".zfb-build/",
+      ".env",
+      ".wrangler/",
+      ".zudo-doc/",
+    ]) {
       expect(gitignore).toContain(line);
     }
   });

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -393,6 +393,7 @@ export async function scaffold(choices: UserChoices): Promise<void> {
     "node_modules",
     "dist",
     ".zfb",
+    ".zfb-build/",
     "",
     "# macOS",
     ".DS_Store",

--- a/packages/create-zudo-doc/templates/base/scripts/setup-doc-skill.sh
+++ b/packages/create-zudo-doc/templates/base/scripts/setup-doc-skill.sh
@@ -121,9 +121,16 @@ done
 # actually exist on the running project's package.json — a fresh
 # create-zudo-doc scaffold has no format script at all, while this repo's own
 # showcase exposes `format` (there is no `format:md` script anywhere, #2918).
+# `format:md` is checked too in case a downstream project defines its own
+# script under that literal name.
 FORMAT_SCRIPT="$(node -e "
 const scripts = (require('$ROOT_DIR/package.json').scripts) || {};
-console.log(scripts.format ? 'format' : (scripts['format:mdx'] ? 'format:mdx' : ''));
+console.log(
+  scripts.format ? 'format'
+  : scripts['format:mdx'] ? 'format:mdx'
+  : scripts['format:md'] ? 'format:md'
+  : ''
+);
 ")"
 if [ -n "$FORMAT_SCRIPT" ]; then
   FORMAT_STEP="Run \`pnpm $FORMAT_SCRIPT\` to format the new/changed MDX files."

--- a/packages/create-zudo-doc/templates/base/scripts/setup-doc-skill.sh
+++ b/packages/create-zudo-doc/templates/base/scripts/setup-doc-skill.sh
@@ -74,6 +74,16 @@ fi
 # Use the main worktree path so symlinks survive worktree removal
 REPO_ROOT="$(git -C "$ROOT_DIR" worktree list | head -1 | awk '{print $1}')"
 
+# Path from the repository root to the project directory: "" at the repo
+# root, "doc/" (trailing slash) when the project lives in a subdirectory
+# (nested layout, #2918). `rev-parse --show-prefix` is relative to the
+# CURRENT worktree's top level, so combining it with REPO_ROOT (the MAIN
+# worktree root, above) reconstructs the equivalent path there even when
+# running from inside a different worktree.
+PROJECT_PREFIX="$(git -C "$ROOT_DIR" rev-parse --show-prefix)"
+REPO_DOCS_DIR="$REPO_ROOT/${PROJECT_PREFIX}src/content/docs"
+REPO_DOCS_JA_DIR="$REPO_ROOT/${PROJECT_PREFIX}src/content/docs-ja"
+
 DOCS_DIR="$ROOT_DIR/src/content/docs"
 
 # Validate docs directory exists
@@ -106,6 +116,26 @@ for dir in "$DOCS_DIR"/*/; do
   DOC_TREE="${DOC_TREE}- ${dirname}/
 "
 done
+
+# The SKILL.md "Format"/"Verify" steps must only reference commands that
+# actually exist on the running project's package.json — a fresh
+# create-zudo-doc scaffold has no format script at all, while this repo's own
+# showcase exposes `format` (there is no `format:md` script anywhere, #2918).
+FORMAT_SCRIPT="$(node -e "
+const scripts = (require('$ROOT_DIR/package.json').scripts) || {};
+console.log(scripts.format ? 'format' : (scripts['format:mdx'] ? 'format:mdx' : ''));
+")"
+if [ -n "$FORMAT_SCRIPT" ]; then
+  FORMAT_STEP="Run \`pnpm $FORMAT_SCRIPT\` to format the new/changed MDX files."
+else
+  FORMAT_STEP="No format script is configured for this project; formatting is optional."
+fi
+
+# Name the project directory explicitly so the instruction resolves correctly
+# even when the project is nested inside a larger git repo (running `pnpm
+# build` from the outer repo root would otherwise invoke the wrong
+# package.json, #2918).
+VERIFY_STEP="Run \`pnpm build\` from \`$ROOT_DIR\` to confirm the site builds correctly."
 
 resolve_targets() {
   case "$TARGET_MODE" in
@@ -145,12 +175,12 @@ generate_skill() {
 
   mkdir -p "$skill_dir"
 
-  ensure_symlink "$skill_dir/docs" "$REPO_ROOT/src/content/docs"
-  echo "  [$target] Created docs symlink -> $REPO_ROOT/src/content/docs"
+  ensure_symlink "$skill_dir/docs" "$REPO_DOCS_DIR"
+  echo "  [$target] Created docs symlink -> $REPO_DOCS_DIR"
 
   if [ "$HAS_JA" = "true" ]; then
-    ensure_symlink "$skill_dir/docs-ja" "$REPO_ROOT/src/content/docs-ja"
-    echo "  [$target] Created docs-ja symlink -> $REPO_ROOT/src/content/docs-ja"
+    ensure_symlink "$skill_dir/docs-ja" "$REPO_DOCS_JA_DIR"
+    echo "  [$target] Created docs-ja symlink -> $REPO_DOCS_JA_DIR"
   fi
 
   cat > "$skill_dir/SKILL.md" << SKILLEOF
@@ -167,7 +197,7 @@ argument-hint: "[-u|--update] [topic keyword, e.g., 'configuration', 'sidebar', 
 # $PROJECT_NAME Documentation Reference
 
 Look up documentation from the $PROJECT_NAME project for $assistant_label.
-Documentation base path: \`src/content/docs\` (relative to repo root)
+Documentation base path: \`src/content/docs\` (relative to the project root: \`$ROOT_DIR\`)
 
 ## Mode Detection
 
@@ -197,7 +227,7 @@ The user has new information and wants to add or update documentation in this re
    the topic. Read them to understand what is already covered.
 3. **Decide create vs update**: If an existing article covers the topic, update
    it. Otherwise, create a new \`.mdx\` file in the appropriate subdirectory.
-4. **Write the content**: Follow the doc-authoring rules in the root CLAUDE.md:
+4. **Write the content**: Follow the doc-authoring rules in this project's CLAUDE.md (\`$ROOT_DIR/CLAUDE.md\`):
    - Required frontmatter: \`title\` (string). Always set \`sidebar_position\`.
      Optional: \`description\`, \`sidebar_label\`, \`tags\`, etc.
    - Do NOT use \`# h1\` in content — the frontmatter \`title\` renders as h1.
@@ -210,8 +240,8 @@ The user has new information and wants to add or update documentation in this re
    \`docs-ja/\` mirroring the English directory structure. Keep code blocks,
    Mermaid diagrams, and \`<HtmlPreview>\` blocks identical — only translate
    surrounding prose. Exception: pages with \`generated: true\` skip translation.
-6. **Format**: Run \`pnpm format:md\` to format the new/changed MDX files.
-7. **Verify**: Run \`pnpm build\` to confirm the site builds correctly.
+6. **Format**: ${FORMAT_STEP}
+7. **Verify**: ${VERIFY_STEP}
 
 ## Documentation Structure
 

--- a/scripts/__tests__/setup-doc-skill.test.ts
+++ b/scripts/__tests__/setup-doc-skill.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { execSync } from "node:child_process";
-import { mkdtempSync, readFileSync, existsSync, rmSync, realpathSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  cpSync,
+  readFileSync,
+  existsSync,
+  rmSync,
+  realpathSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -205,5 +214,90 @@ describe("setup-doc-skill.sh", () => {
     expect(
       existsSync(join(fakeHome, ".claude", "skills", TEST_SKILL_NAME)),
     ).toBe(false);
+  });
+
+  describe("nested-subdir project (#2918)", () => {
+    // Builds a throwaway git repo where the "project" lives at <repo>/doc/
+    // instead of at the repo root, then runs the real script against it.
+    // This reproduces the shape a project has when it's a subdirectory of a
+    // larger monorepo checkout.
+    let fixtureRoot: string;
+    let fixtureHome: string;
+    let projectDir: string;
+
+    beforeEach(() => {
+      fixtureRoot = mkdtempSync(join(tmpdir(), "zudo-doc-nested-fixture-"));
+      fixtureHome = mkdtempSync(join(tmpdir(), "zudo-doc-nested-home-"));
+      projectDir = join(fixtureRoot, "doc");
+
+      execSync("git init -q", { cwd: fixtureRoot });
+
+      mkdirSync(join(projectDir, "scripts"), { recursive: true });
+      mkdirSync(
+        join(projectDir, "src", "content", "docs", "getting-started"),
+        { recursive: true },
+      );
+      writeFileSync(
+        join(projectDir, "src", "content", "docs", "getting-started", "index.mdx"),
+        "---\ntitle: Test\n---\n",
+      );
+      cpSync(SCRIPT_PATH, join(projectDir, "scripts", "setup-doc-skill.sh"));
+      writeFileSync(
+        join(projectDir, "package.json"),
+        JSON.stringify({ name: "nested-project", scripts: {} }),
+      );
+    });
+
+    afterEach(() => {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+      rmSync(fixtureHome, { recursive: true, force: true });
+    });
+
+    function runFixtureScript(): string {
+      return execSync(
+        `bash "${join(projectDir, "scripts", "setup-doc-skill.sh")}" "${TEST_SKILL_NAME}"`,
+        {
+          cwd: projectDir,
+          encoding: "utf-8",
+          timeout: 30_000,
+          env: { ...process.env, HOME: fixtureHome },
+        },
+      );
+    }
+
+    it("resolves the docs symlink to an existing dir under <repo>/doc/", () => {
+      runFixtureScript();
+
+      const docsLink = join(projectDir, ".claude", "skills", TEST_SKILL_NAME, "docs");
+      expect(existsSync(docsLink)).toBe(true);
+
+      const resolved = realpathSync(docsLink);
+      expect(resolved).toBe(realpathSync(join(projectDir, "src", "content", "docs")));
+    });
+
+    it("generates a SKILL.md with no absent-script commands and nested-correct paths", () => {
+      runFixtureScript();
+
+      const skillMd = readFileSync(
+        join(projectDir, ".claude", "skills", TEST_SKILL_NAME, "SKILL.md"),
+        "utf-8",
+      );
+
+      // The fixture's package.json has no format script — the step must say
+      // so rather than reference a script that doesn't exist.
+      expect(skillMd).not.toContain("pnpm format:md");
+      expect(skillMd).not.toContain("pnpm format`");
+      expect(skillMd).toContain(
+        "No format script is configured for this project",
+      );
+
+      // Build/verify and doc-base-path instructions must name the nested
+      // project directory explicitly, not just "repo root".
+      expect(skillMd).toContain(`Run \`pnpm build\` from \`${projectDir}\``);
+      expect(skillMd).toContain(
+        `(relative to the project root: \`${projectDir}\`)`,
+      );
+      expect(skillMd).toContain(`${projectDir}/CLAUDE.md`);
+    });
   });
 });

--- a/scripts/setup-doc-skill.sh
+++ b/scripts/setup-doc-skill.sh
@@ -121,9 +121,16 @@ done
 # actually exist on the running project's package.json — a fresh
 # create-zudo-doc scaffold has no format script at all, while this repo's own
 # showcase exposes `format` (there is no `format:md` script anywhere, #2918).
+# `format:md` is checked too in case a downstream project defines its own
+# script under that literal name.
 FORMAT_SCRIPT="$(node -e "
 const scripts = (require('$ROOT_DIR/package.json').scripts) || {};
-console.log(scripts.format ? 'format' : (scripts['format:mdx'] ? 'format:mdx' : ''));
+console.log(
+  scripts.format ? 'format'
+  : scripts['format:mdx'] ? 'format:mdx'
+  : scripts['format:md'] ? 'format:md'
+  : ''
+);
 ")"
 if [ -n "$FORMAT_SCRIPT" ]; then
   FORMAT_STEP="Run \`pnpm $FORMAT_SCRIPT\` to format the new/changed MDX files."

--- a/scripts/setup-doc-skill.sh
+++ b/scripts/setup-doc-skill.sh
@@ -74,6 +74,16 @@ fi
 # Use the main worktree path so symlinks survive worktree removal
 REPO_ROOT="$(git -C "$ROOT_DIR" worktree list | head -1 | awk '{print $1}')"
 
+# Path from the repository root to the project directory: "" at the repo
+# root, "doc/" (trailing slash) when the project lives in a subdirectory
+# (nested layout, #2918). `rev-parse --show-prefix` is relative to the
+# CURRENT worktree's top level, so combining it with REPO_ROOT (the MAIN
+# worktree root, above) reconstructs the equivalent path there even when
+# running from inside a different worktree.
+PROJECT_PREFIX="$(git -C "$ROOT_DIR" rev-parse --show-prefix)"
+REPO_DOCS_DIR="$REPO_ROOT/${PROJECT_PREFIX}src/content/docs"
+REPO_DOCS_JA_DIR="$REPO_ROOT/${PROJECT_PREFIX}src/content/docs-ja"
+
 DOCS_DIR="$ROOT_DIR/src/content/docs"
 
 # Validate docs directory exists
@@ -106,6 +116,26 @@ for dir in "$DOCS_DIR"/*/; do
   DOC_TREE="${DOC_TREE}- ${dirname}/
 "
 done
+
+# The SKILL.md "Format"/"Verify" steps must only reference commands that
+# actually exist on the running project's package.json — a fresh
+# create-zudo-doc scaffold has no format script at all, while this repo's own
+# showcase exposes `format` (there is no `format:md` script anywhere, #2918).
+FORMAT_SCRIPT="$(node -e "
+const scripts = (require('$ROOT_DIR/package.json').scripts) || {};
+console.log(scripts.format ? 'format' : (scripts['format:mdx'] ? 'format:mdx' : ''));
+")"
+if [ -n "$FORMAT_SCRIPT" ]; then
+  FORMAT_STEP="Run \`pnpm $FORMAT_SCRIPT\` to format the new/changed MDX files."
+else
+  FORMAT_STEP="No format script is configured for this project; formatting is optional."
+fi
+
+# Name the project directory explicitly so the instruction resolves correctly
+# even when the project is nested inside a larger git repo (running `pnpm
+# build` from the outer repo root would otherwise invoke the wrong
+# package.json, #2918).
+VERIFY_STEP="Run \`pnpm build\` from \`$ROOT_DIR\` to confirm the site builds correctly."
 
 resolve_targets() {
   case "$TARGET_MODE" in
@@ -145,12 +175,12 @@ generate_skill() {
 
   mkdir -p "$skill_dir"
 
-  ensure_symlink "$skill_dir/docs" "$REPO_ROOT/src/content/docs"
-  echo "  [$target] Created docs symlink -> $REPO_ROOT/src/content/docs"
+  ensure_symlink "$skill_dir/docs" "$REPO_DOCS_DIR"
+  echo "  [$target] Created docs symlink -> $REPO_DOCS_DIR"
 
   if [ "$HAS_JA" = "true" ]; then
-    ensure_symlink "$skill_dir/docs-ja" "$REPO_ROOT/src/content/docs-ja"
-    echo "  [$target] Created docs-ja symlink -> $REPO_ROOT/src/content/docs-ja"
+    ensure_symlink "$skill_dir/docs-ja" "$REPO_DOCS_JA_DIR"
+    echo "  [$target] Created docs-ja symlink -> $REPO_DOCS_JA_DIR"
   fi
 
   cat > "$skill_dir/SKILL.md" << SKILLEOF
@@ -167,7 +197,7 @@ argument-hint: "[-u|--update] [topic keyword, e.g., 'configuration', 'sidebar', 
 # $PROJECT_NAME Documentation Reference
 
 Look up documentation from the $PROJECT_NAME project for $assistant_label.
-Documentation base path: \`src/content/docs\` (relative to repo root)
+Documentation base path: \`src/content/docs\` (relative to the project root: \`$ROOT_DIR\`)
 
 ## Mode Detection
 
@@ -197,7 +227,7 @@ The user has new information and wants to add or update documentation in this re
    the topic. Read them to understand what is already covered.
 3. **Decide create vs update**: If an existing article covers the topic, update
    it. Otherwise, create a new \`.mdx\` file in the appropriate subdirectory.
-4. **Write the content**: Follow the doc-authoring rules in the root CLAUDE.md:
+4. **Write the content**: Follow the doc-authoring rules in this project's CLAUDE.md (\`$ROOT_DIR/CLAUDE.md\`):
    - Required frontmatter: \`title\` (string). Always set \`sidebar_position\`.
      Optional: \`description\`, \`sidebar_label\`, \`tags\`, etc.
    - Do NOT use \`# h1\` in content — the frontmatter \`title\` renders as h1.
@@ -210,8 +240,8 @@ The user has new information and wants to add or update documentation in this re
    \`docs-ja/\` mirroring the English directory structure. Keep code blocks,
    Mermaid diagrams, and \`<HtmlPreview>\` blocks identical — only translate
    surrounding prose. Exception: pages with \`generated: true\` skip translation.
-6. **Format**: Run \`pnpm format:md\` to format the new/changed MDX files.
-7. **Verify**: Run \`pnpm build\` to confirm the site builds correctly.
+6. **Format**: ${FORMAT_STEP}
+7. **Verify**: ${VERIFY_STEP}
 
 ## Documentation Structure
 


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2916
- parent PR
    - https://github.com/zudolab/zudo-doc/pull/2903

---

## Summary

Epic-PR for the **Nested Scaffold** epic (#2916), part of super-epic #2902. Makes `create-zudo-doc` output correct when scaffolding into a nested subdirectory of an existing repo, keeping repo-root and worktree behavior intact. Targets super base `base/sweep-260718`; super-PR (#2903) merges the batch into `main`.

## Changes

- **#2917 — `.gitignore` covers `.zfb-build/`.** Added `.zfb-build/` (a distinct dir from `.zfb`) to the generated `.gitignore` build-artifact group in `scaffold.ts`, so a nested scaffold no longer commits ~27MB of build output. New `scaffold.test.ts` assertion.
- **#2918 — nested-subdir symlinks + runtime-conditional SKILL.md.** `setup-doc-skill.sh` now re-applies the project's path prefix (`git rev-parse --show-prefix`) on top of the main-worktree `REPO_ROOT`, so docs symlinks resolve under `<repo>/<prefix>/src/content/...` (empty prefix at root → unchanged; worktree still targets the main worktree per convention). The generated SKILL.md computes its format/build/verify commands and doc-base path at runtime from the running project's `package.json` + detected prefix (no more `pnpm format:md` when absent; paths name the subdirectory). Both byte-identical script copies updated; `pnpm check:template-drift` passes; nested + root/worktree regression tests added (13/13).
- **#2919 — confirm pass (PASS).** End-to-end #2885 repro with the workspace generator across nested / root / worktree layouts: symlinks resolve, `.zfb-build/` ignored, SKILL.md references only existing scripts with nested-correct paths, no root/worktree regression.

## Deferred (raised as `agent-found`, need maintainer decision)
- #2935 — worktree-layout mismatch between the docs symlink target (main worktree) and the generated SKILL.md instructions (`$ROOT_DIR`); only diverges in the worktree edge case, resolution needs a worktree-semantics decision.
- #2934 — `setup-zudo-doc-wisdom.sh` (showcase-only, not generator/template-drift) carries similar "relative to repo root" wording.

## Review
`/codex-review` on the full epic diff: nested-scaffold paths correct; one P2 deferred (see #2935).