### PR TITLE
Batch theme and documentation cleanups

### DIFF
--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -1269,6 +1269,10 @@ describe("scaffold — CLAUDE.md generation", () => {
     expect(withDocHistory).toContain("pnpm dev:history");
     expect(withDocHistory).toContain("pnpm dev:network");
     expect(withDocHistory).toContain("pnpm dev:zfb:network");
+    expect(withDocHistory).toContain("**Trusted networks only:**");
+    expect(withDocHistory).toContain(
+      "UNPUBLISHED local commits — to anyone on the LAN via the `/doc-history/*` proxy",
+    );
     expect(withDocHistory).toContain("pnpm run dev:zfb -- <flags>");
 
     await scaffold(baseChoices);
@@ -1280,6 +1284,7 @@ describe("scaffold — CLAUDE.md generation", () => {
     expect(without).not.toContain("run-p");
     expect(without).toContain("zfb dev server (port 4321)");
     expect(without).not.toContain("dev:network");
+    expect(without).not.toContain("Trusted networks only");
   });
 
   it("documents the built-in MDX components the seed content uses (CategoryNav) (#2703)", async () => {

--- a/packages/create-zudo-doc/src/claude-md-gen.ts
+++ b/packages/create-zudo-doc/src/claude-md-gen.ts
@@ -49,6 +49,9 @@ export function generateCLAUDEFile(choices: UserChoices): string {
       `- \`${pmRunCommand(pm, "dev:network")}\` — same, but zfb binds \`--host 0.0.0.0\` for LAN access (\`${pmRunCommand(pm, "dev:zfb:network")}\` individually); the doc-history server stays loopback-only and LAN clients reach it through zfb's \`/doc-history/*\` dev proxy`,
     );
     lines.push(
+      `- **Trusted networks only:** this also serves your git doc-history — including UNPUBLISHED local commits — to anyone on the LAN via the \`/doc-history/*\` proxy`,
+    );
+    lines.push(
       `- \`run-p\` swallows trailing args, so other zfb flags don't forward through \`${pmRunCommand(pm, "dev")}\` — pass them directly instead: \`${pm} run dev:zfb -- <flags>\``,
     );
   } else {

--- a/packages/create-zudo-doc/templates/base/scripts/setup-doc-skill.sh
+++ b/packages/create-zudo-doc/templates/base/scripts/setup-doc-skill.sh
@@ -81,6 +81,8 @@ REPO_ROOT="$(git -C "$ROOT_DIR" worktree list | head -1 | awk '{print $1}')"
 # worktree root, above) reconstructs the equivalent path there even when
 # running from inside a different worktree.
 PROJECT_PREFIX="$(git -C "$ROOT_DIR" rev-parse --show-prefix)"
+MAIN_PROJECT_DIR="$REPO_ROOT/${PROJECT_PREFIX}"
+MAIN_PROJECT_DIR="${MAIN_PROJECT_DIR%/}"
 REPO_DOCS_DIR="$REPO_ROOT/${PROJECT_PREFIX}src/content/docs"
 REPO_DOCS_JA_DIR="$REPO_ROOT/${PROJECT_PREFIX}src/content/docs-ja"
 
@@ -142,7 +144,7 @@ fi
 # even when the project is nested inside a larger git repo (running `pnpm
 # build` from the outer repo root would otherwise invoke the wrong
 # package.json, #2918).
-VERIFY_STEP="Run \`pnpm build\` from \`$ROOT_DIR\` to confirm the site builds correctly."
+VERIFY_STEP="Run \`pnpm build\` from \`$MAIN_PROJECT_DIR\` to confirm the site builds correctly."
 
 resolve_targets() {
   case "$TARGET_MODE" in
@@ -204,7 +206,7 @@ argument-hint: "[-u|--update] [topic keyword, e.g., 'configuration', 'sidebar', 
 # $PROJECT_NAME Documentation Reference
 
 Look up documentation from the $PROJECT_NAME project for $assistant_label.
-Documentation base path: \`src/content/docs\` (relative to the project root: \`$ROOT_DIR\`)
+Documentation base path: \`src/content/docs\` (relative to the project root: \`$MAIN_PROJECT_DIR\`)
 
 ## Mode Detection
 
@@ -234,7 +236,7 @@ The user has new information and wants to add or update documentation in this re
    the topic. Read them to understand what is already covered.
 3. **Decide create vs update**: If an existing article covers the topic, update
    it. Otherwise, create a new \`.mdx\` file in the appropriate subdirectory.
-4. **Write the content**: Follow the doc-authoring rules in this project's CLAUDE.md (\`$ROOT_DIR/CLAUDE.md\`):
+4. **Write the content**: Follow the doc-authoring rules in this project's CLAUDE.md (\`$MAIN_PROJECT_DIR/CLAUDE.md\`):
    - Required frontmatter: \`title\` (string). Always set \`sidebar_position\`.
      Optional: \`description\`, \`sidebar_label\`, \`tags\`, etc.
    - Do NOT use \`# h1\` in content — the frontmatter \`title\` renders as h1.

--- a/packages/zudo-doc/src/config/component-tokens.ts
+++ b/packages/zudo-doc/src/config/component-tokens.ts
@@ -514,7 +514,7 @@ export const COMPONENT_TOKENS: ComponentToken[] = [
     surface: "chrome",
     category: "typography",
     description:
-      "Font family of the navigation sidebar — covers BOTH the desktop `#desktop-sidebar` rail and the mobile drawer, so one override styles both viewports and neither drifts onto a different face. Defaults to the `--zdc-chrome-font` seam (a no-op until redefined).",
+      "Font family of the navigation sidebar — covers BOTH the desktop `#desktop-sidebar` rail and the mobile drawer, so one override styles both viewports and neither drifts onto a different face. Defaults to the `--zdc-chrome-font` seam (a no-op until redefined). Verify granular MOBILE chrome-font overrides with `zfb build`/preview, not `pnpm dev`: the current zfb dev server strips island-root `data-*` attributes, so the mobile selector silently does not match.",
   },
   {
     cssVar: "--zdc-toc-font",
@@ -525,6 +525,6 @@ export const COMPONENT_TOKENS: ComponentToken[] = [
     surface: "chrome",
     category: "typography",
     description:
-      "Font family of the table of contents — covers BOTH the desktop right rail and the mobile collapsible TOC, so one override styles both viewports. Defaults to the `--zdc-chrome-font` seam (a no-op until redefined), which also keeps the mobile TOC on the chrome font rather than the prose font of the `.zd-content` it renders inside.",
+      "Font family of the table of contents — covers BOTH the desktop right rail and the mobile collapsible TOC, so one override styles both viewports. Defaults to the `--zdc-chrome-font` seam (a no-op until redefined), which also keeps the mobile TOC on the chrome font rather than the prose font of the `.zd-content` it renders inside. Verify granular MOBILE chrome-font overrides with `zfb build`/preview, not `pnpm dev`: the current zfb dev server strips island-root `data-*` attributes, so the mobile selector silently does not match.",
   },
 ];

--- a/packages/zudo-doc/src/theme-packs-registry/__tests__/validator.test.ts
+++ b/packages/zudo-doc/src/theme-packs-registry/__tests__/validator.test.ts
@@ -237,6 +237,37 @@ describe("validateThemePack", () => {
     expect(extraFontFace.issues.some((i) => i.rule === "font-face-parity")).toBe(true);
   });
 
+  it("rejects a local @font-face source missing from fontFiles", () => {
+    const result = validateThemePack(
+      baseInput({
+        cssContent: VALID_FOUNDRY_CSS.replace("Inter-latin.woff2", "Missing.woff2"),
+      }),
+    );
+    const issue = result.issues.find((i) => i.rule === "font-file-missing");
+    expect(issue?.severity).toBe("error");
+    expect(result.valid).toBe(false);
+  });
+
+  it("accepts local @font-face sources listed in fontFiles", () => {
+    const result = validateThemePack(baseInput());
+    expect(result.issues.filter((i) => i.rule === "font-file-missing")).toEqual([]);
+  });
+
+  it("skips non-local and cache-busted @font-face sources", () => {
+    const cssContent = VALID_FOUNDRY_CSS.replace(
+      'url("./fonts/Inter-latin.woff2")',
+      [
+        'url("data:font/woff2;base64,AA==")',
+        'url("https://example.com/Inter.woff2")',
+        'url("../fonts/Inter.woff2")',
+        'url("./fonts/Inter.woff2?v=1")',
+        'url("./fonts/Inter.woff2#variation")',
+      ].join(", "),
+    );
+    const result = validateThemePack(baseInput({ cssContent, fontFiles: [] }));
+    expect(result.issues.filter((i) => i.rule === "font-file-missing")).toEqual([]);
+  });
+
   it("requires OFL.txt when font binaries ship", () => {
     const result = validateThemePack(baseInput({ fontFiles: ["Inter-latin.woff2"] }));
     expect(result.issues.some((i) => i.rule === "ofl-required")).toBe(true);
@@ -291,6 +322,14 @@ html[data-theme-pack="futura-editorial"] header[data-header] { background: var(-
       }),
     );
     expect(result.issues.some((i) => i.rule === "commercial-font-denylist")).toBe(false);
+  });
+
+  it("does NOT flag a commercial typeface mentioned only in a CSS comment", () => {
+    const result = validateThemePack(
+      baseInput({ cssContent: `/* Futura substitute: Inter */\n${VALID_FOUNDRY_CSS}` }),
+    );
+    expect(result.issues.some((i) => i.rule === "commercial-font-denylist")).toBe(false);
+    expect(result.valid).toBe(true);
   });
 
   it("rejects preview swatches that aren't plain resolved colors", () => {

--- a/packages/zudo-doc/src/theme-packs-registry/validator.ts
+++ b/packages/zudo-doc/src/theme-packs-registry/validator.ts
@@ -9,11 +9,11 @@
 // schema; `pack.css` presence/absence; every rule scoped under
 // `html[data-theme-pack="<slug>"]`; the known-custom-property-name manifest;
 // preview swatches are plain resolved colors; `fonts.loaded` ⇄ `@font-face`
-// parity; `OFL.txt` presence when font files ship; the commercial-typeface
-// denylist; the `!important` allowlist (the h2–h4 heading-rule
-// `border-image` carve-out); no `color-scheme:` declarations; no `[data-theme]` selectors. A
-// total-payload-size overage is a WARNING, not an error (Decision 6.7's
-// soft ~250 KB budget).
+// parity; local `@font-face` sources exist in `fonts/`; `OFL.txt` presence when
+// font files ship; the commercial-typeface denylist; the `!important`
+// allowlist (the h2–h4 heading-rule `border-image` carve-out); no
+// `color-scheme:` declarations; no `[data-theme]` selectors. A total-payload-
+// size overage is a WARNING, not an error (Decision 6.7's soft ~250 KB budget).
 
 import {
   themePackMetaSchema,
@@ -280,6 +280,34 @@ function checkFontFaceParity(
   }
 }
 
+function checkFontFileExistence(
+  cssContent: string,
+  fontFiles: string[],
+  issues: ThemePackValidationIssue[],
+): void {
+  const availableFiles = new Set(fontFiles);
+  const urlRe = /url\(\s*(?:"([^"]*)"|'([^']*)'|([^)]*))\s*\)/gi;
+
+  for (const rule of parseTopLevelRules(cssContent)) {
+    if (!isFontFaceRule(rule)) continue;
+
+    let match: RegExpExecArray | null;
+    while ((match = urlRe.exec(rule.body)) !== null) {
+      const url = (match[1] ?? match[2] ?? match[3] ?? "").trim();
+      if (!url.startsWith("./fonts/") || /[?#]/.test(url)) continue;
+
+      const basename = url.slice("./fonts/".length).split("/").pop();
+      if (!basename || availableFiles.has(basename)) continue;
+
+      issues.push({
+        rule: "font-file-missing",
+        severity: "error",
+        message: `@font-face references "${url}" but "${basename}" is not present in fonts/`,
+      });
+    }
+  }
+}
+
 function isPlainColorValue(value: string): boolean {
   const v = value.trim();
   if (/var\(|light-dark\(/i.test(v)) return false;
@@ -326,7 +354,10 @@ function checkCommercialDenylist(
   // every scoping selector, making such a pack impossible to author. Strip the
   // scoping attribute selector before scanning so the check only sees real font
   // references (@font-face src + font-family stacks + meta font names).
-  const scannedCss = (cssContent ?? "").replace(/\[data-theme-pack="[^"]*"\]/g, "");
+  const scannedCss = stripComments(cssContent ?? "").replace(
+    /\[data-theme-pack="[^"]*"\]/g,
+    "",
+  );
   const haystack = [
     scannedCss,
     meta.fonts.sans,
@@ -408,6 +439,7 @@ export function validateThemePack(input: ThemePackValidationInput): ThemePackVal
     checkImportantAllowlist(input.cssContent, issues);
     checkNoColorScheme(input.cssContent, issues);
     checkNoDataThemeSelector(input.cssContent, issues);
+    checkFontFileExistence(input.cssContent, input.fontFiles, issues);
   }
 
   if (meta) {

--- a/packages/zudo-doc/src/theme-packs/hearth/pack.css
+++ b/packages/zudo-doc/src/theme-packs/hearth/pack.css
@@ -292,9 +292,8 @@ html[data-theme-pack="hearth"] .zd-content blockquote {
   color: light-dark(oklch(0.38 0.052 42), oklch(0.83 0.032 70));
 }
 
-/* admonitions: soft-cornered, warm-shadowed, hearth icon swaps on
-   the prototype's three variants (candle / coffee / fire); the other
-   four variants keep the stock icons */
+/* admonitions: soft-cornered, warm-shadowed, with a distinct icon
+   from the hearth and fireside vocabulary for every variant */
 html[data-theme-pack="hearth"] [data-admonition] {
   box-shadow: 0 8px 18px -14px light-dark(oklch(0.42 0.09 45 / 0.2), oklch(0.05 0.01 45 / 0.6));
 }
@@ -304,8 +303,20 @@ html[data-theme-pack="hearth"] [data-admonition="note"] .admonition-title::befor
 html[data-theme-pack="hearth"] [data-admonition="tip"] .admonition-title::before {
   content: "☕ ";
 }
+html[data-theme-pack="hearth"] [data-admonition="info"] .admonition-title::before {
+  content: "📜 ";
+}
 html[data-theme-pack="hearth"] [data-admonition="warning"] .admonition-title::before {
   content: "🔥 ";
+}
+html[data-theme-pack="hearth"] [data-admonition="important"] .admonition-title::before {
+  content: "🔔 ";
+}
+html[data-theme-pack="hearth"] [data-admonition="danger"] .admonition-title::before {
+  content: "🧯 ";
+}
+html[data-theme-pack="hearth"] [data-admonition="caution"] .admonition-title::before {
+  content: "♨️ ";
 }
 
 /* table: brick Fraunces header over an accent rule, warm row hover */

--- a/scripts/__tests__/setup-doc-skill.test.ts
+++ b/scripts/__tests__/setup-doc-skill.test.ts
@@ -81,6 +81,23 @@ describe("setup-doc-skill.sh", () => {
     expect(skillMd).toContain("zudo-doc");
   });
 
+  it("uses the main worktree project path in generated instructions", () => {
+    runScript(TEST_SKILL_NAME, fakeHome);
+
+    const skillMd = readFileSync(
+      join(PROJECT_ROOT, ".claude", "skills", TEST_SKILL_NAME, "SKILL.md"),
+      "utf-8",
+    );
+
+    expect(skillMd).toContain(
+      `Run \`pnpm build\` from \`${MAIN_WORKTREE_ROOT}\``,
+    );
+    expect(skillMd).toContain(
+      `(relative to the project root: \`${MAIN_WORKTREE_ROOT}\`)`,
+    );
+    expect(skillMd).toContain(`${MAIN_WORKTREE_ROOT}/CLAUDE.md`);
+  });
+
   it("creates docs symlink pointing to src/content/docs", () => {
     runScript(TEST_SKILL_NAME, fakeHome);
 

--- a/scripts/setup-doc-skill.sh
+++ b/scripts/setup-doc-skill.sh
@@ -81,6 +81,8 @@ REPO_ROOT="$(git -C "$ROOT_DIR" worktree list | head -1 | awk '{print $1}')"
 # worktree root, above) reconstructs the equivalent path there even when
 # running from inside a different worktree.
 PROJECT_PREFIX="$(git -C "$ROOT_DIR" rev-parse --show-prefix)"
+MAIN_PROJECT_DIR="$REPO_ROOT/${PROJECT_PREFIX}"
+MAIN_PROJECT_DIR="${MAIN_PROJECT_DIR%/}"
 REPO_DOCS_DIR="$REPO_ROOT/${PROJECT_PREFIX}src/content/docs"
 REPO_DOCS_JA_DIR="$REPO_ROOT/${PROJECT_PREFIX}src/content/docs-ja"
 
@@ -142,7 +144,7 @@ fi
 # even when the project is nested inside a larger git repo (running `pnpm
 # build` from the outer repo root would otherwise invoke the wrong
 # package.json, #2918).
-VERIFY_STEP="Run \`pnpm build\` from \`$ROOT_DIR\` to confirm the site builds correctly."
+VERIFY_STEP="Run \`pnpm build\` from \`$MAIN_PROJECT_DIR\` to confirm the site builds correctly."
 
 resolve_targets() {
   case "$TARGET_MODE" in
@@ -204,7 +206,7 @@ argument-hint: "[-u|--update] [topic keyword, e.g., 'configuration', 'sidebar', 
 # $PROJECT_NAME Documentation Reference
 
 Look up documentation from the $PROJECT_NAME project for $assistant_label.
-Documentation base path: \`src/content/docs\` (relative to the project root: \`$ROOT_DIR\`)
+Documentation base path: \`src/content/docs\` (relative to the project root: \`$MAIN_PROJECT_DIR\`)
 
 ## Mode Detection
 
@@ -234,7 +236,7 @@ The user has new information and wants to add or update documentation in this re
    the topic. Read them to understand what is already covered.
 3. **Decide create vs update**: If an existing article covers the topic, update
    it. Otherwise, create a new \`.mdx\` file in the appropriate subdirectory.
-4. **Write the content**: Follow the doc-authoring rules in this project's CLAUDE.md (\`$ROOT_DIR/CLAUDE.md\`):
+4. **Write the content**: Follow the doc-authoring rules in this project's CLAUDE.md (\`$MAIN_PROJECT_DIR/CLAUDE.md\`):
    - Required frontmatter: \`title\` (string). Always set \`sidebar_position\`.
      Optional: \`description\`, \`sidebar_label\`, \`tags\`, etc.
    - Do NOT use \`# h1\` in content — the frontmatter \`title\` renders as h1.

--- a/src/config/frontmatter-preview-renderers.tsx
+++ b/src/config/frontmatter-preview-renderers.tsx
@@ -23,11 +23,11 @@ import type { FrontmatterCellRenderer } from "@takazudo/zudo-doc/metainfo";
 type PillColor = "danger" | "success" | "warning" | "info" | "muted";
 
 const pillColorClass: Record<PillColor, string> = {
-  danger: "bg-danger text-fg",
-  success: "bg-success text-fg",
-  warning: "bg-warning text-fg",
-  info: "bg-info text-fg",
-  muted: "bg-surface text-muted border border-muted",
+  danger: "zd-fm-pill--danger",
+  success: "zd-fm-pill--success",
+  warning: "zd-fm-pill--warning",
+  info: "zd-fm-pill--info",
+  muted: "zd-fm-pill--muted",
 };
 
 function Pill({ children, color }: { children: ReactNode; color: PillColor }) {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -73,3 +73,32 @@
 @theme {
   --color-page-loading-overlay: color-mix(in oklch, var(--color-overlay) 60%, transparent);
 }
+
+/* Showcase-only frontmatter preview pills. These explicit rules keep the
+   role-dynamic classes available even though src/config is not an @source
+   root, and mirror the package admonition's 12% semantic-color tint. */
+.zd-fm-pill--danger {
+  color: var(--color-danger);
+  background-color: color-mix(in srgb, var(--color-danger) 12%, var(--color-bg));
+}
+
+.zd-fm-pill--success {
+  color: var(--color-success);
+  background-color: color-mix(in srgb, var(--color-success) 12%, var(--color-bg));
+}
+
+.zd-fm-pill--warning {
+  color: var(--color-warning);
+  background-color: color-mix(in srgb, var(--color-warning) 12%, var(--color-bg));
+}
+
+.zd-fm-pill--info {
+  color: var(--color-info);
+  background-color: color-mix(in srgb, var(--color-info) 12%, var(--color-bg));
+}
+
+.zd-fm-pill--muted {
+  color: var(--color-muted);
+  background-color: color-mix(in srgb, var(--color-muted) 12%, var(--color-bg));
+  border: 1px solid var(--color-muted);
+}


### PR DESCRIPTION
Closes #2961.
Supersedes #2864, #2863, #2935, #2951, #2898.
Contrast follow-up remains tracked in #2869.

## Summary

- complete Hearth admonition icons and harden theme-pack font validation
- adopt explicit 12% tinted frontmatter pills and preserve their generated CSS emission
- align generated doc-skill paths with the main worktree and add the trusted-LAN doc-history caveat
- document the zfb mobile island-root attribute development discrepancy and provide a ready-to-file upstream draft in topic PR 2990

## Verification

- package build and tests: 1,579 passing
- create-zudo-doc tests: 573 passing
- setup-doc-skill tests: 14 passing
- template and fixture-settings drift checks
- showcase typecheck and 388-page build
- all five pill rules and all seven Hearth icon rules emitted
- manager review: no additional actionable code findings

## Known contrast caveat

The required 16-pack light/dark sweep covered 160 role cases. Eight are below 4.5:1 with the locked 12% tint treatment:

- Foundry light: danger 4.336529, success 4.319082, warning 4.166166, info 4.380641
- Hearth light warning: 4.431064
- Sumi light warning: 4.186459
- Washi light warning: 4.449113
- Washi light muted: 4.391564

No narrow correction preserves both the exact 12% tint and raw semantic role colors; coordinated theme palette work remains tracked in #2869.
