### PR TITLE
fix(create-zudo-doc): remove unused Cloudflare adapter

### DIFF
--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -1351,7 +1351,7 @@ describe("scaffold — generated package.json", () => {
     expect(pkg.devDependencies["html-validate"]).toBeUndefined();
   });
 
-  it("includes the coordinated zfb family, @takazudo/zudo-doc, and @takazudo/zdtp unconditionally", async () => {
+  it("includes the required zfb packages, @takazudo/zudo-doc, and @takazudo/zdtp unconditionally", async () => {
     // diff and @takazudo/zdtp are unconditional dependencies regardless of
     // docHistory/designTokenPanel selection — see the #2660 completion
     // comment: packageOwnedRoutes always bundles the doc-history-area path
@@ -1360,9 +1360,9 @@ describe("scaffold — generated package.json", () => {
     const pkg = await fs.readJson(projectPath("test-doc", "package.json"));
     expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.90");
     expect(pkg.dependencies["@takazudo/zfb-runtime"]).toBe("0.1.0-next.90");
-    expect(pkg.dependencies["@takazudo/zfb-adapter-cloudflare"]).toBe(
-      "0.1.0-next.90",
-    );
+    // The default scaffold is pure static and emits no Worker-only routes or
+    // adapter config. Consumers add a deploy-target adapter when they opt in.
+    expect(pkg.dependencies["@takazudo/zfb-adapter-cloudflare"]).toBeUndefined();
     expect(pkg.dependencies["@takazudo/zfb-md-wasm"]).toBe("0.1.0-next.90");
     expect(pkg.dependencies["@takazudo/zudo-doc"]).toMatch(/^\^\d+\.\d+\.\d+/);
     expect(pkg.dependencies["diff"]).toBeDefined();

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -673,9 +673,6 @@ function generatePackageJson(choices: UserChoices) {
     // resource-aware island pipeline.
     "@takazudo/zfb": "0.1.0-next.90",
     "@takazudo/zfb-runtime": "0.1.0-next.90",
-    // zfb-adapter-cloudflare — required for any route with `prerender = false`.
-    // Pinned in lockstep with @takazudo/zfb.
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.90",
     "@takazudo/zfb-md-wasm": "0.1.0-next.90",
     // @takazudo/zudo-doc — published from this monorepo via
     // .github/workflows/publish-zudo-doc.yml. The pin here is bumped in

--- a/scripts/check-pin-parity.mjs
+++ b/scripts/check-pin-parity.mjs
@@ -4,11 +4,11 @@
 // Pin-parity gate (W4A — #1732). Failure mode:
 //   "W1A §5#4 — pin sources out of lockstep"
 //
-// The same upstream zfb-family release is represented across five surfaces
-// that must stay in lockstep:
+// The upstream zfb-family packages used by generated projects are represented
+// across five surfaces that must stay in lockstep:
 //
 //   1. Root package.json `@takazudo/zfb` engine pin.
-//   2. Root package.json companion pins (runtime, adapter, and md-wasm).
+//   2. Root package.json companion pins (runtime and md-wasm).
 //   3. packages/create-zudo-doc/src/scaffold.ts — the literal versions emitted
 //      into generated downstream package.json files by `generatePackageJson()`.
 //      A fresh scaffold gets EXACTLY these versions.
@@ -43,13 +43,14 @@ const SCAFFOLD_TS_PATH = resolve(
 );
 const ZUDO_DOC_PKG_PATH = resolve(ROOT_DIR, "packages/zudo-doc/package.json");
 
-// External upstream packages: scaffold pin must equal root dependencies[pkg].
+// External upstream packages emitted by the scaffold: each pin must equal
+// root dependencies[pkg]. The Cloudflare adapter is intentionally absent: the
+// default scaffold is pure static and consumers choose their deploy adapter.
 // @takazudo/zdtp is included here so the scaffold's emitted zdtp pin is
 // parity-checked against root dependencies — same staleness class as #2381 / #2445.
 const PINNED_PACKAGES = [
   "@takazudo/zfb",
   "@takazudo/zfb-runtime",
-  "@takazudo/zfb-adapter-cloudflare",
   "@takazudo/zfb-md-wasm",
   "@takazudo/zdtp",
 ];


### PR DESCRIPTION
Closes #3078.

## Summary

- stop adding `@takazudo/zfb-adapter-cloudflare` to every generated project
- keep the repository host's adapter pin unchanged for its Worker-only routes
- update pin-parity policy so release automation does not require the adapter in static scaffolds
- add regression coverage asserting the adapter is absent from generated dependencies

## Why

The default scaffold intentionally emits no Worker-only routes and leaves `adapter` unset for a pure-static build. Installing a Cloudflare adapter without wiring it into `zudoDoc()` was therefore a dead dependency and made generated deployment behavior misleading. Consumers that opt into Cloudflare Workers can continue to add the adapter and use the documented `adapter` setting.

## Test plan

- `pnpm exec vitest run src/__tests__/scaffold.test.ts src/__tests__/zfb-config-gen.test.ts`
- `pnpm exec vitest run scripts/__tests__/check-pin-parity.test.ts`
- `node scripts/check-pin-parity.mjs`
- `pnpm typecheck`
- `pnpm build`
- `pnpm exec vitest run --config vitest.slow.config.ts src/__tests__/barebone-build.slow.test.ts`
- `git diff --check`

## Review

- direct code review completed with no actionable findings
- UI verification not applicable (generator dependency/policy change only)
