### PR TITLE
fix(setup-doc-skill): compare resolved paths so tracked-skill linking is idempotent behind symlinks

### DIFF
--- a/packages/create-zudo-doc/templates/base/scripts/setup-doc-skill.sh
+++ b/packages/create-zudo-doc/templates/base/scripts/setup-doc-skill.sh
@@ -201,6 +201,19 @@ if [ ! -d "$DOCS_DIR" ]; then
   exit 1
 fi
 
+# Helper: physical (symlink-resolved) form of a directory path; echoes the
+# input unchanged when it is not a directory. Stock macOS ships no realpath(1)
+# and BSD readlink has no -f, so `cd` + `pwd -P` is the only resolver available
+# on every platform this script targets (it is also copied verbatim into
+# downstream projects by create-zudo-doc, so it must stay portable).
+physical_dir() {
+  if [ -d "$1" ]; then
+    (cd "$1" && pwd -P)
+  else
+    printf '%s\n' "$1"
+  fi
+}
+
 # Helper: replace a symlink or file at the given path
 ensure_symlink() {
   local link_path="$1"
@@ -228,7 +241,17 @@ safe_link_tracked_skill() {
   if [ -L "$link_path" ]; then
     local current_target
     current_target="$(readlink "$link_path")"
-    if [ "$current_target" = "$link_target" ]; then
+    # Compare where the link actually LANDS, not the literal string it stores.
+    # link_target is built from MAIN_PROJECT_DIR, which comes from
+    # `git worktree list` and is therefore always PHYSICAL, while an existing
+    # link may hold an unresolved path for the same directory. A raw string
+    # compare then mis-reports our own correct link as foreign whenever the
+    # project or its parents sit behind a symlink (macOS $TMPDIR: /var ->
+    # /private/var; also a symlinked $HOME or repo checkout), so the link was
+    # skipped with a spurious "already links to ..." warning instead of
+    # no-opping (zudolab/zudo-doc#3156 D4).
+    if [ "$current_target" = "$link_target" ] ||
+      [ "$(physical_dir "$link_path")" = "$(physical_dir "$link_target")" ]; then
       return 0 # already correct -> no-op
     fi
     if [ -e "$link_path" ]; then

--- a/packages/create-zudo-doc/templates/base/scripts/setup-doc-skill.sh
+++ b/packages/create-zudo-doc/templates/base/scripts/setup-doc-skill.sh
@@ -207,8 +207,15 @@ fi
 # on every platform this script targets (it is also copied verbatim into
 # downstream projects by create-zudo-doc, so it must stay portable).
 physical_dir() {
-  if [ -d "$1" ]; then
-    (cd "$1" && pwd -P)
+  local resolved
+  # Fall back to the input on ANY resolution failure -- notably an unreadable
+  # directory, where `cd` fails and the subshell yields "". Without the
+  # non-empty guard, two different unreadable paths would both collapse to ""
+  # and compare EQUAL, silently skipping a link that should have been created.
+  # stderr is suppressed so a permission-denied probe stays quiet.
+  if [ -d "$1" ] && resolved="$(cd "$1" 2>/dev/null && pwd -P)" &&
+    [ -n "$resolved" ]; then
+    printf '%s\n' "$resolved"
   else
     printf '%s\n' "$1"
   fi

--- a/scripts/__tests__/setup-doc-skill.test.ts
+++ b/scripts/__tests__/setup-doc-skill.test.ts
@@ -327,11 +327,15 @@ describe("setup-doc-skill.sh", () => {
 
       // Build/verify and doc-base-path instructions must name the nested
       // project directory explicitly, not just "repo root".
-      expect(skillMd).toContain(`Run \`pnpm build\` from \`${projectDir}\``);
+      // The script derives these from `git worktree list`, which always
+      // reports the PHYSICAL path, so compare against the resolved fixture
+      // path — on macOS $TMPDIR is /var/... symlinked to /private/var/...
+      const projectDirReal = realpathSync(projectDir);
+      expect(skillMd).toContain(`Run \`pnpm build\` from \`${projectDirReal}\``);
       expect(skillMd).toContain(
-        `(relative to the project root: \`${projectDir}\`)`,
+        `(relative to the project root: \`${projectDirReal}\`)`,
       );
-      expect(skillMd).toContain(`${projectDir}/CLAUDE.md`);
+      expect(skillMd).toContain(`${projectDirReal}/CLAUDE.md`);
     });
   });
 });
@@ -767,6 +771,38 @@ describe("tracked-skill linking (#3156)", () => {
 
       expect(output).not.toContain("Linked tracked skill 'check-docs'");
       expect(output).not.toContain("WARNING");
+      expect(realpathSync(join(fixtureHome, ".claude", "skills", "check-docs"))).toBe(
+        realpathSync(skillDir),
+      );
+    });
+
+    it("no-ops when the existing link reaches this project's source through a symlinked path", () => {
+      makeFixture("tracked-fixture");
+      const skillDir = makeTrackedSkill("claude", "check-docs");
+      mkdirSync(join(fixtureHome, ".claude", "skills"), { recursive: true });
+
+      // Point the pre-existing global link at the SAME skill directory, but
+      // reached through a symlinked alias of the project root, so the string
+      // stored in the link differs from the physical path the script derives
+      // from `git worktree list`. This is the portable stand-in for macOS's
+      // /var -> /private/var $TMPDIR symlink, which is what made the original
+      // bug reproduce only on macOS while Linux CI stayed green.
+      const aliasSkillDir = join(
+        fixtureRoot,
+        "alias",
+        ".claude",
+        "skills",
+        "check-docs",
+      );
+      execSync(`ln -s "${projectDir}" "${join(fixtureRoot, "alias")}"`);
+      execSync(
+        `ln -s "${aliasSkillDir}" "${join(fixtureHome, ".claude", "skills", "check-docs")}"`,
+      );
+
+      const output = runFixtureScript();
+
+      expect(output).not.toContain("WARNING");
+      expect(output).not.toContain("Linked tracked skill 'check-docs'");
       expect(realpathSync(join(fixtureHome, ".claude", "skills", "check-docs"))).toBe(
         realpathSync(skillDir),
       );

--- a/scripts/setup-doc-skill.sh
+++ b/scripts/setup-doc-skill.sh
@@ -201,6 +201,19 @@ if [ ! -d "$DOCS_DIR" ]; then
   exit 1
 fi
 
+# Helper: physical (symlink-resolved) form of a directory path; echoes the
+# input unchanged when it is not a directory. Stock macOS ships no realpath(1)
+# and BSD readlink has no -f, so `cd` + `pwd -P` is the only resolver available
+# on every platform this script targets (it is also copied verbatim into
+# downstream projects by create-zudo-doc, so it must stay portable).
+physical_dir() {
+  if [ -d "$1" ]; then
+    (cd "$1" && pwd -P)
+  else
+    printf '%s\n' "$1"
+  fi
+}
+
 # Helper: replace a symlink or file at the given path
 ensure_symlink() {
   local link_path="$1"
@@ -228,7 +241,17 @@ safe_link_tracked_skill() {
   if [ -L "$link_path" ]; then
     local current_target
     current_target="$(readlink "$link_path")"
-    if [ "$current_target" = "$link_target" ]; then
+    # Compare where the link actually LANDS, not the literal string it stores.
+    # link_target is built from MAIN_PROJECT_DIR, which comes from
+    # `git worktree list` and is therefore always PHYSICAL, while an existing
+    # link may hold an unresolved path for the same directory. A raw string
+    # compare then mis-reports our own correct link as foreign whenever the
+    # project or its parents sit behind a symlink (macOS $TMPDIR: /var ->
+    # /private/var; also a symlinked $HOME or repo checkout), so the link was
+    # skipped with a spurious "already links to ..." warning instead of
+    # no-opping (zudolab/zudo-doc#3156 D4).
+    if [ "$current_target" = "$link_target" ] ||
+      [ "$(physical_dir "$link_path")" = "$(physical_dir "$link_target")" ]; then
       return 0 # already correct -> no-op
     fi
     if [ -e "$link_path" ]; then

--- a/scripts/setup-doc-skill.sh
+++ b/scripts/setup-doc-skill.sh
@@ -207,8 +207,15 @@ fi
 # on every platform this script targets (it is also copied verbatim into
 # downstream projects by create-zudo-doc, so it must stay portable).
 physical_dir() {
-  if [ -d "$1" ]; then
-    (cd "$1" && pwd -P)
+  local resolved
+  # Fall back to the input on ANY resolution failure -- notably an unreadable
+  # directory, where `cd` fails and the subshell yields "". Without the
+  # non-empty guard, two different unreadable paths would both collapse to ""
+  # and compare EQUAL, silently skipping a link that should have been created.
+  # stderr is suppressed so a permission-denied probe stays quiet.
+  if [ -d "$1" ] && resolved="$(cd "$1" 2>/dev/null && pwd -P)" &&
+    [ -n "$resolved" ]; then
+    printf '%s\n' "$resolved"
   else
     printf '%s\n' "$1"
   fi


### PR DESCRIPTION
## Summary

`safe_link_tracked_skill` compared the **literal string** stored in an existing symlink against a link target built from `MAIN_PROJECT_DIR`. That variable comes from `git worktree list`, which always reports the **physical** path, while `ROOT_DIR` comes from `cd` + `pwd` (logical). When the project or any parent sits behind a symlink, the two forms name the same directory but differ as strings — so the script mis-read its own correct link as foreign and skipped it with a spurious `already links to ...` warning instead of no-opping.

This surfaced as two macOS-only failures in `scripts/__tests__/setup-doc-skill.test.ts` (macOS `$TMPDIR` is `/var/...`, a symlink to `/private/var/...`). It is a genuine product bug, not just a test-fixture mismatch: any user with a symlinked `$HOME` or repo checkout gets their tracked skill silently skipped.

## Changes

- **`scripts/setup-doc-skill.sh`** — new portable `physical_dir` helper (`cd` + `pwd -P`; stock macOS has no `realpath(1)` and BSD `readlink` has no `-f`), and `safe_link_tracked_skill` now compares where the link actually *lands* rather than the raw string. The raw-string equality is kept as a fast path, and the dangling-symlink branch is unchanged.
- `physical_dir` falls back to its raw input on **any** resolution failure. Without that guard an unreadable directory makes `cd` fail and the subshell yield `""`, so two different unreadable paths would both collapse to the empty string and compare **equal** — silently skipping a link that should have been created. `cd`'s permission-denied noise is suppressed.
- **`packages/create-zudo-doc/templates/base/scripts/setup-doc-skill.sh`** — kept byte-identical (the script is copied verbatim into downstream scaffolds; enforced by `pnpm check:template-drift`).
- **`scripts/__tests__/setup-doc-skill.test.ts`** — nested-fixture assertions now expect the resolved project path, which is what the script legitimately emits. Added a regression test that reaches the skill dir through a deliberate symlinked alias.

## Test Plan

- `npx vitest run scripts/__tests__/setup-doc-skill.test.ts` — 44 passed (was 41 passed / 2 failed on macOS).
- `pnpm test:unit` — 916 passed, 0 failed.
- The new symlink-alias test was **verified to fail against the pre-fix script**, so it is a real guard rather than a vacuous one. It reproduces on Linux too — the original defect was invisible to CI because only macOS symlinks `$TMPDIR`.
- `pnpm check:template-drift` — clean.