### PR TITLE
fix(claude-resources): exclude build dirs by basename at any depth

### DIFF
--- a/packages/zudo-doc/src/plugins/internal/claude-resources/__tests__/generate.test.ts
+++ b/packages/zudo-doc/src/plugins/internal/claude-resources/__tests__/generate.test.ts
@@ -678,6 +678,164 @@ describe("generateClaudeResourcesDocs", () => {
   });
 
   // ---------------------------------------------------------------------------
+  // Depth-independent directory-name exclusions (#3200)
+  // ---------------------------------------------------------------------------
+
+  describe("depth-independent directory-name exclusions", () => {
+    const excludedNames = [
+      "node_modules",
+      "worktrees",
+      "dist",
+      "out",
+      "public",
+      "__inbox",
+      "test-results",
+    ];
+
+    it.each(excludedNames)(
+      "excludes a nested %s/ directory, not just one at the scan root",
+      (name) => {
+        fs.mkdirSync(path.join(tmpDir, "sub", name), { recursive: true });
+        fs.writeFileSync(
+          path.join(tmpDir, "sub", name, "CLAUDE.md"),
+          `# nested ${name} instructions — should be excluded`,
+        );
+
+        const result = generateClaudeResourcesDocs({
+          claudeDir,
+          projectRoot: tmpDir,
+          docsDir,
+        });
+
+        // Only root/CLAUDE.md (from the fixture).
+        expect(result.claudemd).toBe(1);
+        expect(
+          fs.existsSync(path.join(docsDir, "claude-md", `sub--${name}.mdx`)),
+        ).toBe(false);
+      },
+    );
+
+    it("still discovers a nested prefix-colliding sibling (sub/dist-extra)", () => {
+      // Name-based exclusion must be an exact basename match, not a prefix —
+      // the depth-independent form of the #2561 boundary guarantee.
+      fs.mkdirSync(path.join(tmpDir, "sub", "dist-extra"), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, "sub", "dist-extra", "CLAUDE.md"),
+        "# nested dist-extra instructions",
+      );
+
+      const result = generateClaudeResourcesDocs({
+        claudeDir,
+        projectRoot: tmpDir,
+        docsDir,
+      });
+
+      expect(result.claudemd).toBe(2);
+      const page = path.join(docsDir, "claude-md", "sub--dist-extra.mdx");
+      expect(fs.existsSync(page)).toBe(true);
+      expect(fs.readFileSync(page, "utf8")).toContain(
+        "nested dist-extra instructions",
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // scanRoot / projectRoot split (#3200)
+  // ---------------------------------------------------------------------------
+
+  describe("scanRoot / projectRoot split", () => {
+    // Layout: tmpDir is the repo root (scanRoot); siteDir is a doc site living
+    // in a repo subdirectory (the real projectRoot).
+    let siteDir: string;
+
+    beforeEach(() => {
+      siteDir = path.join(tmpDir, "site");
+      fs.mkdirSync(siteDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(siteDir, "CLAUDE.md"),
+        "# site instructions",
+      );
+    });
+
+    it("walks from scanRoot and derives relPath/slug against it", () => {
+      const result = generateClaudeResourcesDocs({
+        claudeDir,
+        projectRoot: siteDir,
+        scanRoot: tmpDir,
+        docsDir,
+      });
+
+      // tmpDir/CLAUDE.md (fixture) + site/CLAUDE.md
+      expect(result.claudemd).toBe(2);
+      const sitePage = path.join(docsDir, "claude-md", "site.mdx");
+      expect(fs.existsSync(sitePage)).toBe(true);
+      const parsed = matter(fs.readFileSync(sitePage, "utf8"));
+      expect(parsed.data.title).toBe("/site/CLAUDE.md");
+      expect(parsed.data.sidebar_label).toBe("site/CLAUDE.md");
+      expect(parsed.content).toContain("site instructions");
+    });
+
+    it("excludes the nested project's own build output", () => {
+      for (const name of ["dist", "public", "out", "test-results"]) {
+        fs.mkdirSync(path.join(siteDir, name), { recursive: true });
+        fs.writeFileSync(
+          path.join(siteDir, name, "CLAUDE.md"),
+          `# site/${name} decoy — should be excluded`,
+        );
+      }
+
+      const result = generateClaudeResourcesDocs({
+        claudeDir,
+        projectRoot: siteDir,
+        scanRoot: tmpDir,
+        docsDir,
+      });
+
+      // Root + site only — all four decoys under site/ are excluded even though
+      // they sit one level below the scan root.
+      expect(result.claudemd).toBe(2);
+    });
+
+    it("excludes e2e/fixtures under the nested project root as well as the scan root", () => {
+      for (const root of [tmpDir, siteDir]) {
+        fs.mkdirSync(path.join(root, "e2e", "fixtures"), { recursive: true });
+        fs.writeFileSync(
+          path.join(root, "e2e", "fixtures", "CLAUDE.md"),
+          "# fixture decoy — should be excluded",
+        );
+      }
+
+      const result = generateClaudeResourcesDocs({
+        claudeDir,
+        projectRoot: siteDir,
+        scanRoot: tmpDir,
+        docsDir,
+      });
+
+      expect(result.claudemd).toBe(2);
+      expect(
+        fs.existsSync(path.join(docsDir, "claude-md", "e2e--fixtures.mdx")),
+      ).toBe(false);
+      expect(
+        fs.existsSync(path.join(docsDir, "claude-md", "site--e2e--fixtures.mdx")),
+      ).toBe(false);
+    });
+
+    it("defaults scanRoot to projectRoot", () => {
+      const result = generateClaudeResourcesDocs({
+        claudeDir,
+        projectRoot: siteDir,
+        docsDir,
+      });
+
+      // Walk confined to site/ — the repo-root CLAUDE.md is never reached.
+      expect(result.claudemd).toBe(1);
+      const rootPage = path.join(docsDir, "claude-md", "root.mdx");
+      expect(fs.readFileSync(rootPage, "utf8")).toContain("site instructions");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // CLAUDE.md repo-relative link downgrade (#2411, Class B)
   // ---------------------------------------------------------------------------
 

--- a/packages/zudo-doc/src/plugins/internal/claude-resources/__tests__/index.test.ts
+++ b/packages/zudo-doc/src/plugins/internal/claude-resources/__tests__/index.test.ts
@@ -158,4 +158,37 @@ describe("runClaudeResourcesPreStep — scanRoot decoupling", () => {
       "/docs-site/CLAUDE.md",
     ]);
   });
+
+  it("(f) excludes build output of nested projects anywhere under scanRoot (#3200)", () => {
+    // The doc site's own build output. Before #3200 the exclude list was
+    // anchored at scanRoot only, so every one of these was still walked once
+    // scanRoot moved above the doc site.
+    for (const name of ["dist", "public", "out", "test-results"]) {
+      fs.mkdirSync(path.join(docsSite, name), { recursive: true });
+      fs.writeFileSync(
+        path.join(docsSite, name, "CLAUDE.md"),
+        `# docs-site/${name} decoy — should be excluded`,
+      );
+    }
+    // A sibling package's build output, two levels below the scan root.
+    fs.mkdirSync(path.join(repoRoot, "app", "dist"), { recursive: true });
+    fs.writeFileSync(
+      path.join(repoRoot, "app", "dist", "CLAUDE.md"),
+      "# app/dist decoy — should be excluded",
+    );
+
+    const counts = runClaudeResourcesPreStep({
+      claudeDir,
+      projectRoot: docsSite,
+      scanRoot: repoRoot,
+    });
+
+    // Still the same three real files — none of the five decoys leak in.
+    expect(counts.claudemd).toBe(3);
+    expect(claudeMdTitles()).toEqual([
+      "/CLAUDE.md",
+      "/app/CLAUDE.md",
+      "/docs-site/CLAUDE.md",
+    ]);
+  });
 });

--- a/packages/zudo-doc/src/plugins/internal/claude-resources/generate.ts
+++ b/packages/zudo-doc/src/plugins/internal/claude-resources/generate.ts
@@ -5,7 +5,18 @@ import { escapeForMdx } from "./escape-for-mdx.js";
 
 export interface ClaudeResourcesConfig {
   claudeDir: string;
+  /**
+   * The doc site's own root. Anchors project-specific excludes and defaults
+   * `scanRoot`. Note this does NOT itself decide where the `CLAUDE.md` walk
+   * runs — that is `scanRoot`.
+   */
   projectRoot?: string;
+  /**
+   * Root of the `CLAUDE.md` walk and the base for the generated pages'
+   * relative paths, titles, and slugs. Defaults to `projectRoot`, so a caller
+   * that sets only `projectRoot` gets the pre-`scanRoot` behaviour.
+   */
+  scanRoot?: string;
   docsDir: string;
 }
 
@@ -13,6 +24,7 @@ interface ClaudeMdItem {
   displayPath: string;
   slug: string;
   relPath: string;
+  absPath: string;
 }
 
 interface CommandItem {
@@ -210,6 +222,29 @@ function downgradeRepoRelativeLinks(content: string): string {
 // CLAUDE.md discovery
 // ---------------------------------------------------------------------------
 
+/**
+ * Directory names skipped by basename at ANY depth of the walk.
+ *
+ * These are build output, vendored trees, and tooling scratch dirs that can
+ * belong to *any* project under the scan root, not just the one at its top
+ * level. Anchoring them to the scan root (the pre-#3200 behaviour) meant a
+ * doc site in a repo subdirectory with `scanRoot` widened to the repo root
+ * still walked its own `dist/`, `public/`, `out/`, and `test-results/` on
+ * every build — the exact nested layout `scanRoot` exists for.
+ *
+ * `.git` needs no entry here: dot-prefixed entries are already skipped at any
+ * depth by the loop below.
+ */
+const EXCLUDED_DIR_NAMES = new Set([
+  "node_modules",
+  "worktrees",
+  "dist",
+  "out",
+  "public",
+  "__inbox",
+  "test-results",
+]);
+
 function findClaudeMdFiles(dir: string, excludeDirs: string[]): string[] {
   const results: string[] = [];
   if (!fs.existsSync(dir)) return results;
@@ -221,7 +256,7 @@ function findClaudeMdFiles(dir: string, excludeDirs: string[]): string[] {
   );
 
   for (const item of fs.readdirSync(dir)) {
-    if (item === "node_modules") continue;
+    if (EXCLUDED_DIR_NAMES.has(item)) continue;
     if (item.startsWith(".")) continue;
     const itemPath = path.join(dir, item);
     // Path-segment-boundary-aware: a raw startsWith(d) would also match a
@@ -255,35 +290,33 @@ function generateClaudemdDocs(
   config: ClaudeResourcesConfig,
 ): ClaudeMdItem[] {
   const projectRoot = config.projectRoot ?? config.claudeDir;
+  const scanRoot = config.scanRoot ?? projectRoot;
   const outputDir = path.join(config.docsDir, "claude-md");
 
   cleanDir(outputDir);
 
+  // Only genuinely location-specific excludes belong here — everything that is
+  // really a *name* lives in EXCLUDED_DIR_NAMES and is skipped at any depth.
+  // `e2e/fixtures` is anchored at both roots because when `scanRoot` sits above
+  // the doc site, the site's own `e2e/fixtures` is not under the scan root's.
   const excludeDirs = [
-    path.join(projectRoot, ".git"),
-    path.join(projectRoot, "node_modules"),
-    path.join(projectRoot, "worktrees"),
-    path.join(projectRoot, "dist"),
-    path.join(projectRoot, "out"),
-    path.join(projectRoot, "public"),
-    path.join(projectRoot, "__inbox"),
-    path.join(projectRoot, "test-results"),
+    path.join(scanRoot, "e2e", "fixtures"),
     path.join(projectRoot, "e2e", "fixtures"),
     path.join(config.docsDir),
   ];
 
-  const files = findClaudeMdFiles(projectRoot, excludeDirs);
+  const files = findClaudeMdFiles(scanRoot, excludeDirs);
   if (files.length === 0) return [];
 
   ensureDir(outputDir);
   const items: ClaudeMdItem[] = [];
 
   for (const filePath of files) {
-    const relPath = path.relative(projectRoot, filePath);
+    const relPath = path.relative(scanRoot, filePath);
     const displayPath = `/${relPath}`;
     const dirPart = path.dirname(relPath);
     const slug = dirPart === "." ? "root" : dirPart.replace(/\//g, "--");
-    items.push({ displayPath, slug, relPath });
+    items.push({ displayPath, slug, relPath, absPath: filePath });
   }
 
   // Sort BEFORE writing: sidebar_position is baked into each generated .mdx,
@@ -308,7 +341,7 @@ function generateClaudemdDocs(
       );
     }
     emittedSlugs.set(item.slug, item.relPath);
-    const content = fs.readFileSync(path.join(projectRoot, item.relPath), "utf8");
+    const content = fs.readFileSync(item.absPath, "utf8");
     const mdx = `---
 title: "${escapeTitle(item.displayPath)}"
 description: "CLAUDE.md at ${escapeTitle(item.displayPath)}"

--- a/packages/zudo-doc/src/plugins/internal/claude-resources/index.ts
+++ b/packages/zudo-doc/src/plugins/internal/claude-resources/index.ts
@@ -71,10 +71,15 @@ export function runClaudeResourcesPreStep(
     ? docsDirInput
     : path.resolve(projectRoot, docsDirInput);
 
-  // The generator's `projectRoot` param IS the CLAUDE.md scan root + relPath
-  // base (it never touches output — output is always `docsDir`), so pass the
-  // resolved scanRoot there while docsDir stays anchored to the real projectRoot.
-  return generateClaudeResourcesDocs({ claudeDir, projectRoot: scanRoot, docsDir });
+  // The generator takes both roots: `scanRoot` is the CLAUDE.md walk root +
+  // relPath base, `projectRoot` anchors the project-specific excludes (neither
+  // touches output — output is always `docsDir`).
+  return generateClaudeResourcesDocs({
+    claudeDir,
+    projectRoot,
+    scanRoot,
+    docsDir,
+  });
 }
 
 export {


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3200

---

## Summary

`claude-resources` built its `excludeDirs` by joining each name onto the resolved scan root, so every entry was anchored at the **top level of `scanRoot` only**. With `scanRoot` widened above the doc site — the nested-project layout `scanRoot` exists for — the site's own `dist/`, `public/`, `out/`, and `test-results/` were still walked on every build, and any `CLAUDE.md` landing in one would be published under a mangled slug beside the real page.

Fixes #3200 with **option (a)** from the report, plus the anchored remainder of option (b). Option (c) (a public `excludeDirs` config field) was not added — it is unnecessary once the defaults are depth-independent, and it would have added a config field to the frozen API surface for a problem the defaults now solve.

## Changes

**`generate.ts`**

- New `EXCLUDED_DIR_NAMES` set — `node_modules`, `worktrees`, `dist`, `out`, `public`, `__inbox`, `test-results` — skipped by **basename at any depth**, matching how `node_modules` was already handled in the same walk.
- `excludeDirs` now holds only genuinely location-specific entries: `docsDir`, and `e2e/fixtures` anchored at **both** the scan root and the real `projectRoot` (it had the same anchoring gap).
- The anchored `.git` entry is dropped as redundant — dot-prefixed entries were already skipped at any depth one line above.
- `ClaudeResourcesConfig` gains `scanRoot`, so `projectRoot` stops secretly meaning "scan root". `scanRoot` defaults to `projectRoot`, so callers passing only `projectRoot` are unchanged.
- Discovered files are read from the absolute path the walk returned rather than rebuilt by joining a root onto `relPath`.

**`index.ts`** — passes both roots instead of forwarding the resolved `scanRoot` as `projectRoot`; the comment that documented the old conflation is corrected.

## Behavior change

A `CLAUDE.md` kept under a **nested** directory named `dist`, `out`, `public`, `worktrees`, `test-results`, or `__inbox` is no longer published. Previously only such a directory at the top level of the scan root was skipped. This repo has no such file, so its own generated output is byte-identical.

## Test Plan

- 13 new tests: table-driven coverage that each excluded basename is skipped when nested; a nested `dist-extra` sibling still discovered (the depth-independent form of the #2561 boundary guarantee); the `scanRoot`/`projectRoot` split for relPath, slug, and title derivation; `e2e/fixtures` excluded at both roots; and the end-to-end runner regression with decoys in `docs-site/{dist,public,out,test-results}` plus a sibling `app/dist`.
- **10 of the 13 fail against the pre-fix source**, so the regression is genuinely covered rather than vacuously green.
- All 44 pre-existing `claude-resources` tests pass **unmodified**, confirming backward compatibility.
- `pnpm b4push`: all 24 checks pass. Full workspace suite green (591 + 1,754 tests); `zfb check` clean.