### PR TITLE
theme-card-resizer-fix: cap theme-pack flyout card at 360px + widen sidebar resizer hit area

### DIFF
--- a/e2e/sidebar-resizer-hit-area.spec.ts
+++ b/e2e/sidebar-resizer-hit-area.spec.ts
@@ -1,0 +1,153 @@
+import type { Page } from "@playwright/test";
+import { test, expect } from "./fixtures";
+import { desktopSidebar, waitForSidebarHydration } from "./sidebar-helpers";
+
+/**
+ * E2E regression for the sidebar-resizer STRADDLE geometry (#3117).
+ *
+ * Bug: the drag handle used to sit entirely INSIDE the sidebar's right edge
+ * (`left: calc(var(--zd-sidebar-w) - 20px); width: 20px`). Whenever the
+ * sidebar content actually overflowed, the native y-scrollbar painted on top
+ * of most of that strip and captured the pointer, leaving only a sliver of
+ * the handle draggable.
+ *
+ * Fix (#3117): the handle now STRADDLES the edge —
+ * `left: calc(var(--zd-sidebar-w) - 4px); width: 16px`
+ * (`packages/zudo-doc/src/sidebar-resizer/sidebar-resizer-init.tsx` /
+ * `index.ts` — kept in parity by
+ * `packages/zudo-doc/src/sidebar-resizer/__tests__/geometry-parity.test.ts`).
+ * That's 4px INSIDE the sidebar (still frequently covered by the scrollbar)
+ * plus 12px OUTSIDE it, over the main content column's left padding — a zone
+ * no native scrollbar ever paints into, since a scrollbar is confined to its
+ * own scrolling element's box. `sidebarRight + 6px` (this spec's drag start
+ * point) sits solidly inside that outside strip: precisely the zone a
+ * scrollbar previously made unreachable.
+ *
+ * This is a real hit-test, not a geometry-math unit test: it drives an actual
+ * `page.mouse` pointer sequence at pixel coordinates derived from the live
+ * `#desktop-sidebar` bounding box, so a regression that shrinks/moves the
+ * handle would make the drag land on ordinary page content instead and this
+ * spec would fail on the width/localStorage assertions below.
+ *
+ * The `sidebar` e2e fixture's content set is tiny (8 pages) and never
+ * naturally overflows `#desktop-sidebar` at any reasonable viewport height —
+ * so {@link forceSidebarOverflow} pads out the nav's content height to
+ * guarantee a REAL native scrollbar renders. Without a genuine scrollbar in
+ * play, this spec would pass just as well against the pre-#3117 fully-inside
+ * geometry, defeating its own purpose.
+ */
+
+const START_PAGE = "/docs/guides/sub-a/page-1";
+const LS_KEY = "zudo-doc-sidebar-width";
+// Mirrors SIDEBAR_STORAGE_KEY in
+// packages/zudo-doc/src/desktop-sidebar-toggle-island/index.tsx.
+const SIDEBAR_VISIBLE_KEY = "zudo-doc-sidebar-visible";
+const HANDLE_SELECTOR = "[data-sidebar-resizer]";
+
+interface Box {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+async function requireSidebarBox(page: Page): Promise<Box> {
+  const box = await desktopSidebar(page).boundingBox();
+  expect(box).not.toBeNull();
+  return box as Box;
+}
+
+/**
+ * Force `#desktop-sidebar` into a genuine overflow-y:auto scroll state,
+ * regardless of how many real pages this fixture's content set happens to
+ * have. Padding the nav's own content height (not the aside itself) keeps
+ * the aside's box — and therefore the fixed-position resizer handle pinned
+ * to its edge — geometrically unaffected; only `scrollHeight` grows.
+ */
+async function forceSidebarOverflow(page: Page): Promise<void> {
+  await page.addStyleTag({ content: "#desktop-sidebar nav { min-height: 3000px; }" });
+  const overflowing = await desktopSidebar(page).evaluate(
+    (el) => el.scrollHeight > el.clientHeight,
+  );
+  expect(overflowing).toBe(true);
+}
+
+test.describe("Sidebar resizer hit area (#3117 straddle geometry)", () => {
+  test.beforeEach(async ({ page }) => {
+    // >=1024px so the `lg:` desktop-sidebar rules are active, and so the
+    // resizer script's own self-guard (`getComputedStyle(sidebar).position
+    // === "fixed"`) passes.
+    await page.setViewportSize({ width: 1600, height: 900 });
+  });
+
+  test("a pointer-drag starting just outside the sidebar's right edge (the strip a scrollbar used to make unreachable) resizes the sidebar and persists the width", async ({
+    page,
+  }) => {
+    await page.goto(START_PAGE, { waitUntil: "load" });
+    await waitForSidebarHydration(page);
+    await forceSidebarOverflow(page);
+
+    await page.locator(HANDLE_SELECTOR).waitFor({ state: "attached" });
+
+    const { x, y, width, height } = await requireSidebarBox(page);
+    const sidebarRight = x + width;
+    // Inside the new 12px OUTSIDE strip: [sidebarRight, sidebarRight + 12].
+    const startX = sidebarRight + 6;
+    const startY = y + height / 2;
+    // "drag ±80px" per the epic's live-check item (#3118 item 4). The
+    // resizer computes the committed width from the pointer's absolute
+    // clientX at drag-end (sidebarLeft is 0), not from the drag delta, so
+    // dragging further right from a start point past the edge still yields a
+    // clear, well-clamped width increase.
+    const endX = startX + 80;
+
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    await page.mouse.move(endX, startY, { steps: 10 });
+    await page.mouse.up();
+
+    // The resizer only commits on drag-end (mouseup / lostpointercapture),
+    // not on every pointermove — see the `commit()` / `onUp` wiring in
+    // sidebar-resizer-init.tsx. `expect.poll` covers the frame between the
+    // synthetic mouseup resolving and the resulting layout settling.
+    await expect
+      .poll(() => desktopSidebar(page).evaluate((el) => el.getBoundingClientRect().width))
+      .toBeGreaterThan(width + 40);
+
+    const widthAfter = await desktopSidebar(page).evaluate(
+      (el) => el.getBoundingClientRect().width,
+    );
+    const stored = await page.evaluate((key) => localStorage.getItem(key), LS_KEY);
+    expect(stored).not.toBeNull();
+    expect(Math.abs(Number(stored) - widthAfter)).toBeLessThanOrEqual(1);
+  });
+
+  test("the desktop sidebar toggle still collapses the sidebar with the widened handle in place", async ({
+    page,
+  }) => {
+    await page.goto(START_PAGE, { waitUntil: "load" });
+    await waitForSidebarHydration(page);
+
+    // Sanity: the handle this test's premise is about actually exists here —
+    // a regression that stopped rendering it would make this test vacuous.
+    await page.locator(HANDLE_SELECTOR).waitFor({ state: "attached" });
+
+    // The straddle geometry's outside strip (sidebarRight .. sidebarRight+12)
+    // overlaps the LEFT half of the toggle button's own box (`left:
+    // var(--zd-sidebar-w)`, `w-[1.5rem]` = 24px, so sidebarRight ..
+    // sidebarRight+24). Both carry the same `z-sidebar` tier, so this is a
+    // genuine "does the click still land on the button" question, not just a
+    // geometry-math check — a real regression here would make this locator
+    // click time out (Playwright's actionability check fails when another
+    // element intercepts the pointer at the target's center point).
+    await page.locator(".zd-desktop-sidebar-toggle").click();
+
+    await expect
+      .poll(() =>
+        page.evaluate(() => document.documentElement.hasAttribute("data-sidebar-hidden")),
+      )
+      .toBe(true);
+    const stored = await page.evaluate((key) => localStorage.getItem(key), SIDEBAR_VISIBLE_KEY);
+    expect(stored).toBe("false");
+  });
+});

--- a/e2e/theme-pack-switcher.spec.ts
+++ b/e2e/theme-pack-switcher.spec.ts
@@ -444,12 +444,16 @@ test.describe("Theme pack switcher", () => {
     // acceptance line: below ~392px viewport, i.e. 360 + 32, the card can no
     // longer hold 360px without exceeding calc(100vw - 2rem)).
     expect(width).toBeLessThan(340);
-    // Roughly matches the calc(100vw - 2rem) formula (2rem = 32px at the
-    // unmodified "default" pack's root font-size — no pack sets a root
-    // font-size override on this fixture's HOME hard-load state). A generous
-    // tolerance absorbs any scrollbar-gutter effect on 100vw rather than
-    // pinning to exact arithmetic.
+    // Matches the calc(100vw - 2rem) formula (2rem = 32px at the unmodified
+    // "default" pack's root font-size — no pack sets a root font-size override
+    // on this fixture's HOME hard-load state).
+    //
+    // The tolerance MUST stay below 16px: a regression from
+    // calc(100vw - 2rem) to calc(100vw - 1rem) yields 304px here, only 16px
+    // from the expected 288px, so a looser bound would let exactly the
+    // regression this test exists to catch pass. 100vw includes the scrollbar
+    // gutter per spec, so there is no scrollbar effect to absorb.
     const expectedClampedWidth = NARROW_VIEWPORT_WIDTH - 32;
-    expect(Math.abs(width - expectedClampedWidth)).toBeLessThanOrEqual(20);
+    expect(Math.abs(width - expectedClampedWidth)).toBeLessThanOrEqual(2);
   });
 });

--- a/e2e/theme-pack-switcher.spec.ts
+++ b/e2e/theme-pack-switcher.spec.ts
@@ -136,6 +136,34 @@ async function isFontFaceLoaded(page: Page, family: string): Promise<boolean> {
   }, family);
 }
 
+/** The open card's rendered width in px (`data-switcher-card`'s
+ *  `w-[360px] max-w-[calc(100vw-2rem)]` — #3116). */
+async function cardWidthPx(page: Page): Promise<number> {
+  const box = await flyoutCard(page).boundingBox();
+  expect(box).not.toBeNull();
+  return (box as { x: number; y: number; width: number; height: number }).width;
+}
+
+/**
+ * How many line fragments the card's description paragraph wraps across.
+ * `Element.getClientRects()` reports a single border-box rect for a
+ * block-level element regardless of internal wrapping, so this instead wraps
+ * a `Range` around the element's inline content — the standard technique for
+ * counting rendered text lines, since a Range's `getClientRects()` yields one
+ * rect per line fragment of the text it spans.
+ */
+async function descriptionLineCount(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const description = document.querySelector(
+      "[data-switcher-card] p.text-caption.text-muted",
+    );
+    if (description === null) return 0;
+    const range = document.createRange();
+    range.selectNodeContents(description);
+    return range.getClientRects().length;
+  });
+}
+
 /** (c)-adjacent: the mode toggle must never move the active pack or its
  *  storage key, in either direction, on whichever pack is currently active. */
 async function assertToggleIndependentOfPack(page: Page, expectedPack: string) {
@@ -363,5 +391,65 @@ test.describe("Theme pack switcher", () => {
 
     await assertToggleIndependentOfPack(page, "foundry");
     expect(await readStoredPack(page)).toBe("foundry");
+  });
+
+  test("a long-description pack (Tidepool) keeps the open card at the fixed 360px width and wraps its description across multiple lines (#3116)", async ({
+    page,
+  }) => {
+    await page.goto(HOME, { waitUntil: "load" });
+    await openFlyout(page);
+
+    // Apply via the browse-all dialog rather than cycling Prev/Next all the
+    // way around — Tidepool sits last in this fixture's pinned cycle order
+    // (see FULL_PACK_CYCLE above).
+    await browseAllButton(page).click();
+    await expect(dialogLocator(page)).toBeVisible();
+    // The dialog replaces the flyout card on screen (ADR Decision 7).
+    await expect(flyoutCard(page)).toBeHidden();
+
+    const tidepoolCard = packCard(page, "Tidepool");
+    await expect(tidepoolCard).toBeVisible({ timeout: 10000 });
+    await tidepoolCard.click();
+    await waitForActivePack(page, "tidepool");
+
+    await page.keyboard.press("Escape");
+    await expect(dialogLocator(page)).toBeHidden();
+
+    // Reopen the flyout to measure the card holding the now-applied pack.
+    await openFlyout(page);
+    await expect(flyoutCard(page)).toContainText("Tidepool");
+
+    const width = await cardWidthPx(page);
+    expect(Math.abs(width - 360)).toBeLessThanOrEqual(2);
+
+    // Tidepool's meta.json description (packages/zudo-doc/src/theme-packs/
+    // tidepool/meta.json) is a 200+ character sentence — comfortably wider
+    // than the card's ~328px text column (360px card minus 2 * 16px
+    // p-hsp-lg padding) at the 14px text-caption size, so it reliably wraps
+    // without needing to extend this fixture's data.
+    expect(await descriptionLineCount(page)).toBeGreaterThan(1);
+  });
+
+  test("at a narrow viewport, the open card is clamped by max-w-[calc(100vw-2rem)] instead of holding the fixed 360px width (#3116)", async ({
+    page,
+  }) => {
+    const NARROW_VIEWPORT_WIDTH = 320;
+    await page.setViewportSize({ width: NARROW_VIEWPORT_WIDTH, height: 700 });
+    await page.goto(HOME, { waitUntil: "load" });
+    await openFlyout(page);
+
+    const width = await cardWidthPx(page);
+
+    // Well under the fixed 360px width — the clamp is active (the epic's
+    // acceptance line: below ~392px viewport, i.e. 360 + 32, the card can no
+    // longer hold 360px without exceeding calc(100vw - 2rem)).
+    expect(width).toBeLessThan(340);
+    // Roughly matches the calc(100vw - 2rem) formula (2rem = 32px at the
+    // unmodified "default" pack's root font-size — no pack sets a root
+    // font-size override on this fixture's HOME hard-load state). A generous
+    // tolerance absorbs any scrollbar-gutter effect on 100vw rather than
+    // pinning to exact arithmetic.
+    const expectedClampedWidth = NARROW_VIEWPORT_WIDTH - 32;
+    expect(Math.abs(width - expectedClampedWidth)).toBeLessThanOrEqual(20);
   });
 });

--- a/packages/zudo-doc/src/__tests__/no-inert-spacing-utilities.test.ts
+++ b/packages/zudo-doc/src/__tests__/no-inert-spacing-utilities.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from "vitest";
+import { createRequire } from "node:module";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve, join, dirname, extname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// ── Why this guard exists (#3116, symptom filed as #3114) ──────────────────
+// Numeric Tailwind spacing utilities (`w-72`, `h-40`, …) generate NOTHING in
+// this project: `src/styles/global.css` imports only `tailwindcss/preflight`
+// + `tailwindcss/utilities` (never the default theme), and `theme.css`
+// defines only NAMED spacing tokens (`--spacing-hsp-*`, `--spacing-vsp-*`,
+// `--spacing-0`, `--spacing-px`) — there is no bare `--spacing`, so Tailwind
+// v4 silently drops every numeric spacing candidate. The theme-pack switcher
+// flyout shipped with `w-72` in source and NO effective width as a result.
+//
+// The fix for a caught violation is EITHER an arbitrary value (`w-[360px]`,
+// the established local convention — see `max-w-[64rem]` in
+// theme-pack-dialog) OR a named token (e.g. `px-hsp-lg`) — NEVER adding a
+// bare `--spacing` to `theme.css`. That would switch on Tailwind's WHOLE
+// numeric spacing scale, which is exactly what the tight-token policy
+// (`packages/zudo-doc/CLAUDE.md`, `src/CLAUDE.md`) intentionally avoids.
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = resolve(__dirname, "../..");
+const SRC_DIR = resolve(__dirname, "..");
+const repoRoot = resolve(__dirname, "../../../..");
+
+// Reuse the exact candidate-extraction + class-shape-validation logic
+// gen-safelist.mjs uses to scan compiled dist/**/*.js for Tailwind class
+// candidates (see that file's own header comment for the lexer design),
+// rather than a hand-rolled class-shape regex.
+const { extractTokens } = await import(resolve(PACKAGE_ROOT, "scripts/gen-safelist.mjs"));
+
+// gen-safelist.mjs's lexer only ever scans COMPILED dist/**/*.js (JSX already
+// transformed away by tsup/esbuild). Feeding it raw .tsx source instead
+// breaks it: the lexer's regex-vs-division heuristic treats the `/` in a JSX
+// closing tag (e.g. `</div>`) as the start of a regex literal — `<` is a
+// regex precursor — and everything after gets mis-tokenized (confirmed
+// empirically: real class strings like "w-72" go missing entirely). So each
+// file is esbuild-transformed (JSX/TS stripped, exactly what tsup does for
+// dist) before handing its text to extractTokens — esbuild is not a direct
+// dependency of this package; resolve it via vite, same pattern as
+// preset.test.ts's node-free eval-graph guard.
+interface EsbuildLike {
+  transform(input: string, options: Record<string, unknown>): Promise<{ code: string }>;
+}
+function loadEsbuild(): EsbuildLike {
+  const vitePkg = require.resolve("vite/package.json", {
+    paths: [process.cwd(), __dirname, repoRoot],
+  });
+  const viteRequire = createRequire(vitePkg);
+  return viteRequire("esbuild") as EsbuildLike;
+}
+
+function findSourceFiles(dir: string): string[] {
+  const results: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    // __tests__ holds specs/fixtures, not shipped package source.
+    if (entry.name === "__tests__") continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...findSourceFiles(full));
+    } else if (/\.tsx?$/.test(entry.name)) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+// Prefixes from the #3116 spec that ride Tailwind's NUMERIC spacing scale
+// (which resolves against the bare `--spacing` token this project never
+// defines). Named tokens (`px-hsp-lg`, `w-icon-sm`, …) don't match this
+// shape at all, so they can never be candidates here.
+const SPACING_PREFIXES = [
+  "w",
+  "h",
+  "size",
+  "min-w",
+  "min-h",
+  "max-w",
+  "max-h",
+  "basis",
+  "p",
+  "px",
+  "py",
+  "pt",
+  "pb",
+  "pl",
+  "pr",
+  "m",
+  "mx",
+  "my",
+  "mt",
+  "mb",
+  "ml",
+  "mr",
+  "gap",
+  "gap-x",
+  "gap-y",
+  "space-x",
+  "space-y",
+  "inset",
+  "inset-x",
+  "inset-y",
+  "top",
+  "right",
+  "bottom",
+  "left",
+  "translate-x",
+  "translate-y",
+  "scroll-m",
+  "scroll-mx",
+  "scroll-my",
+  "scroll-mt",
+  "scroll-mb",
+  "scroll-ml",
+  "scroll-mr",
+];
+
+// Anchors the WHOLE candidate token — after optional variant prefixes
+// (`lg:`, `hover:`, or an arbitrary selector variant like `[&_nav]:` — this
+// codebase uses that form, e.g. breadcrumb.tsx's `[&_nav]:mb-0`) and an
+// optional `!`/`-` important/negative marker — to `<prefix>-<digits>`.
+// Fractions (`w-1/2`) and arbitrary VALUES (`w-[360px]`) never reach this
+// shape: extractTokens keeps the literal `/` and `[...]` characters in the
+// token, and this regex requires the token to END immediately after the
+// digits.
+const VARIANT = "(?:[a-zA-Z0-9_-]+:|\\[[^\\]]*\\]:)*";
+const NUMERIC_SPACING_RE = new RegExp(
+  `^${VARIANT}!?-?(?:${SPACING_PREFIXES.join("|")})-(\\d+(?:\\.\\d+)?)$`,
+);
+
+interface Violation {
+  file: string;
+  token: string;
+}
+
+async function scanForViolations(): Promise<Violation[]> {
+  const esbuild = loadEsbuild();
+  const files = findSourceFiles(SRC_DIR);
+  const violations: Violation[] = [];
+  for (const file of files) {
+    const raw = readFileSync(file, "utf8");
+    const loader = extname(file) === ".tsx" ? "tsx" : "ts";
+    const { code } = await esbuild.transform(raw, { loader, jsx: "transform", format: "esm" });
+    const tokens = extractTokens(code, new Set<string>());
+    for (const token of tokens) {
+      const match = token.match(NUMERIC_SPACING_RE);
+      // "-0" is excluded: --spacing-0 is a real named token (theme.css).
+      // "-px" never matches \d+ in the first place, so it needs no carve-out.
+      if (match && match[1] !== "0") {
+        violations.push({ file: file.replace(`${repoRoot}/`, ""), token });
+      }
+    }
+  }
+  return violations;
+}
+
+describe("package source has no inert numeric spacing utilities (#3116)", () => {
+  it("contains zero numeric spacing-scale utility candidates", async () => {
+    const violations = await scanForViolations();
+    if (violations.length > 0) {
+      const list = violations.map((v) => `  ${v.file}: "${v.token}"`).join("\n");
+      throw new Error(
+        "Found numeric Tailwind spacing utilities that generate NOTHING in this project " +
+          "(no bare --spacing token is defined — see theme.css and this file's header " +
+          `comment):\n${list}\n\n` +
+          "Fix: replace each with an arbitrary value (e.g. w-[360px], the established " +
+          "convention) or a named spacing token (e.g. px-hsp-lg). Do NOT add a bare " +
+          "--spacing to theme.css — that would switch on Tailwind's whole numeric scale, " +
+          "against the tight-token policy.",
+      );
+    }
+    expect(violations).toEqual([]);
+  });
+});

--- a/packages/zudo-doc/src/find-in-page/find-bar.tsx
+++ b/packages/zudo-doc/src/find-in-page/find-bar.tsx
@@ -84,7 +84,7 @@ export function FindBar({ visible, onClose, findInPage, containerSelector }: Fin
     <div className="fixed top-[3.5rem] right-0 z-dropdown flex items-center gap-hsp-sm py-hsp-xs px-hsp-md bg-surface border-b border-l border-muted rounded-bl-lg shadow-md">
       <input
         ref={inputRef}
-        className="w-48 py-[4px] px-hsp-sm rounded text-small bg-bg border border-muted text-fg outline-none focus:border-accent"
+        className="w-[12rem] py-[4px] px-hsp-sm rounded text-small bg-bg border border-muted text-fg outline-none focus:border-accent"
         type="text"
         value={query}
         placeholder="Find in page..."

--- a/packages/zudo-doc/src/sidebar-resizer/__tests__/geometry-parity.test.ts
+++ b/packages/zudo-doc/src/sidebar-resizer/__tests__/geometry-parity.test.ts
@@ -54,13 +54,16 @@ function extractHandleGeometry(file: string): HandleGeometry {
   }
   const block = src.slice(start, end);
 
-  const leftMatch = block.match(/left:\s*"([^"]+)"/);
-  const widthMatch = block.match(/width:\s*"([^"]+)"/);
-  if (!leftMatch || !widthMatch) {
+  // Narrow the captures themselves, not just the match arrays: under
+  // noUncheckedIndexedAccess a non-null match still types `[1]` as
+  // `string | undefined`, so checking the arrays alone fails to typecheck.
+  const left = block.match(/left:\s*"([^"]+)"/)?.[1];
+  const width = block.match(/width:\s*"([^"]+)"/)?.[1];
+  if (left === undefined || width === undefined) {
     throw new Error(`Could not find both 'left' and 'width' in the handle.style Object.assign in ${file}`);
   }
 
-  return { left: leftMatch[1], width: widthMatch[1] };
+  return { left, width };
 }
 
 describe("sidebar resizer handle geometry parity", () => {

--- a/packages/zudo-doc/src/sidebar-resizer/__tests__/geometry-parity.test.ts
+++ b/packages/zudo-doc/src/sidebar-resizer/__tests__/geometry-parity.test.ts
@@ -1,0 +1,95 @@
+// Drift guard for the two hand-duplicated resizer-handle geometry blocks
+// (zudolab/zudo-doc#3117):
+//
+//   - packages/zudo-doc/src/sidebar-resizer/index.ts
+//     (`initSidebarResizer()`, the exported module API)
+//   - packages/zudo-doc/src/sidebar-resizer/sidebar-resizer-init.tsx
+//     (`SIDEBAR_RESIZER_INIT_SCRIPT`, the inline body-end script string the
+//     shipped layout actually runs)
+//
+// Both call `Object.assign(handle.style, { ... left, width, ... })` with the
+// exact same `left`/`width` values, but one is real TypeScript and the other
+// is a minified single-line script string embedded via `dangerouslySetInnerHTML`
+// — their surrounding syntax can never be made textually identical the way
+// e.g. doc-history-exclude/__tests__/parity.test.ts compares whole function
+// bodies. So this guard extracts just the two geometry values from each file's
+// `Object.assign(handle.style, …)` call and compares those.
+//
+// If this test fails: the two copies' handle geometry has drifted. Make the
+// `left`/`width` values identical again in both
+// sidebar-resizer/index.ts and sidebar-resizer/sidebar-resizer-init.tsx.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// src/sidebar-resizer/__tests__/ → src/sidebar-resizer/
+const resizerDir = resolve(__dirname, "..");
+
+const MODULE_API_FILE = resolve(resizerDir, "index.ts");
+const INLINE_SCRIPT_FILE = resolve(resizerDir, "sidebar-resizer-init.tsx");
+
+interface HandleGeometry {
+  left: string;
+  width: string;
+}
+
+/**
+ * Extract the `left`/`width` values from the FIRST `Object.assign(handle.style,
+ * { … })` call in a file. Scoped to `handle.style` (not `ghost.style`, which
+ * also sets a `width` for the drag-ghost line) by slicing from that literal
+ * substring up to the call's closing `)`.
+ */
+function extractHandleGeometry(file: string): HandleGeometry {
+  const src = readFileSync(file, "utf-8");
+  const start = src.indexOf("Object.assign(handle.style");
+  if (start === -1) {
+    throw new Error(`Could not locate 'Object.assign(handle.style' in ${file}`);
+  }
+  const end = src.indexOf(");", start);
+  if (end === -1) {
+    throw new Error(`Could not locate the closing ');' for the handle.style Object.assign in ${file}`);
+  }
+  const block = src.slice(start, end);
+
+  const leftMatch = block.match(/left:\s*"([^"]+)"/);
+  const widthMatch = block.match(/width:\s*"([^"]+)"/);
+  if (!leftMatch || !widthMatch) {
+    throw new Error(`Could not find both 'left' and 'width' in the handle.style Object.assign in ${file}`);
+  }
+
+  return { left: leftMatch[1], width: widthMatch[1] };
+}
+
+describe("sidebar resizer handle geometry parity", () => {
+  it("keeps left/width identical between the module API and the inline script", () => {
+    const moduleGeometry = extractHandleGeometry(MODULE_API_FILE);
+    const scriptGeometry = extractHandleGeometry(INLINE_SCRIPT_FILE);
+    expect(scriptGeometry).toEqual(moduleGeometry);
+  });
+
+  it("matches the specced straddle geometry (#3117)", () => {
+    // Pinned literal — not just cross-file equality — so a change that
+    // updates both copies IDENTICALLY but drifts away from the specced
+    // straddle geometry still fails loudly.
+    const expected: HandleGeometry = {
+      left: "calc(var(--zd-sidebar-w) - 4px)",
+      width: "16px",
+    };
+    expect(extractHandleGeometry(MODULE_API_FILE)).toEqual(expected);
+    expect(extractHandleGeometry(INLINE_SCRIPT_FILE)).toEqual(expected);
+  });
+
+  it("self-test: the extractor actually reads real geometry values, not an empty match", () => {
+    // Guards against the comparisons above passing vacuously (e.g. both
+    // sides silently reducing to the same falsy value after a refactor of
+    // the extractor itself).
+    const geometry = extractHandleGeometry(MODULE_API_FILE);
+    expect(geometry.left.length).toBeGreaterThan(0);
+    expect(geometry.width.length).toBeGreaterThan(0);
+    expect(geometry.left).toContain("--zd-sidebar-w");
+    expect(geometry.width).toMatch(/^\d+px$/);
+  });
+});

--- a/packages/zudo-doc/src/sidebar-resizer/index.ts
+++ b/packages/zudo-doc/src/sidebar-resizer/index.ts
@@ -14,8 +14,9 @@
 //
 // What the resizer does
 // ---------------------
-// Finds `#desktop-sidebar` and grafts a 20px-wide drag handle onto its
-// right edge. The handle:
+// Finds `#desktop-sidebar` and grafts a 16px-wide drag handle straddling its
+// right edge (4px inside, 12px outside — see the geometry comment below for
+// why). The handle:
 //
 //   * is keyboard-accessible (tab into it, then Arrow keys / Home / End
 //     to step the width by `STEP` pixels, clamped to MIN_W…MAX_W),
@@ -112,16 +113,23 @@ export function initSidebarResizer(): void {
   //
   // top:3.5rem + left:calc mirror the doc-layout #desktop-sidebar geometry
   // (top-[3.5rem], left:0, width:var(--zd-sidebar-w)) — those layout constants
-  // live in the same package's doc-layout.tsx. 20px is wider than every common
-  // native y-scrollbar (~12-17px on Win/Linux classic; 0 on macOS overlay) so a
-  // draggable strip always remains visible to the LEFT of the scrollbar when
-  // sidebar content overflows. zudolab/zudo-doc#1660
+  // live in the same package's doc-layout.tsx. The strip STRADDLES the
+  // sidebar's right edge: 4px inside (still useful when the sidebar doesn't
+  // overflow) + 12px outside, over the main content column's left padding
+  // (main offsets by exactly lg:ml-[var(--zd-sidebar-w)] — see doc-layout.tsx).
+  // A wider-than-scrollbar inside-only strip (the former 20px/#1660 rationale)
+  // does NOT keep the handle draggable: the native y-scrollbar renders on top
+  // of it and captures the pointer regardless of strip width. Straddling puts
+  // most of the grab area BESIDE the scrollbar, where no native control can
+  // intercept the pointer, while deliberately leaving the scrollbar column
+  // itself non-draggable so native scrolling still works there.
+  // zudolab/zudo-doc#3117
   Object.assign(handle.style, {
     position: "fixed",
     top: "3.5rem",
     bottom: "0",
-    left: "calc(var(--zd-sidebar-w) - 20px)",
-    width: "20px",
+    left: "calc(var(--zd-sidebar-w) - 4px)",
+    width: "16px",
     cursor: "col-resize",
     zIndex: "var(--z-index-sidebar)",
     transition: "background 0.15s",

--- a/packages/zudo-doc/src/sidebar-resizer/sidebar-resizer-init.tsx
+++ b/packages/zudo-doc/src/sidebar-resizer/sidebar-resizer-init.tsx
@@ -88,10 +88,18 @@ export const SIDEBAR_RESIZER_INIT_SCRIPT = `(function(){
     // absolute child of the overflow-y:auto sidebar it scrolled away with the
     // content and height:100% only covered the visible padding box. zudolab/zudo-doc#1821
     // top:3.5rem + left:calc mirror the layout's #desktop-sidebar geometry
-    // (top-[3.5rem], left:0, width:var(--zd-sidebar-w)). 20px hit area > native
-    // y-scrollbar (~12-17px) keeps a draggable strip left of the scrollbar when
-    // the sidebar overflows. zudolab/zudo-doc#1660
-    Object.assign(handle.style,{position:"fixed",top:"3.5rem",bottom:"0",left:"calc(var(--zd-sidebar-w) - 20px)",width:"20px",cursor:"col-resize",zIndex:"var(--z-index-sidebar)",transition:"background 0.15s"});
+    // (top-[3.5rem], left:0, width:var(--zd-sidebar-w)). The strip STRADDLES
+    // the sidebar's right edge: 4px inside (still useful when the sidebar
+    // doesn't overflow) + 12px outside, over the main content column's left
+    // padding (main offsets by exactly lg:ml-[var(--zd-sidebar-w)] — see
+    // doc-layout.tsx). A wider-than-scrollbar inside-only strip (the former
+    // 20px/#1660 rationale) does NOT keep the handle draggable: the native
+    // y-scrollbar renders on top of it and captures the pointer regardless of
+    // strip width. Straddling puts most of the grab area BESIDE the
+    // scrollbar, where no native control can intercept the pointer, while
+    // deliberately leaving the scrollbar column itself non-draggable so
+    // native scrolling still works there. zudolab/zudo-doc#3117
+    Object.assign(handle.style,{position:"fixed",top:"3.5rem",bottom:"0",left:"calc(var(--zd-sidebar-w) - 4px)",width:"16px",cursor:"col-resize",zIndex:"var(--z-index-sidebar)",transition:"background 0.15s"});
 
     var dragging=false,focused=false;
 

--- a/packages/zudo-doc/src/theme-pack-dialog/index.tsx
+++ b/packages/zudo-doc/src/theme-pack-dialog/index.tsx
@@ -219,7 +219,7 @@ export function ThemePackDialog({ open, onClose, order, active, base }: ThemePac
                     {order.map((entry) => (
                       <div
                         key={entry.slug}
-                        className="h-40 animate-pulse rounded-lg border border-muted bg-surface/50"
+                        className="h-[10rem] animate-pulse rounded-lg border border-muted bg-surface/50"
                       />
                     ))}
                   </div>

--- a/packages/zudo-doc/src/theme-pack-switcher/__tests__/theme-pack-switcher-interaction.test.tsx
+++ b/packages/zudo-doc/src/theme-pack-switcher/__tests__/theme-pack-switcher-interaction.test.tsx
@@ -25,6 +25,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { render } from "preact";
 import { act } from "preact/test-utils";
 import { ThemePackSwitcher, type ThemePackSwitcherProps } from "../index.js";
+import { THEME_PACK_ATTR } from "../theme-pack-sync.js";
 
 const PROPS: ThemePackSwitcherProps = {
   active: "default",
@@ -58,6 +59,10 @@ afterEach(() => {
     mounted.remove();
     mounted = null;
   }
+  // `connectActivePackSync` reads this attribute on mount (real-DOM sync,
+  // ADR Decision 7) — restore the absent-attribute default so a later test
+  // that relies on the "default" fallback isn't shadowed by a leftover value.
+  document.documentElement.removeAttribute(THEME_PACK_ATTR);
 });
 
 describe("ThemePackSwitcher — real-DOM interaction", () => {
@@ -110,5 +115,59 @@ describe("ThemePackSwitcher — real-DOM interaction", () => {
     });
 
     expect(document.activeElement).toBe(launcher);
+  });
+
+  // Cheap local proxy for the #3116 Screenshot Requirement Contract (the
+  // heavy browser-level pass is a separate Wave-2 sub-issue): with a
+  // long-description pack active, the open card must be the fixed 360px
+  // arbitrary-value width (never the inert `w-72`) and the description
+  // must carry `break-words` so an unbroken long line can't stretch the
+  // card to the full viewport (the Tidepool scenario from issue #3114).
+  it("open card is fixed-width w-[360px] (never w-72) and the description wraps", () => {
+    const longDescription =
+      "A very long theme-pack description that must wrap across multiple lines instead of stretching the card to the full viewport width, mirroring the Tidepool pack scenario from issue #3114.";
+    // connectActivePackSync resolves the active slug from the real DOM on
+    // mount (ADR Decision 7), not from the `active` prop alone — set it here
+    // so `resolveActiveEntry` matches this test's custom pack instead of
+    // falling back to "default" (afterEach clears this for other tests).
+    document.documentElement.setAttribute(THEME_PACK_ATTR, "long-desc-pack");
+    const container = mount({
+      active: "long-desc-pack",
+      order: [
+        {
+          slug: "long-desc-pack",
+          name: "Long Desc Pack",
+          mode: "light",
+          description: longDescription,
+        },
+      ],
+      base: "/",
+    });
+
+    const launcher = container.querySelector<HTMLButtonElement>("[data-switcher-launcher]");
+    act(() => {
+      launcher!.click();
+    });
+
+    const card = container.querySelector<HTMLDivElement>("[data-switcher-card]");
+    expect(card).not.toBeNull();
+    expect(card!.className).toContain("w-[360px]");
+    expect(card!.className).not.toMatch(/(?:^|\s)w-72(?:\s|$)/);
+    // The viewport-safety cap from #2825 is untouched by this fix.
+    expect(card!.className).toContain("max-w-[calc(100vw-2rem)]");
+
+    const description = Array.from(card!.querySelectorAll("p")).find(
+      (p) => p.textContent === longDescription,
+    );
+    expect(description).toBeDefined();
+    expect(description!.className).toContain("break-words");
+
+    // The card stays anchored bottom-right above the launcher — the fixed
+    // positioning lives on the switcher's root wrapper, unaffected by this
+    // fix; confirm it survived untouched.
+    const root = container.querySelector("[data-theme-pack-switcher]");
+    expect(root!.className).toContain("fixed");
+    expect(root!.className).toContain("right-hsp-lg");
+    expect(root!.className).toContain("bottom-hsp-lg");
   });
 });

--- a/packages/zudo-doc/src/theme-pack-switcher/index.tsx
+++ b/packages/zudo-doc/src/theme-pack-switcher/index.tsx
@@ -222,7 +222,7 @@ export function ThemePackSwitcher({ active, order, base }: ThemePackSwitcherProp
           role="dialog"
           aria-label="Theme pack switcher"
           data-switcher-card
-          class="flex w-72 max-w-[calc(100vw-2rem)] flex-col gap-vsp-2xs rounded-lg border border-muted bg-surface p-hsp-lg shadow-lg focus-visible:outline-2 focus-visible:outline-accent"
+          class="flex w-[360px] max-w-[calc(100vw-2rem)] flex-col gap-vsp-2xs rounded-lg border border-muted bg-surface p-hsp-lg shadow-lg focus-visible:outline-2 focus-visible:outline-accent"
         >
           <div class="flex items-start justify-between gap-hsp-sm">
             {/* min-w-0 + break-words: a flex child's min-width:auto would let a
@@ -258,7 +258,7 @@ export function ThemePackSwitcher({ active, order, base }: ThemePackSwitcherProp
             </span>
           )}
           {entry !== null && entry.description !== "" && (
-            <p class="text-caption text-muted">{entry.description}</p>
+            <p class="break-words text-caption text-muted">{entry.description}</p>
           )}
           <div class="flex items-center justify-between gap-hsp-sm">
             <button
@@ -293,7 +293,7 @@ export function ThemePackSwitcher({ active, order, base }: ThemePackSwitcherProp
         title="Theme packs"
         data-switcher-launcher
         onClick={() => setOpen(!open)}
-        class="flex h-10 w-10 items-center justify-center rounded-full border border-muted bg-surface text-fg shadow-lg transition-colors hover:text-accent focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2"
+        class="flex h-[2.5rem] w-[2.5rem] items-center justify-center rounded-full border border-muted bg-surface text-fg shadow-lg transition-colors hover:text-accent focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2"
       >
         <PaletteIcon className="h-icon-md w-icon-md" />
       </button>


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3115

---

## Summary

Two independent package-owned UI fixes in `@takazudo/zudo-doc`, from epic #3115, plus permanent regression coverage.

### 1. Theme-pack flyout card grew to (near) full viewport width — #3116

Root cause was **not** a missing width. The card already had `w-72`, but **numeric Tailwind spacing utilities generate nothing in this project**: `src/styles/global.css` imports only `tailwindcss/preflight` + `tailwindcss/utilities` (never the default theme), and the package `theme.css` defines only *named* spacing tokens (`--spacing-hsp-*`, `--spacing-vsp-*`, `--spacing-0`, `--spacing-px`) — there is no bare `--spacing`. Tailwind v4 therefore silently drops every `w-72`-style candidate, leaving the card with only `max-w-[calc(100vw-2rem)]` and auto-sizing to its description.

The same silent no-op affected 4 spots across 3 files. All replaced with arbitrary values (which always generate — the established local convention):

| File | Before | After |
|---|---|---|
| `theme-pack-switcher/index.tsx` (card) | `w-72` | `w-[360px]` |
| `theme-pack-switcher/index.tsx` (launcher) | `h-10 w-10` | `h-[2.5rem] w-[2.5rem]` |
| `theme-pack-dialog/index.tsx` (skeleton) | `h-40` | `h-[10rem]` |
| `find-in-page/find-bar.tsx` (input) | `w-48` | `w-[12rem]` |

`360px` is deliberately **px, not rem**: the Beacon pack sets root font-size 112.5%, so a rem cap would drift to ~405px there. Verified in-browser — under Beacon the card stays exactly 360px while the (rem-based) launcher grows to 45px, which is the intended split. Fixed width rather than max-width-only so the card doesn't resize while cycling Prev/Next. `break-words` added to the description so an unbroken token can't overflow.

Plus a **guard test** (`no-inert-spacing-utilities.test.ts`) so numeric spacing utilities can't silently no-op again.

### 2. Sidebar resize handle was hard to grab — #3117

The handle was a 20px strip placed entirely *inside* the sidebar's right edge. `#desktop-sidebar` is `overflow-y: auto`, so when content overflows the native scrollbar paints on top and **captures the pointer** — the original "20px > scrollbar" rationale (#1660) does not hold, because strip width is irrelevant when the scrollbar is above it.

Now straddles the boundary: `left: calc(var(--zd-sidebar-w) - 4px); width: 16px` — 4px inside + **12px outside**, over the content column's left padding where nothing intercepts the pointer. The scrollbar column itself stays deliberately non-draggable, so native scrolling (including thumb-drag) is preserved — verified.

The geometry existed in **two hand-duplicated implementations** (the inline body-end script and the exported `sidebar-resizer` module API); both updated and pinned together by a parity guard test.

### 3. Confirm pass + permanent regressions — #3118

Browser verification of both fixes, and Playwright specs so the guarantees outlive the one-time check.

## Verification

**Unit / build**
- `pnpm test` green: `packages/zudo-doc` 161 files / 1719 tests; create-zudo-doc 580; doc-history-server 73; search-worker 44.
- Host + both package typechecks clean.
- Built stylesheet confirms the fix reaches the browser: `.w-\[360px\]{width:360px}` generated, zero `.w-72` occurrences.
- Both new guard tests verified **fail-then-pass** (reintroduce `w-72` → red; inject 1px geometry drift → red).

**Browser (measured, at 1280x900)**
- Long-description packs (`tidepool` 160ch, `eink` 185ch — the longest of 31): card exactly **360px**, description wraps to 3–4 lines, anchored bottom-right above the launcher, no page overflow.
- Shortest pack (`phosphor` 87ch): still 360px and visually sound — no dead whitespace.
- Launcher **40x40** (45px under Beacon's 112.5% root, card unchanged at 360px).
- Resizer drag at `sidebarRight + 6px`: `--zd-sidebar-w` 256 → 342px, persisted to `localStorage`, ghost line and hover state present, restored after reload.
- Toggle tab still collapses/expands the sidebar despite a measured 12x48px overlap with the widened handle — it wins hit-testing at every point inside its own box.
- Native sidebar scrolling (wheel and thumb-drag) unaffected.

**The resizer test was made discriminating, not merely passing.** Playwright's default headless launch passes `--hide-scrollbars`, giving a 0px scrollbar — under which the original failure mode *cannot occur*, so a green result would prove nothing. With `ignoreDefaultArgs: ["--hide-scrollbars"]` a real 15px space-taking scrollbar appears, and restoring the old geometry at runtime reproduces the original bug (pointer lands on `ASIDE#desktop-sidebar`, no resize) while the new geometry resizes correctly. Same browser, same drag: fails on old, passes on new.

A measured nuance: with a real scrollbar the handle's 4px inside portion is nearly dead (only the 1px border column reaches it), so the effective grab area is ~13px — 12 outside + 1 border. That is the intended design; the inside 4px earns its place only when the sidebar does not overflow.

**e2e** — 12/12 specs pass locally, including 4 new ones. All CI guards (spec-naming, wait-debt, flaky-tracking, fixture-settings-drift) pass. No fixture data needed extending.

## Review findings (both fixed here)

1. The geometry parity test failed `tsc --noEmit` under `noUncheckedIndexedAccess` — guarding a `RegExpMatchArray` does not narrow `[1]` to `string`. This would have failed CI's Type Check. Worth noting *why* it escaped the implementing agents: `tsup` runs with `dts: false`, so **a passing build proves nothing about types** in this package.
2. The narrow-viewport spec could not fail. `|width − 288| ≤ 20` passes at both 288 (correct) and 304 (the value if the clamp regressed to `calc(100vw - 1rem)`), so it would have passed through the exact regression it existed to catch. Tightened to ±2.

## Out of scope — raised, not fixed

Two **pre-existing** resizer defects the browser pass surfaced (neither introduced here):

- #3120 — `aria-valuenow` reports `192` (`MIN_W`) while the sidebar is at 256px, because `parseFloat` cannot read the unresolved `clamp(14rem, 20vw, 22rem)` a custom property returns. Self-corrects only after the first drag.
- #3121 — no grab-offset compensation: the edge snaps to the cursor on the first move (grab +6, drag +80, get +86). Always existed, but this change makes it the common case rather than the edge case.

## Topics

Merged into the base locally with `--no-ff` (the merge commits are the record); no per-topic PRs, since a PR targeting `base/**` triggers a full CI run for something closed immediately.

- `theme-card-resizer-fix/spacing-utilities` — #3116 — `f0b50a987`
- `theme-card-resizer-fix/resizer-hit-area` — #3117 — `d68656b38`
- `theme-card-resizer-fix/confirm` — #3118 — `3f09ff5b6`
