### PR TITLE
fix(test): resolve package-only deps in packed-tarball slow fixtures

### DIFF
--- a/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
+++ b/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
@@ -91,6 +91,45 @@ const devServers: ChildProcess[] = [];
 // Helpers
 // ---------------------------------------------------------------------------
 
+/** Populate a packed-tarball fixture's `node_modules` with everything the build
+ *  needs EXCEPT `@takazudo/zudo-doc` itself (the caller extracts that from the
+ *  tarball).
+ *
+ *  Two source directories, in this order:
+ *
+ *  1. the workspace-root `node_modules` — the root package's own deps, plus
+ *     whatever pnpm happened to hoist there;
+ *  2. **this package's** `node_modules` — under pnpm's strict (non-hoisting)
+ *     layout a dependency declared only by `packages/zudo-doc/package.json`
+ *     lives HERE and is absent from the root entirely. `gray-matter` is the
+ *     load-bearing case: `dist/md-utils/index.js` imports it at build time, so
+ *     a root-only sweep produces `Cannot find package 'gray-matter' imported
+ *     from …/dist/md-utils/index.js` and every packed-tarball group fails
+ *     (zudolab/zudo-doc#3189).
+ *
+ *  Root wins on collision — pass 2 only fills gaps — so the resolution order a
+ *  real consumer sees is preserved. `@takazudo` is skipped in both passes; the
+ *  caller links that scope itself. */
+function linkFixtureNodeModules(nm: string): void {
+  const wsNm = join(WORKSPACE_ROOT, "node_modules");
+  const pkgNm = join(PKG_ROOT, "node_modules");
+
+  // readdirSync includes dotfiles (e.g. `.bin`) by default — unlike a bare
+  // shell glob, no `dotglob` equivalent needed here.
+  for (const entry of readdirSync(wsNm)) {
+    if (entry === "@takazudo") continue;
+    symlinkSync(join(wsNm, entry), join(nm, entry));
+  }
+
+  if (!existsSync(pkgNm)) return;
+  for (const entry of readdirSync(pkgNm)) {
+    if (entry === "@takazudo") continue;
+    // Root already provided it — keep the root copy (see "root wins" above).
+    if (existsSync(join(nm, entry))) continue;
+    symlinkSync(join(pkgNm, entry), join(nm, entry));
+  }
+}
+
 /** Create a temporary copy of the fixture, set up node_modules + pages symlinks,
  *  and write an empty `.zfb/doc-history-meta.json` seed so zfb can resolve the
  *  `#doc-history-meta` import on the first run. Returns the temp dir path.
@@ -1184,12 +1223,10 @@ function setupNoSrcFixture(fixtureSrc: string, tarballPath: string): string {
   const wsNm = join(WORKSPACE_ROOT, "node_modules");
   const nm = join(dir, "node_modules");
   mkdirSync(nm);
-  // Symlink every top-level workspace node_modules entry EXCEPT @takazudo
-  // (`.bin`, `.pnpm`, preact, zod, gray-matter, … all needed at build time).
-  for (const entry of readdirSync(wsNm)) {
-    if (entry === "@takazudo") continue;
-    symlinkSync(join(wsNm, entry), join(nm, entry));
-  }
+  // `.bin`, `.pnpm`, preact, zod, gray-matter, … all needed at build time.
+  // gray-matter comes from the PACKAGE's node_modules under pnpm, not the
+  // root — see linkFixtureNodeModules (#3189).
+  linkFixtureNodeModules(nm);
   // @takazudo: real dir; symlink every @takazudo/* EXCEPT zudo-doc.
   const scopeDir = join(nm, "@takazudo");
   mkdirSync(scopeDir);
@@ -1355,12 +1392,7 @@ function setupTargetManifestFixture(
   const wsNm = join(WORKSPACE_ROOT, "node_modules");
   const nm = join(dir, "node_modules");
   mkdirSync(nm);
-  // readdirSync includes dotfiles (e.g. `.bin`) by default — unlike a bare
-  // shell glob, no `dotglob` equivalent needed here.
-  for (const entry of readdirSync(wsNm)) {
-    if (entry === "@takazudo") continue;
-    symlinkSync(join(wsNm, entry), join(nm, entry));
-  }
+  linkFixtureNodeModules(nm);
   const scopeDir = join(nm, "@takazudo");
   mkdirSync(scopeDir);
   for (const entry of readdirSync(join(wsNm, "@takazudo"))) {


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3189
- parent PR
    - https://github.com/zudolab/zudo-doc/pull/3173

---

## Summary

Fixes the red nightly exam. Found while running `test:slow` as the manager verification pass of epic #3174; unrelated to that epic's changes and reproduced on the untouched base.

## Root cause

`setupNoSrcFixture` and `setupTargetManifestFixture` populated the fixture's `node_modules` by sweeping the **workspace-root** `node_modules` only. Under pnpm's strict, non-hoisting layout, a dependency declared solely by `packages/zudo-doc/package.json` lives in *that package's* `node_modules` and is absent from the root entirely.

`gray-matter` is exactly that case — declared by the package, imported at build time by `dist/md-utils/index.js`, and **not present at the workspace root**:

```
$ ls -d node_modules/gray-matter                  → ABSENT at root
$ ls -d packages/zudo-doc/node_modules/gray-matter → PRESENT in package
```

So every packed-tarball fixture build died with:

```
Cannot find package 'gray-matter' imported from .../dist/md-utils/index.js
❯ startZfbDev … zfb dev exited early (code 1)
```

The old code's own comment asserted the opposite (`preact, zod, gray-matter, … all needed at build time`), which is presumably why this went unnoticed — the list named gray-matter as if the root sweep covered it.

## Fix

New `linkFixtureNodeModules(nm)` helper, used by both fixture setups:

1. sweep the workspace root (unchanged behavior);
2. then fill **gaps only** from `PKG_ROOT/node_modules`.

Root wins on collision, so a real consumer's resolution order is preserved; `@takazudo` is skipped in both passes since the callers link that scope themselves.

## Verification

- `pnpm --filter @takazudo/zudo-doc test:slow` — **25 failed | 62 passed → 87 passed** (all 4 previously-broken groups green: S1 no-src, TM build+check+css, TM group 2, TM group 4)
- `pnpm --filter @takazudo/zudo-doc test` — 1739/1739 green
- `pnpm check` — no errors
- `/light-review` → `/codex-review`: "The helper correctly supplements root-level modules with package-local dependencies and is applied to both packed-tarball fixture paths. No actionable regressions were identified."

Closes #3189

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/3192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788253210&installation_model_id=20910&pr_number=3192&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F3192&signature=dddd925e141ef53a5f4166c07ab3c2a59fbb4ec96145c56bcc418f254da3aea7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->