### PR TITLE
fix: re-inject mermaid enlarge button after theme re-render (#3132); close bare-fragment guard hole (#3131)

### DIFF
--- a/packages/zudo-doc/src/mermaid-enlarge/__tests__/mermaid-enlarge-button-injection.test.tsx
+++ b/packages/zudo-doc/src/mermaid-enlarge/__tests__/mermaid-enlarge-button-injection.test.tsx
@@ -1,0 +1,170 @@
+/** @vitest-environment happy-dom */
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+/**
+ * Real-DOM regression tests for the enlarge-button injection loop
+ * (zudolab/zudo-doc#3132 — "mermaid enlarge broken").
+ *
+ * Mermaid diagrams render client-side, so unlike images (SSR-wrapped in
+ * `figure.zd-enlargeable`) the enlarge button is injected into the diagram
+ * container by this island. The mermaid init script's re-render path
+ * (`reinitMermaid` in code-syntax/mermaid-init-script.ts) restores each
+ * diagram from its cached source with `el.textContent = src`, which deletes
+ * every child of the container — the injected button included. The island
+ * used to guard injection on the `data-mermaid-enlarge-ready` attribute,
+ * which survives that wipe, so the button never came back: on a full page
+ * load the design-token panel re-applies persisted `:root` overrides after
+ * first paint, the mermaid observer re-renders, and both the button and the
+ * `:has(.zd-enlarge-btn)` border affordance vanished for the rest of the
+ * page's life. Soft navigation re-applies identical values, so its gate
+ * (#2181) no-ops and the button survived — hence "works on arrival, gone
+ * after reload".
+ *
+ * These tests replay the DOM sequence the init script produces; they do not
+ * load mermaid itself.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { render } from "preact";
+import { act } from "preact/test-utils";
+import { MermaidEnlarge } from "../index.js";
+
+const DIAGRAM_SOURCE = "graph LR\n  A[Start] --> B[End]";
+const RENDERED_SVG = '<svg class="flowchart"><g></g></svg>';
+
+/** Build the SSG shape a doc page ships: `main > .zd-content > div.mermaid`. */
+function mountPage(): { container: HTMLElement; islandHost: HTMLElement } {
+  document.body.innerHTML = `
+    <main>
+      <article class="zd-content">
+        <div class="mermaid" data-mermaid>${DIAGRAM_SOURCE}</div>
+      </article>
+    </main>
+    <div id="island-host"></div>
+  `;
+  const container = document.querySelector<HTMLElement>(".mermaid");
+  const islandHost = document.querySelector<HTMLElement>("#island-host");
+  if (!container || !islandHost) throw new Error("fixture markup did not mount");
+  return { container, islandHost };
+}
+
+/** Replay what `mermaid.run` + the init script do to a container. */
+function simulateMermaidRender(container: HTMLElement): void {
+  container.innerHTML = RENDERED_SVG;
+  container.setAttribute("data-processed", "true");
+  container.setAttribute("data-mermaid-rendered", "");
+  container.setAttribute("data-mermaid-src", DIAGRAM_SOURCE);
+}
+
+/**
+ * Replay `reinitMermaid`: restore the cached source (wiping every child),
+ * then drop the render markers so the next init pass regenerates.
+ */
+function simulateMermaidReinit(container: HTMLElement): void {
+  const src = container.getAttribute("data-mermaid-src");
+  if (src !== null) container.textContent = src;
+  container.querySelector("svg")?.remove();
+  container.removeAttribute("data-processed");
+  container.removeAttribute("data-mermaid-rendered");
+}
+
+/** MutationObserver callbacks are microtasks — let them flush. */
+async function flushObservers(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function enlargeButton(container: HTMLElement): HTMLElement | null {
+  return container.querySelector<HTMLElement>(":scope > .zd-enlarge-btn");
+}
+
+afterEach(() => {
+  const host = document.querySelector("#island-host");
+  if (host) render(null, host);
+  document.body.innerHTML = "";
+});
+
+describe("MermaidEnlarge — enlarge-button injection", () => {
+  it("injects the button when the diagram renders after the island mounts", async () => {
+    const { container, islandHost } = mountPage();
+    act(() => {
+      render(<MermaidEnlarge />, islandHost);
+    });
+    expect(enlargeButton(container)).toBeNull();
+
+    simulateMermaidRender(container);
+    await flushObservers();
+
+    expect(enlargeButton(container)).not.toBeNull();
+    expect(container.classList.contains("zd-mermaid-enlargeable")).toBe(true);
+  });
+
+  it("injects the button when the diagram already rendered before the island mounts", async () => {
+    const { container, islandHost } = mountPage();
+    simulateMermaidRender(container);
+
+    act(() => {
+      render(<MermaidEnlarge />, islandHost);
+    });
+    await flushObservers();
+
+    expect(enlargeButton(container)).not.toBeNull();
+  });
+
+  it("does not inject a second button on a repeat scan", async () => {
+    const { container, islandHost } = mountPage();
+    act(() => {
+      render(<MermaidEnlarge />, islandHost);
+    });
+    simulateMermaidRender(container);
+    await flushObservers();
+    // Any extra mutation inside the scope triggers another scan pass.
+    container.setAttribute("data-mermaid-rendered", "");
+    await flushObservers();
+
+    expect(container.querySelectorAll(":scope > .zd-enlarge-btn")).toHaveLength(1);
+  });
+
+  it("re-injects the button after a theme re-render wipes it (#3132)", async () => {
+    const { container, islandHost } = mountPage();
+    act(() => {
+      render(<MermaidEnlarge />, islandHost);
+    });
+    simulateMermaidRender(container);
+    await flushObservers();
+    expect(enlargeButton(container)).not.toBeNull();
+
+    // The re-render restores the cached source, deleting the button. The
+    // `data-mermaid-enlarge-ready` attribute survives — that is exactly what
+    // used to make the loss permanent.
+    simulateMermaidReinit(container);
+    await flushObservers();
+    expect(enlargeButton(container)).toBeNull();
+    expect(container.hasAttribute("data-mermaid-enlarge-ready")).toBe(true);
+
+    simulateMermaidRender(container);
+    await flushObservers();
+
+    expect(enlargeButton(container)).not.toBeNull();
+  });
+
+  it("survives repeated theme re-renders", async () => {
+    const { container, islandHost } = mountPage();
+    act(() => {
+      render(<MermaidEnlarge />, islandHost);
+    });
+    simulateMermaidRender(container);
+    await flushObservers();
+
+    for (let i = 0; i < 3; i++) {
+      simulateMermaidReinit(container);
+      await flushObservers();
+      simulateMermaidRender(container);
+      await flushObservers();
+    }
+
+    expect(container.querySelectorAll(":scope > .zd-enlarge-btn")).toHaveLength(1);
+  });
+});

--- a/packages/zudo-doc/src/mermaid-enlarge/index.tsx
+++ b/packages/zudo-doc/src/mermaid-enlarge/index.tsx
@@ -22,6 +22,7 @@ import {
 
 const CONTENT_SCOPE_SELECTOR = "main .zd-content";
 const DIAGRAM_SVG_SELECTOR = ":scope > svg";
+const INJECTED_BTN_SELECTOR = ":scope > .zd-enlarge-btn";
 const BTN_INJECTED_ATTR = "data-mermaid-enlarge-ready";
 
 const ZOOM_STEP = 1.25;
@@ -82,7 +83,16 @@ export function MermaidEnlarge() {
     let mutationObserver: MutationObserver | null = null;
 
     function injectButton(container: HTMLElement) {
-      if (container.hasAttribute(BTN_INJECTED_ATTR)) return;
+      // Gate on the button actually being in the DOM, not on the ready
+      // attribute alone (zudolab/zudo-doc#3132). The mermaid init script's
+      // re-render path restores each diagram from its cached source with
+      // `el.textContent = src`, which deletes every child of the container —
+      // including this injected button — while leaving the attribute and the
+      // `.zd-mermaid-enlargeable` class untouched. An attribute-only guard
+      // therefore made the button unrecoverable after the first theme/token
+      // re-render (which fires on a full page load as soon as the design-token
+      // panel re-applies persisted overrides to `:root`).
+      if (container.querySelector(INJECTED_BTN_SELECTOR) !== null) return;
       const rendered =
         container.hasAttribute("data-mermaid-rendered") ||
         container.querySelector(DIAGRAM_SVG_SELECTOR) !== null;

--- a/src/__tests__/content-fragment-links.test.ts
+++ b/src/__tests__/content-fragment-links.test.ts
@@ -108,7 +108,11 @@ describe("repository content fragment links", () => {
     for (const source of files) {
       const body = readFileSync(source, "utf8");
       const withoutCode = withoutFencedCode(body);
-      const links = withoutCode.matchAll(/\]\(([^)\s]+#[^)\s]+)(?:\s+[^)]*)?\)/g);
+      // The path part is `*`, not `+`: a bare same-page fragment (`](#anchor)`)
+      // has nothing before the `#`, and `resolveContentTarget` maps that empty
+      // path back to the source file. Requiring a path here silently exempted
+      // every same-page anchor from this guard (zudolab/zudo-doc#3131).
+      const links = withoutCode.matchAll(/\]\(([^)\s]*#[^)\s]+)(?:\s+[^)]*)?\)/g);
 
       for (const match of links) {
         const href = match[1]!;

--- a/src/content/docs-ja/reference/design-token-panel.mdx
+++ b/src/content/docs-ja/reference/design-token-panel.mdx
@@ -25,7 +25,7 @@ export default defineConfig(
 
 <Note>
 
-設定フィールドは `designTokenPanel` です。`true` に設定するとパネルが有効になります。ホスト側の設定ファイルは不要です — `designTokenPanelConfigModule` で独自のビルダーを指定しない限り、パネルはパッケージのデフォルトビルダー（`@takazudo/zudo-doc/design-token-panel-config`）を使用します（詳しくは下記の[パネルのカスタマイズ](#パネルのカスタマイズ)を参照）。
+設定フィールドは `designTokenPanel` です。`true` に設定するとパネルが有効になります。ホスト側の設定ファイルは不要です — `designTokenPanelConfigModule` で独自のビルダーを指定しない限り、パネルはパッケージのデフォルトビルダー（`@takazudo/zudo-doc/design-token-panel-config`）を使用します（詳しくは下記の[パネルのカスタマイズ](#パネルを有効にする-パネルのカスタマイズ)を参照）。
 
 </Note>
 

--- a/src/content/docs/reference/design-token-panel.mdx
+++ b/src/content/docs/reference/design-token-panel.mdx
@@ -25,7 +25,7 @@ When enabled, a palette icon appears in the header (to the left of the search ic
 
 <Note>
 
-The config field is `designTokenPanel` — set it to `true` to enable the panel. No host config file is required: the panel uses the package-default builder (`@takazudo/zudo-doc/design-token-panel-config`), derived from the shipped token manifest and the bundled color schemes, unless you point `designTokenPanelConfigModule` at your own (see [Customizing the panel](#customizing-the-panel) below).
+The config field is `designTokenPanel` — set it to `true` to enable the panel. No host config file is required: the panel uses the package-default builder (`@takazudo/zudo-doc/design-token-panel-config`), derived from the shipped token manifest and the bundled color schemes, unless you point `designTokenPanelConfigModule` at your own (see [Customizing the panel](#enabling-the-panel-customizing-the-panel) below).
 
 </Note>
 


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3132
    - https://github.com/zudolab/zudo-doc/issues/3131

---

## Summary

Two independent bugs, worked in parallel worktrees and merged into this base branch.

### topic `mermaid-enlarge` — #3132 (real code bug, fixed)

The Mermaid enlarge/fullscreen affordance vanished after a full browser reload.

**Root cause.** `MermaidEnlarge` injects `.zd-enlarge-btn` as a DOM child of each mermaid container. The mermaid init script's re-render path restores each diagram with `el.textContent = src`, which deletes **every** child — the injected button included — while leaving attributes and classes intact. The guard was `container.hasAttribute("data-mermaid-enlarge-ready")`, and that attribute survives the wipe, so the button was never re-injected. The visible border is `:has(.zd-enlarge-btn)`, so the box disappeared with it.

**Why reload differed from first view.** The re-render is gated on a real theme/token change to `:root`. On a full load, the design-token-panel bootstrap re-applies persisted overrides — a genuine change — so the gate opens and the wipe lands ~300ms in. On client-side nav the containers arrive fresh and the gate no-ops. The guard was the bug: *any* post-first-paint theme change (theme toggle, token edit, theme-pack switch) destroyed the button the same way.

**Fix.** One guard line — gate on `:scope > .zd-enlarge-btn` actually being present rather than on the marker attribute. Each wipe is itself a mutation in the island's observed scope, so the next scan re-injects.

### topic `linkwarn-asymmetry` — #3131 (**not** the reported bug — content difference + a guard hole)

The report described 4 broken-link warnings on an EN page vs 0 on its JA counterpart, and suspected locale-conditional anchor handling in zudo-doc.

**That asymmetry does not reproduce, and there is no locale-conditional code.** A control probe produced 16 EN / 16 JA warnings — perfectly symmetric. `headingIds: hierarchical` and `linkValidation` are configured once for all collections, the slug allocator takes no locale input, and there is no anchor-migration shim or client-side scroll fallback.

What was actually wrong was **1-vs-1, not 4-vs-0**: a single leaf-slug bare anchor existed in `reference/design-token-panel.mdx`, in **both** locales, genuinely dead in the emitted HTML. It shipped silently because it sits inside a `<Note>` block, and zfb's link validation does not descend into MDX JSX / container-directive children (filed upstream as Takazudo/zudo-front-builder#2184).

It also exposed a hole in this repo's own guard: `content-fragment-links.test.ts` matched `/\]\(([^)\s]+#[^)\s]+)/` — requiring at least one character before the `#`, so **bare same-page anchors never matched** and every same-page fragment in the corpus was silently exempt. Changed `+` → `*`. Because it is a raw-text scan, it also covers the `<Note>` / `:::note` contexts zfb's validator skips.

## Changes

| file | what |
|---|---|
| `packages/zudo-doc/src/mermaid-enlarge/index.tsx` | guard on button presence, not the marker attribute |
| `packages/zudo-doc/src/mermaid-enlarge/__tests__/mermaid-enlarge-button-injection.test.tsx` | new — 5 cases replaying render → reinit → re-render |
| `src/__tests__/content-fragment-links.test.ts` | widen matcher to cover bare same-page fragments |
| `src/content/docs/reference/design-token-panel.mdx` | leaf slug → hierarchical id |
| `src/content/docs-ja/reference/design-token-panel.mdx` | same, per the bilingual rule |

## Verification

- `pnpm check` clean; root unit 865 passed, package suites 2421 passed
- `pnpm build` exit 0, 419 pages, **0 broken-link warnings**
- Both regression tests confirmed to actually fail when their fix is reverted
- **Browser-verified** against a production build (the unit tests are happy-dom only): after a full reload, container count == `.zd-enlarge-btn` count (4/4); after forcing a `:root` token change, the pre-trigger buttons and SVGs were all destroyed and 4 fresh buttons re-injected — direct proof the wipe fires and recovery works. Enlarge dialog opens with a cloned SVG. No console errors.

## Known issue found but deliberately not fixed here

#3134 — the EN `/docs/reference/design-token-panel/` page renders its entire body as a `<pre data-zfb-content-fallback>` blob while JA renders normally. Reproduced independently. Left open (`needs-decision`) because it is not root-caused — the two sources' brace constructs are identical — and a speculative fix would mask the real defect.
