### PR TITLE
fix(docs): point doc-history-server anchors at the generated heading slugs

### DIFF
--- a/src/content/docs-ja/reference/doc-history-server.mdx
+++ b/src/content/docs-ja/reference/doc-history-server.mdx
@@ -37,7 +37,7 @@ pnpm dev:history
 doc-history-server --port 4322 --content-dir src/content/docs
 ```
 
-`i18n`も有効な場合、`create-zudo-doc`はセカンダリロケール用の`--locale <lang>:src/content/docs-<lang>`フラグを自動的に追加します。別のフラグでサーバーを手動実行したい場合は、下記の[サーバーオプション](#サーバーオプション)を参照してください。
+`i18n`も有効な場合、`create-zudo-doc`はセカンダリロケール用の`--locale <lang>:src/content/docs-<lang>`フラグを自動的に追加します。別のフラグでサーバーを手動実行したい場合は、下記の[サーバーオプション](#サーバーモード（ローカル開発）-サーバーオプション)を参照してください。
 
 ### エンドポイント
 

--- a/src/content/docs/reference/doc-history-server.mdx
+++ b/src/content/docs/reference/doc-history-server.mdx
@@ -37,7 +37,7 @@ Under the hood, that script resolves to:
 doc-history-server --port 4322 --content-dir src/content/docs
 ```
 
-When `i18n` is also enabled, `create-zudo-doc` appends a `--locale <lang>:src/content/docs-<lang>` flag for the secondary locale automatically. To run the server manually with other flags, see [Server Options](#server-options) below.
+When `i18n` is also enabled, `create-zudo-doc` appends a `--locale <lang>:src/content/docs-<lang>` flag for the secondary locale automatically. To run the server manually with other flags, see [Server Options](#server-mode-local-development-server-options) below.
 
 ### Endpoints
 


### PR DESCRIPTION
## Summary

`src/content/docs/reference/doc-history-server.mdx` and its JA counterpart linked to plain heading anchors (`#server-options` / `#サーバーオプション`), but zfb generates **hierarchical** heading slugs (parent section + heading). Both links resolved to nothing, so the "see Server Options below" cross-references were dead in both locales.

Repointed each at the actual generated slug:

- EN → `#server-mode-local-development-server-options`
- JA → `#サーバーモード（ローカル開発）-サーバーオプション`

Found while bumping the zfb family in #3040; verified pre-existing (the live site, built from `main` on next.89, uses the same slug scheme), so it was raised separately rather than folded into that PR.

## Test Plan

- `pnpm build` — the four `broken link: #server-options` / `#サーバーオプション` warnings are gone; 390 pages build clean
- Parsed both built pages: each anchor's target heading `id` now exists, and neither page has any remaining dangling in-page anchor

Closes #3041

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/3042"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787194930&installation_model_id=20910&pr_number=3042&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F3042&signature=11057f136162886c6d1f9150844c7edba5efc397d25ed44599b2fc19411376b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->