### PR TITLE
[Gen Z-Index Params] Parameterize gen-z-index bin (paths, wrapper, md-table, validation)

### DIFF
--- a/packages/zudo-doc/bin/gen-z-index.mjs
+++ b/packages/zudo-doc/bin/gen-z-index.mjs
@@ -14,15 +14,18 @@
 //   gen-z-index --check                       # verify committed block is up to date (exit 1 on drift)
 //   gen-z-index --tokens <path> --css <path>  # use non-conventional source/destination paths
 //   gen-z-index --no-theme-wrapper            # emit bare --z-index-<name> declarations, no @theme wrapper
+//   gen-z-index --md-table <path>             # also generate/verify a Z_INDEX_TABLE region in a
+//                                              # markdown/MDX file (opt-in, no conventional default path)
 //
-// MUST be run with the project root as cwd — it resolves --tokens/--css (or
-// their conventional defaults) against process.cwd(), NOT against this file's
-// location. A consuming project's own package.json scripts (e.g.
-// gen:z-index / check:z-index) are responsible for invoking it from the
-// project root. This generator is opt-in per project — a project only needs
-// it when overriding one of the default tiers shipped unconditionally by
-// @takazudo/zudo-doc/theme.css — and it is not wired into this repo's own
-// b4push or CI; that integration was retired in zudolab/zudo-doc#2661.
+// MUST be run with the project root as cwd — it resolves --tokens/--css/
+// --md-table (or their conventional defaults) against process.cwd(), NOT
+// against this file's location. A consuming project's own package.json
+// scripts (e.g. gen:z-index / check:z-index) are responsible for invoking it
+// from the project root. This generator is opt-in per project — a project
+// only needs it when overriding one of the default tiers shipped
+// unconditionally by @takazudo/zudo-doc/theme.css — and it is not wired into
+// this repo's own b4push or CI; that integration was retired in
+// zudolab/zudo-doc#2661.
 //
 // The block is a Tailwind v4 `@theme { --z-index-<name>: <value>; }` for every
 // tier, so Tailwind generates `z-<name>` utilities and raw CSS can reference
@@ -30,13 +33,23 @@
 // wrapper and emits bare `--z-index-<name>: <value>;` declarations instead,
 // for projects that want to compose the block into their own `@theme` block.
 //
+// `--md-table <path>` additionally generates/verifies a second, independent
+// `GENERATED:Z_INDEX_TABLE` region — a `| Token | Kind | Role |` table, one
+// row per tier — inside a markdown/MDX file at <path>. It uses the MDX-safe
+// brace-comment marker form `{/* GENERATED:Z_INDEX_TABLE_BEGIN/END */}`
+// rather than an HTML `<!-- -->` comment, because an HTML comment is a parse
+// error in MDX. `--check` verifies BOTH regions when --md-table is given;
+// drift in either exits 1. Like the CSS block, the md-table region must be
+// seeded once by hand (just the marker pair) before the generator can find
+// it to replace.
+//
 // Pure Node (fs only — NO npm deps, no minimist). Idempotent: running twice
 // produces no diff.
 //
 // MAINTENANCE: edit src/config/z-index-tokens.ts (the source of truth), then
-// run `pnpm gen:z-index` (or the equivalent --tokens/--css invocation) and
-// commit the regenerated CSS. Never hand-edit the block between the
-// BEGIN/END markers.
+// run `pnpm gen:z-index` (or the equivalent --tokens/--css/--md-table
+// invocation) and commit the regenerated CSS (and md table, if used). Never
+// hand-edit either block between its BEGIN/END markers.
 
 import { readFileSync, writeFileSync, realpathSync } from "node:fs";
 import { resolve } from "node:path";
@@ -45,17 +58,26 @@ import { fileURLToPath } from "node:url";
 const BEGIN_MARKER = "GENERATED:Z_INDEX_BEGIN";
 const END_MARKER = "GENERATED:Z_INDEX_END";
 
+// MDX-safe markers for the optional --md-table region. An HTML `<!-- -->`
+// comment is a parse error in MDX, which is the entire reason this region
+// uses the brace-comment form instead — both markers are the literal,
+// complete text that must appear (on their own line) in the seeded file.
+const MD_TABLE_BEGIN_MARKER = "{/* GENERATED:Z_INDEX_TABLE_BEGIN */}";
+const MD_TABLE_END_MARKER = "{/* GENERATED:Z_INDEX_TABLE_END */}";
+
 // Conventional paths, relative to the project root (process.cwd()). Used as
 // the default --tokens/--css values AND as the literal text shown in the
 // generated header / log messages when no override is given — this is what
 // keeps the default invocation's output byte-identical to pre-flag output.
+// --md-table has NO conventional default: it's an opt-in region and there's
+// no natural project-wide path to assume, so it stays undefined unless given.
 const DEFAULT_TOKENS_PATH = "src/config/z-index-tokens.ts";
 const DEFAULT_CSS_PATH = "src/styles/global.css";
 
 const TIER_NAME_RE = /^[a-z0-9-]+$/;
 
 const FLAG_USAGE =
-  "Supported flags: --check, --tokens <path>, --css <path>, --no-theme-wrapper.";
+  "Supported flags: --check, --tokens <path>, --css <path>, --md-table <path>, --no-theme-wrapper.";
 
 /**
  * Hand-rolled argv parser (no minimist — this bin stays dependency-free).
@@ -64,8 +86,10 @@ const FLAG_USAGE =
  * boolean flag (`--no-theme-wrapper=x`) are all hard errors — this bin does
  * not silently ignore or guess at malformed invocations.
  *
- * Returns `{ check, tokens, css, noThemeWrapper }`; `tokens`/`css` are
- * `undefined` when not passed (callers apply the conventional defaults).
+ * Returns `{ check, tokens, css, mdTable, noThemeWrapper }`; `tokens`/`css`/
+ * `mdTable` are `undefined` when not passed (callers apply the conventional
+ * defaults — `mdTable` has none, so it stays undefined and the md-table
+ * region is skipped entirely).
  *
  * Exported for unit testing.
  */
@@ -74,6 +98,7 @@ export function parseArgs(argv) {
     check: false,
     tokens: undefined,
     css: undefined,
+    mdTable: undefined,
     noThemeWrapper: false,
   };
   const seen = new Set();
@@ -85,7 +110,7 @@ export function parseArgs(argv) {
     const inlineValue = eqIdx === -1 ? undefined : raw.slice(eqIdx + 1);
 
     const isBoolean = flag === "--check" || flag === "--no-theme-wrapper";
-    const isValueFlag = flag === "--tokens" || flag === "--css";
+    const isValueFlag = flag === "--tokens" || flag === "--css" || flag === "--md-table";
 
     if (!isBoolean && !isValueFlag) {
       throw new Error(`Unknown flag "${raw}". ${FLAG_USAGE}`);
@@ -106,9 +131,10 @@ export function parseArgs(argv) {
       continue;
     }
 
-    // Value flag (--tokens / --css): accept an inline `=value`, otherwise
-    // consume the next argv token. A missing/empty value or a next token
-    // that looks like another flag is a hard error, not a silent default.
+    // Value flag (--tokens / --css / --md-table): accept an inline `=value`,
+    // otherwise consume the next argv token. A missing/empty value or a next
+    // token that looks like another flag is a hard error, not a silent
+    // default.
     let value = inlineValue;
     if (value === undefined) {
       const next = argv[i + 1];
@@ -123,6 +149,7 @@ export function parseArgs(argv) {
     }
     if (flag === "--tokens") result.tokens = value;
     if (flag === "--css") result.css = value;
+    if (flag === "--md-table") result.mdTable = value;
   }
 
   return result;
@@ -322,18 +349,23 @@ function shellQuote(value) {
  * `gen-z-index` — is used because a project customizing --tokens/--css has
  * no guarantee it also defined a package.json script alias for that exact
  * invocation; `pnpm exec` resolves the package-local bin regardless.
+ *
+ * `mdTablePath` has no conventional default (undefined = --md-table wasn't
+ * given), so its mere presence always disqualifies the byte-identity case.
  */
-function buildRerunCommand({ tokensPath, cssPath, themeWrapper }) {
+function buildRerunCommand({ tokensPath, cssPath, themeWrapper, mdTablePath }) {
   const isDefault =
     tokensPath === DEFAULT_TOKENS_PATH &&
     cssPath === DEFAULT_CSS_PATH &&
-    themeWrapper === true;
+    themeWrapper === true &&
+    mdTablePath === undefined;
   if (isDefault) return "pnpm gen:z-index";
 
   const parts = ["pnpm exec gen-z-index"];
   if (tokensPath !== DEFAULT_TOKENS_PATH) parts.push(`--tokens ${shellQuote(tokensPath)}`);
   if (cssPath !== DEFAULT_CSS_PATH) parts.push(`--css ${shellQuote(cssPath)}`);
   if (!themeWrapper) parts.push("--no-theme-wrapper");
+  if (mdTablePath !== undefined) parts.push(`--md-table ${shellQuote(mdTablePath)}`);
   return parts.join(" ");
 }
 
@@ -352,6 +384,14 @@ function buildRerunCommand({ tokensPath, cssPath, themeWrapper }) {
  * `@theme { ... }` block; `false` (the `--no-theme-wrapper` CLI flag) emits
  * bare `--z-index-<name>: <value>;` declarations at 2-space indent instead,
  * for projects composing the block into their own `@theme` block.
+ *
+ * Deliberately does NOT accept `mdTablePath`: the CSS block's own content
+ * must depend only on the CSS-region flags (--tokens/--css/--no-theme-
+ * wrapper), never on whether --md-table happens to be passed in a given
+ * invocation — otherwise adding/dropping --md-table would flip the embedded
+ * rerun-guidance text and manufacture CSS-region drift unrelated to any
+ * actual tier change. `main()`'s own drift/error messages use
+ * `buildRerunCommand` directly (with `mdTablePath`) for that guidance instead.
  *
  * Exported for unit testing.
  */
@@ -386,7 +426,18 @@ export function buildBlock(tiers, options = {}) {
   return lines.join("\n");
 }
 
-/** Counts non-overlapping occurrences of `marker` in `str`. */
+/**
+ * Counts non-overlapping occurrences of `marker` in `str`. This is a plain
+ * substring count, not a "stand-alone marker line" match — a known,
+ * pre-existing tradeoff inherited from the CSS `@theme` region (whose BEGIN/
+ * END text is embedded mid-comment-line, e.g. `  /* GENERATED:Z_INDEX_BEGIN`,
+ * so a stricter "must be the whole line" rule would break it). This means a
+ * doc page that quotes the literal `--md-table` marker text in prose or a
+ * fenced code example (e.g. to explain the generator) is misread as a real
+ * duplicate marker. The failure mode is loud (a clear "duplicate markers"
+ * error), not silent corruption, so this is accepted rather than adding
+ * markdown-aware parsing to a dependency-free bin.
+ */
 function countOccurrences(str, marker) {
   let count = 0;
   let idx = str.indexOf(marker);
@@ -398,59 +449,145 @@ function countOccurrences(str, marker) {
 }
 
 /**
- * Replace the existing BEGIN…END block in `css` with `block`. Requires
+ * Replace the existing BEGIN…END block in `source` with `block`. Requires
  * EXACTLY one BEGIN and one END marker, with BEGIN preceding END — throws a
  * clear, distinct error for each failure mode: missing (the block must be
- * seeded once by hand), duplicated, or inverted markers. `cssPath` is used
+ * seeded once by hand), duplicated, or inverted markers.
+ *
+ * `beginMarker`/`endMarker` default to the CSS `@theme` block's markers so
+ * existing call sites (the CSS region) are unaffected; the `--md-table`
+ * region passes `MD_TABLE_BEGIN_MARKER`/`MD_TABLE_END_MARKER` instead — same
+ * function, parameterized, mirroring how gen-component-tokens.mjs reuses one
+ * `replaceBlock` across its content/chrome surfaces. `filePath` is used
  * purely for error-message context (pass the conventional default or an
- * explicit --css value).
+ * explicit --css/--md-table value).
  *
  * Exported for unit testing.
  */
-export function replaceBlock(css, block, cssPath = DEFAULT_CSS_PATH) {
-  const beginCount = countOccurrences(css, BEGIN_MARKER);
-  const endCount = countOccurrences(css, END_MARKER);
+export function replaceBlock(
+  source,
+  block,
+  beginMarker = BEGIN_MARKER,
+  endMarker = END_MARKER,
+  filePath = DEFAULT_CSS_PATH,
+) {
+  const beginCount = countOccurrences(source, beginMarker);
+  const endCount = countOccurrences(source, endMarker);
 
   if (beginCount === 0 || endCount === 0) {
     throw new Error(
-      `Could not find ${BEGIN_MARKER} … ${END_MARKER} markers in ${cssPath}.\n` +
+      `Could not find ${beginMarker} … ${endMarker} markers in ${filePath}.\n` +
         `Seed the marker block once by hand, then re-run the generator.`,
     );
   }
   if (beginCount > 1 || endCount > 1) {
     throw new Error(
-      `Found duplicate GENERATED:Z_INDEX markers in ${cssPath} (${beginCount} BEGIN, ` +
-        `${endCount} END; expected exactly one of each). Remove the extra marker(s) by ` +
-        `hand, then re-run the generator.`,
+      `Found duplicate markers in ${filePath} (${beginCount} BEGIN "${beginMarker}", ` +
+        `${endCount} END "${endMarker}"; expected exactly one of each). Remove the extra ` +
+        `marker(s) by hand, then re-run the generator.`,
     );
   }
 
-  const beginIdx = css.indexOf(BEGIN_MARKER);
-  const endIdx = css.indexOf(END_MARKER);
+  const beginIdx = source.indexOf(beginMarker);
+  const endIdx = source.indexOf(endMarker);
   if (beginIdx > endIdx) {
     throw new Error(
-      `GENERATED:Z_INDEX markers in ${cssPath} are inverted — the END marker appears ` +
-        `before the BEGIN marker. Fix the marker order by hand, then re-run the generator.`,
+      `Markers in ${filePath} are inverted — the END marker (${endMarker}) appears before ` +
+        `the BEGIN marker (${beginMarker}). Fix the marker order by hand, then re-run the ` +
+        `generator.`,
     );
   }
 
-  // Expand to the full comment line that opens the block ("  /* GENERATED:...")
-  // and to the end of the closing "*/ " line so the whole region is replaced.
-  const lineStart = css.lastIndexOf("\n", beginIdx) + 1;
-  const afterEnd = css.indexOf("\n", endIdx);
-  const lineEnd = afterEnd === -1 ? css.length : afterEnd;
-  return css.slice(0, lineStart) + block + css.slice(lineEnd);
+  // Expand to the full line that opens the block and to the end of the line
+  // that closes it, so the whole region (CSS comment or MDX brace-comment) is
+  // replaced.
+  const lineStart = source.lastIndexOf("\n", beginIdx) + 1;
+  const afterEnd = source.indexOf("\n", endIdx);
+  const lineEnd = afterEnd === -1 ? source.length : afterEnd;
+  return source.slice(0, lineStart) + block + source.slice(lineEnd);
+}
+
+/**
+ * Collapses whitespace runs — including an embedded literal newline from a
+ * multi-line `purpose:` source string (the source grammar permits a raw
+ * newline between the opening/closing quotes; only braces/backslashes/
+ * escaped quotes are rejected, see `assertSupportedPurposeGrammar`) — into a
+ * single space, and trims the result. A markdown/GFM table cell cannot
+ * contain a raw newline without corrupting the row.
+ */
+function collapseWhitespace(str) {
+  return str.replace(/\s+/g, " ").trim();
+}
+
+/** Escapes a literal `|` so it can't be misread as a table-cell boundary. */
+function escapeTableCell(str) {
+  return str.replace(/\|/g, "\\|");
+}
+
+/**
+ * Build the full `--md-table` region (markers included): a GFM
+ * `| Token | Kind | Role |` table, one row per tier, in source order.
+ *   - Token: the tier name.
+ *   - Kind: the tier's optional `kind` field, or `-` when absent.
+ *   - Role: the tier's optional `purpose` field with internal whitespace/
+ *     newlines collapsed to single spaces, or `-` when absent/empty.
+ * `|` in any cell is escaped so a stray pipe in a purpose string can't
+ * corrupt the table structure.
+ *
+ * `options.tokensPath` feeds the "do not hand-edit" note beneath the BEGIN
+ * marker (same default/meaning as `buildBlock`'s `tokensPath`).
+ * `options.beginMarker`/`options.endMarker` default to the MDX-safe
+ * `MD_TABLE_BEGIN_MARKER`/`MD_TABLE_END_MARKER` pair — overridable for tests,
+ * same convention as `replaceBlock`.
+ *
+ * Exported for unit testing.
+ */
+export function buildMdTable(tiers, options = {}) {
+  const {
+    tokensPath = DEFAULT_TOKENS_PATH,
+    beginMarker = MD_TABLE_BEGIN_MARKER,
+    endMarker = MD_TABLE_END_MARKER,
+  } = options;
+
+  const lines = [];
+  lines.push(beginMarker);
+  lines.push("");
+  lines.push(
+    `_Generated by \`gen-z-index --md-table\`; do not hand-edit — edit \`${tokensPath}\` instead._`,
+  );
+  lines.push("");
+  lines.push("| Token | Kind | Role |");
+  lines.push("| --- | --- | --- |");
+  for (const tier of tiers) {
+    const token = escapeTableCell(tier.name);
+    const kind = escapeTableCell(tier.kind ?? "-");
+    // Collapse first, THEN decide the fallback — a whitespace-only purpose
+    // (e.g. "   ") is truthy but collapses to "", which must still fall back
+    // to "-" rather than emit a blank Role cell.
+    const collapsedPurpose = tier.purpose ? collapseWhitespace(tier.purpose) : "";
+    const role = collapsedPurpose ? escapeTableCell(collapsedPurpose) : "-";
+    lines.push(`| ${token} | ${kind} | ${role} |`);
+  }
+  lines.push("");
+  lines.push(endMarker);
+  return lines.join("\n");
 }
 
 /**
  * CLI entrypoint. `argv` defaults to the real process argv (minus the node/
  * script prefix) so `isDirectInvocation()` below can call `main()` with no
  * arguments, while tests can pass a synthetic argv without touching
- * `process.argv`. Resolves --tokens/--css against `process.cwd()` (the
- * project root) for actual file I/O, but threads the AS-GIVEN path strings
- * (conventional defaults or explicit flag values) through to every message
- * and into the generated header — never the resolved absolute path — so the
- * committed CSS never embeds a machine-specific path.
+ * `process.argv`. Resolves --tokens/--css/--md-table against `process.cwd()`
+ * (the project root) for actual file I/O, but threads the AS-GIVEN path
+ * strings (conventional defaults or explicit flag values) through to every
+ * message and into the generated header — never the resolved absolute path —
+ * so the committed CSS/md file never embeds a machine-specific path.
+ *
+ * The CSS `@theme` region is always generated/verified. The `--md-table`
+ * region is entirely opt-in: when `--md-table <path>` isn't passed, no md
+ * file is read, built, or written, and `--check` only covers the CSS region
+ * (unchanged from pre-`--md-table` behavior). When it IS passed, `--check`
+ * covers BOTH regions — drift in either exits 1.
  *
  * Exported for unit testing.
  */
@@ -459,6 +596,7 @@ export function main(argv = process.argv.slice(2)) {
   const tokensPath = args.tokens ?? DEFAULT_TOKENS_PATH;
   const cssPath = args.css ?? DEFAULT_CSS_PATH;
   const themeWrapper = !args.noThemeWrapper;
+  const mdTablePath = args.mdTable;
 
   const root = process.cwd();
   const tokensAbsPath = resolve(root, tokensPath);
@@ -469,28 +607,66 @@ export function main(argv = process.argv.slice(2)) {
 
   const tiers = parseTiers(tokensSrc, tokensPath);
   const block = buildBlock(tiers, { tokensPath, cssPath, themeWrapper });
-  const next = replaceBlock(css, block, cssPath);
+  const nextCss = replaceBlock(css, block, BEGIN_MARKER, END_MARKER, cssPath);
+
+  let mdAbsPath;
+  let mdSrc;
+  let nextMd;
+  if (mdTablePath !== undefined) {
+    mdAbsPath = resolve(root, mdTablePath);
+    mdSrc = readFileSync(mdAbsPath, "utf8");
+    const mdBlock = buildMdTable(tiers, { tokensPath });
+    nextMd = replaceBlock(
+      mdSrc,
+      mdBlock,
+      MD_TABLE_BEGIN_MARKER,
+      MD_TABLE_END_MARKER,
+      mdTablePath,
+    );
+  }
 
   if (args.check) {
-    if (next !== css) {
+    let drift = false;
+    if (nextCss !== css) {
       console.error(`z-index codegen drift detected: ${cssPath} is out of date.`);
+      drift = true;
+    }
+    if (mdTablePath !== undefined && nextMd !== mdSrc) {
+      console.error(`z-index codegen drift detected: ${mdTablePath} is out of date.`);
+      drift = true;
+    }
+    if (drift) {
       console.error(
-        `Run \`${buildRerunCommand({ tokensPath, cssPath, themeWrapper })}\` and commit the result.`,
+        `Run \`${buildRerunCommand({ tokensPath, cssPath, themeWrapper, mdTablePath })}\` and commit the result.`,
       );
       return 1;
     }
-    console.log(`OK — z-index @theme block is up to date (${tiers.length} tiers).`);
-    return 0;
-  }
-
-  if (next === css) {
     console.log(
-      `z-index @theme block already up to date (${tiers.length} tiers); no change.`,
+      mdTablePath !== undefined
+        ? `OK — z-index @theme block and md table are up to date (${tiers.length} tiers).`
+        : `OK — z-index @theme block is up to date (${tiers.length} tiers).`,
     );
     return 0;
   }
-  writeFileSync(cssAbsPath, next);
-  console.log(`Wrote z-index @theme block to ${cssPath} (${tiers.length} tiers).`);
+
+  if (nextCss === css) {
+    console.log(
+      `z-index @theme block already up to date (${tiers.length} tiers); no change.`,
+    );
+  } else {
+    writeFileSync(cssAbsPath, nextCss);
+    console.log(`Wrote z-index @theme block to ${cssPath} (${tiers.length} tiers).`);
+  }
+
+  if (mdTablePath !== undefined) {
+    if (nextMd === mdSrc) {
+      console.log(`z-index table already up to date at ${mdTablePath}; no change.`);
+    } else {
+      writeFileSync(mdAbsPath, nextMd);
+      console.log(`Wrote z-index table to ${mdTablePath} (${tiers.length} tiers).`);
+    }
+  }
+
   return 0;
 }
 

--- a/packages/zudo-doc/bin/gen-z-index.mjs
+++ b/packages/zudo-doc/bin/gen-z-index.mjs
@@ -525,6 +525,27 @@ function escapeTableCell(str) {
 }
 
 /**
+ * Escapes the characters MDX treats as syntax in text position — `<` (JSX
+ * tag open) and `{`/`}` (expression delimiters) — as character references,
+ * so a purpose like "search <dialog>" is emitted as literal text instead of
+ * failing MDX compilation as an unclosed JSX element. `&` is escaped FIRST
+ * so a purpose that already spells out an entity (e.g. "&lt;") stays
+ * literal `&lt;` on the rendered page instead of collapsing to `<`, and so
+ * the replacements below can never double-escape their own output.
+ *
+ * Braces cannot reach here via the CLI (`assertSupportedPurposeGrammar`
+ * rejects them at parse time), but `buildMdTable` is an exported helper that
+ * accepts hand-built tier arrays, so it defends against them itself.
+ */
+function escapeMdxText(str) {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/\{/g, "&#123;")
+    .replace(/\}/g, "&#125;");
+}
+
+/**
  * Build the full `--md-table` region (markers included): a GFM
  * `| Token | Kind | Role |` table, one row per tier, in source order.
  *   - Token: the tier name.
@@ -532,7 +553,10 @@ function escapeTableCell(str) {
  *   - Role: the tier's optional `purpose` field with internal whitespace/
  *     newlines collapsed to single spaces, or `-` when absent/empty.
  * `|` in any cell is escaped so a stray pipe in a purpose string can't
- * corrupt the table structure.
+ * corrupt the table structure. The Role cell is additionally MDX-escaped
+ * (`&` first, then `<`/`{`/`}` — see `escapeMdxText`) so a purpose like
+ * "search <dialog>" can't make the emitted .mdx fail to compile as an
+ * unclosed JSX element.
  *
  * `options.tokensPath` feeds the "do not hand-edit" note beneath the BEGIN
  * marker (same default/meaning as `buildBlock`'s `tokensPath`).
@@ -565,7 +589,12 @@ export function buildMdTable(tiers, options = {}) {
     // (e.g. "   ") is truthy but collapses to "", which must still fall back
     // to "-" rather than emit a blank Role cell.
     const collapsedPurpose = tier.purpose ? collapseWhitespace(tier.purpose) : "";
-    const role = collapsedPurpose ? escapeTableCell(collapsedPurpose) : "-";
+    // Role is the only free-text cell (Token is ^[a-z0-9-]+$, Kind is
+    // global|local|-), so it alone needs MDX escaping on top of the pipe
+    // escaping.
+    const role = collapsedPurpose
+      ? escapeTableCell(escapeMdxText(collapsedPurpose))
+      : "-";
     lines.push(`| ${token} | ${kind} | ${role} |`);
   }
   lines.push("");

--- a/packages/zudo-doc/bin/gen-z-index.mjs
+++ b/packages/zudo-doc/bin/gen-z-index.mjs
@@ -6,59 +6,265 @@
 // src/config/z-index-tokens.ts.
 //
 // Reads from the project root (process.cwd()). Conventional paths:
-//   - Tokens: src/config/z-index-tokens.ts
-//   - CSS:    src/styles/global.css
+//   - Tokens: src/config/z-index-tokens.ts (override with --tokens <path>)
+//   - CSS:    src/styles/global.css (override with --css <path>)
 //
 // Usage (after pnpm install, via scripts in package.json):
-//   gen-z-index            # rewrite the @theme block in global.css
-//   gen-z-index --check    # verify committed block is up to date (exit 1 on drift)
+//   gen-z-index                               # rewrite the @theme block (conventional paths)
+//   gen-z-index --check                       # verify committed block is up to date (exit 1 on drift)
+//   gen-z-index --tokens <path> --css <path>  # use non-conventional source/destination paths
+//   gen-z-index --no-theme-wrapper            # emit bare --z-index-<name> declarations, no @theme wrapper
 //
-// MUST be run with the project root as cwd (it resolves source paths against
-// process.cwd(), NOT against this file's location). The package.json scripts and
-// b4push satisfy this; CI's no-install z-index job invokes the file by path
-// from the repo root: `node packages/zudo-doc/bin/gen-z-index.mjs --check`.
+// MUST be run with the project root as cwd — it resolves --tokens/--css (or
+// their conventional defaults) against process.cwd(), NOT against this file's
+// location. A consuming project's own package.json scripts (e.g.
+// gen:z-index / check:z-index) are responsible for invoking it from the
+// project root. This generator is opt-in per project — a project only needs
+// it when overriding one of the default tiers shipped unconditionally by
+// @takazudo/zudo-doc/theme.css — and it is not wired into this repo's own
+// b4push or CI; that integration was retired in zudolab/zudo-doc#2661.
 //
 // The block is a Tailwind v4 `@theme { --z-index-<name>: <value>; }` for every
 // tier, so Tailwind generates `z-<name>` utilities and raw CSS can reference
-// `z-index: var(--z-index-<name>)`.
+// `z-index: var(--z-index-<name>)`. `--no-theme-wrapper` drops the `@theme`
+// wrapper and emits bare `--z-index-<name>: <value>;` declarations instead,
+// for projects that want to compose the block into their own `@theme` block.
 //
-// Pure Node (fs only — NO npm deps). Idempotent: running twice produces no diff.
+// Pure Node (fs only — NO npm deps, no minimist). Idempotent: running twice
+// produces no diff.
 //
-// MAINTENANCE: edit src/config/z-index-tokens.ts (the source of truth), then run
-// `pnpm gen:z-index` and commit the regenerated global.css. Never hand-edit the
-// block between the BEGIN/END markers.
+// MAINTENANCE: edit src/config/z-index-tokens.ts (the source of truth), then
+// run `pnpm gen:z-index` (or the equivalent --tokens/--css invocation) and
+// commit the regenerated CSS. Never hand-edit the block between the
+// BEGIN/END markers.
 
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync, realpathSync } from "node:fs";
 import { resolve } from "node:path";
-
-// Project root is always the current working directory — this is a project bin,
-// not a monorepo script.
-const ROOT = process.cwd();
-
-const TOKENS_PATH = resolve(ROOT, "src/config/z-index-tokens.ts");
-const CSS_PATH = resolve(ROOT, "src/styles/global.css");
+import { fileURLToPath } from "node:url";
 
 const BEGIN_MARKER = "GENERATED:Z_INDEX_BEGIN";
 const END_MARKER = "GENERATED:Z_INDEX_END";
 
+// Conventional paths, relative to the project root (process.cwd()). Used as
+// the default --tokens/--css values AND as the literal text shown in the
+// generated header / log messages when no override is given — this is what
+// keeps the default invocation's output byte-identical to pre-flag output.
+const DEFAULT_TOKENS_PATH = "src/config/z-index-tokens.ts";
+const DEFAULT_CSS_PATH = "src/styles/global.css";
+
+const TIER_NAME_RE = /^[a-z0-9-]+$/;
+
+const FLAG_USAGE =
+  "Supported flags: --check, --tokens <path>, --css <path>, --no-theme-wrapper.";
+
+/**
+ * Hand-rolled argv parser (no minimist — this bin stays dependency-free).
+ * Supports `--flag value` and `--flag=value` for value flags. Unknown flags,
+ * repeated flags, a missing value for a value flag, and a value attached to a
+ * boolean flag (`--no-theme-wrapper=x`) are all hard errors — this bin does
+ * not silently ignore or guess at malformed invocations.
+ *
+ * Returns `{ check, tokens, css, noThemeWrapper }`; `tokens`/`css` are
+ * `undefined` when not passed (callers apply the conventional defaults).
+ *
+ * Exported for unit testing.
+ */
+export function parseArgs(argv) {
+  const result = {
+    check: false,
+    tokens: undefined,
+    css: undefined,
+    noThemeWrapper: false,
+  };
+  const seen = new Set();
+
+  for (let i = 0; i < argv.length; i++) {
+    const raw = argv[i];
+    const eqIdx = raw.startsWith("--") ? raw.indexOf("=") : -1;
+    const flag = eqIdx === -1 ? raw : raw.slice(0, eqIdx);
+    const inlineValue = eqIdx === -1 ? undefined : raw.slice(eqIdx + 1);
+
+    const isBoolean = flag === "--check" || flag === "--no-theme-wrapper";
+    const isValueFlag = flag === "--tokens" || flag === "--css";
+
+    if (!isBoolean && !isValueFlag) {
+      throw new Error(`Unknown flag "${raw}". ${FLAG_USAGE}`);
+    }
+    if (seen.has(flag)) {
+      throw new Error(`Flag "${flag}" was passed more than once.`);
+    }
+    seen.add(flag);
+
+    if (isBoolean) {
+      if (inlineValue !== undefined) {
+        throw new Error(
+          `Flag "${flag}" does not take a value (got "${raw}"); it is a boolean switch.`,
+        );
+      }
+      if (flag === "--check") result.check = true;
+      if (flag === "--no-theme-wrapper") result.noThemeWrapper = true;
+      continue;
+    }
+
+    // Value flag (--tokens / --css): accept an inline `=value`, otherwise
+    // consume the next argv token. A missing/empty value or a next token
+    // that looks like another flag is a hard error, not a silent default.
+    let value = inlineValue;
+    if (value === undefined) {
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith("--")) {
+        throw new Error(`Flag "${flag}" requires a value (e.g. "${flag} <path>").`);
+      }
+      value = next;
+      i++;
+    }
+    if (value === "") {
+      throw new Error(`Flag "${flag}" requires a non-empty value.`);
+    }
+    if (flag === "--tokens") result.tokens = value;
+    if (flag === "--css") result.css = value;
+  }
+
+  return result;
+}
+
+/**
+ * Structural validations that apply regardless of `kind`/`purpose` usage,
+ * plus the opt-in per-kind value-uniqueness check. Called by `parseTiers`
+ * after regex-extraction, and exported separately so tests can exercise it
+ * directly against hand-built tier arrays.
+ *
+ * - Rejects an empty tiers array (preserves the pre-refactor behavior).
+ * - Rejects a tier name that doesn't match `^[a-z0-9-]+$`.
+ * - Rejects duplicate tier names.
+ * - If at least one tier carries `kind`, rejects two "global" tiers sharing a
+ *   value. "local" tiers MAY share a value with each other; kind-less tiers
+ *   are exempt from this check entirely.
+ *
+ * Exported for unit testing.
+ */
+export function validateTiers(tiers, tokensPath = DEFAULT_TOKENS_PATH) {
+  if (tiers.length === 0) {
+    throw new Error(`Z_INDEX_TIERS in ${tokensPath} parsed to an empty list`);
+  }
+
+  const seenNames = new Set();
+  for (const tier of tiers) {
+    if (!TIER_NAME_RE.test(tier.name)) {
+      throw new Error(
+        `Invalid tier name "${tier.name}" in ${tokensPath}: tier names must match ` +
+          `${TIER_NAME_RE} (lowercase letters, digits, hyphens only).`,
+      );
+    }
+    if (seenNames.has(tier.name)) {
+      throw new Error(
+        `Duplicate tier name "${tier.name}" in ${tokensPath}. Tier names must be unique.`,
+      );
+    }
+    seenNames.add(tier.name);
+  }
+
+  const anyKinded = tiers.some((tier) => tier.kind !== undefined);
+  if (anyKinded) {
+    const seenGlobalValues = new Map();
+    for (const tier of tiers) {
+      if (tier.kind !== "global") continue;
+      const existing = seenGlobalValues.get(tier.value);
+      if (existing !== undefined) {
+        throw new Error(
+          `Duplicate z-index value ${tier.value} shared by "global" tiers "${existing}" ` +
+            `and "${tier.name}" in ${tokensPath}. Global tiers must have unique values ` +
+            `(local tiers may share a value).`,
+        );
+      }
+      seenGlobalValues.set(tier.value, tier.name);
+    }
+  }
+
+  return tiers;
+}
+
+/**
+ * Scans the raw Z_INDEX_TIERS array body for `purpose:` fields and rejects
+ * any whose quoted value contains a brace or a backslash (which also covers
+ * escaped quotes) BEFORE the per-object splitter runs. The per-object
+ * splitter below uses a non-greedy `{...}` match to isolate each tier object,
+ * which only works when no field value contains a brace — a purpose string
+ * with a stray `}` would silently truncate the object split and corrupt
+ * parsing instead of failing loudly. Only a flat, plain double-quoted string
+ * is supported; a newline between `purpose:` and the opening quote is fine
+ * (the field-key regexes below all use `\s*`, which matches newlines).
+ */
+function assertSupportedPurposeGrammar(body, tokensPath) {
+  const purposeKeyRe = /purpose:\s*/g;
+  let m;
+  while ((m = purposeKeyRe.exec(body)) !== null) {
+    const afterKey = m.index + m[0].length;
+    if (body[afterKey] !== '"') {
+      // Not immediately followed by a quote — not a value this scan can
+      // confirm is a real field; let the per-object parser's generic
+      // "malformed tier object" error handle it if it really is one.
+      continue;
+    }
+    let i = afterKey + 1;
+    let closed = false;
+    for (; i < body.length; i++) {
+      const ch = body[i];
+      if (ch === "{" || ch === "}" || ch === "\\") {
+        throw new Error(
+          `Unsupported purpose string grammar in ${tokensPath}: purpose values may not ` +
+            `contain braces, backslashes, or escaped quotes — only flat, plain double-quoted ` +
+            `strings are supported (the object parser cannot safely handle anything else). ` +
+            `Offending text near: ${JSON.stringify(body.slice(afterKey, Math.min(afterKey + 40, body.length)))}`,
+        );
+      }
+      if (ch === '"') {
+        closed = true;
+        break;
+      }
+    }
+    if (!closed) {
+      throw new Error(
+        `Unterminated purpose string in ${tokensPath} (no closing double quote found).`,
+      );
+    }
+    purposeKeyRe.lastIndex = i + 1;
+  }
+}
+
 /**
  * Parse the Z_INDEX_TIERS array out of z-index-tokens.ts WITHOUT importing it
  * (this bin is a dependency-free .mjs and cannot resolve TypeScript). Reads
- * each `{ name: "...", value: <n>, ... }` object literal. Throws on a malformed
- * source so drift between the parser and the file surfaces loudly.
+ * each `{ name: "...", value: <n>, kind?: "global"|"local", purpose?: "..." }`
+ * object literal. Throws on a malformed source, an unsupported purpose-string
+ * grammar, or an unknown `kind` value so drift between the parser and the
+ * file surfaces loudly. Delegates the structural invariants (non-empty,
+ * name shape, duplicate names, per-kind value uniqueness) to `validateTiers`.
+ *
+ * `tokensPath` is used purely for error-message context — pass the same path
+ * string (conventional default or an explicit --tokens value) that was used
+ * to read `src`, so the thrown error tells the reader exactly which file to
+ * fix.
+ *
+ * Exported for unit testing.
  */
-function parseTiers(src) {
+export function parseTiers(src, tokensPath = DEFAULT_TOKENS_PATH) {
   const arrayMatch = src.match(
     /export const Z_INDEX_TIERS[^=]*=\s*\[([\s\S]*?)\];/,
   );
   if (!arrayMatch) {
     throw new Error(
-      `Could not locate "export const Z_INDEX_TIERS = [ ... ]" in ${TOKENS_PATH}`,
+      `Could not locate "export const Z_INDEX_TIERS = [ ... ]" in ${tokensPath}`,
     );
   }
   const body = arrayMatch[1];
+
+  assertSupportedPurposeGrammar(body, tokensPath);
+
   const tiers = [];
-  // Each tier is a `{ ... }` object literal; iterate top-level braces.
+  // Each tier is a `{ ... }` object literal; iterate top-level braces. Safe
+  // because assertSupportedPurposeGrammar above already ruled out braces
+  // inside any purpose string.
   const objectRe = /\{([\s\S]*?)\}/g;
   let m;
   while ((m = objectRe.exec(body)) !== null) {
@@ -67,55 +273,167 @@ function parseTiers(src) {
     const valueMatch = obj.match(/value:\s*(-?\d+)/);
     if (!nameMatch || !valueMatch) {
       throw new Error(
-        `Malformed tier object in Z_INDEX_TIERS (missing name/value): ${obj.trim()}`,
+        `Malformed tier object in Z_INDEX_TIERS (missing name/value) in ${tokensPath}: ${obj.trim()}`,
       );
     }
-    tiers.push({ name: nameMatch[1], value: Number(valueMatch[1]) });
+
+    const tier = { name: nameMatch[1], value: Number(valueMatch[1]) };
+
+    const kindMatch = obj.match(/kind:\s*"([^"]*)"/);
+    if (kindMatch) {
+      const kindValue = kindMatch[1];
+      if (kindValue !== "global" && kindValue !== "local") {
+        throw new Error(
+          `Invalid kind "${kindValue}" for tier "${tier.name}" in ${tokensPath} ` +
+            `(expected "global" or "local").`,
+        );
+      }
+      tier.kind = kindValue;
+    }
+
+    const purposeMatch = obj.match(/purpose:\s*"([^"]*)"/);
+    if (purposeMatch) {
+      tier.purpose = purposeMatch[1];
+    }
+
+    tiers.push(tier);
   }
-  if (tiers.length === 0) {
-    throw new Error(`Z_INDEX_TIERS in ${TOKENS_PATH} parsed to an empty list`);
-  }
-  return tiers;
+
+  return validateTiers(tiers, tokensPath);
+}
+
+/**
+ * Wraps a path in double quotes so it copy-pastes safely into a shell even
+ * when it contains a space (an unquoted `--tokens a b.ts` would otherwise
+ * split into two argv tokens on rerun).
+ */
+function shellQuote(value) {
+  return `"${value}"`;
+}
+
+/**
+ * Builds the rerun-guidance command shown in the generated header comment and
+ * in main()'s drift/error messages. Returns the exact legacy "pnpm
+ * gen:z-index" text when every option is at its conventional default (the
+ * byte-identity case); otherwise builds an explicit, directly-runnable
+ * `pnpm exec gen-z-index ...` invocation carrying only the non-default flags
+ * (quoted), so the guidance always reruns with the SAME effective options
+ * that produced the current output. `pnpm exec` — rather than a bare
+ * `gen-z-index` — is used because a project customizing --tokens/--css has
+ * no guarantee it also defined a package.json script alias for that exact
+ * invocation; `pnpm exec` resolves the package-local bin regardless.
+ */
+function buildRerunCommand({ tokensPath, cssPath, themeWrapper }) {
+  const isDefault =
+    tokensPath === DEFAULT_TOKENS_PATH &&
+    cssPath === DEFAULT_CSS_PATH &&
+    themeWrapper === true;
+  if (isDefault) return "pnpm gen:z-index";
+
+  const parts = ["pnpm exec gen-z-index"];
+  if (tokensPath !== DEFAULT_TOKENS_PATH) parts.push(`--tokens ${shellQuote(tokensPath)}`);
+  if (cssPath !== DEFAULT_CSS_PATH) parts.push(`--css ${shellQuote(cssPath)}`);
+  if (!themeWrapper) parts.push("--no-theme-wrapper");
+  return parts.join(" ");
 }
 
 /**
  * Build the full generated block (markers included). Two leading spaces of
  * indentation match the surrounding `@theme` style in global.css.
+ *
+ * `options.tokensPath`/`options.cssPath` feed the "Source of truth:" and
+ * rerun-guidance lines in the header comment — pass the SAME path strings
+ * (conventional defaults or explicit --tokens/--css values) used to read/
+ * write the actual files, so a reader of the committed CSS can tell exactly
+ * where the block came from and how to regenerate it. With every option at
+ * its default, the header is byte-identical to the pre-flag generator.
+ *
+ * `options.themeWrapper` (default `true`) wraps the declarations in an
+ * `@theme { ... }` block; `false` (the `--no-theme-wrapper` CLI flag) emits
+ * bare `--z-index-<name>: <value>;` declarations at 2-space indent instead,
+ * for projects composing the block into their own `@theme` block.
+ *
+ * Exported for unit testing.
  */
-function buildBlock(tiers) {
+export function buildBlock(tiers, options = {}) {
+  const {
+    tokensPath = DEFAULT_TOKENS_PATH,
+    cssPath = DEFAULT_CSS_PATH,
+    themeWrapper = true,
+  } = options;
+
   const lines = [];
   lines.push(`  /* ${BEGIN_MARKER}`);
   lines.push(
-    `   * GENERATED:Z_INDEX — do not hand-edit; run pnpm gen:z-index.`,
+    `   * GENERATED:Z_INDEX — do not hand-edit; run ${buildRerunCommand({ tokensPath, cssPath, themeWrapper })}.`,
   );
-  lines.push(
-    `   * Source of truth: src/config/z-index-tokens.ts. Tailwind v4 reads the`,
-  );
+  lines.push(`   * Source of truth: ${tokensPath}. Tailwind v4 reads the`);
   lines.push(
     `   * --z-index-<name> theme key and generates a z-<name> utility. */`,
   );
-  lines.push(`  @theme {`);
-  for (const tier of tiers) {
-    lines.push(`    --z-index-${tier.name}: ${tier.value};`);
+  if (themeWrapper) {
+    lines.push(`  @theme {`);
+    for (const tier of tiers) {
+      lines.push(`    --z-index-${tier.name}: ${tier.value};`);
+    }
+    lines.push(`  }`);
+  } else {
+    for (const tier of tiers) {
+      lines.push(`  --z-index-${tier.name}: ${tier.value};`);
+    }
   }
-  lines.push(`  }`);
   lines.push(`  /* ${END_MARKER} */`);
   return lines.join("\n");
 }
 
+/** Counts non-overlapping occurrences of `marker` in `str`. */
+function countOccurrences(str, marker) {
+  let count = 0;
+  let idx = str.indexOf(marker);
+  while (idx !== -1) {
+    count++;
+    idx = str.indexOf(marker, idx + marker.length);
+  }
+  return count;
+}
+
 /**
- * Replace the existing BEGIN…END block in `css` with `block`. Throws if the
- * markers are missing (the block must be seeded once by hand — see global.css).
+ * Replace the existing BEGIN…END block in `css` with `block`. Requires
+ * EXACTLY one BEGIN and one END marker, with BEGIN preceding END — throws a
+ * clear, distinct error for each failure mode: missing (the block must be
+ * seeded once by hand), duplicated, or inverted markers. `cssPath` is used
+ * purely for error-message context (pass the conventional default or an
+ * explicit --css value).
+ *
+ * Exported for unit testing.
  */
-function replaceBlock(css, block) {
-  const beginIdx = css.indexOf(BEGIN_MARKER);
-  const endIdx = css.indexOf(END_MARKER);
-  if (beginIdx === -1 || endIdx === -1) {
+export function replaceBlock(css, block, cssPath = DEFAULT_CSS_PATH) {
+  const beginCount = countOccurrences(css, BEGIN_MARKER);
+  const endCount = countOccurrences(css, END_MARKER);
+
+  if (beginCount === 0 || endCount === 0) {
     throw new Error(
-      `Could not find ${BEGIN_MARKER} … ${END_MARKER} markers in ${CSS_PATH}.\n` +
+      `Could not find ${BEGIN_MARKER} … ${END_MARKER} markers in ${cssPath}.\n` +
         `Seed the marker block once by hand, then re-run the generator.`,
     );
   }
+  if (beginCount > 1 || endCount > 1) {
+    throw new Error(
+      `Found duplicate GENERATED:Z_INDEX markers in ${cssPath} (${beginCount} BEGIN, ` +
+        `${endCount} END; expected exactly one of each). Remove the extra marker(s) by ` +
+        `hand, then re-run the generator.`,
+    );
+  }
+
+  const beginIdx = css.indexOf(BEGIN_MARKER);
+  const endIdx = css.indexOf(END_MARKER);
+  if (beginIdx > endIdx) {
+    throw new Error(
+      `GENERATED:Z_INDEX markers in ${cssPath} are inverted — the END marker appears ` +
+        `before the BEGIN marker. Fix the marker order by hand, then re-run the generator.`,
+    );
+  }
+
   // Expand to the full comment line that opens the block ("  /* GENERATED:...")
   // and to the end of the closing "*/ " line so the whole region is replaced.
   const lineStart = css.lastIndexOf("\n", beginIdx) + 1;
@@ -124,27 +442,44 @@ function replaceBlock(css, block) {
   return css.slice(0, lineStart) + block + css.slice(lineEnd);
 }
 
-function main() {
-  const check = process.argv.includes("--check");
+/**
+ * CLI entrypoint. `argv` defaults to the real process argv (minus the node/
+ * script prefix) so `isDirectInvocation()` below can call `main()` with no
+ * arguments, while tests can pass a synthetic argv without touching
+ * `process.argv`. Resolves --tokens/--css against `process.cwd()` (the
+ * project root) for actual file I/O, but threads the AS-GIVEN path strings
+ * (conventional defaults or explicit flag values) through to every message
+ * and into the generated header — never the resolved absolute path — so the
+ * committed CSS never embeds a machine-specific path.
+ *
+ * Exported for unit testing.
+ */
+export function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  const tokensPath = args.tokens ?? DEFAULT_TOKENS_PATH;
+  const cssPath = args.css ?? DEFAULT_CSS_PATH;
+  const themeWrapper = !args.noThemeWrapper;
 
-  const tokensSrc = readFileSync(TOKENS_PATH, "utf8");
-  const css = readFileSync(CSS_PATH, "utf8");
+  const root = process.cwd();
+  const tokensAbsPath = resolve(root, tokensPath);
+  const cssAbsPath = resolve(root, cssPath);
 
-  const tiers = parseTiers(tokensSrc);
-  const block = buildBlock(tiers);
-  const next = replaceBlock(css, block);
+  const tokensSrc = readFileSync(tokensAbsPath, "utf8");
+  const css = readFileSync(cssAbsPath, "utf8");
 
-  if (check) {
+  const tiers = parseTiers(tokensSrc, tokensPath);
+  const block = buildBlock(tiers, { tokensPath, cssPath, themeWrapper });
+  const next = replaceBlock(css, block, cssPath);
+
+  if (args.check) {
     if (next !== css) {
+      console.error(`z-index codegen drift detected: ${cssPath} is out of date.`);
       console.error(
-        "z-index codegen drift detected: src/styles/global.css is out of date.",
+        `Run \`${buildRerunCommand({ tokensPath, cssPath, themeWrapper })}\` and commit the result.`,
       );
-      console.error("Run `pnpm gen:z-index` and commit the result.");
       return 1;
     }
-    console.log(
-      `OK — z-index @theme block is up to date (${tiers.length} tiers).`,
-    );
+    console.log(`OK — z-index @theme block is up to date (${tiers.length} tiers).`);
     return 0;
   }
 
@@ -154,11 +489,30 @@ function main() {
     );
     return 0;
   }
-  writeFileSync(CSS_PATH, next);
-  console.log(
-    `Wrote z-index @theme block to src/styles/global.css (${tiers.length} tiers).`,
-  );
+  writeFileSync(cssAbsPath, next);
+  console.log(`Wrote z-index @theme block to ${cssPath} (${tiers.length} tiers).`);
   return 0;
 }
 
-process.exit(main());
+// Run the CLI only when executed directly, NOT when imported by tests (an
+// import must not write global.css or exit the process as a side effect — it
+// would break `pnpm test`). Compare REAL paths on both sides: when invoked
+// through the pnpm bin shim, argv[1] is the `node_modules/.bin/…` symlink,
+// NOT the real file, so a raw path-equality check is always false and
+// main() would silently no-op. realpathSync resolves the shim/symlink to the
+// real file on both sides so direct invocation is detected however the bin
+// is launched.
+function isDirectInvocation() {
+  if (!process.argv[1]) return false;
+  try {
+    return (
+      realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1])
+    );
+  } catch {
+    return false;
+  }
+}
+
+if (isDirectInvocation()) {
+  process.exit(main());
+}

--- a/packages/zudo-doc/src/__tests__/gen-z-index.test.ts
+++ b/packages/zudo-doc/src/__tests__/gen-z-index.test.ts
@@ -1,0 +1,598 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { resolve, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+
+// Import the generator functions directly so the test exercises the same
+// logic the CLI uses, without needing a built dist or running Node as a child.
+// The .mjs is plain ESM with no Node built-ins called at import time (only
+// inside main(), which itself only runs behind the isDirectInvocation()
+// guard), so dynamic import works fine from vitest's ESM environment and
+// never writes a file or calls process.exit as a side effect.
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Import via relative path that steps outside src/ into bin/.
+// Vitest resolves this at test time; it is NOT compiled by tsup.
+const { parseArgs, parseTiers, validateTiers, buildBlock, replaceBlock, main } =
+  await import(resolve(__dirname, "../../bin/gen-z-index.mjs"));
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+const BEGIN_MARKER = "GENERATED:Z_INDEX_BEGIN";
+const END_MARKER = "GENERATED:Z_INDEX_END";
+
+const DEFAULT_TOKENS_PATH = "src/config/z-index-tokens.ts";
+const DEFAULT_CSS_PATH = "src/styles/global.css";
+
+/** Minimal global.css shell with BEGIN/END markers (real comment syntax). */
+function wrapInCss(inner: string): string {
+  return `/* preamble */\n\n${inner}\n`;
+}
+
+function seededBlock(inner: string): string {
+  return `  /* ${BEGIN_MARKER}\n   * old comment */\n${inner}\n  /* ${END_MARKER} */`;
+}
+
+/** The 13 default tiers (name/value only) — mirrors defaultZIndexTiers. */
+const DEFAULT_TIER_DATA: Array<{ name: string; value: number }> = [
+  { name: "content", value: 0 },
+  { name: "local-1", value: 1 },
+  { name: "local-2", value: 2 },
+  { name: "local-3", value: 3 },
+  { name: "sidebar", value: 10 },
+  { name: "toolbar", value: 20 },
+  { name: "dropdown", value: 30 },
+  { name: "popover", value: 40 },
+  { name: "modal-backdrop", value: 50 },
+  { name: "modal", value: 60 },
+  { name: "toast", value: 70 },
+  { name: "tooltip", value: 80 },
+  { name: "drag", value: 90 },
+];
+
+/** Builds a Z_INDEX_TIERS source file from plain name/value pairs. */
+function tokensSrcFromTiers(
+  tiers: ReadonlyArray<{ name: string; value: number; kind?: string; purpose?: string }>,
+): string {
+  const objects = tiers.map((tier) => {
+    const fields = [`name: "${tier.name}"`, `value: ${tier.value}`];
+    if (tier.kind !== undefined) fields.push(`kind: "${tier.kind}"`);
+    if (tier.purpose !== undefined) fields.push(`purpose: "${tier.purpose}"`);
+    return `  { ${fields.join(", ")} },`;
+  });
+  return `export const Z_INDEX_TIERS = [\n${objects.join("\n")}\n];\n`;
+}
+
+// The exact legacy header + block text for DEFAULT_TIER_DATA at conventional
+// paths with the @theme wrapper — this is the byte-identity golden value.
+const GOLDEN_DEFAULT_BLOCK = [
+  `  /* ${BEGIN_MARKER}`,
+  `   * GENERATED:Z_INDEX — do not hand-edit; run pnpm gen:z-index.`,
+  `   * Source of truth: src/config/z-index-tokens.ts. Tailwind v4 reads the`,
+  `   * --z-index-<name> theme key and generates a z-<name> utility. */`,
+  `  @theme {`,
+  ...DEFAULT_TIER_DATA.map((t) => `    --z-index-${t.name}: ${t.value};`),
+  `  }`,
+  `  /* ${END_MARKER} */`,
+].join("\n");
+
+// ── Import side effects ────────────────────────────────────────────────────
+
+describe("Import side effects", () => {
+  it("importing the module does not invoke main() (no process.exit, no thrown error)", () => {
+    // Reaching this point at all — with process.exitCode still unset — proves
+    // the top-level dynamic import above never wrote a file or exited via
+    // main(); main() only runs behind the isDirectInvocation() realpath gate.
+    expect(process.exitCode).toBeUndefined();
+    expect(typeof main).toBe("function");
+    expect(typeof parseTiers).toBe("function");
+    expect(typeof buildBlock).toBe("function");
+    expect(typeof replaceBlock).toBe("function");
+    expect(typeof validateTiers).toBe("function");
+    expect(typeof parseArgs).toBe("function");
+  });
+});
+
+// ── parseArgs ──────────────────────────────────────────────────────────────
+
+describe("parseArgs", () => {
+  it("returns defaults for an empty argv", () => {
+    expect(parseArgs([])).toEqual({
+      check: false,
+      tokens: undefined,
+      css: undefined,
+      noThemeWrapper: false,
+    });
+  });
+
+  it("parses --check", () => {
+    expect(parseArgs(["--check"]).check).toBe(true);
+  });
+
+  it("parses --tokens with a separate value", () => {
+    expect(parseArgs(["--tokens", "custom/tokens.ts"]).tokens).toBe("custom/tokens.ts");
+  });
+
+  it("parses --tokens=value", () => {
+    expect(parseArgs(["--tokens=custom/tokens.ts"]).tokens).toBe("custom/tokens.ts");
+  });
+
+  it("parses --css with a separate value and --css=value", () => {
+    expect(parseArgs(["--css", "custom/theme.css"]).css).toBe("custom/theme.css");
+    expect(parseArgs(["--css=custom/theme.css"]).css).toBe("custom/theme.css");
+  });
+
+  it("parses --no-theme-wrapper", () => {
+    expect(parseArgs(["--no-theme-wrapper"]).noThemeWrapper).toBe(true);
+  });
+
+  it("parses a combination of flags together", () => {
+    const args = parseArgs([
+      "--check",
+      "--tokens",
+      "a/tokens.ts",
+      "--css=b/theme.css",
+      "--no-theme-wrapper",
+    ]);
+    expect(args).toEqual({
+      check: true,
+      tokens: "a/tokens.ts",
+      css: "b/theme.css",
+      noThemeWrapper: true,
+    });
+  });
+
+  it("throws on an unknown flag", () => {
+    expect(() => parseArgs(["--bogus"])).toThrow(/Unknown flag "--bogus"/);
+  });
+
+  it("throws on a repeated flag", () => {
+    expect(() => parseArgs(["--check", "--check"])).toThrow(/passed more than once/);
+    expect(() =>
+      parseArgs(["--tokens", "a.ts", "--tokens", "b.ts"]),
+    ).toThrow(/passed more than once/);
+  });
+
+  it("throws when --tokens is missing a value at end of argv", () => {
+    expect(() => parseArgs(["--tokens"])).toThrow(/requires a value/);
+  });
+
+  it("throws when --tokens is immediately followed by another flag", () => {
+    expect(() => parseArgs(["--tokens", "--css", "x.css"])).toThrow(/requires a value/);
+  });
+
+  it("throws on --tokens= with an empty value", () => {
+    expect(() => parseArgs(["--tokens="])).toThrow(/non-empty value/);
+  });
+
+  it("throws when --no-theme-wrapper is given a value", () => {
+    expect(() => parseArgs(["--no-theme-wrapper=true"])).toThrow(/does not take a value/);
+  });
+
+  it("throws when --check is given a value", () => {
+    expect(() => parseArgs(["--check=true"])).toThrow(/does not take a value/);
+  });
+});
+
+// ── parseTiers ─────────────────────────────────────────────────────────────
+
+describe("parseTiers", () => {
+  it("extracts name/value pairs in source order", () => {
+    const src = tokensSrcFromTiers([
+      { name: "content", value: 0 },
+      { name: "modal", value: 50 },
+    ]);
+    const tiers = parseTiers(src);
+    expect(tiers).toEqual([
+      { name: "content", value: 0 },
+      { name: "modal", value: 50 },
+    ]);
+  });
+
+  it("captures an optional kind field", () => {
+    const src = tokensSrcFromTiers([{ name: "toolbar", value: 20, kind: "global" }]);
+    const tiers = parseTiers(src);
+    expect(tiers[0]).toMatchObject({ name: "toolbar", value: 20, kind: "global" });
+  });
+
+  it("throws on an unknown kind value", () => {
+    const src = tokensSrcFromTiers([{ name: "toolbar", value: 20, kind: "bogus" }]);
+    expect(() => parseTiers(src)).toThrow(/Invalid kind "bogus".*toolbar/s);
+  });
+
+  it("captures an optional purpose field", () => {
+    const src = tokensSrcFromTiers([
+      { name: "toolbar", value: 20, purpose: "sticky top header" },
+    ]);
+    const tiers = parseTiers(src);
+    expect(tiers[0].purpose).toBe("sticky top header");
+  });
+
+  it("tolerates a newline between purpose: and the opening quote", () => {
+    const src = `export const Z_INDEX_TIERS = [
+  {
+    name: "sidebar",
+    value: 10,
+    purpose:
+      "persistent layout chrome: desktop sidebar, TOC, sidebar-toggle handle, resizer handle",
+    kind: "global",
+  },
+];
+`;
+    const tiers = parseTiers(src);
+    expect(tiers[0]).toMatchObject({
+      name: "sidebar",
+      value: 10,
+      kind: "global",
+      purpose:
+        "persistent layout chrome: desktop sidebar, TOC, sidebar-toggle handle, resizer handle",
+    });
+  });
+
+  it("rejects a purpose string containing a brace", () => {
+    const src = `export const Z_INDEX_TIERS = [
+  { name: "x", value: 1, purpose: "bad } text" },
+];`;
+    expect(() => parseTiers(src)).toThrow(/Unsupported purpose string grammar/);
+  });
+
+  it("rejects a purpose string containing a backslash", () => {
+    const src = `export const Z_INDEX_TIERS = [
+  { name: "x", value: 1, purpose: "bad \\\\ text" },
+];`;
+    expect(() => parseTiers(src)).toThrow(/Unsupported purpose string grammar/);
+  });
+
+  it("rejects a purpose string containing an escaped quote", () => {
+    const src = `export const Z_INDEX_TIERS = [
+  { name: "x", value: 1, purpose: "bad \\" text" },
+];`;
+    expect(() => parseTiers(src)).toThrow(/Unsupported purpose string grammar/);
+  });
+
+  it("throws when the Z_INDEX_TIERS export is absent, naming the given tokensPath", () => {
+    const src = `export const OTHER = [];`;
+    expect(() => parseTiers(src, "custom/path/tokens.ts")).toThrow(
+      /Could not locate.*custom\/path\/tokens\.ts/,
+    );
+  });
+
+  it("throws when a tier object is missing name/value", () => {
+    const src = `export const Z_INDEX_TIERS = [
+  { value: 1 },
+];`;
+    expect(() => parseTiers(src)).toThrow(/Malformed tier object/);
+  });
+
+  it("throws when the array is empty, naming the given tokensPath", () => {
+    const src = `export const Z_INDEX_TIERS = [];`;
+    expect(() => parseTiers(src, "custom/path/tokens.ts")).toThrow(
+      /custom\/path\/tokens\.ts parsed to an empty list/,
+    );
+  });
+});
+
+// ── validateTiers ──────────────────────────────────────────────────────────
+
+describe("validateTiers", () => {
+  it("rejects an empty tiers array", () => {
+    expect(() => validateTiers([])).toThrow(/parsed to an empty list/);
+  });
+
+  it("rejects a tier name with characters outside [a-z0-9-]", () => {
+    expect(() => validateTiers([{ name: "Content", value: 0 }])).toThrow(
+      /Invalid tier name "Content"/,
+    );
+    expect(() => validateTiers([{ name: "modal_backdrop", value: 0 }])).toThrow(
+      /Invalid tier name "modal_backdrop"/,
+    );
+  });
+
+  it("accepts lowercase/digit/hyphen tier names", () => {
+    expect(() =>
+      validateTiers([{ name: "modal-backdrop-2", value: 0 }]),
+    ).not.toThrow();
+  });
+
+  it("rejects duplicate tier names", () => {
+    expect(() =>
+      validateTiers([
+        { name: "modal", value: 10 },
+        { name: "modal", value: 20 },
+      ]),
+    ).toThrow(/Duplicate tier name "modal"/);
+  });
+
+  it("rejects two 'global' tiers sharing a value", () => {
+    expect(() =>
+      validateTiers([
+        { name: "a", value: 10, kind: "global" },
+        { name: "b", value: 10, kind: "global" },
+      ]),
+    ).toThrow(/Duplicate z-index value 10 shared by "global" tiers "a" and "b"/);
+  });
+
+  it("allows two 'local' tiers to share a value", () => {
+    expect(() =>
+      validateTiers([
+        { name: "local-1", value: 1, kind: "local" },
+        { name: "local-2", value: 1, kind: "local" },
+      ]),
+    ).not.toThrow();
+  });
+
+  it("exempts kind-less tiers from the value-uniqueness check, even when other tiers carry kind", () => {
+    expect(() =>
+      validateTiers([
+        { name: "a", value: 5 },
+        { name: "b", value: 5 },
+        { name: "c", value: 20, kind: "global" },
+      ]),
+    ).not.toThrow();
+  });
+
+  it("does not enforce value uniqueness at all when no tier carries kind", () => {
+    expect(() =>
+      validateTiers([
+        { name: "a", value: 5 },
+        { name: "b", value: 5 },
+      ]),
+    ).not.toThrow();
+  });
+});
+
+// ── buildBlock ─────────────────────────────────────────────────────────────
+
+describe("buildBlock", () => {
+  it("produces the byte-identical legacy block for default-tiers at conventional paths (golden test)", () => {
+    const block = buildBlock(DEFAULT_TIER_DATA);
+    expect(block).toBe(GOLDEN_DEFAULT_BLOCK);
+  });
+
+  it("reflects a custom --tokens value in the 'Source of truth' line and rerun guidance", () => {
+    const block = buildBlock([{ name: "content", value: 0 }], {
+      tokensPath: "sub-packages/design-system/z-index-tokens.ts",
+    });
+    expect(block).toContain(
+      "Source of truth: sub-packages/design-system/z-index-tokens.ts.",
+    );
+    expect(block).toContain(
+      'run pnpm exec gen-z-index --tokens "sub-packages/design-system/z-index-tokens.ts".',
+    );
+    // css untouched (default), so it must not appear in the rerun command
+    expect(block).not.toContain("--css");
+  });
+
+  it("reflects a custom --css value in the rerun guidance only", () => {
+    const block = buildBlock([{ name: "content", value: 0 }], {
+      cssPath: "web/app/styles/theme.css",
+    });
+    expect(block).toContain('run pnpm exec gen-z-index --css "web/app/styles/theme.css".');
+    expect(block).not.toContain("--tokens");
+    expect(block).toContain(`Source of truth: ${DEFAULT_TOKENS_PATH}.`);
+  });
+
+  it("includes --no-theme-wrapper in the rerun guidance when set, even at default paths", () => {
+    const block = buildBlock([{ name: "content", value: 0 }], { themeWrapper: false });
+    expect(block).toContain("run pnpm exec gen-z-index --no-theme-wrapper.");
+  });
+
+  it("combines all three overrides in the rerun guidance, quoting each path", () => {
+    const block = buildBlock([{ name: "content", value: 0 }], {
+      tokensPath: "a/tokens.ts",
+      cssPath: "b/theme.css",
+      themeWrapper: false,
+    });
+    expect(block).toContain(
+      'run pnpm exec gen-z-index --tokens "a/tokens.ts" --css "b/theme.css" --no-theme-wrapper.',
+    );
+  });
+
+  it("quotes a path containing a space so the rerun guidance copy-pastes safely", () => {
+    const block = buildBlock([{ name: "content", value: 0 }], {
+      tokensPath: "my tokens/z-index-tokens.ts",
+    });
+    expect(block).toContain('--tokens "my tokens/z-index-tokens.ts"');
+  });
+
+  it("--no-theme-wrapper: drops the @theme wrapper and emits bare declarations at 2-space indent", () => {
+    const block = buildBlock(
+      [
+        { name: "content", value: 0 },
+        { name: "modal", value: 50 },
+      ],
+      { themeWrapper: false },
+    );
+    expect(block).not.toContain("@theme {");
+    expect(block).not.toContain("  }\n");
+    const expected = [
+      `  /* ${BEGIN_MARKER}`,
+      `   * GENERATED:Z_INDEX — do not hand-edit; run pnpm exec gen-z-index --no-theme-wrapper.`,
+      `   * Source of truth: ${DEFAULT_TOKENS_PATH}. Tailwind v4 reads the`,
+      `   * --z-index-<name> theme key and generates a z-<name> utility. */`,
+      `  --z-index-content: 0;`,
+      `  --z-index-modal: 50;`,
+      `  /* ${END_MARKER} */`,
+    ].join("\n");
+    expect(block).toBe(expected);
+  });
+
+  it("wraps declarations at 4-space indent inside @theme when themeWrapper is true (default)", () => {
+    const block = buildBlock([{ name: "content", value: 0 }]);
+    expect(block).toContain("    --z-index-content: 0;");
+  });
+});
+
+// ── replaceBlock ───────────────────────────────────────────────────────────
+
+describe("replaceBlock", () => {
+  it("replaces the block between BEGIN and END markers", () => {
+    const existing = wrapInCss(seededBlock("  @theme {\n    --z-index-content: 0;\n  }"));
+    const next = replaceBlock(existing, buildBlock([{ name: "content", value: 1 }]));
+    expect(next).toContain("--z-index-content: 1;");
+    expect(next).not.toContain("old comment");
+  });
+
+  it("preserves surrounding content outside the block", () => {
+    const prefix = "/* prefix content */\n\n";
+    const suffix = "\n/* suffix content */\n";
+    const css = `${prefix}${seededBlock("  @theme {\n    --z-index-content: 0;\n  }")}${suffix}`;
+    const next = replaceBlock(css, buildBlock([{ name: "content", value: 1 }]));
+    expect(next.startsWith(prefix)).toBe(true);
+    expect(next).toContain(suffix);
+  });
+
+  it("throws, naming the given cssPath, when both markers are missing", () => {
+    expect(() => replaceBlock("/* nothing here */\n", "block", "custom/theme.css")).toThrow(
+      /Could not find.*custom\/theme\.css/,
+    );
+  });
+
+  it("throws when only the END marker is missing", () => {
+    expect(() => replaceBlock(`${BEGIN_MARKER}\n`, "block")).toThrow(/Could not find/);
+  });
+
+  it("throws on duplicate BEGIN markers", () => {
+    const css = `${BEGIN_MARKER}\n${BEGIN_MARKER}\n${END_MARKER}`;
+    expect(() => replaceBlock(css, "block", "custom/theme.css")).toThrow(
+      /duplicate GENERATED:Z_INDEX markers.*custom\/theme\.css/s,
+    );
+  });
+
+  it("throws on duplicate END markers", () => {
+    const css = `${BEGIN_MARKER}\n${END_MARKER}\n${END_MARKER}`;
+    expect(() => replaceBlock(css, "block")).toThrow(/duplicate GENERATED:Z_INDEX markers/);
+  });
+
+  it("throws on inverted markers (END before BEGIN)", () => {
+    const css = `${END_MARKER}\n${BEGIN_MARKER}`;
+    expect(() => replaceBlock(css, "block", "custom/theme.css")).toThrow(
+      /custom\/theme\.css are inverted/s,
+    );
+  });
+});
+
+// ── Idempotency ────────────────────────────────────────────────────────────
+
+describe("Idempotency", () => {
+  it("running buildBlock + replaceBlock twice produces no diff", () => {
+    const initial = wrapInCss(seededBlock("  @theme {\n    --z-index-content: 0;\n  }"));
+    const first = replaceBlock(initial, buildBlock(DEFAULT_TIER_DATA));
+    const second = replaceBlock(first, buildBlock(DEFAULT_TIER_DATA));
+    expect(second).toBe(first);
+  });
+});
+
+// ── main() — CLI integration ────────────────────────────────────────────────
+
+describe("main()", () => {
+  let tmpDir: string;
+  let originalCwd: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tmpDir = mkdtempSync(join(tmpdir(), "gen-z-index-test-"));
+    process.chdir(tmpDir);
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(tmpDir, { recursive: true, force: true });
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it("writes the block using non-conventional --tokens/--css paths, with messages carrying those actual paths", () => {
+    mkdirSync(join(tmpDir, "sub-packages/design-system"), { recursive: true });
+    mkdirSync(join(tmpDir, "web/app/styles"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, "sub-packages/design-system/z-index-tokens.ts"),
+      tokensSrcFromTiers([{ name: "content", value: 0 }]),
+    );
+    writeFileSync(
+      join(tmpDir, "web/app/styles/theme.css"),
+      wrapInCss(seededBlock("  @theme {\n  }")),
+    );
+
+    const code = main([
+      "--tokens",
+      "sub-packages/design-system/z-index-tokens.ts",
+      "--css",
+      "web/app/styles/theme.css",
+    ]);
+    expect(code).toBe(0);
+
+    const written = readFileSync(join(tmpDir, "web/app/styles/theme.css"), "utf8");
+    expect(written).toContain("--z-index-content: 0;");
+    expect(written).toContain(
+      "Source of truth: sub-packages/design-system/z-index-tokens.ts.",
+    );
+
+    const logged = logSpy.mock.calls.flat().join("\n");
+    expect(logged).toContain("web/app/styles/theme.css");
+    expect(logged).not.toContain(DEFAULT_CSS_PATH);
+  });
+
+  it("--check reports drift with the actual css path and a working rerun command", () => {
+    mkdirSync(join(tmpDir, "custom"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, "custom/tokens.ts"),
+      tokensSrcFromTiers([{ name: "content", value: 0 }]),
+    );
+    writeFileSync(
+      join(tmpDir, "custom/theme.css"),
+      wrapInCss(seededBlock("  @theme {\n    --z-index-content: 999;\n  }")),
+    );
+
+    const code = main(["--check", "--tokens", "custom/tokens.ts", "--css", "custom/theme.css"]);
+    expect(code).toBe(1);
+
+    const errored = errorSpy.mock.calls.flat().join("\n");
+    expect(errored).toContain("custom/theme.css");
+    expect(errored).toContain(
+      'pnpm exec gen-z-index --tokens "custom/tokens.ts" --css "custom/theme.css"',
+    );
+  });
+
+  it("--check passes when the committed block already matches", () => {
+    mkdirSync(join(tmpDir, "src/config"), { recursive: true });
+    mkdirSync(join(tmpDir, "src/styles"), { recursive: true });
+    writeFileSync(join(tmpDir, DEFAULT_TOKENS_PATH), tokensSrcFromTiers(DEFAULT_TIER_DATA));
+    writeFileSync(join(tmpDir, DEFAULT_CSS_PATH), wrapInCss(GOLDEN_DEFAULT_BLOCK));
+
+    const code = main(["--check"]);
+    expect(code).toBe(0);
+    expect(logSpy.mock.calls.flat().join("\n")).toMatch(/up to date \(13 tiers\)/);
+  });
+
+  it("--no-theme-wrapper writes bare declarations end to end", () => {
+    mkdirSync(join(tmpDir, "src/config"), { recursive: true });
+    mkdirSync(join(tmpDir, "src/styles"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, DEFAULT_TOKENS_PATH),
+      tokensSrcFromTiers([{ name: "content", value: 0 }]),
+    );
+    writeFileSync(join(tmpDir, DEFAULT_CSS_PATH), wrapInCss(seededBlock("  @theme {\n  }")));
+
+    main(["--no-theme-wrapper"]);
+    const written = readFileSync(join(tmpDir, DEFAULT_CSS_PATH), "utf8");
+    expect(written).not.toContain("@theme {");
+    expect(written).toContain("  --z-index-content: 0;");
+  });
+
+  it("propagates a validation error (empty tiers) from main() with the actual tokens path", () => {
+    mkdirSync(join(tmpDir, "src/config"), { recursive: true });
+    mkdirSync(join(tmpDir, "src/styles"), { recursive: true });
+    writeFileSync(join(tmpDir, DEFAULT_TOKENS_PATH), `export const Z_INDEX_TIERS = [];`);
+    writeFileSync(join(tmpDir, DEFAULT_CSS_PATH), wrapInCss(seededBlock("  @theme {\n  }")));
+
+    expect(() => main([])).toThrow(
+      new RegExp(`${DEFAULT_TOKENS_PATH.replace(/\//g, "\\/")} parsed to an empty list`),
+    );
+  });
+});

--- a/packages/zudo-doc/src/__tests__/gen-z-index.test.ts
+++ b/packages/zudo-doc/src/__tests__/gen-z-index.test.ts
@@ -619,6 +619,46 @@ describe("buildMdTable", () => {
     expect(table).toContain("| toolbar | - | header \\| toolbar boundary |");
   });
 
+  it("escapes < in the purpose so MDX renders it as literal text, not an unclosed JSX element", () => {
+    const table = buildMdTable([
+      {
+        name: "modal",
+        value: 60,
+        kind: "global",
+        purpose: "mobile sidebar drawer panel, search <dialog>",
+      },
+    ]);
+    expect(table).toContain(
+      "| modal | global | mobile sidebar drawer panel, search &lt;dialog> |",
+    );
+    // The raw tag text must not survive anywhere in the emitted region.
+    expect(table).not.toContain("<dialog>");
+    // & was escaped BEFORE <, so our own &lt; is not double-escaped.
+    expect(table).not.toContain("&amp;lt;");
+  });
+
+  it("escapes { and } in the purpose so MDX can't read them as expression delimiters", () => {
+    const table = buildMdTable([
+      { name: "toolbar", value: 20, purpose: "renders {props.title} inline" },
+    ]);
+    expect(table).toContain("| toolbar | - | renders &#123;props.title&#125; inline |");
+    expect(table).not.toContain("{props.title}");
+  });
+
+  it("escapes & first: a purpose already containing &lt; stays literal instead of collapsing to <", () => {
+    const table = buildMdTable([
+      { name: "toolbar", value: 20, purpose: "write &lt; for a less-than sign" },
+    ]);
+    expect(table).toContain("| toolbar | - | write &amp;lt; for a less-than sign |");
+  });
+
+  it("layers MDX escaping with pipe escaping in the same purpose", () => {
+    const table = buildMdTable([
+      { name: "toolbar", value: 20, purpose: "header | search <dialog>" },
+    ]);
+    expect(table).toContain("| toolbar | - | header \\| search &lt;dialog> |");
+  });
+
   it("reflects a custom tokensPath in the 'do not hand-edit' note", () => {
     const table = buildMdTable([{ name: "content", value: 0 }], {
       tokensPath: "sub-packages/design-system/z-index-tokens.ts",
@@ -651,6 +691,26 @@ describe("Idempotency", () => {
     const mdBlock = buildMdTable(DEFAULT_TIER_DATA);
     const first = replaceBlock(initial, mdBlock, MD_TABLE_BEGIN_MARKER, MD_TABLE_END_MARKER);
     const second = replaceBlock(first, mdBlock, MD_TABLE_BEGIN_MARKER, MD_TABLE_END_MARKER);
+    expect(second).toBe(first);
+  });
+
+  it("the md-table region stays idempotent when purposes need MDX escaping (escape output is stable input)", () => {
+    // The escaped table text itself contains & / < sequences (&lt;, &#123;);
+    // idempotency holds because each run re-derives the block from the raw
+    // tier data, never from the previously-escaped table.
+    const tiers = [
+      { name: "modal", value: 60, purpose: "search <dialog> & friends" },
+      { name: "toolbar", value: 20, purpose: "renders {props.title}" },
+    ];
+    const initial = wrapInMd(seededMdBlock("old table"));
+    const mdBlock = buildMdTable(tiers);
+    const first = replaceBlock(initial, mdBlock, MD_TABLE_BEGIN_MARKER, MD_TABLE_END_MARKER);
+    const second = replaceBlock(
+      first,
+      buildMdTable(tiers),
+      MD_TABLE_BEGIN_MARKER,
+      MD_TABLE_END_MARKER,
+    );
     expect(second).toBe(first);
   });
 });
@@ -810,6 +870,39 @@ describe("main()", () => {
     expect(logSpy.mock.calls.flat().join("\n")).toContain(
       "z-index table already up to date at docs/z-index.mdx; no change.",
     );
+  });
+
+  it("--md-table escapes an MDX-hostile purpose end to end and stays byte-identical on re-run", () => {
+    mkdirSync(join(tmpDir, "src/config"), { recursive: true });
+    mkdirSync(join(tmpDir, "src/styles"), { recursive: true });
+    mkdirSync(join(tmpDir, "docs"), { recursive: true });
+    // The historical template tier that motivated this escaping: its purpose
+    // embeds a literal <dialog>. (Braces can't reach the CLI path — the
+    // purpose grammar guard rejects them at parse time.)
+    writeFileSync(
+      join(tmpDir, DEFAULT_TOKENS_PATH),
+      tokensSrcFromTiers([
+        {
+          name: "modal",
+          value: 60,
+          kind: "global",
+          purpose: "mobile sidebar drawer panel, search <dialog>",
+        },
+      ]),
+    );
+    writeFileSync(join(tmpDir, DEFAULT_CSS_PATH), wrapInCss(seededBlock("  @theme {\n  }")));
+    writeFileSync(join(tmpDir, "docs/z-index.mdx"), wrapInMd(seededMdBlock("old table")));
+
+    expect(main(["--md-table", "docs/z-index.mdx"])).toBe(0);
+    const afterFirstRun = readFileSync(join(tmpDir, "docs/z-index.mdx"), "utf8");
+    expect(afterFirstRun).toContain(
+      "| modal | global | mobile sidebar drawer panel, search &lt;dialog> |",
+    );
+    expect(afterFirstRun).not.toContain("<dialog>");
+
+    expect(main(["--md-table", "docs/z-index.mdx"])).toBe(0);
+    const afterSecondRun = readFileSync(join(tmpDir, "docs/z-index.mdx"), "utf8");
+    expect(afterSecondRun).toBe(afterFirstRun);
   });
 
   it("--check with --md-table passes when both regions already match", () => {

--- a/packages/zudo-doc/src/__tests__/gen-z-index.test.ts
+++ b/packages/zudo-doc/src/__tests__/gen-z-index.test.ts
@@ -3,6 +3,7 @@ import { resolve, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
 
 // Import the generator functions directly so the test exercises the same
 // logic the CLI uses, without needing a built dist or running Node as a child.
@@ -14,16 +15,43 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // Import via relative path that steps outside src/ into bin/.
 // Vitest resolves this at test time; it is NOT compiled by tsup.
-const { parseArgs, parseTiers, validateTiers, buildBlock, replaceBlock, main } =
-  await import(resolve(__dirname, "../../bin/gen-z-index.mjs"));
+const BIN_PATH = resolve(__dirname, "../../bin/gen-z-index.mjs");
+const { parseArgs, parseTiers, validateTiers, buildBlock, buildMdTable, replaceBlock, main } =
+  await import(BIN_PATH);
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
 const BEGIN_MARKER = "GENERATED:Z_INDEX_BEGIN";
 const END_MARKER = "GENERATED:Z_INDEX_END";
+const MD_TABLE_BEGIN_MARKER = "{/* GENERATED:Z_INDEX_TABLE_BEGIN */}";
+const MD_TABLE_END_MARKER = "{/* GENERATED:Z_INDEX_TABLE_END */}";
 
 const DEFAULT_TOKENS_PATH = "src/config/z-index-tokens.ts";
 const DEFAULT_CSS_PATH = "src/styles/global.css";
+
+/** Minimal seeded markdown/MDX shell with the md-table BEGIN/END markers. */
+function wrapInMd(inner: string): string {
+  return `# Z-Index Reference\n\n${inner}\n`;
+}
+
+function seededMdBlock(inner: string): string {
+  return `${MD_TABLE_BEGIN_MARKER}\n${inner}\n${MD_TABLE_END_MARKER}`;
+}
+
+/**
+ * Spawns the real bin as a child `node` process (proves actual exit codes,
+ * which importing the module and calling `main()` in-process cannot — an
+ * uncaught throw inside an imported function doesn't set `process.exitCode`
+ * the way a real CLI invocation does). Runs with `cwd` as the process root,
+ * same contract as `main()`'s own `process.cwd()` resolution.
+ */
+function runCli(args: string[], cwd: string): { status: number | null; stdout: string; stderr: string } {
+  const result = spawnSync(process.execPath, [BIN_PATH, ...args], {
+    cwd,
+    encoding: "utf8",
+  });
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+}
 
 /** Minimal global.css shell with BEGIN/END markers (real comment syntax). */
 function wrapInCss(inner: string): string {
@@ -88,6 +116,7 @@ describe("Import side effects", () => {
     expect(typeof main).toBe("function");
     expect(typeof parseTiers).toBe("function");
     expect(typeof buildBlock).toBe("function");
+    expect(typeof buildMdTable).toBe("function");
     expect(typeof replaceBlock).toBe("function");
     expect(typeof validateTiers).toBe("function");
     expect(typeof parseArgs).toBe("function");
@@ -127,18 +156,26 @@ describe("parseArgs", () => {
     expect(parseArgs(["--no-theme-wrapper"]).noThemeWrapper).toBe(true);
   });
 
+  it("parses --md-table with a separate value and --md-table=value", () => {
+    expect(parseArgs(["--md-table", "docs/z-index.mdx"]).mdTable).toBe("docs/z-index.mdx");
+    expect(parseArgs(["--md-table=docs/z-index.mdx"]).mdTable).toBe("docs/z-index.mdx");
+  });
+
   it("parses a combination of flags together", () => {
     const args = parseArgs([
       "--check",
       "--tokens",
       "a/tokens.ts",
       "--css=b/theme.css",
+      "--md-table",
+      "docs/z-index.mdx",
       "--no-theme-wrapper",
     ]);
     expect(args).toEqual({
       check: true,
       tokens: "a/tokens.ts",
       css: "b/theme.css",
+      mdTable: "docs/z-index.mdx",
       noThemeWrapper: true,
     });
   });
@@ -156,6 +193,14 @@ describe("parseArgs", () => {
 
   it("throws when --tokens is missing a value at end of argv", () => {
     expect(() => parseArgs(["--tokens"])).toThrow(/requires a value/);
+  });
+
+  it("throws when --md-table is missing a value at end of argv", () => {
+    expect(() => parseArgs(["--md-table"])).toThrow(/requires a value/);
+  });
+
+  it("throws when --md-table is immediately followed by another flag", () => {
+    expect(() => parseArgs(["--md-table", "--check"])).toThrow(/requires a value/);
   });
 
   it("throws when --tokens is immediately followed by another flag", () => {
@@ -422,6 +467,16 @@ describe("buildBlock", () => {
     const block = buildBlock([{ name: "content", value: 0 }]);
     expect(block).toContain("    --z-index-content: 0;");
   });
+
+  it("ignores an mdTablePath-shaped option key — the CSS block's content must never depend on --md-table", () => {
+    // buildBlock deliberately has no mdTablePath parameter: passing one in
+    // the options bag must be a no-op, not silently threaded through, so
+    // adding/removing --md-table on the CLI can never manufacture CSS-region
+    // drift. Confirmed against the golden block for the strongest possible
+    // "no effect" proof.
+    const block = buildBlock(DEFAULT_TIER_DATA, { mdTablePath: "docs/z-index.mdx" } as never);
+    expect(block).toBe(GOLDEN_DEFAULT_BLOCK);
+  });
 });
 
 // ── replaceBlock ───────────────────────────────────────────────────────────
@@ -443,10 +498,10 @@ describe("replaceBlock", () => {
     expect(next).toContain(suffix);
   });
 
-  it("throws, naming the given cssPath, when both markers are missing", () => {
-    expect(() => replaceBlock("/* nothing here */\n", "block", "custom/theme.css")).toThrow(
-      /Could not find.*custom\/theme\.css/,
-    );
+  it("throws, naming the given filePath, when both markers are missing", () => {
+    expect(() =>
+      replaceBlock("/* nothing here */\n", "block", BEGIN_MARKER, END_MARKER, "custom/theme.css"),
+    ).toThrow(/Could not find.*custom\/theme\.css/);
   });
 
   it("throws when only the END marker is missing", () => {
@@ -455,21 +510,129 @@ describe("replaceBlock", () => {
 
   it("throws on duplicate BEGIN markers", () => {
     const css = `${BEGIN_MARKER}\n${BEGIN_MARKER}\n${END_MARKER}`;
-    expect(() => replaceBlock(css, "block", "custom/theme.css")).toThrow(
-      /duplicate GENERATED:Z_INDEX markers.*custom\/theme\.css/s,
-    );
+    expect(() =>
+      replaceBlock(css, "block", BEGIN_MARKER, END_MARKER, "custom/theme.css"),
+    ).toThrow(/duplicate markers.*custom\/theme\.css/s);
   });
 
   it("throws on duplicate END markers", () => {
     const css = `${BEGIN_MARKER}\n${END_MARKER}\n${END_MARKER}`;
-    expect(() => replaceBlock(css, "block")).toThrow(/duplicate GENERATED:Z_INDEX markers/);
+    expect(() => replaceBlock(css, "block")).toThrow(/duplicate markers/);
   });
 
   it("throws on inverted markers (END before BEGIN)", () => {
     const css = `${END_MARKER}\n${BEGIN_MARKER}`;
-    expect(() => replaceBlock(css, "block", "custom/theme.css")).toThrow(
-      /custom\/theme\.css are inverted/s,
+    expect(() =>
+      replaceBlock(css, "block", BEGIN_MARKER, END_MARKER, "custom/theme.css"),
+    ).toThrow(/custom\/theme\.css are inverted/s);
+  });
+
+  it("uses a custom beginMarker/endMarker pair instead of the CSS defaults", () => {
+    const altBegin = "{/* GENERATED:Z_INDEX_TABLE_BEGIN */}";
+    const altEnd = "{/* GENERATED:Z_INDEX_TABLE_END */}";
+    const source = `intro\n${altBegin}\nold\n${altEnd}\noutro\n`;
+    const next = replaceBlock(source, `${altBegin}\nnew\n${altEnd}`, altBegin, altEnd, "doc.mdx");
+    expect(next).toBe(`intro\n${altBegin}\nnew\n${altEnd}\noutro\n`);
+  });
+
+  it("does not confuse the CSS markers with the md-table markers when both are present", () => {
+    const altBegin = "{/* GENERATED:Z_INDEX_TABLE_BEGIN */}";
+    const altEnd = "{/* GENERATED:Z_INDEX_TABLE_END */}";
+    const source = `${seededBlock("  @theme {\n  }")}\n${altBegin}\nold table\n${altEnd}\n`;
+    // Replacing the CSS region must not touch the md-table region below it.
+    const next = replaceBlock(source, buildBlock([{ name: "content", value: 0 }]));
+    expect(next).toContain(altBegin);
+    expect(next).toContain("old table");
+  });
+});
+
+// ── buildMdTable ───────────────────────────────────────────────────────────
+
+describe("buildMdTable", () => {
+  it("emits the MDX-safe marker pair, header row, and separator row", () => {
+    const table = buildMdTable([{ name: "content", value: 0 }]);
+    expect(table.startsWith(MD_TABLE_BEGIN_MARKER)).toBe(true);
+    expect(table.endsWith(MD_TABLE_END_MARKER)).toBe(true);
+    expect(table).toContain("| Token | Kind | Role |");
+    expect(table).toContain("| --- | --- | --- |");
+  });
+
+  it("emits one row per tier, in source order", () => {
+    const table = buildMdTable([
+      { name: "content", value: 0 },
+      { name: "modal", value: 50 },
+    ]);
+    const contentIdx = table.indexOf("| content |");
+    const modalIdx = table.indexOf("| modal |");
+    expect(contentIdx).toBeGreaterThan(-1);
+    expect(modalIdx).toBeGreaterThan(contentIdx);
+  });
+
+  it("falls back to '-' for a kind-less tier", () => {
+    const table = buildMdTable([{ name: "content", value: 0 }]);
+    expect(table).toContain("| content | - | - |");
+  });
+
+  it("falls back to '-' for a whitespace-only purpose (collapses to empty, not a blank cell)", () => {
+    const table = buildMdTable([{ name: "content", value: 0, purpose: "   " }]);
+    expect(table).toContain("| content | - | - |");
+  });
+
+  it("renders the kind field when present", () => {
+    const table = buildMdTable([{ name: "toolbar", value: 20, kind: "global" }]);
+    expect(table).toContain("| toolbar | global | - |");
+  });
+
+  it("renders a single-line purpose field verbatim", () => {
+    const table = buildMdTable([
+      { name: "toolbar", value: 20, purpose: "sticky top header" },
+    ]);
+    expect(table).toContain("| toolbar | - | sticky top header |");
+  });
+
+  it("collapses internal newlines/whitespace from a multi-line purpose string into single spaces", () => {
+    const table = buildMdTable([
+      {
+        name: "sidebar",
+        value: 10,
+        kind: "global",
+        purpose:
+          "persistent layout chrome: desktop sidebar, TOC,\n      sidebar-toggle handle,   resizer handle",
+      },
+    ]);
+    expect(table).toContain(
+      "| sidebar | global | persistent layout chrome: desktop sidebar, TOC, sidebar-toggle handle, resizer handle |",
     );
+    // No raw newline may survive inside the table region — it would corrupt
+    // the row for any GFM table renderer.
+    const tableRegion = table.slice(
+      table.indexOf("| --- | --- | --- |"),
+      table.indexOf(MD_TABLE_END_MARKER),
+    );
+    expect(tableRegion).not.toContain("\n      ");
+  });
+
+  it("escapes a literal | in the purpose text so it can't be misread as a cell boundary", () => {
+    const table = buildMdTable([
+      { name: "toolbar", value: 20, purpose: "header | toolbar boundary" },
+    ]);
+    expect(table).toContain("| toolbar | - | header \\| toolbar boundary |");
+  });
+
+  it("reflects a custom tokensPath in the 'do not hand-edit' note", () => {
+    const table = buildMdTable([{ name: "content", value: 0 }], {
+      tokensPath: "sub-packages/design-system/z-index-tokens.ts",
+    });
+    expect(table).toContain("sub-packages/design-system/z-index-tokens.ts");
+  });
+
+  it("accepts a custom beginMarker/endMarker pair", () => {
+    const table = buildMdTable([{ name: "content", value: 0 }], {
+      beginMarker: "{/* CUSTOM_BEGIN */}",
+      endMarker: "{/* CUSTOM_END */}",
+    });
+    expect(table.startsWith("{/* CUSTOM_BEGIN */}")).toBe(true);
+    expect(table.endsWith("{/* CUSTOM_END */}")).toBe(true);
   });
 });
 
@@ -480,6 +643,14 @@ describe("Idempotency", () => {
     const initial = wrapInCss(seededBlock("  @theme {\n    --z-index-content: 0;\n  }"));
     const first = replaceBlock(initial, buildBlock(DEFAULT_TIER_DATA));
     const second = replaceBlock(first, buildBlock(DEFAULT_TIER_DATA));
+    expect(second).toBe(first);
+  });
+
+  it("running buildMdTable + replaceBlock twice produces no diff", () => {
+    const initial = wrapInMd(seededMdBlock("old table"));
+    const mdBlock = buildMdTable(DEFAULT_TIER_DATA);
+    const first = replaceBlock(initial, mdBlock, MD_TABLE_BEGIN_MARKER, MD_TABLE_END_MARKER);
+    const second = replaceBlock(first, mdBlock, MD_TABLE_BEGIN_MARKER, MD_TABLE_END_MARKER);
     expect(second).toBe(first);
   });
 });
@@ -594,5 +765,256 @@ describe("main()", () => {
     expect(() => main([])).toThrow(
       new RegExp(`${DEFAULT_TOKENS_PATH.replace(/\//g, "\\/")} parsed to an empty list`),
     );
+  });
+
+  // ── --md-table integration ─────────────────────────────────────────────
+
+  it("--md-table writes both the CSS block and the md table in one run", () => {
+    mkdirSync(join(tmpDir, "src/config"), { recursive: true });
+    mkdirSync(join(tmpDir, "src/styles"), { recursive: true });
+    mkdirSync(join(tmpDir, "docs"), { recursive: true });
+    writeFileSync(join(tmpDir, DEFAULT_TOKENS_PATH), tokensSrcFromTiers(DEFAULT_TIER_DATA));
+    writeFileSync(join(tmpDir, DEFAULT_CSS_PATH), wrapInCss(seededBlock("  @theme {\n  }")));
+    writeFileSync(join(tmpDir, "docs/z-index.mdx"), wrapInMd(seededMdBlock("old table")));
+
+    const code = main(["--md-table", "docs/z-index.mdx"]);
+    expect(code).toBe(0);
+
+    const writtenCss = readFileSync(join(tmpDir, DEFAULT_CSS_PATH), "utf8");
+    expect(writtenCss).toContain("--z-index-content: 0;");
+
+    const writtenMd = readFileSync(join(tmpDir, "docs/z-index.mdx"), "utf8");
+    expect(writtenMd).toContain("| content | - | - |");
+    expect(writtenMd).not.toContain("old table");
+
+    const logged = logSpy.mock.calls.flat().join("\n");
+    expect(logged).toContain("docs/z-index.mdx");
+  });
+
+  it("--md-table is idempotent end to end: a second run makes no further change", () => {
+    mkdirSync(join(tmpDir, "src/config"), { recursive: true });
+    mkdirSync(join(tmpDir, "src/styles"), { recursive: true });
+    mkdirSync(join(tmpDir, "docs"), { recursive: true });
+    writeFileSync(join(tmpDir, DEFAULT_TOKENS_PATH), tokensSrcFromTiers(DEFAULT_TIER_DATA));
+    writeFileSync(join(tmpDir, DEFAULT_CSS_PATH), wrapInCss(seededBlock("  @theme {\n  }")));
+    writeFileSync(join(tmpDir, "docs/z-index.mdx"), wrapInMd(seededMdBlock("old table")));
+
+    main(["--md-table", "docs/z-index.mdx"]);
+    const afterFirstRun = readFileSync(join(tmpDir, "docs/z-index.mdx"), "utf8");
+
+    logSpy.mockClear();
+    const code = main(["--md-table", "docs/z-index.mdx"]);
+    expect(code).toBe(0);
+    const afterSecondRun = readFileSync(join(tmpDir, "docs/z-index.mdx"), "utf8");
+    expect(afterSecondRun).toBe(afterFirstRun);
+    expect(logSpy.mock.calls.flat().join("\n")).toContain(
+      "z-index table already up to date at docs/z-index.mdx; no change.",
+    );
+  });
+
+  it("--check with --md-table passes when both regions already match", () => {
+    mkdirSync(join(tmpDir, "src/config"), { recursive: true });
+    mkdirSync(join(tmpDir, "src/styles"), { recursive: true });
+    mkdirSync(join(tmpDir, "docs"), { recursive: true });
+    writeFileSync(join(tmpDir, DEFAULT_TOKENS_PATH), tokensSrcFromTiers(DEFAULT_TIER_DATA));
+    writeFileSync(join(tmpDir, DEFAULT_CSS_PATH), wrapInCss(GOLDEN_DEFAULT_BLOCK));
+    writeFileSync(
+      join(tmpDir, "docs/z-index.mdx"),
+      wrapInMd(buildMdTable(DEFAULT_TIER_DATA)),
+    );
+
+    const code = main(["--check", "--md-table", "docs/z-index.mdx"]);
+    expect(code).toBe(0);
+    expect(logSpy.mock.calls.flat().join("\n")).toContain(
+      "z-index @theme block and md table are up to date (13 tiers).",
+    );
+  });
+
+  it("--check with --md-table fails on CSS drift even when the md table is clean", () => {
+    mkdirSync(join(tmpDir, "src/config"), { recursive: true });
+    mkdirSync(join(tmpDir, "src/styles"), { recursive: true });
+    mkdirSync(join(tmpDir, "docs"), { recursive: true });
+    writeFileSync(join(tmpDir, DEFAULT_TOKENS_PATH), tokensSrcFromTiers(DEFAULT_TIER_DATA));
+    // CSS block is stale (wrong value) — md table is already correct.
+    writeFileSync(
+      join(tmpDir, DEFAULT_CSS_PATH),
+      wrapInCss(seededBlock("  @theme {\n    --z-index-content: 999;\n  }")),
+    );
+    writeFileSync(
+      join(tmpDir, "docs/z-index.mdx"),
+      wrapInMd(buildMdTable(DEFAULT_TIER_DATA)),
+    );
+
+    const code = main(["--check", "--md-table", "docs/z-index.mdx"]);
+    expect(code).toBe(1);
+    const errored = errorSpy.mock.calls.flat().join("\n");
+    expect(errored).toContain(`${DEFAULT_CSS_PATH} is out of date`);
+    expect(errored).not.toContain("docs/z-index.mdx is out of date");
+  });
+
+  it("--check with --md-table fails on md-table drift even when the CSS block is clean", () => {
+    mkdirSync(join(tmpDir, "src/config"), { recursive: true });
+    mkdirSync(join(tmpDir, "src/styles"), { recursive: true });
+    mkdirSync(join(tmpDir, "docs"), { recursive: true });
+    writeFileSync(join(tmpDir, DEFAULT_TOKENS_PATH), tokensSrcFromTiers(DEFAULT_TIER_DATA));
+    writeFileSync(join(tmpDir, DEFAULT_CSS_PATH), wrapInCss(GOLDEN_DEFAULT_BLOCK));
+    // md table region is stale (seeded placeholder, never generated).
+    writeFileSync(join(tmpDir, "docs/z-index.mdx"), wrapInMd(seededMdBlock("old table")));
+
+    const code = main(["--check", "--md-table", "docs/z-index.mdx"]);
+    expect(code).toBe(1);
+    const errored = errorSpy.mock.calls.flat().join("\n");
+    expect(errored).toContain("docs/z-index.mdx is out of date");
+    expect(errored).not.toContain(`${DEFAULT_CSS_PATH} is out of date`);
+    expect(errored).toContain('--md-table "docs/z-index.mdx"');
+  });
+
+  it("throws loudly when the md-table markers are missing from the seeded file", () => {
+    mkdirSync(join(tmpDir, "src/config"), { recursive: true });
+    mkdirSync(join(tmpDir, "src/styles"), { recursive: true });
+    mkdirSync(join(tmpDir, "docs"), { recursive: true });
+    writeFileSync(join(tmpDir, DEFAULT_TOKENS_PATH), tokensSrcFromTiers(DEFAULT_TIER_DATA));
+    writeFileSync(join(tmpDir, DEFAULT_CSS_PATH), wrapInCss(GOLDEN_DEFAULT_BLOCK));
+    writeFileSync(join(tmpDir, "docs/z-index.mdx"), "# Z-Index Reference\n\nNo markers here.\n");
+
+    expect(() => main(["--md-table", "docs/z-index.mdx"])).toThrow(
+      /Could not find.*docs\/z-index\.mdx/,
+    );
+  });
+
+  it("throws loudly on inverted md-table markers", () => {
+    mkdirSync(join(tmpDir, "src/config"), { recursive: true });
+    mkdirSync(join(tmpDir, "src/styles"), { recursive: true });
+    mkdirSync(join(tmpDir, "docs"), { recursive: true });
+    writeFileSync(join(tmpDir, DEFAULT_TOKENS_PATH), tokensSrcFromTiers(DEFAULT_TIER_DATA));
+    writeFileSync(join(tmpDir, DEFAULT_CSS_PATH), wrapInCss(GOLDEN_DEFAULT_BLOCK));
+    writeFileSync(
+      join(tmpDir, "docs/z-index.mdx"),
+      `${MD_TABLE_END_MARKER}\n${MD_TABLE_BEGIN_MARKER}\n`,
+    );
+
+    expect(() => main(["--md-table", "docs/z-index.mdx"])).toThrow(
+      /docs\/z-index\.mdx are inverted/,
+    );
+  });
+
+  it("throws loudly on duplicate md-table markers", () => {
+    mkdirSync(join(tmpDir, "src/config"), { recursive: true });
+    mkdirSync(join(tmpDir, "src/styles"), { recursive: true });
+    mkdirSync(join(tmpDir, "docs"), { recursive: true });
+    writeFileSync(join(tmpDir, DEFAULT_TOKENS_PATH), tokensSrcFromTiers(DEFAULT_TIER_DATA));
+    writeFileSync(join(tmpDir, DEFAULT_CSS_PATH), wrapInCss(GOLDEN_DEFAULT_BLOCK));
+    writeFileSync(
+      join(tmpDir, "docs/z-index.mdx"),
+      `${MD_TABLE_BEGIN_MARKER}\nold\n${MD_TABLE_END_MARKER}\n${MD_TABLE_BEGIN_MARKER}\nold2\n${MD_TABLE_END_MARKER}\n`,
+    );
+
+    expect(() => main(["--md-table", "docs/z-index.mdx"])).toThrow(
+      /duplicate markers.*docs\/z-index\.mdx/s,
+    );
+  });
+});
+
+// ── CLI (spawned node process) — exit codes ─────────────────────────────────
+//
+// The tests above import the module and call its exported functions
+// in-process — accurate for behavior, but they cannot observe a real process
+// exit code (an in-process throw doesn't set process.exitCode the way the
+// top-level `process.exit(main())` / uncaught-exception path does when the
+// bin is actually run). These tests spawn a real `node bin/gen-z-index.mjs`
+// child process against a temp-dir project so the exit code itself is proven,
+// not just the message text.
+
+describe("CLI (spawned node process) — exit codes", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "gen-z-index-cli-test-"));
+    mkdirSync(join(tmpDir, "src/config"), { recursive: true });
+    mkdirSync(join(tmpDir, "src/styles"), { recursive: true });
+    mkdirSync(join(tmpDir, "docs"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /** Seeds the project with an already-up-to-date CSS block + tokens file. */
+  function seedCleanCss() {
+    writeFileSync(join(tmpDir, DEFAULT_TOKENS_PATH), tokensSrcFromTiers(DEFAULT_TIER_DATA));
+    writeFileSync(join(tmpDir, DEFAULT_CSS_PATH), wrapInCss(GOLDEN_DEFAULT_BLOCK));
+  }
+
+  /** Seeds the project with an already-up-to-date md table at docs/z-index.mdx. */
+  function seedCleanMdTable() {
+    writeFileSync(join(tmpDir, "docs/z-index.mdx"), wrapInMd(buildMdTable(DEFAULT_TIER_DATA)));
+  }
+
+  it("exits non-zero on an unknown flag", () => {
+    seedCleanCss();
+    const { status, stderr } = runCli(["--bogus"], tmpDir);
+    expect(status).not.toBe(0);
+    expect(stderr).toContain('Unknown flag "--bogus"');
+  });
+
+  it("exits non-zero when a value flag is missing its value", () => {
+    seedCleanCss();
+    const { status, stderr } = runCli(["--tokens"], tmpDir);
+    expect(status).not.toBe(0);
+    expect(stderr).toContain("requires a value");
+  });
+
+  it("exits non-zero when --md-table is missing its value", () => {
+    seedCleanCss();
+    const { status, stderr } = runCli(["--md-table"], tmpDir);
+    expect(status).not.toBe(0);
+    expect(stderr).toContain("requires a value");
+  });
+
+  it("--check exits non-zero when only the CSS region has drifted (md table clean)", () => {
+    writeFileSync(join(tmpDir, DEFAULT_TOKENS_PATH), tokensSrcFromTiers(DEFAULT_TIER_DATA));
+    writeFileSync(
+      join(tmpDir, DEFAULT_CSS_PATH),
+      wrapInCss(seededBlock("  @theme {\n    --z-index-content: 999;\n  }")),
+    );
+    seedCleanMdTable();
+
+    const { status, stderr } = runCli(["--check", "--md-table", "docs/z-index.mdx"], tmpDir);
+    expect(status).toBe(1);
+    expect(stderr).toContain(`${DEFAULT_CSS_PATH} is out of date`);
+    expect(stderr).not.toContain("docs/z-index.mdx is out of date");
+  });
+
+  it("--check exits non-zero when only the md-table region has drifted (CSS clean)", () => {
+    seedCleanCss();
+    writeFileSync(join(tmpDir, "docs/z-index.mdx"), wrapInMd(seededMdBlock("stale table")));
+
+    const { status, stderr } = runCli(["--check", "--md-table", "docs/z-index.mdx"], tmpDir);
+    expect(status).toBe(1);
+    expect(stderr).toContain("docs/z-index.mdx is out of date");
+    expect(stderr).not.toContain(`${DEFAULT_CSS_PATH} is out of date`);
+  });
+
+  it("--check exits 0 when both regions are already clean", () => {
+    seedCleanCss();
+    seedCleanMdTable();
+
+    const { status, stdout } = runCli(["--check", "--md-table", "docs/z-index.mdx"], tmpDir);
+    expect(status).toBe(0);
+    expect(stdout).toContain("up to date");
+  });
+
+  it("a normal (non-check) run exits 0 and writes both regions", () => {
+    writeFileSync(join(tmpDir, DEFAULT_TOKENS_PATH), tokensSrcFromTiers(DEFAULT_TIER_DATA));
+    writeFileSync(join(tmpDir, DEFAULT_CSS_PATH), wrapInCss(seededBlock("  @theme {\n  }")));
+    writeFileSync(join(tmpDir, "docs/z-index.mdx"), wrapInMd(seededMdBlock("stale table")));
+
+    const { status } = runCli(["--md-table", "docs/z-index.mdx"], tmpDir);
+    expect(status).toBe(0);
+
+    const writtenCss = readFileSync(join(tmpDir, DEFAULT_CSS_PATH), "utf8");
+    expect(writtenCss).toContain("--z-index-content: 0;");
+    const writtenMd = readFileSync(join(tmpDir, "docs/z-index.mdx"), "utf8");
+    expect(writtenMd).toContain("| content | - | - |");
   });
 });


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3278
- parent PR
    - https://github.com/zudolab/zudo-doc/pull/3273

---

## Summary

Epic #3278 under super-epic #3272. Parameterizes the dependency-free package bin `packages/zudo-doc/bin/gen-z-index.mjs` so consumer projects with non-conventional layouts can use it directly (and the ~290-line zzmod fork becomes deletable downstream). Two waves + one review fix, all in `bin/gen-z-index.mjs` + its new test suite:

- **Wave 1 (#3279)** — testable-sibling refactor mirroring `gen-component-tokens.mjs`: exported `parseArgs`/`parseTiers`/`validateTiers`/`buildBlock`/`replaceBlock`/`main` + `isDirectInvocation()` realpath guard; hand-rolled dep-free argv parser (`--check`, `--tokens <path>`, `--css <path>`, `--no-theme-wrapper`; unknown/repeated/missing-value flags are hard errors); all messages and the generated header thread the actual paths (byte-identical output preserved for the default invocation — golden test); `parseTiers` captures optional `kind`/`purpose` with an explicit supported-grammar pre-scan; unconditional validations (empty list, tier-name charset, duplicate names, marker order/exactly-one-of-each) + opt-in per-kind value uniqueness; stale header claims removed.
- **Wave 2 (#3280)** — `--md-table <path>` second region with MDX-safe `{/* GENERATED:Z_INDEX_TABLE_* */}` markers (HTML comments are MDX parse errors); `| Token | Kind | Role |` table via exported `buildMdTable` (kind fallback `-`, whitespace collapsing, pipe escaping); `--check` covers both regions; CLI-level spawned-process exit-code tests (unknown flag, per-region drift, clean run, missing values).
- **Review fix** — `/deep-review` (codex) P1: Role cells now MDX-escape `&` → `<` → `{` → `}` (in that order, no double-escaping) via `escapeMdxText`, so a purpose like the historical `search <dialog>` can no longer emit an unclosed-JSX MDX compile error into the generated table. 7 regression tests added.

## Verification

- Package suite on the merged base: 1971 tests / 179 files green (103 of them new for gen-z-index)
- Root `pnpm b4push`: all 24 checks passed
- Live-executed CLI examples in a scratch project: generate + idempotent re-run, both-region `--check` drift detection, all error exit codes
- CI on this PR: 21/21 green

## Out of scope (deliberate, per epic)

Showcase codegen resurrection (retired #2661), API.md's stale check:z-index line, customizing.mdx retirement notes, design-system.mdx hand-maintained table, zzmod fork deletion (downstream, after a published release).

## Deferred (tracked)

#3290 (`agent-found`): marker detection is substring-based — a doc page quoting the marker text false-positives as duplicate markers (loud error, not corruption; pre-existing in the CSS region; smarter matcher needs a design decision).