### PR TITLE
DocHistory: thread exclusions through plugin capture

### DIFF
--- a/packages/doc-history-server/package.json
+++ b/packages/doc-history-server/package.json
@@ -45,6 +45,10 @@
       "types": "./dist/concurrency.d.ts",
       "default": "./dist/concurrency.js"
     },
+    "./exclude": {
+      "types": "./dist/exclude.d.ts",
+      "default": "./dist/exclude.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [
@@ -52,12 +56,12 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsup src/index.ts src/cli.ts src/git-history.ts src/types.ts src/concurrency.ts --format esm --dts",
+    "build": "tsup src/index.ts src/cli.ts src/git-history.ts src/types.ts src/concurrency.ts src/exclude.ts --format esm --dts",
     "dev": "tsx src/index.ts",
     "generate": "tsx src/cli.ts",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
-    "prepare": "tsup src/index.ts src/cli.ts src/git-history.ts src/types.ts src/concurrency.ts --format esm --dts --silent"
+    "prepare": "tsup src/index.ts src/cli.ts src/git-history.ts src/types.ts src/concurrency.ts src/exclude.ts --format esm --dts --silent"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/doc-history-server/src/__tests__/args.test.ts
+++ b/packages/doc-history-server/src/__tests__/args.test.ts
@@ -42,6 +42,7 @@ describe("parseCliArgs", () => {
       outDir: "dist/history",
       locales: [],
       maxEntries: 50,
+      exclude: [],
     });
   });
 
@@ -55,6 +56,10 @@ describe("parseCliArgs", () => {
       "ja:src/content/docs-ja",
       "--max-entries",
       "10",
+      "--exclude",
+      "drafts/**",
+      "--exclude",
+      "internal/*",
     ]);
     expect(result).toEqual({
       contentDir: expect.stringMatching(/src[\\/]content[\\/]docs$/),
@@ -63,6 +68,7 @@ describe("parseCliArgs", () => {
         { key: "ja", dir: expect.stringMatching(/src[\\/]content[\\/]docs-ja$/) },
       ],
       maxEntries: 10,
+      exclude: ["drafts/**", "internal/*"],
     });
   });
 
@@ -174,6 +180,7 @@ describe("parseServerArgs", () => {
       port: 3000,
       host: "127.0.0.1",
       allowLan: false,
+      exclude: [],
     });
   });
 

--- a/packages/doc-history-server/src/__tests__/exclude.test.ts
+++ b/packages/doc-history-server/src/__tests__/exclude.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { compileExclude } from "../exclude.js";
+
+describe("compileExclude", () => {
+  it("matches ** across any number of segments", () => {
+    const isExcluded = compileExclude(["guides/**/draft"]);
+    expect(isExcluded("guides/draft")).toBe(true);
+    expect(isExcluded("guides/internal/deep/draft")).toBe(true);
+  });
+
+  it("matches * only within one segment", () => {
+    const isExcluded = compileExclude(["guides/*"]);
+    expect(isExcluded("guides/intro")).toBe(true);
+    expect(isExcluded("guides/nested/intro")).toBe(false);
+  });
+
+  it("matches ? as exactly one non-slash character", () => {
+    const isExcluded = compileExclude(["release-?.notes"]);
+    expect(isExcluded("release-1.notes")).toBe(true);
+    expect(isExcluded("release-10.notes")).toBe(false);
+  });
+
+  it("matches literal text exactly and escapes regexp syntax", () => {
+    const isExcluded = compileExclude(["api/v1.0+(legacy)"]);
+    expect(isExcluded("api/v1.0+(legacy)")).toBe(true);
+    expect(isExcluded("api/v1x00legacy")).toBe(false);
+  });
+
+  it("does not match an unrelated slug", () => {
+    expect(compileExclude(["drafts/**"])("guides/intro")).toBe(false);
+  });
+
+  it("never excludes when the pattern list is empty", () => {
+    expect(compileExclude([])("anything/nested")).toBe(false);
+  });
+
+  it("matches the root index slug", () => {
+    expect(compileExclude(["index"])("index")).toBe(true);
+  });
+});

--- a/packages/doc-history-server/src/__tests__/server.test.ts
+++ b/packages/doc-history-server/src/__tests__/server.test.ts
@@ -16,6 +16,7 @@ vi.mock("../git-history.js", () => ({
   collectContentFiles: vi.fn().mockReturnValue([
     { filePath: "/fake/docs/getting-started.mdx", slug: "getting-started" },
     { filePath: "/fake/docs/guides/page-1.mdx", slug: "guides/page-1" },
+    { filePath: "/fake/docs/private/draft.mdx", slug: "private/draft" },
   ]),
   getDocHistoryAsync: vi.fn().mockImplementation((_filePath, slug) =>
     Promise.resolve({
@@ -36,6 +37,7 @@ vi.mock("../git-history.js", () => ({
 
 // Import after mocks are set up
 const { startServer } = await import("../server.js");
+const { getDocHistoryAsync } = await import("../git-history.js");
 
 let server: http.Server;
 let baseUrl: string;
@@ -90,6 +92,7 @@ beforeAll(async () => {
     contentDir: "/fake/docs",
     locales: [],
     maxEntries: 50,
+    exclude: ["private/**"],
   });
 
   await ready;
@@ -173,6 +176,16 @@ describe("Server routes", () => {
     );
     expect(res.status).toBe(404);
     expect(data!.error).toContain("No doc found");
+  });
+
+  it("GET /doc-history/<excluded-slug>.json returns 404", async () => {
+    const callsBeforeRequest = vi.mocked(getDocHistoryAsync).mock.calls.length;
+    const { res, data } = await fetchJson(
+      `${baseUrl}/doc-history/private/draft.json`,
+    );
+    expect(res.status).toBe(404);
+    expect(data!.error).toContain("No doc found");
+    expect(getDocHistoryAsync).toHaveBeenCalledTimes(callsBeforeRequest);
   });
 
   it("GET /doc-history/getting-started.json?cachebust=1 ignores the query string", async () => {

--- a/packages/doc-history-server/src/args.ts
+++ b/packages/doc-history-server/src/args.ts
@@ -84,6 +84,7 @@ export interface CommonArgs {
   contentDir: string;
   locales: LocaleEntry[];
   maxEntries: number;
+  exclude: string[];
 }
 
 export interface ServerArgs extends CommonArgs {
@@ -103,7 +104,7 @@ export interface CliArgs extends CommonArgs {
   outDir: string;
 }
 
-/** Parse shared flags (--content-dir, --locale, --max-entries) */
+/** Parse shared flags (--content-dir, --locale, --max-entries, --exclude) */
 export function parseCommonArgs(
   args: string[],
   extra: {
@@ -113,6 +114,7 @@ export function parseCommonArgs(
   let contentDir = "";
   const locales: LocaleEntry[] = [];
   let maxEntries = 50;
+  const exclude: string[] = [];
 
   for (let i = 0; i < args.length; i++) {
     const flag = args[i];
@@ -125,6 +127,9 @@ export function parseCommonArgs(
         break;
       case "--locale":
         locales.push(parseLocaleArg(next()));
+        break;
+      case "--exclude":
+        exclude.push(next());
         break;
       case "--max-entries": {
         const raw = next();
@@ -152,7 +157,7 @@ export function parseCommonArgs(
     process.exit(1);
   }
 
-  return { contentDir, locales, maxEntries };
+  return { contentDir, locales, maxEntries, exclude };
 }
 
 /**

--- a/packages/doc-history-server/src/cli.ts
+++ b/packages/doc-history-server/src/cli.ts
@@ -5,15 +5,18 @@ import { parseCliArgs } from "./args.js";
 import { collectContentFiles, getDocHistoryAsync } from "./git-history.js";
 import { getContentDirEntries } from "./shared.js";
 import { makeSemaphore, defaultGitConcurrency } from "./concurrency.js";
+import { compileExclude } from "./exclude.js";
 
 async function generate(options: {
   contentDir: string;
   locales: Array<{ key: string; dir: string }>;
   outDir: string;
   maxEntries: number;
+  exclude: string[];
 }): Promise<number> {
-  const { contentDir, locales, outDir, maxEntries } = options;
+  const { contentDir, locales, outDir, maxEntries, exclude } = options;
   const startTime = performance.now();
+  const isExcluded = compileExclude(exclude);
 
   const dirEntries = getContentDirEntries(contentDir, locales);
 
@@ -32,7 +35,7 @@ async function generate(options: {
   const tasks: Promise<void>[] = [];
 
   for (const [localeKey, dir] of dirEntries) {
-    const files = collectContentFiles(dir);
+    const files = collectContentFiles(dir).filter(({ slug }) => !isExcluded(slug));
     const label = localeKey ?? "default";
     console.log(`Processing ${label}: ${files.length} files in ${dir}`);
 

--- a/packages/doc-history-server/src/exclude.ts
+++ b/packages/doc-history-server/src/exclude.ts
@@ -1,0 +1,41 @@
+/** Compile doc-history exclude globs into a reusable slug predicate. */
+export function compileExclude(patterns: string[]): (slug: string) => boolean {
+  const matchers = patterns.map((pattern) => {
+    let source = "";
+
+    for (let i = 0; i < pattern.length; i++) {
+      const char = pattern[i];
+
+      // A trailing /** includes the parent itself because ** may span zero
+      // segments. Elsewhere, **/ consumes any number of complete segments.
+      if (char === "/" && pattern.slice(i + 1) === "**") {
+        source += "(?:/.*)?";
+        break;
+      }
+      if (pattern.slice(i, i + 3) === "**/") {
+        source += "(?:[^/]+/)*";
+        i += 2;
+        continue;
+      }
+      if (pattern.slice(i, i + 2) === "**") {
+        source += ".*";
+        i++;
+        continue;
+      }
+      if (char === "*") {
+        source += "[^/]*";
+        continue;
+      }
+      if (char === "?") {
+        source += "[^/]";
+        continue;
+      }
+
+      source += char?.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
+    }
+
+    return new RegExp(`^${source}$`);
+  });
+
+  return (slug) => matchers.some((matcher) => matcher.test(slug));
+}

--- a/packages/doc-history-server/src/server.ts
+++ b/packages/doc-history-server/src/server.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import { statSync } from "node:fs";
 import { collectContentFiles, getDocHistoryAsync } from "./git-history.js";
 import { getContentDirEntries } from "./shared.js";
+import { compileExclude } from "./exclude.js";
 
 export interface ServerOptions {
   port: number;
@@ -11,6 +12,7 @@ export interface ServerOptions {
   contentDir: string;
   locales: Array<{ key: string; dir: string }>;
   maxEntries: number;
+  exclude: string[];
 }
 
 /** Interval (ms) at which the file index is refreshed to pick up new/renamed files */
@@ -70,11 +72,13 @@ function sendJson(res: ServerResponse, status: number, data: unknown, origin?: s
 /** Build a slug→filePath lookup map from content directories */
 function buildFileIndex(
   dirEntries: Array<[string | null, string]>,
+  isExcluded: (slug: string) => boolean,
 ): Map<string, { filePath: string; slug: string }> {
   const index = new Map<string, { filePath: string; slug: string }>();
   for (const [localeKey, contentDir] of dirEntries) {
     const files = collectContentFiles(contentDir);
     for (const file of files) {
+      if (isExcluded(file.slug)) continue;
       const prefixedSlug = localeKey ? `${localeKey}/${file.slug}` : file.slug;
       index.set(prefixedSlug, file);
     }
@@ -102,9 +106,10 @@ async function handleDocHistory(
 
 /** Create and start the HTTP server */
 export function startServer(options: ServerOptions): void {
-  const { port, host, contentDir, locales, maxEntries } = options;
+  const { port, host, contentDir, locales, maxEntries, exclude } = options;
   const dirEntries = getContentDirEntries(contentDir, locales);
-  let fileIndex = buildFileIndex(dirEntries);
+  const isExcluded = compileExclude(exclude);
+  let fileIndex = buildFileIndex(dirEntries, isExcluded);
   console.log(`Indexed ${fileIndex.size} documents`);
 
   // Periodically refresh file index to pick up new/renamed files during dev.
@@ -120,7 +125,7 @@ export function startServer(options: ServerOptions): void {
     try {
       const currentMtime = getContentDirsMtime(dirEntries);
       if (currentMtime === lastMtime) return; // nothing changed — skip walk
-      fileIndex = buildFileIndex(dirEntries);
+      fileIndex = buildFileIndex(dirEntries, isExcluded);
       lastMtime = currentMtime;
     } catch {
       // Ignore refresh errors — keep using the last good index

--- a/packages/zudo-doc/src/__tests__/fixtures/route-injection-i18n/src/config/settings.ts
+++ b/packages/zudo-doc/src/__tests__/fixtures/route-injection-i18n/src/config/settings.ts
@@ -56,6 +56,7 @@ export const settings = {
   dynamicPageTransition: false,
   frontmatterPreview: false,
   docHistory: false,
+  docHistoryExclude: [],
   bodyFootUtilArea: false,
   htmlPreview: undefined,
   versions: false,

--- a/packages/zudo-doc/src/__tests__/fixtures/route-injection/src/config/settings.ts
+++ b/packages/zudo-doc/src/__tests__/fixtures/route-injection/src/config/settings.ts
@@ -51,6 +51,7 @@ export const settings = {
   dynamicPageTransition: false,
   frontmatterPreview: false,
   docHistory: false,
+  docHistoryExclude: [],
   bodyFootUtilArea: false,
   htmlPreview: undefined,
   versions: false,

--- a/packages/zudo-doc/src/__tests__/preset.test.ts
+++ b/packages/zudo-doc/src/__tests__/preset.test.ts
@@ -218,6 +218,7 @@ const fixtureSettings: PresetSettings = {
     },
   ],
   docHistory: true,
+  docHistoryExclude: ["drafts/**"],
   claudeResources: { claudeDir: ".claude" },
   githubAutolinksRepo: "zudolab/zudo-doc",
   packageOwnedRoutes: true,
@@ -313,6 +314,7 @@ describe("zudoDocPreset plugins (bare-specifier descriptors)", () => {
       docsDir: "src/content/docs",
       locales: { ja: { dir: "src/content/docs-ja" } },
       base: "/",
+      exclude: ["drafts/**"],
     });
     expect(byName["@takazudo/zudo-doc/plugins/search-index"]).toEqual({
       docsDir: "src/content/docs",
@@ -356,6 +358,19 @@ describe("zudoDocPreset plugins (bare-specifier descriptors)", () => {
       themePack: "foundry",
       themePacks: ["default", "foundry"],
     });
+  });
+
+  it("defaults doc-history exclude patterns to an empty array", () => {
+    const result = zudoDocPreset({
+      settings: { ...fixtureSettings, docHistoryExclude: undefined },
+      buildDocsSchema: buildFixtureSchema,
+      directiveVocabulary: fixtureDirectives,
+    });
+    const docHistory = result.plugins.find(
+      (plugin) => plugin.name === "@takazudo/zudo-doc/plugins/doc-history",
+    );
+
+    expect(docHistory?.options?.["exclude"]).toEqual([]);
   });
 
   it("omits claude-resources / doc-history / llms-txt / changelog when their settings are falsy", () => {

--- a/packages/zudo-doc/src/config.ts
+++ b/packages/zudo-doc/src/config.ts
@@ -159,6 +159,7 @@ export const DEFAULT_SETTINGS: Settings = {
   dynamicPageTransition: false,
   frontmatterPreview: false,
   docHistory: false,
+  docHistoryExclude: [],
   bodyFootUtilArea: false,
   htmlPreview: undefined,
   versions: false,
@@ -412,6 +413,14 @@ export interface ZudoDocConfig {
    * @default false
    */
   docHistory?: boolean;
+  /**
+   * Glob patterns matched against the doc slug (path minus extension, `/index`
+   * stripped, root = `index`) that exclude matching pages from git-history
+   * capture entirely. Excluded pages have no dropdown JSON or
+   * Created/Updated/Author block; matching is locale/version-independent.
+   * @default []
+   */
+  docHistoryExclude?: string[];
   /**
    * Body-foot utility area (doc-history / view-source), or `false` to disable.
    * @default false

--- a/packages/zudo-doc/src/plugins/doc-history.ts
+++ b/packages/zudo-doc/src/plugins/doc-history.ts
@@ -34,7 +34,7 @@ const plugin: ZfbPlugin = {
   name: "doc-history",
 
   async preBuild(ctx: ZfbBuildHookContext) {
-    const { docsDir, locales } = ctx.options;
+    const { docsDir, locales, exclude } = ctx.options;
     // Validate each locale entry before passing downstream so a misconfigured
     // locales map surfaces a clear error instead of a confusing runtime crash.
     if (locales != null) {
@@ -51,6 +51,13 @@ const plugin: ZfbPlugin = {
         }
       }
     }
+    if (
+      exclude != null &&
+      (!Array.isArray(exclude) ||
+        exclude.some((pattern) => typeof pattern !== "string"))
+    ) {
+      throw new Error("[doc-history] invalid exclude: expected string[]");
+    }
     await runDocHistoryMetaStep({
       projectRoot: ctx.projectRoot,
       docsDir: typeof docsDir === "string" ? docsDir : "src/content/docs",
@@ -58,6 +65,7 @@ const plugin: ZfbPlugin = {
         locales != null
           ? (locales as Record<string, { dir: string }>)
           : undefined,
+      exclude: exclude as string[] | undefined,
     });
   },
 

--- a/packages/zudo-doc/src/plugins/internal/doc-history/__tests__/pre-build-manifest.test.ts
+++ b/packages/zudo-doc/src/plugins/internal/doc-history/__tests__/pre-build-manifest.test.ts
@@ -133,6 +133,45 @@ describe("runDocHistoryMetaStep (#2517)", () => {
     expect(manifest["untracked"]).toBeUndefined();
   });
 
+  it("omits excluded slugs for every locale while preserving remaining order", async () => {
+    const docsAbs = path.resolve(projectRoot, DOCS_DIR);
+    const jaAbs = path.resolve(projectRoot, JA_DIR);
+    stubFiles({
+      [docsAbs]: ["keep.mdx", "drafts/hidden.mdx", "last.mdx"],
+      [jaAbs]: ["keep.mdx", "drafts/hidden.mdx", "last.mdx"],
+    });
+    const meta = {
+      oldest: { author: "Alice", date: "2024-01-01T00:00:00Z" },
+      newest: { author: "Alice", date: "2024-01-02T00:00:00Z" },
+    };
+    mocks.getAllFilesFirstLastMetaAsync.mockResolvedValue(
+      new Map([
+        [`${docsAbs}/keep.mdx`, meta],
+        [`${docsAbs}/drafts/hidden.mdx`, meta],
+        [`${docsAbs}/last.mdx`, meta],
+        [`${jaAbs}/keep.mdx`, meta],
+        [`${jaAbs}/drafts/hidden.mdx`, meta],
+        [`${jaAbs}/last.mdx`, meta],
+      ]),
+    );
+
+    const { runDocHistoryMetaStep } = await import("../pre-build.js");
+    await runDocHistoryMetaStep({
+      projectRoot,
+      docsDir: DOCS_DIR,
+      locales: { ja: { dir: JA_DIR } },
+      exclude: ["drafts/**"],
+      logger: { info() {} },
+    });
+
+    expect(Object.keys(JSON.parse(readManifest()))).toEqual([
+      "keep",
+      "last",
+      "ja/keep",
+      "ja/last",
+    ]);
+  });
+
   it("short-circuits to literal `{}\\n` under SKIP_DOC_HISTORY=1 without walking git", async () => {
     process.env["SKIP_DOC_HISTORY"] = "1";
     const { runDocHistoryMetaStep } = await import("../pre-build.js");

--- a/packages/zudo-doc/src/plugins/internal/doc-history/__tests__/should-generate-postbuild.test.ts
+++ b/packages/zudo-doc/src/plugins/internal/doc-history/__tests__/should-generate-postbuild.test.ts
@@ -1,9 +1,24 @@
 import { describe, it, expect } from "vitest";
 import {
+  buildGenerateCliArgs,
   shouldGeneratePostBuild,
   DOC_HISTORY_GEN_ENV,
   DOC_HISTORY_SKIP_POSTBUILD_ENV,
 } from "../index.js";
+
+describe("buildGenerateCliArgs", () => {
+  it("emits one --exclude pair per slug glob", () => {
+    const args = buildGenerateCliArgs(
+      { docsDir: "src/content/docs", exclude: ["a/**", "b"] },
+      "dist",
+    );
+
+    const excludeValues = args.flatMap((arg, index) =>
+      arg === "--exclude" ? [args[index + 1]] : [],
+    );
+    expect(excludeValues).toEqual(["a/**", "b"]);
+  });
+});
 
 // #1986: postBuild per-page JSON generation flipped from opt-out to opt-in for
 // local builds. These cases lock in the decision table so a future refactor

--- a/packages/zudo-doc/src/plugins/internal/doc-history/index.ts
+++ b/packages/zudo-doc/src/plugins/internal/doc-history/index.ts
@@ -59,6 +59,8 @@ export interface DocHistoryOptions {
   docsDir: string;
   /** Optional non-default locales, keyed by locale code (e.g. `{ ja: { dir: "src/content/docs-ja" } }`). */
   locales?: Record<string, DocHistoryLocaleConfig>;
+  /** Slug globs excluded from pre-build metadata and post-build history JSON. */
+  exclude?: string[];
   /**
    * Port the standalone `@takazudo/zudo-doc-history-server` listens on.
    * Defaults to `4322` to match the server's CLI default. Only used by
@@ -306,6 +308,12 @@ export function buildGenerateCliArgs(
   if (options.locales) {
     for (const [key, locale] of Object.entries(options.locales)) {
       args.push("--locale", `${key}:${locale.dir}`);
+    }
+  }
+
+  if (options.exclude) {
+    for (const pattern of options.exclude) {
+      args.push("--exclude", pattern);
     }
   }
 

--- a/packages/zudo-doc/src/plugins/internal/doc-history/pre-build.ts
+++ b/packages/zudo-doc/src/plugins/internal/doc-history/pre-build.ts
@@ -53,6 +53,7 @@ import {
   collectContentFiles,
   getAllFilesFirstLastMetaAsync,
 } from "@takazudo/zudo-doc-history-server/git-history";
+import { compileExclude } from "@takazudo/zudo-doc-history-server/exclude";
 
 /** A single non-default locale entry; mirrors `settings.locales[*]`. */
 export interface DocHistoryMetaLocaleConfig {
@@ -78,6 +79,8 @@ export interface RunDocHistoryMetaOptions {
   docsDir: string;
   /** Optional non-default locales, keyed by locale code. */
   locales?: Record<string, DocHistoryMetaLocaleConfig>;
+  /** Slug globs excluded from the emitted metadata manifest. */
+  exclude?: string[];
   /**
    * Optional versioned docs (e.g. legacy `1.0`). Each version produces
    * its own default-locale collection plus per-locale variants.
@@ -169,9 +172,11 @@ export async function runDocHistoryMetaStep(
   // is critical for byte-identical JSON output: JSON key insertion order below
   // follows this list, independent of anything git emits.
   const jobs: Array<{ composedSlug: string; filePath: string }> = [];
+  const isExcluded = compileExclude(options.exclude ?? []);
   for (const [localeKey, contentDir] of dirEntries) {
     const files = collectContentFiles(contentDir);
     for (const { filePath, slug } of files) {
+      if (isExcluded(slug)) continue;
       const composedSlug = localeKey ? `${localeKey}/${slug}` : slug;
       jobs.push({ composedSlug, filePath });
     }

--- a/packages/zudo-doc/src/preset.ts
+++ b/packages/zudo-doc/src/preset.ts
@@ -93,6 +93,7 @@ export interface PresetSettings {
   llmsTxt?: boolean;
   changelogs?: PresetChangelogConfig[] | false;
   docHistory?: boolean;
+  docHistoryExclude?: string[];
   claudeResources?: PresetClaudeResourcesConfig | false;
   /** "owner/repo" — when set, enables `#123` / SHA autolinks in markdown. Omit to disable entirely. */
   githubAutolinksRepo?: string;
@@ -554,6 +555,7 @@ function buildPlugins(
               docsDir: settings.docsDir,
               locales: localeRecord,
               base: settings.base,
+              exclude: settings.docHistoryExclude ?? [],
             },
           },
         ]

--- a/packages/zudo-doc/src/settings.ts
+++ b/packages/zudo-doc/src/settings.ts
@@ -331,6 +331,7 @@ export interface Settings {
   dynamicPageTransition: boolean;
   frontmatterPreview: FrontmatterPreviewConfig | false;
   docHistory: boolean;
+  docHistoryExclude: string[];
   bodyFootUtilArea: BodyFootUtilAreaConfig | false;
   htmlPreview: HtmlPreviewConfig | undefined;
   versions: VersionConfig[] | false;


### PR DESCRIPTION
Closes #2975.

Threads exclusion globs through the preset and doc-history plugin into both prebuild metadata capture and postbuild history generation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/2995"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787003021&installation_id=130359969&pr_number=2995&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F2995&signature=a4279da349b2b4618dac3c870ff5ae4a22faddd4078781905f82d9355049afea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->