### PR TITLE
fix(auto-logo): swap ink/knockout color roles to match the takazudomodular model

### DIFF
--- a/packages/zudo-doc/src/auto-logo/__tests__/auto-logo.test.tsx
+++ b/packages/zudo-doc/src/auto-logo/__tests__/auto-logo.test.tsx
@@ -3,6 +3,23 @@
 import { describe, it, expect } from "vitest";
 import { render } from "preact-render-to-string";
 import { AutoLogo, pickGlyphName } from "../index.js";
+import {
+  GLYPH_NAMES,
+  GLYPH_SHAPES,
+  PLATE_SHAPE,
+  INNER_FRAME_SHAPE,
+  RAY_SHAPES,
+  DISC_SHAPE,
+} from "../shapes.js";
+
+// The two color-role tokens of the shapes.ts color contract (#3108):
+// ink paints the frame, rays, and disc; knockout paints the plate and glyph.
+const INK = "currentColor";
+const KO = "var(--color-bg)";
+
+function escapeRe(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 
 describe("AutoLogo", () => {
   it("is deterministic — same seed renders identical markup", () => {
@@ -20,9 +37,9 @@ describe("AutoLogo", () => {
   it("renders the decorated-plate structure: plate, frame, 4 corner rays, disc, glyph", () => {
     const html = render(<AutoLogo seed="zudo-doc" />);
     expect(html).toContain('viewBox="0 0 200 105"');
-    expect(html).toContain('fill="currentColor"');
-    // knockouts resolve through the page-bg token, never a hardcoded color
-    expect(html).toContain("var(--color-bg)");
+    // both color roles resolve through theme tokens, never a hardcoded color
+    expect(html).toContain(INK);
+    expect(html).toContain(KO);
     expect(html).not.toMatch(/#[0-9a-fA-F]{3,6}\b/);
     // 4 corner rays
     expect(html.match(/<line[^>]*stroke-width="1.4"/g)).toHaveLength(4);
@@ -33,8 +50,73 @@ describe("AutoLogo", () => {
     expect(html).toContain(`data-auto-logo="${pickGlyphName("zudo-doc")}"`);
   });
 
+  // Serialization-level counterpart to the data-level role assertions below —
+  // proves the attrs actually reach the rendered markup.
+  it("paints the plate with the knockout token and the frame/rays/disc with ink", () => {
+    const html = render(<AutoLogo seed="zudo-doc" />);
+
+    // full-bleed plate rect (200×105) — page background, NOT ink
+    expect(html).toMatch(new RegExp(`<rect[^>]*width="200"[^>]*height="105"[^>]*fill="${escapeRe(KO)}"`));
+    // inset frame rect (188×93) — ink stroke, no fill
+    expect(html).toMatch(new RegExp(`<rect[^>]*width="188"[^>]*fill="none"[^>]*stroke="${escapeRe(INK)}"`));
+    // all 4 corner rays — ink stroke
+    expect(html.match(new RegExp(`<line[^>]*stroke="${escapeRe(INK)}"[^>]*stroke-width="1.4"`, "g"))).toHaveLength(4);
+    // centered disc — ink fill
+    expect(html).toMatch(new RegExp(`<circle[^>]*r="34"[^>]*fill="${escapeRe(INK)}"`));
+  });
+
+  it("knocks the seeded glyph out of the ink disc (no ink inside the glyph group)", () => {
+    const html = render(<AutoLogo seed="zudo-doc" />);
+    const glyphGroup = /<g transform="[^"]*">([\s\S]*)<\/g>/.exec(html)?.[1];
+    expect(glyphGroup, "glyph <g> should be present in the rendered output").toBeTruthy();
+    expect(glyphGroup).toContain(KO);
+    // `var(--color-bg)` does not contain the substring "currentColor", so this
+    // is a real assertion that no glyph primitive is painted in ink.
+    expect(glyphGroup).not.toContain(INK);
+  });
+
   it("passes the class prop through to the root svg", () => {
     const html = render(<AutoLogo seed="x" class="w-[320px] text-fg" />);
     expect(html).toContain('class="w-[320px] text-fg"');
+  });
+});
+
+describe("shapes.ts color contract", () => {
+  it("plate is the knockout; frame, rays, and disc are ink", () => {
+    expect(PLATE_SHAPE.attrs["fill"]).toBe(KO);
+    expect(INNER_FRAME_SHAPE.attrs["fill"]).toBe("none");
+    expect(INNER_FRAME_SHAPE.attrs["stroke"]).toBe(INK);
+    expect(RAY_SHAPES).toHaveLength(4);
+    for (const [i, ray] of RAY_SHAPES.entries()) {
+      expect(ray.attrs["stroke"], `RAY_SHAPES[${i}].stroke`).toBe(INK);
+    }
+    expect(DISC_SHAPE.attrs["fill"]).toBe(INK);
+  });
+
+  // A single seeded render only exercises one glyph — assert the color roles
+  // at the data level so all 8 are covered.
+  it("declares exactly the 8 known glyphs", () => {
+    expect(GLYPH_NAMES).toHaveLength(8);
+    expect(new Set(GLYPH_NAMES)).toEqual(
+      new Set(["book", "doc", "bookmark", "compass", "terminal", "bulb", "chat", "layers"]),
+    );
+  });
+
+  it.each(GLYPH_NAMES)("%s glyph: every painted fill/stroke is the knockout token", (name) => {
+    const shapes = GLYPH_SHAPES[name]!;
+    expect(shapes.length).toBeGreaterThan(0);
+
+    let painted = 0;
+    for (const [i, shape] of shapes.entries()) {
+      for (const attr of ["fill", "stroke"] as const) {
+        const value = shape.attrs[attr];
+        if (value === undefined || value === "none") continue;
+        expect(value, `${name}[${i}].${attr}`).toBe(KO);
+        painted++;
+      }
+    }
+    // guards against a glyph whose primitives carry no color attrs at all,
+    // which would make the loop above pass vacuously
+    expect(painted, `${name} should paint at least one fill/stroke`).toBeGreaterThan(0);
   });
 });

--- a/packages/zudo-doc/src/auto-logo/__tests__/standalone.test.ts
+++ b/packages/zudo-doc/src/auto-logo/__tests__/standalone.test.ts
@@ -2,6 +2,20 @@ import { describe, it, expect } from "vitest";
 import { renderAutoLogoStandaloneSvg } from "../standalone.js";
 import { pickGlyphName } from "../shapes.js";
 
+// Luminance-mask colors the two shapes.ts tokens are substituted with:
+// ink (currentColor) -> white (visible), knockout (var(--color-bg)) -> black.
+const VISIBLE = "#fff";
+const CUT = "#000";
+
+/** The `<mask …>…</mask>` inner content — the final output rect sits OUTSIDE
+ *  it and is also `fill="#000"`, so whole-document assertions on the mask
+ *  colors would be ambiguous. */
+function maskContentOf(svg: string): string {
+  const match = /<mask\b[^>]*>([\s\S]*)<\/mask>/.exec(svg);
+  expect(match, "standalone SVG should contain a <mask> element").not.toBeNull();
+  return match![1]!;
+}
+
 describe("renderAutoLogoStandaloneSvg", () => {
   it("is deterministic — same seed produces byte-identical output", () => {
     const a = renderAutoLogoStandaloneSvg("zudo-doc");
@@ -22,6 +36,49 @@ describe("renderAutoLogoStandaloneSvg", () => {
     const svg = renderAutoLogoStandaloneSvg("zudo-doc");
     expect(svg).not.toContain("var(");
     expect(svg).not.toContain("currentColor");
+  });
+
+  // #3108 role swap: the plate is cut away, the frame/rays/disc are visible,
+  // and the glyph is punched back out of the disc. Scoped to the mask content
+  // because the final output rect (outside the mask) is also fill="#000".
+  it("maps the swapped color roles into the mask: plate cut, frame/rays/disc visible, glyph cut", () => {
+    const mask = maskContentOf(renderAutoLogoStandaloneSvg("zudo-doc"));
+
+    // full-bleed plate rect (200×105) — cut away (a no-op over the black default)
+    expect(mask).toMatch(new RegExp(`<rect[^>]*width="200"[^>]*height="105"[^>]*fill="${CUT}"`));
+    // inset frame rect (188 wide) — visible stroke, unfilled
+    expect(mask).toMatch(new RegExp(`<rect[^>]*width="188"[^>]*fill="none"[^>]*stroke="${VISIBLE}"`));
+    // all 4 corner rays — visible strokes
+    expect(mask.match(new RegExp(`<line[^>]*stroke="${VISIBLE}"[^>]*stroke-width="1.4"`, "g"))).toHaveLength(4);
+    // centered disc — visible fill
+    expect(mask).toMatch(new RegExp(`<circle[^>]*r="34"[^>]*fill="${VISIBLE}"`));
+  });
+
+  it("punches the glyph out of the disc — no visible paint inside the glyph group", () => {
+    const mask = maskContentOf(renderAutoLogoStandaloneSvg("zudo-doc"));
+    const glyphGroup = /<g transform="[^"]*">([\s\S]*)<\/g>/.exec(mask)?.[1];
+    expect(glyphGroup, "mask content should contain the transformed glyph group").toBeTruthy();
+    expect(glyphGroup).toContain(CUT);
+    expect(glyphGroup).not.toContain(VISIBLE);
+  });
+
+  it("applies the swapped roles for every glyph, not just the default seed", () => {
+    // one seed per distinct glyph, so all 8 glyph shape sets are exercised
+    const seen = new Map<string, string>();
+    for (let i = 0; i < 200 && seen.size < 8; i++) {
+      const seed = `seed-${i}`;
+      const glyph = pickGlyphName(seed);
+      if (!seen.has(glyph)) seen.set(glyph, seed);
+    }
+    expect(seen.size, "probe pool should cover all 8 glyphs").toBe(8);
+
+    for (const [glyph, seed] of seen) {
+      const mask = maskContentOf(renderAutoLogoStandaloneSvg(seed));
+      const glyphGroup = /<g transform="[^"]*">([\s\S]*)<\/g>/.exec(mask)?.[1];
+      expect(glyphGroup, `${glyph} glyph group`).toBeTruthy();
+      expect(glyphGroup, `${glyph} glyph should be cut out, not visible`).not.toContain(VISIBLE);
+      expect(mask, `${glyph}: disc stays visible`).toMatch(new RegExp(`<circle[^>]*r="34"[^>]*fill="${VISIBLE}"`));
+    }
   });
 
   it("reuses pickGlyphName so the ejected glyph matches logo: \"auto\" mode", () => {

--- a/packages/zudo-doc/src/auto-logo/index.tsx
+++ b/packages/zudo-doc/src/auto-logo/index.tsx
@@ -9,11 +9,14 @@
 // centered disc + a line-art glyph — generated purely from the site name.
 // Same seed always produces the same logo; no stored asset, no client JS.
 //
-// Color contract: the plate fills `currentColor` (give the element `text-fg`)
-// and every frame line / disc knockout uses `var(--color-bg)` so the logo
-// sits visually "knocked out" against the page background and adapts to
-// light/dark automatically. The visual recipe is the `plate-rays-icon`
-// variant picked from the design prototype (cclogs `auto-logo-gen`).
+// Color contract: the plate fills `var(--color-bg)` so the tile interior is
+// the page background, and the frame lines, corner rays, and center disc are
+// drawn in `currentColor` (give the element `text-fg`); the glyph is then
+// knocked back out of the disc with `var(--color-bg)`. Both tokens are
+// theme-driven, so the logo adapts to light/dark automatically and light
+// mode is the exact inverse of dark. The visual recipe is the
+// `plate-rays-icon` variant picked from the design prototype (cclogs
+// `auto-logo-gen`).
 //
 // Glyph shapes + plate geometry live in ./shapes.ts as plain data, shared
 // with the dependency-free standalone SVG builder (./standalone.ts, epic

--- a/packages/zudo-doc/src/auto-logo/shapes.ts
+++ b/packages/zudo-doc/src/auto-logo/shapes.ts
@@ -4,9 +4,12 @@
 // both consumers render the exact same geometry from a single source and
 // cannot drift (issue #3048).
 //
-// Color contract: colors are carried as the same string tokens the JSX
-// component always used — "currentColor" for ink (plate + glyph) and
-// "var(--color-bg)" for knockouts (frame, rays, disc). `AutoLogo` spreads
+// Color contract: colors are carried as the same two string tokens the JSX
+// component always used — "currentColor" for ink (frame, rays, disc) and
+// "var(--color-bg)" for knockouts (plate + glyph). The tile interior is the
+// page background, over which ink paints the thin frame, the 4 corner rays,
+// and the center disc; the glyph is then knocked back out of that disc
+// (issue #3108 — matches the takazudomodular model). `AutoLogo` spreads
 // these attrs verbatim (they resolve correctly in a live, styled SVG);
 // `standalone.ts` substitutes both tokens with concrete luminance-mask
 // colors when serializing (no `var(`/`currentColor` can reach an ejected
@@ -27,16 +30,21 @@ export const CX = W / 2;
 export const CY = H / 2;
 export const DISC_R = 34;
 
+/** Ink color token — the element's own color (see the color contract above). */
+const INK = "currentColor";
+
 /** Knockout color token — page background (see the color contract above). */
 const KO = "var(--color-bg)";
 
-/** Full-bleed plate rect. */
+/** Full-bleed plate rect, filled with the page background so the tile
+ *  interior reads as the page itself (opaque, not `fill: "none"`, so it also
+ *  covers a textured page background). */
 export const PLATE_SHAPE: ShapePrimitive = {
   el: "rect",
-  attrs: { x: 0, y: 0, width: W, height: H, fill: "currentColor" },
+  attrs: { x: 0, y: 0, width: W, height: H, fill: KO },
 };
 
-/** Thin inner frame stroke, knocked out against the page background. */
+/** Thin inner frame stroke, drawn in ink over the plate. */
 export const INNER_FRAME_SHAPE: ShapePrimitive = {
   el: "rect",
   attrs: {
@@ -45,12 +53,12 @@ export const INNER_FRAME_SHAPE: ShapePrimitive = {
     width: W - INSET * 2,
     height: H - INSET * 2,
     fill: "none",
-    stroke: KO,
+    stroke: INK,
     "stroke-width": 1.6,
   },
 };
 
-/** 4 diagonal corner rays, each stopping just short of the disc edge. */
+/** 4 diagonal corner rays in ink, each stopping just short of the disc edge. */
 export const RAY_SHAPES: ShapePrimitive[] = (
   [
     [INSET, INSET],
@@ -65,14 +73,14 @@ export const RAY_SHAPES: ShapePrimitive[] = (
   const stop = (len - DISC_R - 7) / len;
   return {
     el: "line",
-    attrs: { x1: x, y1: y, x2: x + dx * stop, y2: y + dy * stop, stroke: KO, "stroke-width": 1.4 },
+    attrs: { x1: x, y1: y, x2: x + dx * stop, y2: y + dy * stop, stroke: INK, "stroke-width": 1.4 },
   } satisfies ShapePrimitive;
 });
 
-/** Centered disc, knocked out against the page background. */
+/** Centered ink disc — the glyph below is knocked back out of it. */
 export const DISC_SHAPE: ShapePrimitive = {
   el: "circle",
-  attrs: { cx: CX, cy: CY, r: DISC_R, fill: KO },
+  attrs: { cx: CX, cy: CY, r: DISC_R, fill: INK },
 };
 
 /** Scale + translate that centers a glyph's 100×100 box onto the disc
@@ -81,10 +89,12 @@ export const GLYPH_SCALE = ((DISC_R * 2) / 100) * 1.05;
 export const GLYPH_TRANSFORM = `translate(${CX - 50 * GLYPH_SCALE}, ${CY - 50 * GLYPH_SCALE}) scale(${GLYPH_SCALE})`;
 
 /** Line-art glyphs drawn in a 100×100 box centered at (50,50), as plain
- *  shape data. The original JSX wrapped each glyph (and some repeated
- *  groups) in a `<g>` that carried no attributes of its own — only React
- *  `key`s for list rendering — so flattening into a single primitive array
- *  per glyph loses no visual information. */
+ *  shape data. Every painted `fill`/`stroke` here is the knockout token, so
+ *  the glyph reads as a hole punched through the ink disc it sits on.
+ *  The original JSX wrapped each glyph (and some repeated groups) in a `<g>`
+ *  that carried no attributes of its own — only React `key`s for list
+ *  rendering — so flattening into a single primitive array per glyph loses
+ *  no visual information. */
 export const GLYPH_SHAPES: Record<string, ShapePrimitive[]> = {
   book: [
     {
@@ -92,12 +102,12 @@ export const GLYPH_SHAPES: Record<string, ShapePrimitive[]> = {
       attrs: {
         d: "M50 30 C42 24, 30 23, 22 26 L22 68 C30 65, 42 66, 50 72 C58 66, 70 65, 78 68 L78 26 C70 23, 58 24, 50 30 Z",
         fill: "none",
-        stroke: "currentColor",
+        stroke: KO,
         "stroke-width": 6,
         "stroke-linejoin": "round",
       },
     },
-    { el: "line", attrs: { x1: 50, y1: 30, x2: 50, y2: 72, stroke: "currentColor", "stroke-width": 5 } },
+    { el: "line", attrs: { x1: 50, y1: 30, x2: 50, y2: 72, stroke: KO, "stroke-width": 5 } },
     ...[0, 1, 2].flatMap(
       (i): ShapePrimitive[] => [
         {
@@ -107,7 +117,7 @@ export const GLYPH_SHAPES: Record<string, ShapePrimitive[]> = {
             y1: 38 + i * 10,
             x2: 43,
             y2: 40 + i * 10,
-            stroke: "currentColor",
+            stroke: KO,
             "stroke-width": 4,
             "stroke-linecap": "round",
           },
@@ -119,7 +129,7 @@ export const GLYPH_SHAPES: Record<string, ShapePrimitive[]> = {
             y1: 40 + i * 10,
             x2: 71,
             y2: 38 + i * 10,
-            stroke: "currentColor",
+            stroke: KO,
             "stroke-width": 4,
             "stroke-linecap": "round",
           },
@@ -130,37 +140,37 @@ export const GLYPH_SHAPES: Record<string, ShapePrimitive[]> = {
   doc: [
     {
       el: "path",
-      attrs: { d: "M32 22 L60 22 L70 32 L70 78 L32 78 Z", fill: "none", stroke: "currentColor", "stroke-width": 6, "stroke-linejoin": "round" },
+      attrs: { d: "M32 22 L60 22 L70 32 L70 78 L32 78 Z", fill: "none", stroke: KO, "stroke-width": 6, "stroke-linejoin": "round" },
     },
     {
       el: "path",
-      attrs: { d: "M60 22 L60 32 L70 32", fill: "none", stroke: "currentColor", "stroke-width": 5, "stroke-linejoin": "round" },
+      attrs: { d: "M60 22 L60 32 L70 32", fill: "none", stroke: KO, "stroke-width": 5, "stroke-linejoin": "round" },
     },
     ...[0, 1, 2].map(
       (i): ShapePrimitive => ({
         el: "line",
-        attrs: { x1: 40, y1: 44 + i * 11, x2: 62, y2: 44 + i * 11, stroke: "currentColor", "stroke-width": 4, "stroke-linecap": "round" },
+        attrs: { x1: 40, y1: 44 + i * 11, x2: 62, y2: 44 + i * 11, stroke: KO, "stroke-width": 4, "stroke-linecap": "round" },
       }),
     ),
   ],
   bookmark: [
     {
       el: "path",
-      attrs: { d: "M34 22 L66 22 L66 78 L50 64 L34 78 Z", fill: "none", stroke: "currentColor", "stroke-width": 6, "stroke-linejoin": "round" },
+      attrs: { d: "M34 22 L66 22 L66 78 L50 64 L34 78 Z", fill: "none", stroke: KO, "stroke-width": 6, "stroke-linejoin": "round" },
     },
-    { el: "line", attrs: { x1: 42, y1: 36, x2: 58, y2: 36, stroke: "currentColor", "stroke-width": 4, "stroke-linecap": "round" } },
+    { el: "line", attrs: { x1: 42, y1: 36, x2: 58, y2: 36, stroke: KO, "stroke-width": 4, "stroke-linecap": "round" } },
   ],
   compass: [
-    { el: "circle", attrs: { cx: 50, cy: 50, r: 26, fill: "none", stroke: "currentColor", "stroke-width": 6 } },
-    { el: "path", attrs: { d: "M60 40 L54 56 L40 60 L46 44 Z", fill: "currentColor" } },
+    { el: "circle", attrs: { cx: 50, cy: 50, r: 26, fill: "none", stroke: KO, "stroke-width": 6 } },
+    { el: "path", attrs: { d: "M60 40 L54 56 L40 60 L46 44 Z", fill: KO } },
   ],
   terminal: [
-    { el: "rect", attrs: { x: 24, y: 30, width: 52, height: 40, rx: 5, fill: "none", stroke: "currentColor", "stroke-width": 6 } },
+    { el: "rect", attrs: { x: 24, y: 30, width: 52, height: 40, rx: 5, fill: "none", stroke: KO, "stroke-width": 6 } },
     {
       el: "path",
-      attrs: { d: "M33 42 L41 50 L33 58", fill: "none", stroke: "currentColor", "stroke-width": 5, "stroke-linecap": "round", "stroke-linejoin": "round" },
+      attrs: { d: "M33 42 L41 50 L33 58", fill: "none", stroke: KO, "stroke-width": 5, "stroke-linecap": "round", "stroke-linejoin": "round" },
     },
-    { el: "line", attrs: { x1: 47, y1: 58, x2: 60, y2: 58, stroke: "currentColor", "stroke-width": 5, "stroke-linecap": "round" } },
+    { el: "line", attrs: { x1: 47, y1: 58, x2: 60, y2: 58, stroke: KO, "stroke-width": 5, "stroke-linecap": "round" } },
   ],
   bulb: [
     {
@@ -168,30 +178,30 @@ export const GLYPH_SHAPES: Record<string, ShapePrimitive[]> = {
       attrs: {
         d: "M50 22 C37 22, 30 32, 30 41 C30 49, 35 53, 39 58 L39 64 L61 64 L61 58 C65 53, 70 49, 70 41 C70 32, 63 22, 50 22 Z",
         fill: "none",
-        stroke: "currentColor",
+        stroke: KO,
         "stroke-width": 6,
         "stroke-linejoin": "round",
       },
     },
-    { el: "line", attrs: { x1: 42, y1: 71, x2: 58, y2: 71, stroke: "currentColor", "stroke-width": 5, "stroke-linecap": "round" } },
-    { el: "line", attrs: { x1: 45, y1: 78, x2: 55, y2: 78, stroke: "currentColor", "stroke-width": 5, "stroke-linecap": "round" } },
+    { el: "line", attrs: { x1: 42, y1: 71, x2: 58, y2: 71, stroke: KO, "stroke-width": 5, "stroke-linecap": "round" } },
+    { el: "line", attrs: { x1: 45, y1: 78, x2: 55, y2: 78, stroke: KO, "stroke-width": 5, "stroke-linecap": "round" } },
   ],
   chat: [
     {
       el: "path",
-      attrs: { d: "M26 28 L74 28 L74 62 L48 62 L36 74 L36 62 L26 62 Z", fill: "none", stroke: "currentColor", "stroke-width": 6, "stroke-linejoin": "round" },
+      attrs: { d: "M26 28 L74 28 L74 62 L48 62 L36 74 L36 62 L26 62 Z", fill: "none", stroke: KO, "stroke-width": 6, "stroke-linejoin": "round" },
     },
-    ...[0, 1, 2].map((i): ShapePrimitive => ({ el: "circle", attrs: { cx: 38 + i * 12, cy: 45, r: 3, fill: "currentColor" } })),
+    ...[0, 1, 2].map((i): ShapePrimitive => ({ el: "circle", attrs: { cx: 38 + i * 12, cy: 45, r: 3, fill: KO } })),
   ],
   layers: [
-    { el: "path", attrs: { d: "M50 22 L78 36 L50 50 L22 36 Z", fill: "none", stroke: "currentColor", "stroke-width": 6, "stroke-linejoin": "round" } },
+    { el: "path", attrs: { d: "M50 22 L78 36 L50 50 L22 36 Z", fill: "none", stroke: KO, "stroke-width": 6, "stroke-linejoin": "round" } },
     {
       el: "path",
-      attrs: { d: "M25 47 L50 60 L75 47", fill: "none", stroke: "currentColor", "stroke-width": 6, "stroke-linecap": "round", "stroke-linejoin": "round" },
+      attrs: { d: "M25 47 L50 60 L75 47", fill: "none", stroke: KO, "stroke-width": 6, "stroke-linecap": "round", "stroke-linejoin": "round" },
     },
     {
       el: "path",
-      attrs: { d: "M25 58 L50 71 L75 58", fill: "none", stroke: "currentColor", "stroke-width": 6, "stroke-linecap": "round", "stroke-linejoin": "round" },
+      attrs: { d: "M25 58 L50 71 L75 58", fill: "none", stroke: KO, "stroke-width": 6, "stroke-linecap": "round", "stroke-linejoin": "round" },
     },
   ],
 };

--- a/packages/zudo-doc/src/auto-logo/standalone.ts
+++ b/packages/zudo-doc/src/auto-logo/standalone.ts
@@ -11,10 +11,16 @@
 // with `var(--color-bg)` — neither resolves inside an external CSS-mask
 // image, where only the alpha channel matters. This builder instead
 // expresses the design via an internal SVG **luminance** `<mask>`: white =
-// visible in the final alpha, black = cut away. `currentColor` (ink: plate +
-// glyph) maps to white; `var(--color-bg)` (knockouts: frame, rays, disc)
+// visible in the final alpha, black = cut away. `currentColor` (ink: frame,
+// rays, disc) maps to white; `var(--color-bg)` (knockouts: plate + glyph)
 // maps to black — so the two tokens both disappear from the output and the
 // design survives purely as alpha.
+//
+// Consequence of the #3108 role swap, and an accepted limitation of this
+// one-color CSS-mask path: the ejected silhouette is frame + rays + a disc
+// with the glyph punched out of it. The plate now maps to black, a no-op
+// against the mask's black default, so the ejected variant's tile interior
+// is transparent where the live component paints an opaque page background.
 
 import {
   W,
@@ -31,10 +37,12 @@ import {
 
 const MASK_ID = "auto-logo-mask";
 
-// currentColor (ink) -> visible in the mask (white); var(--color-bg)
-// (knockout) -> cut away (black). These are the only two color tokens any
-// shape in shapes.ts ever carries, so substituting both guarantees the
-// output contains neither `var(` nor `currentColor`.
+// currentColor (ink: frame, rays, disc) -> visible in the mask (white);
+// var(--color-bg) (knockout: plate + glyph) -> cut away (black). These are
+// the only two color tokens any shape in shapes.ts ever carries, so
+// substituting both guarantees the output contains neither `var(` nor
+// `currentColor`. The map itself is role-agnostic — it keys on the tokens,
+// so the #3108 role swap flowed through it without an edit here.
 const MASK_COLORS: Record<string, string> = {
   currentColor: "#fff",
   "var(--color-bg)": "#000",
@@ -64,8 +72,8 @@ export function renderAutoLogoStandaloneSvg(seed: string): string {
   const glyphName = pickGlyphName(seed);
   const glyphShapes = GLYPH_SHAPES[glyphName]!;
 
-  // Mask content order: white full-plate rect -> black knockouts (inner
-  // frame stroke, 4 rays, disc) -> white glyph shapes on the disc.
+  // Mask content order: black full-plate rect -> white ink (inner frame
+  // stroke, 4 rays, disc) -> black glyph shapes punched back out of the disc.
   const maskContent =
     renderShape(PLATE_SHAPE) +
     renderShape(INNER_FRAME_SHAPE) +


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3108
    - https://github.com/zudolab/zudo-doc/issues/3107 (epic)

---

## Summary

The generated hero logo (`AutoLogo`, rendered when `logo: "auto"` — the default for every fresh `create-zudo-doc` scaffold) rendered inverted relative to the takazudomodular model: a foreground-filled tile interior with a dark center disc and a light glyph, where the model is a page-background interior with light frame lines, light corner rays, a light disc, and a dark glyph knocked out of it.

`shapes.ts` is the single source of truth both the live Preact renderer and the standalone eject builder read, so the whole fix is a role swap of its two color tokens.

| Shape | Before | After |
|---|---|---|
| `PLATE_SHAPE` fill | `currentColor` | `var(--color-bg)` |
| `INNER_FRAME_SHAPE` stroke | `var(--color-bg)` | `currentColor` |
| `RAY_SHAPES` stroke (all 4) | `var(--color-bg)` | `currentColor` |
| `DISC_SHAPE` fill | `var(--color-bg)` | `currentColor` |
| `GLYPH_SHAPES` non-`"none"` `fill`/`stroke` (all 8 glyphs) | `currentColor` | `var(--color-bg)` |

Light mode is the exact inverse of dark for free — both roles are theme-driven tokens.

## Changes

- **`shapes.ts`** — the token swap, plus an `INK` constant introduced alongside the existing `KO`. The ink side was previously a bare `"currentColor"` literal repeated ~25 times across the glyph data; naming both roles at the point of use is what makes the contract checkable and keeps a future swap from being a find-and-replace over string literals. Header and per-shape doc comments rewritten for the new contract.
- **`index.tsx`** — header comment only, no logic.
- **`standalone.ts`** — comments only, no logic. `MASK_COLORS` is deliberately untouched: it keys on the tokens, not the roles, so the swap flows through it automatically. The comment now records that, plus the accepted limitation below.
- **Both test files** — strengthened color assertions (details under Test Plan).

### Side effect: the ejected SVG silhouette corrects itself too

`zudo-doc eject logo` serializes the same shape data through a luminance mask. Before this change the ejected asset was a solid tile with the frame/rays/disc cut out — i.e. it baked in the same inverted look. After the swap the mask resolves to frame + rays + a disc with the glyph punched out (verified: 6 visible primitives, 3 cut).

The one difference from the live component is that the ejected variant's tile interior is **transparent** where the live one paints an opaque `var(--color-bg)`. That is inherent to the one-color CSS-mask path (the plate maps to `#000`, a no-op against the mask's black default) and is a documented, accepted limitation per the issue — not a bug. Over a flat page background the two are visually identical; they diverge only over a textured background. This is now recorded in `standalone.ts`'s header.

The plate deliberately stays an **opaque** `var(--color-bg)` fill rather than `fill: "none"`, preserving the strict two-token invariant that `MASK_COLORS` and the guard tests depend on.

## Test Plan

| Gate | Result |
|---|---|
| `pnpm --filter @takazudo/zudo-doc test` | 1700 passed / 156 files |
| `pnpm test:packages` (all 4 workspace packages) | passed |
| `pnpm test:unit` (root) | 864 passed, 2 skipped |
| `pnpm --filter @takazudo/zudo-doc build` | OK |
| `pnpm check` (tsc) | no errors |
| `pnpm check:template-drift` | no drift |
| `pnpm lint:tokens` / `check:package-safelist` / `check:component-tokens` | all OK |
| Visual, dark + light | matches the contract |

### The new assertions are load-bearing

Running the new suite against the pre-swap `shapes.ts`: **14 assertions fail there and pass after the swap.** Coverage added:

- **Data-level role assertions** for `PLATE_SHAPE` / `INNER_FRAME_SHAPE` / all 4 `RAY_SHAPES` / `DISC_SHAPE`.
- **`it.each` over `GLYPH_NAMES`** asserting every non-`"none"` `fill`/`stroke` is `var(--color-bg)` across all 8 glyphs, with a `painted > 0` counter so a glyph carrying no color attrs can't pass vacuously. A single seeded render only exercises one glyph, so this is the real coverage gate.
- **Rendered-output assertions** scoped per element — the plate is distinguished from the frame rect by `width="200"` vs `width="188"` rather than a bare `toContain`, plus a glyph-group assertion that `currentColor` is absent inside the `<g>`.
- **Standalone:** all mask-role assertions are scoped to the extracted `<mask …>…</mask>` substring, because the final output rect outside the mask is also `fill="#000"` and a whole-document `toContain` would be ambiguous. Added a seed-search probe loop covering all 8 glyphs, asserting the pool actually spans 8 so it can't silently cover fewer.

The pre-existing no-hex-colors and no-`var(`/`currentColor` guards stay green.

### Visual verification

Built the `theme` e2e fixture (`logo: "auto"`) and served the real `dist/`, screenshotting the home hero at 1440×900 in both modes. Computed styles at the element level:

| | dark | light |
|---|---|---|
| page bg | `oklch(0.185 0 0)` | `oklch(0.965 0.004 65)` |
| plate fill | `oklch(0.185 0 0)` — equals page bg | `oklch(0.965 0.004 65)` — equals page bg |
| frame + ray stroke | `oklch(0.965 0 0)` — ink | `oklch(0.185 0.005 65)` — ink |
| disc fill | `oklch(0.965 0 0)` — ink | `oklch(0.185 0.005 65)` — ink |
| glyph paint | `oklch(0.185 0 0)` — page bg | `oklch(0.965 0.004 65)` — page bg |

All four **Forbidden** states from the Screenshot Requirement Contract are confirmed absent in dark mode (no ink-filled interior, no dark disc, no light glyph on a dark disc, no dark frame/rays), and light mode is the exact inverse. The rendered result matches the takazudomodular reference.

## Out of scope (verified, not assumed)

Both the EN and JA `configuration.mdx` describe the logo generically ("a framed 'decorated plate' mark that adapts to light/dark automatically") with no color-role claims, so the epic's decision to leave docs untouched holds — I checked rather than taking it on faith. `create-zudo-doc` templates, OGP, `eject-logo` sources, `shapes-parity.test.tsx` (tag counts, unaffected), and e2e fixtures likewise need no edits; their tests all pass unchanged.

## Screenshot Requirement Contract

Source: the two reference screenshots on #3108.

**Expected (dark mode):** tile interior renders the page background; thin light inner frame; 4 light diagonal corner rays; solid light center disc; dark glyph knocked out of the disc.

**Forbidden (dark mode)** — the state the screenshot is correcting: light-filled tile interior; dark center disc; light glyph on a dark disc; dark frame lines / rays.

**Expected (light mode):** the exact inverse — dark frame, rays, and disc over a light interior, with a light glyph knocked out of the dark disc.

**Unknown / free:** which glyph appears (deterministically seeded by site name); exact shades, which come from the active theme pack.

**Viewport:** desktop; the home hero logo slot (`w-[320px]`, aspect 1200/630).
