### PR TITLE
fix(theme): preserve the active theme-pack stylesheet across SPA soft navigations

### DIFF
--- a/e2e/theme-pack-spa-nav-flash.spec.ts
+++ b/e2e/theme-pack-spa-nav-flash.spec.ts
@@ -1,0 +1,204 @@
+import type { Page } from "@playwright/test";
+import { test, expect } from "./fixtures";
+import { spaClick } from "./nav-helpers";
+import {
+  THEME_PACK_LINK_SELECTOR,
+  THEME_PACK_LINK_LOADING_SELECTOR,
+  closeFlyout,
+  nextPackButton,
+  openFlyout,
+  waitForActivePack,
+} from "./theme-pack-helpers";
+
+/**
+ * E2E regression for the theme-pack soft-nav FOUC (epic zudolab/zudo-doc#3136,
+ * confirm sub-issue #3138).
+ *
+ * Bug: on a site with a non-default active theme pack, every SPA soft
+ * navigation briefly flashed the DEFAULT zudo-doc chrome before the
+ * theme-pack look returned. Cause: zfb's ClientRouter head swap removed the
+ * runtime pack `<link>` because the incoming SSR head never carried a link
+ * with a matching href — the swap's href-match persistence rule only keeps a
+ * live head link in place when the INCOMING document already has one at the
+ * same href, so the pack link was always spliced out, then (at best)
+ * reinserted after paint by the after-swap fallback handler.
+ *
+ * Fix (`da3c9d9a5`): `buildThemePackBootstrap`
+ * (`packages/zudo-doc/src/theme/theme-pack-provider.tsx`) now also registers
+ * a `zfb:before-swap` listener that injects a matching
+ * `<link data-zd-theme-pack-css>` into `event.newDocument.head` BEFORE zfb
+ * runs the swap. The incoming document now satisfies the href-match rule, so
+ * the LIVE (already loaded, already applied) link is never removed at all —
+ * zero removal, zero refetch, zero unstyled frame. The after-swap handler
+ * remains as fallback/cleanup only.
+ *
+ * Assertion technique (mirrors `sidebar-spa-nav-flash.spec.ts`'s header
+ * comment): polling only the post-swap resting state cannot catch a flash —
+ * by the time a poll observes it, a same-frame remove-then-reinsert would
+ * already look identical to "never removed". Instead this spec proves the
+ * invariant directly across the ENTIRE swap window:
+ *   1. Stamp the live pack `<link>` with a JS marker property (proves element
+ *      IDENTITY — a same-href replacement link would not carry the marker).
+ *   2. Install a `MutationObserver` on `document.head` that records every
+ *      removal of a `link[data-zd-theme-pack-css]` node, for the whole test
+ *      (not just one swap) — a remove-then-reinsert is caught even if both
+ *      happen inside the same task/frame, which rAF sampling could miss.
+ *   3. Install a second `MutationObserver` on `<html>` watching the
+ *      `data-theme-pack` attribute, recording any observed value other than
+ *      the active slug — proves the attribute is held continuously, not just
+ *      before/after.
+ * Both observers are installed ONCE, before the first navigation, and stay
+ * attached across the swap (a soft nav keeps the same `window`/`document`
+ * realm — that continuity is exactly what the bug exploited) — so the same
+ * cumulative counters cover both the forward SPA nav and the subsequent
+ * `page.goBack()` history traversal without re-arming.
+ *
+ * Routed to the `theme` fixture (port 4502, `themePackSwitcher: true`,
+ * "foundry" pinned second in the fixture's `themePacks` cycle — see
+ * `e2e/fixtures/theme/src/config/settings.ts`) via the `theme*` filename
+ * prefix (testMatch convention, see `e2e/CLAUDE.md`).
+ *
+ * Navigation pair: the theme fixture ships a single real doc page
+ * (`/docs/getting-started`), so the SPA hop below is doc page <-> home —
+ * the same pair `theme-pack-switcher.spec.ts`'s own
+ * "persists across an SPA navigation" test already relies on. The doc page's
+ * breadcrumb renders a `href="/"` Home crumb (`packages/zudo-doc/src/breadcrumb`),
+ * which is what `spaClick` clicks here.
+ */
+
+const DOC_PAGE = "/docs/getting-started";
+const HOME = "/";
+
+test.describe("Theme-pack SPA-nav flash (#3136 / #3138)", () => {
+  test("the active pack's stylesheet link is never removed across an SPA navigation or a history traversal", async ({
+    page,
+  }) => {
+    await page.goto(DOC_PAGE, { waitUntil: "load" });
+    await openFlyout(page);
+    await nextPackButton(page).click();
+    await waitForActivePack(page, "foundry");
+    await closeFlyout(page);
+
+    // Precondition: the zero-flash guarantee assumes a committed link
+    // already exists — start from a clean, settled state (no in-flight
+    // loading-variant link left over from the switch).
+    await expect(page.locator(THEME_PACK_LINK_SELECTOR)).toHaveCount(1);
+    await expect(page.locator(THEME_PACK_LINK_LOADING_SELECTOR)).toHaveCount(0);
+
+    // Stamp the live link's identity and arm both observers, once, before
+    // the first navigation.
+    const armed = await page.evaluate(() => {
+      const link = document.querySelector<HTMLLinkElement>(
+        "link[data-zd-theme-pack-css]",
+      );
+      if (!link) return false;
+
+      const w = window as unknown as {
+        __packLinkProbe__: {
+          originalHref: string | null;
+          linkRemovals: number;
+          badAttrSightings: string[];
+        };
+      };
+      (link as unknown as Record<string, unknown>).__zdPackLinkMarker__ = true;
+      w.__packLinkProbe__ = {
+        originalHref: link.getAttribute("href"),
+        linkRemovals: 0,
+        badAttrSightings: [],
+      };
+
+      const headObserver = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+          for (const node of Array.from(mutation.removedNodes)) {
+            if (
+              node instanceof HTMLElement &&
+              node.matches("link[data-zd-theme-pack-css]")
+            ) {
+              w.__packLinkProbe__.linkRemovals += 1;
+            }
+          }
+        }
+      });
+      headObserver.observe(document.head, { childList: true });
+
+      const attrObserver = new MutationObserver(() => {
+        const value = document.documentElement.getAttribute("data-theme-pack");
+        if (value !== "foundry") {
+          w.__packLinkProbe__.badAttrSightings.push(String(value));
+        }
+      });
+      attrObserver.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ["data-theme-pack"],
+      });
+
+      return true;
+    });
+    expect(armed).toBe(true);
+
+    // Forward SPA navigation via the breadcrumb's Home link.
+    const navigatedHome = await spaClick(page, HOME);
+    expect(navigatedHome).toBe(true);
+    await waitForActivePack(page, "foundry");
+
+    await assertPackLinkNeverRemoved(page);
+
+    // History traversal (browser back) shares the exact same swap path
+    // (zfb's popstate handler runs the identical zfb:before-swap /
+    // zfb:after-swap sequence) — re-assert the same invariants without
+    // re-arming the observers, since they are still attached.
+    await page.goBack();
+    await waitForActivePack(page, "foundry");
+
+    await assertPackLinkNeverRemoved(page);
+  });
+});
+
+/**
+ * Read the cumulative probe state and assert the non-removal / identity /
+ * attribute-continuity invariants. Safe to call repeatedly across multiple
+ * navigations — the counters never reset.
+ */
+async function assertPackLinkNeverRemoved(page: Page) {
+  const probe = await page.evaluate(() => {
+    const w = window as unknown as {
+      __packLinkProbe__: {
+        originalHref: string | null;
+        linkRemovals: number;
+        badAttrSightings: string[];
+      };
+    };
+    const links = Array.from(
+      document.querySelectorAll<HTMLLinkElement>("link[data-zd-theme-pack-css]"),
+    );
+    const marked = links.filter(
+      (link) => (link as unknown as Record<string, unknown>).__zdPackLinkMarker__ === true,
+    );
+    return {
+      ...w.__packLinkProbe__,
+      linkCount: links.length,
+      markedCount: marked.length,
+      markedConnected: marked.length === 1 ? marked[0]!.isConnected : false,
+      markedHref: marked.length === 1 ? marked[0]!.getAttribute("href") : null,
+    };
+  });
+
+  // The head MutationObserver never saw the pack link removed — not even
+  // transiently within the same swap.
+  expect(probe.linkRemovals).toBe(0);
+
+  // Exactly one pack-link node exists, and it is THE SAME element that was
+  // marked before the navigation (identity, not just a same-href
+  // replacement) — still connected, with its href unchanged.
+  expect(probe.linkCount).toBe(1);
+  expect(probe.markedCount).toBe(1);
+  expect(probe.markedConnected).toBe(true);
+  expect(probe.markedHref).toBe(probe.originalHref);
+
+  // The <html data-theme-pack> attribute was never observed at any value
+  // other than the active slug across the whole swap window.
+  expect(probe.badAttrSightings).toEqual([]);
+
+  // No loading-variant link left dangling either.
+  await expect(page.locator(THEME_PACK_LINK_LOADING_SELECTOR)).toHaveCount(0);
+}

--- a/e2e/theme-pack-spa-nav-flash.spec.ts
+++ b/e2e/theme-pack-spa-nav-flash.spec.ts
@@ -44,9 +44,14 @@ import {
  *      (not just one swap) — a remove-then-reinsert is caught even if both
  *      happen inside the same task/frame, which rAF sampling could miss.
  *   3. Install a second `MutationObserver` on `<html>` watching the
- *      `data-theme-pack` attribute, recording any observed value other than
- *      the active slug — proves the attribute is held continuously, not just
- *      before/after.
+ *      `data-theme-pack` attribute with `attributeOldValue: true`. Consecutive
+ *      synchronous mutations of the same attribute (e.g. a preserve-then-
+ *      reapply pair) are delivered as multiple records in the SAME callback
+ *      invocation, so reading only the live attribute value at callback time
+ *      would see nothing but the already-settled final value — the callback
+ *      instead reconstructs the value that held immediately after EACH
+ *      record (the next record's `oldValue`, or the live value for the last
+ *      record) and flags any of them that isn't the active slug.
  * Both observers are installed ONCE, before the first navigation, and stay
  * attached across the swap (a soft nav keeps the same `window`/`document`
  * realm — that continuity is exactly what the bug exploited) — so the same
@@ -121,15 +126,21 @@ test.describe("Theme-pack SPA-nav flash (#3136 / #3138)", () => {
       });
       headObserver.observe(document.head, { childList: true });
 
-      const attrObserver = new MutationObserver(() => {
-        const value = document.documentElement.getAttribute("data-theme-pack");
-        if (value !== "foundry") {
-          w.__packLinkProbe__.badAttrSightings.push(String(value));
+      const attrObserver = new MutationObserver((mutations) => {
+        for (let i = 0; i < mutations.length; i++) {
+          const after =
+            i + 1 < mutations.length
+              ? (mutations[i + 1] as MutationRecord).oldValue
+              : document.documentElement.getAttribute("data-theme-pack");
+          if (after !== "foundry") {
+            w.__packLinkProbe__.badAttrSightings.push(String(after));
+          }
         }
       });
       attrObserver.observe(document.documentElement, {
         attributes: true,
         attributeFilter: ["data-theme-pack"],
+        attributeOldValue: true,
       });
 
       return true;
@@ -146,13 +157,47 @@ test.describe("Theme-pack SPA-nav flash (#3136 / #3138)", () => {
     // History traversal (browser back) shares the exact same swap path
     // (zfb's popstate handler runs the identical zfb:before-swap /
     // zfb:after-swap sequence) — re-assert the same invariants without
-    // re-arming the observers, since they are still attached.
-    await page.goBack();
+    // re-arming the head/attribute observers, since they are still attached.
+    // `page.goBack()` resolves once the history URL commits, which can be
+    // BEFORE zfb's swap has even started — and since data-theme-pack is
+    // already "foundry" here, a plain waitForActivePack would pass
+    // immediately without the swap ever running. Arm a zfb:after-swap wait
+    // first (mirrors spaClick's technique) so the assertions genuinely
+    // observe a completed back-navigation swap.
+    await waitForAfterSwap(page, () => page.goBack());
     await waitForActivePack(page, "foundry");
 
     await assertPackLinkNeverRemoved(page);
   });
 });
+
+/**
+ * Arm a one-shot `zfb:after-swap` listener, run `action` (e.g.
+ * `page.goBack()`), then wait for the swap to actually complete. Mirrors
+ * `spaClick`'s listener-then-wait shape in `nav-helpers.ts`; unlike
+ * `spaClick`, `action` is a Playwright API call rather than an in-page click,
+ * so there is no click-vs-listener race to guard against — the arm step is
+ * awaited to completion before `action` runs.
+ */
+async function waitForAfterSwap(page: Page, action: () => Promise<unknown>): Promise<void> {
+  await page.evaluate(() => {
+    (window as unknown as { __zfbBackSwapFired__?: boolean }).__zfbBackSwapFired__ = false;
+    document.addEventListener(
+      "zfb:after-swap",
+      () => {
+        (window as unknown as { __zfbBackSwapFired__?: boolean }).__zfbBackSwapFired__ = true;
+      },
+      { once: true },
+    );
+  });
+  await action();
+  await page.waitForFunction(
+    () =>
+      (window as unknown as { __zfbBackSwapFired__?: boolean }).__zfbBackSwapFired__ === true,
+    undefined,
+    { timeout: 10000 },
+  );
+}
 
 /**
  * Read the cumulative probe state and assert the non-removal / identity /

--- a/e2e/theme-pack-spa-nav-flash.spec.ts
+++ b/e2e/theme-pack-spa-nav-flash.spec.ts
@@ -43,15 +43,29 @@ import {
  *      removal of a `link[data-zd-theme-pack-css]` node, for the whole test
  *      (not just one swap) — a remove-then-reinsert is caught even if both
  *      happen inside the same task/frame, which rAF sampling could miss.
- *   3. Install a second `MutationObserver` on `<html>` watching the
- *      `data-theme-pack` attribute with `attributeOldValue: true`. Consecutive
- *      synchronous mutations of the same attribute (e.g. a preserve-then-
- *      reapply pair) are delivered as multiple records in the SAME callback
- *      invocation, so reading only the live attribute value at callback time
- *      would see nothing but the already-settled final value — the callback
- *      instead reconstructs the value that held immediately after EACH
- *      record (the next record's `oldValue`, or the live value for the last
- *      record) and flags any of them that isn't the active slug.
+ *   3. Watch `<html data-theme-pack>` for any PAINT-VISIBLE wrong value, two
+ *      ways: a `MutationObserver` that checks the settled value at each
+ *      callback, plus a `requestAnimationFrame` sampler.
+ *
+ *      Deliberately NOT asserted here: the intermediate values a single
+ *      mutation batch passes through. zfb's `swapRootAttributes`
+ *      (`@takazudo/zfb-runtime/dist/client-router/swap-functions.js`) strips
+ *      EVERY `<html>` attribute, applies the incoming document's, then
+ *      re-applies the `preserveHtmlAttrs` set last — all in one synchronous
+ *      function. So `data-theme-pack` provably transits
+ *      `null` -> "default" -> "foundry" on every swap (measured: all three
+ *      land in ONE observer callback, which is delivered at the microtask
+ *      checkpoint AFTER the task completes). The browser cannot paint
+ *      mid-task, so those intermediates are unobservable to a user — a
+ *      per-record reconstruction would fail on correct code.
+ *
+ *      This is why the link and the attribute need DIFFERENT techniques. A
+ *      same-task remove-then-reinsert of the `<link>` is a real flash: the
+ *      reinserted stylesheet is non-blocking and applies asynchronously, so
+ *      a frame paints unstyled. A same-task attribute churn is not: style
+ *      resolution at paint time reads only the final value. Hence removal
+ *      counting + identity for the link (step 2), settled/frame sampling for
+ *      the attribute.
  * Both observers are installed ONCE, before the first navigation, and stay
  * attached across the swap (a soft nav keeps the same `window`/`document`
  * realm — that continuity is exactly what the bug exploited) — so the same
@@ -102,14 +116,18 @@ test.describe("Theme-pack SPA-nav flash (#3136 / #3138)", () => {
         __packLinkProbe__: {
           originalHref: string | null;
           linkRemovals: number;
-          badAttrSightings: string[];
+          badSettledAttrs: string[];
+          badFrameAttrs: string[];
+          framesSampled: number;
         };
       };
       (link as unknown as Record<string, unknown>).__zdPackLinkMarker__ = true;
       w.__packLinkProbe__ = {
         originalHref: link.getAttribute("href"),
         linkRemovals: 0,
-        badAttrSightings: [],
+        badSettledAttrs: [],
+        badFrameAttrs: [],
+        framesSampled: 0,
       };
 
       const headObserver = new MutationObserver((mutations) => {
@@ -126,22 +144,33 @@ test.describe("Theme-pack SPA-nav flash (#3136 / #3138)", () => {
       });
       headObserver.observe(document.head, { childList: true });
 
-      const attrObserver = new MutationObserver((mutations) => {
-        for (let i = 0; i < mutations.length; i++) {
-          const after =
-            i + 1 < mutations.length
-              ? (mutations[i + 1] as MutationRecord).oldValue
-              : document.documentElement.getAttribute("data-theme-pack");
-          if (after !== "foundry") {
-            w.__packLinkProbe__.badAttrSightings.push(String(after));
-          }
+      // Callbacks fire at the microtask checkpoint, after the mutating task
+      // has run to completion — so the value read here is the one the next
+      // paint will use. A batch that SETTLES on the wrong value is a real
+      // flash and is caught; intermediates within a batch are not (see the
+      // header comment).
+      const attrObserver = new MutationObserver(() => {
+        const settled = document.documentElement.getAttribute("data-theme-pack");
+        if (settled !== "foundry") {
+          w.__packLinkProbe__.badSettledAttrs.push(String(settled));
         }
       });
       attrObserver.observe(document.documentElement, {
         attributes: true,
         attributeFilter: ["data-theme-pack"],
-        attributeOldValue: true,
       });
+
+      // Direct paint-level evidence: sample at every rendering opportunity
+      // for the rest of the test. Runs across both navigations.
+      const sampleFrame = () => {
+        w.__packLinkProbe__.framesSampled += 1;
+        const value = document.documentElement.getAttribute("data-theme-pack");
+        if (value !== "foundry") {
+          w.__packLinkProbe__.badFrameAttrs.push(String(value));
+        }
+        requestAnimationFrame(sampleFrame);
+      };
+      requestAnimationFrame(sampleFrame);
 
       return true;
     });
@@ -210,7 +239,9 @@ async function assertPackLinkNeverRemoved(page: Page) {
       __packLinkProbe__: {
         originalHref: string | null;
         linkRemovals: number;
-        badAttrSightings: string[];
+        badSettledAttrs: string[];
+        badFrameAttrs: string[];
+        framesSampled: number;
       };
     };
     const links = Array.from(
@@ -240,9 +271,13 @@ async function assertPackLinkNeverRemoved(page: Page) {
   expect(probe.markedConnected).toBe(true);
   expect(probe.markedHref).toBe(probe.originalHref);
 
-  // The <html data-theme-pack> attribute was never observed at any value
-  // other than the active slug across the whole swap window.
-  expect(probe.badAttrSightings).toEqual([]);
+  // The <html data-theme-pack> attribute never SETTLED on, nor was ever
+  // painted at, any value other than the active slug across the whole swap
+  // window. The frame count guards against a vacuous pass (an rAF sampler
+  // that never ran would report no bad frames either).
+  expect(probe.badSettledAttrs).toEqual([]);
+  expect(probe.badFrameAttrs).toEqual([]);
+  expect(probe.framesSampled).toBeGreaterThan(0);
 
   // No loading-variant link left dangling either.
   await expect(page.locator(THEME_PACK_LINK_LOADING_SELECTOR)).toHaveCount(0);

--- a/packages/zudo-doc/docs/adr/theme-packs.md
+++ b/packages/zudo-doc/docs/adr/theme-packs.md
@@ -222,7 +222,8 @@ IMMEDIATELY AFTER `<ColorSchemeProvider …/>`, and emits in order:
        document.write('<link rel="stylesheet" data-zd-theme-pack-css href="'
          + base + 'theme-packs/' + slug + '/pack.css?v=' + packs[slug] + '">');
      }
-     document.addEventListener(AFTER_NAVIGATE_EVENT, /* re-apply, see SPA below */);
+     document.addEventListener(BEFORE_SWAP_EVENT, /* pre-swap injection, PRIMARY — see SPA below */);
+     document.addEventListener(AFTER_NAVIGATE_EVENT, /* re-apply, FALLBACK/cleanup — see SPA below */);
    })();
    ```
 
@@ -292,11 +293,32 @@ fallback `"default"`), `subscribeThemePackChanged(listener): () => void` —
 mirroring `color-scheme-sync.ts`'s shapes so two mounted switcher surfaces
 stay in sync.
 
-**SPA navigation:** the bootstrap's `AFTER_NAVIGATE_EVENT` handler
-(`src/transitions/page-events.ts` constant, same as the color-mode
-bootstrap) re-resolves the slug from localStorage (validated) and re-asserts
-both the html attribute and — if the link is missing after a head swap —
-re-inserts it via `appendChild`. Idempotent when nothing changed.
+**SPA navigation (fix for zudolab/zudo-doc#3136, sub-issue #3137):** the
+PRIMARY persistence mechanism is a `BEFORE_SWAP_EVENT` (`"zfb:before-swap"`,
+`src/transitions/page-events.ts` constant) listener. zfb's client-router
+dispatches this event with a mutable `event.newDocument` BEFORE running
+`swapHeadElements`, whose persistence rule keeps a live head
+`link[rel=stylesheet]` in place only when the INCOMING document's head
+already contains a stylesheet link with the exact same `href` — otherwise the
+live link is removed. Because the incoming SSR head never carries the runtime
+pack link, without this handler every soft navigation on a non-default pack
+dropped the link, and the subsequent `appendChild` re-insertion (below)
+applied the stylesheet non-blocking and asynchronously — a real, visible
+flash of the default look before it applied. The before-swap handler closes
+that gap: it re-resolves the active slug and, for a non-default pack whose
+href is not already present in `event.newDocument.head`, injects a matching
+`<link data-zd-theme-pack-css>` into `event.newDocument.head` (via
+`createElement`/`appendChild` on `newDocument`, never on `document`). zfb's
+href-match then treats the LIVE link as persisted — it never leaves the head,
+so there is no removal, no refetch, and no unstyled frame.
+
+The `AFTER_NAVIGATE_EVENT` handler is now FALLBACK/cleanup: it re-resolves the
+slug from localStorage (validated) and re-asserts both the html attribute
+and — if the link is somehow still missing after the swap — re-inserts it via
+`appendChild`; it also removes stale/wrong-slug links and handles the
+`default`-slug case (which the before-swap handler intentionally skips, since
+there is nothing to persist for the stock look). Idempotent when nothing
+changed.
 
 **Ordering note (MUST-verify in #2822):** the runtime-inserted link is
 appended to head end, hence after the main bundle stylesheet; the

--- a/packages/zudo-doc/src/theme/__tests__/theme-pack-provider.test.tsx
+++ b/packages/zudo-doc/src/theme/__tests__/theme-pack-provider.test.tsx
@@ -22,7 +22,7 @@ import ThemePackProvider, {
   resolveThemePackSsrSlug,
   themePackVersionMap,
 } from "../theme-pack-provider.js";
-import { AFTER_NAVIGATE_EVENT } from "../../transitions/page-events.js";
+import { AFTER_NAVIGATE_EVENT, BEFORE_SWAP_EVENT } from "../../transitions/page-events.js";
 import {
   THEME_PACK_ATTR,
   THEME_PACK_LINK_ATTR,
@@ -61,13 +61,39 @@ class FakeBootstrapHead {
     if (idx >= 0) this.children.splice(idx, 1);
     el.parentNode = null;
   }
+  // Only "link" is exercised by the before-swap handler — it queries all
+  // links then filters by rel/href itself (see production code comment on
+  // NOT interpolating href into a selector).
+  querySelectorAll(selector: string): FakeBootstrapLink[] {
+    if (selector === "link") return [...this.children];
+    throw new Error(`unexpected selector "${selector}"`);
+  }
 }
+
+// Stand-in for the `newDocument` zfb's `zfb:before-swap` event carries — a
+// SEPARATE (not-yet-live) document-like object with its own `head` and
+// `createElement`, distinct from the live `document` fake above.
+class FakeNewDocument {
+  head: FakeBootstrapHead;
+  constructor(initialLinks: FakeBootstrapLink[] = []) {
+    this.head = new FakeBootstrapHead();
+    for (const link of initialLinks) this.head.appendChild(link);
+  }
+  createElement(_tag: string): FakeBootstrapLink {
+    return new FakeBootstrapLink();
+  }
+}
+
+// The before-swap handler receives a real event with a `newDocument` field;
+// every other handler in this file (after-navigate) is fired with no
+// argument, so the shared listener signature makes it optional.
+type BootstrapEventHandler = (event?: { newDocument?: unknown }) => void;
 
 interface BootstrapEnv {
   document: {
     documentElement: { getAttribute(n: string): string | null };
     write: ReturnType<typeof vi.fn>;
-    addEventListener: (type: string, handler: () => void) => void;
+    addEventListener: (type: string, handler: BootstrapEventHandler) => void;
     createElement: (tag: string) => FakeBootstrapLink;
     querySelectorAll: (selector: string) => FakeBootstrapLink[];
     head: FakeBootstrapHead;
@@ -75,14 +101,15 @@ interface BootstrapEnv {
   window: Record<string, unknown>;
   attr: (name: string) => string | null;
   head: FakeBootstrapHead;
-  listeners: Map<string, Array<() => void>>;
+  listeners: Map<string, BootstrapEventHandler[]>;
   fireAfterNavigate: () => void;
+  fireBeforeSwap: (newDocument: unknown) => void;
 }
 
 function makeBootstrapEnv(stored: string | null, storageThrows = false): BootstrapEnv {
   const attrs = new Map<string, string>();
   const head = new FakeBootstrapHead();
-  const listeners = new Map<string, Array<() => void>>();
+  const listeners = new Map<string, BootstrapEventHandler[]>();
   const doc: BootstrapEnv["document"] = {
     documentElement: {
       getAttribute: (n: string) => attrs.get(n) ?? null,
@@ -121,6 +148,11 @@ function makeBootstrapEnv(stored: string | null, storageThrows = false): Bootstr
     listeners,
     fireAfterNavigate: () => {
       for (const handler of listeners.get(AFTER_NAVIGATE_EVENT) ?? []) handler();
+    },
+    fireBeforeSwap: (newDocument: unknown) => {
+      for (const handler of listeners.get(BEFORE_SWAP_EVENT) ?? []) {
+        handler({ newDocument });
+      }
     },
     // Stashed so runBootstrap can reach it.
     ...({ __storage: localStorageFake } as object),
@@ -284,6 +316,97 @@ describe("buildThemePackBootstrap (executed)", () => {
       expect(env.head.children).toHaveLength(0);
       expect(env.attr(THEME_PACK_ATTR)).toBe("default");
     });
+  });
+
+  describe("BEFORE_SWAP injection handler (primary SPA soft-nav persistence, #3137)", () => {
+    it("registers exactly one listener on the zfb before-swap event, alongside the after-swap one", () => {
+      const env = makeBootstrapEnv(null);
+      runBootstrap(buildThemePackBootstrap("default", ENABLED, "/"), env);
+      expect(env.listeners.get(BEFORE_SWAP_EVENT)).toHaveLength(1);
+      expect(env.listeners.get(AFTER_NAVIGATE_EVENT)).toHaveLength(1);
+    });
+
+    it("injects a matching link into newDocument.head for a CONFIGURED pack with EMPTY localStorage", () => {
+      // The scaffolded fixed-theme-site path the bug report is about: no
+      // switcher, no stored preference — just settings.themePack != "default".
+      const env = makeBootstrapEnv(null);
+      runBootstrap(buildThemePackBootstrap("foundry", ENABLED, "/"), env);
+      expect(env.document.write).toHaveBeenCalledTimes(1);
+
+      const newDoc = new FakeNewDocument();
+      env.fireBeforeSwap(newDoc);
+
+      expect(newDoc.head.children).toHaveLength(1);
+      const link = newDoc.head.children[0]!;
+      expect(link.getAttribute("rel")).toBe("stylesheet");
+      expect(link.hasAttribute(THEME_PACK_LINK_ATTR)).toBe(true);
+      expect(link.getAttribute("href")).toBe("/theme-packs/foundry/pack.css?v=1.2.3");
+    });
+
+    it("does nothing when the resolved slug is default (stock look has no pack.css)", () => {
+      const env = makeBootstrapEnv(null);
+      runBootstrap(buildThemePackBootstrap("default", ENABLED, "/"), env);
+
+      const newDoc = new FakeNewDocument();
+      env.fireBeforeSwap(newDoc);
+
+      expect(newDoc.head.children).toHaveLength(0);
+    });
+
+    it("does nothing when newDocument is the live document (defensive no-op)", () => {
+      const env = makeBootstrapEnv("foundry");
+      runBootstrap(buildThemePackBootstrap("default", ENABLED, "/"), env);
+      expect(env.head.children).toHaveLength(0);
+
+      // Fire with the SAME reference used as the shadowed `document` global.
+      // Without the `newDocument === document` guard this would append a
+      // second link straight into the LIVE head via env.document.createElement
+      // / env.head.appendChild — corrupting the live document.
+      env.fireBeforeSwap(env.document);
+
+      expect(env.head.children).toHaveLength(0);
+    });
+
+    it("does nothing when newDocument.head already has a stylesheet link with the exact href", () => {
+      const env = makeBootstrapEnv("foundry");
+      runBootstrap(buildThemePackBootstrap("default", ENABLED, "/"), env);
+
+      const existing = new FakeBootstrapLink();
+      existing.setAttribute("rel", "stylesheet");
+      existing.setAttribute("href", "/theme-packs/foundry/pack.css?v=1.2.3");
+      const newDoc = new FakeNewDocument([existing]);
+
+      env.fireBeforeSwap(newDoc);
+
+      expect(newDoc.head.children).toEqual([existing]);
+    });
+
+    it("does NOT count a rel=preload link with the same href as present — a stylesheet link is still injected", () => {
+      const env = makeBootstrapEnv("foundry");
+      runBootstrap(buildThemePackBootstrap("default", ENABLED, "/"), env);
+
+      const preload = new FakeBootstrapLink();
+      preload.setAttribute("rel", "preload");
+      preload.setAttribute("href", "/theme-packs/foundry/pack.css?v=1.2.3");
+      const newDoc = new FakeNewDocument([preload]);
+
+      env.fireBeforeSwap(newDoc);
+
+      expect(newDoc.head.children).toHaveLength(2);
+      const injected = newDoc.head.children.find((l) => l !== preload)!;
+      expect(injected.getAttribute("rel")).toBe("stylesheet");
+      expect(injected.hasAttribute(THEME_PACK_LINK_ATTR)).toBe(true);
+      expect(injected.getAttribute("href")).toBe("/theme-packs/foundry/pack.css?v=1.2.3");
+    });
+  });
+
+  it("emits identical script text across repeated calls with the same arguments (build-static contract)", () => {
+    // zfb's scriptsAlreadyRan dedupe is keyed on textContent — the bootstrap
+    // must be a pure function of its inputs so every page's inline script is
+    // byte-identical and the handlers are never double-registered.
+    expect(buildThemePackBootstrap("foundry", ENABLED, "/")).toBe(
+      buildThemePackBootstrap("foundry", ENABLED, "/"),
+    );
   });
 });
 

--- a/packages/zudo-doc/src/theme/theme-pack-provider.tsx
+++ b/packages/zudo-doc/src/theme/theme-pack-provider.tsx
@@ -1,6 +1,7 @@
 // ThemePackProvider — the FOUC-safe theme-pack bootstrap, sibling of
 // `color-scheme-provider.tsx` (ADR `docs/adr/theme-packs.md`, Decision 3
-// "Hard-load bootstrap"; epic Theme Core #2812, sub-issue #2822).
+// "Hard-load bootstrap"; epic Theme Core #2812, sub-issue #2822; soft-nav FOUC
+// fix zudolab/zudo-doc#3136, sub-issue #3137).
 //
 // Rendered by `head-with-defaults` IMMEDIATELY AFTER `<ColorSchemeProvider/>`.
 // Emits, in order:
@@ -21,22 +22,42 @@
 //      configured pack is `default`) so a no-JS visitor gets the configured
 //      look, matching the SSR `data-theme-pack` html attribute.
 //
-// The script also registers the AFTER_NAVIGATE re-apply handler: zfb's
-// Strategy B head swap drops the runtime pack link on every soft navigation
-// (the incoming SSR head never carries one), so the handler re-resolves the
-// slug, re-asserts the html attribute, and re-inserts the link via
-// `createElement`/`appendChild` — NEVER `document.write`, which after load
-// would clobber the document. Slug resolution is stored-first (validated) per
-// the ADR, with a validated LIVE `<html data-theme-pack>` fallback before the
-// configured default: `data-theme-pack` rides `preserveHtmlAttrs`, so when
-// persistence failed during a runtime switch (private mode / disabled
-// storage) the user's in-session pack survives soft navigations instead of
-// silently reverting (review finding). On hard load the live attribute is the
-// SSR-rendered configured slug, so the fallback is behavior-identical there.
+// SPA soft navigation (zfb Strategy B) — PRIMARY mechanism is a
+// `BEFORE_SWAP_EVENT` ("zfb:before-swap") listener. zfb dispatches this event
+// with a mutable `event.newDocument` BEFORE it runs `swapHeadElements`, whose
+// persistence rule keeps a live head `<link rel=stylesheet>` in place only
+// when the INCOMING document's head already contains a stylesheet link with
+// the exact same `href`. The incoming SSR head never carries the runtime pack
+// link, so without this handler the swap always removes it. The handler
+// re-resolves the active slug and, for a non-default pack whose href is not
+// already present in `event.newDocument.head`, injects a matching
+// `<link data-zd-theme-pack-css>` into `event.newDocument.head` via
+// `createElement`/`appendChild` (mutating `newDocument`, never `document` —
+// at this point `newDocument` is a separate, not-yet-live document). zfb's
+// href-match then treats the LIVE link as persisted: it is spliced out of the
+// swap and simply stays in the (already loaded, already applied) live head —
+// zero removal, zero refetch, zero unstyled frame.
+//
+// The AFTER_NAVIGATE re-apply handler remains as FALLBACK / cleanup: it
+// re-resolves the slug, re-asserts the html attribute, and — only if the pack
+// link is somehow still missing after the swap (e.g. the before-swap handler
+// didn't run, or a mismatch needs correcting) — re-inserts it via
+// `createElement`/`appendChild`, and removes stale/wrong-slug links (including
+// dropping the link entirely when the resolved slug is `default`). It also
+// covers the default-pack case, which the before-swap handler intentionally
+// skips (there is nothing to persist for `default`). Neither handler EVER
+// uses `document.write` after load — that would clobber the live document.
+// Slug resolution is stored-first (validated) per the ADR, with a validated
+// LIVE `<html data-theme-pack>` fallback before the configured default:
+// `data-theme-pack` rides `preserveHtmlAttrs`, so when persistence failed
+// during a runtime switch (private mode / disabled storage) the user's
+// in-session pack survives soft navigations instead of silently reverting
+// (review finding). On hard load the live attribute is the SSR-rendered
+// configured slug, so the fallback is behavior-identical there.
 // The script's text is build-static and identical
 // on every page, so zfb's already-executed-script dedupe
 // (`scriptsAlreadyRan`, keyed on textContent) guarantees it runs exactly once
-// per hard load — the handler is never double-registered.
+// per hard load — neither handler is ever double-registered.
 //
 // Values are inlined as JSON literals (mirroring `buildColorModeBootstrap`)
 // so the script body is fully self-contained. It additionally publishes the
@@ -46,7 +67,10 @@
 // pack URLs from.
 
 import type { JSX } from "preact";
-import { AFTER_NAVIGATE_EVENT } from "../transitions/page-events.js";
+import {
+  AFTER_NAVIGATE_EVENT,
+  BEFORE_SWAP_EVENT,
+} from "../transitions/page-events.js";
 import {
   DEFAULT_THEME_PACK_SLUG,
   THEME_PACK_ATTR,
@@ -119,6 +143,7 @@ export function buildThemePackBootstrap(
   const defaultSlug = JSON.stringify(DEFAULT_THEME_PACK_SLUG);
   const runtimeGlobal = JSON.stringify(THEME_PACK_RUNTIME_GLOBAL);
   const afterNav = JSON.stringify(AFTER_NAVIGATE_EVENT);
+  const beforeSwap = JSON.stringify(BEFORE_SWAP_EVENT);
   return `(function(){
 var configured=${configured};
 var packs=${packs};
@@ -133,6 +158,20 @@ var slug=resolveSlug();
 document.documentElement.setAttribute(ATTR,slug);
 if(slug!==DEFAULT_SLUG){document.write('<link rel="stylesheet" '+LINK_ATTR+' href="'+packHref(slug)+'">');}
 window[${runtimeGlobal}]={base:base,packs:packs,configured:configured};
+document.addEventListener(${beforeSwap},function(e){
+var s=resolveSlug();
+if(s===DEFAULT_SLUG)return;
+var nd=e.newDocument;
+if(!nd||nd===document)return;
+var want=packHref(s);
+var links=nd.head.querySelectorAll("link");
+for(var i=0;i<links.length;i++){var l=links[i];if(l.getAttribute("rel")==="stylesheet"&&l.getAttribute("href")===want)return;}
+var nl=nd.createElement("link");
+nl.setAttribute("rel","stylesheet");
+nl.setAttribute(LINK_ATTR,"");
+nl.setAttribute("href",want);
+nd.head.appendChild(nl);
+});
 document.addEventListener(${afterNav},function(){
 var s=resolveSlug();
 document.documentElement.setAttribute(ATTR,s);

--- a/packages/zudo-doc/src/transitions/page-events.ts
+++ b/packages/zudo-doc/src/transitions/page-events.ts
@@ -62,6 +62,24 @@ export const BEFORE_NAVIGATE_EVENT = "zfb:before-preparation";
 export const AFTER_NAVIGATE_EVENT = "zfb:after-swap";
 
 /**
+ * Event name fired just BEFORE the new page's `<body>` (and `<head>`) are
+ * swapped into the live document. Today resolves to `"zfb:before-swap"` —
+ * dispatched by zfb's client-router with a mutable `event.newDocument`
+ * carrying the incoming document that is about to replace the live one
+ * (zudolab/zudo-doc#3136 / #3137). Consumers that need to influence the
+ * incoming document BEFORE zfb's head-swap persistence logic runs (e.g.
+ * injecting a `<link>` so an href-matching stylesheet survives the swap
+ * instead of being removed and re-fetched) must mutate `event.newDocument`
+ * synchronously from a handler registered on this event — by the time
+ * `AFTER_NAVIGATE_EVENT` fires the swap has already completed. This module
+ * does not export a subscribe helper for it (unlike `onBeforeNavigate` /
+ * `onAfterNavigate`) because the one current consumer
+ * (`theme-pack-provider.tsx`) needs the raw event object's `newDocument`,
+ * not just a bare notification.
+ */
+export const BEFORE_SWAP_EVENT = "zfb:before-swap";
+
+/**
  * Subscribe to "navigation start" — runs `handler` each time the user
  * navigates away from the current page. zfb's `<ClientRouter />`
  * intercepts same-origin link clicks and dispatches


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3136

---

## Summary

On a site with a non-default active theme pack, every SPA soft navigation briefly flashed the **default** zudo-doc chrome (near-black header/sidebar from the stock `theme.css` tokens) before the theme-pack look returned. Reported from a downstream project scaffolded with a fixed theme pack (`themePack: "<slug>"`, no switcher), and reproducible on any theme-pack-active page.

Hard loads were already FOUC-safe — `buildThemePackBootstrap` `document.write`s a render-blocking pack `<link>` pre-paint. Soft navigations were not: zfb's `swapHeadElements` keeps a live head stylesheet only when the **incoming** document's head carries a link with the same `href`. The runtime pack link never exists in the incoming SSR head, so the swap removed it; the `zfb:after-swap` re-insert ran post-swap and, being non-blocking, applied asynchronously — missing the next paint.

Fix is package-side only (no zfb change, no scaffolder change).

## Changes

**Wave 1 — the fix (#3137)**

- `theme-pack-provider.tsx`: `buildThemePackBootstrap` now also registers a `zfb:before-swap` listener that injects a matching `<link rel="stylesheet" data-zd-theme-pack-css>` into `event.newDocument.head` when the resolved active slug is non-default. zfb's exact-href persistence then keeps the **live, already-loaded** link in place — zero removal, zero refetch, zero unthemed frame. Guards: default slug, missing/live `newDocument`, and an href already present (matched by iterating candidate links and comparing `getAttribute("href")`, so `rel="preload"` doesn't count and no href is interpolated into a selector).
- `transitions/page-events.ts`: added `BEFORE_SWAP_EVENT`. Deliberately **not** re-exported from `transitions/index.ts` — that is the frozen 1.0 public surface.
- The `zfb:after-swap` handler is unchanged and demoted to fallback/cleanup (it still owns the default-slug link removal and mismatch correction).
- Provider unit suite extended: injection shape and exact href including `?v=`, every no-op guard, the `configuredSlug: "foundry"` + empty-localStorage case (the scaffolded fixed-theme path the bug was reported from), and a build-static determinism check so zfb's `scriptsAlreadyRan` textContent dedupe keeps the run-once-per-hard-load contract.
- ADR `theme-packs.md` Decision 3 updated: before-swap injection is primary, after-swap is fallback.

**Wave 2 — the regression guard (#3138)**

- New `e2e/theme-pack-spa-nav-flash.spec.ts` (theme fixture): proves the active pack link is never removed across an SPA soft navigation **or** a `page.goBack()` history traversal, via element identity + a `document.head` MutationObserver rather than end-state polling.

## Verification

- `pnpm b4push` — all 24 checks pass.
- Theme e2e suite — 25/25 pass.
- **Negative control**: with the `zfb:before-swap` listener neutered (package **and** fixture rebuilt), the new spec fails with `linkRemovals: 1` — the guard demonstrably catches the reported bug rather than passing vacuously.
- Codex review: clean, no findings.

One assertion in the Wave-2 spec was corrected during verification (`86150975e`). Its `<html data-theme-pack>` observer reconstructed the value after each `MutationRecord`; zfb's `swapRootAttributes` strips every `<html>` attribute, applies the incoming document's, then re-applies the `preserveHtmlAttrs` set last — all in one synchronous function — so the attribute provably transits `null → "default" → "foundry"` on every swap. Measured: all three records land in one observer callback, and rAF sampling across the swap window only ever sees `"foundry"`. The browser cannot paint mid-task, so those intermediates are unobservable and the assertion failed on correct code. It now checks the settled value per callback plus per-frame sampling, guarded by a frame count. The link observer is unchanged — for a stylesheet link a same-task remove-then-reinsert *is* a real flash, because the reinserted sheet is non-blocking.

## Downstream

The theme-pack feature is package-owned, so scaffolded projects receive this via the next `@takazudo/zudo-doc` lockstep release. No action in this PR.