### PR TITLE
[Tauri CSP Verify] Verify the Mode 1 reader's CSP inside a real built webview

### DIFF
--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -111,11 +111,18 @@ the two CDNs the content genuinely uses, `object-src 'none'`,
 
 ```sh
 GEN_DOC_HISTORY=1 pnpm build
+
+# Prerequisite (#3264): src-tauri/ ships no icons/ directory, but
+# tauri::generate_context!() panics without icons/icon.png — see below.
+mkdir -p src-tauri/icons && cp src-tauri-dev/icons/icon.png src-tauri/icons/icon.png
+
 cd src-tauri && cargo tauri build --no-bundle
 # launch the binary directly — do NOT go through `cargo tauri dev` or
 # `cargo tauri build --debug` (see below for why), and do NOT launch it via
 # `cargo run` / `cargo tauri`
 open target/release/zudo-doc          # or run the binary path directly
+
+rm -rf icons                          # never commit this
 ```
 
 **`cargo tauri dev` and `cargo tauri build --debug` do not verify this.**
@@ -129,13 +136,13 @@ and Tauri's nonce injection actually apply. This is the trap that made the
 whole verification epic necessary — a dev run "working" proves nothing about
 the CSP.
 
-Building a Mode 1 release binary for the first time also requires a workaround
-for #3264: `src-tauri/` has no `icons/` directory in git, but
-`tauri::generate_context!()` panics without `icons/icon.png` even with
-`bundle.icon: []` and `bundle.active: false`. Copy an **RGBA PNG** (Tauri's
-icon decoder panics on RGB/grayscale/indexed color types — e.g.
-`src-tauri-dev/icons/icon.png` already is one) to `src-tauri/icons/icon.png`
-before building, then delete it — this file must never be committed.
+**Why the icon step above is needed (#3264).** `src-tauri/` has no `icons/`
+directory in git, but `tauri::generate_context!()` panics without
+`icons/icon.png` even with `bundle.icon: []` and `bundle.active: false` — the
+empty `icon` array does not exempt it. It must be an **RGBA PNG**: Tauri's icon
+decoder panics on RGB/grayscale/indexed color types (`src-tauri-dev/icons/icon.png`
+already is one, which is why the recipe copies that). Delete it after building —
+this file must never be committed.
 
 ### Surfaces checked and verdicts
 

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -81,9 +81,12 @@ the two CDNs the content genuinely uses, `object-src 'none'`,
 
 - `script-src … https://esm.sh` — Mermaid is loaded at runtime via
   `import("https://esm.sh/mermaid@11…")` (`packages/zudo-doc/src/code-syntax/mermaid-init-script.ts`).
-- `script-src` / `style-src` / `font-src … https://cdn.jsdelivr.net` — KaTeX CSS
-  + fonts are pulled from jsDelivr when a page uses math
-  (`packages/zudo-doc/src/head/doc-head.tsx`); `script-src` also covers the
+- `script-src` / `style-src` / `font-src … https://cdn.jsdelivr.net` — reserved
+  for a KaTeX CSS/webfont jsDelivr load that `packages/zudo-doc/src/head/doc-head.tsx`
+  is wired to emit; **verification (below) found this codebase's actual `MathBlock`
+  never takes that path** — it renders KaTeX server-side at build time and ships
+  no jsdelivr reference at all (zudolab/zudo-doc#3265 asks whether this grant is
+  therefore removable; not acted on here). `script-src` also covers the
   `HtmlPreview` `externalScripts`/`externalStyles` demo on the
   `components/html-preview` doc page (e.g. the `@tailwindcss/browser` CDN
   recipe), since a `srcdoc` iframe inherits its parent document's CSP.
@@ -129,9 +132,10 @@ the CSP.
 Building a Mode 1 release binary for the first time also requires a workaround
 for #3264: `src-tauri/` has no `icons/` directory in git, but
 `tauri::generate_context!()` panics without `icons/icon.png` even with
-`bundle.icon: []` and `bundle.active: false`. Copy any PNG to
-`src-tauri/icons/icon.png` before building, then delete it — this file must
-never be committed.
+`bundle.icon: []` and `bundle.active: false`. Copy an **RGBA PNG** (Tauri's
+icon decoder panics on RGB/grayscale/indexed color types — e.g.
+`src-tauri-dev/icons/icon.png` already is one) to `src-tauri/icons/icon.png`
+before building, then delete it — this file must never be committed.
 
 ### Surfaces checked and verdicts
 

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -94,14 +94,56 @@ the two CDNs the content genuinely uses, `object-src 'none'`,
   **server-side** (`pages/api/_ai-chat-client.ts`), never from the browser, and
   the offline reader has no server anyway.
 
-> **On-device verification still required (mac).** This CSP was reasoned from the
-> site's measured resource use but has **not** been verified inside a built Tauri
-> webview. In particular, when a CSP is set Tauri injects a nonce for its own IPC
-> script, which can cause the browser to ignore `'unsafe-inline'` and block the
-> site's inline pre-paint scripts. Run `cargo tauri build` (or `cargo tauri dev`)
-> and confirm the reader still renders — Mermaid diagrams, KaTeX math, code
-> highlighting, sidebar/theme pre-paint — before relying on the bundled app.
-> `bundle.active` is `false`, so nothing ships this CSP until a deliberate bundle.
+> **Verified working inside a built Tauri webview (2026-08-03, tauri-cli 2.10.1,
+> macOS).** All four at-risk surfaces pass — see "CSP verification
+> (zudolab/zudo-doc#3246)" below for the reproduce recipe, the one real (but
+> harmless) violation found, and per-surface verdicts. `bundle.active` is
+> `false`, so nothing ships this CSP until a deliberate bundle.
+
+## CSP verification (zudolab/zudo-doc#3246)
+
+**Verified:** 2026-08-03, tauri-cli 2.10.1, macOS.
+
+### How to reproduce it
+
+```sh
+GEN_DOC_HISTORY=1 pnpm build
+cd src-tauri && cargo tauri build --no-bundle
+# launch the binary directly — do NOT go through `cargo tauri dev` or
+# `cargo tauri build --debug` (see below for why), and do NOT launch it via
+# `cargo run` / `cargo tauri`
+open target/release/zudo-doc          # or run the binary path directly
+```
+
+**`cargo tauri dev` and `cargo tauri build --debug` do not verify this.**
+`src-tauri/src/main.rs` sets `const IS_DEV: bool = cfg!(debug_assertions)` and
+branches on it: any debug build (`dev`, or `build --debug`) opens
+`WebviewUrl::External("http://localhost:4321/")` — the zfb dev server over
+plain `http://` — never the embedded `frontendDist`. Only a **release** build
+(`cargo tauri build`, no `--debug`) uses `WebviewUrl::default()`, which serves
+the bundled `../dist` over the `tauri://` app protocol where the shipped CSP
+and Tauri's nonce injection actually apply. This is the trap that made the
+whole verification epic necessary — a dev run "working" proves nothing about
+the CSP.
+
+Building a Mode 1 release binary for the first time also requires a workaround
+for #3264: `src-tauri/` has no `icons/` directory in git, but
+`tauri::generate_context!()` panics without `icons/icon.png` even with
+`bundle.icon: []` and `bundle.active: false`. Copy any PNG to
+`src-tauri/icons/icon.png` before building, then delete it — this file must
+never be committed.
+
+### Surfaces checked and verdicts
+
+| Surface | Verdict |
+|---|---|
+| Code highlighting | PASS — computed styles on `hi-*` classes return real distinct `oklch(...)` colors, so the `--zd-syntax-*` token CSS survives `style-src`. |
+| KaTeX | PASS — and the epic's premise was wrong: `MathBlock` renders KaTeX **server-side at build time** (`packages/zudo-doc/src/math-block/index.tsx`); the site never loads `katex.min.css` or its webfonts from jsdelivr. Identical behavior confirmed in a plain Chromium browser against the same `dist/`, so this was never a CSP/Tauri-specific concern (see zudolab/zudo-doc#3265, not acted on here). |
+| Mermaid | PASS, with one real violation on record: `style-src-attr`/`style-src-elem` block inline `style=""` writes from `esm.sh/d3-selection` and `esm.sh/mermaid` — Tauri's nonce injection neutralizes `'unsafe-inline'` for those sub-directives. This is the epic's predicted failure, landing on **style** rather than **script**. It causes no visible defect: colored-shape ratio and diagram geometry match a plain-browser rendering of the same `dist/` exactly. |
+| Sidebar + theme pre-paint | PASS — no `script-src` violations anywhere. Verified with a seeded non-default state (light theme against a dark OS, sidebar collapsed): a full app quit + relaunch showed the correct state already applied in the DOM at `PageLoadEvent::Finished`, before the window is shown, and an 8-frame rapid capture showed no flash. |
+
+No CSP change was made — #3249 (fix-forward) closed as a no-op because every
+surface passed. The policy stands exactly as written in #2240/#2312.
 
 ### Capabilities — `remote.urls`
 


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3246
- parent PR
    - https://github.com/zudolab/zudo-doc/pull/3231

---

## Summary

**The Mode 1 reader's CSP is now verified working inside a real release Tauri webview. No CSP change was needed.**

#2240 / #2312 shipped a restrictive CDN-aware CSP for `src-tauri` (previously `"csp": null`), but it was **reasoned from measured resource use, never observed working**. The specific worry: Tauri's CSP nonce injection can neutralize `'unsafe-inline'`, which would kill the inline pre-paint scripts — a failure that only shows up in a real webview. This epic closes that gap. Documentation-only diff; the policy stands as written.

## What the verification found

The predicted nonce-vs-`'unsafe-inline'` failure **is real — but it landed on style, not script.** `esm.sh/d3-selection` and `esm.sh/mermaid` write inline `style=""` heavily, and those writes are blocked (`style-src-attr` / `style-src-elem`). Verified benign: colored-shape ratio and geometry match a plain browser rendering the same `dist/`. **No `script-src` violations anywhere** — the pre-paint scripts, the highest-risk item, came through clean.

| Surface | Verdict | Evidence |
|---|---|---|
| Code highlighting | PASS | computed styles on `hi-*` classes return real distinct oklch colors, not defaults |
| KaTeX | PASS | typeset math; **premise corrected** — rendered server-side at build time, never fetches jsdelivr fonts at all |
| Mermaid | PASS | real CSP violations present but no visible defect; structural comparison against a plain browser matches |
| Sidebar + theme pre-paint | PASS | non-default state seeded (light theme vs dark OS, sidebar collapsed), quit, relaunched; DOM correct at `PageLoadEvent::Finished` before the window is shown; 8-frame capture shows no flash |

## The trap this epic existed to document

`cargo tauri dev` and `cargo tauri build --debug` **do not verify this**. `main.rs` sets `const IS_DEV: bool = cfg!(debug_assertions)` and branches: any debug build opens `WebviewUrl::External("http://localhost:4321/")` — the zfb dev server over plain `http://` — never the embedded assets. Only a release build serves `../dist` over the `tauri://` app protocol, where the shipped CSP and Tauri's nonce injection actually apply. A dev run "working" proves nothing about the CSP.

`src-tauri/README.md` now carries the result, the reproduce recipe, and that reason.

## Follow-ups raised, not fixed here

- **#3264** — `src-tauri/icons/` is absent from git but `generate_context!()` requires `icons/icon.png` regardless of `"icon": []` and `bundle.active: false`, making Mode 1 unbuildable from a clean checkout. Both verification waves worked around it; the recipe now documents the workaround inline, before the build command.
- **#3265** — the `font-src` grant for jsdelivr existed for KaTeX webfonts this codebase never fetches. (The `script-src` grant **is** used — HtmlPreview loads Tailwind's browser build from it.)

## Sub-issues

#3247 (capture) · #3248 (verify) · #3249 (fix-forward — **closed as a no-op**, per its own exit condition) · #3250 (record)
