### PR TITLE
Tint frontmatter status pills

### DIFF
--- a/src/config/frontmatter-preview-renderers.tsx
+++ b/src/config/frontmatter-preview-renderers.tsx
@@ -23,11 +23,11 @@ import type { FrontmatterCellRenderer } from "@takazudo/zudo-doc/metainfo";
 type PillColor = "danger" | "success" | "warning" | "info" | "muted";
 
 const pillColorClass: Record<PillColor, string> = {
-  danger: "bg-danger text-fg",
-  success: "bg-success text-fg",
-  warning: "bg-warning text-fg",
-  info: "bg-info text-fg",
-  muted: "bg-surface text-muted border border-muted",
+  danger: "zd-fm-pill--danger",
+  success: "zd-fm-pill--success",
+  warning: "zd-fm-pill--warning",
+  info: "zd-fm-pill--info",
+  muted: "zd-fm-pill--muted",
 };
 
 function Pill({ children, color }: { children: ReactNode; color: PillColor }) {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -73,3 +73,32 @@
 @theme {
   --color-page-loading-overlay: color-mix(in oklch, var(--color-overlay) 60%, transparent);
 }
+
+/* Showcase-only frontmatter preview pills. These explicit rules keep the
+   role-dynamic classes available even though src/config is not an @source
+   root, and mirror the package admonition's 12% semantic-color tint. */
+.zd-fm-pill--danger {
+  color: var(--color-danger);
+  background-color: color-mix(in srgb, var(--color-danger) 12%, var(--color-bg));
+}
+
+.zd-fm-pill--success {
+  color: var(--color-success);
+  background-color: color-mix(in srgb, var(--color-success) 12%, var(--color-bg));
+}
+
+.zd-fm-pill--warning {
+  color: var(--color-warning);
+  background-color: color-mix(in srgb, var(--color-warning) 12%, var(--color-bg));
+}
+
+.zd-fm-pill--info {
+  color: var(--color-info);
+  background-color: color-mix(in srgb, var(--color-info) 12%, var(--color-bg));
+}
+
+.zd-fm-pill--muted {
+  color: var(--color-muted);
+  background-color: color-mix(in srgb, var(--color-muted) 12%, var(--color-bg));
+  border: 1px solid var(--color-muted);
+}


### PR DESCRIPTION
Parent: #2961
Follow-up remains tracked in #2869.

## Summary

- adopt explicit 12% semantic tint classes for frontmatter status pills
- preserve dynamic class emission outside Tailwind source scanning

## Verification caveat

The required 16-pack sweep found 8 of 160 cases below 4.5:1. The floor is 4.166166:1 at Foundry light warning. Exact failures are documented in the root PR and integration topic; no broad theme-palette rewrite was made.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787000954&installation_id=130359969&pr_number=2987&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2987&signature=cea0a298bcd14ce4bf6ac9a1b36fb9701a89438a4f38e837571b34220df516d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->