### PR TITLE
Document mobile chrome-font dev limitation

### DIFF
--- a/packages/create-zudo-doc/templates/base/scripts/setup-doc-skill.sh
+++ b/packages/create-zudo-doc/templates/base/scripts/setup-doc-skill.sh
@@ -81,6 +81,8 @@ REPO_ROOT="$(git -C "$ROOT_DIR" worktree list | head -1 | awk '{print $1}')"
 # worktree root, above) reconstructs the equivalent path there even when
 # running from inside a different worktree.
 PROJECT_PREFIX="$(git -C "$ROOT_DIR" rev-parse --show-prefix)"
+MAIN_PROJECT_DIR="$REPO_ROOT/${PROJECT_PREFIX}"
+MAIN_PROJECT_DIR="${MAIN_PROJECT_DIR%/}"
 REPO_DOCS_DIR="$REPO_ROOT/${PROJECT_PREFIX}src/content/docs"
 REPO_DOCS_JA_DIR="$REPO_ROOT/${PROJECT_PREFIX}src/content/docs-ja"
 
@@ -142,7 +144,7 @@ fi
 # even when the project is nested inside a larger git repo (running `pnpm
 # build` from the outer repo root would otherwise invoke the wrong
 # package.json, #2918).
-VERIFY_STEP="Run \`pnpm build\` from \`$ROOT_DIR\` to confirm the site builds correctly."
+VERIFY_STEP="Run \`pnpm build\` from \`$MAIN_PROJECT_DIR\` to confirm the site builds correctly."
 
 resolve_targets() {
   case "$TARGET_MODE" in
@@ -204,7 +206,7 @@ argument-hint: "[-u|--update] [topic keyword, e.g., 'configuration', 'sidebar', 
 # $PROJECT_NAME Documentation Reference
 
 Look up documentation from the $PROJECT_NAME project for $assistant_label.
-Documentation base path: \`src/content/docs\` (relative to the project root: \`$ROOT_DIR\`)
+Documentation base path: \`src/content/docs\` (relative to the project root: \`$MAIN_PROJECT_DIR\`)
 
 ## Mode Detection
 
@@ -234,7 +236,7 @@ The user has new information and wants to add or update documentation in this re
    the topic. Read them to understand what is already covered.
 3. **Decide create vs update**: If an existing article covers the topic, update
    it. Otherwise, create a new \`.mdx\` file in the appropriate subdirectory.
-4. **Write the content**: Follow the doc-authoring rules in this project's CLAUDE.md (\`$ROOT_DIR/CLAUDE.md\`):
+4. **Write the content**: Follow the doc-authoring rules in this project's CLAUDE.md (\`$MAIN_PROJECT_DIR/CLAUDE.md\`):
    - Required frontmatter: \`title\` (string). Always set \`sidebar_position\`.
      Optional: \`description\`, \`sidebar_label\`, \`tags\`, etc.
    - Do NOT use \`# h1\` in content — the frontmatter \`title\` renders as h1.

--- a/packages/zudo-doc/src/config/component-tokens.ts
+++ b/packages/zudo-doc/src/config/component-tokens.ts
@@ -514,7 +514,7 @@ export const COMPONENT_TOKENS: ComponentToken[] = [
     surface: "chrome",
     category: "typography",
     description:
-      "Font family of the navigation sidebar — covers BOTH the desktop `#desktop-sidebar` rail and the mobile drawer, so one override styles both viewports and neither drifts onto a different face. Defaults to the `--zdc-chrome-font` seam (a no-op until redefined).",
+      "Font family of the navigation sidebar — covers BOTH the desktop `#desktop-sidebar` rail and the mobile drawer, so one override styles both viewports and neither drifts onto a different face. Defaults to the `--zdc-chrome-font` seam (a no-op until redefined). Verify granular MOBILE chrome-font overrides with `zfb build`/preview, not `pnpm dev`: the current zfb dev server strips island-root `data-*` attributes, so the mobile selector silently does not match.",
   },
   {
     cssVar: "--zdc-toc-font",
@@ -525,6 +525,6 @@ export const COMPONENT_TOKENS: ComponentToken[] = [
     surface: "chrome",
     category: "typography",
     description:
-      "Font family of the table of contents — covers BOTH the desktop right rail and the mobile collapsible TOC, so one override styles both viewports. Defaults to the `--zdc-chrome-font` seam (a no-op until redefined), which also keeps the mobile TOC on the chrome font rather than the prose font of the `.zd-content` it renders inside.",
+      "Font family of the table of contents — covers BOTH the desktop right rail and the mobile collapsible TOC, so one override styles both viewports. Defaults to the `--zdc-chrome-font` seam (a no-op until redefined), which also keeps the mobile TOC on the chrome font rather than the prose font of the `.zd-content` it renders inside. Verify granular MOBILE chrome-font overrides with `zfb build`/preview, not `pnpm dev`: the current zfb dev server strips island-root `data-*` attributes, so the mobile selector silently does not match.",
   },
 ];

--- a/packages/zudo-doc/src/theme-packs-registry/__tests__/validator.test.ts
+++ b/packages/zudo-doc/src/theme-packs-registry/__tests__/validator.test.ts
@@ -237,6 +237,37 @@ describe("validateThemePack", () => {
     expect(extraFontFace.issues.some((i) => i.rule === "font-face-parity")).toBe(true);
   });
 
+  it("rejects a local @font-face source missing from fontFiles", () => {
+    const result = validateThemePack(
+      baseInput({
+        cssContent: VALID_FOUNDRY_CSS.replace("Inter-latin.woff2", "Missing.woff2"),
+      }),
+    );
+    const issue = result.issues.find((i) => i.rule === "font-file-missing");
+    expect(issue?.severity).toBe("error");
+    expect(result.valid).toBe(false);
+  });
+
+  it("accepts local @font-face sources listed in fontFiles", () => {
+    const result = validateThemePack(baseInput());
+    expect(result.issues.filter((i) => i.rule === "font-file-missing")).toEqual([]);
+  });
+
+  it("skips non-local and cache-busted @font-face sources", () => {
+    const cssContent = VALID_FOUNDRY_CSS.replace(
+      'url("./fonts/Inter-latin.woff2")',
+      [
+        'url("data:font/woff2;base64,AA==")',
+        'url("https://example.com/Inter.woff2")',
+        'url("../fonts/Inter.woff2")',
+        'url("./fonts/Inter.woff2?v=1")',
+        'url("./fonts/Inter.woff2#variation")',
+      ].join(", "),
+    );
+    const result = validateThemePack(baseInput({ cssContent, fontFiles: [] }));
+    expect(result.issues.filter((i) => i.rule === "font-file-missing")).toEqual([]);
+  });
+
   it("requires OFL.txt when font binaries ship", () => {
     const result = validateThemePack(baseInput({ fontFiles: ["Inter-latin.woff2"] }));
     expect(result.issues.some((i) => i.rule === "ofl-required")).toBe(true);
@@ -291,6 +322,14 @@ html[data-theme-pack="futura-editorial"] header[data-header] { background: var(-
       }),
     );
     expect(result.issues.some((i) => i.rule === "commercial-font-denylist")).toBe(false);
+  });
+
+  it("does NOT flag a commercial typeface mentioned only in a CSS comment", () => {
+    const result = validateThemePack(
+      baseInput({ cssContent: `/* Futura substitute: Inter */\n${VALID_FOUNDRY_CSS}` }),
+    );
+    expect(result.issues.some((i) => i.rule === "commercial-font-denylist")).toBe(false);
+    expect(result.valid).toBe(true);
   });
 
   it("rejects preview swatches that aren't plain resolved colors", () => {

--- a/packages/zudo-doc/src/theme-packs-registry/validator.ts
+++ b/packages/zudo-doc/src/theme-packs-registry/validator.ts
@@ -9,11 +9,11 @@
 // schema; `pack.css` presence/absence; every rule scoped under
 // `html[data-theme-pack="<slug>"]`; the known-custom-property-name manifest;
 // preview swatches are plain resolved colors; `fonts.loaded` ⇄ `@font-face`
-// parity; `OFL.txt` presence when font files ship; the commercial-typeface
-// denylist; the `!important` allowlist (the h2–h4 heading-rule
-// `border-image` carve-out); no `color-scheme:` declarations; no `[data-theme]` selectors. A
-// total-payload-size overage is a WARNING, not an error (Decision 6.7's
-// soft ~250 KB budget).
+// parity; local `@font-face` sources exist in `fonts/`; `OFL.txt` presence when
+// font files ship; the commercial-typeface denylist; the `!important`
+// allowlist (the h2–h4 heading-rule `border-image` carve-out); no
+// `color-scheme:` declarations; no `[data-theme]` selectors. A total-payload-
+// size overage is a WARNING, not an error (Decision 6.7's soft ~250 KB budget).
 
 import {
   themePackMetaSchema,
@@ -280,6 +280,34 @@ function checkFontFaceParity(
   }
 }
 
+function checkFontFileExistence(
+  cssContent: string,
+  fontFiles: string[],
+  issues: ThemePackValidationIssue[],
+): void {
+  const availableFiles = new Set(fontFiles);
+  const urlRe = /url\(\s*(?:"([^"]*)"|'([^']*)'|([^)]*))\s*\)/gi;
+
+  for (const rule of parseTopLevelRules(cssContent)) {
+    if (!isFontFaceRule(rule)) continue;
+
+    let match: RegExpExecArray | null;
+    while ((match = urlRe.exec(rule.body)) !== null) {
+      const url = (match[1] ?? match[2] ?? match[3] ?? "").trim();
+      if (!url.startsWith("./fonts/") || /[?#]/.test(url)) continue;
+
+      const basename = url.slice("./fonts/".length).split("/").pop();
+      if (!basename || availableFiles.has(basename)) continue;
+
+      issues.push({
+        rule: "font-file-missing",
+        severity: "error",
+        message: `@font-face references "${url}" but "${basename}" is not present in fonts/`,
+      });
+    }
+  }
+}
+
 function isPlainColorValue(value: string): boolean {
   const v = value.trim();
   if (/var\(|light-dark\(/i.test(v)) return false;
@@ -326,7 +354,10 @@ function checkCommercialDenylist(
   // every scoping selector, making such a pack impossible to author. Strip the
   // scoping attribute selector before scanning so the check only sees real font
   // references (@font-face src + font-family stacks + meta font names).
-  const scannedCss = (cssContent ?? "").replace(/\[data-theme-pack="[^"]*"\]/g, "");
+  const scannedCss = stripComments(cssContent ?? "").replace(
+    /\[data-theme-pack="[^"]*"\]/g,
+    "",
+  );
   const haystack = [
     scannedCss,
     meta.fonts.sans,
@@ -408,6 +439,7 @@ export function validateThemePack(input: ThemePackValidationInput): ThemePackVal
     checkImportantAllowlist(input.cssContent, issues);
     checkNoColorScheme(input.cssContent, issues);
     checkNoDataThemeSelector(input.cssContent, issues);
+    checkFontFileExistence(input.cssContent, input.fontFiles, issues);
   }
 
   if (meta) {

--- a/packages/zudo-doc/src/theme-packs/hearth/pack.css
+++ b/packages/zudo-doc/src/theme-packs/hearth/pack.css
@@ -292,9 +292,8 @@ html[data-theme-pack="hearth"] .zd-content blockquote {
   color: light-dark(oklch(0.38 0.052 42), oklch(0.83 0.032 70));
 }
 
-/* admonitions: soft-cornered, warm-shadowed, hearth icon swaps on
-   the prototype's three variants (candle / coffee / fire); the other
-   four variants keep the stock icons */
+/* admonitions: soft-cornered, warm-shadowed, with a distinct icon
+   from the hearth and fireside vocabulary for every variant */
 html[data-theme-pack="hearth"] [data-admonition] {
   box-shadow: 0 8px 18px -14px light-dark(oklch(0.42 0.09 45 / 0.2), oklch(0.05 0.01 45 / 0.6));
 }
@@ -304,8 +303,20 @@ html[data-theme-pack="hearth"] [data-admonition="note"] .admonition-title::befor
 html[data-theme-pack="hearth"] [data-admonition="tip"] .admonition-title::before {
   content: "☕ ";
 }
+html[data-theme-pack="hearth"] [data-admonition="info"] .admonition-title::before {
+  content: "📜 ";
+}
 html[data-theme-pack="hearth"] [data-admonition="warning"] .admonition-title::before {
   content: "🔥 ";
+}
+html[data-theme-pack="hearth"] [data-admonition="important"] .admonition-title::before {
+  content: "🔔 ";
+}
+html[data-theme-pack="hearth"] [data-admonition="danger"] .admonition-title::before {
+  content: "🧯 ";
+}
+html[data-theme-pack="hearth"] [data-admonition="caution"] .admonition-title::before {
+  content: "♨️ ";
 }
 
 /* table: brick Fraunces header over an accent rule, warm row hover */

--- a/scripts/__tests__/setup-doc-skill.test.ts
+++ b/scripts/__tests__/setup-doc-skill.test.ts
@@ -81,6 +81,23 @@ describe("setup-doc-skill.sh", () => {
     expect(skillMd).toContain("zudo-doc");
   });
 
+  it("uses the main worktree project path in generated instructions", () => {
+    runScript(TEST_SKILL_NAME, fakeHome);
+
+    const skillMd = readFileSync(
+      join(PROJECT_ROOT, ".claude", "skills", TEST_SKILL_NAME, "SKILL.md"),
+      "utf-8",
+    );
+
+    expect(skillMd).toContain(
+      `Run \`pnpm build\` from \`${MAIN_WORKTREE_ROOT}\``,
+    );
+    expect(skillMd).toContain(
+      `(relative to the project root: \`${MAIN_WORKTREE_ROOT}\`)`,
+    );
+    expect(skillMd).toContain(`${MAIN_WORKTREE_ROOT}/CLAUDE.md`);
+  });
+
   it("creates docs symlink pointing to src/content/docs", () => {
     runScript(TEST_SKILL_NAME, fakeHome);
 

--- a/scripts/setup-doc-skill.sh
+++ b/scripts/setup-doc-skill.sh
@@ -81,6 +81,8 @@ REPO_ROOT="$(git -C "$ROOT_DIR" worktree list | head -1 | awk '{print $1}')"
 # worktree root, above) reconstructs the equivalent path there even when
 # running from inside a different worktree.
 PROJECT_PREFIX="$(git -C "$ROOT_DIR" rev-parse --show-prefix)"
+MAIN_PROJECT_DIR="$REPO_ROOT/${PROJECT_PREFIX}"
+MAIN_PROJECT_DIR="${MAIN_PROJECT_DIR%/}"
 REPO_DOCS_DIR="$REPO_ROOT/${PROJECT_PREFIX}src/content/docs"
 REPO_DOCS_JA_DIR="$REPO_ROOT/${PROJECT_PREFIX}src/content/docs-ja"
 
@@ -142,7 +144,7 @@ fi
 # even when the project is nested inside a larger git repo (running `pnpm
 # build` from the outer repo root would otherwise invoke the wrong
 # package.json, #2918).
-VERIFY_STEP="Run \`pnpm build\` from \`$ROOT_DIR\` to confirm the site builds correctly."
+VERIFY_STEP="Run \`pnpm build\` from \`$MAIN_PROJECT_DIR\` to confirm the site builds correctly."
 
 resolve_targets() {
   case "$TARGET_MODE" in
@@ -204,7 +206,7 @@ argument-hint: "[-u|--update] [topic keyword, e.g., 'configuration', 'sidebar', 
 # $PROJECT_NAME Documentation Reference
 
 Look up documentation from the $PROJECT_NAME project for $assistant_label.
-Documentation base path: \`src/content/docs\` (relative to the project root: \`$ROOT_DIR\`)
+Documentation base path: \`src/content/docs\` (relative to the project root: \`$MAIN_PROJECT_DIR\`)
 
 ## Mode Detection
 
@@ -234,7 +236,7 @@ The user has new information and wants to add or update documentation in this re
    the topic. Read them to understand what is already covered.
 3. **Decide create vs update**: If an existing article covers the topic, update
    it. Otherwise, create a new \`.mdx\` file in the appropriate subdirectory.
-4. **Write the content**: Follow the doc-authoring rules in this project's CLAUDE.md (\`$ROOT_DIR/CLAUDE.md\`):
+4. **Write the content**: Follow the doc-authoring rules in this project's CLAUDE.md (\`$MAIN_PROJECT_DIR/CLAUDE.md\`):
    - Required frontmatter: \`title\` (string). Always set \`sidebar_position\`.
      Optional: \`description\`, \`sidebar_label\`, \`tags\`, etc.
    - Do NOT use \`# h1\` in content — the frontmatter \`title\` renders as h1.

--- a/src/config/frontmatter-preview-renderers.tsx
+++ b/src/config/frontmatter-preview-renderers.tsx
@@ -23,11 +23,11 @@ import type { FrontmatterCellRenderer } from "@takazudo/zudo-doc/metainfo";
 type PillColor = "danger" | "success" | "warning" | "info" | "muted";
 
 const pillColorClass: Record<PillColor, string> = {
-  danger: "bg-danger text-fg",
-  success: "bg-success text-fg",
-  warning: "bg-warning text-fg",
-  info: "bg-info text-fg",
-  muted: "bg-surface text-muted border border-muted",
+  danger: "zd-fm-pill--danger",
+  success: "zd-fm-pill--success",
+  warning: "zd-fm-pill--warning",
+  info: "zd-fm-pill--info",
+  muted: "zd-fm-pill--muted",
 };
 
 function Pill({ children, color }: { children: ReactNode; color: PillColor }) {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -73,3 +73,32 @@
 @theme {
   --color-page-loading-overlay: color-mix(in oklch, var(--color-overlay) 60%, transparent);
 }
+
+/* Showcase-only frontmatter preview pills. These explicit rules keep the
+   role-dynamic classes available even though src/config is not an @source
+   root, and mirror the package admonition's 12% semantic-color tint. */
+.zd-fm-pill--danger {
+  color: var(--color-danger);
+  background-color: color-mix(in srgb, var(--color-danger) 12%, var(--color-bg));
+}
+
+.zd-fm-pill--success {
+  color: var(--color-success);
+  background-color: color-mix(in srgb, var(--color-success) 12%, var(--color-bg));
+}
+
+.zd-fm-pill--warning {
+  color: var(--color-warning);
+  background-color: color-mix(in srgb, var(--color-warning) 12%, var(--color-bg));
+}
+
+.zd-fm-pill--info {
+  color: var(--color-info);
+  background-color: color-mix(in srgb, var(--color-info) 12%, var(--color-bg));
+}
+
+.zd-fm-pill--muted {
+  color: var(--color-muted);
+  background-color: color-mix(in srgb, var(--color-muted) 12%, var(--color-bg));
+  border: 1px solid var(--color-muted);
+}


### PR DESCRIPTION
Parent: #2961
Source follow-up: #2898 is superseded by this documentation change.

# Issue #2971 review

Self-review: foreground complete; findings: none found
Final commit: 0ae26a046a435d3424b9b8eb143952da90959f86
Worktree: clean
Review log: /tmp/x-wt-teams-2961-reviews/2971.md

## Scope

- Changed only `packages/zudo-doc/src/config/component-tokens.ts`.
- Appended the requested zfb dev-server warning to the `--zdc-sidebar-font` and `--zdc-toc-font` descriptions.
- No selectors, defaults, or behavior changed.

## Checks

- `git diff --check` — passed.
- TypeScript 5.9.3 file-level `tsc --noEmit` sanity — passed.
- `node --experimental-strip-types --check packages/zudo-doc/src/config/component-tokens.ts` — passed.
- Full build, E2E, server, browser, and visual checks intentionally not run; Wave 2 owns central checks.

## Review findings and risk

No actionable findings. Residual risk is limited to prose accuracy if upstream zfb behavior changes before this warning is removed. No visual impact is expected because this is description text only.

## Draft upstream zfb issue body (do not file automatically)

Suggested title: `Dev server drops island-root data-* attributes retained by production build`

### Summary

The zfb dev server drops author-declared `data-*` attributes from the root element of a client island during SSR, while `zfb build` preserves the same attributes. This dev/build discrepancy makes selectors anchored to island-root `data-*` attributes silently fail only during development.

This was observed in `zudo-doc` with the mobile chrome-font tokens `--zdc-sidebar-font` and `--zdc-toc-font`. Their mobile rules target `aside[data-zd-mobile-sidebar]` and `div[data-zd-mobile-toc]`; granular mobile overrides appear broken under `pnpm dev`, but work in built and previewed output.

### Minimal reproduction

1. In a zfb docs project with a client island whose root renders an author-declared `data-*` attribute, clear both the zfb graph cache and Vite cache, then restart the dev server:

   ```sh
   rm -f .zfb/graph.bin
   rm -rf node_modules/.vite
   pnpm dev
   ```

2. On a doc route, render a mobile island root and a granular font rule such as:

   ```tsx
   <aside data-zd-mobile-sidebar>Mobile navigation</aside>
   ```

   ```css
   :root {
     --zdc-sidebar-font: "Courier New", monospace;
   }

   aside[data-zd-mobile-sidebar] {
     font-family: var(--zdc-sidebar-font);
   }
   ```

   The rule is intentionally anchored to the island-root attribute, matching how the mobile surface is distinguished from other chrome.

3. Inspect the dev server's SSR HTML for the route. The island root is present, but `data-zd-mobile-sidebar` is absent, so the selector does not match.

4. Run `zfb build` for the same project and inspect the generated SSR HTML for the same route. The built HTML retains `data-zd-mobile-sidebar`, and the selector matches. The same discrepancy is reproducible with `data-zd-mobile-toc` on a `<div>` island root. Previewing the production build also shows the expected font.

### Expected behavior

Development SSR and production-build SSR should emit the same author-declared island-root `data-*` attributes. Selectors anchored to those attributes should therefore behave consistently in dev, build, and preview.

### Actual behavior

The dev server strips the island-root `data-*` attributes, while `zfb build` preserves them. As a result, per-surface mobile chrome-font overrides silently no-op only in dev. Production output is correct.

### Impact

This is a developer-experience and dev/prod consistency issue. Authors can incorrectly conclude that granular mobile chrome fonts are unsupported because `--zdc-sidebar-font` and `--zdc-toc-font` do not reach their mobile surfaces under the dev server, even though the same configuration works after build. Until fixed, these mobile overrides must be verified with `zfb build` and preview rather than `pnpm dev`.

### Tracking note

The original downstream report, zudolab/zudo-doc#2898, was superseded-closed after the work was incorporated into zudolab/zudo-doc#2961. This draft is the upstream follow-up; it has not been filed automatically.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787000961&installation_id=130359969&pr_number=2990&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2990&signature=7e226c65310c8f30cf7bc6bc41986d8047288ce4ca7570ac9207c2c6a1dafb91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->