### PR TITLE
Z-Index Marker Match: line-anchor and fence-exclude gen-z-index marker detection

### DIFF
--- a/packages/zudo-doc/bin/gen-z-index.mjs
+++ b/packages/zudo-doc/bin/gen-z-index.mjs
@@ -41,7 +41,9 @@
 // error in MDX. `--check` verifies BOTH regions when --md-table is given;
 // drift in either exits 1. Like the CSS block, the md-table region must be
 // seeded once by hand (just the marker pair) before the generator can find
-// it to replace.
+// it to replace. On this surface ONLY, marker lines inside a CommonMark
+// fenced code block are ignored, so a doc page may reproduce the marker
+// verbatim while explaining the generator (see `scanMarkerLines`).
 //
 // Pure Node (fs only — NO npm deps, no minimist). Idempotent: running twice
 // produces no diff.
@@ -426,6 +428,21 @@ export function buildBlock(tiers, options = {}) {
   return lines.join("\n");
 }
 
+// CommonMark fenced-code-block rules (https://spec.commonmark.org/0.31.2/
+// #fenced-code-blocks), transcribed only as far as `scanMarkerLines` needs
+// them. Each of these is a rule a `trim()` + `startsWith` approximation gets
+// wrong, which is why they are spelled out here rather than eyeballed:
+//
+//   - An opening fence carries AT MOST three spaces of indentation. Four
+//     spaces makes the line indented code, not a fence.
+//   - A backtick opening fence's info string may not itself contain a
+//     backtick (a tilde fence's info string may contain anything).
+//   - A closing fence repeats the SAME character, at least as many times as
+//     the opener, followed by whitespace only — so an info-string line such
+//     as ```js does not close an already-open fence.
+const OPEN_FENCE_RE = /^ {0,3}(`{3,}|~{3,})(.*)$/;
+const CLOSE_FENCE_RE = /^ {0,3}(`{3,}|~{3,})[ \t]*$/;
+
 /**
  * Walks `source` line by line and returns the character offsets (into
  * `source`, in source order) of every LINE-ANCHORED occurrence of `marker` —
@@ -444,23 +461,61 @@ export function buildBlock(tiers, options = {}) {
  * closed by a trailing brace-comment on the same line) — while rejecting a
  * line where the marker is only part of a prose sentence.
  *
- * Walks one line at a time (no per-line fence-state tracking yet) so a future
- * CommonMark fenced-code-region exclusion can extend this same loop rather
- * than requiring a restructure.
+ * `options.excludeFencedCode` (default `false`) additionally tracks
+ * CommonMark fenced-code state (see the two regexes above) and makes every
+ * line from an opening fence through its closing fence — inclusive, and
+ * through end-of-source for an unterminated fence — ineligible. It is
+ * OFF by default and passed only from the `--md-table` surface: fences are a
+ * markdown construct, and the CSS surface must keep byte-identical behaviour.
+ *
+ * ACCEPTED LIMITATION: a marker line inside a **four-space-indented** code
+ * block is still counted. Indented code is not a fence, and detecting it
+ * needs far more markdown awareness (list-item continuation indentation,
+ * paragraph interruption rules) than a dependency-free bin should carry —
+ * zudolab/zudo-doc#3290 names fenced code, not indented code. The failure
+ * mode stays loud (a "duplicate markers" error), never silent corruption.
  *
  * Exported for unit testing.
  */
-export function scanMarkerLines(source, marker) {
+export function scanMarkerLines(source, marker, options = {}) {
+  const { excludeFencedCode = false } = options;
   const RESIDUE_RE = /^[\s{}/*]*$/;
   const offsets = [];
+  // `{ char, length }` while inside an open fenced region, else null.
+  let fence = null;
   let lineStart = 0;
   while (lineStart <= source.length) {
     const newlineIdx = source.indexOf("\n", lineStart);
     const lineEnd = newlineIdx === -1 ? source.length : newlineIdx;
     const line = source.slice(lineStart, lineEnd);
-    const markerIdxInLine = line.indexOf(marker);
-    if (markerIdxInLine !== -1 && RESIDUE_RE.test(line.replace(marker, ""))) {
-      offsets.push(lineStart + markerIdxInLine);
+
+    let eligible = true;
+    if (excludeFencedCode) {
+      // Classify against the line minus a CRLF carriage return, so the
+      // "whitespace only after a closing fence" rule still holds on a CRLF
+      // source. Offsets are unaffected — `line` itself is untouched.
+      const text = line.endsWith("\r") ? line.slice(0, -1) : line;
+      if (fence !== null) {
+        const close = CLOSE_FENCE_RE.exec(text);
+        if (close && close[1][0] === fence.char && close[1].length >= fence.length) {
+          fence = null;
+        }
+        eligible = false;
+      } else {
+        const open = OPEN_FENCE_RE.exec(text);
+        const backtickInInfoString = open !== null && open[1][0] === "`" && open[2].includes("`");
+        if (open !== null && !backtickInInfoString) {
+          fence = { char: open[1][0], length: open[1].length };
+          eligible = false;
+        }
+      }
+    }
+
+    if (eligible) {
+      const markerIdxInLine = line.indexOf(marker);
+      if (markerIdxInLine !== -1 && RESIDUE_RE.test(line.replace(marker, ""))) {
+        offsets.push(lineStart + markerIdxInLine);
+      }
     }
     if (newlineIdx === -1) break;
     lineStart = newlineIdx + 1;
@@ -483,6 +538,11 @@ export function scanMarkerLines(source, marker) {
  * purely for error-message context (pass the conventional default or an
  * explicit --css/--md-table value).
  *
+ * `options.excludeFencedCode` is forwarded verbatim to `scanMarkerLines` and
+ * is gated on the SURFACE, not on the marker strings: only the `--md-table`
+ * call site passes it. Defaulting it off keeps every CSS call site — and its
+ * output — byte-unchanged.
+ *
  * Exported for unit testing.
  */
 export function replaceBlock(
@@ -491,9 +551,12 @@ export function replaceBlock(
   beginMarker = BEGIN_MARKER,
   endMarker = END_MARKER,
   filePath = DEFAULT_CSS_PATH,
+  options = {},
 ) {
-  const beginOffsets = scanMarkerLines(source, beginMarker);
-  const endOffsets = scanMarkerLines(source, endMarker);
+  const { excludeFencedCode = false } = options;
+  const scanOptions = { excludeFencedCode };
+  const beginOffsets = scanMarkerLines(source, beginMarker, scanOptions);
+  const endOffsets = scanMarkerLines(source, endMarker, scanOptions);
 
   if (beginOffsets.length === 0 || endOffsets.length === 0) {
     throw new Error(
@@ -672,6 +735,7 @@ export function main(argv = process.argv.slice(2)) {
       MD_TABLE_BEGIN_MARKER,
       MD_TABLE_END_MARKER,
       mdTablePath,
+      { excludeFencedCode: true },
     );
   }
 

--- a/packages/zudo-doc/bin/gen-z-index.mjs
+++ b/packages/zudo-doc/bin/gen-z-index.mjs
@@ -427,32 +427,53 @@ export function buildBlock(tiers, options = {}) {
 }
 
 /**
- * Counts non-overlapping occurrences of `marker` in `str`. This is a plain
- * substring count, not a "stand-alone marker line" match — a known,
- * pre-existing tradeoff inherited from the CSS `@theme` region (whose BEGIN/
- * END text is embedded mid-comment-line, e.g. `  /* GENERATED:Z_INDEX_BEGIN`,
- * so a stricter "must be the whole line" rule would break it). This means a
- * doc page that quotes the literal `--md-table` marker text in prose or a
- * fenced code example (e.g. to explain the generator) is misread as a real
- * duplicate marker. The failure mode is loud (a clear "duplicate markers"
- * error), not silent corruption, so this is accepted rather than adding
- * markdown-aware parsing to a dependency-free bin.
+ * Walks `source` line by line and returns the character offsets (into
+ * `source`, in source order) of every LINE-ANCHORED occurrence of `marker` —
+ * a line where removing the marker text leaves behind only whitespace and
+ * comment/brace delimiter characters. This is the single scanner both
+ * `replaceBlock`'s validation (duplicate/missing/inverted) and its splice
+ * positions read from, so counting and locating can never diverge: a marker
+ * mentioned in prose (e.g. "see GENERATED:Z_INDEX_BEGIN for details") is
+ * invisible to this scanner, whether it appears before, between, or after the
+ * real structural markers.
+ *
+ * Predicate: for a line containing `marker`, `line.replace(marker, "")` must
+ * match `/^[\s{}/*]*$/`. This covers both real marker forms — the CSS
+ * mid-comment-line pair (e.g. `  /* GENERATED:Z_INDEX_BEGIN`) and the MDX
+ * whole-line brace-comment pair (e.g. `{/* GENERATED:Z_INDEX_TABLE_BEGIN`,
+ * closed by a trailing brace-comment on the same line) — while rejecting a
+ * line where the marker is only part of a prose sentence.
+ *
+ * Walks one line at a time (no per-line fence-state tracking yet) so a future
+ * CommonMark fenced-code-region exclusion can extend this same loop rather
+ * than requiring a restructure.
+ *
+ * Exported for unit testing.
  */
-function countOccurrences(str, marker) {
-  let count = 0;
-  let idx = str.indexOf(marker);
-  while (idx !== -1) {
-    count++;
-    idx = str.indexOf(marker, idx + marker.length);
+export function scanMarkerLines(source, marker) {
+  const RESIDUE_RE = /^[\s{}/*]*$/;
+  const offsets = [];
+  let lineStart = 0;
+  while (lineStart <= source.length) {
+    const newlineIdx = source.indexOf("\n", lineStart);
+    const lineEnd = newlineIdx === -1 ? source.length : newlineIdx;
+    const line = source.slice(lineStart, lineEnd);
+    const markerIdxInLine = line.indexOf(marker);
+    if (markerIdxInLine !== -1 && RESIDUE_RE.test(line.replace(marker, ""))) {
+      offsets.push(lineStart + markerIdxInLine);
+    }
+    if (newlineIdx === -1) break;
+    lineStart = newlineIdx + 1;
   }
-  return count;
+  return offsets;
 }
 
 /**
  * Replace the existing BEGIN…END block in `source` with `block`. Requires
- * EXACTLY one BEGIN and one END marker, with BEGIN preceding END — throws a
- * clear, distinct error for each failure mode: missing (the block must be
- * seeded once by hand), duplicated, or inverted markers.
+ * EXACTLY one line-anchored BEGIN and one line-anchored END marker (per
+ * `scanMarkerLines`), with BEGIN preceding END — throws a clear, distinct
+ * error for each failure mode: missing (the block must be seeded once by
+ * hand), duplicated, or inverted markers.
  *
  * `beginMarker`/`endMarker` default to the CSS `@theme` block's markers so
  * existing call sites (the CSS region) are unaffected; the `--md-table`
@@ -471,25 +492,25 @@ export function replaceBlock(
   endMarker = END_MARKER,
   filePath = DEFAULT_CSS_PATH,
 ) {
-  const beginCount = countOccurrences(source, beginMarker);
-  const endCount = countOccurrences(source, endMarker);
+  const beginOffsets = scanMarkerLines(source, beginMarker);
+  const endOffsets = scanMarkerLines(source, endMarker);
 
-  if (beginCount === 0 || endCount === 0) {
+  if (beginOffsets.length === 0 || endOffsets.length === 0) {
     throw new Error(
       `Could not find ${beginMarker} … ${endMarker} markers in ${filePath}.\n` +
         `Seed the marker block once by hand, then re-run the generator.`,
     );
   }
-  if (beginCount > 1 || endCount > 1) {
+  if (beginOffsets.length > 1 || endOffsets.length > 1) {
     throw new Error(
-      `Found duplicate markers in ${filePath} (${beginCount} BEGIN "${beginMarker}", ` +
-        `${endCount} END "${endMarker}"; expected exactly one of each). Remove the extra ` +
+      `Found duplicate markers in ${filePath} (${beginOffsets.length} BEGIN "${beginMarker}", ` +
+        `${endOffsets.length} END "${endMarker}"; expected exactly one of each). Remove the extra ` +
         `marker(s) by hand, then re-run the generator.`,
     );
   }
 
-  const beginIdx = source.indexOf(beginMarker);
-  const endIdx = source.indexOf(endMarker);
+  const beginIdx = beginOffsets[0];
+  const endIdx = endOffsets[0];
   if (beginIdx > endIdx) {
     throw new Error(
       `Markers in ${filePath} are inverted — the END marker (${endMarker}) appears before ` +

--- a/packages/zudo-doc/bin/gen-z-index.mjs
+++ b/packages/zudo-doc/bin/gen-z-index.mjs
@@ -448,8 +448,38 @@ export function buildBlock(tiers, options = {}) {
 //     the opener, followed by whitespace only — so an info-string line such
 //     as ```js does not close an already-open fence. It carries no list
 //     marker of its own, which is why only OPEN_FENCE_RE accepts one.
-const OPEN_FENCE_RE = /^ {0,3}(?:(?:[-*+]|\d{1,9}[.)])[ \t]+)?(`{3,}|~{3,})(.*)$/;
-const CLOSE_FENCE_RE = /^ {0,3}(`{3,}|~{3,})[ \t]*$/;
+//   - A closing fence's indentation allowance is measured from the OPENING
+//     fence, not from column zero: inside a container the closer sits at the
+//     container's content column and may carry up to three further spaces.
+//     So the bound is `opener indent + 3`, where the opener's indent is its
+//     leading spaces PLUS any list-marker prefix width. A flat three-space
+//     cap is wrong for any marker four or more characters wide (`10) `, or
+//     `1.` followed by two spaces): the item's real closer would be rejected,
+//     the fence would never close, and every marker below it would stay
+//     ineligible. Since the opener's indent is never negative, a closer at
+//     0-3 spaces still closes a fence opened at ANY indent.
+//   - Indentation is measured in COLUMNS, with a tab advancing to the next
+//     four-column tab stop. The opener accepts a tab as list-marker padding,
+//     and `"1.\t".length` (3) undercounts that item's real content column
+//     (4) — which would then reject a legal closer sitting at column + 3.
+const OPEN_FENCE_RE = /^( {0,3}(?:(?:[-*+]|\d{1,9}[.)])[ \t]+)?)(`{3,}|~{3,})(.*)$/;
+const CLOSE_FENCE_RE = /^( *)(`{3,}|~{3,})[ \t]*$/;
+
+/**
+ * Column width of an opening fence's prefix (leading spaces plus any
+ * list-marker prefix), expanding tabs to CommonMark's four-column tab stops —
+ * see the tab-stop rule in the block comment above. `CLOSE_FENCE_RE` matches
+ * spaces only, so the closer side needs no equivalent (and accepting a
+ * tab-indented closer would widen behaviour the pre-existing `^ {0,3}` cap
+ * never had).
+ */
+function fenceIndentColumns(prefix) {
+  let column = 0;
+  for (const ch of prefix) {
+    column = ch === "\t" ? column + 4 - (column % 4) : column + 1;
+  }
+  return column;
+}
 
 /**
  * Walks `source` line by line and returns the character offsets (into
@@ -489,7 +519,10 @@ export function scanMarkerLines(source, marker, options = {}) {
   const { excludeFencedCode = false } = options;
   const RESIDUE_RE = /^[\s{}/*]*$/;
   const offsets = [];
-  // `{ char, length }` while inside an open fenced region, else null.
+  // `{ char, length, indent }` while inside an open fenced region, else null.
+  // `indent` is the opening fence's content COLUMN (leading spaces plus any
+  // list-marker prefix, tabs expanded), which bounds how far its closer may be
+  // indented.
   let fence = null;
   let lineStart = 0;
   while (lineStart <= source.length) {
@@ -505,15 +538,24 @@ export function scanMarkerLines(source, marker, options = {}) {
       const text = line.endsWith("\r") ? line.slice(0, -1) : line;
       if (fence !== null) {
         const close = CLOSE_FENCE_RE.exec(text);
-        if (close && close[1][0] === fence.char && close[1].length >= fence.length) {
+        if (
+          close &&
+          close[2][0] === fence.char &&
+          close[2].length >= fence.length &&
+          close[1].length <= fence.indent + 3
+        ) {
           fence = null;
         }
         eligible = false;
       } else {
         const open = OPEN_FENCE_RE.exec(text);
-        const backtickInInfoString = open !== null && open[1][0] === "`" && open[2].includes("`");
+        const backtickInInfoString = open !== null && open[2][0] === "`" && open[3].includes("`");
         if (open !== null && !backtickInInfoString) {
-          fence = { char: open[1][0], length: open[1].length };
+          fence = {
+            char: open[2][0],
+            length: open[2].length,
+            indent: fenceIndentColumns(open[1]),
+          };
           eligible = false;
         }
       }

--- a/packages/zudo-doc/bin/gen-z-index.mjs
+++ b/packages/zudo-doc/bin/gen-z-index.mjs
@@ -435,12 +435,20 @@ export function buildBlock(tiers, options = {}) {
 //
 //   - An opening fence carries AT MOST three spaces of indentation. Four
 //     spaces makes the line indented code, not a fence.
+//   - A fence may open on a list-item line (`- ```mdx`), because the list
+//     marker is a container prefix rather than content. Missing this one is
+//     not a harmless false negative: the item's closing fence — indented to
+//     the item's content column, so carrying NO list marker — would then be
+//     read as a fresh opener and swallow every marker below it, silently
+//     splicing the generated block into the quoted example. Loud failure is
+//     acceptable here; silent corruption is not.
 //   - A backtick opening fence's info string may not itself contain a
 //     backtick (a tilde fence's info string may contain anything).
 //   - A closing fence repeats the SAME character, at least as many times as
 //     the opener, followed by whitespace only — so an info-string line such
-//     as ```js does not close an already-open fence.
-const OPEN_FENCE_RE = /^ {0,3}(`{3,}|~{3,})(.*)$/;
+//     as ```js does not close an already-open fence. It carries no list
+//     marker of its own, which is why only OPEN_FENCE_RE accepts one.
+const OPEN_FENCE_RE = /^ {0,3}(?:(?:[-*+]|\d{1,9}[.)])[ \t]+)?(`{3,}|~{3,})(.*)$/;
 const CLOSE_FENCE_RE = /^ {0,3}(`{3,}|~{3,})[ \t]*$/;
 
 /**

--- a/packages/zudo-doc/src/__tests__/gen-z-index.test.ts
+++ b/packages/zudo-doc/src/__tests__/gen-z-index.test.ts
@@ -225,6 +225,44 @@ describe("scanMarkerLines with excludeFencedCode", () => {
     },
   );
 
+  it.each(["-", "*", "+", "1.", "10)"])(
+    "opens a fence on a list-item line beginning with %s",
+    (marker) => {
+      // The list marker is a container prefix, not content. Missing this
+      // opener is what turns the item's own closing fence (indented, so
+      // carrying no marker) into a bogus opener that swallows the real
+      // region below — see the replaceBlock regression test.
+      const source = [
+        `${marker} \`\`\`mdx`,
+        `  ${MD_TABLE_BEGIN_MARKER}`,
+        "  ```",
+        "",
+        MD_TABLE_BEGIN_MARKER,
+        "",
+      ].join("\n");
+      expect(scanMarkerLines(source, MD_TABLE_BEGIN_MARKER, FENCED)).toEqual([
+        source.lastIndexOf(MD_TABLE_BEGIN_MARKER),
+      ]);
+    },
+  );
+
+  it("does not mistake a list marker for extra indentation on a four-space-indented line", () => {
+    // Guards the optional list-prefix group against relaxing the 0-3 space
+    // rule by backtracking (`^ {0,3}` + optional prefix must not add up to a
+    // four-space allowance).
+    const source = ["    ```", `    ${MD_TABLE_BEGIN_MARKER}`, "    ```", ""].join("\n");
+    expect(scanMarkerLines(source, MD_TABLE_BEGIN_MARKER, FENCED)).toEqual([
+      source.indexOf(MD_TABLE_BEGIN_MARKER),
+    ]);
+  });
+
+  it("does not open a fence on a list marker with no space before the backticks", () => {
+    const source = ["-```mdx", MD_TABLE_BEGIN_MARKER, ""].join("\n");
+    expect(scanMarkerLines(source, MD_TABLE_BEGIN_MARKER, FENCED)).toEqual([
+      source.indexOf(MD_TABLE_BEGIN_MARKER),
+    ]);
+  });
+
   it("does NOT treat a four-space-indented ``` line as a fence (accepted limitation)", () => {
     // Four spaces makes it an indented code block, which this scanner
     // deliberately does not model — the marker inside is still counted.
@@ -873,6 +911,29 @@ describe("replaceBlock with excludeFencedCode", () => {
     expect(() => replaceMd(mdDoc(indented, "old table"), NEW_TABLE)).toThrow(
       /duplicate markers.*doc\.mdx/s,
     );
+  });
+
+  it("replaces the real pair when the quoting fence opens on a list-item line", () => {
+    // Regression: a missed `- ```mdx` opener left the quoted markers eligible
+    // AND turned the item's indented closing fence into a bogus opener that
+    // hid the real pair — so exactly one valid-looking pair survived and the
+    // generated block was spliced into the quoted example instead. Silent
+    // corruption, where wave 1 had thrown a loud duplicate-marker error.
+    const listDoc = (inner: string) =>
+      [
+        "- Seed the region by hand:",
+        "",
+        "- ```mdx",
+        `  ${MD_TABLE_BEGIN_MARKER}`,
+        `  ${MD_TABLE_END_MARKER}`,
+        "  ```",
+        "",
+        MD_TABLE_BEGIN_MARKER,
+        inner,
+        MD_TABLE_END_MARKER,
+        "",
+      ].join("\n");
+    expect(replaceMd(listDoc("old table"), NEW_TABLE)).toBe(listDoc("new table"));
   });
 
   it("does not count a real marker pair that follows an unterminated fence", () => {

--- a/packages/zudo-doc/src/__tests__/gen-z-index.test.ts
+++ b/packages/zudo-doc/src/__tests__/gen-z-index.test.ts
@@ -16,8 +16,16 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // Import via relative path that steps outside src/ into bin/.
 // Vitest resolves this at test time; it is NOT compiled by tsup.
 const BIN_PATH = resolve(__dirname, "../../bin/gen-z-index.mjs");
-const { parseArgs, parseTiers, validateTiers, buildBlock, buildMdTable, replaceBlock, main } =
-  await import(BIN_PATH);
+const {
+  parseArgs,
+  parseTiers,
+  validateTiers,
+  buildBlock,
+  buildMdTable,
+  replaceBlock,
+  scanMarkerLines,
+  main,
+} = await import(BIN_PATH);
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
@@ -120,6 +128,52 @@ describe("Import side effects", () => {
     expect(typeof replaceBlock).toBe("function");
     expect(typeof validateTiers).toBe("function");
     expect(typeof parseArgs).toBe("function");
+    expect(typeof scanMarkerLines).toBe("function");
+  });
+});
+
+// ── scanMarkerLines ────────────────────────────────────────────────────────
+
+describe("scanMarkerLines", () => {
+  it("counts the CSS mid-comment-line BEGIN form", () => {
+    const source = `  /* ${BEGIN_MARKER}\n`;
+    const offsets = scanMarkerLines(source, BEGIN_MARKER);
+    expect(offsets).toEqual([source.indexOf(BEGIN_MARKER)]);
+  });
+
+  it("counts the CSS mid-comment-line END form", () => {
+    const source = `  /* ${END_MARKER} */\n`;
+    const offsets = scanMarkerLines(source, END_MARKER);
+    expect(offsets).toEqual([source.indexOf(END_MARKER)]);
+  });
+
+  it("counts the MDX whole-line brace-comment form", () => {
+    const source = `${MD_TABLE_BEGIN_MARKER}\n`;
+    const offsets = scanMarkerLines(source, MD_TABLE_BEGIN_MARKER);
+    expect(offsets).toEqual([0]);
+  });
+
+  it("does not count a prose mention of the marker", () => {
+    const source = `The generator finds ${BEGIN_MARKER} in your CSS.\n`;
+    expect(scanMarkerLines(source, BEGIN_MARKER)).toEqual([]);
+  });
+
+  it("finds only the structural occurrence when a prose mention and a real marker both appear", () => {
+    const source = `see ${BEGIN_MARKER} for details\n  /* ${BEGIN_MARKER}\n`;
+    const offsets = scanMarkerLines(source, BEGIN_MARKER);
+    const realIdx = source.indexOf(BEGIN_MARKER, source.indexOf("\n"));
+    expect(offsets).toEqual([realIdx]);
+  });
+
+  it("returns offsets in source order across multiple structural occurrences", () => {
+    const source = `  /* ${BEGIN_MARKER}\nmiddle\n  /* ${BEGIN_MARKER}\n`;
+    const offsets = scanMarkerLines(source, BEGIN_MARKER);
+    expect(offsets).toHaveLength(2);
+    expect(offsets[0]).toBeLessThan(offsets[1]!);
+  });
+
+  it("returns an empty array when the marker is absent entirely", () => {
+    expect(scanMarkerLines("nothing here\n", BEGIN_MARKER)).toEqual([]);
   });
 });
 
@@ -543,6 +597,47 @@ describe("replaceBlock", () => {
     const next = replaceBlock(source, buildBlock([{ name: "content", value: 0 }]));
     expect(next).toContain(altBegin);
     expect(next).toContain("old table");
+  });
+
+  it("a prose mention of the marker plus one real marker pair replaces correctly (does not throw duplicate)", () => {
+    const prose = `see ${BEGIN_MARKER} for details\n\n`;
+    const source = `${prose}${seededBlock("  @theme {\n    --z-index-content: 0;\n  }")}`;
+    const next = replaceBlock(source, buildBlock([{ name: "content", value: 1 }]));
+    expect(next).toContain(prose);
+    expect(next).toContain("--z-index-content: 1;");
+    expect(next).not.toContain("old comment");
+  });
+
+  it("splices at the structural BEGIN marker when a prose mention of BEGIN precedes it", () => {
+    // A bare source.indexOf(beginMarker) would land on the prose mention
+    // (which comes first in the file) and corrupt the splice by cutting the
+    // prose line in half instead of replacing the real comment block.
+    const prose = `Note: search for ${BEGIN_MARKER} to find the block.\n`;
+    const source = `${prose}${seededBlock("  @theme {\n    --z-index-content: 0;\n  }")}\n`;
+    const next = replaceBlock(source, buildBlock([{ name: "content", value: 1 }]));
+    expect(next.startsWith(prose)).toBe(true);
+    expect(next).toContain("--z-index-content: 1;");
+    expect(next).not.toContain("old comment");
+  });
+
+  it("splices through to the structural END marker when a prose mention of END sits between the real markers", () => {
+    // A bare source.indexOf(endMarker) would land on this prose line (it
+    // appears earlier in the file than the real closing marker) and
+    // truncate the splice there, leaving the real END marker line behind as
+    // stray leftover text instead of being replaced — silent corruption,
+    // not a loud error.
+    const prose = `mentions ${END_MARKER} in passing`;
+    const inner = `  @theme {\n    --z-index-content: 0;\n  }\n${prose}`;
+    const source = wrapInCss(seededBlock(inner));
+    const next = replaceBlock(source, buildBlock([{ name: "content", value: 1 }]));
+
+    expect(next).toContain("--z-index-content: 1;");
+    expect(next).not.toContain("old comment");
+    expect(next).not.toContain(prose);
+    // Exactly one END marker survives — the one baked into the freshly
+    // built block. A stray leftover from a mislocated splice would leave
+    // two.
+    expect(next.split(END_MARKER)).toHaveLength(2);
   });
 });
 

--- a/packages/zudo-doc/src/__tests__/gen-z-index.test.ts
+++ b/packages/zudo-doc/src/__tests__/gen-z-index.test.ts
@@ -177,6 +177,176 @@ describe("scanMarkerLines", () => {
   });
 });
 
+// ── scanMarkerLines — fenced code exclusion (md surface only) ───────────────
+
+describe("scanMarkerLines with excludeFencedCode", () => {
+  const FENCED = { excludeFencedCode: true };
+
+  /** Offsets of every quoted-or-real marker occurrence, in source order. */
+  function allOccurrences(source: string): number[] {
+    const found: number[] = [];
+    let idx = source.indexOf(MD_TABLE_BEGIN_MARKER);
+    while (idx !== -1) {
+      found.push(idx);
+      idx = source.indexOf(MD_TABLE_BEGIN_MARKER, idx + 1);
+    }
+    return found;
+  }
+
+  it("ignores a marker line inside a backtick fence and finds the real one outside", () => {
+    const source = ["```mdx", MD_TABLE_BEGIN_MARKER, "```", "", MD_TABLE_BEGIN_MARKER, ""].join("\n");
+    expect(scanMarkerLines(source, MD_TABLE_BEGIN_MARKER, FENCED)).toEqual([
+      source.lastIndexOf(MD_TABLE_BEGIN_MARKER),
+    ]);
+  });
+
+  it("ignores a marker line inside a tilde fence", () => {
+    const source = ["~~~mdx", MD_TABLE_BEGIN_MARKER, "~~~", "", MD_TABLE_BEGIN_MARKER, ""].join("\n");
+    expect(scanMarkerLines(source, MD_TABLE_BEGIN_MARKER, FENCED)).toEqual([
+      source.lastIndexOf(MD_TABLE_BEGIN_MARKER),
+    ]);
+  });
+
+  it.each([1, 2, 3])(
+    "treats a fence indented by %i space(s) as a fence (up to three are allowed)",
+    (spaces) => {
+      const indent = " ".repeat(spaces);
+      const source = [
+        `${indent}\`\`\``,
+        MD_TABLE_BEGIN_MARKER,
+        `${indent}\`\`\``,
+        "",
+        MD_TABLE_BEGIN_MARKER,
+        "",
+      ].join("\n");
+      expect(scanMarkerLines(source, MD_TABLE_BEGIN_MARKER, FENCED)).toEqual([
+        source.lastIndexOf(MD_TABLE_BEGIN_MARKER),
+      ]);
+    },
+  );
+
+  it("does NOT treat a four-space-indented ``` line as a fence (accepted limitation)", () => {
+    // Four spaces makes it an indented code block, which this scanner
+    // deliberately does not model — the marker inside is still counted.
+    const source = [
+      "    ```",
+      `    ${MD_TABLE_BEGIN_MARKER}`,
+      "    ```",
+      "",
+      MD_TABLE_BEGIN_MARKER,
+      "",
+    ].join("\n");
+    expect(scanMarkerLines(source, MD_TABLE_BEGIN_MARKER, FENCED)).toEqual(
+      allOccurrences(source),
+    );
+  });
+
+  it("does not let an info-string line (```js) close an open fence", () => {
+    const source = [
+      "```",
+      MD_TABLE_BEGIN_MARKER,
+      "```js",
+      MD_TABLE_BEGIN_MARKER,
+      "```",
+      "",
+      MD_TABLE_BEGIN_MARKER,
+      "",
+    ].join("\n");
+    expect(scanMarkerLines(source, MD_TABLE_BEGIN_MARKER, FENCED)).toEqual([
+      source.lastIndexOf(MD_TABLE_BEGIN_MARKER),
+    ]);
+  });
+
+  it("does not let a closing fence shorter than the opening fence close it", () => {
+    const source = [
+      "````",
+      MD_TABLE_BEGIN_MARKER,
+      "```",
+      MD_TABLE_BEGIN_MARKER,
+      "````",
+      "",
+      MD_TABLE_BEGIN_MARKER,
+      "",
+    ].join("\n");
+    expect(scanMarkerLines(source, MD_TABLE_BEGIN_MARKER, FENCED)).toEqual([
+      source.lastIndexOf(MD_TABLE_BEGIN_MARKER),
+    ]);
+  });
+
+  it("lets a closing fence longer than the opening fence close it", () => {
+    const source = ["```", MD_TABLE_BEGIN_MARKER, "`````", MD_TABLE_BEGIN_MARKER, ""].join("\n");
+    expect(scanMarkerLines(source, MD_TABLE_BEGIN_MARKER, FENCED)).toEqual([
+      source.lastIndexOf(MD_TABLE_BEGIN_MARKER),
+    ]);
+  });
+
+  it("does not let a tilde line close a backtick fence", () => {
+    const source = [
+      "```",
+      MD_TABLE_BEGIN_MARKER,
+      "~~~",
+      MD_TABLE_BEGIN_MARKER,
+      "```",
+      "",
+      MD_TABLE_BEGIN_MARKER,
+      "",
+    ].join("\n");
+    expect(scanMarkerLines(source, MD_TABLE_BEGIN_MARKER, FENCED)).toEqual([
+      source.lastIndexOf(MD_TABLE_BEGIN_MARKER),
+    ]);
+  });
+
+  it("does not open a backtick fence whose info string contains a backtick", () => {
+    const source = ["``` see `code`", MD_TABLE_BEGIN_MARKER, ""].join("\n");
+    expect(scanMarkerLines(source, MD_TABLE_BEGIN_MARKER, FENCED)).toEqual([
+      source.indexOf(MD_TABLE_BEGIN_MARKER),
+    ]);
+  });
+
+  it("opens a tilde fence even when its info string contains a backtick", () => {
+    const source = ["~~~ see `code`", MD_TABLE_BEGIN_MARKER, "~~~", ""].join("\n");
+    expect(scanMarkerLines(source, MD_TABLE_BEGIN_MARKER, FENCED)).toEqual([]);
+  });
+
+  it("treats everything after an unterminated fence as fenced", () => {
+    const source = [
+      MD_TABLE_BEGIN_MARKER,
+      "```",
+      MD_TABLE_BEGIN_MARKER,
+      "still fenced",
+      MD_TABLE_BEGIN_MARKER,
+      "",
+    ].join("\n");
+    expect(scanMarkerLines(source, MD_TABLE_BEGIN_MARKER, FENCED)).toEqual([0]);
+  });
+
+  it("keeps offsets correct and still closes fences on a CRLF source", () => {
+    const source = ["```", MD_TABLE_BEGIN_MARKER, "```", MD_TABLE_BEGIN_MARKER, ""].join("\r\n");
+    expect(scanMarkerLines(source, MD_TABLE_BEGIN_MARKER, FENCED)).toEqual([
+      source.lastIndexOf(MD_TABLE_BEGIN_MARKER),
+    ]);
+  });
+
+  it("closes a fence whose closing line carries trailing whitespace", () => {
+    const source = ["```", MD_TABLE_BEGIN_MARKER, "```  \t", MD_TABLE_BEGIN_MARKER, ""].join("\n");
+    expect(scanMarkerLines(source, MD_TABLE_BEGIN_MARKER, FENCED)).toEqual([
+      source.lastIndexOf(MD_TABLE_BEGIN_MARKER),
+    ]);
+  });
+
+  it("finds a marker on a final line with no trailing newline", () => {
+    const source = ["```", MD_TABLE_BEGIN_MARKER, "```", MD_TABLE_BEGIN_MARKER].join("\n");
+    expect(scanMarkerLines(source, MD_TABLE_BEGIN_MARKER, FENCED)).toEqual([
+      source.lastIndexOf(MD_TABLE_BEGIN_MARKER),
+    ]);
+  });
+
+  it("counts a fenced marker when the option is off — the CSS surface's behaviour", () => {
+    const source = ["```", MD_TABLE_BEGIN_MARKER, "```", MD_TABLE_BEGIN_MARKER, ""].join("\n");
+    expect(scanMarkerLines(source, MD_TABLE_BEGIN_MARKER)).toEqual(allOccurrences(source));
+  });
+});
+
 // ── parseArgs ──────────────────────────────────────────────────────────────
 
 describe("parseArgs", () => {
@@ -641,6 +811,149 @@ describe("replaceBlock", () => {
   });
 });
 
+// ── replaceBlock — fenced code exclusion (md surface) ──────────────────────
+
+describe("replaceBlock with excludeFencedCode", () => {
+  const NEW_TABLE = `${MD_TABLE_BEGIN_MARKER}\nnew table\n${MD_TABLE_END_MARKER}`;
+
+  function replaceMd(source: string, block: string): string {
+    return replaceBlock(source, block, MD_TABLE_BEGIN_MARKER, MD_TABLE_END_MARKER, "doc.mdx", {
+      excludeFencedCode: true,
+    });
+  }
+
+  /** A doc that first QUOTES the marker pair inside `fenceLines`, then carries the real region. */
+  function mdDoc(fenceLines: string[], tableInner: string): string {
+    return [
+      "Seed the region by hand:",
+      "",
+      ...fenceLines,
+      "",
+      MD_TABLE_BEGIN_MARKER,
+      tableInner,
+      MD_TABLE_END_MARKER,
+      "",
+    ].join("\n");
+  }
+
+  const BACKTICK_FENCE = ["```mdx", MD_TABLE_BEGIN_MARKER, MD_TABLE_END_MARKER, "```"];
+  const TILDE_FENCE = ["~~~mdx", MD_TABLE_BEGIN_MARKER, MD_TABLE_END_MARKER, "~~~"];
+
+  it("replaces the real pair when a backtick fence quotes the marker lines", () => {
+    const next = replaceMd(mdDoc(BACKTICK_FENCE, "old table"), NEW_TABLE);
+    expect(next).toBe(mdDoc(BACKTICK_FENCE, "new table"));
+  });
+
+  it("replaces the real pair when a tilde fence quotes the marker lines", () => {
+    const next = replaceMd(mdDoc(TILDE_FENCE, "old table"), NEW_TABLE);
+    expect(next).toBe(mdDoc(TILDE_FENCE, "new table"));
+  });
+
+  it.each([1, 2, 3])(
+    "replaces the real pair when the quoting fence is indented by %i space(s)",
+    (spaces) => {
+      const indent = " ".repeat(spaces);
+      const fence = [
+        `${indent}\`\`\`mdx`,
+        MD_TABLE_BEGIN_MARKER,
+        MD_TABLE_END_MARKER,
+        `${indent}\`\`\``,
+      ];
+      expect(replaceMd(mdDoc(fence, "old table"), NEW_TABLE)).toBe(mdDoc(fence, "new table"));
+    },
+  );
+
+  it("still throws on a marker quoted inside a four-space-indented code block (accepted limitation)", () => {
+    const indented = [
+      "    ```",
+      `    ${MD_TABLE_BEGIN_MARKER}`,
+      `    ${MD_TABLE_END_MARKER}`,
+      "    ```",
+    ];
+    expect(() => replaceMd(mdDoc(indented, "old table"), NEW_TABLE)).toThrow(
+      /duplicate markers.*doc\.mdx/s,
+    );
+  });
+
+  it("does not count a real marker pair that follows an unterminated fence", () => {
+    const source = ["```", "", MD_TABLE_BEGIN_MARKER, "old table", MD_TABLE_END_MARKER, ""].join(
+      "\n",
+    );
+    expect(() => replaceMd(source, NEW_TABLE)).toThrow(/Could not find.*doc\.mdx/s);
+  });
+
+  it("replaces the real pair when an unterminated fence follows it", () => {
+    const trailing = (inner: string) =>
+      [MD_TABLE_BEGIN_MARKER, inner, MD_TABLE_END_MARKER, "", "```", MD_TABLE_BEGIN_MARKER, ""].join(
+        "\n",
+      );
+    expect(replaceMd(trailing("old table"), NEW_TABLE)).toBe(trailing("new table"));
+  });
+
+  it("splices at the right offsets on a CRLF source", () => {
+    const source = [
+      "```",
+      MD_TABLE_BEGIN_MARKER,
+      "```",
+      "",
+      MD_TABLE_BEGIN_MARKER,
+      "old table",
+      MD_TABLE_END_MARKER,
+      "outro",
+      "",
+    ].join("\r\n");
+    // The CR that precedes the END line's LF sits INSIDE the replaced region,
+    // so it is consumed along with the old block — pre-existing splice
+    // behaviour (`replaceBlock` cuts at the LF), unchanged by fence handling.
+    const expected =
+      ["```", MD_TABLE_BEGIN_MARKER, "```", "", ""].join("\r\n") + NEW_TABLE + "\noutro\r\n";
+    expect(replaceMd(source, NEW_TABLE)).toBe(expected);
+  });
+
+  it("splices correctly when the END marker is the final line with no trailing newline", () => {
+    const source = [
+      "```",
+      MD_TABLE_BEGIN_MARKER,
+      "```",
+      "",
+      MD_TABLE_BEGIN_MARKER,
+      "old table",
+      MD_TABLE_END_MARKER,
+    ].join("\n");
+    const expected = ["```", MD_TABLE_BEGIN_MARKER, "```", "", ""].join("\n") + NEW_TABLE;
+    expect(replaceMd(source, NEW_TABLE)).toBe(expected);
+  });
+
+  it("stays idempotent on an md source containing a fenced marker quote", () => {
+    const mdBlock = buildMdTable(DEFAULT_TIER_DATA);
+    const first = replaceMd(mdDoc(BACKTICK_FENCE, "old table"), mdBlock);
+    const second = replaceMd(first, mdBlock);
+    expect(second).toBe(first);
+  });
+
+  it("leaves the CSS surface's fence-blind behaviour intact — a fenced marker still counts there", () => {
+    const source = wrapInCss(
+      [
+        "```",
+        `  /* ${BEGIN_MARKER}`,
+        `  /* ${END_MARKER} */`,
+        "```",
+        seededBlock("  @theme {\n  }"),
+      ].join("\n"),
+    );
+    expect(() => replaceBlock(source, buildBlock([{ name: "content", value: 0 }]))).toThrow(
+      /duplicate markers/,
+    );
+  });
+
+  it("produces byte-identical CSS output for the default tiers", () => {
+    const initial = wrapInCss(seededBlock("  @theme {\n  }"));
+    expect(replaceBlock(initial, buildBlock(DEFAULT_TIER_DATA))).toBe(
+      `/* preamble */\n\n${GOLDEN_DEFAULT_BLOCK}\n`,
+    );
+  });
+});
+
 // ── buildMdTable ───────────────────────────────────────────────────────────
 
 describe("buildMdTable", () => {
@@ -944,6 +1257,37 @@ describe("main()", () => {
 
     const logged = logSpy.mock.calls.flat().join("\n");
     expect(logged).toContain("docs/z-index.mdx");
+  });
+
+  it("--md-table ignores a marker pair quoted inside a fenced code block", () => {
+    mkdirSync(join(tmpDir, "src/config"), { recursive: true });
+    mkdirSync(join(tmpDir, "src/styles"), { recursive: true });
+    mkdirSync(join(tmpDir, "docs"), { recursive: true });
+    writeFileSync(join(tmpDir, DEFAULT_TOKENS_PATH), tokensSrcFromTiers(DEFAULT_TIER_DATA));
+    writeFileSync(join(tmpDir, DEFAULT_CSS_PATH), wrapInCss(seededBlock("  @theme {\n  }")));
+    // A doc page explaining the generator reproduces the marker pair verbatim
+    // inside a fence, then carries the real region below it.
+    const quoted = [
+      "Seed the region by hand:",
+      "",
+      "```mdx",
+      MD_TABLE_BEGIN_MARKER,
+      MD_TABLE_END_MARKER,
+      "```",
+      "",
+    ].join("\n");
+    writeFileSync(join(tmpDir, "docs/z-index.mdx"), `${quoted}\n${seededMdBlock("old table")}\n`);
+
+    expect(main(["--md-table", "docs/z-index.mdx"])).toBe(0);
+
+    const writtenMd = readFileSync(join(tmpDir, "docs/z-index.mdx"), "utf8");
+    expect(writtenMd.startsWith(quoted)).toBe(true);
+    expect(writtenMd).toContain("| content | - | - |");
+    expect(writtenMd).not.toContain("old table");
+
+    // Round-trip: the freshly written file is already up to date.
+    expect(main(["--check", "--md-table", "docs/z-index.mdx"])).toBe(0);
+    expect(readFileSync(join(tmpDir, "docs/z-index.mdx"), "utf8")).toBe(writtenMd);
   });
 
   it("--md-table is idempotent end to end: a second run makes no further change", () => {

--- a/packages/zudo-doc/src/__tests__/gen-z-index.test.ts
+++ b/packages/zudo-doc/src/__tests__/gen-z-index.test.ts
@@ -246,6 +246,85 @@ describe("scanMarkerLines with excludeFencedCode", () => {
     },
   );
 
+  it.each(["10) ", "1.  ", "-   "])(
+    "closes a list-item fence whose closer sits at a content column of four or more (prefix %j)",
+    (prefix) => {
+      // The closer carries no list marker of its own — it sits at the item's
+      // content column, which a four-or-more-character marker prefix pushes
+      // past a flat three-space cap. Rejecting it left the fence open, so
+      // every marker below stayed ineligible and the real one vanished.
+      const indent = " ".repeat(prefix.length);
+      const source = [
+        `${prefix}\`\`\`mdx`,
+        `${indent}${MD_TABLE_BEGIN_MARKER}`,
+        `${indent}\`\`\``,
+        "",
+        MD_TABLE_BEGIN_MARKER,
+        "",
+      ].join("\n");
+      expect(scanMarkerLines(source, MD_TABLE_BEGIN_MARKER, FENCED)).toEqual([
+        source.lastIndexOf(MD_TABLE_BEGIN_MARKER),
+      ]);
+    },
+  );
+
+  it.each([0, 1, 2, 3])(
+    "still closes a list-item fence with a closer indented by only %i space(s)",
+    (spaces) => {
+      // Measuring the allowance from the opener must be a SUPERSET of the old
+      // flat 0-3 rule, never narrower: a shallow closer keeps closing a fence
+      // opened at any indent.
+      const source = [
+        "10) ```mdx",
+        `    ${MD_TABLE_BEGIN_MARKER}`,
+        `${" ".repeat(spaces)}\`\`\``,
+        "",
+        MD_TABLE_BEGIN_MARKER,
+        "",
+      ].join("\n");
+      expect(scanMarkerLines(source, MD_TABLE_BEGIN_MARKER, FENCED)).toEqual([
+        source.lastIndexOf(MD_TABLE_BEGIN_MARKER),
+      ]);
+    },
+  );
+
+  it("expands a tab in the list-marker padding to CommonMark's four-column tab stops", () => {
+    // The opener regex accepts a tab as list-marker padding, and `"1.\t"` is
+    // three CHARACTERS but four COLUMNS. Measuring characters would cap the
+    // closer at six spaces and reject this legal one at seven.
+    const source = [
+      "1.\t```mdx",
+      `    ${MD_TABLE_BEGIN_MARKER}`,
+      "       ```",
+      "",
+      MD_TABLE_BEGIN_MARKER,
+      "",
+    ].join("\n");
+    expect(scanMarkerLines(source, MD_TABLE_BEGIN_MARKER, FENCED)).toEqual([
+      source.lastIndexOf(MD_TABLE_BEGIN_MARKER),
+    ]);
+  });
+
+  it("closes at exactly the opener's content column + 3, but not one space further", () => {
+    // Proves the new allowance is a BOUND, not an anything-goes relaxation.
+    const fenceDoc = (closerSpaces: number) =>
+      [
+        "10) ```mdx",
+        `    ${MD_TABLE_BEGIN_MARKER}`,
+        `${" ".repeat(closerSpaces)}\`\`\``,
+        "",
+        MD_TABLE_BEGIN_MARKER,
+        "",
+      ].join("\n");
+    // Content column 4 + three further spaces of slack = 7.
+    const atBound = fenceDoc(7);
+    expect(scanMarkerLines(atBound, MD_TABLE_BEGIN_MARKER, FENCED)).toEqual([
+      atBound.lastIndexOf(MD_TABLE_BEGIN_MARKER),
+    ]);
+    // One past it: the fence never closes, so nothing below is eligible.
+    expect(scanMarkerLines(fenceDoc(8), MD_TABLE_BEGIN_MARKER, FENCED)).toEqual([]);
+  });
+
   it("does not mistake a list marker for extra indentation on a four-space-indented line", () => {
     // Guards the optional list-prefix group against relaxing the 0-3 space
     // rule by backtracking (`^ {0,3}` + optional prefix must not add up to a
@@ -927,6 +1006,28 @@ describe("replaceBlock with excludeFencedCode", () => {
         `  ${MD_TABLE_BEGIN_MARKER}`,
         `  ${MD_TABLE_END_MARKER}`,
         "  ```",
+        "",
+        MD_TABLE_BEGIN_MARKER,
+        inner,
+        MD_TABLE_END_MARKER,
+        "",
+      ].join("\n");
+    expect(replaceMd(listDoc("old table"), NEW_TABLE)).toBe(listDoc("new table"));
+  });
+
+  it("replaces the real pair when the quoting fence opens on a wide-marker list item", () => {
+    // Regression: `10) ` opens the fence (wave 2), but its closer sits at the
+    // item's content column 4 — past the old flat three-space cap. The fence
+    // therefore never closed, the real pair below stayed ineligible, and a
+    // perfectly valid doc threw "Could not find … markers".
+    const listDoc = (inner: string) =>
+      [
+        "10) Seed the region by hand:",
+        "",
+        "10) ```mdx",
+        `    ${MD_TABLE_BEGIN_MARKER}`,
+        `    ${MD_TABLE_END_MARKER}`,
+        "    ```",
         "",
         MD_TABLE_BEGIN_MARKER,
         inner,


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3301
- parent PR
    - https://github.com/zudolab/zudo-doc/pull/3300

---

## Summary

`countOccurrences()` in `packages/zudo-doc/bin/gen-z-index.mjs` counted marker occurrences by plain substring match, so a doc page that *quotes* the marker text — in prose, or in a fenced code block explaining the generator — was misread as a duplicate marker and failed validation. This epic replaces that with a structural matcher, without breaking either real marker form (the CSS mid-comment-line pair or the MDX whole-line brace-comment pair).

No real-world impact existed before this change — nothing in `src/content/`, `docs/`, or `packages/create-zudo-doc/templates/` quotes the markers. This is hardening against a documented, accepted limitation whose failure mode was loud, never silent corruption.

## Changes

### One scanner, line-anchored (#3302)

`countOccurrences` and the bare `source.indexOf(marker)` locate calls are both gone. `scanMarkerLines(source, marker, options)` walks the source line by line and returns the offsets of every **line-anchored** occurrence — a line where removing the marker leaves only whitespace and comment/brace delimiters (`line.replace(marker, "")` matches `/^[\s{}/*]*$/`). `replaceBlock` derives **both** its duplicate/missing/inverted validation and its splice positions from that one result.

That structural change is the point: tightening only the count would have let a quoted marker *before* the real one pass validation and then become the splice position — turning today's loud error into silent corruption. Counting and locating can no longer diverge.

All three error paths keep their shape and message, and the full-line splice expansion is unchanged.

### Fenced-code exclusion, md surface only (#3303)

`options.excludeFencedCode` (default off, passed only from the `--md-table` call site) adds CommonMark fence state to the same scanner, so a marker quoted inside a fenced code block is not counted. The CSS path is byte-unchanged — gating is on the **surface**, not on sniffing the marker strings.

Fence rules honoured, each one a case a `trim()` + `startsWith` approximation gets wrong:

- an opening fence permits at most three leading spaces (four-space-indented code is not a fence)
- a closing fence must use the same character, be at least as long, and carry only whitespace after it (an info-string line like ````js``` does not close a fence)
- a backtick fence's info string may not itself contain a backtick
- an unterminated fence extends to end of source
- offsets survive CRLF endings and a final line with no trailing newline

### Two review findings, both fixed

- **List-item fence openers** (caught by the wave-2 child's own self-review): `- ```mdx` is a valid CommonMark opener. Missing it was not a harmless false negative — the item's closing fence, indented to the content column and carrying no list marker, was then read as a *fresh opener* that swallowed the real marker pair below, splicing the generated table into the quoted example. A silent-corruption regression against the epic's own invariant.
- **List-content closer indentation** (caught by codex review of the merged branch, reproduced before fixing): the closer is bounded by its opener's content column + 3, not a flat 3. A fence opened after a wide marker like `10) ` has its closer at column 4, which the flat cap rejected — leaving the fence open and hiding the real markers behind a loud missing-markers error. Tab-stop expansion is applied to the opener prefix so `1.\t` counts as 4 columns, not 3.

## Accepted limitation (documented, not fixed)

An exact marker line inside a **four-space-indented** code block is still a false positive. #3290 names fenced code, not indented code, and indented-code detection needs far more markdown awareness (list-item continuation, paragraph interruption) than a dependency-free bin should carry. The failure mode stays loud.

## Verification

- `pnpm --filter @takazudo/zudo-doc test` — **2074 passed / 181 files** (2025 before this epic; +49 new).
- Every fence rule is mutation-tested: removing any one of them fails a specific test.
- CSS surface byte-identity proven differentially against the pre-change bin across fixture × option combinations — identical output *and* identical throw messages.
- Round-trip idempotence on the md surface, unit-level and end-to-end (`--md-table` then `--check` → exit 0, file unchanged).

Closes #3302, closes #3303.
