### PR TITLE
Update global CSS drift rationale

### DIFF
--- a/.template-drift-allowlist
+++ b/.template-drift-allowlist
@@ -21,19 +21,21 @@
 # The template ships a fixed ~29-line @import chain (Tailwind preflight +
 # utilities, the five @takazudo/zudo-doc/*.css artifacts, three @source scan
 # roots, and an empty @theme token-override slot) — see #2655/#2660. The
-# showcase's own global.css additionally declares ~300 lines of its OWN
-# @theme token block (the full three-tier color/spacing/typography system
-# documented in src/CLAUDE.md) plus extra @source roots for
+# showcase now shares the template's package-theme contract by importing both
+# `@takazudo/zudo-doc/theme.css` and `@takazudo/zudo-doc/safelist.css`. Its
+# remaining intentional differences are extra @source roots for
 # packages/zudo-doc/**, packages/create-zudo-doc/templates/**, src/hooks/**,
-# src/utils/** (paths the minimal template's own scan roots don't need to
-# cover) and several project-specific base-style rules (find-in-page/search
-# highlight colors, version-switcher responsive visibility). Byte parity is
-# neither expected nor desired; the separate, unconditional
-# check_global_css_legacy_tokens() guard in scripts/check-template-drift.sh
+# and src/utils/** (paths the minimal template's own scan roots don't need),
+# an unconditional `@takazudo/zdtp/styles.css` import because the showcase
+# always enables the design token panel, and the single
+# `--color-page-loading-overlay` token in a trailing @theme override block.
+# Byte parity is therefore neither expected nor desired; the separate,
+# unconditional check_global_css_legacy_tokens() guard in
+# scripts/check-template-drift.sh
 # (#2621, rewritten for the minimal form by #2663) still catches the drift
 # classes that matter: a legacy pre-ramp-restructure token reference, or the
-# template losing its `@import "@takazudo/zudo-doc/theme.css"` default
-# token-set import.
+# loss of the `@import "@takazudo/zudo-doc/theme.css"` default token-set
+# import.
 src/styles/global.css
 
 # ── tsconfig.json ───────────────────────────────────────────────────────────


### PR DESCRIPTION
Parent: #2960

## Summary

- correct the global CSS drift-allowlist rationale for the package-theme contract
- preserve the existing template CSS because its theme and safelist imports are already correct

## Tests

- `pnpm check:template-drift`
- `git diff --check`
- foreground self-review

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786998989&installation_id=130359969&pr_number=2982&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2982&signature=634539bdeb603d04721d8b9a7dc2fab6f70d50929c037f9e0af49c9c5297c110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->