### PR TITLE
docs(e2e): stop documenting a fast path that skips fixture setup

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -96,12 +96,15 @@ pnpm check:worker  # generated binding + custom Worker typecheck
 pnpm test:worker   # builds first, then runs Workers-runtime/SQLite DO tests
 pnpm verify:worker-dry-run # builds first, then verifies the Wrangler production bundle
 
-# Single-fixture E2E fast path (builds only the named fixture, then runs only its tests):
-E2E_FIXTURES=smoke npx playwright test --project smoke
-E2E_FIXTURES=sidebar npx playwright test --project sidebar
+# Single-fixture E2E fast path. Run setup-fixtures.sh yourself: playwright.config.ts
+# has no globalSetup, so a bare `npx playwright test` builds nothing and would run
+# against a stale fixture dist/ (cheap no-op when already warm).
+export E2E_FIXTURES=smoke
+bash e2e/setup-fixtures.sh && npx playwright test --project smoke
 ```
 
-The `E2E_FIXTURES=<name>` fast path builds only the named fixture (caches via
+`E2E_FIXTURES=<name>` scopes both halves — `setup-fixtures.sh` builds only that
+fixture and the runner boots only its webServer. It builds only the named fixture (caches via
 `.build-marker.sha256`; force-rebuild with `E2E_FORCE_REBUILD=1`) and boots only
 its Playwright webServer. Repeated runs skip the build when inputs are unchanged.
 

--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -90,10 +90,23 @@ All fixtures are pre-built sequentially with `zfb build` (with `SKIP_DOC_HISTORY
 ```bash
 pnpm test:e2e                                           # Full suite (setup + all tests)
 pnpm test:e2e:ci                                        # CI suite (excludes @flaky + @local-only tests)
-npx playwright test e2e/smoke-search.spec.ts --project smoke  # Single test file
-npx playwright test --project smoke                      # All tests for one fixture
-E2E_FIXTURES=smoke npx playwright test --project smoke  # Fast path: build + boot only smoke
 ```
+
+**A bare `npx playwright test` does NOT build fixtures.** `playwright.config.ts` has
+no `globalSetup`, and `setup-fixtures.sh` runs only as the first half of the
+`test:e2e*` scripts above. Invoking Playwright directly therefore tests whatever
+`e2e/fixtures/<name>/dist/` happens to be on disk — which silently means stale HTML
+after any fixture-content edit. Run setup yourself first:
+
+```bash
+export E2E_FIXTURES=smoke                               # scopes BOTH setup and the runner
+bash e2e/setup-fixtures.sh                              # REQUIRED — cheap no-op when warm
+npx playwright test --project smoke                     # all tests for that fixture
+npx playwright test e2e/smoke-search.spec.ts --project smoke   # or a single file
+```
+
+The staleness itself is guarded — `compute_build_hash()` covers each fixture's
+`src/content/` — but the marker is only consulted when the script actually runs.
 
 **Fast path**: `E2E_FIXTURES=<name>` scopes both `setup-fixtures.sh` (builds only that fixture) and `playwright.config.ts` (boots only its webServer, zero stagger); repeated runs skip the build when inputs are unchanged (`e2e/fixtures/<name>/.build-marker.sha256` tracks the hash); `E2E_FORCE_REBUILD=1` forces a full rebuild.
 


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3223

---

## Summary

Auto-fix from the Cleanup Batch epic (#3208) for the `agent-found` issue #3223.

`e2e/CLAUDE.md` and `TESTING.md` both documented a bare `npx playwright test ... --project smoke` as the single-fixture "fast path", described as "build + boot only smoke". It does not build. `playwright.config.ts` has no `globalSetup`, and `e2e/setup-fixtures.sh` runs only as the first half of the `test:e2e*` npm scripts — so invoking Playwright directly runs against whatever `e2e/fixtures/<name>/dist/` is already on disk.

This bit during the epic's confirm pass: verifying #3212's new spec with the documented command failed with `No element matched: main code` against a `dist/` built ~90 minutes before the fixture MDX was written. After `bash e2e/setup-fixtures.sh` the same command passes 12/12.

The failure mode is asymmetric: here it was a false *negative*, but for an assertion of the form "this element must NOT overflow", stale HTML yields a false *pass*.

## Changes

Documentation only — both files now show the required `bash e2e/setup-fixtures.sh` call, with a short note on why it is not optional. The staleness guard itself was never broken: `compute_build_hash()` already covers each fixture's `src/content/`; it simply never gets consulted when the script is not run.

## Deliberately not done

Issue #3223 also proposed adding a `globalSetup` to `playwright.config.ts`, which would make the direct `npx playwright test` path correct by construction rather than by documentation. That is the better fix, but it changes shared infrastructure gating every e2e run in CI and cannot be validated without a full Playwright matrix run — outside what an auto-fix pass should land unreviewed at the tail of an epic. Left for a human; #3223's closing comment records it.

Closes #3223

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/3224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788297277&installation_model_id=20910&pr_number=3224&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F3224&signature=7fc48a7c03ed97f5c3cf7556165be8a6923dd83597a8c95425c44524ead3ccf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->