### PR TITLE
fix(layout): restore desktop TOC sticky scroll-follow

### DIFF
--- a/e2e/smoke-toc.spec.ts
+++ b/e2e/smoke-toc.spec.ts
@@ -48,6 +48,48 @@ test.describe("TOC: desktop table of contents", () => {
     await expect(activeLink).toHaveCount(1, { timeout: 5000 });
   });
 
+  // Regression guard for the sticky scroll-follow break (PR #3202). <Toc>'s nav
+  // is `sticky top-[3.5rem]`, but a sticky box can only travel within its
+  // PARENT's box — and zfb's classless <Island> div sits between the nav and
+  // the layout wrapper doc-page-shell controls. When that wrapper was
+  // `hidden xl:block` (#3082), the Island div was auto-height, collapsed to
+  // exactly the nav's height, and the nav lost its entire travel range: it
+  // scrolled off the top with the page instead of pinning. Asserting the nav's
+  // viewport y at several offsets is what catches that — CSS-level checks on
+  // the nav pass either way, since `position: sticky` / `top: 56px` were never
+  // the thing that broke.
+  test("TOC stays pinned to the viewport while the page scrolls", async ({ page }) => {
+    await page.goto(PAGE, { waitUntil: "load" });
+
+    const tocNav = page.locator('[aria-label="Table of contents"]');
+    await expect(tocNav).toBeVisible({ timeout: 5000 });
+
+    // Matches `sticky top-[3.5rem]` on <Toc>'s nav — it clears the 3.5rem header.
+    const STICKY_TOP = 56;
+
+    const maxScroll = await page.evaluate(
+      () => document.documentElement.scrollHeight - window.innerHeight,
+    );
+    // Guard the guard: if the fixture page ever gets short enough that it
+    // barely scrolls, pinning becomes unfalsifiable and this test would pass
+    // vacuously.
+    expect(maxScroll).toBeGreaterThan(600);
+
+    const navY = async () => {
+      const box = await tocNav.boundingBox();
+      return box === null ? null : Math.round(box.y);
+    };
+
+    await expect.poll(navY).toBe(STICKY_TOP);
+
+    // Stay clear of the very bottom, where the content band's own end legitimately
+    // starts pushing the sticky box back up.
+    for (const fraction of [0.3, 0.6]) {
+      await page.evaluate((y) => window.scrollTo(0, y), Math.round(maxScroll * fraction));
+      await expect.poll(navY).toBe(STICKY_TOP);
+    }
+  });
+
   test("scroll spy updates aria-current when scrolling to a different section", async ({
     page,
   }) => {

--- a/packages/zudo-doc/src/doc-page-shell/index.tsx
+++ b/packages/zudo-doc/src/doc-page-shell/index.tsx
@@ -265,15 +265,15 @@ export function createDocPageShell<S extends Settings = Settings>(
           // contributes no gap; the bare-nav override branch above is already
           // self-hiding via <Toc>'s own `hidden xl:flex`. (#3082)
           //
-          // `xl:flex` (NOT `xl:block`) is load-bearing for the TOC's sticky
-          // scroll-follow: a sticky box can only travel within its parent's
-          // box, and the classless <Island> div sits between this wrapper and
-          // <Toc>'s sticky <nav>. Under `xl:block` that div is auto-height, so
-          // it collapses to exactly the nav's height and the nav has zero
-          // travel — it scrolls away with the page instead of pinning. As a
-          // flex container this wrapper stretches the Island div to full
-          // content-band height (default `align-items: stretch`), restoring
-          // the travel range. (#3202)
+          // Making this wrapper a FLEX container (rather than a plain block
+          // one) is load-bearing for the TOC's sticky scroll-follow: a sticky
+          // box can only travel within its parent's box, and the classless
+          // <Island> div sits between this wrapper and <Toc>'s sticky <nav>.
+          // As a block container the Island div is auto-height, so it
+          // collapses to exactly the nav's height and the nav has zero travel
+          // — it scrolls away with the page instead of pinning. Flex stretches
+          // the Island div to the full content-band height (default
+          // `align-items: stretch`), restoring the travel range. (#3202)
           (
             <div class="hidden xl:flex">
               {Island({

--- a/packages/zudo-doc/src/doc-page-shell/index.tsx
+++ b/packages/zudo-doc/src/doc-page-shell/index.tsx
@@ -264,8 +264,18 @@ export function createDocPageShell<S extends Settings = Settings>(
           // left at mobile widths. Hide the flex child itself below xl so it
           // contributes no gap; the bare-nav override branch above is already
           // self-hiding via <Toc>'s own `hidden xl:flex`. (#3082)
+          //
+          // `xl:flex` (NOT `xl:block`) is load-bearing for the TOC's sticky
+          // scroll-follow: a sticky box can only travel within its parent's
+          // box, and the classless <Island> div sits between this wrapper and
+          // <Toc>'s sticky <nav>. Under `xl:block` that div is auto-height, so
+          // it collapses to exactly the nav's height and the nav has zero
+          // travel — it scrolls away with the page instead of pinning. As a
+          // flex container this wrapper stretches the Island div to full
+          // content-band height (default `align-items: stretch`), restoring
+          // the travel range. (#3202)
           (
-            <div class="hidden xl:block">
+            <div class="hidden xl:flex">
               {Island({
                 when: "load",
                 children: <Toc headings={headings} title={tocTitle} />,

--- a/packages/zudo-doc/src/doclayout/doc-layout.tsx
+++ b/packages/zudo-doc/src/doclayout/doc-layout.tsx
@@ -392,7 +392,7 @@ export function DocLayout(props: DocLayoutProps): JSX.Element {
               The inter-column `gap` is unconditional so ANY visible `toc` slot
               (including a custom always-visible override) is separated from
               <main>. The package default TOC instead hides its own flex child
-              below xl (see doc-page-shell's `hidden xl:block` wrapper) so it
+              below xl (see doc-page-shell's `hidden xl:flex` wrapper) so it
               contributes no phantom gap on mobile — where an in-flow but
               zero-width TOC wrapper would otherwise push a larger right inset
               than left onto the content. (#3082)


### PR DESCRIPTION
## Summary

The desktop right-rail TOC stopped pinning to the viewport: it scrolled away with the page content, taking the active-heading highlight off-screen with it.

Root cause is the `hidden xl:block` wrapper added in be9174a1f (#3082). zfb's `<Island>` renders a **classless** `<div>` (`IslandProps` has no `class`), so that wrapper sits one level above it:

```
.zd-doc-content-band  (flex, align-items: stretch)
├── <main>                          ← tall
└── <div class="hidden xl:…">       ← flex child, stretches to band height ✓
    └── <div>                       ← <Island> wrapper, classless
        └── <nav class="sticky top-[3.5rem]">
```

Before #3082 the Island div *was* the flex child and got stretched. Afterwards it became an ordinary auto-height block, collapsing to exactly the nav's height — and since a sticky box can only travel within its parent's box, the nav's travel range went to zero.

Making the wrapper a flex container restores the stretch (`align-items: stretch` is the default), so the Island div again fills the content band.

## Screenshot Requirement Contract

**Expected:**
- At any scroll offset on a long doc page (xl viewport), the TOC `<nav>` stays pinned at `top: 3.5rem`. ✅
- The active heading is highlighted and updates as the reader scrolls. ✅

**Forbidden:**
- The TOC scrolling out of the viewport with the page, leaving only the tail of the list (`Persistence` / `Implementation` / `Settings Reference`) at the top. ✅ no longer occurs

**Viewport:** xl and wider (the desktop TOC is `hidden xl:flex`).

## Changes

- `packages/zudo-doc/src/doc-page-shell/index.tsx` — default-TOC wrapper `hidden xl:block` → `hidden xl:flex`, with a comment recording why the display type is load-bearing.
- `packages/zudo-doc/src/doclayout/doc-layout.tsx` — updated the stale cross-reference to that wrapper.
- `e2e/smoke-toc.spec.ts` — new regression test asserting the nav's viewport y across scroll offsets.

## Test Plan

Measured in Chromium at 1600x900 on `/docs/reference/design-token-panel/` — nav `getBoundingClientRect().top` by `scrollY`:

| scrollY | before | after |
|---|---|---|
| 0 | 56 | 56 |
| 1500 | **-1444** | 56 |
| 3000 | **-2944** | 56 |

Island div height: 844 (identical to the nav — zero travel) → 11518 (full band height).

**Only one bug, not two.** The scroll-spy was never broken — `aria-current` tracked the scroll position correctly both before and after. The missing highlight in the report was simply the highlighted row being off-screen with the nav.

**No layout side effects at xl.** The change affects only cross-axis stretch:

| viewport | nav / island / wrapper width | gap | band `column-gap` |
|---|---|---|---|
| 1280 | 280 / 280 / 280 | 38 | 38.4px |
| 1600 | 280 / 280 / 280 | 48 | 48px |
| 1920 | 280 / 280 / 280 | 58 | 57.6px |

**#3082's mobile fix is intact.** Below xl both class sets compute to `display: none`, so the change is a no-op there — verified 1 visible flex child and symmetric 24/24 article insets at 390px and 767px.

**Regression test verified red/green:** the new spec fails against the pre-fix build (nav y `-762`) and passes against the fixed one, so it is a genuine guard rather than a vacuous one. A `maxScroll` assertion keeps it from passing vacuously if the fixture page is ever shortened.

Also run: `pnpm b4push` — all 24 checks pass. Codex review returned no findings.

## Related

Raised separately while verifying, both pre-existing and unrelated:
- #3203 — long inline `<code>` causes 84px horizontal page scroll at 390px
- #3204 — `check-package-safelist` scans comments, so prose naming a class fails the build