### PR TITLE
Scaffold DX Tiny Fixes: exam-fixture 13-file sync + docHistory dev:network

### DIFF
--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -1127,6 +1127,12 @@ describe("scaffold — bodyFootUtil auto-enables docHistory (#1795 behavior, re-
     );
     expect(config).toContain("docHistory: true");
     expect(config).toContain("bodyFootUtilArea: {");
+
+    const pkg = await fs.readJson(projectPath("test-body-foot", "package.json"));
+    expect(pkg.scripts["dev:zfb:network"]).toBe("zfb dev --host 0.0.0.0");
+    expect(pkg.scripts["dev:network"]).toBe(
+      "run-p dev:zfb:network dev:history",
+    );
   });
 });
 
@@ -1245,6 +1251,9 @@ describe("scaffold — CLAUDE.md generation", () => {
     expect(withDocHistory).toContain("run-p");
     expect(withDocHistory).toContain("pnpm dev:zfb");
     expect(withDocHistory).toContain("pnpm dev:history");
+    expect(withDocHistory).toContain("pnpm dev:network");
+    expect(withDocHistory).toContain("pnpm dev:zfb:network");
+    expect(withDocHistory).toContain("pnpm run dev:zfb -- <flags>");
 
     await scaffold(baseChoices);
     const without = await fs.readFile(
@@ -1254,6 +1263,7 @@ describe("scaffold — CLAUDE.md generation", () => {
     expect(without).not.toContain("doc-history API server");
     expect(without).not.toContain("run-p");
     expect(without).toContain("zfb dev server (port 4321)");
+    expect(without).not.toContain("dev:network");
   });
 
   it("documents the built-in MDX components the seed content uses (CategoryNav) (#2703)", async () => {
@@ -1381,6 +1391,10 @@ describe("scaffold — generated package.json", () => {
     expect(pkg.scripts["dev:history"]).toBe(
       "doc-history-server --port 4322 --content-dir src/content/docs",
     );
+    expect(pkg.scripts["dev:zfb:network"]).toBe("zfb dev --host 0.0.0.0");
+    expect(pkg.scripts["dev:network"]).toBe(
+      "run-p dev:zfb:network dev:history",
+    );
     expect(pkg.devDependencies["npm-run-all2"]).toBe("^7.0.2");
   });
 
@@ -1390,6 +1404,8 @@ describe("scaffold — generated package.json", () => {
     expect(pkg.scripts.dev).toBe("zfb dev");
     expect(pkg.scripts["dev:zfb"]).toBeUndefined();
     expect(pkg.scripts["dev:history"]).toBeUndefined();
+    expect(pkg.scripts["dev:zfb:network"]).toBeUndefined();
+    expect(pkg.scripts["dev:network"]).toBeUndefined();
     expect(pkg.devDependencies["npm-run-all2"]).toBeUndefined();
   });
 
@@ -1434,6 +1450,10 @@ describe("scaffold — generated package.json", () => {
     expect(pkg.scripts.dev).toBe("run-p dev:zfb dev:history");
     expect(pkg.scripts["dev:history"]).toBe(
       "doc-history-server --port 4322 --content-dir src/content/docs",
+    );
+    expect(pkg.scripts["dev:zfb:network"]).toBe("zfb dev --host 0.0.0.0");
+    expect(pkg.scripts["dev:network"]).toBe(
+      "run-p dev:zfb:network dev:history",
     );
     expect(pkg.devDependencies["npm-run-all2"]).toBe("^7.0.2");
   });

--- a/packages/create-zudo-doc/src/claude-md-gen.ts
+++ b/packages/create-zudo-doc/src/claude-md-gen.ts
@@ -45,6 +45,12 @@ export function generateCLAUDEFile(choices: UserChoices): string {
     lines.push(
       `- \`${pmRunCommand(pm, "dev")}\` — runs the zfb dev server (port 4321) and the doc-history API server (port 4322) concurrently via \`run-p\` (\`${pmRunCommand(pm, "dev:zfb")}\` / \`${pmRunCommand(pm, "dev:history")}\` individually)`,
     );
+    lines.push(
+      `- \`${pmRunCommand(pm, "dev:network")}\` — same, but zfb binds \`--host 0.0.0.0\` for LAN access (\`${pmRunCommand(pm, "dev:zfb:network")}\` individually); the doc-history server stays loopback-only and LAN clients reach it through zfb's \`/doc-history/*\` dev proxy`,
+    );
+    lines.push(
+      `- \`run-p\` swallows trailing args, so other zfb flags don't forward through \`${pmRunCommand(pm, "dev")}\` — pass them directly instead: \`${pm} run dev:zfb -- <flags>\``,
+    );
   } else {
     lines.push(`- \`${pmRunCommand(pm, "dev")}\` — zfb dev server (port 4321)`);
   }

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -821,6 +821,13 @@ function generatePackageJson(choices: UserChoices) {
     // `run-p` (npm-run-all2, added to devDependencies above) runs both.
     scripts.dev = "run-p dev:zfb dev:history";
     scripts["dev:zfb"] = "zfb dev";
+    // run-p swallows trailing args and npm-run-all2 v7's `{@}` placeholder
+    // strips flag names, so `pnpm dev -- --host 0.0.0.0` is silently ignored
+    // (verified in issue #2940) — dev:network is a dedicated LAN-bound script
+    // instead. Only zfb binds 0.0.0.0; the history server stays loopback-only
+    // and LAN clients reach it through zfb's `/doc-history/*` dev proxy.
+    scripts["dev:zfb:network"] = "zfb dev --host 0.0.0.0";
+    scripts["dev:network"] = "run-p dev:zfb:network dev:history";
     // Relative --content-dir/--locale paths are resolved by resolveContentPath
     // (packages/doc-history-server/src/args.ts) against INIT_CWD (falling back
     // to process.cwd()) — correct for the supported invocation (`<pm> dev` /

--- a/packages/zudo-doc/src/__tests__/fixtures/target-manifest/CLAUDE.md
+++ b/packages/zudo-doc/src/__tests__/fixtures/target-manifest/CLAUDE.md
@@ -1,7 +1,7 @@
 # target-manifest-confirm
 
 Confirm-gate fixture (epic zudolab/zudo-doc#2651, #2659) proving the locked
-12-file minimal-scaffold manifest builds, dev-serves, hydrates, and
+13-file minimal-scaffold manifest builds, dev-serves, hydrates, and
 typechecks from the npm-packed `@takazudo/zudo-doc` package. Not a real
 project — do not scaffold from this directory.
 

--- a/packages/zudo-doc/src/__tests__/fixtures/target-manifest/pnpm-workspace.yaml
+++ b/packages/zudo-doc/src/__tests__/fixtures/target-manifest/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+# pnpm 11 defaults minimumReleaseAge to 1440min; its exclude matcher can't match this project's peer-nested lockfile keys (upstream pnpm bug), so disable the gate outright.
+minimumReleaseAge: 0

--- a/packages/zudo-doc/src/__tests__/fixtures/target-manifest/zfb.config.ts
+++ b/packages/zudo-doc/src/__tests__/fixtures/target-manifest/zfb.config.ts
@@ -1,5 +1,5 @@
 // Target-manifest confirm fixture (Wave 5, epic zudolab/zudo-doc#2651, #2659).
-// This IS the whole config surface under test — the locked 12-file manifest's
+// This IS the whole config surface under test — the locked 13-file manifest's
 // central claim ("one config file") lives or dies on this file typechecking
 // and building cleanly through `zudoDoc()` (#2657), with NO local shim and a
 // tsconfig that `include`s `pages/` (so the doc stub below is really
@@ -10,7 +10,7 @@ import { zudoDoc } from "@takazudo/zudo-doc/config";
 export default defineConfig(
   zudoDoc({
     siteName: "Target Manifest Confirm",
-    siteDescription: "Locked 12-file minimal-scaffold confirm fixture",
+    siteDescription: "Locked minimal-scaffold confirm fixture",
     sitemap: true,
     // Assertion group 2 (island-set diff) requires this ON — the
     // DesignTokenPanelBootstrap island must reach the SAME pages a

--- a/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
+++ b/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
@@ -64,7 +64,7 @@ const FIXTURE_SRC = resolve(__dirname, "fixtures/route-injection");
  *  to exercise the locale-prefixed injected route (`/[locale]/docs/[[...slug]]`). */
 const FIXTURE_I18N_SRC = resolve(__dirname, "fixtures/route-injection-i18n");
 
-/** The locked 12-file target-manifest fixture (epic zudolab/zudo-doc#2651 Wave
+/** The locked 13-file target-manifest fixture (epic zudolab/zudo-doc#2651 Wave
  *  5, #2659) — see the "Case TM" section near the end of this file. */
 const TARGET_MANIFEST_FIXTURE_SRC = resolve(__dirname, "fixtures/target-manifest");
 
@@ -1177,15 +1177,16 @@ describe("S1 no-src: published package (routes-src/, no src/) renders injected r
 // ---------------------------------------------------------------------------
 // Case TM — target-manifest confirm (epic zudolab/zudo-doc#2651 Wave 5, #2659).
 //
-// The locked 12-file minimal-scaffold manifest (#2653 decision wave):
+// The locked 13-file minimal-scaffold manifest (#2653 decision wave):
 //
 //   zfb.config.ts  package.json  tsconfig.json  CLAUDE.md  .gitignore  .npmrc
+//   pnpm-workspace.yaml
 //   pages/index.tsx                       — 1-line re-export
 //   pages/docs/[[...slug]].tsx            — self-contained doc stub (REQUIRED)
 //   src/content/docs/getting-started/{index,introduction,installation}.mdx
 //   src/styles/global.css                 — ~22 ln
 //
-// committed verbatim at fixtures/target-manifest/ (12 files, guarded by the
+// committed verbatim at fixtures/target-manifest/ (13 files, guarded by the
 // "group 6" file-count test below). Built from the NPM-PACKED package (mirrors
 // Case S1's `packPackage()`/tarball-extraction flow, not the cheap workspace
 // symlink `setupFixture()` used by Cases A–DTP/HOME/B) so the confirm proof
@@ -1390,12 +1391,12 @@ function countFilesRecursive(dir: string): number {
 }
 
 // ---------------------------------------------------------------------------
-// Group 6 — fixture file count == the locked 12-file manifest.
+// Group 6 — fixture file count == the locked 13-file manifest.
 // ---------------------------------------------------------------------------
 
-describe("TM group 6: fixture file count matches the locked 12-file manifest exactly", () => {
-  it("fixtures/target-manifest/ contains exactly 12 files (guards floor creep)", () => {
-    expect(countFilesRecursive(TARGET_MANIFEST_FIXTURE_SRC)).toBe(12);
+describe("TM group 6: fixture file count matches the locked 13-file manifest exactly", () => {
+  it("fixtures/target-manifest/ contains exactly 13 files (guards floor creep)", () => {
+    expect(countFilesRecursive(TARGET_MANIFEST_FIXTURE_SRC)).toBe(13);
   });
 });
 

--- a/src/content/docs-ja/guides/doc-history.mdx
+++ b/src/content/docs-ja/guides/doc-history.mdx
@@ -153,6 +153,8 @@ dist/doc-history/
 
 開発モードでは、doc-history-serverがポート4322でスタンドアロンREST APIサーバーとして実行され、zfb開発サーバーと同時に起動されます。これは既存プロジェクトで`docHistory: true`を設定するだけで自動的に得られるものではありません — `docHistory`を選択した新規`create-zudo-doc` scaffoldは、`dev`スクリプトとして`run-p dev:zfb dev:history`（`zfb dev`とインストール済みの`doc-history-server`バイナリを同時に実行）を生成します。これは、単純な`zfb dev`だけではポート4322のサーバーが起動しないためです。doc-historyのzfbプラグインの`devMiddleware`フックがブラウザからの`/doc-history/*`リクエストをこのサーバーにプロキシします。
 
+`run-p`は末尾の引数を飲み込んでしまうため、これらのscaffoldでは`pnpm dev -- --host 0.0.0.0`を渡しても静かに無視されます。LANアクセスが必要な場合は代わりに専用の`pnpm dev:network`スクリプトを使ってください。zfbだけが`0.0.0.0`にバインドされ、doc-history-serverはループバック限定のまま（同じ`/doc-history/*`プロキシ経由でアクセスされます）。それ以外のzfbフラグを渡したい場合は、`pnpm dev`経由ではなく`<pm> run dev:zfb -- <flags>`でzfbプロセスへ直接転送してください。
+
 履歴パネルを開くと、その場でgitコマンドが実行されます -- 事前生成は不要です。サーバーのファイルインデックスは10秒ごとにリフレッシュされるため、新しいファイルやリネームされたファイルが自動的に検出されます。これにより、履歴は最新のコミットと常に同期されます。
 
 <Warning>

--- a/src/content/docs/guides/doc-history.mdx
+++ b/src/content/docs/guides/doc-history.mdx
@@ -153,6 +153,8 @@ dist/doc-history/
 
 In dev mode, the doc-history-server runs as a standalone REST API server on port 4322, launched concurrently with the zfb dev server. This is not automatic just from setting `docHistory: true` in an existing project — a fresh `create-zudo-doc` scaffold with `docHistory` selected emits a `dev` script of `run-p dev:zfb dev:history` (running `zfb dev` and the installed `doc-history-server` bin concurrently) specifically because a plain `zfb dev` never starts the :4322 server on its own. The doc-history zfb plugin's `devMiddleware` hook proxies `/doc-history/*` requests from the browser to this server.
 
+Because `run-p` swallows trailing args, `pnpm dev -- --host 0.0.0.0` is silently ignored on these scaffolds — use the dedicated `pnpm dev:network` script instead, which binds zfb to `0.0.0.0` for LAN access while the doc-history server stays loopback-only (reached via the same `/doc-history/*` proxy). For any other zfb flag, forward it directly to the zfb process with `<pm> run dev:zfb -- <flags>` rather than through `pnpm dev`.
+
 When you open the history panel, it runs git commands on the fly -- no pre-generation needed. The server's file index refreshes every 10 seconds, so new or renamed files are picked up automatically. This means history is always up-to-date with your latest commits.
 
 <Warning>


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/2943
- parent PR
    - https://github.com/zudolab/zudo-doc/pull/2942

---

## Summary

Epic-PR for **Scaffold DX Tiny Fixes** (#2943), a child epic of super-epic #2941. Bundles two independent tiny generator/test-hygiene fixes from the 260718-2 sweep:

1. **#2944** — Sync the exam-tier `target-manifest` fixture back to the real 13-file `create-zudo-doc` scaffold (#2923 added `pnpm-workspace.yaml`; fixture still had 12 files + stale "12-file" guards).
2. **#2945** — Restore LAN-access DX for docHistory scaffolds: ship a `dev:network` script (zfb LAN-bound + history server) and document `<pm> run dev:zfb -- <flags>` forwarding.

Targets the super-epic base `base/sweep-260718-2`.

## Topic PRs
(to be added as topics are completed)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786968806&installation_id=130359969&pr_number=2950&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2950&signature=c943ea4a29108421d996167f73f4b99230aa39314f59e734245bb071aa59ad06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->