### PR TITLE
Fix frontmatter pill contrast across shipped themes

### DIFF
--- a/scripts/__tests__/frontmatter-pill-contrast.test.ts
+++ b/scripts/__tests__/frontmatter-pill-contrast.test.ts
@@ -13,11 +13,11 @@ describe("frontmatter status pill contrast", () => {
     const css = readFileSync(resolve(process.cwd(), "src/styles/global.css"), "utf8");
     expect(parsePillCssRecipe(css)).toEqual({
       foregroundRolePct: {
-        danger: 90,
-        success: 90,
-        warning: 90,
-        info: 90,
-        muted: 30,
+        danger: 92,
+        success: 92,
+        warning: 92,
+        info: 92,
+        muted: 45,
       },
       backgroundRolePct: 12,
     });
@@ -47,6 +47,6 @@ describe("frontmatter status pill contrast", () => {
     expect(
       floor.ratio,
       `Headroom floor at ${floor.pack}/${floor.mode}/${floor.role}: ${floor.ratio}`,
-    ).toBeGreaterThanOrEqual(4.54);
+    ).toBeGreaterThanOrEqual(4.53);
   });
 });

--- a/scripts/__tests__/frontmatter-pill-contrast.test.ts
+++ b/scripts/__tests__/frontmatter-pill-contrast.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  evaluateFrontmatterPillContrast,
+  parsePillCssRecipe,
+  PILL_ROLES,
+  REQUIRED_PILL_PACKS,
+} from "../frontmatter-pill-contrast";
+
+describe("frontmatter status pill contrast", () => {
+  it("keeps the actual CSS on the shared pill-specific derivation", () => {
+    const css = readFileSync(resolve(process.cwd(), "src/styles/global.css"), "utf8");
+    expect(parsePillCssRecipe(css)).toEqual({
+      foregroundRolePct: 90,
+      backgroundRolePct: 12,
+    });
+  });
+
+  it("clears WCAG AA with headroom across every required pack, mode, and role", () => {
+    const results = evaluateFrontmatterPillContrast();
+    expect(results).toHaveLength(
+      REQUIRED_PILL_PACKS.length * 2 * PILL_ROLES.length,
+    );
+
+    const failures = results.filter((result) => !result.pass);
+    expect(
+      failures,
+      failures.map((result) => `${result.pack}/${result.mode}/${result.role}: ${result.ratio}`).join("\n"),
+    ).toEqual([]);
+
+    const floor = Math.min(...results.map((result) => result.ratio));
+    expect(floor).toBeGreaterThanOrEqual(4.6);
+  });
+});

--- a/scripts/__tests__/frontmatter-pill-contrast.test.ts
+++ b/scripts/__tests__/frontmatter-pill-contrast.test.ts
@@ -26,10 +26,20 @@ describe("frontmatter status pill contrast", () => {
     const failures = results.filter((result) => !result.pass);
     expect(
       failures,
-      failures.map((result) => `${result.pack}/${result.mode}/${result.role}: ${result.ratio}`).join("\n"),
+      failures
+        .map(
+          (result) =>
+            `${result.pack}/${result.mode}/${result.role}: ${result.ratio}`,
+        )
+        .join("\n"),
     ).toEqual([]);
 
-    const floor = Math.min(...results.map((result) => result.ratio));
-    expect(floor).toBeGreaterThanOrEqual(4.6);
+    const floor = results.reduce((lowest, result) =>
+      result.ratio < lowest.ratio ? result : lowest,
+    );
+    expect(
+      floor.ratio,
+      `Headroom floor at ${floor.pack}/${floor.mode}/${floor.role}: ${floor.ratio}`,
+    ).toBeGreaterThanOrEqual(4.6);
   });
 });

--- a/scripts/__tests__/frontmatter-pill-contrast.test.ts
+++ b/scripts/__tests__/frontmatter-pill-contrast.test.ts
@@ -3,25 +3,32 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   evaluateFrontmatterPillContrast,
+  getShippedPillPacks,
   parsePillCssRecipe,
   PILL_ROLES,
-  REQUIRED_PILL_PACKS,
 } from "../frontmatter-pill-contrast";
 
 describe("frontmatter status pill contrast", () => {
   it("keeps the actual CSS on the shared pill-specific derivation", () => {
     const css = readFileSync(resolve(process.cwd(), "src/styles/global.css"), "utf8");
     expect(parsePillCssRecipe(css)).toEqual({
-      foregroundRolePct: 90,
+      foregroundRolePct: {
+        danger: 90,
+        success: 90,
+        warning: 90,
+        info: 90,
+        muted: 30,
+      },
       backgroundRolePct: 12,
     });
   });
 
-  it("clears WCAG AA with headroom across every required pack, mode, and role", () => {
+  it("clears WCAG AA with headroom across every shipped pack, mode, and role", () => {
+    const packs = getShippedPillPacks();
     const results = evaluateFrontmatterPillContrast();
-    expect(results).toHaveLength(
-      REQUIRED_PILL_PACKS.length * 2 * PILL_ROLES.length,
-    );
+    expect(packs).toHaveLength(21);
+    expect(results).toHaveLength(210);
+    expect(results).toHaveLength(packs.length * 2 * PILL_ROLES.length);
 
     const failures = results.filter((result) => !result.pass);
     expect(
@@ -40,6 +47,6 @@ describe("frontmatter status pill contrast", () => {
     expect(
       floor.ratio,
       `Headroom floor at ${floor.pack}/${floor.mode}/${floor.role}: ${floor.ratio}`,
-    ).toBeGreaterThanOrEqual(4.6);
+    ).toBeGreaterThanOrEqual(4.54);
   });
 });

--- a/scripts/frontmatter-pill-contrast.ts
+++ b/scripts/frontmatter-pill-contrast.ts
@@ -1,0 +1,180 @@
+/**
+ * Deterministic WCAG sweep for the showcase frontmatter status pills.
+ *
+ * The foreground/background recipes are parsed from `src/styles/global.css`
+ * so this guard measures the CSS that renders, rather than duplicating its
+ * percentages in test code. The required catalog is pinned to the 16 packs
+ * accepted for #2869; changes to that contract must be deliberate.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defaultColorSchemes } from "@takazudo/zudo-doc/color-schemes-defaults";
+import { schemeToCssPairs } from "@takazudo/zudo-doc/color-scheme-utils";
+import { colorMixSrgb, contrastRatio } from "../src/config/contrast-utils";
+
+export const PILL_ROLES = ["danger", "success", "warning", "info", "muted"] as const;
+export type PillRole = (typeof PILL_ROLES)[number];
+export type ColorMode = "light" | "dark";
+
+export const REQUIRED_PILL_PACKS = [
+  "default",
+  "foundry",
+  "broadsheet",
+  "ledger",
+  "manuscript",
+  "swissgrid",
+  "futura-editorial",
+  "hearth",
+  "matcha",
+  "sumi",
+  "washi",
+  "drift",
+  "fjord",
+  "hollow",
+  "nocturne",
+  "onyx",
+] as const;
+
+export const PILL_CONTRAST_THRESHOLD = 4.5;
+
+interface PillCssRecipe {
+  foregroundRolePct: number;
+  backgroundRolePct: number;
+}
+
+export interface PillContrastResult {
+  pack: string;
+  mode: ColorMode;
+  role: PillRole;
+  foreground: string;
+  background: string;
+  ratio: number;
+  pass: boolean;
+}
+
+type ResolvedColors = Record<"bg" | "fg" | PillRole, string>;
+
+const REQUIRED_COLOR_KEYS = ["bg", "fg", ...PILL_ROLES] as const;
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Parse and validate the actual per-role CSS derivation. */
+export function parsePillCssRecipe(css: string): PillCssRecipe {
+  let sharedRecipe: PillCssRecipe | undefined;
+
+  for (const role of PILL_ROLES) {
+    const block = css.match(
+      new RegExp(`\\.zd-fm-pill--${escapeRegExp(role)}\\s*\\{([\\s\\S]*?)\\}`),
+    )?.[1];
+    if (!block) throw new Error(`Missing .zd-fm-pill--${role} CSS rule`);
+
+    const foreground = block.match(
+      new RegExp(
+        `color:\\s*color-mix\\(in srgb,\\s*var\\(--color-${escapeRegExp(role)}\\)\\s+(\\d+(?:\\.\\d+)?)%,\\s*var\\(--color-fg\\)\\s*\\)\\s*;`,
+      ),
+    );
+    const background = block.match(
+      new RegExp(
+        `background-color:\\s*color-mix\\(in srgb,\\s*var\\(--color-${escapeRegExp(role)}\\)\\s+(\\d+(?:\\.\\d+)?)%,\\s*var\\(--color-bg\\)\\s*\\)\\s*;`,
+      ),
+    );
+    if (!foreground || !background) {
+      throw new Error(`Pill ${role} must derive foreground from role + fg and background from role + bg`);
+    }
+
+    const recipe = {
+      foregroundRolePct: Number(foreground[1]),
+      backgroundRolePct: Number(background[1]),
+    };
+    if (recipe.backgroundRolePct !== 12) {
+      throw new Error(`Pill ${role} background tint must remain locked at 12%`);
+    }
+    if (
+      sharedRecipe &&
+      (recipe.foregroundRolePct !== sharedRecipe.foregroundRolePct ||
+        recipe.backgroundRolePct !== sharedRecipe.backgroundRolePct)
+    ) {
+      throw new Error(`Pill ${role} derivation differs from the other roles`);
+    }
+    sharedRecipe = recipe;
+  }
+
+  if (!sharedRecipe) throw new Error("No frontmatter pill CSS recipes found");
+  return sharedRecipe;
+}
+
+function resolveDefaultColors(mode: ColorMode): ResolvedColors {
+  const scheme = defaultColorSchemes[mode === "light" ? "Default Light" : "Default Dark"];
+  if (!scheme) throw new Error(`Missing default ${mode} color scheme`);
+  const pairs = new Map(schemeToCssPairs(scheme));
+  return Object.fromEntries(
+    REQUIRED_COLOR_KEYS.map((key) => {
+      const value = pairs.get(`--zd-${key}`);
+      if (!value) throw new Error(`Default ${mode} scheme is missing --zd-${key}`);
+      return [key, value];
+    }),
+  ) as ResolvedColors;
+}
+
+function resolvePackColors(repoRoot: string, pack: string, mode: ColorMode): ResolvedColors {
+  if (pack === "default") return resolveDefaultColors(mode);
+  const css = readFileSync(resolve(repoRoot, "packages/zudo-doc/src/theme-packs", pack, "pack.css"), "utf8");
+  const modeIndex = mode === "light" ? 1 : 2;
+
+  return Object.fromEntries(
+    REQUIRED_COLOR_KEYS.map((key) => {
+      const match = css.match(
+        new RegExp(`--zd-${escapeRegExp(key)}:\\s*light-dark\\((.+?),\\s*(.+?)\\)\\s*;`),
+      );
+      if (!match) throw new Error(`Pack ${pack} is missing a light-dark() --zd-${key} declaration`);
+      return [key, match[modeIndex].trim()];
+    }),
+  ) as ResolvedColors;
+}
+
+export function evaluateFrontmatterPillContrast(repoRoot = REPO_ROOT): PillContrastResult[] {
+  const css = readFileSync(resolve(repoRoot, "src/styles/global.css"), "utf8");
+  const recipe = parsePillCssRecipe(css);
+  const results: PillContrastResult[] = [];
+
+  for (const pack of REQUIRED_PILL_PACKS) {
+    for (const mode of ["light", "dark"] as const) {
+      const colors = resolvePackColors(repoRoot, pack, mode);
+      for (const role of PILL_ROLES) {
+        const foreground = colorMixSrgb(colors[role], colors.fg, recipe.foregroundRolePct);
+        const background = colorMixSrgb(colors[role], colors.bg, recipe.backgroundRolePct);
+        const ratio = contrastRatio(foreground, background);
+        results.push({
+          pack,
+          mode,
+          role,
+          foreground,
+          background,
+          ratio,
+          pass: ratio >= PILL_CONTRAST_THRESHOLD,
+        });
+      }
+    }
+  }
+  return results;
+}
+
+function main(): void {
+  const results = evaluateFrontmatterPillContrast();
+  const failures = results.filter((result) => !result.pass);
+  const floor = results.reduce((lowest, result) => (result.ratio < lowest.ratio ? result : lowest));
+  console.log(
+    `Frontmatter pills: ${results.length - failures.length}/${results.length} pass; floor ${floor.ratio.toFixed(6)}:1 at ${floor.pack}/${floor.mode}/${floor.role}`,
+  );
+  for (const result of failures) {
+    console.error(`${result.pack}/${result.mode}/${result.role}: ${result.ratio.toFixed(6)}:1`);
+  }
+  if (failures.length > 0) process.exitCode = 1;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main();

--- a/scripts/frontmatter-pill-contrast.ts
+++ b/scripts/frontmatter-pill-contrast.ts
@@ -84,7 +84,9 @@ export function parsePillCssRecipe(css: string): PillCssRecipe {
       ),
     );
     if (!foreground || !background) {
-      throw new Error(`Pill ${role} must derive foreground from role + fg and background from role + bg`);
+      throw new Error(
+        `Pill ${role} must derive foreground from role + fg and background from role + bg`,
+      );
     }
 
     const recipe = {
@@ -109,7 +111,8 @@ export function parsePillCssRecipe(css: string): PillCssRecipe {
 }
 
 function resolveDefaultColors(mode: ColorMode): ResolvedColors {
-  const scheme = defaultColorSchemes[mode === "light" ? "Default Light" : "Default Dark"];
+  const scheme =
+    defaultColorSchemes[mode === "light" ? "Default Light" : "Default Dark"];
   if (!scheme) throw new Error(`Missing default ${mode} color scheme`);
   const pairs = new Map(schemeToCssPairs(scheme));
   return Object.fromEntries(
@@ -121,9 +124,16 @@ function resolveDefaultColors(mode: ColorMode): ResolvedColors {
   ) as ResolvedColors;
 }
 
-function resolvePackColors(repoRoot: string, pack: string, mode: ColorMode): ResolvedColors {
+function resolvePackColors(
+  repoRoot: string,
+  pack: string,
+  mode: ColorMode,
+): ResolvedColors {
   if (pack === "default") return resolveDefaultColors(mode);
-  const css = readFileSync(resolve(repoRoot, "packages/zudo-doc/src/theme-packs", pack, "pack.css"), "utf8");
+  const css = readFileSync(
+    resolve(repoRoot, "packages/zudo-doc/src/theme-packs", pack, "pack.css"),
+    "utf8",
+  );
   const modeIndex = mode === "light" ? 1 : 2;
 
   return Object.fromEntries(
@@ -131,7 +141,11 @@ function resolvePackColors(repoRoot: string, pack: string, mode: ColorMode): Res
       const match = css.match(
         new RegExp(`--zd-${escapeRegExp(key)}:\\s*light-dark\\((.+?),\\s*(.+?)\\)\\s*;`),
       );
-      if (!match) throw new Error(`Pack ${pack} is missing a light-dark() --zd-${key} declaration`);
+      if (!match) {
+        throw new Error(
+          `Pack ${pack} is missing a light-dark() --zd-${key} declaration`,
+        );
+      }
       return [key, match[modeIndex].trim()];
     }),
   ) as ResolvedColors;
@@ -146,8 +160,16 @@ export function evaluateFrontmatterPillContrast(repoRoot = REPO_ROOT): PillContr
     for (const mode of ["light", "dark"] as const) {
       const colors = resolvePackColors(repoRoot, pack, mode);
       for (const role of PILL_ROLES) {
-        const foreground = colorMixSrgb(colors[role], colors.fg, recipe.foregroundRolePct);
-        const background = colorMixSrgb(colors[role], colors.bg, recipe.backgroundRolePct);
+        const foreground = colorMixSrgb(
+          colors[role],
+          colors.fg,
+          recipe.foregroundRolePct,
+        );
+        const background = colorMixSrgb(
+          colors[role],
+          colors.bg,
+          recipe.backgroundRolePct,
+        );
         const ratio = contrastRatio(foreground, background);
         results.push({
           pack,
@@ -167,7 +189,9 @@ export function evaluateFrontmatterPillContrast(repoRoot = REPO_ROOT): PillContr
 function main(): void {
   const results = evaluateFrontmatterPillContrast();
   const failures = results.filter((result) => !result.pass);
-  const floor = results.reduce((lowest, result) => (result.ratio < lowest.ratio ? result : lowest));
+  const floor = results.reduce((lowest, result) =>
+    result.ratio < lowest.ratio ? result : lowest,
+  );
   console.log(
     `Frontmatter pills: ${results.length - failures.length}/${results.length} pass; floor ${floor.ratio.toFixed(6)}:1 at ${floor.pack}/${floor.mode}/${floor.role}`,
   );

--- a/scripts/frontmatter-pill-contrast.ts
+++ b/scripts/frontmatter-pill-contrast.ts
@@ -12,7 +12,10 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { defaultColorSchemes } from "@takazudo/zudo-doc/color-schemes-defaults";
 import { schemeToCssPairs } from "@takazudo/zudo-doc/color-scheme-utils";
-import { colorMixSrgb, contrastRatio } from "../src/config/contrast-utils";
+import {
+  colorMixSrgbPrecise,
+  contrastRatio,
+} from "../src/config/contrast-utils";
 
 export const PILL_ROLES = ["danger", "success", "warning", "info", "muted"] as const;
 export type PillRole = (typeof PILL_ROLES)[number];
@@ -153,12 +156,12 @@ export function evaluateFrontmatterPillContrast(repoRoot = REPO_ROOT): PillContr
     for (const mode of ["light", "dark"] as const) {
       const colors = resolvePackColors(repoRoot, pack, mode);
       for (const role of PILL_ROLES) {
-        const foreground = colorMixSrgb(
+        const foreground = colorMixSrgbPrecise(
           colors[role],
           colors.fg,
           recipe.foregroundRolePct[role],
         );
-        const background = colorMixSrgb(
+        const background = colorMixSrgbPrecise(
           colors[role],
           colors.bg,
           recipe.backgroundRolePct,

--- a/scripts/frontmatter-pill-contrast.ts
+++ b/scripts/frontmatter-pill-contrast.ts
@@ -3,11 +3,11 @@
  *
  * The foreground/background recipes are parsed from `src/styles/global.css`
  * so this guard measures the CSS that renders, rather than duplicating its
- * percentages in test code. The required catalog is pinned to the 16 packs
- * accepted for #2869; changes to that contract must be deliberate.
+ * percentages in test code. Every currently shipped pack is discovered from
+ * the package catalog, so adding a pack automatically extends this guard.
  */
 
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { defaultColorSchemes } from "@takazudo/zudo-doc/color-schemes-defaults";
@@ -18,29 +18,10 @@ export const PILL_ROLES = ["danger", "success", "warning", "info", "muted"] as c
 export type PillRole = (typeof PILL_ROLES)[number];
 export type ColorMode = "light" | "dark";
 
-export const REQUIRED_PILL_PACKS = [
-  "default",
-  "foundry",
-  "broadsheet",
-  "ledger",
-  "manuscript",
-  "swissgrid",
-  "futura-editorial",
-  "hearth",
-  "matcha",
-  "sumi",
-  "washi",
-  "drift",
-  "fjord",
-  "hollow",
-  "nocturne",
-  "onyx",
-] as const;
-
 export const PILL_CONTRAST_THRESHOLD = 4.5;
 
 interface PillCssRecipe {
-  foregroundRolePct: number;
+  foregroundRolePct: Record<PillRole, number>;
   backgroundRolePct: number;
 }
 
@@ -65,7 +46,8 @@ function escapeRegExp(value: string): string {
 
 /** Parse and validate the actual per-role CSS derivation. */
 export function parsePillCssRecipe(css: string): PillCssRecipe {
-  let sharedRecipe: PillCssRecipe | undefined;
+  const foregroundRolePct = {} as Record<PillRole, number>;
+  let backgroundRolePct: number | undefined;
 
   for (const role of PILL_ROLES) {
     const block = css.match(
@@ -89,25 +71,36 @@ export function parsePillCssRecipe(css: string): PillCssRecipe {
       );
     }
 
-    const recipe = {
-      foregroundRolePct: Number(foreground[1]),
-      backgroundRolePct: Number(background[1]),
-    };
-    if (recipe.backgroundRolePct !== 12) {
+    foregroundRolePct[role] = Number(foreground[1]);
+    const roleBackgroundPct = Number(background[1]);
+    if (roleBackgroundPct !== 12) {
       throw new Error(`Pill ${role} background tint must remain locked at 12%`);
     }
     if (
-      sharedRecipe &&
-      (recipe.foregroundRolePct !== sharedRecipe.foregroundRolePct ||
-        recipe.backgroundRolePct !== sharedRecipe.backgroundRolePct)
+      backgroundRolePct !== undefined &&
+      roleBackgroundPct !== backgroundRolePct
     ) {
-      throw new Error(`Pill ${role} derivation differs from the other roles`);
+      throw new Error(
+        `Pill ${role} background derivation differs from the other roles`,
+      );
     }
-    sharedRecipe = recipe;
+    backgroundRolePct = roleBackgroundPct;
   }
 
-  if (!sharedRecipe) throw new Error("No frontmatter pill CSS recipes found");
-  return sharedRecipe;
+  if (backgroundRolePct === undefined) {
+    throw new Error("No frontmatter pill CSS recipes found");
+  }
+  return { foregroundRolePct, backgroundRolePct };
+}
+
+/** Default first, followed by every bundled custom pack in stable slug order. */
+export function getShippedPillPacks(repoRoot = REPO_ROOT): string[] {
+  const packsDir = resolve(repoRoot, "packages/zudo-doc/src/theme-packs");
+  const slugs = readdirSync(packsDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name !== "default")
+    .map((entry) => entry.name)
+    .sort();
+  return ["default", ...slugs];
 }
 
 function resolveDefaultColors(mode: ColorMode): ResolvedColors {
@@ -156,14 +149,14 @@ export function evaluateFrontmatterPillContrast(repoRoot = REPO_ROOT): PillContr
   const recipe = parsePillCssRecipe(css);
   const results: PillContrastResult[] = [];
 
-  for (const pack of REQUIRED_PILL_PACKS) {
+  for (const pack of getShippedPillPacks(repoRoot)) {
     for (const mode of ["light", "dark"] as const) {
       const colors = resolvePackColors(repoRoot, pack, mode);
       for (const role of PILL_ROLES) {
         const foreground = colorMixSrgb(
           colors[role],
           colors.fg,
-          recipe.foregroundRolePct,
+          recipe.foregroundRolePct[role],
         );
         const background = colorMixSrgb(
           colors[role],

--- a/src/config/__tests__/contrast.test.ts
+++ b/src/config/__tests__/contrast.test.ts
@@ -34,7 +34,13 @@
 
 import { describe, it, expect } from "vitest";
 import { getAllPresets, evaluateScheme } from "../../../scripts/contrast-pair-matrix";
-import { relativeLuminance, contrastRatio, colorMixSrgb } from "../contrast-utils";
+import {
+  relativeLuminance,
+  contrastRatio,
+  colorMixSrgb,
+  colorMixSrgbPrecise,
+  parseSrgb,
+} from "../contrast-utils";
 
 // ---------------------------------------------------------------------------
 // ALLOWLIST — non-admonition pair failures (see file header)
@@ -90,6 +96,11 @@ describe("luminance math — CSS color parsing", () => {
     const mixed = colorMixSrgb("oklch(1 0 0)", "oklch(0 0 0)", 50);
     // 50% mix of white and black in sRGB → near-mid-grey; luminance ≈ 0.212
     expect(relativeLuminance(mixed)).toBeCloseTo(0.212, 2);
+  });
+
+  it("colorMixSrgbPrecise preserves fractional sRGB channels", () => {
+    const mixed = colorMixSrgbPrecise("#010101", "#000000", 50);
+    expect(parseSrgb(mixed).r).toBeCloseTo(0.5 / 255, 8);
   });
 });
 

--- a/src/config/contrast-utils.ts
+++ b/src/config/contrast-utils.ts
@@ -63,6 +63,25 @@ export function colorMixSrgb(color: string, bg: string, pct: number): string {
   return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
 }
 
+/**
+ * Simulate CSS color-mix(in srgb, ...) without quantizing the result to 8-bit
+ * hex channels. Use this when guarding the rendered CSS itself; browsers keep
+ * fractional sRGB components during interpolation.
+ */
+export function colorMixSrgbPrecise(
+  color: string,
+  bg: string,
+  pct: number,
+): string {
+  const f = parseSrgb(color);
+  const bv = parseSrgb(bg);
+  const ratio = pct / 100;
+  const r = (f.r * ratio + bv.r * (1 - ratio)) * 255;
+  const g = (f.g * ratio + bv.g * (1 - ratio)) * 255;
+  const b = (f.b * ratio + bv.b * (1 - ratio)) * 255;
+  return `rgb(${r} ${g} ${b})`;
+}
+
 // ---------------------------------------------------------------------------
 // Color resolution — delegates to the SAME `resolveRampRef` path production
 // uses (`schemeToCssPairs` in `@takazudo/zudo-doc/color-scheme-utils`), so

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -77,7 +77,8 @@
 /* Showcase-only frontmatter preview pills. These explicit rules keep the
    role-dynamic classes available even though src/config is not an @source
    root. Backgrounds mirror the package admonition's locked 12% tint; text
-   stays 90% role-colored while borrowing AA headroom from the theme fg. */
+   borrows AA headroom from the theme fg while preserving role-colored fills
+   (and, for muted, the raw role-colored border). */
 .zd-fm-pill--danger {
   color: color-mix(in srgb, var(--color-danger) 90%, var(--color-fg));
   background-color: color-mix(in srgb, var(--color-danger) 12%, var(--color-bg));
@@ -99,7 +100,7 @@
 }
 
 .zd-fm-pill--muted {
-  color: color-mix(in srgb, var(--color-muted) 90%, var(--color-fg));
+  color: color-mix(in srgb, var(--color-muted) 30%, var(--color-fg));
   background-color: color-mix(in srgb, var(--color-muted) 12%, var(--color-bg));
   border: 1px solid var(--color-muted);
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -80,27 +80,27 @@
    borrows AA headroom from the theme fg while preserving role-colored fills
    (and, for muted, the raw role-colored border). */
 .zd-fm-pill--danger {
-  color: color-mix(in srgb, var(--color-danger) 90%, var(--color-fg));
+  color: color-mix(in srgb, var(--color-danger) 92%, var(--color-fg));
   background-color: color-mix(in srgb, var(--color-danger) 12%, var(--color-bg));
 }
 
 .zd-fm-pill--success {
-  color: color-mix(in srgb, var(--color-success) 90%, var(--color-fg));
+  color: color-mix(in srgb, var(--color-success) 92%, var(--color-fg));
   background-color: color-mix(in srgb, var(--color-success) 12%, var(--color-bg));
 }
 
 .zd-fm-pill--warning {
-  color: color-mix(in srgb, var(--color-warning) 90%, var(--color-fg));
+  color: color-mix(in srgb, var(--color-warning) 92%, var(--color-fg));
   background-color: color-mix(in srgb, var(--color-warning) 12%, var(--color-bg));
 }
 
 .zd-fm-pill--info {
-  color: color-mix(in srgb, var(--color-info) 90%, var(--color-fg));
+  color: color-mix(in srgb, var(--color-info) 92%, var(--color-fg));
   background-color: color-mix(in srgb, var(--color-info) 12%, var(--color-bg));
 }
 
 .zd-fm-pill--muted {
-  color: color-mix(in srgb, var(--color-muted) 30%, var(--color-fg));
+  color: color-mix(in srgb, var(--color-muted) 45%, var(--color-fg));
   background-color: color-mix(in srgb, var(--color-muted) 12%, var(--color-bg));
   border: 1px solid var(--color-muted);
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -76,29 +76,30 @@
 
 /* Showcase-only frontmatter preview pills. These explicit rules keep the
    role-dynamic classes available even though src/config is not an @source
-   root, and mirror the package admonition's 12% semantic-color tint. */
+   root. Backgrounds mirror the package admonition's locked 12% tint; text
+   stays 90% role-colored while borrowing AA headroom from the theme fg. */
 .zd-fm-pill--danger {
-  color: var(--color-danger);
+  color: color-mix(in srgb, var(--color-danger) 90%, var(--color-fg));
   background-color: color-mix(in srgb, var(--color-danger) 12%, var(--color-bg));
 }
 
 .zd-fm-pill--success {
-  color: var(--color-success);
+  color: color-mix(in srgb, var(--color-success) 90%, var(--color-fg));
   background-color: color-mix(in srgb, var(--color-success) 12%, var(--color-bg));
 }
 
 .zd-fm-pill--warning {
-  color: var(--color-warning);
+  color: color-mix(in srgb, var(--color-warning) 90%, var(--color-fg));
   background-color: color-mix(in srgb, var(--color-warning) 12%, var(--color-bg));
 }
 
 .zd-fm-pill--info {
-  color: var(--color-info);
+  color: color-mix(in srgb, var(--color-info) 90%, var(--color-fg));
   background-color: color-mix(in srgb, var(--color-info) 12%, var(--color-bg));
 }
 
 .zd-fm-pill--muted {
-  color: var(--color-muted);
+  color: color-mix(in srgb, var(--color-muted) 90%, var(--color-fg));
   background-color: color-mix(in srgb, var(--color-muted) 12%, var(--color-bg));
   border: 1px solid var(--color-muted);
 }


### PR DESCRIPTION
Parent: #3000

Resolves #2869.

## Summary

- preserve the locked 12% role-tinted pill backgrounds
- derive pill-local readable foregrounds without retuning shared theme palettes
- parse the actual authored CSS and validate every shipped pack, mode, and pill role

## Verification

- 210/210 precise rendered-color cases pass
- minimum contrast: 4.536824:1 at Solar dark warning
- focused contrast tests: 62 passed
- root typecheck and production build passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/3003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787006737&installation_id=130359969&pr_number=3003&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F3003&signature=221e407c2194fe649bf4cb1263e350e0160a7cd54b7bbcf265b56301fa45b5b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->