### PR TITLE
Parity Coverage: expand A2 byte-parity fixture + site-wide parity attestation

### DIFF
--- a/packages/zudo-doc/src/__tests__/fixtures/route-injection/src/content/docs/getting-started/coverage.mdx
+++ b/packages/zudo-doc/src/__tests__/fixtures/route-injection/src/content/docs/getting-started/coverage.mdx
@@ -1,0 +1,64 @@
+---
+title: Coverage
+description: Second fixture page exercising hierarchical heading-ID collisions, GFM task lists, GFM footnotes, and directive shapes
+tier: gold
+---
+
+COVERAGE-UNIQUE-MARKER: second-content-file-render-proof
+
+This page exists to give the A2 byte-parity fixture standing coverage of
+constructs `getting-started/index.mdx` does not exercise: colliding
+hierarchical heading IDs, a GFM task list, a GFM footnote, and both a
+container and a text directive (see zudolab/zudo-doc#3179).
+
+## Overview
+
+The top-level overview section.
+
+### Details
+
+A nested section under the top-level overview, reusing the word "Details" —
+also used by the second top-level section below.
+
+#### Overview
+
+A third heading reusing the word "Overview", nested three levels deep. The
+hierarchical heading-ID allocator must still give this a distinct id from
+the top-level "Overview" heading above.
+
+### Configuration
+
+A sibling nested section under the top-level overview.
+
+## Details
+
+A second top-level section reusing the word "Details" used by the nested
+section above, at a different depth.
+
+### Overview
+
+A fourth heading reusing the word "Overview", nested one level under this
+second "Details" section.
+
+## Task List
+
+- [x] Completed fixture task
+- [ ] Pending fixture task
+
+## Footnote
+
+This sentence carries a footnote reference[^coverage-note].
+
+[^coverage-note]: This is the footnote definition, rendered at the bottom of the page.
+
+## Directives
+
+A container directive:
+
+:::note
+
+A `:::note` container directive rendered as an admonition.
+
+:::
+
+A text (inline) directive, mixed into prose: :hl[highlighted inline text] sits inline with the surrounding sentence.

--- a/packages/zudo-doc/src/__tests__/fixtures/route-injection/zfb.config.ts
+++ b/packages/zudo-doc/src/__tests__/fixtures/route-injection/zfb.config.ts
@@ -5,7 +5,8 @@
 // seam by building and asserting rendered HTML from injected routes.
 
 import { defineConfig } from "zfb/config";
-import { zudoDocPreset } from "@takazudo/zudo-doc/preset";
+import { zudoDocPreset, type DirectiveVocabulary } from "@takazudo/zudo-doc/preset";
+import { defaultDirectiveVocabulary } from "@takazudo/zudo-doc/directive-vocabulary-defaults";
 import { settings } from "./src/config/settings";
 import { z } from "zod";
 
@@ -24,7 +25,18 @@ function buildDocsSchema() {
   });
 }
 
-const directiveVocabulary = {};
+// A2 #3179 — the canonical seven container admonitions (note/tip/info/
+// warning/danger/caution/details), plus one TEXT-shape directive (`:hl[…]`)
+// that `getting-started/coverage.mdx` exercises for directive-shape
+// coverage. `mark` is a plain HTML intrinsic element — it needs no
+// component wiring (unlike the admonition names, which resolve through
+// createMdxComponents' Note/Tip/… map).
+const directiveVocabulary: DirectiveVocabulary = {
+  ...defaultDirectiveVocabulary,
+  hl: { component: "mark", kind: "text", titleFromLabel: false },
+};
+
+const preset = zudoDocPreset({ settings, buildDocsSchema, directiveVocabulary });
 
 export default defineConfig({
   framework: "preact",
@@ -32,5 +44,12 @@ export default defineConfig({
   tailwind: { enabled: true },
   base: settings.base,
   // No adapter — static output only (no SSR routes needed for this proof).
-  ...zudoDocPreset({ settings, buildDocsSchema, directiveVocabulary }),
+  ...preset,
+  markdown: {
+    ...preset.markdown,
+    // A2 #3179 — zfb's `gfm` default is conservative (strikethrough + table
+    // only); coverage.mdx's task list and footnote need the other two GFM
+    // constructs turned on explicitly.
+    gfm: { taskListItem: true, footnoteDefinition: true },
+  },
 });

--- a/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
+++ b/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
@@ -304,6 +304,66 @@ describe("A2 no-stub: injected routes render correct HTML (packageOwnedRoutes:tr
     expect(highlightedBlock).not.toMatch(/\bstyle=/);
   });
 
+  // #3179 — Case A2 fixture growth: `getting-started/coverage.mdx` is a
+  // second content file in the same fixture, exercising constructs
+  // `getting-started/index.mdx` never touched — hierarchical heading-ID
+  // collisions, a GFM task list, a GFM footnote, and both directive shapes
+  // (container + text). Standing coverage so a future zfb bump can't
+  // silently regress any of these. All four tests read the same
+  // `fixtureDir` built by the "setup" test above — no extra build needed.
+  it("coverage: /docs/getting-started/coverage/ HTML gives colliding heading texts distinct hierarchical ids", () => {
+    const html = readBuiltHtml(fixtureDir, "docs/getting-started/coverage/index.html");
+    // "Overview" appears three times (h2, h4, h3) and "Details" twice (h3, h2)
+    // at different nesting depths; headingIds: { strategy: "hierarchical" }
+    // (pinned in the preset) must still give every one of them a distinct,
+    // ancestor-prefixed id rather than falling back to a `-1`/`-2` dedup
+    // counter (which would mean the allocator treated them as flat collisions).
+    const ids = [
+      "overview",
+      "overview-details",
+      "overview-details-overview",
+      "overview-configuration",
+      "details",
+      "details-overview",
+    ];
+    for (const id of ids) {
+      expectHtmlAttr(html, "id", id);
+    }
+    expect(html).not.toContain("id=overview-1");
+    expect(html).not.toContain("id=details-1");
+  });
+
+  it("coverage: /docs/getting-started/coverage/ HTML renders a GFM task list with checked + unchecked checkboxes", () => {
+    const html = readBuiltHtml(fixtureDir, "docs/getting-started/coverage/index.html");
+    const checkboxes =
+      html
+        .match(/<input\b[^>]*>/g)
+        ?.filter((tag) => /\btype=(?:"checkbox"|'checkbox'|checkbox)(?=[\s>/])/.test(tag)) ?? [];
+    expect(checkboxes).toHaveLength(2);
+    expect(checkboxes.some((tag) => /\bchecked\b/.test(tag))).toBe(true);
+    expect(checkboxes.some((tag) => !/\bchecked\b/.test(tag))).toBe(true);
+  });
+
+  it("coverage: /docs/getting-started/coverage/ HTML renders a GFM footnote (reference + definition)", () => {
+    const html = readBuiltHtml(fixtureDir, "docs/getting-started/coverage/index.html");
+    expect(html).toContain("data-footnote-ref");
+    expectHtmlAttr(html, "href", "#user-content-fn-coverage-note");
+    expectHtmlAttr(html, "id", "user-content-fn-coverage-note");
+    expect(html).toContain("data-footnote-backref");
+  });
+
+  it("coverage: /docs/getting-started/coverage/ HTML renders both directive shapes (container admonition + inline text directive)", () => {
+    const html = readBuiltHtml(fixtureDir, "docs/getting-started/coverage/index.html");
+    // Container: `:::note` resolves through the canonical seven
+    // (`defaultDirectiveVocabulary`) to the real Admonition component.
+    expectHtmlAttr(html, "data-admonition", "note");
+    expect(html).toContain("<p class=admonition-title>Note</p>");
+    // Text: `:hl[…]` resolves to a plain `<mark>` intrinsic element
+    // (directiveVocabulary's `hl: { component: "mark", kind: "text" }`) —
+    // no component wiring needed, and it renders inline (not a block).
+    expect(html).toContain("<mark>highlighted inline text</mark>");
+  });
+
   // CB #2501 baseline: `settings.chromeBindingsModule` is unset in this
   // fixture, so `buildFrontmatterPreviewEntries` stays at its package-default
   // `() => []` stub and the FrontmatterPreview table stays absent — the
@@ -470,6 +530,37 @@ describe("A2 no-stub: injected routes render correct HTML (packageOwnedRoutes:tr
   // (as this entry and the three above did) instead.
   //
   // All of it traces to already-merged, intentional PRs; no unattributed bytes.
+  //
+  // 2026-08-02 re-baseline (zudolab/zudo-doc#3179, A2 fixture-coverage growth):
+  // a second content file, `src/content/docs/getting-started/coverage.mdx`,
+  // was added to the fixture (see the "coverage:" tests above) to give the
+  // hierarchical heading-ID allocator, GFM task lists, GFM footnotes, and
+  // both directive shapes standing build coverage. Two of the three parity
+  // hashes below move as a direct, fully-accounted-for consequence:
+  //
+  //   - `/404.html` is UNCHANGED — confirmed byte-for-byte against a clean
+  //     rebuild of the prior fixture state (pre-#3179 zfb.config.ts, no
+  //     coverage.mdx) in a separate scratch directory, per the
+  //     `dist/`-is-gitignored caveat below (NOT a `git stash` check). 404 is
+  //     nav-isolated (`routes/404.tsx` sets `hideSidebar`/`sidebarOverride`),
+  //     so a new sibling doc page cannot reach it, and doesn't.
+  //   - `/docs/getting-started/index.html` MOVES, purely from the sidebar/
+  //     pager now having a second page in the "Getting Started" category:
+  //       * the `SidebarTree` island's `data-props` JSON gains a `children`
+  //         array entry for `getting-started/coverage`
+  //       * the "Getting Started" sidebar row, previously a childless leaf
+  //         link, gains the collapse/expand toggle button + a nested
+  //         one-item children list (category-with-children markup instead
+  //         of category-without-children markup)
+  //       * the doc-pager's `nav.next` slot, previously an empty `<div></div>`,
+  //         now renders a real link to the new Coverage page
+  //     No other bytes changed — confirmed by diffing this file's HTML
+  //     against the same clean rebuild used for the `/404.html` check above.
+  //   - A brand-new third hash, `/docs/getting-started/coverage/index.html`,
+  //     is added below (see the next `it`) for the new page itself.
+  //
+  // All of it traces to this one intentional, self-contained change; no
+  // unattributed bytes.
 
   it("parity: /404.html normalized-HTML sha256 is stable (stub-defaults path)", () => {
     const html = readBuiltHtml(fixtureDir, "404.html");
@@ -478,7 +569,12 @@ describe("A2 no-stub: injected routes render correct HTML (packageOwnedRoutes:tr
 
   it("parity: /docs/getting-started/index.html normalized-HTML sha256 is stable (stub-defaults path)", () => {
     const html = readBuiltHtml(fixtureDir, "docs/getting-started/index.html");
-    expect(sha256Html(html)).toMatchInlineSnapshot(`"62e37d7a7ce1e72fca33e8b79749c2b39b99c9d30c2796602dff05cee49a338a"`);
+    expect(sha256Html(html)).toMatchInlineSnapshot(`"b2977dd1dfcc36d0fc2b2c8714fc3a10448447dea53d23effe071a22cf8235ad"`);
+  });
+
+  it("parity: /docs/getting-started/coverage/index.html normalized-HTML sha256 is stable (new page, #3179)", () => {
+    const html = readBuiltHtml(fixtureDir, "docs/getting-started/coverage/index.html");
+    expect(sha256Html(html)).toMatchInlineSnapshot(`"a679efa6beaf718e773cefc3b60006aabca4a6bd7f5628b88ae411973154ffe0"`);
   });
 });
 

--- a/packages/zudo-doc/src/preset.ts
+++ b/packages/zudo-doc/src/preset.ts
@@ -36,6 +36,9 @@
 import { z } from "zod";
 import type { ColorScheme } from "./color-scheme-utils.js";
 import type { TagVocabularyEntry } from "./settings.js";
+// Type-only — erased by esbuild before the node-builtin-free eval-graph
+// bundle runs (mirrors config.ts's `@takazudo/zfb/config` type-only import).
+import type { DirectiveSpec } from "@takazudo/zfb/config";
 
 // ---------------------------------------------------------------------------
 // Input contract — structurally typed so the preset is portable to every
@@ -150,12 +153,18 @@ export interface PresetSettings {
 
 /**
  * The directives recipe map (`markdown.features.directives`): directive name →
- * the JSX component name it resolves to (registered in the host's
- * `pages/_mdx-components.ts`). Passed in rather than hardcoded so a project can
- * register its own directives without editing the preset; the showcase passes
- * the canonical seven (note/tip/info/warning/danger/caution/details).
+ * either a bare JSX component name string (registered in the host's
+ * `pages/_mdx-components.ts`), or a full {@link DirectiveSpec} object when a
+ * project needs a non-default shape (`kind: "leaf" | "text"`) or wants to
+ * suppress `titleFromLabel`. Mirrors zfb's own `markdown.features.directives`
+ * value type 1:1 (widened from a bare-string-only map — zfb 1.1.0's
+ * `DirectiveSpec` union was already accepted by the underlying `directives`
+ * feature; this alias had just not caught up). Passed in rather than
+ * hardcoded so a project can register its own directives without editing the
+ * preset; the showcase passes the canonical seven
+ * (note/tip/info/warning/danger/caution/details), all in short form.
  */
-export type DirectiveVocabulary = Record<string, string>;
+export type DirectiveVocabulary = Record<string, DirectiveSpec>;
 
 /**
  * The UI-string translation table (`src/config/i18n.ts` `translations`).


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3178
- parent PR
    - https://github.com/zudolab/zudo-doc/pull/3173

---

## Summary

Epic #3178 of super-epic #3172. Two workstreams: **standing** parity coverage (committed here) and a **one-time** site-wide attestation (a report, no code).

## Changes

### A2 fixture expansion (#3179)

New fixture page `getting-started/coverage.mdx` exercising the constructs the A2 byte-parity fixture was blind to:

- **Colliding heading texts at different depths** — "Overview" ×3 and "Details" ×2 resolving to 6 distinct hierarchical IDs (`overview`, `overview-details`, `overview-details-overview`, `overview-configuration`, `details`, `details-overview`).
- **GFM task list** (checked + unchecked) and a **GFM footnote** (reference + definition).
- A `:::note` **container** directive and a `:hl[…]` **text** directive.

Plus **4 new standing markup assertions** rather than a one-off manual check, including negative guards (`not.toContain("id=overview-1")` / `"id=details-1"`) so a silent regression from hierarchical prefixing to a flat dedup counter fails the suite.

Snapshot bookkeeping:

- `/docs/getting-started/index.html` re-baselined `62e37d7a…` → `b2977dd1…`. The byte diff is exactly the predicted sidebar/pager delta: the `SidebarTree` island's `data-props` gains a child entry, the "Getting Started" row turns from a childless leaf into a category with a collapse toggle, and the doc-pager's previously-empty `nav.next` now links to Coverage.
- **`/404.html` did NOT move**, as the sub-issue predicted (it is nav-isolated via `hideSidebar`/`sidebarOverride`). Verified by two independent scratch-dir builds — deliberately *not* a `git stash` check, per the caveat in the test file about gitignored `dist/`.
- New third parity hash for the Coverage page.
- Dated attribution paragraph added to the in-file changelog block.

### `DirectiveVocabulary` widened

`packages/zudo-doc/src/preset.ts`: `Record<string, string>` → `Record<string, DirectiveSpec>` (type-only import from `@takazudo/zfb/config`, erased before the node-builtin-free eval-graph bundle).

zfb's underlying `directives` feature already accepted the `DirectiveSpec` union; only this alias had not caught up, so a `kind: "text"` directive could not be expressed without an `as any`. Backward compatible — the value is only ever spread into zfb's `directives`, never read value-by-value, so no consumer narrows on `string`.

### Site-wide parity attestation (#3180) — report only, no code

Full report: https://github.com/zudolab/zudo-doc/issues/3178#issuecomment-5157207606

**43 of 426 routes changed between `0.1.0-next.90` and `1.1.0`; 0 unexplained.** Every changed span attributed by *class erasure* — strip each class's markup signature from both sides and re-hash — not by eyeballing. All four active classes are next.90 defects that 1.1.0 fixes; nothing regressed.

| Class | Routes |
| --- | --- |
| A — fences nested in a container went unhighlighted | 36 |
| B — bracket-label container directives | 4 |
| D — mermaid × HTML-minifier whitespace | 4 |
| C — CJK emphasis retokenisation | 1 |
| E — hierarchical heading IDs | 0 (measured — no span touches an `id=`) |
| F — GFM footnotes / task lists | 0 on the real site |

The F zero was **vacuous** (the showcase never opts into those GFM features), so it was re-run with `gfm.taskListItem` / `footnoteDefinition` forced on: next.90 silently destroys the content — 0 checkboxes, 0 footnote refs, the whole definitions section absent — while 1.1.0 renders it. Class attested for real, not inferred from release notes.

Stated limits: class B's exact upstream parser trigger could not be recovered from build output and was deliberately not invented (class, routes, and direction are unambiguous; the mechanism is not), and its erasure proof is text-level rather than markup-level on 2 routes, with the full markup residue enumerated in the report.

## Verification

- `pnpm --filter @takazudo/zudo-doc test:slow` — 87/87 → **92/92**
- `pnpm --filter @takazudo/zudo-doc test` — 1739/1739 · `pnpm check` clean · `pnpm build:workspace` OK
- `/deep-review` → `/codex-review`: "safely widens the directive vocabulary to zfb's existing DirectiveSpec type… no actionable regressions"
- No pin/override/lockfile changes committed; `check-pin-parity.mjs` green; scratch worktree removed and both trees confirmed clean

## Follow-up raised

#3197 — 17 checklist items across 2 published showcase routes render as literal `[ ]` because `gfm.taskListItem` is off. Found during the attestation; not a parity diff (both versions render it identically wrong).

Closes #3179, closes #3180