### PR TITLE
fix: keep doc-title rule visible when meta is absent (#3025)

### DIFF
--- a/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
+++ b/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
@@ -561,8 +561,8 @@ describe("CB chrome-bindings: chromeBindingsModule wires host bindings into crea
   });
 
   // Positional proof: the badge renders AFTER </h1> and BEFORE the metainfo
-  // block (`DocMetainfoArea` → `DocMetainfo`, identified by its distinctive
-  // wrapper class — see metainfo/doc-metainfo.tsx), matching the documented
+  // block (`DocMetainfoArea` → `DocMetainfo`, identified by its stable
+  // `data-doc-metainfo` hook — see metainfo/doc-metainfo.tsx), matching the documented
   // placement in doc-content-header/index.tsx. The CB setup flips
   // `docMetainfo: true` + supplies a `docHistoryMeta` entry (via
   // chrome-bindings.tsx) so a REAL metainfo block renders here, rather than
@@ -571,7 +571,7 @@ describe("CB chrome-bindings: chromeBindingsModule wires host bindings into crea
     const html = readBuiltHtml(fixtureDir, "docs/getting-started/index.html");
     const h1CloseIdx = html.indexOf("</h1>");
     const badgeIdx = html.indexOf("doc-content-header-extra-marker");
-    const metainfoIdx = html.indexOf("border-t border-fg pt-vsp-xs");
+    const metainfoIdx = html.indexOf("data-doc-metainfo");
     expect(h1CloseIdx).toBeGreaterThan(-1);
     expect(badgeIdx).toBeGreaterThan(h1CloseIdx);
     expect(metainfoIdx).toBeGreaterThan(badgeIdx);

--- a/packages/zudo-doc/src/doc-content-header/__tests__/doc-content-header.test.tsx
+++ b/packages/zudo-doc/src/doc-content-header/__tests__/doc-content-header.test.tsx
@@ -27,7 +27,8 @@ function makeEntry(data: Record<string, unknown> = {}): DocPageEntry {
   } as unknown as DocPageEntry;
 }
 
-const BASELINE_HTML = '<h1 class="text-heading font-bold mb-vsp-xs">Test Page</h1>';
+const BASELINE_HTML =
+  '<h1 class="text-heading font-bold border-b border-fg pb-vsp-xs mb-vsp-xs">Test Page</h1>';
 
 describe("createDocContentHeader — docContentHeaderExtras seam", () => {
   it("slot unset: renders byte-identical output to the pre-seam header", () => {

--- a/packages/zudo-doc/src/doc-content-header/index.tsx
+++ b/packages/zudo-doc/src/doc-content-header/index.tsx
@@ -132,9 +132,7 @@ export function createDocContentHeader<S extends Settings = Settings>(
             not the doc-metainfo block below — so it stays visible on pages with
             no Created/Updated/Author meta (the meta block returns null and would
             otherwise take its old top border with it). */}
-        <h1 class="text-heading font-bold border-b border-fg pb-vsp-xs mb-vsp-xs">
-          {entry.data.title}
-        </h1>
+        <h1 class="text-heading font-bold border-b border-fg pb-vsp-xs mb-vsp-xs">{entry.data.title}</h1>
 
         {/* Host-bound extras slot (ctx.hostBindings.docContentHeaderExtras).
             Default absent → renders nothing. Fires on versioned pages too —

--- a/packages/zudo-doc/src/doc-content-header/index.tsx
+++ b/packages/zudo-doc/src/doc-content-header/index.tsx
@@ -128,7 +128,13 @@ export function createDocContentHeader<S extends Settings = Settings>(
   }: DocContentHeaderProps): JSX.Element {
     return (
       <>
-        <h1 class="text-heading font-bold mb-vsp-xs">{entry.data.title}</h1>
+        {/* Bottom border reads as the title's rule (#3025). Kept on the h1 —
+            not the doc-metainfo block below — so it stays visible on pages with
+            no Created/Updated/Author meta (the meta block returns null and would
+            otherwise take its old top border with it). */}
+        <h1 class="text-heading font-bold border-b border-fg pb-vsp-xs mb-vsp-xs">
+          {entry.data.title}
+        </h1>
 
         {/* Host-bound extras slot (ctx.hostBindings.docContentHeaderExtras).
             Default absent → renders nothing. Fires on versioned pages too —

--- a/packages/zudo-doc/src/doc-page-shell/index.tsx
+++ b/packages/zudo-doc/src/doc-page-shell/index.tsx
@@ -329,7 +329,11 @@ export function createDocPageShell<S extends Settings = Settings>(
              Fragment (not <div>) so children become direct children of
              <article class="zd-content">, picking up the flow-space rule. */
           <>
-            <h1 class="text-heading font-bold mb-vsp-xs">{autoIndexLabel}</h1>
+            {/* Bottom border reads as the title's rule (#3025) — see the h1 in
+                doc-content-header; kept here too so auto-index pages match. */}
+            <h1 class="text-heading font-bold border-b border-fg pb-vsp-xs mb-vsp-xs">
+              {autoIndexLabel}
+            </h1>
 
             {/* Build-time date block — chrome parity (#1461). */}
             {metainfoSlot}

--- a/packages/zudo-doc/src/doc-page-shell/index.tsx
+++ b/packages/zudo-doc/src/doc-page-shell/index.tsx
@@ -331,9 +331,7 @@ export function createDocPageShell<S extends Settings = Settings>(
           <>
             {/* Bottom border reads as the title's rule (#3025) — see the h1 in
                 doc-content-header; kept here too so auto-index pages match. */}
-            <h1 class="text-heading font-bold border-b border-fg pb-vsp-xs mb-vsp-xs">
-              {autoIndexLabel}
-            </h1>
+            <h1 class="text-heading font-bold border-b border-fg pb-vsp-xs mb-vsp-xs">{autoIndexLabel}</h1>
 
             {/* Build-time date block — chrome parity (#1461). */}
             {metainfoSlot}

--- a/packages/zudo-doc/src/metainfo/doc-metainfo.tsx
+++ b/packages/zudo-doc/src/metainfo/doc-metainfo.tsx
@@ -124,7 +124,9 @@ export function DocMetainfo(props: DocMetainfoProps): VNode | null {
   if (!hasInfo) return null;
 
   return (
-    <div class="flex flex-wrap items-center gap-x-hsp-md gap-y-vsp-2xs text-caption text-fg mb-vsp-md border-t border-fg pt-vsp-xs">
+    // The horizontal rule that used to sit here (border-t) moved to the h1's
+    // bottom border (#3025) so it stays visible when this block is absent.
+    <div class="flex flex-wrap items-center gap-x-hsp-md gap-y-vsp-2xs text-caption text-fg mb-vsp-md">
       {createdAt && (
         <span class="inline-flex items-center gap-hsp-2xs">
           <ClockIcon />

--- a/packages/zudo-doc/src/metainfo/doc-metainfo.tsx
+++ b/packages/zudo-doc/src/metainfo/doc-metainfo.tsx
@@ -126,7 +126,12 @@ export function DocMetainfo(props: DocMetainfoProps): VNode | null {
   return (
     // The horizontal rule that used to sit here (border-t) moved to the h1's
     // bottom border (#3025) so it stays visible when this block is absent.
-    <div class="flex flex-wrap items-center gap-x-hsp-md gap-y-vsp-2xs text-caption text-fg mb-vsp-md">
+    // data-doc-metainfo is a stable hook for positional tests (the old tests
+    // keyed off the removed border-t class string).
+    <div
+      data-doc-metainfo
+      class="flex flex-wrap items-center gap-x-hsp-md gap-y-vsp-2xs text-caption text-fg mb-vsp-md"
+    >
       {createdAt && (
         <span class="inline-flex items-center gap-hsp-2xs">
           <ClockIcon />

--- a/packages/zudo-doc/src/theme-packs/nocturne/pack.css
+++ b/packages/zudo-doc/src/theme-packs/nocturne/pack.css
@@ -285,6 +285,10 @@ html[data-theme-pack="nocturne"] main nav[aria-label="Breadcrumb"] a:hover {
 html[data-theme-pack="nocturne"] .zd-content h1 {
   font-size: 2.9rem;
   line-height: 1.12;
+  /* the gold-hairline ::after is this pack's title rule — drop the default
+     h1 border-b and its padding (#3025) so it doesn't double up */
+  border-bottom: 0;
+  padding-bottom: 0;
 }
 html[data-theme-pack="nocturne"] .zd-content h1::after {
   content: "";

--- a/packages/zudo-doc/src/theme-packs/observatory/pack.css
+++ b/packages/zudo-doc/src/theme-packs/observatory/pack.css
@@ -340,6 +340,9 @@ html[data-theme-pack="observatory"] main nav[aria-label="Breadcrumb"] a:hover {
 html[data-theme-pack="observatory"] .zd-content h1 {
   position: relative;
   padding-bottom: 0.8rem;
+  /* the constellation ::after is this pack's title rule — drop the default
+     h1 border-b (#3025) so it doesn't double up */
+  border-bottom: 0;
 }
 html[data-theme-pack="observatory"] .zd-content h1::after {
   content: "";

--- a/packages/zudo-doc/src/theme-packs/onyx/pack.css
+++ b/packages/zudo-doc/src/theme-packs/onyx/pack.css
@@ -253,6 +253,12 @@ html[data-theme-pack="onyx"] a[data-nav-active] {
 }
 
 /* h1: serif display over a short gold rule */
+html[data-theme-pack="onyx"] .zd-content h1 {
+  /* the short gold ::after rule is this pack's title rule — drop the default
+     h1 border-b and its padding (#3025) so it doesn't double up */
+  border-bottom: 0;
+  padding-bottom: 0;
+}
 html[data-theme-pack="onyx"] .zd-content h1::after {
   content: "";
   display: block;

--- a/packages/zudo-doc/src/theme-packs/phosphor/pack.css
+++ b/packages/zudo-doc/src/theme-packs/phosphor/pack.css
@@ -279,6 +279,10 @@ html[data-theme-pack="phosphor"] .zd-content h1 {
   color: var(--zd-accent);
   font-size: 2.9rem;
   line-height: 1.1;
+  /* the CRT prompt/cursor pseudo-elements are this pack's title treatment —
+     drop the default h1 border-b and its padding (#3025) */
+  border-bottom: 0;
+  padding-bottom: 0;
 }
 html[data-theme-pack="phosphor"] .zd-content h1::before {
   content: "> ";

--- a/packages/zudo-doc/src/theme-packs/sumi/pack.css
+++ b/packages/zudo-doc/src/theme-packs/sumi/pack.css
@@ -274,6 +274,9 @@ html[data-theme-pack="sumi"] .zd-content h1 {
   position: relative;
   padding-bottom: 0.95rem;
   margin-bottom: 0.9rem;
+  /* the brush-stroke ::after is this pack's title rule — drop the default
+     h1 border-b (#3025) so it doesn't double up */
+  border-bottom: 0;
 }
 html[data-theme-pack="sumi"] .zd-content h1::after {
   content: "";

--- a/packages/zudo-doc/src/theme-packs/swissgrid/pack.css
+++ b/packages/zudo-doc/src/theme-packs/swissgrid/pack.css
@@ -264,6 +264,10 @@ html[data-theme-pack="swissgrid"] .zd-content {
 html[data-theme-pack="swissgrid"] .zd-content h1 {
   font-size: clamp(2.3rem, 5vw + 1rem, 3.1rem);
   line-height: 1.02;
+  /* the red-bar ::after is this pack's title rule — drop the default h1
+     border-b and its padding (#3025) so it doesn't double up */
+  border-bottom: 0;
+  padding-bottom: 0;
 }
 html[data-theme-pack="swissgrid"] .zd-content h1::after {
   content: "";

--- a/packages/zudo-doc/src/theme-packs/washi/pack.css
+++ b/packages/zudo-doc/src/theme-packs/washi/pack.css
@@ -312,6 +312,12 @@ html[data-theme-pack="washi"] .zd-content > p[data-doc-description] {
 /* signature move #2 — the h1 carries a small tilted 藍 seal, like a
    maker's hanko stamp on the sheet (platform CJK font renders the
    glyph — decorative content character, Decision 5 CJK rule) */
+html[data-theme-pack="washi"] .zd-content h1 {
+  /* washi's title treatment is the tilted 藍 seal (::after), not an
+     underline — drop the default h1 border-b and its padding (#3025) */
+  border-bottom: 0;
+  padding-bottom: 0;
+}
 html[data-theme-pack="washi"] .zd-content h1::after {
   content: "藍";
   display: inline-block;


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3025

---

## Summary

The horizontal rule under a doc page's h1 title was defined as the **top border of the Created/Updated/Author meta block** (`doc-metainfo.tsx`). That block returns `null` when a page has no doc-history meta (pages excluded via `docHistoryExclude` such as `/docs/claude-md/*`, versioned pages, etc.), so the rule — which visually reads as the h1 title's underline — vanished on those pages.

This moves the rule onto the **h1's own bottom border** so it is always present, and reconciles the change with the theme-pack system.

- has meta → border shown (unchanged)
- no meta → border shown (fixed; was hidden)

## Changes

**Core fix (both page-title render paths):**
- `doc-content-header/index.tsx` — entry doc pages: h1 gains `border-b border-fg pb-vsp-xs`.
- `doc-page-shell/index.tsx` — auto-index category pages: same h1 border.
- `metainfo/doc-metainfo.tsx` — dropped `border-t border-fg pt-vsp-xs` from the meta block; added a stable `data-doc-metainfo` hook. The h1's existing `mb-vsp-xs` supplies the same 14px gap the meta block's `pt-vsp-xs` did, so the has-meta layout is pixel-identical.

No design-token/theme change was needed — the existing `border-fg` color is preserved.

**Theme-pack reconciliation (review follow-up):**
The default border lives on `.zd-content h1`, so packs that decorate the title via a pseudo-element would render a duplicate rule. Reset `border-bottom: 0` (+ coupled padding where the pack sets none) on the 7 packs that own their title decoration: `nocturne`, `observatory`, `onyx`, `phosphor`, `sumi`, `swissgrid`, `washi`. Packs with their own h1 border (`foundry`, `broadsheet`, `brutalist`, `ledger`) already override via cascade; plain packs correctly show the default border.

**Tests:**
- `doc-content-header.test.tsx` — baseline updated to the new h1 markup.
- `route-injection-build.slow.test.ts` — positional metainfo lookup keyed off `data-doc-metainfo` instead of the removed class string.

## Scope note

Only the doc-page title (which had the meta-coupled border) is affected. Tag/versions/home page titles never rendered this border and are intentionally left unchanged.

## Test Plan

- ✅ Typecheck (`pnpm check`), 1624 package unit tests, 803 root unit tests, package safelist check — all green.
- ✅ Visual + deterministic computed-style verification (light + dark):
  - no-meta page (`/docs/claude-md/*`): border now renders under the h1 (was absent).
  - has-meta page: single border under h1, meta `border-top: 0` (no doubling), spacing unchanged.
  - 12 theme packs measured: decorated packs show `border-b: 0` + their `::after` only (no duplicate); own-border packs unchanged; plain/default/futura show the default border.

## Screenshot Requirement Contract

Expected:
- With meta: h1 has a horizontal border directly below it, then the Created/Updated/Author row (unchanged).
- Without meta: the same horizontal border still renders directly below the h1.
- Border color/weight/spacing consistent between states.

Forbidden:
- A no-meta page showing no border under the h1 (the bug this fixes).
- The border doubling (title bottom-border AND meta top-border, or default border + a theme pack's own decoration).
- Vertical spacing regressing on either state.

Viewport: desktop doc layout; both light and dark themes.
