### PR TITLE
fix(layout): equalize mobile doc content left/right inset

### DIFF
--- a/packages/zudo-doc/src/doc-page-shell/index.tsx
+++ b/packages/zudo-doc/src/doc-page-shell/index.tsx
@@ -257,10 +257,21 @@ export function createDocPageShell<S extends Settings = Settings>(
     const tocOverride = shouldRenderToc
       ? customTocIsPresent
         ? <Toc headings={headings} title={tocTitle} />
-        : (Island({
-            when: "load",
-            children: <Toc headings={headings} title={tocTitle} />,
-          }) as unknown as VNode)
+        : // The zfb <Island> wrapper renders a bare <div> with no class, so
+          // below xl (where <Toc> itself is `hidden xl:flex`) it would remain
+          // an in-flow, zero-width flex child of the content band and reserve a
+          // phantom `gap` on the right of <main> — a larger right inset than
+          // left at mobile widths. Hide the flex child itself below xl so it
+          // contributes no gap; the bare-nav override branch above is already
+          // self-hiding via <Toc>'s own `hidden xl:flex`. (#3082)
+          (
+            <div class="hidden xl:block">
+              {Island({
+                when: "load",
+                children: <Toc headings={headings} title={tocTitle} />,
+              }) as unknown as VNode}
+            </div>
+          )
       : undefined;
     const mobileTocOverride = shouldRenderToc
       ? (Island({

--- a/packages/zudo-doc/src/doclayout/doc-layout.tsx
+++ b/packages/zudo-doc/src/doclayout/doc-layout.tsx
@@ -389,15 +389,16 @@ export function DocLayout(props: DocLayoutProps): JSX.Element {
         >
           <div class="flex min-h-[calc(100vh-3.5rem)] justify-center">
             {/*
-              Gap is xl-only: below xl the desktop TOC (`hidden xl:flex`) is
-              display:none but its wrapper still renders as a zero-width block
-              flex child, so an unconditional `gap` would reserve phantom space
-              on the right of <main> — the content would sit with a larger right
-              inset than left at mobile widths. Gate the gap to xl so it applies
-              exactly when the TOC column is a real second column. (#3082)
+              The inter-column `gap` is unconditional so ANY visible `toc` slot
+              (including a custom always-visible override) is separated from
+              <main>. The package default TOC instead hides its own flex child
+              below xl (see doc-page-shell's `hidden xl:block` wrapper) so it
+              contributes no phantom gap on mobile — where an in-flow but
+              zero-width TOC wrapper would otherwise push a larger right inset
+              than left onto the content. (#3082)
             */}
             <div
-              class="zd-doc-content-band flex w-full xl:gap-[clamp(1.5rem,3vw,4rem)]"
+              class="zd-doc-content-band flex w-full gap-[clamp(1.5rem,3vw,4rem)]"
               {...(!showSidebar ? { "data-zd-nosidebar": "" } : {})}
               {...(contentWide ? { "data-zd-wide": "" } : {})}
             >

--- a/packages/zudo-doc/src/doclayout/doc-layout.tsx
+++ b/packages/zudo-doc/src/doclayout/doc-layout.tsx
@@ -388,8 +388,16 @@ export function DocLayout(props: DocLayoutProps): JSX.Element {
           }`}
         >
           <div class="flex min-h-[calc(100vh-3.5rem)] justify-center">
+            {/*
+              Gap is xl-only: below xl the desktop TOC (`hidden xl:flex`) is
+              display:none but its wrapper still renders as a zero-width block
+              flex child, so an unconditional `gap` would reserve phantom space
+              on the right of <main> — the content would sit with a larger right
+              inset than left at mobile widths. Gate the gap to xl so it applies
+              exactly when the TOC column is a real second column. (#3082)
+            */}
             <div
-              class="zd-doc-content-band flex w-full gap-[clamp(1.5rem,3vw,4rem)]"
+              class="zd-doc-content-band flex w-full xl:gap-[clamp(1.5rem,3vw,4rem)]"
               {...(!showSidebar ? { "data-zd-nosidebar": "" } : {})}
               {...(contentWide ? { "data-zd-wide": "" } : {})}
             >


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3083
    - https://github.com/zudolab/zudo-doc/issues/3082

---

## Summary

At mobile / narrow widths the doc content column had more empty space on the **right** than the **left** (`article.zd-content`: left 24px / right **48px** at 390px). The `.zd-doc-content-band` reserved its flex `gap` to the right of `<main>` even below the `xl` breakpoint, where the desktop TOC column is hidden — because the TOC's zfb `<Island>` wrapper (a classless `<div>`) stayed an in-flow, zero-width flex child.

## Fix

- Keep the band's inter-column `gap` **unconditional**, so any genuinely visible `toc` slot (including a custom always-visible override passed to `DocLayout`) stays separated from `<main>` — no API regression.
- Eliminate the phantom gap at its source: the package **default** TOC's Island wrapper now sits inside a `hidden xl:block` wrapper, so below `xl` it is `display:none` and contributes no flex child. (The bare-nav override branch was already self-hiding via `<Toc>`'s own `hidden xl:flex`.)

## Files

- `packages/zudo-doc/src/doclayout/doc-layout.tsx` — band gap kept unconditional + explanatory comment.
- `packages/zudo-doc/src/doc-page-shell/index.tsx` — `hidden xl:block` wrapper around the default TOC's Island.

## Verification (browser geometry, headless)

| width | left | right | band flex children | TOC |
|---|---|---|---|---|
| 390px | 24 | 24 | 1 | hidden |
| 767px | 24 | 24 | 1 | hidden |
| 1024/1279px | (sidebar) | — | 1 | hidden (unchanged) |
| 1280/1366px | — | — | 2 | visible, gap preserved |

- Mobile insets symmetric (was 24/48 → now 24/24); no horizontal scroll at any width; `pnpm check` clean; all 1685 package tests pass.