### PR TITLE
fix: stop importing the optional peer zudo-doc-history-server from the always-bundled chrome graph

### DIFF
--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -1351,13 +1351,14 @@ describe("scaffold — generated package.json", () => {
     expect(pkg.devDependencies["html-validate"]).toBeUndefined();
   });
 
-  it("includes the required zfb packages, @takazudo/zudo-doc, @takazudo/zdtp, and @takazudo/zudo-doc-history-server unconditionally", async () => {
-    // diff, @takazudo/zdtp, and @takazudo/zudo-doc-history-server are
-    // unconditional dependencies regardless of docHistory/designTokenPanel
-    // selection — packageOwnedRoutes always bundles the doc-history-area path
-    // (which imports both `diff` and `@takazudo/zudo-doc-history-server/exclude`
-    // at module scope, #2342 / #3080) and the chrome-derive seam always imports
-    // DesignTokenPanelBootstrap (which imports @takazudo/zdtp, #2668).
+  it("includes the required zfb packages, @takazudo/zudo-doc, and @takazudo/zdtp unconditionally", async () => {
+    // diff and @takazudo/zdtp are unconditional dependencies regardless of
+    // docHistory/designTokenPanel selection — packageOwnedRoutes always bundles
+    // the doc-history-area path (which imports `diff` at module scope, #2342)
+    // and the chrome-derive seam always imports DesignTokenPanelBootstrap
+    // (which imports @takazudo/zdtp, #2668).
+    // @takazudo/zudo-doc-history-server is NOT in this set — see the
+    // docHistory-gating test below (#3110).
     await scaffold(baseChoices);
     const pkg = await fs.readJson(projectPath("test-doc", "package.json"));
     expect(pkg.dependencies["@takazudo/zfb"]).toBe("0.1.0-next.96");
@@ -1369,9 +1370,6 @@ describe("scaffold — generated package.json", () => {
     expect(pkg.dependencies["@takazudo/zudo-doc"]).toMatch(/^\^\d+\.\d+\.\d+/);
     expect(pkg.dependencies["diff"]).toBeDefined();
     expect(pkg.dependencies["@takazudo/zdtp"]).toBeDefined();
-    // #3080: docHistory-OFF barebone must still carry this — the module-scope
-    // `/exclude` import bundles it regardless of the setting.
-    expect(pkg.dependencies["@takazudo/zudo-doc-history-server"]).toBeDefined();
     expect(pkg.dependencies["astro"]).toBeUndefined();
     expect(pkg.dependencies["shiki"]).toBeUndefined();
     expect(pkg.dependencies["@shikijs/transformers"]).toBeUndefined();
@@ -1397,12 +1395,20 @@ describe("scaffold — generated package.json", () => {
     expect(without.devDependencies["pagefind"]).toBeUndefined();
   });
 
-  it("adds @takazudo/zudo-doc-history-server unconditionally — docHistory off AND on (#3080)", async () => {
-    // Regression guard for #3080: the dep used to be gated behind docHistory,
-    // but @takazudo/zudo-doc/dist/doc-history-area/index.js imports
-    // @takazudo/zudo-doc-history-server/exclude at module scope, so a
-    // docHistory-OFF scaffold still bundles it and must declare it or `zfb
-    // build` fails at esbuild "Could not resolve".
+  it("adds @takazudo/zudo-doc-history-server only when docHistory is on (#3110)", async () => {
+    // The dep was briefly unconditional (#3080) because
+    // @takazudo/zudo-doc/dist/doc-history-area/index.js imported
+    // @takazudo/zudo-doc-history-server/exclude at MODULE scope, and
+    // packageOwnedRoutes always bundles that path — so even a docHistory-OFF
+    // project had to declare the package or `zfb build` died at esbuild with
+    // "Could not resolve".
+    //
+    // #3110 fixed the root cause: compileExclude moved into @takazudo/zudo-doc
+    // itself, so the always-bundled graph no longer references this optional
+    // peer at all. The dep is therefore gated on the feature again — a
+    // docHistory-OFF project must NOT carry it (that is the whole point of the
+    // fix; asserting `toBeUndefined` here is what stops the workaround
+    // silently creeping back).
     await scaffold({
       ...baseChoices,
       projectName: "test-history-dep-off",
@@ -1411,8 +1417,10 @@ describe("scaffold — generated package.json", () => {
     const off = await fs.readJson(
       projectPath("test-history-dep-off", "package.json"),
     );
-    expect(off.dependencies["@takazudo/zudo-doc-history-server"]).toBeDefined();
+    expect(off.dependencies["@takazudo/zudo-doc-history-server"]).toBeUndefined();
 
+    // docHistory ON still needs it: the zfb doc-history plugin eagerly imports
+    // @takazudo/zudo-doc-history-server/git-history at plugin-init time.
     await scaffold({
       ...baseChoices,
       projectName: "test-history-dep",

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -751,23 +751,14 @@ function generatePackageJson(choices: UserChoices) {
     // the "@takazudo/zdtp dep implication" note in
     // packages/zudo-doc/docs/adr/route-injection-seam.md.
     "@takazudo/zdtp": "0.4.9",
-    // @takazudo/zudo-doc-history-server — SAME "unconditional at build time
-    // despite being an optional peer" class as `diff` (#2342) and
-    // `@takazudo/zdtp` (#2668) above. `@takazudo/zudo-doc/dist/doc-history-area/
-    // index.js` imports `@takazudo/zudo-doc-history-server/exclude`
-    // (compileExclude) at MODULE scope, and packageOwnedRoutes always bundles
-    // the doc-history-area path — so every project pulls this import into the
-    // esbuild graph, `docHistory` setting or not; only history RENDERING is
-    // gated on the setting, not the import. Without this dep a docHistory-OFF
-    // scaffold fails `zfb build` with "Could not resolve
-    // '@takazudo/zudo-doc-history-server/exclude'" (#3080). It IS an optional
-    // peerDependency of @takazudo/zudo-doc (^4.4.3), but pnpm does not
-    // auto-install peers, so a missing copy produces no install warning and
-    // shipped silently until build time. The pin stays lockstep with the root
-    // version (parity-guarded — INTERNAL_PINNED_PACKAGES in
-    // scripts/check-pin-parity.mjs). docHistory-ON projects additionally need
-    // npm-run-all2 for the two-process dev script — see the docHistory block below.
-    "@takazudo/zudo-doc-history-server": "^4.4.8",
+    // (@takazudo/zudo-doc-history-server is NOT here — it is gated on the
+    // docHistory feature, see the block below. It was briefly unconditional
+    // (#3080) to work around doc-history-area importing its `/exclude` subpath
+    // at module scope; that root cause was fixed in #3110 by moving
+    // compileExclude into @takazudo/zudo-doc itself, so the workaround is gone
+    // and a docHistory-OFF project no longer carries the dep. A package-side
+    // reachability guard now prevents the class from returning — see
+    // packages/zudo-doc/src/__tests__/optional-peer-reachability.test.ts.)
   };
 
   const devDeps: Record<string, string> = {
@@ -787,15 +778,26 @@ function generatePackageJson(choices: UserChoices) {
   }
 
   if (choices.features.includes("docHistory")) {
-    // (Both `diff` AND `@takazudo/zudo-doc-history-server` are now unconditional
-    // base deps — see the `deps` block above: packageOwnedRoutes always bundles
-    // the doc-history-area path, whose module-scope imports pull both in
-    // regardless of this feature flag. #2342 / #3080.)
-    // When docHistory is selected the zfb plugin
-    // (@takazudo/zudo-doc/plugins/doc-history) additionally, at plugin-init time,
-    // eagerly imports @takazudo/zudo-doc-history-server/git-history — the same
-    // dep, so it is already satisfied by the unconditional entry (was W8A #1739,
-    // when the dep was still gated here).
+    // (`diff` remains an unconditional base dep — see the `deps` block above:
+    // packageOwnedRoutes always bundles the doc-history-area path, whose
+    // module-scope `diff` import is pulled in regardless of this flag. #2342.)
+    //
+    // @takazudo/zudo-doc-history-server is gated HERE, on the feature, because
+    // that is the only graph that actually reaches it: the zfb plugin
+    // (@takazudo/zudo-doc/plugins/doc-history) eagerly imports
+    // @takazudo/zudo-doc-history-server/git-history at plugin-init time, and the
+    // plugin is only wired when docHistory is on (W8A #1739). It is an optional
+    // peerDependency of @takazudo/zudo-doc and pnpm does not auto-install peers,
+    // so a docHistory-ON project must declare it directly. The pin stays lockstep
+    // with the root version (parity-guarded — INTERNAL_PINNED_PACKAGES in
+    // scripts/check-pin-parity.mjs, and rewritten at release time by
+    // scripts/release-create-zudo-doc.sh step 2d).
+    //
+    // It was briefly unconditional (#3080) because doc-history-area imported
+    // `/exclude` at module scope from the always-bundled chrome graph; #3110
+    // moved compileExclude into @takazudo/zudo-doc, so docHistory-OFF projects
+    // no longer need the package at all.
+    deps["@takazudo/zudo-doc-history-server"] = "^4.4.8";
     // tsx is no longer needed here: the relocated package plugin imports the
     // runner directly (no `tsx -e` spawn) since the package ships compiled
     // dist/ — package-first migration #2321 (#2337).

--- a/packages/doc-history-server/src/exclude.ts
+++ b/packages/doc-history-server/src/exclude.ts
@@ -1,3 +1,18 @@
+// DUPLICATED BY DESIGN — keep in sync with
+// packages/zudo-doc/src/doc-history-exclude/index.ts (the canonical copy).
+//
+// `@takazudo/zudo-doc` used to import this module via the `/exclude` subpath,
+// but it does so from its always-bundled chrome graph while this package is only
+// an OPTIONAL peer — which broke `docHistory: false` builds at esbuild
+// (zudolab/zudo-doc#3110). The reverse direction is not available either: this
+// package is a standalone, dependency-free Node server/CLI and cannot take on
+// `@takazudo/zudo-doc` (framework peers + a package cycle). Hence two copies,
+// pinned together by
+// packages/zudo-doc/src/doc-history-exclude/__tests__/parity.test.ts.
+//
+// The `./exclude` subpath export stays published — removing it would be a
+// breaking change for any external consumer.
+
 /** Compile doc-history exclude globs into a reusable slug predicate. */
 export function compileExclude(patterns: string[]): (slug: string) => boolean {
   const matchers = patterns.map((pattern) => {

--- a/packages/zudo-doc/src/__tests__/optional-peer-reachability.test.ts
+++ b/packages/zudo-doc/src/__tests__/optional-peer-reachability.test.ts
@@ -30,6 +30,7 @@
 
 import { describe, it, expect } from "vitest";
 import { createRequire } from "node:module";
+import { existsSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -96,6 +97,55 @@ function packageNameOf(specifier: string): string {
   return specifier.startsWith("@") ? parts.slice(0, 2).join("/") : (parts[0] ?? specifier);
 }
 
+const SELF = "@takazudo/zudo-doc";
+
+/**
+ * Map a package SELF-import (`@takazudo/zudo-doc/chrome-bindings`) back to its
+ * source file, so the walk keeps traversing instead of stopping at the boundary.
+ *
+ * The route sources genuinely contain these — `routes/_chrome.tsx` imports
+ * `@takazudo/zudo-doc/chrome-bindings`, and `copy-routes-src.mjs` rewrites more
+ * relative specifiers into this form for the published copy. Treating them as
+ * external would silently truncate the graph, so an optional peer imported
+ * beneath one of those boundaries would go undetected — the guard would report
+ * "clean" while the consumer's build still broke.
+ *
+ * Resolution goes through the real `exports` map (`./dist/x.js` → `src/x.ts|tsx`)
+ * rather than guessing, and THROWS on an unmappable subpath: a silent skip here
+ * would reintroduce exactly the blind spot this function exists to close.
+ */
+function resolveSelfImport(specifier: string): string | null {
+  const require = createRequire(import.meta.url);
+  const pkg = require(resolve(pkgRoot, "package.json")) as {
+    exports: Record<string, { default?: string } | string>;
+  };
+
+  const subpath = specifier === SELF ? "." : `.${specifier.slice(SELF.length)}`;
+  const entry = pkg.exports[subpath];
+  const distPath = typeof entry === "string" ? entry : entry?.default;
+
+  if (!distPath) {
+    throw new Error(
+      `Self-import "${specifier}" has no package.json#exports entry — the ` +
+        `reachability guard cannot traverse it. Add the export, or update this test.`,
+    );
+  }
+  // Non-JS assets (./theme.css etc.) legitimately end the walk.
+  if (!distPath.endsWith(".js")) return null;
+
+  const base = distPath.replace(/^\.\/dist\//, "").replace(/\.js$/, "");
+  for (const ext of [".ts", ".tsx"]) {
+    const candidate = resolve(pkgRoot, "src", base + ext);
+    if (existsSync(candidate)) return candidate;
+  }
+
+  throw new Error(
+    `Self-import "${specifier}" maps to "${distPath}", but no matching source ` +
+      `file was found at src/${base}.ts(x). The reachability guard would ` +
+      `silently stop traversing here.`,
+  );
+}
+
 /** Bare (non-relative, non-absolute) specifiers reachable from the entrypoints. */
 async function collectBareSpecifiers(entryPoints: string[]): Promise<Set<string>> {
   const esbuild = loadEsbuild();
@@ -125,6 +175,15 @@ async function collectBareSpecifiers(entryPoints: string[]): Promise<Set<string>
           build.onResolve({ filter: /.*/ }, (args) => {
             if (args.kind === "entry-point") return null;
             if (args.path.startsWith(".") || args.path.startsWith("/")) return null;
+
+            // Keep walking THROUGH package self-imports — they are internal
+            // boundaries, not dependencies. Stopping here would hide any
+            // optional peer imported beneath them.
+            if (args.path === SELF || args.path.startsWith(`${SELF}/`)) {
+              const source = resolveSelfImport(args.path);
+              return source ? { path: source } : { path: args.path, external: true };
+            }
+
             seen.add(args.path);
             // External: never touch disk, so the result reflects the graph
             // rather than whatever happens to be installed.
@@ -196,5 +255,13 @@ describe("always-bundled route graph does not reach un-allowlisted optional peer
     // stops holding, the collector is under-reporting rather than the graph
     // having genuinely cleaned up.
     expect(names.has("diff")).toBe(true);
+
+    // Package self-imports must be TRAVERSED, never collected as dependencies.
+    // `routes/_chrome.tsx` imports `@takazudo/zudo-doc/chrome-bindings`, and
+    // copy-routes-src.mjs rewrites more relative specifiers into this form for
+    // the published copy. A self-import showing up here means the walk stopped
+    // at that boundary, so anything importing an optional peer beneath it would
+    // go unreported — the guard would pass while a consumer's build broke.
+    expect([...specifiers].filter((s) => s === SELF || s.startsWith(`${SELF}/`))).toEqual([]);
   });
 });

--- a/packages/zudo-doc/src/__tests__/optional-peer-reachability.test.ts
+++ b/packages/zudo-doc/src/__tests__/optional-peer-reachability.test.ts
@@ -1,0 +1,200 @@
+// OPTIONAL-PEER REACHABILITY GUARD (zudolab/zudo-doc#3110).
+//
+// The failure mode this exists to catch, which has now shipped THREE times
+// (#2342 `diff`, #2668 `@takazudo/zdtp`, #3110
+// `@takazudo/zudo-doc-history-server`):
+//
+//   A module in the ALWAYS-bundled route/chrome graph imports an OPTIONAL
+//   peerDependency at module scope. Because `packageOwnedRoutes` is on by
+//   default, esbuild must RESOLVE that specifier on every build — even for a
+//   project whose settings switch the corresponding feature off, and which
+//   therefore never installed the package. pnpm does not auto-install peers and
+//   an optional one produces NO install warning, so the gap is invisible until
+//   a consumer's `zfb build` dies with `Could not resolve "<pkg>"`.
+//
+// Nothing else catches this: unit tests import from source (every workspace
+// package is present), and this repo's own build installs every optional peer.
+// Only a reachability analysis over the real route entrypoints sees it.
+//
+// MECHANISM: bundle the injected doc routes with esbuild, intercepting every
+// bare specifier via an `onResolve` hook that marks it external. Nothing is read
+// from disk, so the guard does not depend on what happens to be installed — it
+// reports what the GRAPH references. Reached optional peers are then diffed
+// against the allowlist below.
+//
+// ── ADDING TO THE ALLOWLIST IS A DELIBERATE CONTRACT CHANGE ──
+// Allowlisting a package means every consuming project must declare it as a
+// direct dependency regardless of its settings (create-zudo-doc does this in
+// `generatePackageJson()`). Prefer fixing the import — move the code into this
+// package, or make the import dynamic/gated — over widening the list.
+
+import { describe, it, expect } from "vitest";
+import { createRequire } from "node:module";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// src/__tests__/ → packages/zudo-doc/
+const pkgRoot = resolve(__dirname, "../..");
+const repoRoot = resolve(pkgRoot, "../..");
+
+// Optional peers that ARE reachable from the always-bundled graph and are an
+// accepted, permanent part of the consumer contract. Each needs a reason.
+const ALLOWED_UNCONDITIONAL_OPTIONAL_PEERS = new Set([
+  // #2342 — doc-history's diff viewer; the chrome graph always bundles the
+  // doc-history path, so `diff` resolves regardless of the docHistory setting.
+  "diff",
+  // #2668 — `chrome/derive`'s `deriveBodyEndIslands` statically imports the real
+  // `DesignTokenPanelBootstrap` (so the island auto-mounts with zero host
+  // wiring); only RENDERING is gated on `designTokenPanel`, not the import.
+  "@takazudo/zdtp",
+  // Reached via `mdx-components → math-block`. Math rendering is settings-gated
+  // but the import is static.
+  "katex",
+  // Reached via `html-preview-wrapper → highlight-runtime` for browser-time
+  // HTML/CSS/JS highlighting.
+  "@takazudo/zfb-md-wasm",
+]);
+
+// The default package-owned doc routes — the actual entrypoints zfb injects when
+// `packageOwnedRoutes` is on. Using the real routes (rather than a single leaf
+// module) means a future regression anywhere in the transitive chrome graph
+// (route → _chrome → createChrome → doc-page-renderer → …) is caught too.
+const ROUTE_ENTRYPOINTS = [
+  "src/routes/docs-slug.tsx",
+  "src/routes/locale-docs-slug.tsx",
+];
+
+interface EsbuildLike {
+  build(opts: Record<string, unknown>): Promise<{ errors: unknown[] }>;
+}
+
+// esbuild is not a direct dependency of this package — it rides in as a
+// transitive of vite/vitest. Resolve it via vite so the guard adds no dep
+// (same approach as `preset.test.ts`).
+function loadEsbuild(): EsbuildLike {
+  const require = createRequire(import.meta.url);
+  const vitePkg = require.resolve("vite/package.json", {
+    paths: [process.cwd(), __dirname, repoRoot],
+  });
+  return createRequire(vitePkg)("esbuild") as EsbuildLike;
+}
+
+function optionalPeersOf(): string[] {
+  const require = createRequire(import.meta.url);
+  const pkg = require(resolve(pkgRoot, "package.json")) as {
+    peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+  };
+  return Object.entries(pkg.peerDependenciesMeta ?? {})
+    .filter(([, meta]) => meta.optional === true)
+    .map(([name]) => name);
+}
+
+/** `@scope/pkg/sub` → `@scope/pkg`; `pkg/sub` → `pkg`. */
+function packageNameOf(specifier: string): string {
+  const parts = specifier.split("/");
+  return specifier.startsWith("@") ? parts.slice(0, 2).join("/") : (parts[0] ?? specifier);
+}
+
+/** Bare (non-relative, non-absolute) specifiers reachable from the entrypoints. */
+async function collectBareSpecifiers(entryPoints: string[]): Promise<Set<string>> {
+  const esbuild = loadEsbuild();
+  const seen = new Set<string>();
+
+  await esbuild.build({
+    entryPoints,
+    bundle: true,
+    write: false,
+    // Required by esbuild whenever there is more than one entry point. Nothing
+    // is written (`write: false`), so this path is never touched.
+    outdir: resolve(pkgRoot, ".optional-peer-guard-nonexistent"),
+    format: "esm",
+    platform: "neutral",
+    jsx: "automatic",
+    jsxImportSource: "preact",
+    logLevel: "silent",
+    plugins: [
+      {
+        name: "collect-bare-specifiers",
+        setup(build: {
+          onResolve(
+            opts: { filter: RegExp },
+            cb: (args: { path: string; kind: string }) => unknown,
+          ): void;
+        }) {
+          build.onResolve({ filter: /.*/ }, (args) => {
+            if (args.kind === "entry-point") return null;
+            if (args.path.startsWith(".") || args.path.startsWith("/")) return null;
+            seen.add(args.path);
+            // External: never touch disk, so the result reflects the graph
+            // rather than whatever happens to be installed.
+            return { path: args.path, external: true };
+          });
+        },
+      },
+    ],
+  });
+
+  return seen;
+}
+
+describe("always-bundled route graph does not reach un-allowlisted optional peers", () => {
+  it("reaches only the accepted unconditional optional peers", async () => {
+    const specifiers = await collectBareSpecifiers(
+      ROUTE_ENTRYPOINTS.map((p) => resolve(pkgRoot, p)),
+    );
+
+    const optional = new Set(optionalPeersOf());
+    const reachedOptional = [
+      ...new Set([...specifiers].map(packageNameOf)),
+    ]
+      .filter((name) => optional.has(name))
+      .sort();
+
+    const unexpected = reachedOptional.filter(
+      (name) => !ALLOWED_UNCONDITIONAL_OPTIONAL_PEERS.has(name),
+    );
+
+    expect(
+      unexpected,
+      `Optional peer(s) ${unexpected.join(", ")} are imported from the always-bundled ` +
+        `route graph. A project that leaves the corresponding feature OFF never installs ` +
+        `them, so its 'zfb build' fails with "Could not resolve". Fix the import (move the ` +
+        `code into this package, or gate/dynamic-import it) rather than widening ` +
+        `ALLOWED_UNCONDITIONAL_OPTIONAL_PEERS.`,
+    ).toEqual([]);
+  });
+
+  it("does not reach @takazudo/zudo-doc-history-server (#3110 regression guard)", async () => {
+    const specifiers = await collectBareSpecifiers(
+      ROUTE_ENTRYPOINTS.map((p) => resolve(pkgRoot, p)),
+    );
+
+    const offenders = [...specifiers].filter(
+      (s) => packageNameOf(s) === "@takazudo/zudo-doc-history-server",
+    );
+
+    expect(
+      offenders,
+      `#3110: doc-history-area must import compileExclude from ` +
+        `src/doc-history-exclude/ (this package), NOT from the optional peer ` +
+        `@takazudo/zudo-doc-history-server. Found: ${offenders.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("self-test: the collector actually walks the graph", async () => {
+    // Proves the two assertions above are not passing vacuously (e.g. an
+    // esbuild/plugin change silently yielding an empty set).
+    const specifiers = await collectBareSpecifiers(
+      ROUTE_ENTRYPOINTS.map((p) => resolve(pkgRoot, p)),
+    );
+    const names = new Set([...specifiers].map(packageNameOf));
+
+    expect(names.has("preact")).toBe(true);
+    expect(names.has("@takazudo/zfb")).toBe(true);
+    // At least one known-allowlisted optional peer must still be seen — if this
+    // stops holding, the collector is under-reporting rather than the graph
+    // having genuinely cleaned up.
+    expect(names.has("diff")).toBe(true);
+  });
+});

--- a/packages/zudo-doc/src/doc-history-area/index.tsx
+++ b/packages/zudo-doc/src/doc-history-area/index.tsx
@@ -20,7 +20,10 @@
 
 import type { VNode } from "preact";
 import { Island } from "@takazudo/zfb";
-import { compileExclude } from "@takazudo/zudo-doc-history-server/exclude";
+// Relative, NOT `@takazudo/zudo-doc-history-server/exclude` — that package is an
+// OPTIONAL peer and this module is in the always-bundled chrome graph, so the
+// cross-package import broke `docHistory: false` builds at esbuild (#3110).
+import { compileExclude } from "../doc-history-exclude/index.js";
 import { BodyFootUtilArea } from "../body-foot-util/index.js";
 import type { ChromeContext } from "../factory-context/index.js";
 import type { Settings } from "../settings.js";

--- a/packages/zudo-doc/src/doc-history-exclude/__tests__/doc-history-exclude.test.ts
+++ b/packages/zudo-doc/src/doc-history-exclude/__tests__/doc-history-exclude.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { compileExclude } from "../index.js";
+
+describe("compileExclude", () => {
+  it("matches ** across any number of segments", () => {
+    const isExcluded = compileExclude(["guides/**/draft"]);
+    expect(isExcluded("guides/draft")).toBe(true);
+    expect(isExcluded("guides/internal/deep/draft")).toBe(true);
+  });
+
+  it("matches * only within one segment", () => {
+    const isExcluded = compileExclude(["guides/*"]);
+    expect(isExcluded("guides/intro")).toBe(true);
+    expect(isExcluded("guides/nested/intro")).toBe(false);
+  });
+
+  it("matches ? as exactly one non-slash character", () => {
+    const isExcluded = compileExclude(["release-?.notes"]);
+    expect(isExcluded("release-1.notes")).toBe(true);
+    expect(isExcluded("release-10.notes")).toBe(false);
+  });
+
+  it("matches literal text exactly and escapes regexp syntax", () => {
+    const isExcluded = compileExclude(["api/v1.0+(legacy)"]);
+    expect(isExcluded("api/v1.0+(legacy)")).toBe(true);
+    expect(isExcluded("api/v1x00legacy")).toBe(false);
+  });
+
+  it("does not match an unrelated slug", () => {
+    expect(compileExclude(["drafts/**"])("guides/intro")).toBe(false);
+  });
+
+  it("never excludes when the pattern list is empty", () => {
+    expect(compileExclude([])("anything/nested")).toBe(false);
+  });
+
+  it("matches the root index slug", () => {
+    expect(compileExclude(["index"])("index")).toBe(true);
+  });
+
+  // A trailing `/**` must also match the parent itself — `**` may span zero
+  // segments. This is the branch `doc-history-area` relies on to suppress the
+  // island for an excluded section's own index page.
+  it("matches the parent itself for a trailing /**", () => {
+    const isExcluded = compileExclude(["drafts/**"]);
+    expect(isExcluded("drafts")).toBe(true);
+    expect(isExcluded("drafts/one")).toBe(true);
+    expect(isExcluded("drafts/one/two")).toBe(true);
+  });
+
+  it("excludes when any one of several patterns matches", () => {
+    const isExcluded = compileExclude(["drafts/**", "internal/*"]);
+    expect(isExcluded("drafts/x")).toBe(true);
+    expect(isExcluded("internal/y")).toBe(true);
+    expect(isExcluded("guides/z")).toBe(false);
+  });
+});

--- a/packages/zudo-doc/src/doc-history-exclude/__tests__/parity.test.ts
+++ b/packages/zudo-doc/src/doc-history-exclude/__tests__/parity.test.ts
@@ -1,0 +1,70 @@
+// Drift guard for the two `compileExclude` copies (zudolab/zudo-doc#3110).
+//
+// The matcher is deliberately duplicated:
+//   - packages/zudo-doc/src/doc-history-exclude/index.ts      (canonical)
+//   - packages/doc-history-server/src/exclude.ts              (copy)
+//
+// Neither package can import the other. `zudo-doc` must not import
+// `@takazudo/zudo-doc-history-server` from its always-bundled chrome graph (that
+// package is an OPTIONAL peer — the #3110 bug). And `doc-history-server` must not
+// import `@takazudo/zudo-doc`: it is a standalone, dependency-free Node
+// server/CLI, so taking on the framework package would drag in its required
+// peers (preact, zfb, zfb-runtime, zod) and create a package cycle.
+//
+// So the copies are pinned by comparing their SOURCE TEXT. This is deliberately
+// stricter than a behavioural corpus (which can miss a divergent edge case) and
+// needs no module resolution — the files are read from disk, so this guard has
+// no build-order or tsconfig `rootDir` coupling.
+//
+// If this test fails: the two implementations diverged. Make the function bodies
+// identical again — edit the canonical copy, then mirror it verbatim into
+// doc-history-server (or vice versa).
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// src/doc-history-exclude/__tests__/ → packages/
+const packagesRoot = resolve(__dirname, "../../../..");
+
+const CANONICAL = resolve(packagesRoot, "zudo-doc/src/doc-history-exclude/index.ts");
+const COPY = resolve(packagesRoot, "doc-history-server/src/exclude.ts");
+
+/**
+ * Extract the `compileExclude` declaration from a source file, dropping the
+ * file's own header comments (the two copies document different context) and
+ * normalizing whitespace so indentation style alone can't fail the guard.
+ */
+function extractImplementation(file: string): string {
+  const src = readFileSync(file, "utf-8");
+  const start = src.indexOf("export function compileExclude");
+
+  if (start === -1) {
+    throw new Error(`Could not locate 'export function compileExclude' in ${file}`);
+  }
+
+  return src
+    .slice(start)
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .join("\n");
+}
+
+describe("compileExclude parity across packages", () => {
+  it("keeps the zudo-doc and doc-history-server copies identical", () => {
+    expect(extractImplementation(COPY)).toBe(extractImplementation(CANONICAL));
+  });
+
+  it("self-test: the extractor actually reads a real implementation", () => {
+    // Guards against the comparison above passing vacuously (e.g. both sides
+    // silently reducing to an empty string after a refactor of the extractor).
+    const canonical = extractImplementation(CANONICAL);
+    expect(canonical).toContain("export function compileExclude");
+    expect(canonical).toContain("new RegExp");
+    expect(canonical.length).toBeGreaterThan(200);
+  });
+});

--- a/packages/zudo-doc/src/doc-history-exclude/index.ts
+++ b/packages/zudo-doc/src/doc-history-exclude/index.ts
@@ -1,0 +1,67 @@
+// doc-history exclude matcher — CANONICAL COPY (zudolab/zudo-doc#3110).
+//
+// This function used to live only in `@takazudo/zudo-doc-history-server`
+// (`/exclude`) and was imported from there by `doc-history-area`. That inverted
+// the dependency direction: `doc-history-area` sits in the ALWAYS-bundled chrome
+// graph (`packageOwnedRoutes`), so esbuild had to resolve the specifier on every
+// build — but `@takazudo/zudo-doc-history-server` is an OPTIONAL peer, absent in
+// `docHistory: false` projects. Result: `Could not resolve
+// "@takazudo/zudo-doc-history-server/exclude"` at bundle time (regression in
+// 4.3.0, from the exclude-filtering work #2962/#2973).
+//
+// The matcher therefore lives here, in the always-present package, and is
+// imported RELATIVELY by its two consumers (`doc-history-area`,
+// `plugins/internal/doc-history/pre-build`). Deliberately NOT a public subpath
+// export — the consumers are internal, and a `./doc-history-exclude` entry would
+// create permanent public API surface for no gain.
+//
+// `@takazudo/zudo-doc-history-server` keeps its own `/exclude` copy: it is a
+// standalone, dependency-free Node server/CLI, so it cannot import this package
+// (that would drag in preact/zfb/zod peers and create a package cycle). The two
+// copies are pinned together by the behavioural parity test in
+// `__tests__/parity.test.ts` — edit both, or that test fails.
+//
+// Keep this module dependency-free and browser-safe (no node builtins): it is
+// reachable from SSR/client chrome code.
+
+/** Compile doc-history exclude globs into a reusable slug predicate. */
+export function compileExclude(patterns: string[]): (slug: string) => boolean {
+  const matchers = patterns.map((pattern) => {
+    let source = "";
+
+    for (let i = 0; i < pattern.length; i++) {
+      const char = pattern[i];
+
+      // A trailing /** includes the parent itself because ** may span zero
+      // segments. Elsewhere, **/ consumes any number of complete segments.
+      if (char === "/" && pattern.slice(i + 1) === "**") {
+        source += "(?:/.*)?";
+        break;
+      }
+      if (pattern.slice(i, i + 3) === "**/") {
+        source += "(?:[^/]+/)*";
+        i += 2;
+        continue;
+      }
+      if (pattern.slice(i, i + 2) === "**") {
+        source += ".*";
+        i++;
+        continue;
+      }
+      if (char === "*") {
+        source += "[^/]*";
+        continue;
+      }
+      if (char === "?") {
+        source += "[^/]";
+        continue;
+      }
+
+      source += char?.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
+    }
+
+    return new RegExp(`^${source}$`);
+  });
+
+  return (slug) => matchers.some((matcher) => matcher.test(slug));
+}

--- a/packages/zudo-doc/src/plugins/internal/doc-history/pre-build.ts
+++ b/packages/zudo-doc/src/plugins/internal/doc-history/pre-build.ts
@@ -53,7 +53,13 @@ import {
   collectContentFiles,
   getAllFilesFirstLastMetaAsync,
 } from "@takazudo/zudo-doc-history-server/git-history";
-import { compileExclude } from "@takazudo/zudo-doc-history-server/exclude";
+// Relative, NOT `@takazudo/zudo-doc-history-server/exclude` (#3110). The
+// `/git-history` import above legitimately stays cross-package — this plugin
+// only loads when `docHistory` is on, so the optional peer is guaranteed
+// present here. `compileExclude` moved into this package because its OTHER
+// consumer (`doc-history-area`) is in the always-bundled chrome graph; both
+// consumers now read the single canonical copy.
+import { compileExclude } from "../../../doc-history-exclude/index.js";
 
 /** A single non-default locale entry; mirrors `settings.locales[*]`. */
 export interface DocHistoryMetaLocaleConfig {

--- a/scripts/release-create-zudo-doc.sh
+++ b/scripts/release-create-zudo-doc.sh
@@ -286,23 +286,23 @@ node -e "
 echo "  ✓ $SCAFFOLD_TS @takazudo/zudo-doc → ^$NEW_VERSION"
 
 # ── Step 2d: Align @takazudo/zudo-doc-history-server pin in scaffold.ts ───────
-# The generated package.json carries a direct @takazudo/zudo-doc-history-server
-# dep (unconditional since #3080 — the doc-history-area chrome imports it at
-# module scope regardless of the docHistory setting). It lives as an
-# object-literal key in the base `deps` block: `"@takazudo/zudo-doc-history-server": "^X.Y.Z"`.
+# A docHistory-enabled generated package.json carries a direct
+# @takazudo/zudo-doc-history-server dep (gated on the feature — it was briefly
+# unconditional under #3080, until #3110 fixed the root cause and moved the pin
+# back into the docHistory block as `deps[...] = "^X.Y.Z"`).
 # It must move in lockstep too, otherwise the direct pin conflicts with the
 # transitive range @takazudo/zudo-doc carries.
-# NOTE: this regex matches the object-literal-key (colon) form. It was rewritten
-# from the pre-#3080 `deps[...] = "..."` bracket-assignment form when the pin
-# was promoted to an unconditional dep — keep it in sync if the pin's syntax
-# ever changes again (check-pin-parity.mjs's readScaffoldPin already tolerates
-# both forms, but this WRITE-side regex is form-specific and must be updated).
+# NOTE: this WRITE-side regex accepts BOTH spellings the pin has used — the
+# bracket-assignment form (`deps["…"] = "^X.Y.Z"`, current) and the
+# object-literal-key form (`"…": "^X.Y.Z"`, #3080-era) — so it no longer breaks
+# when the pin moves between a conditional block and the base `deps` literal.
+# check-pin-parity.mjs's READ-side readScaffoldPin already tolerates both.
 echo ""
 echo "▶ Aligning @takazudo/zudo-doc-history-server pin in scaffold.ts..."
 node -e "
   const fs = require('fs');
   const src = fs.readFileSync('$SCAFFOLD_TS', 'utf-8');
-  const re = /(\"@takazudo\/zudo-doc-history-server\"\s*:\s*\")\^?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?(\")/;
+  const re = /(\"@takazudo\/zudo-doc-history-server\"\s*(?::|\]\s*=)\s*\")\^?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?(\")/;
   if (!re.test(src)) {
     console.error('Error: could not locate @takazudo/zudo-doc-history-server pin in $SCAFFOLD_TS');
     process.exit(1);


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3110

---

## Summary

`docHistory: false` projects could not build at all. `doc-history-area/index.tsx` imported `compileExclude` from `@takazudo/zudo-doc-history-server/exclude` at **module top level**, and that module sits in the always-bundled chrome graph (`packageOwnedRoutes`) — so esbuild had to resolve the specifier on every build, regardless of the `docHistory` setting. But the package is an **optional** peer, so a project that never enabled doc history never installed it:

```
✘ [ERROR] Could not resolve "@takazudo/zudo-doc-history-server/exclude"
```

Regression in 4.3.0, from the exclude-filtering work (#2962 / #2973): the dependency direction was inverted — a required module depending on an optional package.

## Approach — issue option 1, adapted

The canonical `compileExclude` moves **into** `@takazudo/zudo-doc` (`src/doc-history-exclude/`), and both consumers import it relatively. No cross-package import remains in the bundled graph.

The issue suggested `zudo-doc-history-server` then import it back from `zudo-doc`. That isn't viable: `doc-history-server` has **zero runtime dependencies** and is documented as a standalone Node server/CLI. Depending on `@takazudo/zudo-doc` would drag in its required peers (preact, zfb, zfb-runtime, zod) for an 85-byte function **and** create a package cycle. So it keeps a local copy — its published `./exclude` export stays, so this is not a breaking change — and the two copies are pinned by a source-identity parity test.

`pre-build.ts`'s `/git-history` import is deliberately left cross-package: that plugin only loads when `docHistory` is on, so the optional peer is guaranteed present.

## Changes

**`@takazudo/zudo-doc`**
- New `src/doc-history-exclude/` — canonical matcher, dependency-free and browser-safe. Deliberately **not** a public subpath export (consumers are internal; a public entry would be permanent API surface for no gain).
- `doc-history-area/index.tsx` + `plugins/internal/doc-history/pre-build.ts` → relative import.
- New `src/__tests__/optional-peer-reachability.test.ts` — regression guard (below).

**`@takazudo/zudo-doc-history-server`**
- `src/exclude.ts` keeps the implementation and its published export; header documents the duplication and why neither direction of import is available.

**`create-zudo-doc`**
- Retires the #3080 workaround: `@takazudo/zudo-doc-history-server` is no longer an unconditional base dep, and returns to the `docHistory` feature block. A `docHistory: false` scaffold no longer carries it.
- `scripts/release-create-zudo-doc.sh` step 2d: its write-side regex matched **only** the colon pin form, so moving the pin into a conditional block would have failed the next release with "could not locate pin" — the exact breakage its own comment warned about. Widened to accept both spellings.

## Regression guard

The issue asked for a `docHistory: false` fixture build. This uses a cheaper, equivalent guard: an esbuild reachability walk over the **real injected doc routes** (`routes/docs-slug.tsx`, `routes/locale-docs-slug.tsx`) that fails when an un-allowlisted **optional** peer enters the graph.

This class has now shipped three times (#2342 `diff`, #2668 `@takazudo/zdtp`, #3110) and nothing else catches it — unit tests import from source, and this repo's own build installs every optional peer. The allowlist holds the four genuinely-reachable accepted ones (`diff`, `@takazudo/zdtp`, `katex`, `@takazudo/zfb-md-wasm`), each with its reason; widening it is called out as a deliberate contract change.

Review follow-up: the guard now also **traverses package self-imports** (`routes/_chrome.tsx` imports `@takazudo/zudo-doc/chrome-bindings`). Treating those as external stopped the walk at that boundary, so an optional peer imported beneath one would have gone unreported. It resolves them back to source via the real `exports` map and throws on an unmappable subpath rather than silently skipping.

## Test Plan

Verified end-to-end against the issue's own repro, not just by unit tests:

- Scaffolded a `docHistory: false` project with `@takazudo/zudo-doc-history-server` **genuinely absent**, installed this package from a packed tarball → **`zfb build` succeeds** (7 pages).
- Reintroduced the old import into the installed `dist/` → reproduced the issue's **exact** error, confirming the harness actually exercises the reported path.
- `docHistory: true` with the peer present → still builds (the dependency-gating change did not break the ON path).
- Both guards verified to **fail** on injected breakage (reintroduced import; drifted copy) rather than assumed to work.
- `pnpm b4push` — all 23 steps green. Package unit tests 1714 passed; generator tests 580 passed.