### PR TITLE
[Version Switcher SPA] Recompute version availability on SPA navigation

### DIFF
--- a/e2e/versioning-spa-nav-availability.spec.ts
+++ b/e2e/versioning-spa-nav-availability.spec.ts
@@ -1,0 +1,163 @@
+import { test, expect } from "./fixtures";
+import { spaClick } from "./nav-helpers";
+
+/**
+ * E2E regression guard for the persisted header's version switcher going
+ * stale on same-locale SPA navigation (epic #3242, closing out #3215's
+ * second-order bug).
+ *
+ * #3215 made the switcher render an archive entry as disabled when the
+ * current slug has no counterpart in that version, instead of a dead link
+ * into a 404. That is correct on initial render. But the header is
+ * persisted across SPA navigation
+ * (`data-zfb-transition-persist="header-${lang}"`), and until #3244 the
+ * `zfb:after-swap` rewire script recomputed hrefs / active state / the
+ * trigger label but NOT which entries are disabled — so after a same-locale
+ * SPA hop the header could show:
+ *   - an entry ENABLED that is actually unavailable on the new page → a
+ *     clickable link straight into a 404 (the severe direction — a narrow
+ *     reintroduction of the exact bug #3215 fixed);
+ *   - an entry DISABLED that is actually available → a dead end that cannot
+ *     be reached, including by keyboard (`tabindex="-1"` never cleared).
+ *
+ * WHY THIS MUST BE A REAL SPA-NAVIGATION TEST, NOT `page.goto()`:
+ * A full page load re-renders the header from scratch via SSR, which always
+ * computes the correct disabled set for whatever page it lands on — that is
+ * true both before and after #3244. Asserting after a `page.goto()` (or a
+ * hard reload) would therefore pass VACUOUSLY on the pre-#3244 code: the
+ * bug only exists in the DOM the client-side swap leaves behind, never in a
+ * freshly-rendered document. If a future maintainer "simplifies" the
+ * navigation below into a `goto()`, this spec stops testing anything and
+ * will keep passing even if the regression comes back. Every page whose
+ * disabled-state is asserted below is reached via `spaClick` (dispatches a
+ * real anchor click + waits for `zfb:after-swap`) — `page.goto()` is used
+ * exactly once per test, only for the neutral landing page described next.
+ *
+ * WHY THE LANDING PAGE IS `/docs/guides` (NOT ONE OF THE TWO PAGES UNDER
+ * TEST): two independent constraints ruled out landing directly on either
+ * `getting-started` or `whats-new`.
+ *   1. Sidebar scope: `getting-started` matches this fixture's single
+ *      `headerNav` `categoryMatch`, so ITS sidebar is scoped to just that
+ *      one entry — there is no in-page link to `whats-new` to click from
+ *      there (confirmed against the built fixture's dist HTML). `guides`
+ *      matches no `categoryMatch`, so its sidebar renders the full site
+ *      tree, with real `<a>` links to both `getting-started` and
+ *      `whats-new`.
+ *   2. An UNRELATED first-paint race rules out landing on `whats-new` via
+ *      `page.goto()` even for tests that don't care about #1:
+ *      `VERSION_SWITCHER_REWIRE_SCRIPT` also runs once synchronously
+ *      inline, at first paint, to cover the one case `zfb:after-swap`
+ *      genuinely does not fire for — the very first page load (see
+ *      `AFTER_NAVIGATE_EVENT`'s doc in `transitions/page-events.ts`). That
+ *      inline `<script>` sits inside `<header>`, which the HTML parser
+ *      reaches BEFORE `<article>` further down the document, so on a plain
+ *      `page.goto()` of a page with unavailable versions, that first
+ *      synchronous run reads no `data-doc-unavailable-versions` attribute
+ *      yet (the article hasn't been parsed) and wrongly leaves every entry
+ *      enabled — independent of, and outside the scope of, this epic's
+ *      SPA-navigation bug (reported separately as a first-paint
+ *      correctness bug in `VERSION_SWITCHER_REWIRE_SCRIPT`). Reaching
+ *      `whats-new` via `spaClick` instead sidesteps that race entirely: by
+ *      the time an `zfb:after-swap` listener runs, the incoming document
+ *      (including its `<article>`) was already fully parsed off-screen
+ *      before the atomic body swap. `guides` (which has no unavailable
+ *      versions) is unaffected by that race either way, so it is safe to
+ *      reach via `page.goto()`.
+ *
+ * `guides` is itself a shared slug (present in both latest and the 1.0
+ * archive — see fixture data below), so landing there also gives each test
+ * a clean, correctly-enabled starting point for the header entry.
+ *
+ * SELECTOR SAFETY — asserting the PERSISTED header, not the inline switcher:
+ * Doc pages render a second version-switcher inline (afterBreadcrumb), which
+ * is swapped-in fresh content re-rendered correctly on every navigation —
+ * asserting against it would prove nothing about this bug class. Every
+ * locator below is scoped to `getByRole("banner")` (the header landmark)
+ * AND to `[data-version-slug]`, an attribute the inline switcher never
+ * renders at all (it has no `rewireConfig`, so `data-version-slug` is
+ * omitted entirely — see version-switcher.tsx's `rewire` flag) — so even a
+ * markup change that dropped the banner-only assumption could not make this
+ * spec silently start reading the inline instance.
+ *
+ * Fixture data (e2e/fixtures/versioning/src/content/):
+ *   - `docs/getting-started` and `docs/guides` exist in BOTH latest and the
+ *     1.0 archive (`docs-v1/getting-started`, `docs-v1/guides`) — "shared
+ *     slugs", so the 1.0 entry is enabled on either.
+ *   - `docs/whats-new` exists ONLY in latest — a "latest-only slug", so the
+ *     1.0 entry is disabled there (the same fixture #3196's regression
+ *     guard in versioning.spec.ts reads via static dist HTML).
+ */
+
+test.describe("Version switcher SPA-navigation availability guard (#3242)", () => {
+  test.beforeEach(async ({ page }) => {
+    // >=1024px so the header switcher's `lg:block` override is active
+    // (matches the viewport every other version-switcher spec uses), and so
+    // the desktop sidebar (source of the in-page links below) is present.
+    await page.setViewportSize({ width: 1280, height: 800 });
+  });
+
+  test("shared slug -> latest-only slug: header entry becomes disabled after SPA nav (severe direction, #3215 reintroduction)", async ({
+    page,
+  }) => {
+    await page.goto("/docs/guides", { waitUntil: "load" });
+
+    const headerEntry = page
+      .getByRole("banner")
+      .locator('[data-version-menu] a[data-version-slug="1.0"]');
+
+    // Sanity check on the landing page: guides is a shared slug, so the
+    // archive entry starts enabled.
+    await expect(headerEntry).not.toHaveAttribute("aria-disabled");
+    await expect(headerEntry).not.toHaveAttribute("tabindex");
+
+    const navigated = await spaClick(page, "/docs/whats-new");
+    expect(navigated).toBe(true);
+
+    // whats-new has no 1.0 counterpart — the persisted header's entry MUST
+    // flip to disabled, or it is a live link into a 404.
+    await expect(headerEntry).toHaveAttribute("aria-disabled", "true");
+    await expect(headerEntry).toHaveAttribute("tabindex", "-1");
+  });
+
+  test("latest-only slug -> shared slug: header entry becomes enabled and genuinely clickable after SPA nav", async ({
+    page,
+  }) => {
+    // Land on the neutral full-tree page, then reach the latest-only page
+    // via a real SPA hop — see the file-level comment for why both the
+    // landing choice and the "no page.goto() on whats-new" rule matter.
+    await page.goto("/docs/guides", { waitUntil: "load" });
+
+    const headerSwitcher = page.getByRole("banner").locator("[data-version-switcher]");
+    const toggle = headerSwitcher.locator("[data-version-toggle]");
+    const headerEntry = headerSwitcher.locator('[data-version-menu] a[data-version-slug="1.0"]');
+
+    const navigatedToDisabled = await spaClick(page, "/docs/whats-new");
+    expect(navigatedToDisabled).toBe(true);
+
+    // Sanity check on the intermediate state: whats-new has no 1.0
+    // counterpart, so the archive entry must be disabled here (this is
+    // itself the severe-direction assertion the other test covers
+    // end-to-end).
+    await expect(headerEntry).toHaveAttribute("aria-disabled", "true");
+    await expect(headerEntry).toHaveAttribute("tabindex", "-1");
+
+    const navigated = await spaClick(page, "/docs/getting-started");
+    expect(navigated).toBe(true);
+
+    // getting-started is shared — the entry must re-enable...
+    await expect(headerEntry).not.toHaveAttribute("aria-disabled");
+    // ...and NOT merely drop aria-disabled while staying keyboard-unreachable
+    // (a half-transition that leaves tabindex="-1" is the milder failure
+    // direction the epic calls out).
+    await expect(headerEntry).not.toHaveAttribute("tabindex");
+
+    // Prove it is genuinely usable, not just attribute-clean: open the real
+    // dropdown and click through. If the class list weren't restored
+    // alongside the attributes (e.g. `pointer-events-none` left on),
+    // Playwright's actionability check on `.click()` would fail here even
+    // though the attribute assertions above already passed.
+    await toggle.click();
+    await headerEntry.click();
+    await page.waitForURL(/\/v\/1\.0\/docs\/getting-started\/?$/);
+  });
+});

--- a/packages/zudo-doc/src/__tests__/config.test.ts
+++ b/packages/zudo-doc/src/__tests__/config.test.ts
@@ -118,6 +118,26 @@ describe("zudoDoc() default-merge semantics", () => {
     ).toThrow(/githubAutolinksRepo is no longer supported/);
   });
 
+  // #3244 codex review finding 2: a comma in a version slug would desync the
+  // comma-joined `data-doc-unavailable-versions` client payload
+  // (`version-availability/index.ts`) from the real `data-version-slug` DOM
+  // value, silently leaving a genuinely-unavailable version's link enabled.
+  it("rejects a version slug containing a comma", () => {
+    expect(() =>
+      zudoDoc({
+        versions: [{ slug: "1,0", label: "1,0", docsDir: "content/v1" }],
+      }),
+    ).toThrow(/Invalid version slug "1,0"/);
+  });
+
+  it("accepts comma-free version slugs", () => {
+    expect(() =>
+      zudoDoc({
+        versions: [{ slug: "1.0", label: "1.0", docsDir: "content/v1" }],
+      }),
+    ).not.toThrow();
+  });
+
   it("omitted field falls back to DEFAULT_SETTINGS (mermaid defaults true)", () => {
     expect(zudoDoc({}).markdown?.features?.mermaid).toBe(true);
   });

--- a/packages/zudo-doc/src/__tests__/preset.test.ts
+++ b/packages/zudo-doc/src/__tests__/preset.test.ts
@@ -286,6 +286,23 @@ describe("zudoDocPreset collections", () => {
     });
     expect(r.collections.map((c) => c.name)).toEqual(["docs"]);
   });
+
+  // #3244 codex review finding 2 follow-up: `zudoDocPreset()` is a
+  // documented, directly-spreadable public entry (see the doc comment above
+  // its definition) — a consumer bypassing `zudoDoc()` must still hit the
+  // comma-free version-slug guard, not just the `zudoDoc()` call path.
+  it("rejects a version slug containing a comma even when called directly (bypassing zudoDoc())", () => {
+    expect(() =>
+      zudoDocPreset({
+        settings: {
+          ...fixtureSettings,
+          versions: [{ slug: "1,0", docsDir: "src/content/docs-v1" }],
+        },
+        buildDocsSchema: buildFixtureSchema,
+        directiveVocabulary: fixtureDirectives,
+      }),
+    ).toThrow(/Invalid version slug "1,0"/);
+  });
 });
 
 describe("zudoDocPreset plugins (bare-specifier descriptors)", () => {

--- a/packages/zudo-doc/src/chrome/derive.tsx
+++ b/packages/zudo-doc/src/chrome/derive.tsx
@@ -428,8 +428,26 @@ export function deriveGetUnavailableVersions(
 // inline version switcher (renderDocPage)
 // ---------------------------------------------------------------------------
 
-/** Derive the inline version-switcher builder bound to the context. */
-export function deriveInlineVersionSwitcher(ctx: ChromeContext) {
+/**
+ * Derive the inline version-switcher builder bound to the context.
+ *
+ * `getUnavailableVersions` is optional so a caller that already built one
+ * (e.g. `createRenderDocPage`, which also emits it as the SPA-rewire client
+ * payload — #3243) can pass that SAME instance instead of a second one being
+ * derived here. `createGetUnavailableVersions` owns a per-(locale, version)
+ * nav-source cache, so two independently-derived instances would each
+ * resolve the nav source and rebuild the auto-index tree from scratch on
+ * their first call per (locale, version) — doubling that work on every
+ * versioned route. Defaults to deriving its own when omitted, so this stays
+ * backward-compatible with a bare `deriveInlineVersionSwitcher(ctx)` call.
+ */
+export function deriveInlineVersionSwitcher(
+  ctx: ChromeContext,
+  getUnavailableVersions: (
+    slug: string | undefined,
+    locale: string,
+  ) => ReadonlySet<string> | undefined = deriveGetUnavailableVersions(ctx),
+) {
   return createInlineVersionSwitcher({
     settings: ctx.settings,
     defaultLocale: ctx.defaultLocale,
@@ -437,7 +455,7 @@ export function deriveInlineVersionSwitcher(ctx: ChromeContext) {
     docsUrl: ctx.docsUrl,
     versionedDocsUrl: ctx.versionedDocsUrl,
     withBase: ctx.withBase,
-    getUnavailableVersions: deriveGetUnavailableVersions(ctx),
+    getUnavailableVersions,
   });
 }
 

--- a/packages/zudo-doc/src/config.ts
+++ b/packages/zudo-doc/src/config.ts
@@ -91,6 +91,7 @@ import { buildDocsSchema as defaultBuildDocsSchema } from "./docs-schema/index.j
 import { defaultDirectiveVocabulary } from "./directive-vocabulary-defaults/index.js";
 import { defaultTranslations } from "./i18n-defaults/index.js";
 import { defaultColorSchemes } from "./color-schemes-defaults/index.js";
+import { assertNoCommaInVersionSlugs } from "./version-availability/index.js";
 
 /** The `settings.claudeResources` block (or `false` when disabled). */
 type ClaudeResourcesConfig =
@@ -652,6 +653,16 @@ export function zudoDoc(user: ZudoDocConfig = {}): ZfbConfig {
   // Safe because nested config types are all-required-field. `settingsOverrides`
   // is a Partial<Settings>.
   const settings: Settings = { ...DEFAULT_SETTINGS, ...settingsOverrides };
+
+  // A version slug rides through `version-availability/index.ts`'s
+  // comma-joined `data-doc-unavailable-versions` client payload unescaped
+  // (issue #3243 locked a flat list over JSON-in-attribute). A slug
+  // containing a comma would serialize ambiguously and desync from the real
+  // `data-version-slug` DOM value on the client (#3244 codex review finding
+  // 2) — reject it here, rather than re-encoding the wire format. Also
+  // enforced inside `zudoDocPreset()` itself (see that call below) since the
+  // preset is separately callable as documented public API.
+  assertNoCommaInVersionSlugs(settings.versions);
 
   const fragment = zudoDocPreset({
     settings,

--- a/packages/zudo-doc/src/doc-page-renderer/__tests__/doc-page-renderer.test.tsx
+++ b/packages/zudo-doc/src/doc-page-renderer/__tests__/doc-page-renderer.test.tsx
@@ -14,6 +14,7 @@ import type { RenderDocPageOptions } from "../index.js";
 import type { DocPageBaseProps } from "../../doc-page-props/index.js";
 import type { ChromeContext } from "../../factory-context/index.js";
 import { makeFakeChromeContext } from "../../__tests__/fixtures/fake-chrome-context.js";
+import { deriveGetUnavailableVersions } from "../../chrome/derive.js";
 
 // ---------------------------------------------------------------------------
 // Minimal fakes factory
@@ -108,4 +109,76 @@ describe("createRenderDocPage — standalone chrome suppression", () => {
       expect(historySlot.props["sourceFileExt"]).toBe(ext);
     },
   );
+});
+
+// ---------------------------------------------------------------------------
+// unavailableVersions client payload (epic #3242, #3243)
+// ---------------------------------------------------------------------------
+
+describe("createRenderDocPage — unavailableVersions payload", () => {
+  it("passes a non-empty unavailable set for a latest-only slug", () => {
+    const resolveNavSource = (_locale: string, versionSlug: string) =>
+      versionSlug === "v1"
+        ? { docs: [{ slug: "test-page", data: {} }], navDocs: [], categoryMeta: new Map() }
+        : { docs: [], navDocs: [], categoryMeta: new Map() };
+    const ctx = makeFakeChromeContext({
+      settings: { versions: [{ slug: "v1" }, { slug: "v2" }] },
+      overrides: { resolveNavSource: resolveNavSource as never },
+    });
+    const renderDocPage = createRenderDocPage(ctx);
+    const vnode = renderDocPage(makeEntryProps(), opts) as VNode<Record<string, unknown>>;
+
+    const real = deriveGetUnavailableVersions(ctx)("test-page", "en");
+    expect(real).toEqual(new Set(["v2"]));
+    expect(vnode.props["unavailableVersions"]).toEqual(real);
+  });
+
+  it("passes an empty unavailable set for a slug shared by every version", () => {
+    const resolveNavSource = () => ({
+      docs: [{ slug: "test-page", data: {} }],
+      navDocs: [],
+      categoryMeta: new Map(),
+    });
+    const ctx = makeFakeChromeContext({
+      settings: { versions: [{ slug: "v1" }, { slug: "v2" }] },
+      overrides: { resolveNavSource: resolveNavSource as never },
+    });
+    const renderDocPage = createRenderDocPage(ctx);
+    const vnode = renderDocPage(makeEntryProps(), opts) as VNode<Record<string, unknown>>;
+
+    const real = deriveGetUnavailableVersions(ctx)("test-page", "en");
+    expect(real).toEqual(new Set());
+    expect(vnode.props["unavailableVersions"]).toEqual(real);
+  });
+
+  it("passes undefined (no attribute) when versioning is not configured", () => {
+    // makeDeps() fixture default already sets settings.versions: false.
+    const ctx = makeDeps();
+    const renderDocPage = createRenderDocPage(ctx);
+    const vnode = renderDocPage(makeEntryProps(), opts) as VNode<Record<string, unknown>>;
+
+    expect(deriveGetUnavailableVersions(ctx)("test-page", "en")).toBeUndefined();
+    expect(vnode.props["unavailableVersions"]).toBeUndefined();
+  });
+
+  it("computes a different (correct) answer for a non-default locale", () => {
+    // applyDefaultLocaleOnlyFilter changes the answer for non-default
+    // locales — the slug exists per-locale in "en" only.
+    const resolveNavSource = (locale: string) =>
+      locale === "en"
+        ? { docs: [{ slug: "test-page", data: {} }], navDocs: [], categoryMeta: new Map() }
+        : { docs: [], navDocs: [], categoryMeta: new Map() };
+    const ctx = makeFakeChromeContext({
+      settings: { versions: [{ slug: "v1" }] },
+      overrides: { resolveNavSource: resolveNavSource as never },
+    });
+    const renderDocPage = createRenderDocPage(ctx);
+    const vnode = renderDocPage(makeEntryProps(), {
+      locale: "ja",
+    }) as VNode<Record<string, unknown>>;
+
+    const real = deriveGetUnavailableVersions(ctx)("test-page", "ja");
+    expect(real).toEqual(new Set(["v1"]));
+    expect(vnode.props["unavailableVersions"]).toEqual(real);
+  });
 });

--- a/packages/zudo-doc/src/doc-page-renderer/index.tsx
+++ b/packages/zudo-doc/src/doc-page-renderer/index.tsx
@@ -27,7 +27,11 @@ import { createDocPageShell } from "../doc-page-shell/index.js";
 import { createDocContentHeader } from "../doc-content-header/index.js";
 import { createDocMetainfoArea } from "../doc-metainfo-area/index.js";
 import { createDocHistoryArea } from "../doc-history-area/index.js";
-import { deriveMdxComponents, deriveInlineVersionSwitcher } from "../chrome/derive.js";
+import {
+  deriveMdxComponents,
+  deriveInlineVersionSwitcher,
+  deriveGetUnavailableVersions,
+} from "../chrome/derive.js";
 import { assertChromeContext } from "../chrome/assert-chrome-context.js";
 
 export type { DocPageBaseProps };
@@ -114,6 +118,14 @@ export interface DocPageRendererDeps {
     currentPath: string;
     currentVersion?: string;
     versionSwitcher: JSX.Element | undefined;
+    /**
+     * This page's unavailable-version slugs, straight from
+     * `getUnavailableVersions(slug, locale)` (`../version-availability`) —
+     * see `DocPageShellProps.unavailableVersions` (`../doc-page-shell`) for
+     * the full absent/empty/populated contract this rides through to the
+     * emitted `data-doc-unavailable-versions` attribute.
+     */
+    unavailableVersions?: ReadonlySet<string>;
     versionBanner?: "unmaintained" | "unreleased";
     versionBannerLatestUrl?: string;
     versionBannerLabels?: VersionBannerLabels;
@@ -179,8 +191,15 @@ export function createRenderDocPage<S extends Settings = Settings>(
     currentVersion?: string,
   ) => Record<string, unknown>;
   const t = ctx.t;
+  // Derived ONCE here (rather than letting `deriveInlineVersionSwitcher`
+  // derive its own) and threaded into it below, so the inline switcher and
+  // the client-payload emission (epic #3242, #3243) share the SAME
+  // `createGetUnavailableVersions` cache instead of each rebuilding the
+  // per-(locale, version) nav-source / auto-index tree independently.
+  const getUnavailableVersions = deriveGetUnavailableVersions(ctx);
   const buildInlineVersionSwitcher = deriveInlineVersionSwitcher(
     ctx,
+    getUnavailableVersions,
   ) as DocPageRendererDeps["buildInlineVersionSwitcher"];
   const DocPageShell = createDocPageShell(ctx) as DocPageRendererDeps["DocPageShell"];
   const DocContentHeader = createDocContentHeader(
@@ -298,6 +317,7 @@ export function createRenderDocPage<S extends Settings = Settings>(
         currentPath={currentPath}
         currentVersion={version?.slug}
         versionSwitcher={buildInlineVersionSwitcher(slug, locale, version?.slug)}
+        unavailableVersions={getUnavailableVersions(slug, locale)}
         versionBanner={versionBannerType}
         versionBannerLatestUrl={versionBannerLatestUrl}
         versionBannerLabels={versionBannerLabels}

--- a/packages/zudo-doc/src/doc-page-shell/__tests__/unavailable-versions-attr.test.tsx
+++ b/packages/zudo-doc/src/doc-page-shell/__tests__/unavailable-versions-attr.test.tsx
@@ -1,0 +1,75 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+/**
+ * Client payload emission (epic #3242, #3243).
+ *
+ * `<DocPageShell>` serializes `unavailableVersions` onto the `<article>`
+ * element via `serializeUnavailableVersions` (`../../version-availability`)
+ * so a same-locale SPA navigation rewire script (#3244) can read the
+ * per-page availability set from swapped content. Verifies the three-state
+ * contract survives all the way into the rendered HTML:
+ *   - absent prop  → no `data-doc-unavailable-versions` attribute at all
+ *   - empty set    → attribute present with an empty value
+ *   - populated set → attribute present with a sorted comma-joined value
+ */
+
+import { describe, expect, it } from "vitest";
+import { render } from "preact-render-to-string";
+import { createDocPageShell } from "../index.js";
+import { makeFakeChromeContext } from "../../__tests__/fixtures/fake-chrome-context.js";
+import { UNAVAILABLE_VERSIONS_ATTR } from "../../version-availability/index.js";
+
+const BASE_PROPS = {
+  locale: "en",
+  slug: "cat",
+  breadcrumbs: [],
+  prev: null,
+  next: null,
+  headings: [],
+  navSection: undefined,
+  sidebarPersistKey: undefined,
+  currentPath: "/docs/cat",
+  versionSwitcher: null,
+  kind: "autoIndex" as const,
+  title: "Cat",
+  autoIndexLabel: "Cat",
+  autoIndexChildren: [],
+};
+
+describe("createDocPageShell — unavailable-versions article attribute", () => {
+  it("omits the attribute entirely when unavailableVersions is undefined", () => {
+    const ctx = makeFakeChromeContext();
+    const DocPageShell = createDocPageShell(ctx);
+    const html = render(<DocPageShell {...BASE_PROPS} />);
+
+    expect(html).not.toContain(UNAVAILABLE_VERSIONS_ATTR);
+  });
+
+  it('emits an empty-value attribute when unavailableVersions is an empty set', () => {
+    const ctx = makeFakeChromeContext();
+    const DocPageShell = createDocPageShell(ctx);
+    const html = render(
+      <DocPageShell {...BASE_PROPS} unavailableVersions={new Set()} />,
+    );
+
+    // preact-render-to-string renders an empty-string attribute value in the
+    // shorthand boolean form (`data-x` rather than `data-x=""`) — DOM-
+    // equivalent (`getAttribute` returns `""` either way), and still
+    // distinguishable from the "absent" case above.
+    expect(html).toContain(UNAVAILABLE_VERSIONS_ATTR);
+    expect(html).not.toContain(`${UNAVAILABLE_VERSIONS_ATTR}="`);
+  });
+
+  it("emits a sorted comma-joined value for a populated set", () => {
+    const ctx = makeFakeChromeContext();
+    const DocPageShell = createDocPageShell(ctx);
+    const html = render(
+      <DocPageShell
+        {...BASE_PROPS}
+        unavailableVersions={new Set(["2.0", "1.0"])}
+      />,
+    );
+
+    expect(html).toContain(`${UNAVAILABLE_VERSIONS_ATTR}="1.0,2.0"`);
+  });
+});

--- a/packages/zudo-doc/src/doc-page-shell/index.tsx
+++ b/packages/zudo-doc/src/doc-page-shell/index.tsx
@@ -26,6 +26,7 @@ import {
   createSidebarPrepaint,
   createSidebarVisibilityPrepaint,
 } from "../sidebar-prepaint/index.js";
+import { serializeUnavailableVersions } from "../version-availability/index.js";
 import { createHeadWithDefaults } from "../head-with-defaults/index.js";
 import { resolveThemePackSsrSlug } from "../theme/theme-pack-provider.js";
 import { createDocBodyEnd } from "../doc-body-end/index.js";
@@ -94,6 +95,20 @@ export interface DocPageShellProps {
   currentVersion?: string;
   /** Inline version switcher VNode for the breadcrumb right-slot. */
   versionSwitcher: ComponentChildren;
+
+  /**
+   * This page's unavailable-version slugs, straight from
+   * `getUnavailableVersions(slug, locale)` (`../version-availability`) —
+   * NOT re-derived here. Serialized onto `<article>` via
+   * `serializeUnavailableVersions` so a same-locale SPA navigation rewire
+   * script (#3244) can read the per-page availability set after the
+   * persisted header's own SSR attributes go stale. `undefined` (no
+   * availability data — e.g. versioning not configured) renders NO
+   * attribute at all; an empty set renders the attribute with an empty
+   * value. See `../version-availability/index.ts` for the full
+   * absent/empty/populated contract.
+   */
+  unavailableVersions?: ReadonlySet<string>;
 
   /** Version banner type ("unmaintained" | "unreleased") or undefined on latest. */
   versionBanner?: "unmaintained" | "unreleased";
@@ -233,6 +248,7 @@ export function createDocPageShell<S extends Settings = Settings>(
       currentPath,
       currentVersion,
       versionSwitcher,
+      unavailableVersions,
       versionBanner,
       versionBannerLatestUrl,
       versionBannerLabels,
@@ -344,6 +360,12 @@ export function createDocPageShell<S extends Settings = Settings>(
         footerOverride={<FooterWithDefaults lang={locale} />}
         bodyEndComponents={<DocBodyEnd />}
         enableClientRouter={settings.dynamicPageTransition}
+        // See the `unavailableVersions` prop doc above and
+        // `../version-availability/index.ts`'s "Client payload contract" for
+        // the attribute name/format. `serializeUnavailableVersions` returns
+        // `{}` (no key) for `undefined`, so an absent attribute really means
+        // "no data" — not "nothing unavailable".
+        articleAttrs={serializeUnavailableVersions(unavailableVersions)}
       >
         {kind === "autoIndex" ? (
           /* Auto-index page: category without an index.mdx.

--- a/packages/zudo-doc/src/doclayout/doc-layout.tsx
+++ b/packages/zudo-doc/src/doclayout/doc-layout.tsx
@@ -166,6 +166,21 @@ export interface DocLayoutProps extends DocLayoutHtmlAttrs {
    */
   afterContent?: ComponentChildren;
 
+  /**
+   * Raw `data-*` attributes spread onto the `<article>` element. This shell
+   * stays version/i18n-agnostic on purpose (see the module header), so it
+   * has no idea what any given key means — it is a generic passthrough, not
+   * a versioning-aware prop. `<DocPageShell>` (one level up) is the actual
+   * owner of the one entry currently threaded through here: the per-page
+   * version-availability payload documented in
+   * `../version-availability/index.ts` (`UNAVAILABLE_VERSIONS_ATTR`). Placed
+   * on `<article>` rather than a new wrapper element because `<article>` is
+   * always present, sits inside `<main>` (swapped content — see the SPA
+   * persist note on the sidebar `<aside>` above), and needs no DOM node of
+   * its own that could shift the `.zd-content` flow-space rhythm.
+   */
+  articleAttrs?: Record<string, string>;
+
   /** Optional desktop TOC rendered alongside `<main>` on wide screens. */
   toc?: ComponentChildren;
 
@@ -245,6 +260,7 @@ export function DocLayout(props: DocLayoutProps): JSX.Element {
     mobileToc,
     main,
     afterContent,
+    articleAttrs,
     toc,
     hideToc = false,
     contentWide = false,
@@ -406,7 +422,7 @@ export function DocLayout(props: DocLayoutProps): JSX.Element {
                 {breadcrumb}
                 {afterBreadcrumb}
                 {!hideToc && mobileToc}
-                <article class="zd-content max-w-none">{main}</article>
+                <article class="zd-content max-w-none" {...articleAttrs}>{main}</article>
                 {afterContent}
               </main>
               {showToc && toc}

--- a/packages/zudo-doc/src/header-with-defaults/index.tsx
+++ b/packages/zudo-doc/src/header-with-defaults/index.tsx
@@ -214,6 +214,7 @@ export function createHeaderWithDefaults<S extends Settings = Settings>(
             defaultLocale,
             trailingSlash: settings.trailingSlash,
             currentLocale: lang,
+            unavailableLabel: labels.unavailable,
           }}
         />
       ) as unknown as VNode;

--- a/packages/zudo-doc/src/header-with-defaults/index.tsx
+++ b/packages/zudo-doc/src/header-with-defaults/index.tsx
@@ -214,7 +214,6 @@ export function createHeaderWithDefaults<S extends Settings = Settings>(
             defaultLocale,
             trailingSlash: settings.trailingSlash,
             currentLocale: lang,
-            unavailableLabel: labels.unavailable,
           }}
         />
       ) as unknown as VNode;

--- a/packages/zudo-doc/src/i18n-version/__tests__/version-switcher-first-paint.test.tsx
+++ b/packages/zudo-doc/src/i18n-version/__tests__/version-switcher-first-paint.test.tsx
@@ -164,10 +164,15 @@ describe("VERSION_SWITCHER_REWIRE_SCRIPT survives first paint before <article> e
 
     new Function(VERSION_SWITCHER_REWIRE_SCRIPT)();
 
-    // Swap to a page where v1 is available again.
+    // Swap to a page where v1 is available again. Must carry the EMPTY
+    // (`""`) payload — not an absent attribute — to mean "available in every
+    // version" (see `version-availability/index.ts`'s three-state contract,
+    // and the #3244 codex review fix in `version-switcher.tsx`'s `rewire()`:
+    // an ABSENT attribute now means "leave disabled state untouched", so an
+    // omitted attribute here would no longer re-enable v1).
     document.body.querySelectorAll("article").forEach((el) => el.remove());
     const freshWrapper = document.createElement("div");
-    freshWrapper.innerHTML = `<article class="zd-content max-w-none"></article>`;
+    freshWrapper.innerHTML = `<article class="zd-content max-w-none" ${UNAVAILABLE_VERSIONS_ATTR}=""></article>`;
     const freshArticle = freshWrapper.firstElementChild;
     if (!freshArticle) throw new Error("fresh article missing");
     document.body.appendChild(freshArticle);

--- a/packages/zudo-doc/src/i18n-version/__tests__/version-switcher-first-paint.test.tsx
+++ b/packages/zudo-doc/src/i18n-version/__tests__/version-switcher-first-paint.test.tsx
@@ -1,0 +1,178 @@
+/** @vitest-environment happy-dom */
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+// Regression guard for the first-paint clobber bug found while arming the
+// #3245 e2e guard: `VERSION_SWITCHER_REWIRE_SCRIPT` is inline in <header>,
+// which parses before <article> in document order. Its unconditional
+// `rewire()` call at script-evaluation time therefore used to run BEFORE the
+// article (carrying `UNAVAILABLE_VERSIONS_ATTR`) exists in the DOM, so
+// `document.querySelector("["+ATTR+"]")` returned null and every SSR-disabled
+// entry was read as "no unavailable slugs" and re-enabled into a live link to
+// a page that 404s. This mirrors `version-switcher-rewire-disabled.test.tsx`
+// (same script, same anchor-property assertions) but drives the REAL
+// first-paint ordering — article absent + `document.readyState === "loading"`
+// at script-eval time — instead of `simulateSwap`'s already-parsed setup.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { render } from "preact-render-to-string";
+import {
+  VersionSwitcher,
+  VERSION_SWITCHER_REWIRE_SCRIPT,
+  type VersionSwitcherRewireConfig,
+} from "../version-switcher.js";
+import type { VersionEntry, VersionSwitcherLabels } from "../types.js";
+import { UNAVAILABLE_VERSIONS_ATTR } from "../../version-availability/index.js";
+import { AFTER_NAVIGATE_EVENT } from "../../transitions/page-events.js";
+
+const labels: VersionSwitcherLabels = {
+  latest: "Latest",
+  switcher: "Version",
+  unavailable: "Not available",
+  allVersions: "All versions",
+};
+
+const versions: VersionEntry[] = [
+  { slug: "v1", label: "v1.x" },
+  { slug: "v2", label: "v2.0" },
+];
+
+const rewireConfig: VersionSwitcherRewireConfig = {
+  base: "",
+  defaultLocale: "en",
+  trailingSlash: false,
+  currentLocale: "en",
+};
+
+/** Real SSR render of the header's VersionSwitcher, v1 disabled, viewing "latest". */
+function renderHeaderSwitcher(): string {
+  return render(
+    <VersionSwitcher
+      versions={versions}
+      currentVersion={undefined}
+      latestUrl="/docs/intro"
+      versionsPageUrl="/docs/versions"
+      versionUrls={{ v1: "/v/v1/docs/intro", v2: "/v/v2/docs/intro" }}
+      unavailableVersions={new Set(["v1"])}
+      labels={labels}
+      idSuffix="header"
+      rewireConfig={rewireConfig}
+    />,
+  );
+}
+
+function articleHtml(): string {
+  return `<article class="zd-content max-w-none" ${UNAVAILABLE_VERSIONS_ATTR}="v1"></article>`;
+}
+
+interface AnchorSnapshot {
+  ariaDisabled: string | null;
+  tabIndex: string | null;
+  title: string | null;
+  className: string;
+  ariaCurrent: string | null;
+}
+
+function anchorProps(root: ParentNode, slug: string): AnchorSnapshot {
+  const a = root.querySelector(`a[data-version-slug="${slug}"]`);
+  if (!a) throw new Error(`no anchor for slug "${slug}"`);
+  return {
+    ariaDisabled: a.getAttribute("aria-disabled"),
+    tabIndex: a.getAttribute("tabindex"),
+    title: a.getAttribute("title"),
+    className: a.className,
+    ariaCurrent: a.getAttribute("aria-current"),
+  };
+}
+
+/** Overrides `document.readyState` for the duration of the callback. */
+function withReadyState<T>(state: DocumentReadyState, fn: () => T): T {
+  const original = Object.getOwnPropertyDescriptor(Document.prototype, "readyState");
+  Object.defineProperty(document, "readyState", {
+    configurable: true,
+    get: () => state,
+  });
+  try {
+    return fn();
+  } finally {
+    if (original) {
+      Object.defineProperty(Document.prototype, "readyState", original);
+    }
+    // Own-property override (set directly on `document`, not the prototype)
+    // must also be removed so it doesn't shadow the restored prototype getter.
+    delete (document as unknown as Record<string, unknown>).readyState;
+  }
+}
+
+describe("VERSION_SWITCHER_REWIRE_SCRIPT survives first paint before <article> exists", () => {
+  let header: HTMLDivElement;
+
+  beforeEach(() => {
+    delete (window as unknown as { __zdVersionSwitcherRewire?: boolean })
+      .__zdVersionSwitcherRewire;
+    header = document.createElement("div");
+    document.body.appendChild(header);
+    header.innerHTML = renderHeaderSwitcher();
+  });
+
+  afterEach(() => {
+    header.remove();
+    document.body.querySelectorAll("article").forEach((el) => el.remove());
+  });
+
+  it("does not clobber SSR-disabled entries when the script runs before <article> is parsed", () => {
+    // Document still parsing, <article> not yet in the DOM — the exact
+    // first-paint ordering an inline <header> script sees in production.
+    withReadyState("loading", () => {
+      new Function(VERSION_SWITCHER_REWIRE_SCRIPT)();
+    });
+
+    // Parsing completes: <article> (carrying the SSR availability payload)
+    // is appended, then DOMContentLoaded fires.
+    const wrapper = document.createElement("div");
+    wrapper.innerHTML = articleHtml();
+    const article = wrapper.firstElementChild;
+    if (!article) throw new Error("articleHtml produced no element");
+    document.body.appendChild(article);
+
+    withReadyState("complete", () => {
+      document.dispatchEvent(new Event("DOMContentLoaded"));
+    });
+
+    const expected = anchorProps(
+      (() => {
+        const div = document.createElement("div");
+        div.innerHTML = renderHeaderSwitcher();
+        return div;
+      })(),
+      "v1",
+    );
+    expect(anchorProps(header, "v1")).toEqual(expected);
+    expect(anchorProps(header, "v1").ariaDisabled).toBe("true");
+  });
+
+  it("still recomputes correctly from a real zfb:after-swap once parsing has completed", () => {
+    // Sanity check that deferring the initial call doesn't regress waves 1-3:
+    // once the document is already "complete", the script must still react
+    // to after-swap the same way `version-switcher-rewire-disabled.test.tsx`
+    // pins.
+    const wrapper = document.createElement("div");
+    wrapper.innerHTML = articleHtml();
+    const article = wrapper.firstElementChild;
+    if (!article) throw new Error("articleHtml produced no element");
+    document.body.appendChild(article);
+
+    new Function(VERSION_SWITCHER_REWIRE_SCRIPT)();
+
+    // Swap to a page where v1 is available again.
+    document.body.querySelectorAll("article").forEach((el) => el.remove());
+    const freshWrapper = document.createElement("div");
+    freshWrapper.innerHTML = `<article class="zd-content max-w-none"></article>`;
+    const freshArticle = freshWrapper.firstElementChild;
+    if (!freshArticle) throw new Error("fresh article missing");
+    document.body.appendChild(freshArticle);
+    document.dispatchEvent(new Event(AFTER_NAVIGATE_EVENT));
+
+    expect(anchorProps(header, "v1").ariaDisabled).toBeNull();
+  });
+});

--- a/packages/zudo-doc/src/i18n-version/__tests__/version-switcher-rewire-disabled.test.tsx
+++ b/packages/zudo-doc/src/i18n-version/__tests__/version-switcher-rewire-disabled.test.tsx
@@ -45,7 +45,6 @@ const rewireConfig: VersionSwitcherRewireConfig = {
   defaultLocale: "en",
   trailingSlash: false,
   currentLocale: "en",
-  unavailableLabel: labels.unavailable,
 };
 
 interface PageState {

--- a/packages/zudo-doc/src/i18n-version/__tests__/version-switcher-rewire-disabled.test.tsx
+++ b/packages/zudo-doc/src/i18n-version/__tests__/version-switcher-rewire-disabled.test.tsx
@@ -1,0 +1,303 @@
+/** @vitest-environment happy-dom */
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+// Drift-guard extension for epic #3242 / #3244: simulates a real
+// `zfb:after-swap` cycle in happy-dom and asserts the persisted header's
+// version-switcher anchors end up matching a fresh SSR render of the
+// destination page across all FIVE SSR-divergent properties (`aria-disabled`,
+// `tabindex`, `title`, the full class list, `aria-current`) — not just hrefs
+// / active state, which `version-switcher.test.tsx` already pins.
+//
+// Wave 1 (#3243) emits the per-page availability payload
+// (`UNAVAILABLE_VERSIONS_ATTR`) onto the swapped `<article>`;
+// `VERSION_SWITCHER_REWIRE_SCRIPT` (`../version-switcher.js`) is the wave-2
+// consumer under test here. This file is kept separate from
+// `version-switcher.test.tsx` (which runs in vitest's default plain-Node
+// environment) because exercising the actual script string end-to-end needs
+// a real DOM (`happy-dom`, declared via the file-scoped pragma above).
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { render } from "preact-render-to-string";
+import {
+  VersionSwitcher,
+  VERSION_SWITCHER_REWIRE_SCRIPT,
+  type VersionSwitcherRewireConfig,
+} from "../version-switcher.js";
+import type { VersionEntry, VersionSwitcherLabels } from "../types.js";
+import { UNAVAILABLE_VERSIONS_ATTR } from "../../version-availability/index.js";
+import { AFTER_NAVIGATE_EVENT } from "../../transitions/page-events.js";
+
+const labels: VersionSwitcherLabels = {
+  latest: "Latest",
+  switcher: "Version",
+  unavailable: "Not available",
+  allVersions: "All versions",
+};
+
+const versions: VersionEntry[] = [
+  { slug: "v1", label: "v1.x" },
+  { slug: "v2", label: "v2.0" },
+];
+
+const rewireConfig: VersionSwitcherRewireConfig = {
+  base: "",
+  defaultLocale: "en",
+  trailingSlash: false,
+  currentLocale: "en",
+  unavailableLabel: labels.unavailable,
+};
+
+interface PageState {
+  /** Pathname the "live" location is set to for this page. */
+  pathname: string;
+  currentVersion?: string;
+  currentSlug: string;
+  /** `undefined` ⇒ the payload attribute is ABSENT (mirrors the 3-state contract). */
+  unavailable: Set<string> | undefined;
+}
+
+function versionUrlsFor(currentSlug: string): Record<string, string> {
+  return {
+    v1: `/v/v1/docs/${currentSlug}`,
+    v2: `/v/v2/docs/${currentSlug}`,
+  };
+}
+
+/** Real SSR render of the header's VersionSwitcher for a given page state. */
+function renderHeaderSwitcher(page: PageState): string {
+  return render(
+    <VersionSwitcher
+      versions={versions}
+      currentVersion={page.currentVersion}
+      latestUrl={`/docs/${page.currentSlug}`}
+      versionsPageUrl="/docs/versions"
+      versionUrls={versionUrlsFor(page.currentSlug)}
+      unavailableVersions={page.unavailable}
+      labels={labels}
+      idSuffix="header"
+      rewireConfig={rewireConfig}
+    />,
+  );
+}
+
+/**
+ * The swapped `<article>` wave 1 emits. `undefined` reproduces the ABSENT
+ * case (no key at all) — see `version-availability/index.ts`'s three-state
+ * contract this mirrors.
+ */
+function articleHtml(unavailable: Set<string> | undefined): string {
+  const attr =
+    unavailable === undefined
+      ? ""
+      : ` ${UNAVAILABLE_VERSIONS_ATTR}="${Array.from(unavailable).sort().join(",")}"`;
+  return `<article class="zd-content max-w-none"${attr}></article>`;
+}
+
+function setArticle(unavailable: Set<string> | undefined): void {
+  document.body.querySelectorAll("article").forEach((el) => el.remove());
+  const wrapper = document.createElement("div");
+  wrapper.innerHTML = articleHtml(unavailable);
+  const article = wrapper.firstElementChild;
+  if (!article) throw new Error("articleHtml produced no element");
+  document.body.appendChild(article);
+}
+
+function setLocation(pathname: string): void {
+  (window as unknown as { happyDOM?: { setURL: (url: string) => void } }).happyDOM?.setURL(
+    `http://localhost${pathname}`,
+  );
+}
+
+interface AnchorSnapshot {
+  ariaDisabled: string | null;
+  tabIndex: string | null;
+  title: string | null;
+  className: string;
+  ariaCurrent: string | null;
+}
+
+function anchorProps(root: ParentNode, slug: string): AnchorSnapshot {
+  const a = root.querySelector(`a[data-version-slug="${slug}"]`);
+  if (!a) throw new Error(`no anchor for slug "${slug}"`);
+  return {
+    ariaDisabled: a.getAttribute("aria-disabled"),
+    tabIndex: a.getAttribute("tabindex"),
+    title: a.getAttribute("title"),
+    className: a.className,
+    ariaCurrent: a.getAttribute("aria-current"),
+  };
+}
+
+/** The properties an SSR render of `page` would produce for `slug`. */
+function expectedProps(page: PageState, slug: string): AnchorSnapshot {
+  const div = document.createElement("div");
+  div.innerHTML = renderHeaderSwitcher(page);
+  return anchorProps(div, slug);
+}
+
+describe("VERSION_SWITCHER_REWIRE_SCRIPT recomputes disabled state on zfb:after-swap (#3244)", () => {
+  let header: HTMLDivElement;
+
+  beforeEach(() => {
+    delete (window as unknown as { __zdVersionSwitcherRewire?: boolean })
+      .__zdVersionSwitcherRewire;
+    header = document.createElement("div");
+    document.body.appendChild(header);
+  });
+
+  afterEach(() => {
+    header.remove();
+    document.body.querySelectorAll("article").forEach((el) => el.remove());
+  });
+
+  /**
+   * Mounts `before`'s SSR header + article, runs the rewire script (this
+   * registers the after-swap listener and performs the harmless initial
+   * pass), then swaps in `after`'s article + location and dispatches the
+   * after-swap event — the same sequence a real same-locale SPA navigation
+   * produces against the persisted header.
+   */
+  function simulateSwap(before: PageState, after: PageState): void {
+    setLocation(before.pathname);
+    header.innerHTML = renderHeaderSwitcher(before);
+    setArticle(before.unavailable);
+    new Function(VERSION_SWITCHER_REWIRE_SCRIPT)();
+
+    setArticle(after.unavailable);
+    setLocation(after.pathname);
+    document.dispatchEvent(new Event(AFTER_NAVIGATE_EVENT));
+  }
+
+  describe("latest active throughout (currentVersion undefined)", () => {
+    const base: Omit<PageState, "unavailable"> = {
+      pathname: "/docs/intro",
+      currentVersion: undefined,
+      currentSlug: "intro",
+    };
+
+    it("disabled -> available: v1 regains full interactivity", () => {
+      const before: PageState = { ...base, unavailable: new Set(["v1"]) };
+      const after: PageState = { ...base, unavailable: new Set() };
+      simulateSwap(before, after);
+
+      expect(anchorProps(header, "v1")).toEqual(expectedProps(after, "v1"));
+      // v2 was never disabled — must stay untouched across the swap.
+      expect(anchorProps(header, "v2")).toEqual(expectedProps(after, "v2"));
+    });
+
+    it("available -> disabled: v1 becomes muted, non-interactive", () => {
+      const before: PageState = { ...base, unavailable: new Set() };
+      const after: PageState = { ...base, unavailable: new Set(["v1"]) };
+      simulateSwap(before, after);
+
+      expect(anchorProps(header, "v1")).toEqual(expectedProps(after, "v1"));
+      expect(anchorProps(header, "v2")).toEqual(expectedProps(after, "v2"));
+    });
+  });
+
+  describe("shared active slug throughout (currentVersion \"v1\" on both pages)", () => {
+    const base: Omit<PageState, "unavailable"> = {
+      pathname: "/v/v1/docs/intro",
+      currentVersion: "v1",
+      currentSlug: "intro",
+    };
+
+    it("disabled -> available: v2 regains full interactivity, v1 stays active", () => {
+      const before: PageState = { ...base, unavailable: new Set(["v2"]) };
+      const after: PageState = { ...base, unavailable: new Set() };
+      simulateSwap(before, after);
+
+      expect(anchorProps(header, "v2")).toEqual(expectedProps(after, "v2"));
+      // The active entry (v1) must be untouched by v2's transition.
+      expect(anchorProps(header, "v1")).toEqual(expectedProps(after, "v1"));
+    });
+
+    it("available -> disabled: v2 becomes muted, non-interactive, v1 stays active", () => {
+      const before: PageState = { ...base, unavailable: new Set() };
+      const after: PageState = { ...base, unavailable: new Set(["v2"]) };
+      simulateSwap(before, after);
+
+      expect(anchorProps(header, "v2")).toEqual(expectedProps(after, "v2"));
+      expect(anchorProps(header, "v1")).toEqual(expectedProps(after, "v1"));
+    });
+  });
+
+  it("restores aria-current when an entry becomes BOTH available and active (property 5)", () => {
+    // Before: viewing "latest", v1 is disabled on this page (v1 is not the
+    // active entry here, so this is a legal SSR state).
+    const before: PageState = {
+      pathname: "/docs/intro",
+      currentVersion: undefined,
+      currentSlug: "intro",
+      unavailable: new Set(["v1"]),
+    };
+    // After: same-locale navigation lands ON v1's own page, where v1 is of
+    // course available. The persisted header must both re-enable v1 AND
+    // mark it active (aria-current="page" + font-bold/text-accent) — a
+    // partial transition would leave it enabled-but-inactive or (worse)
+    // still disabled while the URL says otherwise.
+    const after: PageState = {
+      pathname: "/v/v1/docs/intro",
+      currentVersion: "v1",
+      currentSlug: "intro",
+      unavailable: new Set(),
+    };
+    simulateSwap(before, after);
+
+    const actual = anchorProps(header, "v1");
+    const expected = expectedProps(after, "v1");
+    expect(actual).toEqual(expected);
+    expect(actual.ariaCurrent).toBe("page");
+    expect(actual.ariaDisabled).toBeNull();
+  });
+
+  it('absent payload leaves every entry enabled ("no availability info" fallback)', () => {
+    const before: PageState = {
+      pathname: "/docs/intro",
+      currentVersion: undefined,
+      currentSlug: "intro",
+      unavailable: new Set(["v1"]),
+    };
+    // The destination page carries NO availability data at all (e.g. a
+    // non-doc page) — must NOT be read as "everything unavailable"; per the
+    // component's own SSR fallback (`!unavailableVersions || …`), it must
+    // render every entry available, matching `expectedProps` built from
+    // `unavailable: undefined`.
+    const after: PageState = {
+      pathname: "/docs/other",
+      currentVersion: undefined,
+      currentSlug: "other",
+      unavailable: undefined,
+    };
+    simulateSwap(before, after);
+
+    expect(anchorProps(header, "v1")).toEqual(expectedProps(after, "v1"));
+    expect(anchorProps(header, "v1").ariaDisabled).toBeNull();
+  });
+
+  it("absent and empty-string payloads produce the identical enabled DOM state", () => {
+    // Pins the three-state contract's documented equivalence for THIS
+    // consumer: `version-availability/index.ts` treats "absent" and
+    // "present, empty" as distinct concepts at the derivation layer, but
+    // once they reach this script both must resolve to "no slug is
+    // unavailable" — the same outcome the SSR component's own
+    // no-unavailableVersions-prop fallback produces.
+    const before: PageState = {
+      pathname: "/docs/intro",
+      currentVersion: undefined,
+      currentSlug: "intro",
+      unavailable: new Set(["v1"]),
+    };
+    const afterAbsent: PageState = { ...before, unavailable: undefined };
+    const afterEmpty: PageState = { ...before, unavailable: new Set() };
+
+    simulateSwap(before, afterAbsent);
+    const absentResult = anchorProps(header, "v1");
+
+    simulateSwap(before, afterEmpty);
+    const emptyResult = anchorProps(header, "v1");
+
+    expect(absentResult).toEqual(emptyResult);
+  });
+});

--- a/packages/zudo-doc/src/i18n-version/__tests__/version-switcher-rewire-disabled.test.tsx
+++ b/packages/zudo-doc/src/i18n-version/__tests__/version-switcher-rewire-disabled.test.tsx
@@ -251,18 +251,28 @@ describe("VERSION_SWITCHER_REWIRE_SCRIPT recomputes disabled state on zfb:after-
     expect(actual.ariaDisabled).toBeNull();
   });
 
-  it('absent payload leaves every entry enabled ("no availability info" fallback)', () => {
+  it("absent payload leaves the SSR-rendered disabled state UNTOUCHED (#3244 codex review finding 1)", () => {
+    // CORRECTED per the #3244 codex review: an ABSENT payload must NOT be
+    // read as "everything available" — that fallback belongs to the EMPTY
+    // (`""`) case only (see the next test). Absent means "no availability
+    // data for this page at all" (`version-availability/index.ts`'s
+    // three-state contract), and a consumer MUST treat that as "nothing to
+    // rewire", leaving whatever the header already shows in place. This
+    // test previously asserted the OPPOSITE (every entry regains full
+    // interactivity on an absent payload) — that assertion encoded the bug:
+    // a page rendered via the public `createDocPageShell` API without an
+    // `unavailableVersions` prop would silently re-enable entries the SSR
+    // correctly disabled, turning them into live 404 links.
     const before: PageState = {
       pathname: "/docs/intro",
       currentVersion: undefined,
       currentSlug: "intro",
       unavailable: new Set(["v1"]),
     };
-    // The destination page carries NO availability data at all (e.g. a
-    // non-doc page) — must NOT be read as "everything unavailable"; per the
-    // component's own SSR fallback (`!unavailableVersions || …`), it must
-    // render every entry available, matching `expectedProps` built from
-    // `unavailable: undefined`.
+    // The destination page carries NO availability data at all (e.g. a page
+    // rendered without an `unavailableVersions` prop) — v1 must STAY
+    // disabled, exactly as the header already rendered it, not flip to
+    // available.
     const after: PageState = {
       pathname: "/docs/other",
       currentVersion: undefined,
@@ -271,32 +281,64 @@ describe("VERSION_SWITCHER_REWIRE_SCRIPT recomputes disabled state on zfb:after-
     };
     simulateSwap(before, after);
 
-    expect(anchorProps(header, "v1")).toEqual(expectedProps(after, "v1"));
-    expect(anchorProps(header, "v1").ariaDisabled).toBeNull();
+    const result = anchorProps(header, "v1");
+    // Disabled-ness (and everything setDisabled owns) is carried over
+    // unchanged from `before`, NOT recomputed from `after`.
+    expect(result.ariaDisabled).toBe("true");
+    expect(result.tabIndex).toBe("-1");
+    expect(result.title).toBe(labels.unavailable);
+    expect(result.className).toContain("text-muted/50");
+    expect(result.className).toContain("cursor-not-allowed");
+    expect(result.className).toContain("pointer-events-none");
+    expect(result.ariaCurrent).toBeNull();
+    // The href IS path-derived and safe to recompute even while disabled.
+    const a = header.querySelector('a[data-version-slug="v1"]');
+    expect(a?.getAttribute("href")).toBe("/v/v1/docs/other");
   });
 
-  it("absent and empty-string payloads produce the identical enabled DOM state", () => {
-    // Pins the three-state contract's documented equivalence for THIS
-    // consumer: `version-availability/index.ts` treats "absent" and
-    // "present, empty" as distinct concepts at the derivation layer, but
-    // once they reach this script both must resolve to "no slug is
-    // unavailable" — the same outcome the SSR component's own
-    // no-unavailableVersions-prop fallback produces.
+  it("absent payload still re-derives href + active state for entries NOT currently disabled", () => {
+    // v2 is enabled on `before` — an absent payload on `after` must still
+    // recompute its path-derived properties (href, active state), since
+    // those are safe regardless of availability data.
     const before: PageState = {
       pathname: "/docs/intro",
       currentVersion: undefined,
       currentSlug: "intro",
       unavailable: new Set(["v1"]),
     };
-    const afterAbsent: PageState = { ...before, unavailable: undefined };
-    const afterEmpty: PageState = { ...before, unavailable: new Set() };
+    const after: PageState = {
+      pathname: "/docs/other",
+      currentVersion: undefined,
+      currentSlug: "other",
+      unavailable: undefined,
+    };
+    simulateSwap(before, after);
 
-    simulateSwap(before, afterAbsent);
-    const absentResult = anchorProps(header, "v1");
+    const a = header.querySelector('a[data-version-slug="v2"]');
+    expect(a?.getAttribute("href")).toBe("/v/v2/docs/other");
+    expect(a?.getAttribute("aria-disabled")).toBeNull();
+  });
 
-    simulateSwap(before, afterEmpty);
-    const emptyResult = anchorProps(header, "v1");
+  it('empty-string payload DOES re-enable every entry ("everything available")', () => {
+    // The EMPTY case (attribute present, value "") is the one the SSR
+    // component's own `!unavailableVersions || …` fallback mirrors — this
+    // is the only case that means "everything available", and it must keep
+    // working exactly as before.
+    const before: PageState = {
+      pathname: "/docs/intro",
+      currentVersion: undefined,
+      currentSlug: "intro",
+      unavailable: new Set(["v1"]),
+    };
+    const after: PageState = {
+      pathname: "/docs/other",
+      currentVersion: undefined,
+      currentSlug: "other",
+      unavailable: new Set(),
+    };
+    simulateSwap(before, after);
 
-    expect(absentResult).toEqual(emptyResult);
+    expect(anchorProps(header, "v1")).toEqual(expectedProps(after, "v1"));
+    expect(anchorProps(header, "v1").ariaDisabled).toBeNull();
   });
 });

--- a/packages/zudo-doc/src/i18n-version/__tests__/version-switcher.test.tsx
+++ b/packages/zudo-doc/src/i18n-version/__tests__/version-switcher.test.tsx
@@ -248,7 +248,6 @@ describe("VersionSwitcher", () => {
           defaultLocale: "en",
           trailingSlash: true,
           currentLocale: "en",
-          unavailableLabel: "Not available",
         }}
       />,
     );

--- a/packages/zudo-doc/src/i18n-version/__tests__/version-switcher.test.tsx
+++ b/packages/zudo-doc/src/i18n-version/__tests__/version-switcher.test.tsx
@@ -248,6 +248,7 @@ describe("VersionSwitcher", () => {
           defaultLocale: "en",
           trailingSlash: true,
           currentLocale: "en",
+          unavailableLabel: "Not available",
         }}
       />,
     );
@@ -255,6 +256,7 @@ describe("VersionSwitcher", () => {
     expect(html).toContain('data-default-locale="en"');
     expect(html).toContain('data-trailing-slash="true"');
     expect(html).toContain('data-current-locale="en"');
+    expect(html).toContain('data-unavailable-label="Not available"');
     expect(html).toContain("data-version-latest");
     expect(html).toContain("data-version-trigger-label");
     expect(html).toContain('data-version-slug="v1"');

--- a/packages/zudo-doc/src/i18n-version/version-switcher.tsx
+++ b/packages/zudo-doc/src/i18n-version/version-switcher.tsx
@@ -615,7 +615,14 @@ label.textContent=activeLabel!=null?activeLabel:state.activeVersion;
 }
 }
 }
-rewire();
+// The initial call is deferred to DOMContentLoaded when the script (inline in
+// <header>, which parses before <article>) would otherwise run before the
+// article element exists. Running early would read a missing ATTR as "no
+// unavailable slugs" and clobber the SSR-correct disabled state with
+// everything-enabled — a first-paint variant of the bug this rewire exists
+// to fix (see the doc comment above; SSR already rendered the right state for
+// this page, so a brief deferral loses nothing).
+if(document.readyState==="loading"){document.addEventListener("DOMContentLoaded",rewire);}else{rewire();}
 document.addEventListener(${JSON.stringify(AFTER_NAVIGATE_EVENT)},rewire);
 })();`;
 

--- a/packages/zudo-doc/src/i18n-version/version-switcher.tsx
+++ b/packages/zudo-doc/src/i18n-version/version-switcher.tsx
@@ -66,6 +66,7 @@
 import type { VNode } from "preact";
 import type { VersionEntry, VersionSwitcherLabels } from "./types.js";
 import { AFTER_NAVIGATE_EVENT } from "../transitions/page-events.js";
+import { UNAVAILABLE_VERSIONS_ATTR } from "../version-availability/index.js";
 
 export interface VersionSwitcherProps {
   /**
@@ -144,6 +145,14 @@ export interface VersionSwitcherRewireConfig {
    * so it can be read once from the SSR container rather than re-derived.
    */
   currentLocale: string;
+  /**
+   * `title` attribute the SSR render puts on a disabled entry
+   * (`VersionSwitcherLabels.unavailable`). Delivered via the container's
+   * `data-*` config bag — like the rest of this interface — rather than
+   * hardcoded in the script, since it's a translated string the client-side
+   * re-wire has no other way to reach (epic #3242, #3244).
+   */
+  unavailableLabel: string;
 }
 
 /** The re-computed per-page menu state {@link computeVersionSwitcherState} returns. */
@@ -353,6 +362,7 @@ export function VersionSwitcher(props: VersionSwitcherProps): VNode {
         "data-default-locale": rewireConfig.defaultLocale,
         "data-trailing-slash": String(rewireConfig.trailingSlash),
         "data-current-locale": rewireConfig.currentLocale,
+        "data-unavailable-label": rewireConfig.unavailableLabel,
       }
     : {};
 
@@ -505,6 +515,29 @@ document.addEventListener(${JSON.stringify(AFTER_NAVIGATE_EVENT)},initVersionSwi
  * {@link VersionSwitcherRewireConfig} is passed), so the inline breadcrumb
  * switcher — re-rendered fresh on every swap — is left alone.
  *
+ * Since #3244, `rewire()` also recomputes each version entry's
+ * enabled/disabled state from the per-page availability payload #3243 emits
+ * onto the swapped `<article>` (`UNAVAILABLE_VERSIONS_ATTR`, imported here
+ * as `ATTR` — see `version-availability/index.ts` for the three-state
+ * contract). The persisted header would otherwise keep showing whichever
+ * entries were disabled/enabled on the PREVIOUS page after a same-locale SPA
+ * navigation — the exact bug epic #3242 exists to fix. Reading the article's
+ * attribute (rather than diffing the header's own prior state) means an
+ * ABSENT attribute and an EMPTY (`""`) one both resolve to "no slug is
+ * unavailable" here, which is intentional: they are indistinguishable at the
+ * point this script decides per-slug availability, and both must produce the
+ * same "everything available" rendering the SSR component's own
+ * `!unavailableVersions || !unavailableVersions.has(slug)` fallback would
+ * produce for the same page (`version-switcher.tsx`'s `isAvailable` check).
+ *
+ * `setDisabled` and the `setActive` guard together transition ALL FIVE
+ * SSR-divergent properties in both directions (`aria-disabled`, `tabindex`,
+ * `title`, the disjoint class sets, `aria-current`) — see the case table in
+ * `__tests__/version-switcher.test.tsx` that pins this against the real SSR
+ * branches. `setActive` runs strictly AFTER `setDisabled` re-enables an
+ * entry, so a newly-available active entry gets `aria-current="page"`
+ * restored instead of silently staying without it.
+ *
  * `window[FLAG]` makes it idempotent: the tag may re-execute on a hard reload or
  * a cross-locale header repaint, but the listener registers exactly once per
  * page lifetime.
@@ -513,6 +546,7 @@ export const VERSION_SWITCHER_REWIRE_SCRIPT = `(function(){
 var FLAG="__zdVersionSwitcherRewire";
 if(window[FLAG])return;
 window[FLAG]=true;
+var ATTR=${JSON.stringify(UNAVAILABLE_VERSIONS_ATTR)};
 var computeVersionSwitcherState=${computeVersionSwitcherState.toString()};
 function setActive(a,active){
 a.classList.toggle("font-bold",active);
@@ -520,11 +554,33 @@ a.classList.toggle("text-accent",active);
 a.classList.toggle("text-fg",!active);
 if(active){a.setAttribute("aria-current","page");}else{a.removeAttribute("aria-current");}
 }
+function setDisabled(a,disabled,unavailableLabel){
+a.classList.toggle("hover:bg-accent/10",!disabled);
+a.classList.toggle("hover:underline",!disabled);
+a.classList.toggle("focus-visible:underline",!disabled);
+a.classList.toggle("text-muted/50",disabled);
+a.classList.toggle("cursor-not-allowed",disabled);
+a.classList.toggle("pointer-events-none",disabled);
+if(disabled){
+a.setAttribute("aria-disabled","true");
+a.setAttribute("tabindex","-1");
+a.setAttribute("title",unavailableLabel);
+a.classList.remove("font-bold","text-accent","text-fg");
+a.removeAttribute("aria-current");
+}else{
+a.removeAttribute("aria-disabled");
+a.removeAttribute("tabindex");
+a.removeAttribute("title");
+}
+}
 function rewire(){
+var articleEl=document.querySelector("["+ATTR+"]");
+var unavailableSlugs=articleEl?(articleEl.getAttribute(ATTR)||"").split(",").filter(Boolean):[];
 var containers=document.querySelectorAll("[data-version-rewire]");
 for(var i=0;i<containers.length;i++){
 var c=containers[i];
 var config={base:c.getAttribute("data-base")||"",defaultLocale:c.getAttribute("data-default-locale")||"",trailingSlash:c.getAttribute("data-trailing-slash")==="true",currentLocale:c.getAttribute("data-current-locale")||""};
+var unavailableLabel=c.getAttribute("data-unavailable-label")||"";
 var versionAnchors=c.querySelectorAll("[data-version-slug]");
 var slugs=[];
 for(var j=0;j<versionAnchors.length;j++){
@@ -543,7 +599,9 @@ var slug=a.getAttribute("data-version-slug");
 if(!slug)continue;
 var href=state.versionHrefs[slug];
 if(href!=null)a.setAttribute("href",href);
-if(!a.hasAttribute("aria-disabled"))setActive(a,state.activeVersion===slug);
+var disabled=unavailableSlugs.indexOf(slug)!==-1;
+setDisabled(a,disabled,unavailableLabel);
+if(!disabled)setActive(a,state.activeVersion===slug);
 }
 var label=c.querySelector("[data-version-trigger-label]");
 if(label){

--- a/packages/zudo-doc/src/i18n-version/version-switcher.tsx
+++ b/packages/zudo-doc/src/i18n-version/version-switcher.tsx
@@ -145,14 +145,6 @@ export interface VersionSwitcherRewireConfig {
    * so it can be read once from the SSR container rather than re-derived.
    */
   currentLocale: string;
-  /**
-   * `title` attribute the SSR render puts on a disabled entry
-   * (`VersionSwitcherLabels.unavailable`). Delivered via the container's
-   * `data-*` config bag — like the rest of this interface — rather than
-   * hardcoded in the script, since it's a translated string the client-side
-   * re-wire has no other way to reach (epic #3242, #3244).
-   */
-  unavailableLabel: string;
 }
 
 /** The re-computed per-page menu state {@link computeVersionSwitcherState} returns. */
@@ -355,6 +347,12 @@ export function VersionSwitcher(props: VersionSwitcherProps): VNode {
   // when no config is supplied so static / inline callers render exactly as
   // before (zudolab/zudo-doc#2553).
   const rewire = rewireConfig != null;
+  // `labels.unavailable` rides on the container alongside the rest of the
+  // rewire config rather than as a `VersionSwitcherRewireConfig` field —
+  // `labels` is already a required prop the component always has in hand,
+  // so this avoids widening the frozen public `VersionSwitcherRewireConfig`
+  // shape with a field every existing caller would need to add (#3244
+  // codex review finding).
   const rewireAttrs = rewireConfig
     ? {
         "data-version-rewire": true,
@@ -362,7 +360,7 @@ export function VersionSwitcher(props: VersionSwitcherProps): VNode {
         "data-default-locale": rewireConfig.defaultLocale,
         "data-trailing-slash": String(rewireConfig.trailingSlash),
         "data-current-locale": rewireConfig.currentLocale,
-        "data-unavailable-label": rewireConfig.unavailableLabel,
+        "data-unavailable-label": labels.unavailable,
       }
     : {};
 

--- a/packages/zudo-doc/src/i18n-version/version-switcher.tsx
+++ b/packages/zudo-doc/src/i18n-version/version-switcher.tsx
@@ -519,14 +519,23 @@ document.addEventListener(${JSON.stringify(AFTER_NAVIGATE_EVENT)},initVersionSwi
  * as `ATTR` — see `version-availability/index.ts` for the three-state
  * contract). The persisted header would otherwise keep showing whichever
  * entries were disabled/enabled on the PREVIOUS page after a same-locale SPA
- * navigation — the exact bug epic #3242 exists to fix. Reading the article's
- * attribute (rather than diffing the header's own prior state) means an
- * ABSENT attribute and an EMPTY (`""`) one both resolve to "no slug is
- * unavailable" here, which is intentional: they are indistinguishable at the
- * point this script decides per-slug availability, and both must produce the
- * same "everything available" rendering the SSR component's own
- * `!unavailableVersions || !unavailableVersions.has(slug)` fallback would
- * produce for the same page (`version-switcher.tsx`'s `isAvailable` check).
+ * navigation — the exact bug epic #3242 exists to fix.
+ *
+ * The three-state contract is preserved faithfully here (fixed after a P2
+ * codex review finding on the original #3244 landing, which collapsed ABSENT
+ * into EMPTY and re-enabled every entry — turning SSR-correct disabled links
+ * into live 404s whenever a page renders through `createDocPageShell` without
+ * an availability payload):
+ *   - attribute ABSENT (`hasAvailabilityData` false) → no availability data
+ *     for the destination page. `setDisabled` is never called for any entry;
+ *     the SSR-rendered disabled/enabled state is left exactly as-is. Only the
+ *     genuinely path-derived bits (href, active state on entries that are
+ *     NOT currently disabled) are recomputed.
+ *   - attribute present, value `""` → empty unavailable set, i.e. "everything
+ *     available" — `setDisabled(a, false, …)` runs for every entry, matching
+ *     the SSR component's own `!unavailableVersions || !unavailableVersions.has(slug)`
+ *     fallback (`version-switcher.tsx`'s `isAvailable` check).
+ *   - attribute present, `"a,b"` → those slugs disabled, the rest enabled.
  *
  * `setDisabled` and the `setActive` guard together transition ALL FIVE
  * SSR-divergent properties in both directions (`aria-disabled`, `tabindex`,
@@ -534,7 +543,11 @@ document.addEventListener(${JSON.stringify(AFTER_NAVIGATE_EVENT)},initVersionSwi
  * `__tests__/version-switcher.test.tsx` that pins this against the real SSR
  * branches. `setActive` runs strictly AFTER `setDisabled` re-enables an
  * entry, so a newly-available active entry gets `aria-current="page"`
- * restored instead of silently staying without it.
+ * restored instead of silently staying without it. In the ABSENT branch,
+ * where `setDisabled` never runs, `setActive` instead reads the anchor's
+ * OWN current `aria-disabled` attribute directly (the only source of truth
+ * left, since availability isn't being recomputed) and skips already-disabled
+ * entries the same way.
  *
  * `window[FLAG]` makes it idempotent: the tag may re-execute on a hard reload or
  * a cross-locale header repaint, but the listener registers exactly once per
@@ -573,7 +586,8 @@ a.removeAttribute("title");
 }
 function rewire(){
 var articleEl=document.querySelector("["+ATTR+"]");
-var unavailableSlugs=articleEl?(articleEl.getAttribute(ATTR)||"").split(",").filter(Boolean):[];
+var hasAvailabilityData=articleEl!==null;
+var unavailableSlugs=hasAvailabilityData?(articleEl.getAttribute(ATTR)||"").split(",").filter(Boolean):[];
 var containers=document.querySelectorAll("[data-version-rewire]");
 for(var i=0;i<containers.length;i++){
 var c=containers[i];
@@ -597,9 +611,14 @@ var slug=a.getAttribute("data-version-slug");
 if(!slug)continue;
 var href=state.versionHrefs[slug];
 if(href!=null)a.setAttribute("href",href);
+if(hasAvailabilityData){
 var disabled=unavailableSlugs.indexOf(slug)!==-1;
 setDisabled(a,disabled,unavailableLabel);
 if(!disabled)setActive(a,state.activeVersion===slug);
+}else{
+var alreadyDisabled=a.getAttribute("aria-disabled")==="true";
+if(!alreadyDisabled)setActive(a,state.activeVersion===slug);
+}
 }
 var label=c.querySelector("[data-version-trigger-label]");
 if(label){

--- a/packages/zudo-doc/src/preset.ts
+++ b/packages/zudo-doc/src/preset.ts
@@ -36,6 +36,7 @@
 import { z } from "zod";
 import type { ColorScheme } from "./color-scheme-utils.js";
 import type { TagVocabularyEntry } from "./settings.js";
+import { assertNoCommaInVersionSlugs } from "./version-availability/index.js";
 // Type-only — erased by esbuild before the node-builtin-free eval-graph
 // bundle runs (mirrors config.ts's `@takazudo/zfb/config` type-only import).
 import type { DirectiveSpec } from "@takazudo/zfb/config";
@@ -298,6 +299,13 @@ export function zudoDocPreset({
   tagVocabulary,
   colorSchemes,
 }: ZudoDocPresetArgs): ZudoDocPresetResult {
+  // `zudoDoc()` (`../config.ts`) already runs this same check, but the
+  // preset is itself a documented, directly-spreadable public entry point —
+  // a consumer calling `zudoDocPreset()` straight (bypassing `zudoDoc()`)
+  // must hit the same comma-free version-slug guard (#3244 codex review
+  // finding 2 follow-up; see `version-availability/index.ts`).
+  assertNoCommaInVersionSlugs(settings.versions);
+
   // `z.toJSONSchema` is a runtime call but the result is a stable JSON
   // document. Compute it once and reuse the same object across every
   // collection definition.

--- a/packages/zudo-doc/src/version-availability/__tests__/version-availability.test.ts
+++ b/packages/zudo-doc/src/version-availability/__tests__/version-availability.test.ts
@@ -19,7 +19,11 @@
  */
 
 import { describe, expect, it, vi } from "vitest";
-import { createGetUnavailableVersions } from "../index.js";
+import {
+  createGetUnavailableVersions,
+  serializeUnavailableVersions,
+  UNAVAILABLE_VERSIONS_ATTR,
+} from "../index.js";
 import type { VersionAvailabilityDeps, VersionAvailabilityNavSource } from "../index.js";
 import type { DocPageEntry } from "../../doc-page-props/index.js";
 
@@ -211,6 +215,41 @@ describe("createGetUnavailableVersions — cache keyed by BOTH locale and versio
     expect(resolveNavSource).toHaveBeenCalledWith("ja", "v1", {
       applyDefaultLocaleOnlyFilter: true,
       keepUnlisted: true,
+    });
+  });
+});
+
+describe("serializeUnavailableVersions — client payload contract (#3243)", () => {
+  it("returns no attribute at all for undefined (no availability data)", () => {
+    const attrs = serializeUnavailableVersions(undefined);
+    expect(attrs).toEqual({});
+    expect(UNAVAILABLE_VERSIONS_ATTR in attrs).toBe(false);
+  });
+
+  it("returns an empty-string attribute for an empty set (nothing unavailable)", () => {
+    const attrs = serializeUnavailableVersions(new Set());
+    expect(attrs).toEqual({ [UNAVAILABLE_VERSIONS_ATTR]: "" });
+  });
+
+  it("returns a sorted comma-joined attribute for a populated set", () => {
+    const attrs = serializeUnavailableVersions(new Set(["2.0", "1.0"]));
+    expect(attrs).toEqual({ [UNAVAILABLE_VERSIONS_ATTR]: "1.0,2.0" });
+  });
+
+  it("is byte-equal to the real createGetUnavailableVersions output for the same call", () => {
+    const resolveNavSource = (locale: string, versionSlug: string) =>
+      makeNavSource({
+        docs:
+          versionSlug === "v1"
+            ? [makeDoc("getting-started")]
+            : [makeDoc("other-page")],
+      });
+    const getUnavailableVersions = createGetUnavailableVersions(
+      makeDeps({ resolveNavSource }),
+    );
+    const real = getUnavailableVersions("getting-started", "en");
+    expect(serializeUnavailableVersions(real)).toEqual({
+      [UNAVAILABLE_VERSIONS_ATTR]: "v2",
     });
   });
 });

--- a/packages/zudo-doc/src/version-availability/index.ts
+++ b/packages/zudo-doc/src/version-availability/index.ts
@@ -28,6 +28,41 @@
 // the real versioned-locale route (`v-locale-docs-slug.tsx`) — otherwise a
 // default-locale-only path can be reported available in a locale whose
 // archived route was never generated.
+//
+// --- Client payload contract (epic #3242, #3243) ----------------------
+//
+// `serializeUnavailableVersions` below encodes a `getUnavailableVersions()`
+// result as a `data-*` attribute so the value survives into the swapped
+// document and a later SPA-navigation rewire script (#3244) can read it
+// without re-deriving availability client-side. Emitted by
+// `doc-page-shell/index.tsx` onto the `<article>` element (swapped content —
+// NOT the persisted header, whose whole problem is that a swap leaves it
+// untouched). Cross-file contract — do not rename `UNAVAILABLE_VERSIONS_ATTR`
+// or change the format without updating every consumer.
+//
+//   attribute name:  data-doc-unavailable-versions
+//   absent           → no availability data for this page (mirrors
+//                      `getUnavailableVersions` returning `undefined`: no
+//                      current slug, or versioning not configured). A
+//                      consumer MUST treat this as "nothing to rewire" —
+//                      never as "everything available" — since defaulting
+//                      an unknown page to "everything available" is exactly
+//                      the silent-404 failure mode #3215/#3242 exist to fix.
+//   value === ""     → the set is empty: this slug is available in every
+//                      configured version.
+//   value === "a,b"  → comma-joined, alphabetically SORTED version slugs
+//                      (sorted so the serialization is deterministic
+//                      regardless of `Set` iteration / `settings.versions`
+//                      order — needed for the byte-equal assertions in
+//                      `__tests__/version-availability.test.ts`).
+//
+// ASSUMPTION: a configured version slug never itself contains a comma. This
+// is not separately enforced here — it holds transitively because version
+// slugs already double as URL path segments (`/v/{slug}/...`, `versionUrls`
+// keys in `inline-version-switcher`), so a comma in one would already break
+// routing before this payload exists. A flat comma-joined list was chosen
+// over JSON-in-attribute per the epic's locked decision (simplicity over a
+// theoretical slug shape nothing else in the codebase supports).
 
 import type { DocPageEntry, DocNavNode } from "../doc-page-props/index.js";
 import type { CategoryMeta } from "../sidebar-tree/index.js";
@@ -129,4 +164,26 @@ export function createGetUnavailableVersions(
     }
     return unavailable;
   };
+}
+
+/**
+ * `data-*` attribute name the client payload rides on — see the module
+ * header's "Client payload contract" section for the full spelling/format
+ * contract. Exported so a future consumer (#3244) reads the same literal
+ * instead of hand-copying the string.
+ */
+export const UNAVAILABLE_VERSIONS_ATTR = "data-doc-unavailable-versions";
+
+/**
+ * Serialize a `getUnavailableVersions()` result into the `data-*` attribute
+ * bag `<DocPageShell>` spreads onto `<article>`. Returns `{}` (no key at
+ * all) for `undefined` input so the attribute is genuinely ABSENT from the
+ * rendered element, preserving the three-state contract documented above —
+ * an empty object here must not be confused with `{ [ATTR]: "" }`.
+ */
+export function serializeUnavailableVersions(
+  unavailableVersions: ReadonlySet<string> | undefined,
+): Record<string, string> {
+  if (unavailableVersions === undefined) return {};
+  return { [UNAVAILABLE_VERSIONS_ATTR]: Array.from(unavailableVersions).sort().join(",") };
 }

--- a/packages/zudo-doc/src/version-availability/index.ts
+++ b/packages/zudo-doc/src/version-availability/index.ts
@@ -56,13 +56,13 @@
 //                      order — needed for the byte-equal assertions in
 //                      `__tests__/version-availability.test.ts`).
 //
-// ASSUMPTION: a configured version slug never itself contains a comma. This
-// is not separately enforced here — it holds transitively because version
-// slugs already double as URL path segments (`/v/{slug}/...`, `versionUrls`
-// keys in `inline-version-switcher`), so a comma in one would already break
-// routing before this payload exists. A flat comma-joined list was chosen
-// over JSON-in-attribute per the epic's locked decision (simplicity over a
-// theoretical slug shape nothing else in the codebase supports).
+// CONSTRAINT: a configured version slug must never contain a comma — enforced
+// at `zudoDoc()` (`../config.ts`), the single validated config entry, which
+// throws a `TypeError` naming the offending slug. That constraint is what
+// makes the flat comma-joined list below safe/unambiguous; it was chosen over
+// re-encoding as JSON-in-attribute per the epic's locked decision (simplicity
+// over a theoretical slug shape nothing else in the codebase supports;
+// #3244 codex review finding 2).
 
 import type { DocPageEntry, DocNavNode } from "../doc-page-props/index.js";
 import type { CategoryMeta } from "../sidebar-tree/index.js";
@@ -186,4 +186,28 @@ export function serializeUnavailableVersions(
 ): Record<string, string> {
   if (unavailableVersions === undefined) return {};
   return { [UNAVAILABLE_VERSIONS_ATTR]: Array.from(unavailableVersions).sort().join(",") };
+}
+
+/**
+ * Enforce the comma-free version-slug constraint the module header's
+ * "Client payload contract" section documents. Shared by BOTH `zudoDoc()`
+ * (`../config.ts`) and `zudoDocPreset()` (`../preset.ts`) — the preset is
+ * itself part of the frozen exported API and documented as directly
+ * spreadable into `defineConfig`, so a consumer calling it straight (bypassing
+ * `zudoDoc()`) must hit the same guard (#3244 codex review finding 2 follow-up).
+ * Throws a `TypeError` naming the offending slug; no-op for `false`/`undefined`.
+ */
+export function assertNoCommaInVersionSlugs(
+  versions: ReadonlyArray<{ slug: string }> | false | undefined,
+): void {
+  if (!versions) return;
+  for (const v of versions) {
+    if (v.slug.includes(",")) {
+      throw new TypeError(
+        `Invalid version slug "${v.slug}": version slugs must not contain commas ` +
+          "(commas are the delimiter in the version-switcher's client-side " +
+          "availability payload — see version-availability/index.ts).",
+      );
+    }
+  }
 }


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3242
- parent PR
    - https://github.com/zudolab/zudo-doc/pull/3231

---

## Summary

The persisted header's version switcher showed a **stale disabled state** after same-locale SPA navigation. One direction reintroduced the 404 that #3215 was written to fix: an entry left enabled but unavailable on the new page is a clickable link to a missing page. The other direction (disabled but actually available) is a milder dead end.

This bug class did not exist before #3215 — it is a second-order consequence of rendering real disabled entries. Only the persisted header is affected; the inline breadcrumb switcher is re-rendered per page and was always correct.

## How it works

Availability reaches the browser as a per-page payload on the swapped document; the rewire script reads it on `zfb:after-swap`.

- **Emit** (#3243) — `data-doc-unavailable-versions` on the `<article>` inside `<main>`, wired centrally in `createRenderDocPage` so every doc route inherits it. Reuses `createGetUnavailableVersions` verbatim so the client payload cannot drift from SSR truth.
- **Consume** (#3244) — `VERSION_SWITCHER_REWIRE_SCRIPT` now transitions all **five** properties the two SSR branches differ in: `aria-disabled`, `tabindex`, `title`, the full (disjoint) class sets, and `aria-current`. Missing `tabindex` alone would leave a re-enabled entry keyboard-unreachable; missing the class swap would leave it `pointer-events-none` while looking enabled.
- **Guard** (#3245) — a Playwright spec that navigates **in-site** (never `goto`) in both directions, asserting on the persisted header. Demonstrated failing before the fix and passing after.

## Two regressions caught before merge

Both were found while hardening, not by the original waves — and both are the same root confusion, that an **absent** payload means "I have no data," not "nothing is unavailable":

1. **First-paint clobber.** The inline `rewire()` ran from `<header>` before `<article>` was parsed, read no attribute, and re-enabled every entry — turning SSR-disabled entries into live 404 links on plain page load, no SPA navigation needed. Worse than the bug this epic targets. Fixed by deferring the initial call behind `document.readyState` / `DOMContentLoaded`.
2. **Absent-payload clobber via the public API.** A `createDocPageShell` caller that omits the new optional prop still SSR-renders disabled entries but emits no attribute. Absent now leaves disabled state **untouched** (href / active state / label still recompute). Two existing assertions that pinned the old "absent ⇒ everything enabled" behavior were rewritten — they encoded the bug.

Also fixed: the comma-joined payload was lossy for a version slug containing a comma, which `VersionConfig.slug: string` permits. Guarded by `assertNoCommaInVersionSlugs()` at config validation (honoring the epic's rejection of JSON-in-attribute), wired into both `zudoDoc()` and the directly-callable `zudoDocPreset()`.

## Coverage

Four test files, each guarding a distinct failure mode: SSR emission (three payload shapes plus a non-default locale), after-swap rewire drift vs fresh SSR output, first-paint non-clobber, and the SPA e2e. 1843 package tests pass.

## Sub-issues

#3243 · #3244 · #3245