### PR TITLE
test(zudo-doc): re-baseline route-injection parity hashes (#3039)

### DIFF
--- a/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
+++ b/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
@@ -322,13 +322,18 @@ describe("A2 no-stub: injected routes render correct HTML (packageOwnedRoutes:tr
   // prior baseline (b1eea45) was rebuilt in a worktree and its normalized HTML
   // diffed byte-for-byte against HEAD. That old build still reproduced the old
   // hashes exactly, so the delta below is the complete and only change —
-  //   - the accent hover/focus pass over non-active header nav, all of it from
-  //     `src/header/nav-overflow-script.ts`: `hover:text-accent` /
-  //     `focus:text-accent` / `focus-visible:text-accent` added to the
-  //     top-level nav link classList swap, the overflow ("···") toggle, and
-  //     the overflow dropdown children (#3011, #3020, #3023)
-  //   - in that same script, the overflow dropdown child's resting colour
-  //     moving `text-muted` → `text-fg` (and its `hover:text-fg` →
+  //   - the accent hover/focus pass over non-active header nav —
+  //     `hover:text-accent` / `focus:text-accent` / `focus-visible:text-accent`
+  //     (#3011, #3020, #3023) — reaching this HTML from two distinct sources:
+  //       * `src/header/header.tsx`, which SSR-renders the overflow ("···")
+  //         toggle unconditionally (this fixture has `headerNav: []`, so the
+  //         button is present-but-hidden rather than absent) — its class
+  //         string is static markup here, not script output
+  //       * `src/header/nav-overflow-script.ts`, whose inlined source carries
+  //         the top-level nav link classList swap and the dropdown-child
+  //         `className` strings
+  //   - in that script, the overflow dropdown child's resting colour moving
+  //     `text-muted` → `text-fg` (and its `hover:text-fg` →
   //     `hover:text-accent`) (#3020)
   //   - `border-b border-fg pb-vsp-xs` on the doc-title `<h1>`
   //     (`src/doc-content-header/index.tsx`) — the title rule is now kept when

--- a/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
+++ b/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
@@ -322,19 +322,22 @@ describe("A2 no-stub: injected routes render correct HTML (packageOwnedRoutes:tr
   // prior baseline (b1eea45) was rebuilt in a worktree and its normalized HTML
   // diffed byte-for-byte against HEAD. That old build still reproduced the old
   // hashes exactly, so the delta below is the complete and only change —
-  //   - the accent hover/focus pass over non-active nav: `hover:text-accent` /
-  //     `focus:text-accent` / `focus-visible:text-accent` added to the header
-  //     overflow ("···") toggle, the header nav classList swap script, the
-  //     overflow dropdown children, and the sidebar nav node class strings
-  //     (#3010, #3011, #3020, #3023)
-  //   - the sidebar non-active child's resting colour moving `text-muted` →
-  //     `text-fg` in the same pass (#3020)
-  //   - `border-b border-fg pb-vsp-xs` on the doc-title `<h1>` — the title rule
-  //     is now kept when meta is absent, which is exactly this fixture's shape
+  //   - the accent hover/focus pass over non-active header nav, all of it from
+  //     `src/header/nav-overflow-script.ts`: `hover:text-accent` /
+  //     `focus:text-accent` / `focus-visible:text-accent` added to the
+  //     top-level nav link classList swap, the overflow ("···") toggle, and
+  //     the overflow dropdown children (#3011, #3020, #3023)
+  //   - in that same script, the overflow dropdown child's resting colour
+  //     moving `text-muted` → `text-fg` (and its `hover:text-fg` →
+  //     `hover:text-accent`) (#3020)
+  //   - `border-b border-fg pb-vsp-xs` on the doc-title `<h1>`
+  //     (`src/doc-content-header/index.tsx`) — the title rule is now kept when
+  //     meta is absent, which is exactly this fixture's shape
   //     (SKIP_DOC_HISTORY=1, no meta), so it newly renders here (#3025)
   // All of it traces to already-merged, intentional PRs; no unattributed bytes,
   // no lost chrome. Only /docs/getting-started/ carries the `<h1>` delta; the
-  // nav deltas hit both pages.
+  // header-nav deltas hit both pages. Note the sidebar-hover PR (#3010) is NOT
+  // in this list — its markup does not reach either fixture page.
 
   it("parity: /404.html normalized-HTML sha256 is stable (stub-defaults path)", () => {
     const html = readBuiltHtml(fixtureDir, "404.html");

--- a/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
+++ b/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
@@ -317,15 +317,33 @@ describe("A2 no-stub: injected routes render correct HTML (packageOwnedRoutes:tr
   //   - the stateDiagram `;`→newline mermaid-init fix + its explanatory
   //     comment (#2909, this epic's Wave-1 mermaid-semicolon-fix)
   // No other bytes changed. See sub-issue #2911 for the full diff.
+  //
+  // 2026-07-21 re-baseline (zudolab/zudo-doc#3039, nightly exam failure): the
+  // prior baseline (b1eea45) was rebuilt in a worktree and its normalized HTML
+  // diffed byte-for-byte against HEAD. That old build still reproduced the old
+  // hashes exactly, so the delta below is the complete and only change —
+  //   - the accent hover/focus pass over non-active nav: `hover:text-accent` /
+  //     `focus:text-accent` / `focus-visible:text-accent` added to the header
+  //     overflow ("···") toggle, the header nav classList swap script, the
+  //     overflow dropdown children, and the sidebar nav node class strings
+  //     (#3010, #3011, #3020, #3023)
+  //   - the sidebar non-active child's resting colour moving `text-muted` →
+  //     `text-fg` in the same pass (#3020)
+  //   - `border-b border-fg pb-vsp-xs` on the doc-title `<h1>` — the title rule
+  //     is now kept when meta is absent, which is exactly this fixture's shape
+  //     (SKIP_DOC_HISTORY=1, no meta), so it newly renders here (#3025)
+  // All of it traces to already-merged, intentional PRs; no unattributed bytes,
+  // no lost chrome. Only /docs/getting-started/ carries the `<h1>` delta; the
+  // nav deltas hit both pages.
 
   it("parity: /404.html normalized-HTML sha256 is stable (stub-defaults path)", () => {
     const html = readBuiltHtml(fixtureDir, "404.html");
-    expect(sha256Html(html)).toMatchInlineSnapshot(`"b2328e098a65b1056ecd8b604dac7baaceed936b61be1caee2b03524119abdb6"`);
+    expect(sha256Html(html)).toMatchInlineSnapshot(`"d7549af919fc7bde43ff26ec6cc11ea7538b4acad02a37cb02c847828a2f7672"`);
   });
 
   it("parity: /docs/getting-started/index.html normalized-HTML sha256 is stable (stub-defaults path)", () => {
     const html = readBuiltHtml(fixtureDir, "docs/getting-started/index.html");
-    expect(sha256Html(html)).toMatchInlineSnapshot(`"e412483fcbf75cd0db3f71cacfb4b251d0bdb30337c6203a21af3e029ac3b04a"`);
+    expect(sha256Html(html)).toMatchInlineSnapshot(`"4195ab62afc33f89e09d210c7b494b72f8e7e0eaab683982b6b983b36e3f43f9"`);
   });
 });
 


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3039

---

## Summary

Fixes the Nightly Exam / `zudo-doc Slow Tests` failure ([run 29771243836](https://github.com/zudolab/zudo-doc/actions/runs/29771243836)). Two of 87 tests failed — the byte-parity sha256 guards for `/404.html` and `/docs/getting-started/index.html` (stub-defaults path) in `packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts`.

That file's own comment requires any hash change be traced to intentional output deltas and reviewed before re-baselining, so this is **not** a blind `--update-snapshots`.

## Verification: intentional drift, not a regression

The previous baseline commit `b1eea45` (2026-07-18, #2911) was rebuilt in a throwaway worktree. It still reproduced the old hashes exactly (88/88 green there), so a byte-for-byte diff of its normalized HTML against HEAD yields the **complete** delta rather than an inferred one. Every changed byte traces to an already-merged PR:

| Delta | Source | PR |
|---|---|---|
| accent hover/focus on the SSR'd overflow (`···`) toggle | `src/header/header.tsx` | #3011, #3020, #3023 |
| accent hover/focus on the nav classList swap + dropdown-child `className`s | `src/header/nav-overflow-script.ts` | #3011, #3020, #3023 |
| overflow dropdown child resting colour `text-muted` → `text-fg` | `src/header/nav-overflow-script.ts` | #3020 |
| `border-b border-fg pb-vsp-xs` on the doc-title `<h1>` | `src/doc-content-header/index.tsx` | #3025 |

The `<h1>` rule is now kept when meta is absent — exactly this fixture's shape (`SKIP_DOC_HISTORY=1`, no meta) — so it newly renders here. No unattributed bytes, no lost chrome. The sidebar-hover PR (#3010) is deliberately absent from the list: its markup does not reach either fixture page.

## Changes

- Update the two inline sha256 snapshots to `d7549af9…` (`/404.html`) and `4195ab62…` (`/docs/getting-started/index.html`).
- Extend the explanatory comment with a dated re-baseline entry recording the attribution above, matching the #2911 precedent — the comment is the audit trail for the next drift.

## Test Plan

- `pnpm --filter @takazudo/zudo-doc test:slow` — **87/87 passing** (was 85/87).
- Old hashes independently recomputed from the baseline worktree's normalized HTML and confirmed byte-identical to the committed snapshots, proving the capture pipeline matches the test's.
- New hashes match both the nightly's `Received` values and the local run.
- `tsc --noEmit -p packages/zudo-doc/tsconfig.json` — clean.
- These are the only two parity-hash guards in the repo, so nothing else drifted.