### PR TITLE
fix(create-zudo-doc): add @takazudo/zudo-doc-history-server to unconditional scaffold deps (#3080)

### DIFF
--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -1351,11 +1351,13 @@ describe("scaffold — generated package.json", () => {
     expect(pkg.devDependencies["html-validate"]).toBeUndefined();
   });
 
-  it("includes the required zfb packages, @takazudo/zudo-doc, and @takazudo/zdtp unconditionally", async () => {
-    // diff and @takazudo/zdtp are unconditional dependencies regardless of
-    // docHistory/designTokenPanel selection — see the #2660 completion
-    // comment: packageOwnedRoutes always bundles the doc-history-area path
-    // and the chrome-derive seam always imports DesignTokenPanelBootstrap.
+  it("includes the required zfb packages, @takazudo/zudo-doc, @takazudo/zdtp, and @takazudo/zudo-doc-history-server unconditionally", async () => {
+    // diff, @takazudo/zdtp, and @takazudo/zudo-doc-history-server are
+    // unconditional dependencies regardless of docHistory/designTokenPanel
+    // selection — packageOwnedRoutes always bundles the doc-history-area path
+    // (which imports both `diff` and `@takazudo/zudo-doc-history-server/exclude`
+    // at module scope, #2342 / #3080) and the chrome-derive seam always imports
+    // DesignTokenPanelBootstrap (which imports @takazudo/zdtp, #2668).
     await scaffold(baseChoices);
     const pkg = await fs.readJson(projectPath("test-doc", "package.json"));
     expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.94");
@@ -1367,6 +1369,9 @@ describe("scaffold — generated package.json", () => {
     expect(pkg.dependencies["@takazudo/zudo-doc"]).toMatch(/^\^\d+\.\d+\.\d+/);
     expect(pkg.dependencies["diff"]).toBeDefined();
     expect(pkg.dependencies["@takazudo/zdtp"]).toBeDefined();
+    // #3080: docHistory-OFF barebone must still carry this — the module-scope
+    // `/exclude` import bundles it regardless of the setting.
+    expect(pkg.dependencies["@takazudo/zudo-doc-history-server"]).toBeDefined();
     expect(pkg.dependencies["astro"]).toBeUndefined();
     expect(pkg.dependencies["shiki"]).toBeUndefined();
     expect(pkg.dependencies["@shikijs/transformers"]).toBeUndefined();
@@ -1392,7 +1397,22 @@ describe("scaffold — generated package.json", () => {
     expect(without.devDependencies["pagefind"]).toBeUndefined();
   });
 
-  it("adds @takazudo/zudo-doc-history-server only when docHistory is enabled", async () => {
+  it("adds @takazudo/zudo-doc-history-server unconditionally — docHistory off AND on (#3080)", async () => {
+    // Regression guard for #3080: the dep used to be gated behind docHistory,
+    // but @takazudo/zudo-doc/dist/doc-history-area/index.js imports
+    // @takazudo/zudo-doc-history-server/exclude at module scope, so a
+    // docHistory-OFF scaffold still bundles it and must declare it or `zfb
+    // build` fails at esbuild "Could not resolve".
+    await scaffold({
+      ...baseChoices,
+      projectName: "test-history-dep-off",
+      features: [],
+    });
+    const off = await fs.readJson(
+      projectPath("test-history-dep-off", "package.json"),
+    );
+    expect(off.dependencies["@takazudo/zudo-doc-history-server"]).toBeDefined();
+
     await scaffold({
       ...baseChoices,
       projectName: "test-history-dep",

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -751,6 +751,23 @@ function generatePackageJson(choices: UserChoices) {
     // the "@takazudo/zdtp dep implication" note in
     // packages/zudo-doc/docs/adr/route-injection-seam.md.
     "@takazudo/zdtp": "0.4.9",
+    // @takazudo/zudo-doc-history-server — SAME "unconditional at build time
+    // despite being an optional peer" class as `diff` (#2342) and
+    // `@takazudo/zdtp` (#2668) above. `@takazudo/zudo-doc/dist/doc-history-area/
+    // index.js` imports `@takazudo/zudo-doc-history-server/exclude`
+    // (compileExclude) at MODULE scope, and packageOwnedRoutes always bundles
+    // the doc-history-area path — so every project pulls this import into the
+    // esbuild graph, `docHistory` setting or not; only history RENDERING is
+    // gated on the setting, not the import. Without this dep a docHistory-OFF
+    // scaffold fails `zfb build` with "Could not resolve
+    // '@takazudo/zudo-doc-history-server/exclude'" (#3080). It IS an optional
+    // peerDependency of @takazudo/zudo-doc (^4.4.3), but pnpm does not
+    // auto-install peers, so a missing copy produces no install warning and
+    // shipped silently until build time. The pin stays lockstep with the root
+    // version (parity-guarded — INTERNAL_PINNED_PACKAGES in
+    // scripts/check-pin-parity.mjs). docHistory-ON projects additionally need
+    // npm-run-all2 for the two-process dev script — see the docHistory block below.
+    "@takazudo/zudo-doc-history-server": "^4.4.4",
   };
 
   const devDeps: Record<string, string> = {
@@ -770,16 +787,15 @@ function generatePackageJson(choices: UserChoices) {
   }
 
   if (choices.features.includes("docHistory")) {
-    // (diff is now an unconditional base dep — see the `deps` block above:
-    // packageOwnedRoutes always bundles the doc-history-area path, so diff is
-    // required regardless of this feature flag.)
-    // @takazudo/zudo-doc has @takazudo/zudo-doc-history-server as an optional
-    // peer dep. When docHistory is selected the zfb plugin
-    // (@takazudo/zudo-doc/plugins/doc-history) eagerly imports its internal
-    // doc-history helpers, which in turn import
-    // @takazudo/zudo-doc-history-server/git-history. Without this dep the
-    // plugin host fails at init with ERR_MODULE_NOT_FOUND — W8A (#1739).
-    deps["@takazudo/zudo-doc-history-server"] = "^4.4.4";
+    // (Both `diff` AND `@takazudo/zudo-doc-history-server` are now unconditional
+    // base deps — see the `deps` block above: packageOwnedRoutes always bundles
+    // the doc-history-area path, whose module-scope imports pull both in
+    // regardless of this feature flag. #2342 / #3080.)
+    // When docHistory is selected the zfb plugin
+    // (@takazudo/zudo-doc/plugins/doc-history) additionally, at plugin-init time,
+    // eagerly imports @takazudo/zudo-doc-history-server/git-history — the same
+    // dep, so it is already satisfied by the unconditional entry (was W8A #1739,
+    // when the dep was still gated here).
     // tsx is no longer needed here: the relocated package plugin imports the
     // runner directly (no `tsx -e` spawn) since the package ships compiled
     // dist/ — package-first migration #2321 (#2337).

--- a/scripts/check-pin-parity.mjs
+++ b/scripts/check-pin-parity.mjs
@@ -146,8 +146,10 @@ const FIRST_PARTY_PEER_CHECKS = [
  * scaffold.ts uses three forms for package pins:
  *   Colon form (object literal):
  *     "@takazudo/zudo-doc": "^0.2.0-next.1",
- *   Bracket-assignment form:
- *     deps["@takazudo/zudo-doc-history-server"] = "^0.2.0-next.1";
+ *   Bracket-assignment form (conditional feature deps, e.g. minisearch):
+ *     deps["<feature-dep>"] = "^0.2.0-next.1";
+ *     (NB: @takazudo/zudo-doc-history-server used to use this form but moved to
+ *      the colon form above when it became an unconditional dep — #3080.)
  *   Constant-reference form (C1 #2362 — the pin is hoisted to a module
  *   constant so the dep pin and the `.zudo-doc.json` provenance seed can't
  *   drift):

--- a/scripts/release-create-zudo-doc.sh
+++ b/scripts/release-create-zudo-doc.sh
@@ -286,16 +286,23 @@ node -e "
 echo "  ✓ $SCAFFOLD_TS @takazudo/zudo-doc → ^$NEW_VERSION"
 
 # ── Step 2d: Align @takazudo/zudo-doc-history-server pin in scaffold.ts ───────
-# The docHistory feature adds a direct @takazudo/zudo-doc-history-server dep to
-# the generated package.json (different syntax — a deps[...] = "..." assignment,
-# not an object-literal key). It must move in lockstep too, otherwise the direct
-# pin (^0.1.0) conflicts with the transitive range @takazudo/zudo-doc carries.
+# The generated package.json carries a direct @takazudo/zudo-doc-history-server
+# dep (unconditional since #3080 — the doc-history-area chrome imports it at
+# module scope regardless of the docHistory setting). It lives as an
+# object-literal key in the base `deps` block: `"@takazudo/zudo-doc-history-server": "^X.Y.Z"`.
+# It must move in lockstep too, otherwise the direct pin conflicts with the
+# transitive range @takazudo/zudo-doc carries.
+# NOTE: this regex matches the object-literal-key (colon) form. It was rewritten
+# from the pre-#3080 `deps[...] = "..."` bracket-assignment form when the pin
+# was promoted to an unconditional dep — keep it in sync if the pin's syntax
+# ever changes again (check-pin-parity.mjs's readScaffoldPin already tolerates
+# both forms, but this WRITE-side regex is form-specific and must be updated).
 echo ""
 echo "▶ Aligning @takazudo/zudo-doc-history-server pin in scaffold.ts..."
 node -e "
   const fs = require('fs');
   const src = fs.readFileSync('$SCAFFOLD_TS', 'utf-8');
-  const re = /(deps\[\"@takazudo\/zudo-doc-history-server\"\]\s*=\s*\")\^?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?(\")/;
+  const re = /(\"@takazudo\/zudo-doc-history-server\"\s*:\s*\")\^?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?(\")/;
   if (!re.test(src)) {
     console.error('Error: could not locate @takazudo/zudo-doc-history-server pin in $SCAFFOLD_TS');
     process.exit(1);


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3080

---

## Summary

A fresh `create-zudo-doc` scaffold with `docHistory` **off** fails `pnpm build` (zfb) at the bundler step:

```
✗ Could not resolve "@takazudo/zudo-doc-history-server/exclude"
  .../@takazudo/zudo-doc/dist/doc-history-area/index.js:3:31
```

`@takazudo/zudo-doc/dist/doc-history-area/index.js` imports `@takazudo/zudo-doc-history-server/exclude` (`compileExclude`) at **module scope**, and `packageOwnedRoutes` always bundles the doc-history-area path — so the import is pulled into every build regardless of the `docHistory` setting. But the generator only added the dep inside the `if (docHistory)` branch of `generatePackageJson()`, so `docHistory`-off scaffolds were missing it. It's an optional `peerDependency` of `@takazudo/zudo-doc` (`^4.4.3`), but pnpm does not auto-install peers, so the gap shipped silently until build time.

This is the same "unconditional-at-build-time despite being an optional peer" class already fixed for `diff` (#2342) and `@takazudo/zdtp` (#2668).

## Changes

- **`packages/create-zudo-doc/src/scaffold.ts`** — promote `@takazudo/zudo-doc-history-server` (`^4.4.4`) into the unconditional `deps` block, alongside `diff` and `@takazudo/zdtp`, with an explanatory comment. Remove the now-redundant conditional `deps[...] = ...` line; the `if (docHistory)` block keeps only its `npm-run-all2` devDep + two-process dev scripts.
- **`scripts/release-create-zudo-doc.sh`** — update Step 2d's lockstep-bump regex from the old bracket-assignment form (`deps["..."] = "..."`) to the new object-literal (colon) form. **Without this, the next release would have failed mid-bump** after already rewriting four package versions + `ZUDO_DOC_PIN` (caught by codex review).
- **`scripts/check-pin-parity.mjs`** — de-stale the `readScaffoldPin` docstring example (history-server is now colon-form; the parser still supports both, and feature deps like `minisearch` still use the bracket form).
- **`packages/create-zudo-doc/src/__tests__/scaffold.test.ts`** — barebone (`features: []`) now asserts the dep is present; the former "only when docHistory enabled" test is rewritten as an unconditional (off **and** on) regression guard.

## Test Plan

- `pnpm test` in `packages/create-zudo-doc` — **575 tests pass** (incl. the new barebone/off-and-on assertions).
- `node scripts/check-pin-parity.mjs` — green (`@takazudo/zudo-doc-history-server = ^4.4.4`, lockstep with root 4.4.4).
- End-to-end: generated a project with the issue's exact flags (`--no-i18n --search --sidebar-filter --claude-resources --image-enlarge --no-tag-governance`, docHistory off) → emitted `package.json` now declares `@takazudo/zudo-doc-history-server: ^4.4.4`.
- Release-script regex verified: old bracket regex no longer matches `scaffold.ts`, new colon regex matches and a simulated bump rewrites the pin correctly (exactly one occurrence).