### PR TITLE
Document trusted-network doc-history exposure

### DIFF
--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -1269,6 +1269,10 @@ describe("scaffold — CLAUDE.md generation", () => {
     expect(withDocHistory).toContain("pnpm dev:history");
     expect(withDocHistory).toContain("pnpm dev:network");
     expect(withDocHistory).toContain("pnpm dev:zfb:network");
+    expect(withDocHistory).toContain("**Trusted networks only:**");
+    expect(withDocHistory).toContain(
+      "UNPUBLISHED local commits — to anyone on the LAN via the `/doc-history/*` proxy",
+    );
     expect(withDocHistory).toContain("pnpm run dev:zfb -- <flags>");
 
     await scaffold(baseChoices);
@@ -1280,6 +1284,7 @@ describe("scaffold — CLAUDE.md generation", () => {
     expect(without).not.toContain("run-p");
     expect(without).toContain("zfb dev server (port 4321)");
     expect(without).not.toContain("dev:network");
+    expect(without).not.toContain("Trusted networks only");
   });
 
   it("documents the built-in MDX components the seed content uses (CategoryNav) (#2703)", async () => {

--- a/packages/create-zudo-doc/src/claude-md-gen.ts
+++ b/packages/create-zudo-doc/src/claude-md-gen.ts
@@ -49,6 +49,9 @@ export function generateCLAUDEFile(choices: UserChoices): string {
       `- \`${pmRunCommand(pm, "dev:network")}\` — same, but zfb binds \`--host 0.0.0.0\` for LAN access (\`${pmRunCommand(pm, "dev:zfb:network")}\` individually); the doc-history server stays loopback-only and LAN clients reach it through zfb's \`/doc-history/*\` dev proxy`,
     );
     lines.push(
+      `- **Trusted networks only:** this also serves your git doc-history — including UNPUBLISHED local commits — to anyone on the LAN via the \`/doc-history/*\` proxy`,
+    );
+    lines.push(
       `- \`run-p\` swallows trailing args, so other zfb flags don't forward through \`${pmRunCommand(pm, "dev")}\` — pass them directly instead: \`${pm} run dev:zfb -- <flags>\``,
     );
   } else {

--- a/packages/zudo-doc/src/theme-packs/hearth/pack.css
+++ b/packages/zudo-doc/src/theme-packs/hearth/pack.css
@@ -292,9 +292,8 @@ html[data-theme-pack="hearth"] .zd-content blockquote {
   color: light-dark(oklch(0.38 0.052 42), oklch(0.83 0.032 70));
 }
 
-/* admonitions: soft-cornered, warm-shadowed, hearth icon swaps on
-   the prototype's three variants (candle / coffee / fire); the other
-   four variants keep the stock icons */
+/* admonitions: soft-cornered, warm-shadowed, with a distinct icon
+   from the hearth and fireside vocabulary for every variant */
 html[data-theme-pack="hearth"] [data-admonition] {
   box-shadow: 0 8px 18px -14px light-dark(oklch(0.42 0.09 45 / 0.2), oklch(0.05 0.01 45 / 0.6));
 }
@@ -304,8 +303,20 @@ html[data-theme-pack="hearth"] [data-admonition="note"] .admonition-title::befor
 html[data-theme-pack="hearth"] [data-admonition="tip"] .admonition-title::before {
   content: "☕ ";
 }
+html[data-theme-pack="hearth"] [data-admonition="info"] .admonition-title::before {
+  content: "📜 ";
+}
 html[data-theme-pack="hearth"] [data-admonition="warning"] .admonition-title::before {
   content: "🔥 ";
+}
+html[data-theme-pack="hearth"] [data-admonition="important"] .admonition-title::before {
+  content: "🔔 ";
+}
+html[data-theme-pack="hearth"] [data-admonition="danger"] .admonition-title::before {
+  content: "🧯 ";
+}
+html[data-theme-pack="hearth"] [data-admonition="caution"] .admonition-title::before {
+  content: "♨️ ";
 }
 
 /* table: brick Fraunces header over an accent rule, warm row hover */

--- a/src/config/frontmatter-preview-renderers.tsx
+++ b/src/config/frontmatter-preview-renderers.tsx
@@ -23,11 +23,11 @@ import type { FrontmatterCellRenderer } from "@takazudo/zudo-doc/metainfo";
 type PillColor = "danger" | "success" | "warning" | "info" | "muted";
 
 const pillColorClass: Record<PillColor, string> = {
-  danger: "bg-danger text-fg",
-  success: "bg-success text-fg",
-  warning: "bg-warning text-fg",
-  info: "bg-info text-fg",
-  muted: "bg-surface text-muted border border-muted",
+  danger: "zd-fm-pill--danger",
+  success: "zd-fm-pill--success",
+  warning: "zd-fm-pill--warning",
+  info: "zd-fm-pill--info",
+  muted: "zd-fm-pill--muted",
 };
 
 function Pill({ children, color }: { children: ReactNode; color: PillColor }) {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -73,3 +73,32 @@
 @theme {
   --color-page-loading-overlay: color-mix(in oklch, var(--color-overlay) 60%, transparent);
 }
+
+/* Showcase-only frontmatter preview pills. These explicit rules keep the
+   role-dynamic classes available even though src/config is not an @source
+   root, and mirror the package admonition's 12% semantic-color tint. */
+.zd-fm-pill--danger {
+  color: var(--color-danger);
+  background-color: color-mix(in srgb, var(--color-danger) 12%, var(--color-bg));
+}
+
+.zd-fm-pill--success {
+  color: var(--color-success);
+  background-color: color-mix(in srgb, var(--color-success) 12%, var(--color-bg));
+}
+
+.zd-fm-pill--warning {
+  color: var(--color-warning);
+  background-color: color-mix(in srgb, var(--color-warning) 12%, var(--color-bg));
+}
+
+.zd-fm-pill--info {
+  color: var(--color-info);
+  background-color: color-mix(in srgb, var(--color-info) 12%, var(--color-bg));
+}
+
+.zd-fm-pill--muted {
+  color: var(--color-muted);
+  background-color: color-mix(in srgb, var(--color-muted) 12%, var(--color-bg));
+  border: 1px solid var(--color-muted);
+}


### PR DESCRIPTION
Parent: #2961
Supersedes #2951.

## Summary

- document that LAN development exposes unpublished doc-history commits through the proxy
- add generated-documentation presence and feature-disabled absence coverage

## Tests

- focused scaffold test
- create-zudo-doc suite: 573 passing

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2989"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787000958&installation_id=130359969&pr_number=2989&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2989&signature=990d6e8e0c3466be7dfe34c84fbddbaaaadd8093c3d86e6af90395c792e5e428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->