### PR TITLE
fix(create-zudo-doc): document bracketed admonition title instead of unsupported `{title="..."}`

### DIFF
--- a/packages/create-zudo-doc/src/__tests__/bugfix-3104-admonition-title-syntax.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/bugfix-3104-admonition-title-syntax.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import type { UserChoices } from "../prompts.js";
+import { generateCLAUDEFile } from "../claude-md-gen.js";
+
+// Regression guard for zudolab/zudo-doc#3104.
+//
+// The generated CLAUDE.md used to document a Docusaurus-style
+// `{title="..."}` admonition attribute. That form is not supported: MDX parses
+// the braces as a JS expression, so a page following the project's own
+// guidance either dies at render with `ReferenceError: title is not defined`
+// (fence written without surrounding blank lines) or builds with the title
+// silently dropped (fence with blank lines). Both were verified against the
+// e2e smoke fixture. The supported form is the bracketed one,
+// `:::note[Custom Title]`, which works with or without blank lines.
+//
+// This file asserts the *grammar* of the generated guidance rather than
+// MDX-compiling it: CLAUDE.md is prose steering coding agents, so the failure
+// mode to prevent is the text drifting back to an unsupported form. Real
+// admonition rendering is covered at the build/e2e tier (the smoke fixture's
+// admonitions-test page).
+
+const baseChoices: UserChoices = {
+  projectName: "test-3104",
+  defaultLang: "en",
+  colorSchemeMode: "single",
+  singleScheme: "Default Dark",
+  features: [],
+  packageManager: "pnpm",
+};
+
+/** Every `:::directive` opener appearing in the generated CLAUDE.md. */
+function directiveOpeners(content: string): string[] {
+  return content.match(/:::[a-z][a-z-]*(?:\[[^\]]*\]|\{[^}]*\})?/g) ?? [];
+}
+
+describe("bugfix #3104 — generated CLAUDE.md documents supported admonition title syntax", () => {
+  it("documents the bracketed title form", () => {
+    const content = generateCLAUDEFile(baseChoices);
+
+    expect(content).toContain(":::note[Custom Title]");
+  });
+
+  it("states explicitly that the braced attribute form is unsupported", () => {
+    const content = generateCLAUDEFile(baseChoices);
+
+    // The negative is the load-bearing part: agents trained on Docusaurus
+    // reach for `{title=...}` by default, and the resulting ReferenceError
+    // does not point back at the directive that caused it.
+    expect(content).toMatch(/NOT supported/);
+    expect(content).toMatch(/ReferenceError: title is not defined/);
+  });
+
+  it("only ever mentions the braced attribute to disown it", () => {
+    const content = generateCLAUDEFile(baseChoices);
+
+    // The braced form is *allowed* to appear — the warning above names it on
+    // purpose. What must never happen is presenting it as usable syntax, which
+    // is how the original bug read ("Each accepts an optional `{title=\"...\"}`
+    // attribute"). So: every line mentioning it must also disown it.
+    const bracedLines = content
+      .split("\n")
+      .filter((line) => /\{\s*title\s*=/.test(line));
+
+    expect(bracedLines.length).toBeGreaterThan(0);
+    for (const line of bracedLines) {
+      expect(line).toMatch(/NOT supported/);
+    }
+  });
+
+  it("never attaches a braced attribute to a directive opener", () => {
+    const openers = directiveOpeners(generateCLAUDEFile(baseChoices));
+
+    expect(openers.length).toBeGreaterThan(0);
+    expect(openers.filter((opener) => opener.includes("{"))).toEqual([]);
+  });
+
+  it("holds for a full-feature scaffold too", () => {
+    const content = generateCLAUDEFile({
+      ...baseChoices,
+      defaultLang: "ja",
+      features: ["i18n", "search", "docHistory", "tagGovernance"],
+    });
+
+    expect(content).toContain(":::note[Custom Title]");
+    expect(directiveOpeners(content).filter((o) => o.includes("{"))).toEqual(
+      [],
+    );
+  });
+});

--- a/packages/create-zudo-doc/src/claude-md-gen.ts
+++ b/packages/create-zudo-doc/src/claude-md-gen.ts
@@ -108,7 +108,17 @@ export function generateCLAUDEFile(choices: UserChoices): string {
   lines.push(`### Admonitions`);
   lines.push(``);
   lines.push(
-    `Available in all MDX files without imports, via directive syntax: \`:::note\`, \`:::tip\`, \`:::info\`, \`:::warning\`, \`:::danger\`, \`:::caution\`, \`:::details\`. Each accepts an optional \`{title="..."}\` attribute.`,
+    `Available in all MDX files without imports, via directive syntax: \`:::note\`, \`:::tip\`, \`:::info\`, \`:::warning\`, \`:::danger\`, \`:::caution\`, \`:::details\`. Each accepts an optional **bracketed** title: \`:::note[Custom Title]\`.`,
+  );
+  lines.push(``);
+  // Agents trained on Docusaurus reach for `{title="..."}` by default, and that
+  // form fails in a way the error message does not point back at: MDX parses the
+  // braces as a JS expression, so the build dies with `ReferenceError: title is
+  // not defined` (or, when the fence has blank lines around it, the title is
+  // silently dropped). Stating the negative explicitly is the whole point of this
+  // paragraph — see zudolab/zudo-doc#3104.
+  lines.push(
+    `Docusaurus-style \`{title="..."}\` is **NOT supported**. MDX parses the braces as a JS expression, so it either fails the build with \`ReferenceError: title is not defined\` or is silently ignored. Always use the bracketed form.`,
   );
   lines.push(``);
   lines.push(`### Headings`);


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3104

---

## Summary

The generated `CLAUDE.md` told readers that admonitions accept a Docusaurus-style `{title="..."}` attribute. That form is never correct — MDX parses the braces as a JS expression — so an agent following the scaffolded project's own `CLAUDE.md` produced a page that failed CI. This is the one file an LLM agent is most likely to treat as authoritative, and the package's own docs (`docs/components/admonitions.mdx`, `markdown-features/admonitions-preset.mdx`) already show the correct bracketed form, so the generated guidance was the outlier.

The failure is disproportionately expensive to diagnose relative to how small the mistake is: it surfaces as a runtime `ReferenceError` at render, so the message never points back at the directive that caused it.

## What the behavior actually is

Verified empirically against the `e2e/fixtures/smoke` project rather than taken from the report — the real behavior is broader than "breaks the build":

| Form | Blank lines around fence | Result |
|---|---|---|
| `:::note{title="X"}` | no | Build fails — `ReferenceError: title is not defined` |
| `:::note{title="X"}` | yes | Builds, but the title is **silently dropped** (renders the default `Note`) |
| `:::note[X]` | either | Title renders correctly |

Without blank lines the directive never parses, so `{title="X"}` leaks into the MDX as a JS expression and the assignment to an undeclared `title` throws under ESM strict mode. With blank lines the directive parses, but the braced attribute is not mapped to the admonition title. Either way the documented form does not work, which is why the fix states the negative rather than just swapping the example.

## Changes

- **`packages/create-zudo-doc/src/claude-md-gen.ts`** — the Admonitions section now documents the bracketed title (`:::note[Custom Title]`) and adds a short paragraph explicitly disowning `{title="..."}`, naming the `ReferenceError` so an agent that hits it can connect the two. Stating the negative is deliberate: agents trained on Docusaurus reach for `{title=...}` by default.
- **`packages/create-zudo-doc/src/__tests__/bugfix-3104-admonition-title-syntax.test.ts`** — new regression guard (5 assertions): the bracketed form is documented, the unsupported form is named as unsupported, every line mentioning `{title=` also disowns it, no `:::directive{...}` opener is ever presented, and both hold for a full-feature scaffold.

The braced form is deliberately still *present* in the generated text — inside the warning. The test therefore asserts the invariant that matters ("only ever mentioned to disown it") rather than banning the substring, which would have contradicted the fix.

## Test Plan

- `pnpm --filter create-zudo-doc test` — 580 passed (15 files), including the 5 new assertions.
- **Regression guard proven non-vacuous**: reverting `claude-md-gen.ts` to the original text fails 4 of the 5 new assertions. (The 5th — the directive-opener check — correctly passes, because the original bug wrote `{title="..."}` detached from any `:::` opener. That asymmetry is why the detached shape is asserted separately.)
- `tsc --noEmit` on the package — clean.
- Local pre-push gates: fixture-settings drift, template drift, pin parity — all pass.
- Empirical build verification of all four syntax/blank-line combinations in the table above, via `zfb build` on the smoke fixture.

## Notes

- No changelog entry: `packages/zudo-doc/CHANGELOG.md` is filled at release time by `/l-make-release`, matching precedent fix commit `7ace05fdb`, which touched only source and tests.
- `packages/create-zudo-doc/src/claude-md-gen.ts` has pre-existing Prettier drift at `HEAD`, left untouched — no CI gate covers TS formatting (the format check is MDX-only), and reformatting would have buried a two-line fix in an unrelated whole-file diff.

Closes #3104