### PR TITLE
[Generator Gaps] Ship claudeSkills via npm + CreateOptions parity + release-age gate counter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ packages/
 ├── search-worker/        # CF Worker for search API
 ├── doc-history-server/   # Doc history REST API + CLI generator
 ├── zudo-doc/             # Shared layout + integration package — owns chrome/routes/islands/plugins/preset (@takazudo/zudo-doc)
-└── create-zudo-doc/      # CLI scaffold tool — emits the locked ~12-file minimal manifest
+└── create-zudo-doc/      # CLI scaffold tool — emits the locked ~13-file minimal manifest
 
 src/
 ├── chrome-bindings.tsx   # Real ChromeHostBindings implementation, wired via zfb.config.ts's chromeBindingsModule

--- a/packages/create-zudo-doc/CLAUDE.md
+++ b/packages/create-zudo-doc/CLAUDE.md
@@ -6,7 +6,7 @@ CLI scaffold tool for creating new zudo-doc documentation sites. Generates a pro
 
 ## Architecture (minimal-scaffold, epic zudolab/zudo-doc#2651 Wave 6 #2660)
 
-The generator emits the **locked ~12-file minimal manifest** — one config file
+The generator emits the **locked ~13-file minimal manifest** — one config file
 (`zfb.config.ts`, `zudoDoc({ ...only fields you chose })`) plus markdown
 content plus a handful of unavoidable root files. Everything else (layout,
 chrome, islands, default `@theme` tokens, even the doc ROUTES themselves via
@@ -59,7 +59,7 @@ left to inject or copy.
 
 | Directory | Role |
 |-----------|------|
-| `templates/base/` | The locked ~12-file minimal manifest (barebone, EN-only): `pages/index.tsx` (1-line re-export), `pages/docs/[[...slug]].tsx` (self-contained doc stub — see its header comment for why it's required), `src/styles/global.css` (~20-line `@import` chain + token-override slot), `tsconfig.json` (5-line extends form). `zfb.config.ts`/`package.json`/`CLAUDE.md`/`.gitignore`/`.npmrc` are generated programmatically, not copied from here. |
+| `templates/base/` | The locked ~13-file minimal manifest (barebone, EN-only): `pages/index.tsx` (1-line re-export), `pages/docs/[[...slug]].tsx` (self-contained doc stub — see its header comment for why it's required), `src/styles/global.css` (~20-line `@import` chain + token-override slot), `tsconfig.json` (5-line extends form). `zfb.config.ts`/`package.json`/`CLAUDE.md`/`.gitignore`/`.npmrc`/`pnpm-workspace.yaml` are generated programmatically, not copied from here. |
 | `templates/features/*/files/` | Feature-specific files copied when a feature is selected. Only `i18n` (locale doc stub), `tauri`, and `tauriDev` (Rust shells) have template directories. `tagGovernance` writes one explicit tag vocabulary/config module in its `postProcess`; all audit/suggest behavior comes from package-owned bins. |
 
 ### Injection anchors — mostly retired

--- a/packages/create-zudo-doc/CLAUDE.md
+++ b/packages/create-zudo-doc/CLAUDE.md
@@ -51,7 +51,7 @@ left to inject or copy.
 | `src/constants.ts` | Feature definitions, supported langs, header-right labels, and the current Default light/dark scheme pairing |
 | `src/utils.ts` | Shared utilities (patchFile, patchDefaultLang, getSecondaryLang) |
 | `src/cli.ts` | CLI argument parsing (minimist) |
-| `src/api.ts` | Programmatic API (`createZudoDoc()`) |
+| `src/api.ts` | Programmatic API (`createZudoDoc()`). `CreateOptions` must stay in sync with `PresetJson` (`preset.ts`) — a field added to one and not the other is a type-level parity gap (#2922). Shape validation for `headerRightItems`/`metaTags` is shared via `preset.ts`'s exported `validateHeaderRightItems()`/`validateMetaTags()` — extend those, don't re-implement the allowlists here. |
 | `src/prompts.ts` | Interactive prompts (@clack/prompts) |
 | `src/index.ts` | Entry point |
 

--- a/packages/create-zudo-doc/src/__tests__/claude-skills-drift.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/claude-skills-drift.test.ts
@@ -1,0 +1,82 @@
+// Monorepo-side drift guard (#2921): the 3 user-facing zudo-doc-* skills
+// ship to consumers as committed mirrors under templates/features/claudeSkills/
+// (npm `files` cannot reach outside the package dir, so scaffold.ts can no
+// longer read the monorepo's root .claude/skills/ at generate time — see
+// scaffold.ts's claudeSkills copy step). This test is the only thing keeping
+// those two copies in sync; nothing else re-derives the template copy from
+// the source of truth.
+//
+// Compares content AFTER running it through @takazudo/mdx-formatter, not
+// raw bytes: lefthook's pre-commit hook formats staged *.md files, so a
+// same-commit copy of an unformatted source would otherwise fail this test
+// on the very commit that adds it. Both sides are formatted in the same
+// temp dir with a single `pnpm dlx` invocation to keep this fast-tier-sized.
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { execFileSync } from "node:child_process";
+import fs from "fs-extra";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = path.resolve(__dirname, "../..");
+const MONOREPO_ROOT = path.resolve(PKG_ROOT, "../..");
+
+const SKILLS = [
+  "zudo-doc-design-system",
+  "zudo-doc-translate",
+  "zudo-doc-version-bump",
+];
+
+function sourcePath(skill: string): string {
+  return path.join(MONOREPO_ROOT, ".claude/skills", skill, "SKILL.md");
+}
+
+function templatePath(skill: string): string {
+  return path.join(
+    PKG_ROOT,
+    "templates/features/claudeSkills/files/.claude/skills",
+    skill,
+    "SKILL.md",
+  );
+}
+
+describe("claudeSkills template copies match their .claude/skills/ source (#2921)", () => {
+  let formatted: Record<string, { source: string; template: string }>;
+
+  beforeAll(async () => {
+    const tempDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "claude-skills-drift-"),
+    );
+    try {
+      const files: { skill: string; side: "source" | "template"; tempFile: string }[] = [];
+      for (const skill of SKILLS) {
+        for (const side of ["source", "template"] as const) {
+          const src = side === "source" ? sourcePath(skill) : templatePath(skill);
+          const tempFile = path.join(tempDir, `${skill}-${side}.md`);
+          await fs.copy(src, tempFile);
+          files.push({ skill, side, tempFile });
+        }
+      }
+
+      execFileSync(
+        "pnpm",
+        ["dlx", "@takazudo/mdx-formatter", "--write", ...files.map((f) => f.tempFile)],
+        { cwd: tempDir, encoding: "utf8" },
+      );
+
+      formatted = {};
+      for (const { skill, side, tempFile } of files) {
+        formatted[skill] ??= { source: "", template: "" };
+        formatted[skill]![side] = await fs.readFile(tempFile, "utf8");
+      }
+    } finally {
+      await fs.remove(tempDir);
+    }
+  }, 60_000);
+
+  it.each(SKILLS)("%s template matches its monorepo source", (skill) => {
+    expect(formatted[skill]!.template).toBe(formatted[skill]!.source);
+  });
+});

--- a/packages/create-zudo-doc/src/__tests__/claude-skills-tarball.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/claude-skills-tarball.test.ts
@@ -1,0 +1,76 @@
+// Fast-tier tarball assertion (#2921): "the package builds" is NOT proof
+// that the claudeSkills feature's 3 skill files actually ship in the npm
+// tarball. npm `files` entries cannot reach outside the package dir, so the
+// old scaffold.ts logic (reading from the monorepo's root .claude/skills/)
+// silently no-op'd under a real npm install — nothing in that path was ever
+// part of the tarball. This asserts the REAL file list `npm pack --dry-run
+// --json` reports (no tarball written to disk, no publish) contains every
+// committed skill template file.
+//
+// Modeled on packages/zudo-doc/src/__tests__/theme-packs-tarball.test.ts.
+// Assumes `dist/` is already populated by a prior
+// `pnpm --filter create-zudo-doc build` — this test only reads the
+// tarball's computed file list, it never triggers a build itself.
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { execFileSync } from "node:child_process";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = resolve(__dirname, "../..");
+
+interface NpmPackDryRunFile {
+  path: string;
+}
+interface NpmPackDryRunEntry {
+  files: NpmPackDryRunFile[];
+}
+
+// See theme-packs-tarball.test.ts for why this scans every `[` instead of
+// naively parsing from the first bracket — some npm/CI combinations leak a
+// lifecycle log line ahead of the JSON array.
+function parsePackJson(stdout: string): NpmPackDryRunEntry[] {
+  for (let i = stdout.indexOf("["); i !== -1; i = stdout.indexOf("[", i + 1)) {
+    try {
+      const value = JSON.parse(stdout.slice(i));
+      if (Array.isArray(value)) return value as NpmPackDryRunEntry[];
+    } catch {
+      // Not the JSON array (e.g. a leaked log line) — keep scanning.
+    }
+  }
+  throw new Error(
+    `npm pack --dry-run --json produced no parseable JSON array. stdout:\n${stdout}`,
+  );
+}
+
+function packFileList(): string[] {
+  const stdout = execFileSync(
+    "npm",
+    ["pack", "--dry-run", "--json", "--ignore-scripts"],
+    { cwd: PKG_ROOT, encoding: "utf8" },
+  );
+  const parsed = parsePackJson(stdout);
+  const entry = parsed[0];
+  if (!entry) throw new Error("npm pack --dry-run --json produced no entries");
+  return entry.files.map((f) => f.path);
+}
+
+describe("npm tarball ships claudeSkills template files (#2921)", () => {
+  let files: string[];
+  beforeAll(() => {
+    files = packFileList();
+  }, 60_000);
+
+  it("includes the 3 user-facing zudo-doc-* skill templates", () => {
+    for (const skill of [
+      "zudo-doc-design-system",
+      "zudo-doc-translate",
+      "zudo-doc-version-bump",
+    ]) {
+      expect(files).toContain(
+        `templates/features/claudeSkills/files/.claude/skills/${skill}/SKILL.md`,
+      );
+    }
+  });
+});

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -16,6 +16,8 @@ import type { UserChoices } from "../prompts.js";
 import { scaffold } from "../scaffold.js";
 import { validateProjectName } from "../utils.js";
 import { createZudoDoc } from "../api.js";
+import type { PresetHeaderRightItem, PresetMetaTagsConfig } from "../preset.js";
+import { validatePreset } from "../preset.js";
 
 // Minimal-scaffold cutover (epic zudolab/zudo-doc#2651). Rewritten from
 // scratch for Wave 7 (#2662) against the locked ~12-file manifest landed by
@@ -1658,5 +1660,146 @@ describe("scaffold — programmatic API rejects invalid project names (F4 #2013)
     });
     const config = await fs.readFile(path.join(targetDir, "zfb.config.ts"), "utf-8");
     expect(config).toContain('themePack: "foundry"');
+  });
+});
+
+describe("createZudoDoc() — CreateOptions preset parity (#2922)", () => {
+  // UserChoices/PresetJson/zfb-config-gen.ts already supported
+  // headerRightItems, metaTags, cjkFriendly, and minifyHtml end to end —
+  // only the programmatic CreateOptions type was missing them. Shape
+  // validation for headerRightItems/metaTags is shared with the preset
+  // (JSON) path via preset.ts's validateHeaderRightItems()/
+  // validateMetaTags(); the "same rule as validatePreset()" tests below
+  // assert both callers reject the identical input with the identical
+  // message, proving the shared helper (not a duplicated allowlist) is in
+  // effect.
+
+  it("createZudoDoc() throws for an unknown headerRightItems component, same rule as validatePreset()", async () => {
+    const invalidItems = [
+      { type: "component", component: "not-a-real-thing" },
+    ] as unknown as PresetHeaderRightItem[];
+    await expect(
+      createZudoDoc({
+        projectName: "valid-name",
+        colorSchemeMode: "single",
+        singleScheme: "Default Dark",
+        headerRightItems: invalidItems,
+        features: [],
+        packageManager: "pnpm",
+      }),
+    ).rejects.toThrow(/unknown component "not-a-real-thing"/);
+    expect(validatePreset({ headerRightItems: invalidItems })).toMatch(
+      /unknown component "not-a-real-thing"/,
+    );
+  });
+
+  it("createZudoDoc() throws for an unsupported headerRightItems type, same message as validatePreset()", async () => {
+    const invalidItems = [
+      { type: "link", href: "https://example.com", label: "Custom" },
+    ] as unknown as PresetHeaderRightItem[];
+    const expectedMessage =
+      /type "link" is not supported in presets \(v1\) — edit zfb\.config\.ts after scaffold/;
+    await expect(
+      createZudoDoc({
+        projectName: "valid-name",
+        colorSchemeMode: "single",
+        singleScheme: "Default Dark",
+        headerRightItems: invalidItems,
+        features: [],
+        packageManager: "pnpm",
+      }),
+    ).rejects.toThrow(expectedMessage);
+    expect(validatePreset({ headerRightItems: invalidItems })).toMatch(expectedMessage);
+  });
+
+  it("createZudoDoc() accepts a valid headerRightItems array and threads it into zfb.config.ts", async () => {
+    const targetDir = await createZudoDoc({
+      projectName: "valid-header-items-test",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      headerRightItems: [
+        { type: "component", component: "github-link" },
+        { type: "trigger", trigger: "ai-chat" },
+      ],
+      features: [],
+      packageManager: "pnpm",
+    });
+    const config = await fs.readFile(path.join(targetDir, "zfb.config.ts"), "utf-8");
+    expect(config).toContain('component: "github-link"');
+    expect(config).toContain('trigger: "ai-chat"');
+  });
+
+  it("createZudoDoc() throws for a non-object metaTags value, same rule as validatePreset()", async () => {
+    const invalidMetaTags = "yes" as unknown as PresetMetaTagsConfig;
+    await expect(
+      createZudoDoc({
+        projectName: "valid-name",
+        colorSchemeMode: "single",
+        singleScheme: "Default Dark",
+        metaTags: invalidMetaTags,
+        features: [],
+        packageManager: "pnpm",
+      }),
+    ).rejects.toThrow(/"metaTags" must be an object/);
+    expect(validatePreset({ metaTags: invalidMetaTags })).toMatch(
+      /"metaTags" must be an object/,
+    );
+  });
+
+  it("createZudoDoc() throws for an invalid metaTags.twitterCard value, same rule as validatePreset()", async () => {
+    const invalidMetaTags = { twitterCard: "player" } as unknown as PresetMetaTagsConfig;
+    const expectedMessage =
+      /"metaTags\.twitterCard" must be "summary", "summary_large_image", or false/;
+    await expect(
+      createZudoDoc({
+        projectName: "valid-name",
+        colorSchemeMode: "single",
+        singleScheme: "Default Dark",
+        metaTags: invalidMetaTags,
+        features: [],
+        packageManager: "pnpm",
+      }),
+    ).rejects.toThrow(expectedMessage);
+    expect(validatePreset({ metaTags: invalidMetaTags })).toMatch(expectedMessage);
+  });
+
+  it("createZudoDoc() accepts a valid metaTags object and threads it into zfb.config.ts", async () => {
+    const targetDir = await createZudoDoc({
+      projectName: "valid-meta-tags-test",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      metaTags: { ogImage: "/img/og.png" },
+      features: [],
+      packageManager: "pnpm",
+    });
+    const config = await fs.readFile(path.join(targetDir, "zfb.config.ts"), "utf-8");
+    expect(config).toContain("metaTags: {");
+    expect(config).toContain('ogImage: "/img/og.png"');
+  });
+
+  it("createZudoDoc() threads cjkFriendly: true into zfb.config.ts", async () => {
+    const targetDir = await createZudoDoc({
+      projectName: "valid-cjk-friendly-test",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      cjkFriendly: true,
+      features: [],
+      packageManager: "pnpm",
+    });
+    const config = await fs.readFile(path.join(targetDir, "zfb.config.ts"), "utf-8");
+    expect(config).toContain("cjkFriendly: true");
+  });
+
+  it("createZudoDoc() threads minifyHtml: false into zfb.config.ts", async () => {
+    const targetDir = await createZudoDoc({
+      projectName: "valid-minify-html-test",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      minifyHtml: false,
+      features: [],
+      packageManager: "pnpm",
+    });
+    const config = await fs.readFile(path.join(targetDir, "zfb.config.ts"), "utf-8");
+    expect(config).toContain("minifyHtml: false");
   });
 });

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -6,6 +6,7 @@ import {
   afterEach,
   beforeAll,
   afterAll,
+  vi,
 } from "vitest";
 import fs from "fs-extra";
 import os from "os";
@@ -603,6 +604,67 @@ describe("scaffold — claudeSkills feature", () => {
     ).toBe(false);
     const pkg = await fs.readJson(projectPath("test-doc", "package.json"));
     expect(pkg.scripts.b4push).toBeUndefined();
+  });
+
+  // Unreachable in a healthy checkout — the template sources are committed
+  // alongside scaffold.ts. Simulated by making fs.pathExists lie about one
+  // skill's TEMPLATE SOURCE path specifically, so the other 2 skills still
+  // take the real (non-mocked) code path. The match is scoped to
+  // "templates/features/claudeSkills" so it can never accidentally match the
+  // generated project's destination path (which lives under a tempDir with
+  // no such segment) — a looser substring match would make the destination
+  // assertion below pass vacuously (the mock lying, not scaffold's own
+  // skip-on-missing behavior).
+  it("warns and skips a skill whose template source is missing", async () => {
+    const realPathExists = fs.pathExists;
+    const pathExistsSpy = vi
+      .spyOn(fs, "pathExists")
+      .mockImplementation(async (p: string) => {
+        if (
+          p.includes(path.join("templates/features/claudeSkills")) &&
+          p.includes("zudo-doc-translate")
+        ) {
+          return false;
+        }
+        return realPathExists(p);
+      });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      await scaffold({
+        ...baseChoices,
+        projectName: "test-claude-skills-missing",
+        features: ["claudeSkills"],
+      });
+    } finally {
+      // Restore before the assertions below so the destination-existence
+      // checks hit the real filesystem, not the mock.
+      pathExistsSpy.mockRestore();
+    }
+
+    try {
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'missing template source for "zudo-doc-translate"',
+        ),
+      );
+      const project = projectPath("test-claude-skills-missing");
+      expect(
+        await fs.pathExists(
+          path.join(project, ".claude/skills/zudo-doc-translate/SKILL.md"),
+        ),
+      ).toBe(false);
+      // The other 2 skills are unaffected by the one missing source.
+      for (const skill of ["zudo-doc-design-system", "zudo-doc-version-bump"]) {
+        expect(
+          await fs.pathExists(
+            path.join(project, `.claude/skills/${skill}/SKILL.md`),
+          ),
+        ).toBe(true);
+      }
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });
 

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -960,7 +960,7 @@ describe("scaffold — pnpm-workspace.yaml (#2923)", () => {
     expect(workspaceYaml).toContain("minimumReleaseAge: 0");
   });
 
-  it("is SKIPPED when scaffolding into an existing pnpm monorepo (never nest a workspace boundary, codex-review finding)", async () => {
+  it("is SKIPPED when scaffolding into an existing pnpm monorepo (never nest a workspace boundary, codex-review finding), and warns the user to disable the gate in the parent workspace", async () => {
     // tempDir (cwd, set up by the outer beforeEach) stands in for a parent
     // monorepo root — e.g. scaffolding into `apps/docs/` under a workspace
     // that already owns a pnpm-workspace.yaml.
@@ -968,10 +968,19 @@ describe("scaffold — pnpm-workspace.yaml (#2923)", () => {
       path.join(tempDir, "pnpm-workspace.yaml"),
       "packages:\n  - packages/*\n",
     );
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     await scaffold({ ...baseChoices, projectName: "test-nested-ws" });
     expect(
       await fs.pathExists(projectPath("test-nested-ws", "pnpm-workspace.yaml")),
     ).toBe(false);
+    // Skipping silently would leave the scaffold blocked by the parent's
+    // minimumReleaseAge default — instead the user is told to disable it there
+    // (codex-review #2920 follow-up).
+    const warned = warnSpy.mock.calls.some((c) =>
+      String(c[0]).includes("minimumReleaseAge: 0"),
+    );
+    expect(warned).toBe(true);
+    warnSpy.mockRestore();
   });
 });
 

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -84,7 +84,8 @@ const baseChoices: UserChoices = {
 // The locked manifest (#2653 Decision 4 / #2660 completion comment).
 // ---------------------------------------------------------------------------
 
-/** The locked ~12-file barebone (EN-only) manifest. */
+/** The locked ~13-file barebone (EN-only) manifest. Grew from 12 to 13 with
+ *  pnpm-workspace.yaml (#2923 — disables pnpm 11's minimumReleaseAge gate). */
 const BAREBONE_MANIFEST = [
   ".gitignore",
   ".npmrc",
@@ -92,6 +93,7 @@ const BAREBONE_MANIFEST = [
   "package.json",
   "pages/docs/[[...slug]].tsx",
   "pages/index.tsx",
+  "pnpm-workspace.yaml",
   "src/content/docs/getting-started/index.mdx",
   "src/content/docs/getting-started/installation.mdx",
   "src/content/docs/getting-started/introduction.mdx",
@@ -129,7 +131,7 @@ const ALL_FEATURES = [
   "noindex",
 ];
 
-describe("scaffold — barebone manifest (locked 12-file shape, #2653 Decision 4)", () => {
+describe("scaffold — barebone manifest (locked 13-file shape, #2653 Decision 4)", () => {
   let files: string[];
 
   beforeAll(async () => {
@@ -142,7 +144,7 @@ describe("scaffold — barebone manifest (locked 12-file shape, #2653 Decision 4
     await fs.remove(dir);
   });
 
-  it("emits EXACTLY the 12 locked-manifest files — no more, no less", () => {
+  it("emits EXACTLY the 13 locked-manifest files — no more, no less", () => {
     expect(files).toEqual(BAREBONE_MANIFEST);
   });
 });
@@ -709,7 +711,7 @@ describe("scaffold — changelog feature", () => {
 });
 
 describe("scaffold — every-feature manifest is exactly base + the documented per-feature deltas", () => {
-  it("all-on scaffold emits exactly the expected 38-file set", async () => {
+  it("all-on scaffold emits exactly the expected 39-file set", async () => {
     await scaffold({
       ...baseChoices,
       projectName: "test-all-on",
@@ -727,6 +729,7 @@ describe("scaffold — every-feature manifest is exactly base + the documented p
       "pages/[locale]/docs/[[...slug]].tsx",
       "pages/docs/[[...slug]].tsx",
       "pages/index.tsx",
+      "pnpm-workspace.yaml",
       "scripts/setup-doc-skill.sh",
       "src-tauri-dev/.gitignore",
       "src-tauri-dev/Cargo.toml",
@@ -935,6 +938,40 @@ describe("scaffold — .npmrc", () => {
     await scaffold(baseChoices);
     const npmrc = await fs.readFile(projectPath("test-doc", ".npmrc"), "utf-8");
     expect(npmrc).toBe("trust-policy-exclude[]=undici-types@6.21.0\n");
+  });
+});
+
+describe("scaffold — pnpm-workspace.yaml (#2923)", () => {
+  it("disables pnpm 11's minimumReleaseAge gate", async () => {
+    await scaffold(baseChoices);
+    const workspaceYaml = await fs.readFile(
+      projectPath("test-doc", "pnpm-workspace.yaml"),
+      "utf-8",
+    );
+    expect(workspaceYaml).toContain("minimumReleaseAge: 0");
+  });
+
+  it("is emitted regardless of the chosen package manager (matches the .npmrc block's unconditional emission)", async () => {
+    await scaffold({ ...baseChoices, projectName: "test-npm-pm", packageManager: "npm" });
+    const workspaceYaml = await fs.readFile(
+      projectPath("test-npm-pm", "pnpm-workspace.yaml"),
+      "utf-8",
+    );
+    expect(workspaceYaml).toContain("minimumReleaseAge: 0");
+  });
+
+  it("is SKIPPED when scaffolding into an existing pnpm monorepo (never nest a workspace boundary, codex-review finding)", async () => {
+    // tempDir (cwd, set up by the outer beforeEach) stands in for a parent
+    // monorepo root — e.g. scaffolding into `apps/docs/` under a workspace
+    // that already owns a pnpm-workspace.yaml.
+    await fs.outputFile(
+      path.join(tempDir, "pnpm-workspace.yaml"),
+      "packages:\n  - packages/*\n",
+    );
+    await scaffold({ ...baseChoices, projectName: "test-nested-ws" });
+    expect(
+      await fs.pathExists(projectPath("test-nested-ws", "pnpm-workspace.yaml")),
+    ).toBe(false);
   });
 });
 

--- a/packages/create-zudo-doc/src/__tests__/utils.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/utils.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect } from "vitest";
-import { pmRunCommand } from "../utils.js";
+import { describe, it, expect, afterEach } from "vitest";
+import fs from "fs-extra";
+import os from "os";
+import path from "path";
+import { hasAncestorPnpmWorkspace, pmRunCommand } from "../utils.js";
 
 describe("pmRunCommand — package.json script invocation per package manager", () => {
   it.each([
@@ -17,5 +20,56 @@ describe("pmRunCommand — package.json script invocation per package manager", 
     for (const script of ["build", "dev", "check", "preview"]) {
       expect(pmRunCommand("bun", script)).toBe(`bun run ${script}`);
     }
+  });
+});
+
+describe("hasAncestorPnpmWorkspace — never-nest guard for pnpm-workspace.yaml (#2923)", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    while (tempDirs.length) {
+      await fs.remove(tempDirs.pop()!);
+    }
+  });
+
+  async function mkTempDir(): Promise<string> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "hasAncestorPnpmWorkspace-test-"));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  it("returns false when no ancestor has a pnpm-workspace.yaml", async () => {
+    const root = await mkTempDir();
+    const projectDir = path.join(root, "my-docs");
+    await fs.ensureDir(projectDir);
+    expect(hasAncestorPnpmWorkspace(projectDir)).toBe(false);
+  });
+
+  it("returns true when the immediate parent has a pnpm-workspace.yaml", async () => {
+    const root = await mkTempDir();
+    await fs.outputFile(path.join(root, "pnpm-workspace.yaml"), "packages:\n  - packages/*\n");
+    const projectDir = path.join(root, "apps/docs");
+    await fs.ensureDir(projectDir);
+    expect(hasAncestorPnpmWorkspace(projectDir)).toBe(true);
+  });
+
+  it("returns true when a workspace root is several levels up", async () => {
+    const root = await mkTempDir();
+    await fs.outputFile(path.join(root, "pnpm-workspace.yaml"), "packages:\n  - packages/*\n");
+    const projectDir = path.join(root, "a/b/c/my-docs");
+    await fs.ensureDir(projectDir);
+    expect(hasAncestorPnpmWorkspace(projectDir)).toBe(true);
+  });
+
+  it("does not check `dir` itself, only its ancestors", async () => {
+    const root = await mkTempDir();
+    const projectDir = path.join(root, "my-docs");
+    await fs.ensureDir(projectDir);
+    // A pnpm-workspace.yaml INSIDE the target dir itself must not count —
+    // scaffold.ts calls this before writing its own, so this only matters
+    // if a caller pre-seeds a target dir, which the "ancestor, not self"
+    // semantics intentionally ignore.
+    await fs.outputFile(path.join(projectDir, "pnpm-workspace.yaml"), "packages:\n  - x\n");
+    expect(hasAncestorPnpmWorkspace(projectDir)).toBe(false);
   });
 });

--- a/packages/create-zudo-doc/src/api.ts
+++ b/packages/create-zudo-doc/src/api.ts
@@ -1,5 +1,7 @@
 import path from "path";
 import { SINGLE_SCHEMES, THEME_PACKS } from "./constants.js";
+import type { PresetHeaderRightItem, PresetMetaTagsConfig } from "./preset.js";
+import { validateHeaderRightItems, validateMetaTags } from "./preset.js";
 import { scaffold } from "./scaffold.js";
 import { initGitRepo, installDependencies, validateProjectName } from "./utils.js";
 
@@ -21,7 +23,17 @@ export interface CreateOptions {
   /** GitHub repository URL — drives the header GitHub link and body-foot
    *  "View source on GitHub" link. Empty = disabled. */
   githubUrl?: string;
+  /** Enable remark-cjk-friendly plugin (intelligent spacing around CJK text). Default: false. */
+  cjkFriendly?: boolean;
+  /** Minify production HTML output. Default: true. */
+  minifyHtml?: boolean;
   packageManager: "pnpm" | "npm" | "yarn" | "bun";
+  /** Header-right items override, validated against the v1 preset allowlist
+   *  (see `validateHeaderRightItems`). When omitted, keeps the package default. */
+  headerRightItems?: PresetHeaderRightItem[];
+  /** Meta tags config, validated against the v1 preset shape
+   *  (see `validateMetaTags`). When omitted, keeps the package defaults. */
+  metaTags?: PresetMetaTagsConfig;
   /** Install dependencies after scaffolding (default: false) */
   install?: boolean;
   /**
@@ -58,6 +70,18 @@ export async function createZudoDoc(options: CreateOptions): Promise<string> {
   if (rest.themePack && !THEME_PACKS.some((t) => t.slug === rest.themePack)) {
     const catalog = THEME_PACKS.map((t) => t.slug).join(", ");
     throw new Error(`Unknown theme pack "${rest.themePack}". Available: ${catalog}`);
+  }
+  // Validate headerRightItems/metaTags shape like the preset (preset.ts) path
+  // does (#2922) — the two validators are shared via preset.ts so this can
+  // never drift from `validatePreset()`'s rules. Booleans (cjkFriendly,
+  // minifyHtml) need no validation.
+  if (rest.headerRightItems !== undefined) {
+    const err = validateHeaderRightItems(rest.headerRightItems);
+    if (err) throw new Error(err);
+  }
+  if (rest.metaTags !== undefined) {
+    const err = validateMetaTags(rest.metaTags);
+    if (err) throw new Error(err);
   }
   const choices = { ...rest, defaultLang: rest.defaultLang ?? "en" };
   await scaffold(choices);

--- a/packages/create-zudo-doc/src/claude-md-gen.ts
+++ b/packages/create-zudo-doc/src/claude-md-gen.ts
@@ -6,7 +6,7 @@ import { capitalize, pmRunCommand } from "./utils.js";
  * zudolab/zudo-doc#2651, Wave 6 #2660). Rewritten from scratch — the old
  * generator described a 64-file project (`src/components/admonitions/`,
  * `src/layouts/`, `src/utils/`, per-page `pages/lib/*` wiring) that no
- * longer exists. The scaffolded project is now ~12 files; almost
+ * longer exists. The scaffolded project is now ~13 files; almost
  * everything referenced here lives in `node_modules/@takazudo/zudo-doc`.
  */
 export function generateCLAUDEFile(choices: UserChoices): string {

--- a/packages/create-zudo-doc/src/preset.ts
+++ b/packages/create-zudo-doc/src/preset.ts
@@ -58,6 +58,94 @@ export interface PresetMetaTagsConfig {
   twitterCreator?: string;
 }
 
+/**
+ * Validates a `headerRightItems` value against the v1 preset allowlist.
+ * Shared by `validatePreset()` (JSON preset path) and `createZudoDoc()`
+ * (programmatic API path, #2922) so the two entry points can never drift.
+ */
+export function validateHeaderRightItems(items: unknown): string | null {
+  if (!Array.isArray(items)) {
+    return `"headerRightItems" must be an array`;
+  }
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i] as unknown;
+    if (item === null || typeof item !== "object" || Array.isArray(item)) {
+      return `headerRightItems[${i}] must be an object`;
+    }
+    const t = (item as { type?: unknown }).type;
+    if (t === "link" || t === "html") {
+      return `headerRightItems[${i}] type "${t}" is not supported in presets (v1) — edit zfb.config.ts after scaffold`;
+    }
+    if (t === "component") {
+      const component = (item as { component?: unknown }).component;
+      if (typeof component !== "string") {
+        return `headerRightItems[${i}].component must be a string`;
+      }
+      if (!VALID_HEADER_RIGHT_COMPONENTS.has(
+        component as PresetHeaderRightComponentName,
+      )) {
+        return `headerRightItems[${i}] unknown component "${component}". Allowed: ${[
+          ...VALID_HEADER_RIGHT_COMPONENTS,
+        ].join(", ")}`;
+      }
+    } else if (t === "trigger") {
+      const trigger = (item as { trigger?: unknown }).trigger;
+      if (typeof trigger !== "string") {
+        return `headerRightItems[${i}].trigger must be a string`;
+      }
+      if (!VALID_HEADER_RIGHT_TRIGGERS.has(
+        trigger as PresetHeaderRightTriggerName,
+      )) {
+        return `headerRightItems[${i}] unknown trigger "${trigger}". Allowed: ${[
+          ...VALID_HEADER_RIGHT_TRIGGERS,
+        ].join(", ")}`;
+      }
+    } else {
+      return `headerRightItems[${i}] must have type "component" or "trigger" (got ${JSON.stringify(t)})`;
+    }
+  }
+  return null;
+}
+
+/**
+ * Validates a `metaTags` value's sub-field types. Shared by `validatePreset()`
+ * (JSON preset path) and `createZudoDoc()` (programmatic API path, #2922) so
+ * the two entry points can never drift.
+ */
+export function validateMetaTags(metaTags: unknown): string | null {
+  if (typeof metaTags !== "object" || metaTags === null || Array.isArray(metaTags)) {
+    return `"metaTags" must be an object`;
+  }
+  const mt = metaTags as PresetMetaTagsConfig;
+  if (mt.description !== undefined && typeof mt.description !== "boolean") {
+    return `"metaTags.description" must be a boolean`;
+  }
+  if (mt.keywords !== undefined && mt.keywords !== false && typeof mt.keywords !== "string") {
+    return `"metaTags.keywords" must be a string or false`;
+  }
+  if (mt.ogImage !== undefined && mt.ogImage !== false && typeof mt.ogImage !== "string") {
+    return `"metaTags.ogImage" must be a string or false`;
+  }
+  if (mt.ogSiteName !== undefined && typeof mt.ogSiteName !== "boolean") {
+    return `"metaTags.ogSiteName" must be a boolean`;
+  }
+  if (
+    mt.twitterCard !== undefined &&
+    mt.twitterCard !== false &&
+    mt.twitterCard !== "summary" &&
+    mt.twitterCard !== "summary_large_image"
+  ) {
+    return `"metaTags.twitterCard" must be "summary", "summary_large_image", or false`;
+  }
+  if (mt.twitterSite !== undefined && typeof mt.twitterSite !== "string") {
+    return `"metaTags.twitterSite" must be a string`;
+  }
+  if (mt.twitterCreator !== undefined && typeof mt.twitterCreator !== "string") {
+    return `"metaTags.twitterCreator" must be a string`;
+  }
+  return null;
+}
+
 export interface PresetJson {
   projectName?: string;
   defaultLang?: string;
@@ -152,78 +240,12 @@ export function validatePreset(json: unknown): string | null {
     return `"minifyHtml" must be a boolean in preset`;
   }
   if (p.headerRightItems !== undefined) {
-    if (!Array.isArray(p.headerRightItems)) {
-      return `"headerRightItems" must be an array in preset`;
-    }
-    for (let i = 0; i < p.headerRightItems.length; i++) {
-      const item = p.headerRightItems[i] as unknown;
-      if (item === null || typeof item !== "object" || Array.isArray(item)) {
-        return `headerRightItems[${i}] must be an object`;
-      }
-      const t = (item as { type?: unknown }).type;
-      if (t === "link" || t === "html") {
-        return `headerRightItems[${i}] type "${t}" is not supported in presets (v1) — edit settings.ts after scaffold`;
-      }
-      if (t === "component") {
-        const component = (item as { component?: unknown }).component;
-        if (typeof component !== "string") {
-          return `headerRightItems[${i}].component must be a string`;
-        }
-        if (!VALID_HEADER_RIGHT_COMPONENTS.has(
-          component as PresetHeaderRightComponentName,
-        )) {
-          return `headerRightItems[${i}] unknown component "${component}". Allowed: ${[
-            ...VALID_HEADER_RIGHT_COMPONENTS,
-          ].join(", ")}`;
-        }
-      } else if (t === "trigger") {
-        const trigger = (item as { trigger?: unknown }).trigger;
-        if (typeof trigger !== "string") {
-          return `headerRightItems[${i}].trigger must be a string`;
-        }
-        if (!VALID_HEADER_RIGHT_TRIGGERS.has(
-          trigger as PresetHeaderRightTriggerName,
-        )) {
-          return `headerRightItems[${i}] unknown trigger "${trigger}". Allowed: ${[
-            ...VALID_HEADER_RIGHT_TRIGGERS,
-          ].join(", ")}`;
-        }
-      } else {
-        return `headerRightItems[${i}] must have type "component" or "trigger" (got ${JSON.stringify(t)})`;
-      }
-    }
+    const err = validateHeaderRightItems(p.headerRightItems);
+    if (err) return err;
   }
   if (p.metaTags !== undefined) {
-    if (typeof p.metaTags !== "object" || p.metaTags === null || Array.isArray(p.metaTags)) {
-      return `"metaTags" must be an object in preset`;
-    }
-    const mt = p.metaTags as PresetMetaTagsConfig;
-    if (mt.description !== undefined && typeof mt.description !== "boolean") {
-      return `"metaTags.description" must be a boolean`;
-    }
-    if (mt.keywords !== undefined && mt.keywords !== false && typeof mt.keywords !== "string") {
-      return `"metaTags.keywords" must be a string or false`;
-    }
-    if (mt.ogImage !== undefined && mt.ogImage !== false && typeof mt.ogImage !== "string") {
-      return `"metaTags.ogImage" must be a string or false`;
-    }
-    if (mt.ogSiteName !== undefined && typeof mt.ogSiteName !== "boolean") {
-      return `"metaTags.ogSiteName" must be a boolean`;
-    }
-    if (
-      mt.twitterCard !== undefined &&
-      mt.twitterCard !== false &&
-      mt.twitterCard !== "summary" &&
-      mt.twitterCard !== "summary_large_image"
-    ) {
-      return `"metaTags.twitterCard" must be "summary", "summary_large_image", or false`;
-    }
-    if (mt.twitterSite !== undefined && typeof mt.twitterSite !== "string") {
-      return `"metaTags.twitterSite" must be a string`;
-    }
-    if (mt.twitterCreator !== undefined && typeof mt.twitterCreator !== "string") {
-      return `"metaTags.twitterCreator" must be a string`;
-    }
+    const err = validateMetaTags(p.metaTags);
+    if (err) return err;
   }
   // Cross-field validation
   if (p.colorSchemeMode === "single" && (p.lightScheme || p.darkScheme)) {

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -6,7 +6,12 @@ import { generateZfbConfig } from "./zfb-config-gen.js";
 import { generateCLAUDEFile } from "./claude-md-gen.js";
 import { composeFeatures } from "./compose.js";
 import { featureModules } from "./features/index.js";
-import { capitalize, getSecondaryLang, pmRunCommand } from "./utils.js";
+import {
+  capitalize,
+  getSecondaryLang,
+  hasAncestorPnpmWorkspace,
+  pmRunCommand,
+} from "./utils.js";
 
 export { getSecondaryLang };
 
@@ -470,6 +475,27 @@ export async function scaffold(choices: UserChoices): Promise<void> {
     path.join(targetDir, ".npmrc"),
     "trust-policy-exclude[]=undici-types@6.21.0\n",
   );
+
+  // Emit a pnpm-workspace.yaml disabling pnpm 11's minimumReleaseAge gate.
+  // pnpm >= 11 defaults minimumReleaseAge to 1440 (1 day), which blocks
+  // `pnpm install`/CI from resolving a freshly-published @takazudo bump for
+  // a full day; the built-in minimumReleaseAgeExclude matcher can't be
+  // pointed at this project's peer-nested lockfile keys (upstream pnpm
+  // limitation), so the gate is disabled outright rather than excluded
+  // per-package. As of pnpm 11, non-auth/registry settings like this one
+  // live in pnpm-workspace.yaml, not .npmrc (.npmrc is auth/registry only).
+  // Skipped when an ANCESTOR directory already has a pnpm-workspace.yaml
+  // (e.g. scaffolding into `apps/docs/` under an existing pnpm monorepo) —
+  // pnpm resolves the nearest pnpm-workspace.yaml upward from cwd as the
+  // workspace root, so writing a new one here would carve the generated
+  // project out of the parent workspace instead of joining it. Mirrors
+  // `initGitRepo`'s "never nest" precedent (see utils.ts).
+  if (!hasAncestorPnpmWorkspace(targetDir)) {
+    await fs.outputFile(
+      path.join(targetDir, "pnpm-workspace.yaml"),
+      "# pnpm 11 defaults minimumReleaseAge to 1440min; its exclude matcher can't match this project's peer-nested lockfile keys (upstream pnpm bug), so disable the gate outright.\nminimumReleaseAge: 0\n",
+    );
+  }
 
   const claudeContent = generateCLAUDEFile(choices);
   await fs.outputFile(path.join(targetDir, "CLAUDE.md"), claudeContent);

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -233,9 +233,6 @@ export async function scaffold(choices: UserChoices): Promise<void> {
   const baseDir = path.join(templatesDir, "base");
   const featuresDir = path.join(templatesDir, "features");
 
-  // Still needed for source-checkout-only assets such as Claude skills.
-  const monorepoRoot = path.resolve(pkgRoot, "../..");
-
   await fs.ensureDir(targetDir);
 
   // 1. Copy base template
@@ -256,18 +253,28 @@ export async function scaffold(choices: UserChoices): Promise<void> {
 
   // 2b. Copy user-facing Claude Code skills when enabled
   // Ships the curated zudo-doc-* skills (design-system, translate, version-bump)
-  // from the monorepo's .claude/skills/ into the user's .claude/skills/.
+  // from the package's own templates/ (npm `files` cannot reach outside the
+  // package dir, so these are committed mirrors of the monorepo's
+  // .claude/skills/, not read from there directly — see #2921).
   if (choices.features.includes("claudeSkills")) {
     const userFacingSkills = [
       "zudo-doc-design-system",
       "zudo-doc-translate",
       "zudo-doc-version-bump",
     ];
+    const skillsTemplateDir = path.join(
+      featuresDir,
+      "claudeSkills/files/.claude/skills",
+    );
     for (const skill of userFacingSkills) {
-      const skillSrc = path.join(monorepoRoot, ".claude/skills", skill);
+      const skillSrc = path.join(skillsTemplateDir, skill);
       const skillDest = path.join(targetDir, ".claude/skills", skill);
       if (await fs.pathExists(skillSrc)) {
         await fs.copy(skillSrc, skillDest);
+      } else {
+        // Defensive only — unreachable in a healthy publish, since the
+        // template files are committed alongside this source.
+        console.warn(`claudeSkills: missing template source for "${skill}", skipping`);
       }
     }
   }

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -495,6 +495,17 @@ export async function scaffold(choices: UserChoices): Promise<void> {
       path.join(targetDir, "pnpm-workspace.yaml"),
       "# pnpm 11 defaults minimumReleaseAge to 1440min; its exclude matcher can't match this project's peer-nested lockfile keys (upstream pnpm bug), so disable the gate outright.\nminimumReleaseAge: 0\n",
     );
+  } else {
+    // Ancestor already has a pnpm-workspace.yaml: we deliberately do NOT write
+    // our own (it would carve this project out of the parent workspace — see
+    // above). But then pnpm applies the PARENT workspace's minimumReleaseAge
+    // (1440min by default in pnpm 11), so freshly-published @takazudo bumps
+    // still can't install for a day — the exact failure this file guards
+    // against. We can't safely edit the parent's config, so instruct the user
+    // to disable the gate there instead of silently leaving them blocked.
+    console.warn(
+      "pnpm-workspace.yaml exists in an ancestor directory — skipping the generated one to avoid nesting a second workspace. If `pnpm install` blocks freshly-published @takazudo releases, add `minimumReleaseAge: 0` to your parent pnpm-workspace.yaml.",
+    );
   }
 
   const claudeContent = generateCLAUDEFile(choices);

--- a/packages/create-zudo-doc/src/utils.ts
+++ b/packages/create-zudo-doc/src/utils.ts
@@ -1,5 +1,6 @@
 import { execSync, execFileSync } from "child_process";
 import fs from "fs-extra";
+import path from "path";
 
 // Project-name grammar (locked by F4 — S4 #2013):
 // /^[a-z0-9][a-z0-9._-]*$/, max 214 chars, unscoped, used as both directory
@@ -118,6 +119,27 @@ export function initGitRepo(dir: string): GitInitResult {
       status: "failed",
       message: err instanceof Error ? err.message : String(err),
     };
+  }
+}
+
+/**
+ * Whether an ANCESTOR of `dir` (walking up from `dir`'s parent, not `dir`
+ * itself — `dir` is the fresh project root and never has one yet) already
+ * has a `pnpm-workspace.yaml`. Mirrors `initGitRepo`'s "never nest"
+ * precedent above: pnpm resolves the nearest `pnpm-workspace.yaml` upward
+ * from cwd as the workspace root, so writing a new one inside an existing
+ * pnpm monorepo (e.g. scaffolding into `apps/docs/` under a parent
+ * workspace) would carve the generated project out of that parent
+ * workspace's install/lockfile instead of joining it (codex-review finding,
+ * #2923).
+ */
+export function hasAncestorPnpmWorkspace(dir: string): boolean {
+  let current = path.dirname(path.resolve(dir));
+  while (true) {
+    if (fs.existsSync(path.join(current, "pnpm-workspace.yaml"))) return true;
+    const parent = path.dirname(current);
+    if (parent === current) return false; // reached the filesystem root
+    current = parent;
   }
 }
 

--- a/packages/create-zudo-doc/templates/features/claudeSkills/files/.claude/skills/zudo-doc-design-system/SKILL.md
+++ b/packages/create-zudo-doc/templates/features/claudeSkills/files/.claude/skills/zudo-doc-design-system/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: zudo-doc-design-system
+description: "Project-specific CSS and component rules for zudo-doc. Must be consulted before writing or editing CSS, Tailwind classes, color tokens, or component markup in this project. Covers: component-first strategy, design token system, three-tier color architecture, and palette index convention. Triggered by 'design system', 'zudo-doc-design-system', 'zudo-doc-css-wisdom' (old name)."
+user-invocable: true
+argument-hint: "[topic: tokens, colors, component-first, palette]"
+---
+
+# zudo-doc CSS & Component Rules
+
+**IMPORTANT**: These rules are mandatory for all code changes in this project that touch CSS, Tailwind classes, color tokens, or component markup. Read the relevant section before making changes.
+
+## How to Use
+
+Based on the topic, read the specific reference doc:
+
+| Topic | File |
+|-------|------|
+| Spacing, typography, layout tokens | `src/content/docs/reference/design-system.mdx` |
+| Component-first methodology | `src/content/docs/reference/component-first.mdx` |
+| Color tokens, palette, schemes | `src/content/docs/reference/color.mdx` |
+
+Read ONLY the file relevant to your task. Apply its rules strictly.
+
+## Quick Rules (always apply)
+
+### Component First (no custom CSS classes)
+
+- **NEVER** create CSS module files, custom class names, or separate stylesheets
+- **ALWAYS** use Tailwind utility classes directly in component markup
+- The component itself is the abstraction — `.card`, `.btn-primary` are forbidden
+- Use props for variants, not CSS modifiers
+
+### Design Tokens (no arbitrary values)
+
+- **NEVER** use Tailwind default colors (`bg-gray-500`, `text-blue-600`) — they are reset to `initial`
+- **NEVER** use arbitrary values (`text-[0.875rem]`, `p-[1.2rem]`) when a token exists
+- **ALWAYS** use project tokens: `text-fg`, `bg-surface`, `border-muted`, `p-hsp-md`, `text-small`
+- Spacing: `hsp-*` (horizontal), `vsp-*` (vertical) — see design-system.mdx for full list
+- Typography: `text-caption`, `text-small`, `text-body`, `text-heading` etc.
+
+### Color Tokens (three-tier system)
+
+- **Tier 1** (ramps): shared `base` (5 stops), `accent` (3 stops), and `state` (`danger`/`success`/`warning`/`info`) OKLCH ramps — no Tailwind utility reaches these directly (no `p0`–`p15`-style classes); they only feed Tier 2
+- **Tier 2** (semantic): `text-fg`, `bg-surface`, `border-muted`, `text-accent` — the only Tailwind-facing color tokens; prefer these always
+- **NEVER** use hardcoded hex values in components
+- Both bundled schemes (`Default Light`, `Default Dark`) share the same ramps; only their per-mode wiring (`map`) differs — see `packages/zudo-doc/src/color-schemes-defaults/index.ts` (package-owned; the former host copy, `src/config/color-schemes.ts`, was deleted as byte-identical dead weight in the minimal-scaffold cutover, epic #2651)
+
+### Search & highlight tokens (role-split)
+
+Highlight roles are deliberately split across dedicated semantic tokens — do **not** share one token across unrelated highlight UIs.
+
+- `matched-keyword-bg` / `matched-keyword-fg` — background and foreground of the search panel `<mark>` element. Driven by `--color-matched-keyword-bg` / `--color-matched-keyword-fg`; live-editable in the Design Token Panel. This is the single source of truth for "why is this color yellow in the search results" — the panel swatch matches the rendered highlight 1:1.
+- `warning` — drives admonitions (`:::warning`), find-in-page (`.find-match`, `.find-match-active`), and any UI that is semantically a warning. Do **not** reuse it for new UI-chrome highlights.
+
+**Rule**: when a new highlight role appears (new kind of mark, new pill, new callout), add a dedicated semantic token rather than bolting it onto `--color-warning` or another existing token. Each visible highlight color should map to exactly one panel swatch.
+
+### Hover-state underline for link-like elements
+
+Any element that navigates (rendered as `<a href>` or behaves as a link) MUST have `hover:underline focus-visible:underline`. Keyboard users need the same affordance as mouse users — never add `hover:underline` without the `focus-visible:underline` pair.
+
+- **Links (do underline)**: doc content links, sidebar items, header main-nav, header overflow menu items, color-tweak panel unselected tabs, search result rows, footer links, doc history entries, breadcrumb trails, mobile TOC entries.
+- **Controls (do NOT underline)**: buttons, toggles, sidebar resizer, palette selectors, color swatches, close icons. These use border/bg hover instead.
+
+Precedents to copy the pattern from: any current `.tsx` component in `src/components/` (e.g. `site-tree-nav.tsx`).
+
+See also: `/css-wisdom` for light-mode / dark-mode contrast rules and the broader three-tier token strategy.
+
+### Server-rendered Preact vs client islands
+
+- Default to **server-rendered Preact `.tsx`** (no `client:*` directive) — emits zero JS. See `src/CLAUDE.md` for the canonical rule: "All components are Preact `.tsx` — there are no `.astro` files."
+- Promote to a **client island** only when interactivity is needed
+- Both follow the same utility-class approach

--- a/packages/create-zudo-doc/templates/features/claudeSkills/files/.claude/skills/zudo-doc-translate/SKILL.md
+++ b/packages/create-zudo-doc/templates/features/claudeSkills/files/.claude/skills/zudo-doc-translate/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: zudo-doc-translate
+description: Translate zudo-doc documentation between English and Japanese with project-specific conventions.
+triggers:
+  - translate
+  - 翻訳
+  - i18n
+  - en to ja
+  - ja to en
+  - translate docs
+  - ドキュメント翻訳
+---
+
+# zudo-doc Translation Skill
+
+Translate documentation between English and Japanese following project-specific conventions.
+
+## i18n Structure
+
+- English docs: `src/content/docs/` — routes at `/docs/...`
+- Japanese docs: `src/content/docs-ja/` — routes at `/ja/docs/...`
+- Directory structures must mirror each other exactly (same filenames, same folder hierarchy)
+- Locale settings: `locales` in `src/config/settings.ts`
+- zfb i18n config: `zfb.config.ts` with `prefixDefaultLocale: false` (English has no prefix, Japanese uses `/ja/`)
+
+## Translation Rules
+
+### Keep in English (do NOT translate)
+
+- Component names: `<Note>`, `<Tip>`, `<Info>`, `<Warning>`, `<Danger>`, `<Tabs>`, `<TabItem>`, `<Details>`
+- Code blocks — code is universal
+- File paths: `src/content/docs/...`, `.claude/skills/...`, etc.
+- CLI commands: `pnpm dev`, `pnpm build`, etc.
+- Technical terms that are standard in English (e.g., component, props, frontmatter, slug)
+- Frontmatter field keys (`title`, `description`, `sidebar_position`, `category`)
+
+### Translate
+
+- Frontmatter field values (e.g., the `title` value, the `description` value)
+- The `title` prop of admonition components (e.g., `<Note title="注意">`)
+- Prose content, headings, list items, table cells (except as noted below)
+
+### Table conventions
+
+- In tables with a "Required" column: use **"Yes"** / **"No"** directly, NOT "はい" / "いいえ" — Japanese conversational yes/no is unnatural in technical documentation
+
+### Internal links
+
+- Adjust link paths when translating:
+  - En→Ja: `/docs/getting-started` → `/ja/docs/getting-started`
+  - Ja→En: `/ja/docs/getting-started` → `/docs/getting-started`
+
+## File Naming
+
+- Japanese files use the **same filenames** as English (e.g., `writing-docs.mdx`)
+- Only the parent directory differs: `docs/` vs `docs-ja/`
+- Example: `src/content/docs/guides/writing-docs.mdx` → `src/content/docs-ja/guides/writing-docs.mdx`
+
+## Workflow
+
+### En→Ja Translation
+
+1. Read the English source file from `src/content/docs/`
+2. Check if the corresponding Japanese file already exists in `src/content/docs-ja/`
+   - If it exists, read it first — use it as a base and update from the English source rather than overwriting from scratch
+   - If it does not exist, create the file at the equivalent path in `src/content/docs-ja/`
+3. Translate the content following the rules above
+4. Verify internal links point to `/ja/docs/...`
+
+### Ja→En Translation
+
+1. Read the Japanese source file from `src/content/docs-ja/`
+2. Check if the corresponding English file already exists in `src/content/docs/`
+   - If it exists, read it first — use it as a base and update from the Japanese source rather than overwriting from scratch
+   - If it does not exist, create the file at the equivalent path in `src/content/docs/`
+3. Translate the content following the rules above
+4. Verify internal links point to `/docs/...` (no `/ja/` prefix)
+
+### Post-Translation Checks
+
+- Frontmatter keys are unchanged (only values translated)
+- All admonition component names remain in English
+- Code blocks are untouched
+- Internal links use the correct locale prefix
+- Directory structure mirrors the source language

--- a/packages/create-zudo-doc/templates/features/claudeSkills/files/.claude/skills/zudo-doc-version-bump/SKILL.md
+++ b/packages/create-zudo-doc/templates/features/claudeSkills/files/.claude/skills/zudo-doc-version-bump/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: zudo-doc-version-bump
+description: >-
+  Bump package version, generate changelog docs, commit, tag, and create GitHub release. Use when:
+  (1) User says 'version bump', 'bump version', 'release', or 'zudo-doc-version-bump', (2) User
+  wants to create a new release of this project.
+user-invocable: true
+disable-model-invocation: true
+argument-description: "Optional: major, minor, or patch to skip the proposal step"
+---
+
+# /zudo-doc-version-bump
+
+Bump the version, generate changelog doc pages, commit, tag, and create a GitHub release.
+
+## Preconditions
+
+Before doing anything else, verify ALL of the following. If any check fails, stop and tell the user.
+
+1. Current branch is `main`
+2. Working tree is clean (`git status --porcelain` returns empty)
+3. At least one `v*` tag exists (`git tag -l 'v*'`). If no tag exists, tell the user to create the initial tag first (e.g. `git tag v0.1.0 && git push --tags`).
+
+Find the latest version tag:
+
+```bash
+git tag -l 'v*' --sort=-v:refname | head -1
+```
+
+## Analyze changes since last tag
+
+Run:
+
+```bash
+git log <last-tag>..HEAD --oneline
+```
+
+and
+
+```bash
+git diff <last-tag>..HEAD --stat
+```
+
+Categorize each commit by its conventional-commit prefix:
+
+- **Breaking Changes**: commits with an exclamation mark suffix (e.g. `feat!:`) or BREAKING CHANGE in body
+- **Features**: `feat:` prefix
+- **Bug Fixes**: `fix:` prefix
+- **Other Changes**: everything else (`docs:`, `chore:`, `refactor:`, `ci:`, `test:`, `style:`, `perf:`, etc.)
+
+## Propose version bump
+
+Based on the changes:
+
+- If there are breaking changes → propose **major** bump
+- If there are features (no breaking) → propose **minor** bump
+- Otherwise → propose **patch** bump
+
+If the user passed an argument (`major`, `minor`, or `patch`), use that directly instead of proposing.
+
+Present the proposal to the user:
+
+```
+Proposed bump: {current} → {new} ({type})
+
+Breaking Changes:
+- description (hash)
+
+Features:
+- description (hash)
+
+Bug Fixes:
+- description (hash)
+
+Other Changes:
+- description (hash)
+```
+
+Only show sections that have entries. **Wait for user confirmation before proceeding.**
+
+If this is a **major** version bump, ask the user whether they want to archive the current docs as a versioned snapshot (i.e. run with `--snapshot`). Explain that this copies the current docs to a versioned directory for the old version.
+
+## Run version-bump.sh
+
+Run the existing version bump script to update package.json and create changelog entry files:
+
+```bash
+./scripts/version-bump.sh {NEW_VERSION}
+# Or with snapshot for major bumps:
+./scripts/version-bump.sh {NEW_VERSION} --snapshot
+```
+
+This script:
+
+1. Updates `version` in `package.json`
+2. Creates `src/content/docs/changelog/{NEW_VERSION}.mdx` (EN)
+3. Creates `src/content/docs-ja/changelog/{NEW_VERSION}.mdx` (JA)
+4. With `--snapshot`: copies current docs to versioned directories and prints settings.ts entry to add
+
+## Fill in changelog content
+
+After the script creates the template files, **replace the placeholder content** with the actual categorized changes from the commit analysis.
+
+### English changelog (`src/content/docs/changelog/{NEW_VERSION}.mdx`)
+
+```mdx
+---
+title: {NEW_VERSION}
+description: Release notes for {NEW_VERSION}.
+sidebar_position: {value from script}
+---
+
+Released: {YYYY-MM-DD}
+
+### Breaking Changes
+
+- Description (commit-hash)
+
+### Features
+
+- Description (commit-hash)
+
+### Bug Fixes
+
+- Description (commit-hash)
+
+### Other Changes
+
+- Description (commit-hash)
+```
+
+### Japanese changelog (`src/content/docs-ja/changelog/{NEW_VERSION}.mdx`)
+
+```mdx
+---
+title: {NEW_VERSION}
+description: {NEW_VERSION}のリリースノート。
+sidebar_position: {value from script}
+---
+
+リリース日: {YYYY-MM-DD}
+
+### 破壊的変更
+
+- Description (commit-hash)
+
+### 機能
+
+- Description (commit-hash)
+
+### バグ修正
+
+- Description (commit-hash)
+
+### その他の変更
+
+- Description (commit-hash)
+```
+
+Rules:
+
+- Only include sections that have entries
+- Use today's date for the release date
+- Each entry should be the commit subject with the short hash in parentheses
+
+## Build and test
+
+Run the full build and test suite to make sure everything is good:
+
+```bash
+pnpm b4push
+```
+
+If anything fails, fix the issue and re-run. Do not proceed with committing until all checks pass.
+
+## Commit changes
+
+Stage and commit **all** version bump changes — include any files modified by b4push formatting fixes:
+
+```bash
+git add package.json src/content/docs/changelog/{NEW_VERSION}.mdx src/content/docs-ja/changelog/{NEW_VERSION}.mdx
+# Also stage any other modified files (e.g. formatting fixes from b4push)
+git diff --name-only | xargs git add
+git commit -m "chore: Bump version to v{NEW_VERSION}"
+```
+
+## Push and wait for CI
+
+Push the commits first (without the tag) and wait for CI to pass:
+
+```bash
+git push
+```
+
+Then check CI status. Use `gh run list --branch main --limit 1 --json status,conclusion,headSha` and verify the `headSha` matches the pushed commit. Poll every 30 seconds, with a **maximum of 10 minutes**. If CI is still running after 10 minutes, ask the user whether to keep waiting or proceed.
+
+If CI fails, investigate the failure with `gh run view <run-id> --log-failed`, fix the issue, commit, and push again.
+
+**Do not tag or publish until CI is green.**
+
+## Tag, push tag, and create GitHub release
+
+**Ask the user for confirmation before tagging.**
+
+```bash
+git tag v{NEW_VERSION}
+git push --tags
+```
+
+After pushing the tag, create a GitHub release. Use `awk` to strip only the YAML frontmatter (first `---` to second `---`) from the changelog file:
+
+```bash
+NOTES=$(awk 'BEGIN{f=0} /^---$/{f++; next} f>=2' src/content/docs/changelog/{NEW_VERSION}.mdx)
+gh release create v{NEW_VERSION} --title "v{NEW_VERSION}" --notes "$NOTES"
+```
+
+## Publish to npm (if applicable)
+
+If the package is **not** marked as `"private": true` in `package.json`, tell the user to publish:
+
+```
+The package is ready for npm publishing. Run:
+
+  pnpm publish
+
+(This requires browser-based 2FA and must be done manually.)
+```
+
+If the package is `"private": true`, skip this step and inform the user:
+
+```
+Package is marked as private — skipping npm publish.
+```
+
+## Done
+
+Report the summary:
+
+- Version bumped: `{OLD_VERSION}` → `{NEW_VERSION}`
+- Changelog created (EN + JA)
+- Git tag: `v{NEW_VERSION}`
+- GitHub release: link to the release
+- npm publish status (published / skipped for private package)

--- a/src/content/docs-ja/getting-started/installation.mdx
+++ b/src/content/docs-ja/getting-started/installation.mdx
@@ -137,6 +137,7 @@ pnpm check
 my-docs/
 ├── .gitignore              # node_modules, dist, .zfb
 ├── .npmrc                  # trust-policy-exclude[]=undici-types@6.21.0
+├── pnpm-workspace.yaml     # minimumReleaseAge: 0（pnpm 11 のリリース経過時間ゲートを無効化）
 ├── CLAUDE.md               # project notes for Claude Code
 ├── package.json            # deps + dev/build/preview/check scripts
 ├── tsconfig.json           # 5-line extends of the package base config

--- a/src/content/docs-ja/reference/create-zudo-doc.mdx
+++ b/src/content/docs-ja/reference/create-zudo-doc.mdx
@@ -217,8 +217,20 @@ await createZudoDoc({
     "docHistory",
     "footerCopyright",
   ],
+  cjkFriendly: false,
+  minifyHtml: true,
+  headerRightItems: [
+    { type: "component", component: "theme-toggle" },
+    { type: "component", component: "github-link" },
+  ],
+  metaTags: {
+    description: true,
+    ogImage: "/img/ogp.png",
+  },
   packageManager: "pnpm",
   install: true,
   git: true,
 });
 ```
+
+`headerRightItems`（[Header Right Items ガイド](../guides/header-right-items.mdx)を参照）と `metaTags`（[設定](../guides/configuration.mdx#metatags)を参照）は、同名の JSON プリセットフィールドと同じ形式を受け付け、同じルールで検証されます — 未知の `headerRightItems` コンポーネント/トリガー名や不正な `metaTags` サブフィールドの型は、スキャフォールド開始前に例外をスローします。

--- a/src/content/docs-ja/reference/create-zudo-doc.mdx
+++ b/src/content/docs-ja/reference/create-zudo-doc.mdx
@@ -233,4 +233,4 @@ await createZudoDoc({
 });
 ```
 
-`headerRightItems`（[Header Right Items ガイド](../guides/header-right-items.mdx)を参照）と `metaTags`（[設定](../guides/configuration.mdx#metatags)を参照）は、同名の JSON プリセットフィールドと同じ形式を受け付け、同じルールで検証されます — 未知の `headerRightItems` コンポーネント/トリガー名や不正な `metaTags` サブフィールドの型は、スキャフォールド開始前に例外をスローします。
+`headerRightItems`（[Header Right Items ガイド](../guides/header-right-items.mdx)を参照）と `metaTags`（[設定](../guides/configuration.mdx#アイデンティティと-url-metatags)を参照）は、同名の JSON プリセットフィールドと同じ形式を受け付け、同じルールで検証されます — 未知の `headerRightItems` コンポーネント/トリガー名や不正な `metaTags` サブフィールドの型は、スキャフォールド開始前に例外をスローします。

--- a/src/content/docs/getting-started/installation.mdx
+++ b/src/content/docs/getting-started/installation.mdx
@@ -137,6 +137,7 @@ A freshly scaffolded project is deliberately small — around a dozen files:
 my-docs/
 ├── .gitignore              # node_modules, dist, .zfb
 ├── .npmrc                  # trust-policy-exclude[]=undici-types@6.21.0
+├── pnpm-workspace.yaml     # minimumReleaseAge: 0 (disables pnpm 11's release-age gate)
 ├── CLAUDE.md               # project notes for Claude Code
 ├── package.json            # deps + dev/build/preview/check scripts
 ├── tsconfig.json           # 5-line extends of the package base config

--- a/src/content/docs/reference/create-zudo-doc.mdx
+++ b/src/content/docs/reference/create-zudo-doc.mdx
@@ -217,8 +217,20 @@ await createZudoDoc({
     "docHistory",
     "footerCopyright",
   ],
+  cjkFriendly: false,
+  minifyHtml: true,
+  headerRightItems: [
+    { type: "component", component: "theme-toggle" },
+    { type: "component", component: "github-link" },
+  ],
+  metaTags: {
+    description: true,
+    ogImage: "/img/ogp.png",
+  },
   packageManager: "pnpm",
   install: true,
   git: true,
 });
 ```
+
+`headerRightItems` (see the [Header Right Items guide](../guides/header-right-items.mdx)) and `metaTags` (see [Configuration](../guides/configuration.mdx#metatags)) accept the same shapes as the JSON preset fields of the same name, and are validated with the same rules — an unknown `headerRightItems` component/trigger name or an invalid `metaTags` sub-field type throws before scaffolding starts.

--- a/src/content/docs/reference/create-zudo-doc.mdx
+++ b/src/content/docs/reference/create-zudo-doc.mdx
@@ -233,4 +233,4 @@ await createZudoDoc({
 });
 ```
 
-`headerRightItems` (see the [Header Right Items guide](../guides/header-right-items.mdx)) and `metaTags` (see [Configuration](../guides/configuration.mdx#metatags)) accept the same shapes as the JSON preset fields of the same name, and are validated with the same rules — an unknown `headerRightItems` component/trigger name or an invalid `metaTags` sub-field type throws before scaffolding starts.
+`headerRightItems` (see the [Header Right Items guide](../guides/header-right-items.mdx)) and `metaTags` (see [Configuration](../guides/configuration.mdx#identity-and-urls-metatags)) accept the same shapes as the JSON preset fields of the same name, and are validated with the same rules — an unknown `headerRightItems` component/trigger name or an invalid `metaTags` sub-field type throws before scaffolding starts.


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2920
- parent PR
    - https://github.com/zudolab/zudo-doc/pull/2903

---

## Summary

Epic-PR for the **Generator Gaps** epic (#2920), part of super-epic #2902. Makes documented `create-zudo-doc` behavior actually true. Targets super base `base/sweep-260718`; super-PR (#2903) merges the batch into `main`.

## Changes

- **#2921 — ship claudeSkills content in the npm package.** npm `files` can't reach `../../.claude/skills`, so `claudeSkills: true` silently no-op'd under a real install. Mirrored the 3 skill sources into `templates/features/claudeSkills/files/.claude/skills/*/SKILL.md` (a nested `.claude/` dot-dir survives `npm pack` — verified), rewired `scaffold.ts` to copy from there (dropped the `monorepoRoot` reach-out), added a defensive missing-source `console.warn`. Guards: a monorepo drift test (template == source, post-format) + a fast-tier tarball test + a scaffold unit test (incl. warn path).
- **#2922 — CreateOptions preset parity.** Added `cjkFriendly` / `minifyHtml` / `headerRightItems` / `metaTags` to `CreateOptions`; extracted `validateHeaderRightItems()` / `validateMetaTags()` into shared helpers used by BOTH `validatePreset()` and `createZudoDoc()` (no allowlist duplication; tests assert identical messages). `validatePreset()` unchanged. EN+JA docs updated.
- **#2923 — disable pnpm 11's `minimumReleaseAge` gate.** Scaffold now emits `pnpm-workspace.yaml` with `minimumReleaseAge: 0` (verified pnpm 11 honors `pnpm-workspace.yaml`, not `.npmrc`; backward-compatible with pnpm 10). Guarded by `hasAncestorPnpmWorkspace()` so it never nests a second workspace boundary; the manifest grew 12→13 files (docs EN+JA, manifest tests, CLAUDE.md counts all updated). A follow-up `console.warn` (codex P1) tells the user to disable the gate in their parent workspace when the nested-skip path is taken.
- **#2924 — confirm (PASS).** Packed a real `create-zudo-doc-4.1.0.tgz`, installed it from the tarball (not the workspace), and scaffolded via `import { createZudoDoc }`: the 3 skill files ship non-empty, all 4 fields thread into `zfb.config.ts`, no happy-path warning, and `pnpm-workspace.yaml` disables the gate.

## Deferred (raised as `agent-found`, need maintainer decision)
- #2937 — the byte-parity-shipped claudeSkills content references monorepo-only paths (broken in a fresh scaffold; content-vs-mechanism design call; relates to #2930).
- #2938 — the zudo-doc exam-tier `target-manifest` fixture is now stale vs the 13-file scaffold (no test break; a deliberate exam-fixture update, mindful of #2911's re-baselined snapshots).

## Review
`/codex-review` on the full epic diff: one P1 (parent-workspace release-age gap) fixed inline; no other actionable regressions.