### PR TITLE
fix: sidebar resizer — report the rendered width and compensate the drag grab offset

### DIFF
--- a/e2e/sidebar-resizer-hit-area.spec.ts
+++ b/e2e/sidebar-resizer-hit-area.spec.ts
@@ -94,11 +94,11 @@ test.describe("Sidebar resizer hit area (#3117 straddle geometry)", () => {
     // Inside the new 12px OUTSIDE strip: [sidebarRight, sidebarRight + 12].
     const startX = sidebarRight + 6;
     const startY = y + height / 2;
-    // "drag ±80px" per the epic's live-check item (#3118 item 4). The
-    // resizer computes the committed width from the pointer's absolute
-    // clientX at drag-end (sidebarLeft is 0), not from the drag delta, so
-    // dragging further right from a start point past the edge still yields a
-    // clear, well-clamped width increase.
+    // "drag ±80px" per the epic's live-check item (#3118 item 4). Since #3121
+    // the committed width is the pointer's clientX minus the grab offset
+    // recorded at pointerdown, so an 80px drag moves the edge by 80px
+    // regardless of where inside the handle it was grabbed. (The exact-delta
+    // guarantee has its own test below; this one only needs a clear increase.)
     const endX = startX + 80;
 
     await page.mouse.move(startX, startY);
@@ -149,5 +149,62 @@ test.describe("Sidebar resizer hit area (#3117 straddle geometry)", () => {
       .toBe(true);
     const stored = await page.evaluate((key) => localStorage.getItem(key), SIDEBAR_VISIBLE_KEY);
     expect(stored).toBe("false");
+  });
+
+  test("the handle reports the rendered sidebar width in aria-valuenow before any interaction (#3120)", async ({
+    page,
+  }) => {
+    await page.goto(START_PAGE, { waitUntil: "load" });
+    await waitForSidebarHydration(page);
+    await page.locator(HANDLE_SELECTOR).waitFor({ state: "attached" });
+
+    // Deliberately BEFORE any drag or key press. The default width is declared
+    // as `clamp(14rem, 20vw, 22rem)`, and getComputedStyle().getPropertyValue()
+    // on a CUSTOM PROPERTY hands back that unresolved substitution value — so
+    // the pre-#3120 `parseFloat(...) || MIN_W` read NaN and reported MIN_W
+    // (192) while the sidebar was actually ~256-320px wide. It self-corrected
+    // after the first interaction, which is exactly why this assertion has to
+    // run first: a test that drags before reading would never have caught it.
+    const { width } = await requireSidebarBox(page);
+    const valuenow = await page.locator(HANDLE_SELECTOR).getAttribute("aria-valuenow");
+
+    expect(valuenow).not.toBeNull();
+    expect(Math.abs(Number(valuenow) - width)).toBeLessThanOrEqual(1);
+  });
+
+  test("an 80px drag moves the sidebar edge by exactly 80px regardless of where in the handle it was grabbed (#3121)", async ({
+    page,
+  }) => {
+    await page.goto(START_PAGE, { waitUntil: "load" });
+    await waitForSidebarHydration(page);
+    await forceSidebarOverflow(page);
+    await page.locator(HANDLE_SELECTOR).waitFor({ state: "attached" });
+
+    const { x, y, width, height } = await requireSidebarBox(page);
+    const sidebarRight = x + width;
+    // 6px OUTSIDE the edge — the realistic grab point once a scrollbar covers
+    // the handle's 4px inside portion.
+    const GRAB_OFFSET = 6;
+    const DRAG_DELTA = 80;
+    const startY = y + height / 2;
+
+    await page.mouse.move(sidebarRight + GRAB_OFFSET, startY);
+    await page.mouse.down();
+    await page.mouse.move(sidebarRight + GRAB_OFFSET + DRAG_DELTA, startY, { steps: 10 });
+    await page.mouse.up();
+
+    await expect
+      .poll(() => desktopSidebar(page).evaluate((el) => el.getBoundingClientRect().width))
+      .toBeGreaterThan(width);
+
+    const widthAfter = await desktopSidebar(page).evaluate(
+      (el) => el.getBoundingClientRect().width,
+    );
+
+    // Pre-#3121 the committed width was `clientX - sidebarLeft` with no grab
+    // compensation, so the edge snapped to the cursor on the first move and
+    // this drag produced width + 86 (the 6px grab offset leaked in). The
+    // tolerance MUST stay below that 6px error or the regression slips through.
+    expect(Math.abs(widthAfter - (width + DRAG_DELTA))).toBeLessThanOrEqual(2);
   });
 });

--- a/packages/zudo-doc/src/sidebar-resizer/index.ts
+++ b/packages/zudo-doc/src/sidebar-resizer/index.ts
@@ -87,7 +87,22 @@ export function initSidebarResizer(): void {
   // (below lg the panel is display:none but still fixed — handle appended, not rendered). zudolab/zudo-doc#1821
   if (getComputedStyle(sidebar).position !== "fixed") return;
 
+  // Read the RENDERED width, not the custom property. getPropertyValue() on a
+  // custom property returns its unresolved substitution value, and the default
+  // declaration is `clamp(14rem, 20vw, 22rem)` — parseFloat on that is NaN, so
+  // the old property-parsing version silently reported MIN_W until the first
+  // drag wrote an explicit px value. That fed a wrong initial aria-valuenow
+  // (192 while the sidebar was at 256) and a wrong first keyboard step.
+  // zudolab/zudo-doc#3120
+  // Captured after the null guard above: `readCurrentWidth` is a hoisted
+  // function declaration, so TS does not carry the narrowing into its body.
+  const sidebarEl: HTMLElement = sidebar;
+
   function readCurrentWidth(): number {
+    const rendered = sidebarEl.getBoundingClientRect().width;
+    if (rendered > 0) return rendered;
+    // Fallback for a not-yet-laid-out sidebar (e.g. display:none at init):
+    // an explicit px value in the custom property still parses.
     const raw = getComputedStyle(document.documentElement).getPropertyValue(
       CSS_PROP,
     );
@@ -226,10 +241,19 @@ export function initSidebarResizer(): void {
     let targetWidth = 0;
     let cleaned = false;
 
+    // Distance from the pointer to the sidebar's right edge at grab time.
+    // Subtracting it keeps the edge under the same point of the handle for the
+    // whole drag; without it the edge snaps to the cursor on the first move
+    // (grab 6px outside, drag +80, get +86). This matters more since the handle
+    // straddles the edge (#3117) — the natural grab point is now ~6px OUTSIDE
+    // it, because a native scrollbar covers most of the inside portion.
+    // zudolab/zudo-doc#3121
+    const grabOffset = e.clientX - sidebarRect.right;
+
     const onMove = (ev: PointerEvent) => {
       targetWidth = Math.max(
         MIN_W,
-        Math.min(MAX_W, ev.clientX - sidebarLeft),
+        Math.min(MAX_W, ev.clientX - grabOffset - sidebarLeft),
       );
       ghost.style.left = sidebarLeft + targetWidth + "px";
     };

--- a/packages/zudo-doc/src/sidebar-resizer/sidebar-resizer-init.tsx
+++ b/packages/zudo-doc/src/sidebar-resizer/sidebar-resizer-init.tsx
@@ -68,7 +68,14 @@ export const SIDEBAR_RESIZER_INIT_SCRIPT = `(function(){
     // (below lg the panel is display:none but still fixed — handle appended, not rendered). zudolab/zudo-doc#1821
     if(getComputedStyle(sidebar).position!=="fixed")return;
 
+    // Read the RENDERED width, not the custom property: getPropertyValue() on a
+    // custom property returns the unresolved substitution value, and the default
+    // declaration is clamp(14rem, 20vw, 22rem) — parseFloat on that is NaN, so
+    // this used to report MIN_W until the first drag wrote an explicit px value
+    // (wrong initial aria-valuenow, wrong first keyboard step). zudolab/zudo-doc#3120
     function readCurrentWidth(){
+      var rendered=sidebar.getBoundingClientRect().width;
+      if(rendered>0)return rendered;
       var raw=getComputedStyle(document.documentElement).getPropertyValue(CSS_PROP);
       return raw?parseFloat(raw)||MIN_W:MIN_W;
     }
@@ -141,7 +148,13 @@ export const SIDEBAR_RESIZER_INIT_SCRIPT = `(function(){
       document.body.appendChild(ghost);
       var targetWidth=0;
       var cleaned=false;
-      function onMove(ev){targetWidth=Math.max(MIN_W,Math.min(MAX_W,ev.clientX-sidebarLeft));ghost.style.left=sidebarLeft+targetWidth+"px";}
+      // Pointer-to-right-edge distance at grab time; subtracting it stops the
+      // edge snapping to the cursor on the first move (grab 6px outside, drag
+      // +80, get +86). Matters more since the handle straddles the edge (#3117)
+      // — the natural grab point is now ~6px OUTSIDE it, because a native
+      // scrollbar covers most of the inside portion. zudolab/zudo-doc#3121
+      var grabOffset=e.clientX-sidebarRect.right;
+      function onMove(ev){targetWidth=Math.max(MIN_W,Math.min(MAX_W,ev.clientX-grabOffset-sidebarLeft));ghost.style.left=sidebarLeft+targetWidth+"px";}
       function cleanup(){
         if(cleaned)return;cleaned=true;
         dragging=false;updateHandleVisual();


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3120
    - https://github.com/zudolab/zudo-doc/issues/3121

---

Closes #3120. Closes #3121.

Two **pre-existing** sidebar-resizer defects found during the browser-verification pass for #3118 (epic #3115). Neither was introduced by #3117 — that change only moved the handle's `left`/`width` — but #3121 became far more visible because of it.

## #3120 — `aria-valuenow` reported `MIN_W` until the first interaction

`readCurrentWidth()` did:

```js
parseFloat(getComputedStyle(document.documentElement).getPropertyValue("--zd-sidebar-w")) || MIN_W
```

For a **custom property**, `getPropertyValue()` returns the *unresolved* substitution value — and the default declaration is `clamp(14rem, 20vw, 22rem)`. `parseFloat` on that string is `NaN`, so `|| MIN_W` kicked in.

**Measured:** `aria-valuenow="192"` while the sidebar rendered at **320px** (1600px viewport, 20vw). Off by 128px.

It self-corrected after the first drag or arrow key, because those write an explicit `--zd-sidebar-w: <px>` inline on the root, which *does* parse. So assistive-tech users were told the separator sat at 192 until they happened to move it, and the first keyboard step started from the wrong base.

**Fix:** read the sidebar's rendered rect width; fall back to parsing the property only when the box has no layout yet (e.g. `display:none` at init).

## #3121 — the edge snapped to the cursor on the first move

The committed width came from `ev.clientX - sidebarLeft`, with no record of *where inside the handle* the grab happened. Grab 6px outside the edge, drag +80, and you got **+86**.

**Fix:** capture the pointer-to-right-edge distance at `pointerdown` and subtract it during the move.

Why #3117 made this matter more: the handle now straddles the edge, and when the sidebar overflows a native scrollbar covers most of the 4px inside portion — so the realistic grab point moved from *inside* the edge to ~6px *outside* it. The jump was always there; it just became the common case.

## Both duplicated implementations

Applied to `sidebar-resizer/index.ts` (module API) **and** the `SIDEBAR_RESIZER_INIT_SCRIPT` inline string in `sidebar-resizer-init.tsx` — the two hand-duplicated copies. The `geometry-parity` guard still passes, since `left`/`width` are unchanged.

## Verification — fail-then-pass, not just green

Two e2e regressions added to `e2e/sidebar-resizer-hit-area.spec.ts`, both confirmed to **fail against a pre-fix fixture build** and pass after rebuilding with the fix:

- `aria-valuenow` is asserted **before any interaction**. This ordering is load-bearing — the bug self-heals after one drag, so a test that dragged first could never have caught it. (Pre-fix: received 128 for `|valuenow − width|`.)
- The drag test pins an **exact 80px delta**, tolerance ±2 — deliberately below the 6px error, so the uncompensated version cannot pass.

Also: `packages/zudo-doc` typecheck clean, 161 files / 1719 unit tests green, package build clean, and the spec-naming / wait-debt / flaky-tracking guards all pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/3122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787756363&installation_model_id=20910&pr_number=3122&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F3122&signature=32123cdcb86b196631e99d38445064b61de748dec4e4e32b6db2be77aaf25c01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->