### PR TITLE
fix(brutalist): exclude the header logo from the slab-ink recolor rule

### DIFF
--- a/packages/zudo-doc/src/theme-packs/brutalist/meta.json
+++ b/packages/zudo-doc/src/theme-packs/brutalist/meta.json
@@ -4,7 +4,7 @@
   "name": "Brutalist",
   "description": "Raw concrete web — stark black on white, 4px slab borders, zero radius, hazard-orange tape. Structure you can see.",
   "mode": "light",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "fonts": {
     "sans": "Space Grotesk",
     "mono": "IBM Plex Mono",

--- a/packages/zudo-doc/src/theme-packs/brutalist/pack.css
+++ b/packages/zudo-doc/src/theme-packs/brutalist/pack.css
@@ -230,17 +230,18 @@ html[data-theme-pack="brutalist"] header[data-header]::after {
    ink. The :not() exclusion skips the popover surfaces nested
    inside the header (nav-more menu, nav dropdown panels, the
    version-switcher menu, the search <dialog>) — those keep their
-   default ink-on-surface colors. */
-html[data-theme-pack="brutalist"] header[data-header] a:not([data-nav-more-menu] *):not([data-nav-item-dropdown] div *):not([data-version-switcher] ul *):not(dialog *):not([aria-current="page"]):not([aria-current="page"] *),
-html[data-theme-pack="brutalist"] header[data-header] button:not([data-nav-more-menu] *):not([data-nav-item-dropdown] div *):not([data-version-switcher] ul *):not(dialog *):not([aria-current="page"]):not([aria-current="page"] *),
-html[data-theme-pack="brutalist"] header[data-header] span:not([data-nav-more-menu] *):not([data-nav-item-dropdown] div *):not([data-version-switcher] ul *):not(dialog *):not([aria-current="page"]):not([aria-current="page"] *),
-html[data-theme-pack="brutalist"] header[data-header] svg:not([data-nav-more-menu] *):not([data-nav-item-dropdown] div *):not([data-version-switcher] ul *):not(dialog *):not([aria-current="page"]):not([aria-current="page"] *) {
+   default ink-on-surface colors — plus the active nav chip and the
+   logo, whose dedicated full-ink rules below must win. */
+html[data-theme-pack="brutalist"] header[data-header] a:not([data-nav-more-menu] *):not([data-nav-item-dropdown] div *):not([data-version-switcher] ul *):not(dialog *):not([aria-current="page"]):not([aria-current="page"] *):not([data-header-logo]):not([data-header-logo] *),
+html[data-theme-pack="brutalist"] header[data-header] button:not([data-nav-more-menu] *):not([data-nav-item-dropdown] div *):not([data-version-switcher] ul *):not(dialog *):not([aria-current="page"]):not([aria-current="page"] *):not([data-header-logo]):not([data-header-logo] *),
+html[data-theme-pack="brutalist"] header[data-header] span:not([data-nav-more-menu] *):not([data-nav-item-dropdown] div *):not([data-version-switcher] ul *):not(dialog *):not([aria-current="page"]):not([aria-current="page"] *):not([data-header-logo]):not([data-header-logo] *),
+html[data-theme-pack="brutalist"] header[data-header] svg:not([data-nav-more-menu] *):not([data-nav-item-dropdown] div *):not([data-version-switcher] ul *):not(dialog *):not([aria-current="page"]):not([aria-current="page"] *):not([data-header-logo]):not([data-header-logo] *) {
   color: color-mix(in srgb, var(--zd-bg) 80%, var(--zd-fg));
 }
-html[data-theme-pack="brutalist"] header[data-header] a:not([data-nav-more-menu] *):not([data-nav-item-dropdown] div *):not([data-version-switcher] ul *):not(dialog *):not([aria-current="page"]):not([aria-current="page"] *):hover,
-html[data-theme-pack="brutalist"] header[data-header] button:not([data-nav-more-menu] *):not([data-nav-item-dropdown] div *):not([data-version-switcher] ul *):not(dialog *):not([aria-current="page"]):not([aria-current="page"] *):hover,
-html[data-theme-pack="brutalist"] header[data-header] a:not([data-nav-more-menu] *):not([data-nav-item-dropdown] div *):not([data-version-switcher] ul *):not(dialog *):not([aria-current="page"]):not([aria-current="page"] *):hover svg,
-html[data-theme-pack="brutalist"] header[data-header] button:not([data-nav-more-menu] *):not([data-nav-item-dropdown] div *):not([data-version-switcher] ul *):not(dialog *):not([aria-current="page"]):not([aria-current="page"] *):hover svg {
+html[data-theme-pack="brutalist"] header[data-header] a:not([data-nav-more-menu] *):not([data-nav-item-dropdown] div *):not([data-version-switcher] ul *):not(dialog *):not([aria-current="page"]):not([aria-current="page"] *):not([data-header-logo]):not([data-header-logo] *):hover,
+html[data-theme-pack="brutalist"] header[data-header] button:not([data-nav-more-menu] *):not([data-nav-item-dropdown] div *):not([data-version-switcher] ul *):not(dialog *):not([aria-current="page"]):not([aria-current="page"] *):not([data-header-logo]):not([data-header-logo] *):hover,
+html[data-theme-pack="brutalist"] header[data-header] a:not([data-nav-more-menu] *):not([data-nav-item-dropdown] div *):not([data-version-switcher] ul *):not(dialog *):not([aria-current="page"]):not([aria-current="page"] *):not([data-header-logo]):not([data-header-logo] *):hover svg,
+html[data-theme-pack="brutalist"] header[data-header] button:not([data-nav-more-menu] *):not([data-nav-item-dropdown] div *):not([data-version-switcher] ul *):not(dialog *):not([aria-current="page"]):not([aria-current="page"] *):not([data-header-logo]):not([data-header-logo] *):hover svg {
   color: var(--zd-bg);
 }
 


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3045

---

## Summary

Auto-fix for the `agent-found` finding #3045 (raised during the Theme A11y epic's final verification): the Brutalist header logo's dedicated full-ink rule (`color: var(--zd-bg)`, specificity ~(0,2,1)) was beaten by the slab-ink recolor rule (~(0,8,3) after the active-nav exclusions), so the logo rendered with the 80%-mix ink — slightly muted vs the pack's stated intent. Never a contrast failure (~13:1 light / ~10:1 dark).

Fix mirrors the active-nav chip repair: append `:not([data-header-logo])` + `:not([data-header-logo] *)` to all 8 slab-ink selector chains (4 base + 4 hover), update the rule's comment, bump `brutalist/meta.json` 1.0.2→1.0.3 (cache-busting contract). Package rebuild verified; codex review of the diff: clean.

Closes #3045.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/3046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787201796&installation_model_id=20910&pr_number=3046&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F3046&signature=48bfcafdfcf4fa5dd7d2b23ff07010c1185b2007f5d0fac89fc5346307893b58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->