### PR TITLE
Add shared class-token source of truth for header nav SSR ↔ overflow-script lockstep (#3023)

### DIFF
--- a/packages/zudo-doc/src/header/__tests__/nav-class-tokens.test.ts
+++ b/packages/zudo-doc/src/header/__tests__/nav-class-tokens.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import {
+  NAV_CHEVRON_ACTIVE,
+  NAV_CHEVRON_INACTIVE,
+  NAV_CHILD_ACTIVE,
+  NAV_CHILD_INACTIVE,
+  NAV_MENU_CHILD_ACTIVE,
+  NAV_MENU_CHILD_INACTIVE,
+  NAV_MENU_PARENT,
+  NAV_MENU_PARENT_ACTIVE_SUFFIX,
+  NAV_MENU_PLAIN,
+  NAV_MENU_PLAIN_ACTIVE_SUFFIX,
+  NAV_TOP_ACTIVE,
+  NAV_TOP_INACTIVE,
+} from "../nav-class-tokens.js";
+import { NAV_OVERFLOW_SCRIPT } from "../nav-overflow-script.js";
+
+const join = (tokens: readonly string[]): string => tokens.join(" ");
+
+// Regression guard for zudolab/zudo-doc#3023. These class strings are the
+// header SSR ↔ nav-overflow-script lockstep. Editing a token below is a
+// deliberate design change: update the pinned expectation here AND the
+// tokens can only be edited in ONE place (nav-class-tokens.ts), which is the
+// whole point — the two consumers can no longer diverge. This test pins the
+// values so an accidental edit can't slip through silently, and proves the
+// browser-script string still carries the exact same classes.
+describe("nav-class-tokens — pinned lockstep values", () => {
+  it("top-level active / inactive", () => {
+    expect(join(NAV_TOP_ACTIVE)).toBe("bg-fg text-bg");
+    expect(join(NAV_TOP_INACTIVE)).toBe(
+      "text-muted hover:text-accent hover:underline focus:underline focus:text-accent",
+    );
+  });
+
+  it("dropdown chevron active / inactive", () => {
+    expect(join(NAV_CHEVRON_ACTIVE)).toBe("text-bg");
+    expect(join(NAV_CHEVRON_INACTIVE)).toBe("text-muted");
+  });
+
+  it("dropdown child active / inactive", () => {
+    expect(join(NAV_CHILD_ACTIVE)).toBe("font-bold text-accent");
+    expect(join(NAV_CHILD_INACTIVE)).toBe(
+      "text-fg hover:text-accent focus-visible:text-accent",
+    );
+  });
+
+  it("overflow menu recipes compose to the exact runtime strings", () => {
+    expect(join(NAV_MENU_PARENT)).toBe(
+      "block px-hsp-md py-vsp-2xs text-small font-bold hover:bg-accent/10 hover:underline focus-visible:underline focus-visible:text-accent text-fg hover:text-accent",
+    );
+    expect(join(NAV_MENU_PARENT_ACTIVE_SUFFIX)).toBe("text-accent");
+    expect(join(NAV_MENU_PLAIN)).toBe(
+      "block px-hsp-md py-vsp-2xs text-small hover:bg-accent/10 hover:underline focus-visible:underline focus-visible:text-accent text-fg hover:text-accent",
+    );
+    expect(join(NAV_MENU_PLAIN_ACTIVE_SUFFIX)).toBe("font-bold text-accent");
+    expect(join(NAV_MENU_CHILD_ACTIVE)).toBe(
+      "block pl-hsp-xl pr-hsp-md py-vsp-2xs text-small font-bold text-accent hover:bg-accent/10 hover:underline focus-visible:underline",
+    );
+    expect(join(NAV_MENU_CHILD_INACTIVE)).toBe(
+      "block pl-hsp-xl pr-hsp-md py-vsp-2xs text-small text-fg hover:bg-accent/10 hover:text-accent hover:underline focus-visible:underline focus-visible:text-accent",
+    );
+  });
+});
+
+// The strings below are the ORIGINAL literals that lived in the script before
+// the shared-constants refactor. Asserting the emitted script still contains
+// them proves the build-time interpolation reproduced the runtime class output
+// byte-for-byte — i.e. this was a no-op refactor, not a behavior change.
+describe("NAV_OVERFLOW_SCRIPT emits the shared tokens verbatim", () => {
+  it("top-level toggle (setTopActive)", () => {
+    expect(NAV_OVERFLOW_SCRIPT).toContain(
+      'a.classList.add("bg-fg", "text-bg");',
+    );
+    expect(NAV_OVERFLOW_SCRIPT).toContain(
+      'a.classList.remove("text-muted", "hover:text-accent", "hover:underline", "focus:underline", "focus:text-accent");',
+    );
+  });
+
+  it("dropdown chevron toggle", () => {
+    expect(NAV_OVERFLOW_SCRIPT).toContain(
+      'svg.classList.add("text-bg"); svg.classList.remove("text-muted");',
+    );
+    expect(NAV_OVERFLOW_SCRIPT).toContain(
+      'svg.classList.add("text-muted"); svg.classList.remove("text-bg");',
+    );
+  });
+
+  it("dropdown child toggle (applyActiveNav)", () => {
+    expect(NAV_OVERFLOW_SCRIPT).toContain(
+      'c.classList.add("font-bold", "text-accent");',
+    );
+    expect(NAV_OVERFLOW_SCRIPT).toContain(
+      'c.classList.add("text-fg", "hover:text-accent", "focus-visible:text-accent");',
+    );
+  });
+
+  it("overflow parent + plain recipes and active suffixes", () => {
+    expect(NAV_OVERFLOW_SCRIPT).toContain(
+      'a.className = "block px-hsp-md py-vsp-2xs text-small font-bold hover:bg-accent/10 hover:underline focus-visible:underline focus-visible:text-accent text-fg hover:text-accent";',
+    );
+    expect(NAV_OVERFLOW_SCRIPT).toContain('a.className += " text-accent";');
+    expect(NAV_OVERFLOW_SCRIPT).toContain(
+      'a2.className = "block px-hsp-md py-vsp-2xs text-small hover:bg-accent/10 hover:underline focus-visible:underline focus-visible:text-accent text-fg hover:text-accent";',
+    );
+    expect(NAV_OVERFLOW_SCRIPT).toContain(
+      'a2.className += " font-bold text-accent";',
+    );
+  });
+
+  it("overflow child recipe (active / inactive)", () => {
+    expect(NAV_OVERFLOW_SCRIPT).toContain(
+      '? "block pl-hsp-xl pr-hsp-md py-vsp-2xs text-small font-bold text-accent hover:bg-accent/10 hover:underline focus-visible:underline"',
+    );
+    expect(NAV_OVERFLOW_SCRIPT).toContain(
+      ': "block pl-hsp-xl pr-hsp-md py-vsp-2xs text-small text-fg hover:bg-accent/10 hover:text-accent hover:underline focus-visible:underline focus-visible:text-accent";',
+    );
+  });
+});

--- a/packages/zudo-doc/src/header/header.tsx
+++ b/packages/zudo-doc/src/header/header.tsx
@@ -45,6 +45,14 @@ import {
   pathForMatch,
 } from "./nav-active.js";
 import { NAV_OVERFLOW_SCRIPT } from "./nav-overflow-script.js";
+import {
+  NAV_CHEVRON_ACTIVE,
+  NAV_CHEVRON_INACTIVE,
+  NAV_CHILD_ACTIVE,
+  NAV_CHILD_INACTIVE,
+  NAV_TOP_ACTIVE,
+  NAV_TOP_INACTIVE,
+} from "./nav-class-tokens.js";
 import { LANGUAGE_SWITCHER_INIT_SCRIPT } from "../i18n-version/language-switcher.js";
 import { VERSION_SWITCHER_REWIRE_SCRIPT } from "../i18n-version/version-switcher.js";
 import type {
@@ -454,15 +462,15 @@ function renderNavItem(
           class={[
             "flex items-center gap-x-hsp-xs px-hsp-md py-vsp-2xs text-small font-medium transition-colors",
             isActive
-              ? "bg-fg text-bg"
-              : "text-muted hover:text-accent hover:underline focus:underline focus:text-accent",
+              ? NAV_TOP_ACTIVE.join(" ")
+              : NAV_TOP_INACTIVE.join(" "),
           ].join(" ")}
         >
           {label}
           <svg
             class={[
               "h-[0.5rem] w-[0.5rem] shrink-0",
-              isActive ? "text-bg" : "text-muted",
+              isActive ? NAV_CHEVRON_ACTIVE.join(" ") : NAV_CHEVRON_INACTIVE.join(" "),
             ].join(" ")}
             fill="none"
             viewBox="0 0 24 24"
@@ -493,7 +501,7 @@ function renderNavItem(
                   data-active={childActive ? "" : undefined}
                   class={[
                     "block px-hsp-md py-vsp-2xs text-small hover:bg-accent/10 hover:underline focus-visible:underline",
-                    childActive ? "font-bold text-accent" : "text-fg hover:text-accent focus-visible:text-accent",
+                    childActive ? NAV_CHILD_ACTIVE.join(" ") : NAV_CHILD_INACTIVE.join(" "),
                   ].join(" ")}
                 >
                   {childLabel}
@@ -514,8 +522,8 @@ function renderNavItem(
       class={[
         "px-hsp-md py-vsp-2xs text-small font-medium transition-colors shrink-0",
         isActive
-          ? "bg-fg text-bg"
-          : "text-muted hover:text-accent hover:underline focus:underline focus:text-accent",
+          ? NAV_TOP_ACTIVE.join(" ")
+          : NAV_TOP_INACTIVE.join(" "),
       ].join(" ")}
     >
       {label}

--- a/packages/zudo-doc/src/header/nav-class-tokens.ts
+++ b/packages/zudo-doc/src/header/nav-class-tokens.ts
@@ -1,0 +1,115 @@
+// Single source of truth for the header desktop-nav class tokens that must
+// stay in lockstep between the SSR markup (`header.tsx`) and the runtime
+// rebuild/toggle script (`nav-overflow-script.ts`).
+//
+// WHY THIS MODULE EXISTS: the same class strings used to live, duplicated, in
+// both files. `header.tsx` paints the active nav item on first render; the
+// inline script re-paints it after SPA navigation and rebuilds the "···"
+// overflow menu — so both files have to agree on the exact class lists. That
+// duplicated knowledge drifted twice (zudolab/zudo-doc#3011 stale-class after
+// navigation, #3016 divergence), each caught only by a throwaway script. Both
+// files now derive their class strings from the arrays below, so the two can
+// no longer silently diverge (guard: #3023).
+//
+// Tokens are ARRAYS, not whole strings, because the two consumers need
+// different shapes: `header.tsx` joins them into `class={}` attributes, while
+// the script both spreads them into `classList.add/remove(...)` calls and
+// joins them into `className` assignments. Keeping them composable per-part
+// also lets the overflow-menu recipes (which intentionally differ from the
+// header-bar items in padding/weight/base) reuse the shared color tokens
+// instead of re-typing them.
+
+// ── Header-bar top-level item: active-state color toggle ─────────────────
+// setTopActive() (script) ↔ the top-level <a> in renderNavItem() (SSR).
+export const NAV_TOP_ACTIVE: readonly string[] = ["bg-fg", "text-bg"];
+export const NAV_TOP_INACTIVE: readonly string[] = [
+  "text-muted",
+  "hover:text-accent",
+  "hover:underline",
+  "focus:underline",
+  "focus:text-accent",
+];
+
+// ── Header-bar dropdown chevron SVG: active-state color toggle ───────────
+// applyActiveNav() (script) ↔ the chevron <svg> in renderNavItem() (SSR).
+export const NAV_CHEVRON_ACTIVE: readonly string[] = ["text-bg"];
+export const NAV_CHEVRON_INACTIVE: readonly string[] = ["text-muted"];
+
+// ── Header-bar dropdown child link: active-state color toggle ────────────
+// applyActiveNav() (script) ↔ the child <a> in renderNavItem() (SSR). The
+// static base (`block px-hsp-md ... focus-visible:underline`) stays inline in
+// header.tsx — the script never rewrites it, so it can't drift across files.
+export const NAV_CHILD_ACTIVE: readonly string[] = ["font-bold", "text-accent"];
+export const NAV_CHILD_INACTIVE: readonly string[] = [
+  "text-fg",
+  "hover:text-accent",
+  "focus-visible:text-accent",
+];
+
+// ── Overflow "···" menu row recipes ──────────────────────────────────────
+// Assembled at runtime by update() in nav-overflow-script.ts. These are menu
+// rows (indented, their own padding/weight), NOT header-bar items, so they
+// intentionally differ from the toggle groups above. Co-located here so the
+// whole header-nav class vocabulary has one home; the shared color tokens
+// (e.g. NAV_CHILD_ACTIVE = "font-bold text-accent") are literally reused.
+const MENU_ROW_BASE: readonly string[] = [
+  "block",
+  "px-hsp-md",
+  "py-vsp-2xs",
+  "text-small",
+];
+const MENU_CHILD_BASE: readonly string[] = [
+  "block",
+  "pl-hsp-xl",
+  "pr-hsp-md",
+  "py-vsp-2xs",
+  "text-small",
+];
+// Resting (inactive) interactive appearance shared by the parent + plain rows.
+const MENU_ROW_RESTING: readonly string[] = [
+  "hover:bg-accent/10",
+  "hover:underline",
+  "focus-visible:underline",
+  "focus-visible:text-accent",
+  "text-fg",
+  "hover:text-accent",
+];
+
+// Overflow bucket: promoted dropdown-parent link (bold label). Active rows
+// additionally get NAV_MENU_PARENT_ACTIVE_SUFFIX appended.
+export const NAV_MENU_PARENT: readonly string[] = [
+  ...MENU_ROW_BASE,
+  "font-bold",
+  ...MENU_ROW_RESTING,
+];
+export const NAV_MENU_PARENT_ACTIVE_SUFFIX: readonly string[] = ["text-accent"];
+
+// Overflow bucket: plain (non-dropdown) item link. Active rows additionally
+// get NAV_MENU_PLAIN_ACTIVE_SUFFIX (= NAV_CHILD_ACTIVE) appended.
+export const NAV_MENU_PLAIN: readonly string[] = [
+  ...MENU_ROW_BASE,
+  ...MENU_ROW_RESTING,
+];
+export const NAV_MENU_PLAIN_ACTIVE_SUFFIX: readonly string[] = [
+  ...NAV_CHILD_ACTIVE,
+];
+
+// Overflow bucket: indented dropdown-child link (active vs resting variants
+// are whole strings — the resting variant interleaves menu affordances with
+// the child color tokens, so it is spelled out rather than composed).
+export const NAV_MENU_CHILD_ACTIVE: readonly string[] = [
+  ...MENU_CHILD_BASE,
+  ...NAV_CHILD_ACTIVE,
+  "hover:bg-accent/10",
+  "hover:underline",
+  "focus-visible:underline",
+];
+export const NAV_MENU_CHILD_INACTIVE: readonly string[] = [
+  ...MENU_CHILD_BASE,
+  "text-fg",
+  "hover:bg-accent/10",
+  "hover:text-accent",
+  "hover:underline",
+  "focus-visible:underline",
+  "focus-visible:text-accent",
+];

--- a/packages/zudo-doc/src/header/nav-overflow-script.ts
+++ b/packages/zudo-doc/src/header/nav-overflow-script.ts
@@ -31,6 +31,39 @@
 // script can be reviewed in isolation.
 
 import { AFTER_NAVIGATE_EVENT } from "../transitions/page-events.js";
+import {
+  NAV_CHEVRON_ACTIVE,
+  NAV_CHEVRON_INACTIVE,
+  NAV_CHILD_ACTIVE,
+  NAV_CHILD_INACTIVE,
+  NAV_MENU_CHILD_ACTIVE,
+  NAV_MENU_CHILD_INACTIVE,
+  NAV_MENU_PARENT,
+  NAV_MENU_PARENT_ACTIVE_SUFFIX,
+  NAV_MENU_PLAIN,
+  NAV_MENU_PLAIN_ACTIVE_SUFFIX,
+  NAV_TOP_ACTIVE,
+  NAV_TOP_INACTIVE,
+} from "./nav-class-tokens.js";
+
+// The class lists spliced into the script below are the SSR ↔ runtime
+// lockstep: they must match the strings header.tsx renders. Both files import
+// them from ./nav-class-tokens so they cannot drift (zudolab/zudo-doc#3023).
+// The script ships as plain text via dangerouslySetInnerHTML and cannot import
+// the arrays at runtime, so these helpers splice the token lists into the
+// script string at module-eval (build) time instead.
+
+// -> `"bg-fg", "text-bg"` — argument list for a classList.add/remove(...) call.
+const clsArgs = (tokens: readonly string[]): string =>
+  tokens.map((token) => JSON.stringify(token)).join(", ");
+
+// -> `"bg-fg text-bg"` — a single class-string literal for `className = ...`.
+const clsLiteral = (tokens: readonly string[]): string =>
+  JSON.stringify(tokens.join(" "));
+
+// -> `" font-bold text-accent"` — leading-space append for `className += ...`.
+const clsAppend = (tokens: readonly string[]): string =>
+  JSON.stringify(" " + tokens.join(" "));
 
 export const NAV_OVERFLOW_SCRIPT = `(function () {
   var cleanupNavOverflow = null;
@@ -89,12 +122,12 @@ export const NAV_OVERFLOW_SCRIPT = `(function () {
     function setTopActive(a, active) {
       if (!a) return;
       if (active) {
-        a.classList.add("bg-fg", "text-bg");
-        a.classList.remove("text-muted", "hover:text-accent", "hover:underline", "focus:underline", "focus:text-accent");
+        a.classList.add(${clsArgs(NAV_TOP_ACTIVE)});
+        a.classList.remove(${clsArgs(NAV_TOP_INACTIVE)});
         a.setAttribute("aria-current", "page");
       } else {
-        a.classList.remove("bg-fg", "text-bg");
-        a.classList.add("text-muted", "hover:text-accent", "hover:underline", "focus:underline", "focus:text-accent");
+        a.classList.remove(${clsArgs(NAV_TOP_ACTIVE)});
+        a.classList.add(${clsArgs(NAV_TOP_INACTIVE)});
         a.removeAttribute("aria-current");
       }
     }
@@ -112,19 +145,19 @@ export const NAV_OVERFLOW_SCRIPT = `(function () {
           if (childActive) {
             anyChild = true;
             c.setAttribute("data-active", "");
-            c.classList.add("font-bold", "text-accent");
-            c.classList.remove("text-fg", "hover:text-accent", "focus-visible:text-accent");
+            c.classList.add(${clsArgs(NAV_CHILD_ACTIVE)});
+            c.classList.remove(${clsArgs(NAV_CHILD_INACTIVE)});
           } else {
             c.removeAttribute("data-active");
-            c.classList.remove("font-bold", "text-accent");
-            c.classList.add("text-fg", "hover:text-accent", "focus-visible:text-accent");
+            c.classList.remove(${clsArgs(NAV_CHILD_ACTIVE)});
+            c.classList.add(${clsArgs(NAV_CHILD_INACTIVE)});
           }
         });
         topActive = parentMatch || anyChild;
         var svg = topA ? topA.querySelector("svg") : null;
         if (svg) {
-          if (topActive) { svg.classList.add("text-bg"); svg.classList.remove("text-muted"); }
-          else { svg.classList.add("text-muted"); svg.classList.remove("text-bg"); }
+          if (topActive) { svg.classList.add(${clsArgs(NAV_CHEVRON_ACTIVE)}); svg.classList.remove(${clsArgs(NAV_CHEVRON_INACTIVE)}); }
+          else { svg.classList.add(${clsArgs(NAV_CHEVRON_INACTIVE)}); svg.classList.remove(${clsArgs(NAV_CHEVRON_ACTIVE)}); }
         }
       } else {
         topActive = activePath !== "" && navPathname(topA) === activePath;
@@ -206,9 +239,9 @@ export const NAV_OVERFLOW_SCRIPT = `(function () {
             a.href = parentLink.href;
             var parentText = parentLink.textContent ? parentLink.textContent.trim().replace(/\\s+/g, " ") : "";
             a.textContent = parentText;
-            a.className = "block px-hsp-md py-vsp-2xs text-small font-bold hover:bg-accent/10 hover:underline focus-visible:underline focus-visible:text-accent text-fg hover:text-accent";
+            a.className = ${clsLiteral(NAV_MENU_PARENT)};
             if (parentLink.getAttribute("aria-current") === "page") {
-              a.className += " text-accent";
+              a.className += ${clsAppend(NAV_MENU_PARENT_ACTIVE_SUFFIX)};
             }
             li.appendChild(a);
             moreMenu.appendChild(li);
@@ -220,8 +253,8 @@ export const NAV_OVERFLOW_SCRIPT = `(function () {
             a.textContent = child.textContent ? child.textContent.trim() : "";
             var isChildActive = child.hasAttribute("data-active");
             a.className = isChildActive
-              ? "block pl-hsp-xl pr-hsp-md py-vsp-2xs text-small font-bold text-accent hover:bg-accent/10 hover:underline focus-visible:underline"
-              : "block pl-hsp-xl pr-hsp-md py-vsp-2xs text-small text-fg hover:bg-accent/10 hover:text-accent hover:underline focus-visible:underline focus-visible:text-accent";
+              ? ${clsLiteral(NAV_MENU_CHILD_ACTIVE)}
+              : ${clsLiteral(NAV_MENU_CHILD_INACTIVE)};
             li.appendChild(a);
             moreMenu.appendChild(li);
           });
@@ -231,9 +264,9 @@ export const NAV_OVERFLOW_SCRIPT = `(function () {
           var a2 = document.createElement("a");
           a2.href = anchor.href;
           a2.textContent = anchor.textContent ? anchor.textContent.trim() : "";
-          a2.className = "block px-hsp-md py-vsp-2xs text-small hover:bg-accent/10 hover:underline focus-visible:underline focus-visible:text-accent text-fg hover:text-accent";
+          a2.className = ${clsLiteral(NAV_MENU_PLAIN)};
           if (anchor.getAttribute("aria-current") === "page") {
-            a2.className += " font-bold text-accent";
+            a2.className += ${clsAppend(NAV_MENU_PLAIN_ACTIVE_SUFFIX)};
           }
           li2.appendChild(a2);
           moreMenu.appendChild(li2);


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3023

---

## Summary

Permanent regression guard for the header-nav class lockstep (#3023). The class strings that must stay in sync between the header SSR markup (`header.tsx`) and the runtime rebuild/toggle script (`nav-overflow-script.ts`) previously lived duplicated in both files and drifted **twice** — #3011 (stale active class after SPA navigation) and #3016 (divergence) — each caught only by a throwaway computed-style script.

This makes drift **structurally impossible** by giving those class lists a single source of truth. Approach chosen on the `needs-decision` issue: **Option 1 — shared class-token constants** (compile-time *prevention*, not runtime detection). No new e2e / tier-governance surface.

## Changes

- **New `packages/zudo-doc/src/header/nav-class-tokens.ts`** — the single source of truth for the lockstepped class tokens, exported as composable **arrays**:
  - top-level item active/inactive (`setTopActive` ↔ SSR nav `<a>`)
  - dropdown chevron active/inactive
  - dropdown child active/inactive (`applyActiveNav` ↔ SSR child `<a>`)
  - the three overflow-bucket recipes (`···` menu parent / child / plain), composed per-part so the menu rows reuse the shared color tokens while keeping their intentionally-different padding/weight/base.
- **`header.tsx`** — imports the toggle-token arrays and `.join(" ")`s them into the four `class={}` expressions (also de-duplicates the two identical top-level active/inactive spots).
- **`nav-overflow-script.ts`** — imports the same arrays; because the script ships as plain text via `dangerouslySetInnerHTML` and can't import at runtime, three tiny build-time helpers (`clsArgs` / `clsLiteral` / `clsAppend`) splice the tokens into the emitted script string. The two files can no longer diverge — they read from one module.
- **New `__tests__/nav-class-tokens.test.ts`** — pins every token value and asserts the emitted `NAV_OVERFLOW_SCRIPT` still contains the exact original class strings.

## Test Plan

- **Pure refactor — output is byte-identical**: SSR class attributes and the runtime-generated (classList toggle + overflow-bucket) class strings are unchanged. The new test pins this by asserting the emitted script contains the original literals verbatim.
- `pnpm --filter @takazudo/zudo-doc build` ✅ (dist re-emitted; eject copy auto-picks up the new module)
- `pnpm --filter @takazudo/zudo-doc test` ✅ — 1624 tests pass (incl. 9 new parity tests)
- `pnpm check` (typecheck) ✅
- `pnpm check:template-drift` ✅ — package-internal files, no template counterpart
- Codex review ✅ — "preserves the existing class-token ordering and generated inline-script output… no behavioral regressions identified"