### PR TITLE
Harden theme-pack font validation

### DIFF
--- a/packages/zudo-doc/src/theme-packs-registry/__tests__/validator.test.ts
+++ b/packages/zudo-doc/src/theme-packs-registry/__tests__/validator.test.ts
@@ -237,6 +237,37 @@ describe("validateThemePack", () => {
     expect(extraFontFace.issues.some((i) => i.rule === "font-face-parity")).toBe(true);
   });
 
+  it("rejects a local @font-face source missing from fontFiles", () => {
+    const result = validateThemePack(
+      baseInput({
+        cssContent: VALID_FOUNDRY_CSS.replace("Inter-latin.woff2", "Missing.woff2"),
+      }),
+    );
+    const issue = result.issues.find((i) => i.rule === "font-file-missing");
+    expect(issue?.severity).toBe("error");
+    expect(result.valid).toBe(false);
+  });
+
+  it("accepts local @font-face sources listed in fontFiles", () => {
+    const result = validateThemePack(baseInput());
+    expect(result.issues.filter((i) => i.rule === "font-file-missing")).toEqual([]);
+  });
+
+  it("skips non-local and cache-busted @font-face sources", () => {
+    const cssContent = VALID_FOUNDRY_CSS.replace(
+      'url("./fonts/Inter-latin.woff2")',
+      [
+        'url("data:font/woff2;base64,AA==")',
+        'url("https://example.com/Inter.woff2")',
+        'url("../fonts/Inter.woff2")',
+        'url("./fonts/Inter.woff2?v=1")',
+        'url("./fonts/Inter.woff2#variation")',
+      ].join(", "),
+    );
+    const result = validateThemePack(baseInput({ cssContent, fontFiles: [] }));
+    expect(result.issues.filter((i) => i.rule === "font-file-missing")).toEqual([]);
+  });
+
   it("requires OFL.txt when font binaries ship", () => {
     const result = validateThemePack(baseInput({ fontFiles: ["Inter-latin.woff2"] }));
     expect(result.issues.some((i) => i.rule === "ofl-required")).toBe(true);
@@ -291,6 +322,14 @@ html[data-theme-pack="futura-editorial"] header[data-header] { background: var(-
       }),
     );
     expect(result.issues.some((i) => i.rule === "commercial-font-denylist")).toBe(false);
+  });
+
+  it("does NOT flag a commercial typeface mentioned only in a CSS comment", () => {
+    const result = validateThemePack(
+      baseInput({ cssContent: `/* Futura substitute: Inter */\n${VALID_FOUNDRY_CSS}` }),
+    );
+    expect(result.issues.some((i) => i.rule === "commercial-font-denylist")).toBe(false);
+    expect(result.valid).toBe(true);
   });
 
   it("rejects preview swatches that aren't plain resolved colors", () => {

--- a/packages/zudo-doc/src/theme-packs-registry/validator.ts
+++ b/packages/zudo-doc/src/theme-packs-registry/validator.ts
@@ -9,11 +9,11 @@
 // schema; `pack.css` presence/absence; every rule scoped under
 // `html[data-theme-pack="<slug>"]`; the known-custom-property-name manifest;
 // preview swatches are plain resolved colors; `fonts.loaded` ⇄ `@font-face`
-// parity; `OFL.txt` presence when font files ship; the commercial-typeface
-// denylist; the `!important` allowlist (the h2–h4 heading-rule
-// `border-image` carve-out); no `color-scheme:` declarations; no `[data-theme]` selectors. A
-// total-payload-size overage is a WARNING, not an error (Decision 6.7's
-// soft ~250 KB budget).
+// parity; local `@font-face` sources exist in `fonts/`; `OFL.txt` presence when
+// font files ship; the commercial-typeface denylist; the `!important`
+// allowlist (the h2–h4 heading-rule `border-image` carve-out); no
+// `color-scheme:` declarations; no `[data-theme]` selectors. A total-payload-
+// size overage is a WARNING, not an error (Decision 6.7's soft ~250 KB budget).
 
 import {
   themePackMetaSchema,
@@ -280,6 +280,34 @@ function checkFontFaceParity(
   }
 }
 
+function checkFontFileExistence(
+  cssContent: string,
+  fontFiles: string[],
+  issues: ThemePackValidationIssue[],
+): void {
+  const availableFiles = new Set(fontFiles);
+  const urlRe = /url\(\s*(?:"([^"]*)"|'([^']*)'|([^)]*))\s*\)/gi;
+
+  for (const rule of parseTopLevelRules(cssContent)) {
+    if (!isFontFaceRule(rule)) continue;
+
+    let match: RegExpExecArray | null;
+    while ((match = urlRe.exec(rule.body)) !== null) {
+      const url = (match[1] ?? match[2] ?? match[3] ?? "").trim();
+      if (!url.startsWith("./fonts/") || /[?#]/.test(url)) continue;
+
+      const basename = url.slice("./fonts/".length).split("/").pop();
+      if (!basename || availableFiles.has(basename)) continue;
+
+      issues.push({
+        rule: "font-file-missing",
+        severity: "error",
+        message: `@font-face references "${url}" but "${basename}" is not present in fonts/`,
+      });
+    }
+  }
+}
+
 function isPlainColorValue(value: string): boolean {
   const v = value.trim();
   if (/var\(|light-dark\(/i.test(v)) return false;
@@ -326,7 +354,10 @@ function checkCommercialDenylist(
   // every scoping selector, making such a pack impossible to author. Strip the
   // scoping attribute selector before scanning so the check only sees real font
   // references (@font-face src + font-family stacks + meta font names).
-  const scannedCss = (cssContent ?? "").replace(/\[data-theme-pack="[^"]*"\]/g, "");
+  const scannedCss = stripComments(cssContent ?? "").replace(
+    /\[data-theme-pack="[^"]*"\]/g,
+    "",
+  );
   const haystack = [
     scannedCss,
     meta.fonts.sans,
@@ -408,6 +439,7 @@ export function validateThemePack(input: ThemePackValidationInput): ThemePackVal
     checkImportantAllowlist(input.cssContent, issues);
     checkNoColorScheme(input.cssContent, issues);
     checkNoDataThemeSelector(input.cssContent, issues);
+    checkFontFileExistence(input.cssContent, input.fontFiles, issues);
   }
 
   if (meta) {


### PR DESCRIPTION
Parent: #2961
Supersedes #2863.

## Summary

- ignore CSS comments during commercial-font denylist validation
- reject missing local font files referenced by `@font-face`
- add focused validator coverage

## Tests

- validator tests: 26 passing
- full package suite: 1,579 passing

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2986"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787000951&installation_id=130359969&pr_number=2986&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2986&signature=919eb6fb217b7a597ed4a95ac3ca05e6875c69e70a7c7e9e747ccca73786283b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->