### PR TITLE
Align doc-skill paths to main worktree

### DIFF
--- a/packages/create-zudo-doc/templates/base/scripts/setup-doc-skill.sh
+++ b/packages/create-zudo-doc/templates/base/scripts/setup-doc-skill.sh
@@ -81,6 +81,8 @@ REPO_ROOT="$(git -C "$ROOT_DIR" worktree list | head -1 | awk '{print $1}')"
 # worktree root, above) reconstructs the equivalent path there even when
 # running from inside a different worktree.
 PROJECT_PREFIX="$(git -C "$ROOT_DIR" rev-parse --show-prefix)"
+MAIN_PROJECT_DIR="$REPO_ROOT/${PROJECT_PREFIX}"
+MAIN_PROJECT_DIR="${MAIN_PROJECT_DIR%/}"
 REPO_DOCS_DIR="$REPO_ROOT/${PROJECT_PREFIX}src/content/docs"
 REPO_DOCS_JA_DIR="$REPO_ROOT/${PROJECT_PREFIX}src/content/docs-ja"
 
@@ -142,7 +144,7 @@ fi
 # even when the project is nested inside a larger git repo (running `pnpm
 # build` from the outer repo root would otherwise invoke the wrong
 # package.json, #2918).
-VERIFY_STEP="Run \`pnpm build\` from \`$ROOT_DIR\` to confirm the site builds correctly."
+VERIFY_STEP="Run \`pnpm build\` from \`$MAIN_PROJECT_DIR\` to confirm the site builds correctly."
 
 resolve_targets() {
   case "$TARGET_MODE" in
@@ -204,7 +206,7 @@ argument-hint: "[-u|--update] [topic keyword, e.g., 'configuration', 'sidebar', 
 # $PROJECT_NAME Documentation Reference
 
 Look up documentation from the $PROJECT_NAME project for $assistant_label.
-Documentation base path: \`src/content/docs\` (relative to the project root: \`$ROOT_DIR\`)
+Documentation base path: \`src/content/docs\` (relative to the project root: \`$MAIN_PROJECT_DIR\`)
 
 ## Mode Detection
 
@@ -234,7 +236,7 @@ The user has new information and wants to add or update documentation in this re
    the topic. Read them to understand what is already covered.
 3. **Decide create vs update**: If an existing article covers the topic, update
    it. Otherwise, create a new \`.mdx\` file in the appropriate subdirectory.
-4. **Write the content**: Follow the doc-authoring rules in this project's CLAUDE.md (\`$ROOT_DIR/CLAUDE.md\`):
+4. **Write the content**: Follow the doc-authoring rules in this project's CLAUDE.md (\`$MAIN_PROJECT_DIR/CLAUDE.md\`):
    - Required frontmatter: \`title\` (string). Always set \`sidebar_position\`.
      Optional: \`description\`, \`sidebar_label\`, \`tags\`, etc.
    - Do NOT use \`# h1\` in content — the frontmatter \`title\` renders as h1.

--- a/packages/zudo-doc/src/theme-packs/hearth/pack.css
+++ b/packages/zudo-doc/src/theme-packs/hearth/pack.css
@@ -292,9 +292,8 @@ html[data-theme-pack="hearth"] .zd-content blockquote {
   color: light-dark(oklch(0.38 0.052 42), oklch(0.83 0.032 70));
 }
 
-/* admonitions: soft-cornered, warm-shadowed, hearth icon swaps on
-   the prototype's three variants (candle / coffee / fire); the other
-   four variants keep the stock icons */
+/* admonitions: soft-cornered, warm-shadowed, with a distinct icon
+   from the hearth and fireside vocabulary for every variant */
 html[data-theme-pack="hearth"] [data-admonition] {
   box-shadow: 0 8px 18px -14px light-dark(oklch(0.42 0.09 45 / 0.2), oklch(0.05 0.01 45 / 0.6));
 }
@@ -304,8 +303,20 @@ html[data-theme-pack="hearth"] [data-admonition="note"] .admonition-title::befor
 html[data-theme-pack="hearth"] [data-admonition="tip"] .admonition-title::before {
   content: "☕ ";
 }
+html[data-theme-pack="hearth"] [data-admonition="info"] .admonition-title::before {
+  content: "📜 ";
+}
 html[data-theme-pack="hearth"] [data-admonition="warning"] .admonition-title::before {
   content: "🔥 ";
+}
+html[data-theme-pack="hearth"] [data-admonition="important"] .admonition-title::before {
+  content: "🔔 ";
+}
+html[data-theme-pack="hearth"] [data-admonition="danger"] .admonition-title::before {
+  content: "🧯 ";
+}
+html[data-theme-pack="hearth"] [data-admonition="caution"] .admonition-title::before {
+  content: "♨️ ";
 }
 
 /* table: brick Fraunces header over an accent rule, warm row hover */

--- a/scripts/__tests__/setup-doc-skill.test.ts
+++ b/scripts/__tests__/setup-doc-skill.test.ts
@@ -81,6 +81,23 @@ describe("setup-doc-skill.sh", () => {
     expect(skillMd).toContain("zudo-doc");
   });
 
+  it("uses the main worktree project path in generated instructions", () => {
+    runScript(TEST_SKILL_NAME, fakeHome);
+
+    const skillMd = readFileSync(
+      join(PROJECT_ROOT, ".claude", "skills", TEST_SKILL_NAME, "SKILL.md"),
+      "utf-8",
+    );
+
+    expect(skillMd).toContain(
+      `Run \`pnpm build\` from \`${MAIN_WORKTREE_ROOT}\``,
+    );
+    expect(skillMd).toContain(
+      `(relative to the project root: \`${MAIN_WORKTREE_ROOT}\`)`,
+    );
+    expect(skillMd).toContain(`${MAIN_WORKTREE_ROOT}/CLAUDE.md`);
+  });
+
   it("creates docs symlink pointing to src/content/docs", () => {
     runScript(TEST_SKILL_NAME, fakeHome);
 

--- a/scripts/setup-doc-skill.sh
+++ b/scripts/setup-doc-skill.sh
@@ -81,6 +81,8 @@ REPO_ROOT="$(git -C "$ROOT_DIR" worktree list | head -1 | awk '{print $1}')"
 # worktree root, above) reconstructs the equivalent path there even when
 # running from inside a different worktree.
 PROJECT_PREFIX="$(git -C "$ROOT_DIR" rev-parse --show-prefix)"
+MAIN_PROJECT_DIR="$REPO_ROOT/${PROJECT_PREFIX}"
+MAIN_PROJECT_DIR="${MAIN_PROJECT_DIR%/}"
 REPO_DOCS_DIR="$REPO_ROOT/${PROJECT_PREFIX}src/content/docs"
 REPO_DOCS_JA_DIR="$REPO_ROOT/${PROJECT_PREFIX}src/content/docs-ja"
 
@@ -142,7 +144,7 @@ fi
 # even when the project is nested inside a larger git repo (running `pnpm
 # build` from the outer repo root would otherwise invoke the wrong
 # package.json, #2918).
-VERIFY_STEP="Run \`pnpm build\` from \`$ROOT_DIR\` to confirm the site builds correctly."
+VERIFY_STEP="Run \`pnpm build\` from \`$MAIN_PROJECT_DIR\` to confirm the site builds correctly."
 
 resolve_targets() {
   case "$TARGET_MODE" in
@@ -204,7 +206,7 @@ argument-hint: "[-u|--update] [topic keyword, e.g., 'configuration', 'sidebar', 
 # $PROJECT_NAME Documentation Reference
 
 Look up documentation from the $PROJECT_NAME project for $assistant_label.
-Documentation base path: \`src/content/docs\` (relative to the project root: \`$ROOT_DIR\`)
+Documentation base path: \`src/content/docs\` (relative to the project root: \`$MAIN_PROJECT_DIR\`)
 
 ## Mode Detection
 
@@ -234,7 +236,7 @@ The user has new information and wants to add or update documentation in this re
    the topic. Read them to understand what is already covered.
 3. **Decide create vs update**: If an existing article covers the topic, update
    it. Otherwise, create a new \`.mdx\` file in the appropriate subdirectory.
-4. **Write the content**: Follow the doc-authoring rules in this project's CLAUDE.md (\`$ROOT_DIR/CLAUDE.md\`):
+4. **Write the content**: Follow the doc-authoring rules in this project's CLAUDE.md (\`$MAIN_PROJECT_DIR/CLAUDE.md\`):
    - Required frontmatter: \`title\` (string). Always set \`sidebar_position\`.
      Optional: \`description\`, \`sidebar_label\`, \`tags\`, etc.
    - Do NOT use \`# h1\` in content — the frontmatter \`title\` renders as h1.


### PR DESCRIPTION
Parent: #2961
Supersedes #2935.

## Summary

- align generated verification and documentation references to the main worktree project path
- preserve nested-project normalization and the issue 2918 symlink convention
- keep source and template scripts byte-identical

## Tests

- setup-doc-skill tests: 14 passing
- template drift check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787000955&installation_id=130359969&pr_number=2988&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2988&signature=10a2ce93b4bd5132071b24448b32b4f772f9dce7e21ad8c9922773b670bd1690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->