### PR TITLE
Pin Parity Fixture: guard, release-wire, and realign the target-manifest zudo-doc pin

### DIFF
--- a/packages/zudo-doc/src/__tests__/fixtures/target-manifest/package.json
+++ b/packages/zudo-doc/src/__tests__/fixtures/target-manifest/package.json
@@ -9,6 +9,6 @@
     "check": "zfb check"
   },
   "dependencies": {
-    "@takazudo/zudo-doc": "^4.5.0"
+    "@takazudo/zudo-doc": "^5.1.1"
   }
 }

--- a/scripts/__tests__/check-pin-parity.test.ts
+++ b/scripts/__tests__/check-pin-parity.test.ts
@@ -1,3 +1,8 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { describe, it, expect } from "vitest";
 
 import {
@@ -174,5 +179,69 @@ describe("evaluateFirstPartyPeer — pinned (exact)", () => {
       actualPeer: "^0.4.0",
     });
     expect(res.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sixth guarded surface (#3307): the target-manifest fixture's
+// @takazudo/zudo-doc dependency must equal scaffold.ts's ZUDO_DOC_PIN.
+// ---------------------------------------------------------------------------
+//
+// Unlike scripts/lib/rewrite-zudo-doc-pins.mjs (#3306), check-pin-parity.mjs
+// takes no --repo-root — it resolves every path relative to ITS OWN file
+// location (see ROOT_DIR at the top of the script). There is no seam to
+// point it at a scratch tree, so the only way to exercise the real
+// drift-detection path end-to-end is to mutate the real fixture file and
+// restore it afterward. The mutation + restore is scoped to a single
+// try/finally around one synchronous execFileSync call, so a crash mid-test
+// still leaves the `finally` write to run and the tree unmutated for anyone
+// downstream.
+describe("target-manifest fixture guard (#3307, negative control)", () => {
+  const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+  const SCRIPT_PATH = resolve(REPO_ROOT, "scripts/check-pin-parity.mjs");
+  const FIXTURE_PKG_PATH = resolve(
+    REPO_ROOT,
+    "packages/zudo-doc/src/__tests__/fixtures/target-manifest/package.json",
+  );
+
+  it("exits non-zero and names the fixture path when its pin drifts from scaffold.ts", () => {
+    const original = readFileSync(FIXTURE_PKG_PATH, "utf-8");
+    try {
+      const mutated = original.replace(
+        /"@takazudo\/zudo-doc":\s*"[^"]+"/,
+        '"@takazudo/zudo-doc": "^0.0.1-wrong-on-purpose"',
+      );
+      // Guards against a regex that silently fails to match: without this,
+      // the test would "pass" on an unmutated (still-correct) fixture.
+      expect(mutated).not.toBe(original);
+      writeFileSync(FIXTURE_PKG_PATH, mutated);
+
+      let status: number | undefined;
+      let stderr = "";
+      try {
+        execFileSync(process.execPath, [SCRIPT_PATH], {
+          encoding: "utf-8",
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+      } catch (error) {
+        const err = error as { status?: number; stderr?: string };
+        status = err.status;
+        stderr = err.stderr ?? "";
+      }
+
+      expect(status).toBe(1);
+      expect(stderr).toContain(FIXTURE_PKG_PATH);
+      expect(stderr).toMatch(/Fixture pin drift/);
+    } finally {
+      writeFileSync(FIXTURE_PKG_PATH, original);
+    }
+  });
+
+  it("passes on the real repo tree and reports the fixture pin (positive control)", () => {
+    const stdout = execFileSync(process.execPath, [SCRIPT_PATH], {
+      encoding: "utf-8",
+    });
+    expect(stdout).toContain("1 fixture pin");
+    expect(stdout).toContain("target-manifest fixture");
   });
 });

--- a/scripts/__tests__/rewrite-zudo-doc-pins.test.ts
+++ b/scripts/__tests__/rewrite-zudo-doc-pins.test.ts
@@ -255,9 +255,16 @@ describe("release-create-zudo-doc.sh wiring", () => {
   const releaseScript = readFileSync(RELEASE_SCRIPT_PATH, "utf-8");
 
   it("invokes the helper with a repo root and the new version", () => {
-    expect(releaseScript).toMatch(
-      /node "\$ROOT_DIR\/scripts\/lib\/rewrite-zudo-doc-pins\.mjs" \\\s*\n\s*--repo-root "\$ROOT_DIR" \\\s*\n\s*--version "\$NEW_VERSION"/,
-    );
+    // Matched without pinning line breaks so reformatting the invocation does
+    // not fail the test — what must hold is that the shell runs THIS script
+    // and hands it the repo root plus the version being released.
+    const command = 'node "$ROOT_DIR/scripts/lib/rewrite-zudo-doc-pins.mjs"';
+    const start = releaseScript.indexOf(command);
+    expect(start).toBeGreaterThan(-1);
+
+    const invocation = releaseScript.slice(start).split("\n\n")[0];
+    expect(invocation).toContain('--repo-root "$ROOT_DIR"');
+    expect(invocation).toContain('--version "$NEW_VERSION"');
   });
 
   it("keeps no inline ZUDO_DOC_PIN rewrite in the shell script", () => {

--- a/scripts/__tests__/rewrite-zudo-doc-pins.test.ts
+++ b/scripts/__tests__/rewrite-zudo-doc-pins.test.ts
@@ -1,0 +1,292 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  rewriteZudoDocPins,
+  SCAFFOLD_TS_RELATIVE,
+  TARGET_MANIFEST_RELATIVE,
+  ZUDO_DOC_PACKAGE,
+} from "../lib/rewrite-zudo-doc-pins.mjs";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const HELPER_PATH = resolve(REPO_ROOT, "scripts/lib/rewrite-zudo-doc-pins.mjs");
+const RELEASE_SCRIPT_PATH = resolve(REPO_ROOT, "scripts/release-create-zudo-doc.sh");
+
+// ---------------------------------------------------------------------------
+// Temp fixture tree — mirrors the two real files' shapes closely enough that a
+// regex/JSON-shape change in the helper is caught here.
+// ---------------------------------------------------------------------------
+
+const SCAFFOLD_SOURCE = (pin: string) => `import { join } from "node:path";
+
+/**
+ * Bumped in lockstep by scripts/release-create-zudo-doc.sh.
+ */
+export const ZUDO_DOC_PIN = "${pin}";
+
+export function generatePackageJson() {
+  return { dependencies: { "@takazudo/zudo-doc": ZUDO_DOC_PIN } };
+}
+`;
+
+const MANIFEST_SOURCE = (pin: string) => `{
+  "name": "target-manifest-confirm",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "zfb dev",
+    "build": "zfb build",
+    "preview": "zfb preview",
+    "check": "zfb check"
+  },
+  "dependencies": {
+    "@takazudo/zudo-doc": "${pin}"
+  }
+}
+`;
+
+const tempRoots: string[] = [];
+
+interface TreeOptions {
+  scaffold?: string | null;
+  manifest?: string | null;
+}
+
+function makeTree({
+  scaffold = SCAFFOLD_SOURCE("^5.1.1"),
+  manifest = MANIFEST_SOURCE("^5.1.1"),
+}: TreeOptions = {}): string {
+  const root = mkdtempSync(resolve(tmpdir(), "rewrite-zudo-doc-pins-"));
+  tempRoots.push(root);
+
+  if (scaffold !== null) {
+    const path = resolve(root, SCAFFOLD_TS_RELATIVE);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, scaffold);
+  }
+  if (manifest !== null) {
+    const path = resolve(root, TARGET_MANIFEST_RELATIVE);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, manifest);
+  }
+  return root;
+}
+
+const readScaffold = (root: string) =>
+  readFileSync(resolve(root, SCAFFOLD_TS_RELATIVE), "utf-8");
+const readManifest = (root: string) =>
+  readFileSync(resolve(root, TARGET_MANIFEST_RELATIVE), "utf-8");
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    rmSync(tempRoots.pop()!, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Module API
+// ---------------------------------------------------------------------------
+
+describe("rewriteZudoDocPins", () => {
+  it("advances both lockstep surfaces to the target version", () => {
+    const root = makeTree();
+
+    const result = rewriteZudoDocPins({ repoRoot: root, version: "9.9.9" });
+
+    expect(result.pin).toBe("^9.9.9");
+    expect(result.files).toEqual([
+      resolve(root, SCAFFOLD_TS_RELATIVE),
+      resolve(root, TARGET_MANIFEST_RELATIVE),
+    ]);
+    expect(readScaffold(root)).toContain('export const ZUDO_DOC_PIN = "^9.9.9";');
+    expect(JSON.parse(readManifest(root)).dependencies[ZUDO_DOC_PACKAGE]).toBe(
+      "^9.9.9",
+    );
+  });
+
+  it("leaves the fixture byte-for-byte identical apart from the version string", () => {
+    const root = makeTree();
+
+    rewriteZudoDocPins({ repoRoot: root, version: "9.9.9" });
+
+    expect(readManifest(root)).toBe(MANIFEST_SOURCE("^9.9.9"));
+  });
+
+  it("handles a prerelease target version", () => {
+    const root = makeTree();
+
+    const result = rewriteZudoDocPins({ repoRoot: root, version: "9.9.9-next.3" });
+
+    expect(result.pin).toBe("^9.9.9-next.3");
+    expect(readScaffold(root)).toContain(
+      'export const ZUDO_DOC_PIN = "^9.9.9-next.3";',
+    );
+    expect(JSON.parse(readManifest(root)).dependencies[ZUDO_DOC_PACKAGE]).toBe(
+      "^9.9.9-next.3",
+    );
+  });
+
+  it("advances a prerelease pin already in the tree", () => {
+    const root = makeTree({
+      scaffold: SCAFFOLD_SOURCE("^5.2.0-next.1"),
+      manifest: MANIFEST_SOURCE("^5.2.0-next.1"),
+    });
+
+    rewriteZudoDocPins({ repoRoot: root, version: "5.2.0" });
+
+    expect(readScaffold(root)).toContain('export const ZUDO_DOC_PIN = "^5.2.0";');
+    expect(readManifest(root)).toBe(MANIFEST_SOURCE("^5.2.0"));
+  });
+
+  it("fails loudly when the fixture dependency key is missing", () => {
+    const root = makeTree({
+      manifest: `{\n  "name": "target-manifest-confirm",\n  "dependencies": {}\n}\n`,
+    });
+
+    expect(() => rewriteZudoDocPins({ repoRoot: root, version: "9.9.9" })).toThrow(
+      /could not locate the @takazudo\/zudo-doc dependency/,
+    );
+  });
+
+  it("fails loudly when ZUDO_DOC_PIN is missing", () => {
+    const root = makeTree({ scaffold: "export const SOMETHING_ELSE = 1;\n" });
+
+    expect(() => rewriteZudoDocPins({ repoRoot: root, version: "9.9.9" })).toThrow(
+      /could not locate the ZUDO_DOC_PIN constant/,
+    );
+  });
+
+  it("fails loudly when a target file does not exist", () => {
+    const root = makeTree({ manifest: null });
+
+    expect(() => rewriteZudoDocPins({ repoRoot: root, version: "9.9.9" })).toThrow(
+      /could not find .*target-manifest[\\/]package\.json/,
+    );
+  });
+
+  it("does not half-write the tree when the second target is unusable", () => {
+    const root = makeTree({ manifest: `{ "dependencies": {} }\n` });
+    const before = readScaffold(root);
+
+    expect(() => rewriteZudoDocPins({ repoRoot: root, version: "9.9.9" })).toThrow();
+
+    expect(readScaffold(root)).toBe(before);
+  });
+
+  it("rejects a version that is not X.Y.Z[-prerelease]", () => {
+    const root = makeTree();
+
+    expect(() => rewriteZudoDocPins({ repoRoot: root, version: "latest" })).toThrow(
+      /invalid version/,
+    );
+    expect(readScaffold(root)).toContain('"^5.1.1"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI — the exact invocation form Step 2c uses
+// ---------------------------------------------------------------------------
+
+describe("rewrite-zudo-doc-pins CLI", () => {
+  it("rewrites both files and names each one on stdout", () => {
+    const root = makeTree();
+
+    const stdout = execFileSync(
+      process.execPath,
+      [HELPER_PATH, "--repo-root", root, "--version", "9.9.9"],
+      { encoding: "utf-8" },
+    );
+
+    expect(stdout).toContain("scaffold.ts");
+    expect(stdout).toContain("target-manifest");
+    expect(stdout).toContain("^9.9.9");
+    expect(readScaffold(root)).toContain('export const ZUDO_DOC_PIN = "^9.9.9";');
+    expect(readManifest(root)).toBe(MANIFEST_SOURCE("^9.9.9"));
+  });
+
+  it("exits non-zero with a clear error when a pin cannot be located", () => {
+    const root = makeTree({ manifest: `{ "dependencies": {} }\n` });
+
+    let status: number | undefined;
+    let stderr = "";
+    try {
+      execFileSync(
+        process.execPath,
+        [HELPER_PATH, "--repo-root", root, "--version", "9.9.9"],
+        { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] },
+      );
+    } catch (error) {
+      const err = error as { status?: number; stderr?: string };
+      status = err.status;
+      stderr = err.stderr ?? "";
+    }
+
+    expect(status).toBe(1);
+    expect(stderr).toMatch(/could not locate the @takazudo\/zudo-doc dependency/);
+  });
+
+  it("exits non-zero when required flags are missing", () => {
+    let status: number | undefined;
+    try {
+      execFileSync(process.execPath, [HELPER_PATH, "--version", "9.9.9"], {
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (error) {
+      status = (error as { status?: number }).status;
+    }
+
+    expect(status).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wiring — the point of the seam is that the release script runs THIS code.
+// Without these two assertions the suite above could pass while Step 2c quietly
+// went back to rewriting pins inline.
+// ---------------------------------------------------------------------------
+
+describe("release-create-zudo-doc.sh wiring", () => {
+  const releaseScript = readFileSync(RELEASE_SCRIPT_PATH, "utf-8");
+
+  it("invokes the helper with a repo root and the new version", () => {
+    expect(releaseScript).toMatch(
+      /node "\$ROOT_DIR\/scripts\/lib\/rewrite-zudo-doc-pins\.mjs" \\\s*\n\s*--repo-root "\$ROOT_DIR" \\\s*\n\s*--version "\$NEW_VERSION"/,
+    );
+  });
+
+  it("keeps no inline ZUDO_DOC_PIN rewrite in the shell script", () => {
+    const inlineNodeBlocks = releaseScript.match(/node -e "[\s\S]*?\n"/g) ?? [];
+    expect(
+      inlineNodeBlocks.filter((block) => block.includes("ZUDO_DOC_PIN")),
+    ).toEqual([]);
+  });
+
+  it("names both rewritten files in the top-level summary", () => {
+    const summary = releaseScript.slice(0, releaseScript.indexOf("ROOT_DIR="));
+    expect(summary).toContain("scaffold.ts");
+    expect(summary).toContain("target-manifest");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Real tree — the helper's relative paths must keep resolving in this repo.
+// (Value parity between the two pins is #3307's guard, not this test's.)
+// ---------------------------------------------------------------------------
+
+describe("repository targets", () => {
+  it("locates both pins in the real repo", () => {
+    expect(readFileSync(resolve(REPO_ROOT, SCAFFOLD_TS_RELATIVE), "utf-8")).toMatch(
+      /export const ZUDO_DOC_PIN\s*=\s*"\^?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?"/,
+    );
+    const manifest = JSON.parse(
+      readFileSync(resolve(REPO_ROOT, TARGET_MANIFEST_RELATIVE), "utf-8"),
+    );
+    expect(typeof manifest.dependencies[ZUDO_DOC_PACKAGE]).toBe("string");
+  });
+});

--- a/scripts/check-pin-parity.mjs
+++ b/scripts/check-pin-parity.mjs
@@ -5,7 +5,7 @@
 //   "W1A §5#4 — pin sources out of lockstep"
 //
 // The upstream zfb-family packages used by generated projects are represented
-// across five surfaces that must stay in lockstep:
+// across six surfaces that must stay in lockstep:
 //
 //   1. Root package.json `@takazudo/zfb` engine pin.
 //   2. Root package.json companion pins (runtime and md-wasm).
@@ -17,6 +17,15 @@
 //   5. packages/zudo-doc/package.json zfb-family `peerDependencies` — caret
 //      floors derived from the exact root pins, so compatible later releases
 //      are accepted without weakening the root/dev/scaffold reproducibility.
+//   6. packages/zudo-doc/src/__tests__/fixtures/target-manifest/package.json —
+//      the confirm-gate fixture's `@takazudo/zudo-doc` dependency, which must
+//      equal the literal ZUDO_DOC_PIN scaffold.ts emits (#3, constant-reference
+//      form). This pin is DOCUMENTARY, not functional: the slow test that
+//      consumes this fixture extracts a packed tarball straight into
+//      `node_modules/@takazudo/zudo-doc` and symlinks the rest, so the
+//      dependency spec is never resolved from the registry — drift here is
+//      invisible to the test suite and would otherwise go uncaught the same
+//      way it silently fell a full major behind between 4.5 and 5.1.1 (#3304).
 //
 // Historically, bumping #1/#2 (e.g. via `pnpm up @takazudo/zfb@latest`)
 // silently left #3/#4/#5 stale. This script makes that drift a CI/b4push error.
@@ -42,6 +51,13 @@ const SCAFFOLD_TS_PATH = resolve(
   "packages/create-zudo-doc/src/scaffold.ts",
 );
 const ZUDO_DOC_PKG_PATH = resolve(ROOT_DIR, "packages/zudo-doc/package.json");
+const TARGET_MANIFEST_PKG_PATH = resolve(
+  ROOT_DIR,
+  "packages/zudo-doc/src/__tests__/fixtures/target-manifest/package.json",
+);
+
+// The single dependency the target-manifest fixture guards (surface #6).
+const FIXTURE_PACKAGE = "@takazudo/zudo-doc";
 
 // External upstream packages emitted by the scaffold: each pin must equal
 // root dependencies[pkg]. The Cloudflare adapter is intentionally absent: the
@@ -59,10 +75,13 @@ const PINNED_PACKAGES = [
 // stripped) must equal root package.json `version` (the lockstep release
 // version). These are NOT in root dependencies — they ARE root.
 //
-// Cross-reference: scripts/release-create-zudo-doc.sh Step 2c (colon form)
-// and Step 2d (bracket-assignment form) are the source of truth that WRITES
-// these pins on every release bump. Keep this list in sync with those steps
-// so any future 3rd internal pin gets guarded here too.
+// Cross-reference: scripts/release-create-zudo-doc.sh Step 2c calls
+// scripts/lib/rewrite-zudo-doc-pins.mjs (the colon-form ZUDO_DOC_PIN rewrite,
+// plus the target-manifest fixture below — #3306), and Step 2d rewrites
+// @takazudo/zudo-doc-history-server inline (bracket-assignment form). Those
+// are the source of truth that WRITES these pins on every release bump. Keep
+// this list in sync with those steps so any future 3rd internal pin gets
+// guarded here too.
 const INTERNAL_PINNED_PACKAGES = [
   "@takazudo/zudo-doc",
   "@takazudo/zudo-doc-history-server",
@@ -325,6 +344,9 @@ function main() {
   const rootPkg = JSON.parse(readFileSync(ROOT_PKG_PATH, "utf-8"));
   const scaffoldSrc = readFileSync(SCAFFOLD_TS_PATH, "utf-8");
   const zudoDocPkg = JSON.parse(readFileSync(ZUDO_DOC_PKG_PATH, "utf-8"));
+  const targetManifestPkg = JSON.parse(
+    readFileSync(TARGET_MANIFEST_PKG_PATH, "utf-8"),
+  );
 
   const mismatches = [];
 
@@ -387,6 +409,39 @@ function main() {
         rootPin: releaseVersion,
         scaffoldPin,
         kind: "internal",
+      });
+    }
+  }
+
+  // ── Fixture: target-manifest package.json must mirror the literal scaffold
+  // pin (#3307). The pin is DOCUMENTARY — see the header comment for why the
+  // slow test that consumes this fixture cannot catch drift here on its own.
+  {
+    const scaffoldPin = readScaffoldPin(scaffoldSrc, FIXTURE_PACKAGE);
+    const fixturePin = targetManifestPkg.dependencies?.[FIXTURE_PACKAGE];
+
+    if (scaffoldPin === null) {
+      // Already reported by the internal-pins loop above; skip to avoid a
+      // duplicate mismatch for the same missing scaffold.ts pin.
+    } else if (fixturePin === undefined) {
+      mismatches.push({
+        pkg: FIXTURE_PACKAGE,
+        reason: `Missing ${FIXTURE_PACKAGE} dependency in the target-manifest fixture`,
+        expected: scaffoldPin,
+        actual: "(missing)",
+        file: TARGET_MANIFEST_PKG_PATH,
+        field: "dependencies",
+        kind: "fixture",
+      });
+    } else if (fixturePin !== scaffoldPin) {
+      mismatches.push({
+        pkg: FIXTURE_PACKAGE,
+        reason: `Fixture pin drift — target-manifest fixture pins ${fixturePin} but scaffold.ts ZUDO_DOC_PIN is ${scaffoldPin}`,
+        expected: scaffoldPin,
+        actual: fixturePin,
+        file: TARGET_MANIFEST_PKG_PATH,
+        field: "dependencies",
+        kind: "fixture",
       });
     }
   }
@@ -523,7 +578,7 @@ function main() {
 
   if (mismatches.length === 0) {
     console.log(
-      `OK — pin parity verified for ${PINNED_PACKAGES.length} external + ${INTERNAL_PINNED_PACKAGES.length} internal + ${ZUDO_DOC_ZFB_PACKAGES.length * 2} workspace-package field(s) + ${FIRST_PARTY_PEER_CHECKS.length} first-party peer floor(s):`,
+      `OK — pin parity verified for ${PINNED_PACKAGES.length} external + ${INTERNAL_PINNED_PACKAGES.length} internal + ${ZUDO_DOC_ZFB_PACKAGES.length * 2} workspace-package field(s) + ${FIRST_PARTY_PEER_CHECKS.length} first-party peer floor(s) + 1 fixture pin:`,
     );
     for (const pkgName of PINNED_PACKAGES) {
       console.log(`  ${pkgName} = ${rootPkg.dependencies[pkgName]}`);
@@ -534,6 +589,9 @@ function main() {
         `  ${pkgName} = ${scaffoldPin} (matches release ${releaseVersion})`,
       );
     }
+    console.log(
+      `  target-manifest fixture dependencies[${FIXTURE_PACKAGE}] = ${targetManifestPkg.dependencies?.[FIXTURE_PACKAGE]} (matches scaffold.ts ZUDO_DOC_PIN)`,
+    );
     for (const pkgName of ZUDO_DOC_ZFB_PACKAGES) {
       const rootPin = rootPkg.dependencies[pkgName];
       console.log(
@@ -573,6 +631,12 @@ function main() {
       console.error(`    field:    ${m.field}`);
       console.error(`    expected: ${m.expected}`);
       console.error(`    actual:   ${m.actual}`);
+    } else if (m.kind === "fixture") {
+      console.error(`  [${m.pkg}]  ${m.reason}`);
+      console.error(`    file:     ${m.file}`);
+      console.error(`    field:    ${m.field}`);
+      console.error(`    expected: ${m.expected}`);
+      console.error(`    actual:   ${m.actual}`);
     } else {
       // workspace-package
       console.error(`  [${m.pkg}]  ${m.reason}`);
@@ -592,6 +656,10 @@ function main() {
   console.error(`  - ${ZUDO_DOC_PKG_PATH}`);
   console.error(
     `      zfb devDependencies must be exact-equal to root pins; zfb peerDependencies and pinned peer floors must be ^<root pin>; the lockstep peer floor must INCLUDE the root version`,
+  );
+  console.error(`  - ${TARGET_MANIFEST_PKG_PATH}`);
+  console.error(
+    `      the fixture's ${FIXTURE_PACKAGE} dependency must equal scaffold.ts's ZUDO_DOC_PIN literal (documentary — see scripts/lib/rewrite-zudo-doc-pins.mjs, which rewrites both on release)`,
   );
   console.error("then re-run this check.");
   return 1;

--- a/scripts/lib/rewrite-zudo-doc-pins.mjs
+++ b/scripts/lib/rewrite-zudo-doc-pins.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+// scripts/lib/rewrite-zudo-doc-pins.mjs
+//
+// Lockstep rewrite of every place the released @takazudo/zudo-doc version is
+// spelled out as a literal (#3306). Two surfaces move together:
+//
+//   1. packages/create-zudo-doc/src/scaffold.ts — the exported `ZUDO_DOC_PIN`
+//      constant, which is the pin a fresh scaffold emits into the generated
+//      downstream package.json.
+//   2. packages/zudo-doc/src/__tests__/fixtures/target-manifest/package.json —
+//      the fixture documented as mirroring "the PUBLISHED shape a real
+//      create-zudo-doc consumer gets". Its pin is documentary (the slow test
+//      extracts a packed tarball rather than resolving from the registry), so
+//      nothing fails when it drifts — which is exactly why it silently fell a
+//      full major behind between 4.5 and 5.1.1.
+//
+// WHY a module instead of a second inline `node -e` in the release script:
+// the release path's failure mode is "the next release breaks", verifiable
+// only by performing a release. Behind an importable seam that takes the repo
+// root as a parameter, the same code the shell step runs is exercised by
+// ordinary unit tests against a temp tree — permanent coverage instead of a
+// one-off manual simulation. (scripts/check-pin-parity.mjs resolves its paths
+// relative to its own location, which is what makes simulating the shell step
+// against a scratch copy fragile; this helper deliberately does not.)
+//
+// Called by:
+//   - scripts/release-create-zudo-doc.sh Step 2c (as a CLI, see the bottom)
+//   - scripts/__tests__/rewrite-zudo-doc-pins.test.ts (as a module)
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+/** Path of the scaffold source, relative to the repo root. */
+export const SCAFFOLD_TS_RELATIVE =
+  "packages/create-zudo-doc/src/scaffold.ts";
+
+/** Path of the target-manifest fixture, relative to the repo root. */
+export const TARGET_MANIFEST_RELATIVE =
+  "packages/zudo-doc/src/__tests__/fixtures/target-manifest/package.json";
+
+/** The dependency key the fixture pins. */
+export const ZUDO_DOC_PACKAGE = "@takazudo/zudo-doc";
+
+// Matches the `ZUDO_DOC_PIN` declaration and captures the quotes around the
+// version so the replacement rewrites only the literal. Tolerates both stable
+// (^X.Y.Z) and prerelease (^X.Y.Z-next.N) forms, with or without the caret —
+// carried over verbatim from the inline Step 2c regex it replaces.
+const SCAFFOLD_PIN_RE =
+  /(export const ZUDO_DOC_PIN\s*=\s*")\^?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?(")/;
+
+// Same shape the release script validates before it gets this far: X.Y.Z with
+// an optional prerelease suffix. An optional leading caret is accepted and
+// normalized away, since the emitted pin always carries one.
+const VERSION_RE = /^\^?([0-9]+\.[0-9]+\.[0-9]+(?:-[a-zA-Z0-9.]+)?)$/;
+
+/**
+ * Rewrite the @takazudo/zudo-doc pin in both lockstep surfaces.
+ *
+ * Throws (never silently no-ops) when either target is missing or does not
+ * contain the pin it is supposed to carry — a silent no-op is precisely the
+ * failure class this helper exists to remove.
+ *
+ * @param {object} options
+ * @param {string} options.repoRoot - absolute path to the repository root
+ * @param {string} options.version - target version, e.g. "5.2.0" or "5.2.0-next.1"
+ * @returns {{ pin: string, files: string[] }} the emitted pin and the absolute
+ *   paths of the files that were rewritten, in the order they were written
+ */
+export function rewriteZudoDocPins({ repoRoot, version } = {}) {
+  if (!repoRoot) {
+    throw new Error("rewriteZudoDocPins: repoRoot is required");
+  }
+  const versionMatch = VERSION_RE.exec(String(version ?? ""));
+  if (!versionMatch) {
+    throw new Error(
+      `rewriteZudoDocPins: invalid version ${JSON.stringify(version)} — expected X.Y.Z or X.Y.Z-<prerelease>`,
+    );
+  }
+  const pin = `^${versionMatch[1]}`;
+
+  const scaffoldPath = resolve(repoRoot, SCAFFOLD_TS_RELATIVE);
+  const manifestPath = resolve(repoRoot, TARGET_MANIFEST_RELATIVE);
+
+  // Read and validate BOTH files before writing either, so a missing pin in
+  // the second one cannot leave the tree half-rewritten.
+  const scaffoldSource = readFileOrThrow(scaffoldPath);
+  if (!SCAFFOLD_PIN_RE.test(scaffoldSource)) {
+    throw new Error(
+      `could not locate the ZUDO_DOC_PIN constant in ${scaffoldPath}`,
+    );
+  }
+
+  const manifestRaw = readFileOrThrow(manifestPath);
+  let manifest;
+  try {
+    manifest = JSON.parse(manifestRaw);
+  } catch (error) {
+    throw new Error(
+      `could not parse ${manifestPath} as JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (
+    !manifest ||
+    typeof manifest.dependencies !== "object" ||
+    manifest.dependencies === null ||
+    typeof manifest.dependencies[ZUDO_DOC_PACKAGE] !== "string"
+  ) {
+    throw new Error(
+      `could not locate the ${ZUDO_DOC_PACKAGE} dependency in ${manifestPath}`,
+    );
+  }
+
+  writeFileSync(scaffoldPath, scaffoldSource.replace(SCAFFOLD_PIN_RE, `$1${pin}$3`));
+
+  manifest.dependencies[ZUDO_DOC_PACKAGE] = pin;
+  // 2-space indent + trailing newline — the shape every other package.json
+  // write in scripts/release-create-zudo-doc.sh produces.
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+  return { pin, files: [scaffoldPath, manifestPath] };
+}
+
+/**
+ * @param {string} path
+ * @returns {string}
+ */
+function readFileOrThrow(path) {
+  try {
+    return readFileSync(path, "utf-8");
+  } catch (error) {
+    if (error instanceof Error && /** @type {any} */ (error).code === "ENOENT") {
+      throw new Error(`could not find ${path}`);
+    }
+    throw error;
+  }
+}
+
+/**
+ * CLI entry — a thin argv parser over `rewriteZudoDocPins`, so the release
+ * script and the unit tests exercise the same code.
+ *
+ * @param {string[]} argv
+ * @returns {number} process exit code
+ */
+export function main(argv) {
+  /** @type {Record<string, string>} */
+  const flags = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--repo-root" || arg === "--version") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        console.error(`Error: ${arg} requires a value`);
+        return usage();
+      }
+      flags[arg] = value;
+      i += 1;
+    } else {
+      console.error(`Error: unknown argument ${arg}`);
+      return usage();
+    }
+  }
+
+  if (!flags["--repo-root"] || !flags["--version"]) {
+    console.error("Error: both --repo-root and --version are required");
+    return usage();
+  }
+
+  try {
+    const { pin, files } = rewriteZudoDocPins({
+      repoRoot: flags["--repo-root"],
+      version: flags["--version"],
+    });
+    for (const file of files) {
+      console.log(`  ✓ ${file} ${ZUDO_DOC_PACKAGE} → ${pin}`);
+    }
+    return 0;
+  } catch (error) {
+    console.error(
+      `Error: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return 1;
+  }
+}
+
+/** @returns {number} */
+function usage() {
+  console.error(
+    "usage: node scripts/lib/rewrite-zudo-doc-pins.mjs --repo-root <dir> --version <X.Y.Z[-next.N]>",
+  );
+  return 1;
+}
+
+const invokedDirectly =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/scripts/release-create-zudo-doc.sh
+++ b/scripts/release-create-zudo-doc.sh
@@ -60,11 +60,15 @@ set -euo pipefail
 #   3. Bumps version in packages/create-zudo-doc/package.json
 #   4. Bumps version in packages/zudo-doc/package.json  (W4A — #1732)
 #   5. Bumps version in packages/doc-history-server/package.json  (W4A — #1732)
-#   6. Bumps the @takazudo/zudo-doc pin in scaffold.ts to ^<new-version>
-#      so the generated package.json points at the zudo-doc version being
-#      released (W4A — #1732). The @takazudo/zfb / @takazudo/zfb-runtime
-#      pins in scaffold.ts are upstream-tracked separately and gated by
-#      scripts/check-pin-parity.mjs — they are NOT touched here.
+#   6. Bumps the @takazudo/zudo-doc pin to ^<new-version> in BOTH lockstep
+#      surfaces — the `ZUDO_DOC_PIN` constant in scaffold.ts (so the generated
+#      package.json points at the zudo-doc version being released, W4A — #1732)
+#      and the target-manifest fixture at
+#      packages/zudo-doc/src/__tests__/fixtures/target-manifest/package.json
+#      (which documents the published shape a consumer gets, #3306). Both are
+#      rewritten by scripts/lib/rewrite-zudo-doc-pins.mjs. The @takazudo/zfb /
+#      @takazudo/zfb-runtime pins in scaffold.ts are upstream-tracked separately
+#      and gated by scripts/check-pin-parity.mjs — they are NOT touched here.
 #   7. Scaffolds EN+JA changelog MDX entries
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -260,30 +264,31 @@ node -e "
 "
 echo "  ✓ $DHS_PKG_JSON → $NEW_VERSION"
 
-# ── Step 2c: Align @takazudo/zudo-doc pin in scaffold.ts (W4A — #1732) ────
-# The generated downstream package.json pins ^X.Y.Z(-next.N)? of @takazudo/zudo-doc;
-# when zudo-doc bumps, the pin must move with it so a fresh scaffold gets
-# the version we just published — including prerelease versions.
-# The pin now lives in the exported `ZUDO_DOC_PIN` constant (scaffold.ts uses it
-# in both generatePackageJson() and scaffold()); check-pin-parity.mjs resolves
-# that constant. The regex matches both stable (^X.Y.Z) and prerelease
-# (^X.Y.Z-next.N) pins. The zfb pins are NOT touched — those track the upstream
-# zfb release cadence and are gated by scripts/check-pin-parity.mjs.
+# ── Step 2c: Align @takazudo/zudo-doc pins — scaffold.ts + fixture (#3306) ────
+# TWO surfaces spell out the released @takazudo/zudo-doc version as a literal
+# and must move together:
+#   - the exported `ZUDO_DOC_PIN` constant in scaffold.ts (used by both
+#     generatePackageJson() and scaffold()), which is what a fresh scaffold's
+#     generated package.json pins — including prerelease versions;
+#   - packages/zudo-doc/src/__tests__/fixtures/target-manifest/package.json,
+#     the fixture documenting the PUBLISHED shape a real consumer gets. Its pin
+#     is documentary (the slow test extracts a packed tarball rather than
+#     resolving from the registry), so drift there fails nothing on its own —
+#     which is how it silently fell a full major behind (#3304).
+# The rewrite lives in scripts/lib/rewrite-zudo-doc-pins.mjs rather than inline
+# here: the release path's failure mode is "the next release breaks", provable
+# only by releasing. Behind an importable seam taking the repo root as a
+# parameter, this exact code is unit-tested against a temp tree
+# (scripts/__tests__/rewrite-zudo-doc-pins.test.ts). It hard-fails if either
+# pin cannot be located, and prints the ✓ line for each file it rewrites.
+# The zfb pins are NOT touched — those track the upstream zfb release cadence
+# and are gated by scripts/check-pin-parity.mjs.
 
 echo ""
-echo "▶ Aligning @takazudo/zudo-doc pin (ZUDO_DOC_PIN) in scaffold.ts..."
-node -e "
-  const fs = require('fs');
-  const src = fs.readFileSync('$SCAFFOLD_TS', 'utf-8');
-  const re = /(export const ZUDO_DOC_PIN\s*=\s*\")\^?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?(\")/;
-  if (!re.test(src)) {
-    console.error('Error: could not locate ZUDO_DOC_PIN constant in $SCAFFOLD_TS');
-    process.exit(1);
-  }
-  const next = src.replace(re, '\$1^$NEW_VERSION\$3');
-  fs.writeFileSync('$SCAFFOLD_TS', next);
-"
-echo "  ✓ $SCAFFOLD_TS @takazudo/zudo-doc → ^$NEW_VERSION"
+echo "▶ Aligning @takazudo/zudo-doc pins (scaffold.ts ZUDO_DOC_PIN + target-manifest fixture)..."
+node "$ROOT_DIR/scripts/lib/rewrite-zudo-doc-pins.mjs" \
+  --repo-root "$ROOT_DIR" \
+  --version "$NEW_VERSION"
 
 # ── Step 2d: Align @takazudo/zudo-doc-history-server pin in scaffold.ts ───────
 # A docHistory-enabled generated package.json carries a direct


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3304
- parent PR
    - https://github.com/zudolab/zudo-doc/pull/3300

---

## Summary

`packages/zudo-doc/src/__tests__/fixtures/target-manifest/package.json` pinned `@takazudo/zudo-doc` at `^4.5.0` while `ZUDO_DOC_PIN` in `packages/create-zudo-doc/src/scaffold.ts` was `^5.1.1` — a full major behind, with nothing guarding it. `CHANGELOG.md` shows the pin was hand-bumped in 4.4.1 and again in 4.4.6, then went unmaintained across 4.5 → 5.1.1: two manual catches followed by silent drift is the signature of a missing guard.

The pin is **documentary, not functional** — the slow test extracts a packed tarball into `node_modules/@takazudo/zudo-doc` and symlinks the rest, so this spec is never resolved from the registry. That is why the staleness produced no test failure and why it could drift indefinitely. The fixture is nonetheless documented as mirroring "the PUBLISHED shape a real `create-zudo-doc` consumer gets", so a pin a major behind made it a misleading reference for exactly the audience it models.

The guard, the release-pipeline wiring, and the corrected value land here as one reviewed change — they are coupled, and splitting them breaks the base:

- the guard **alone** fails immediately (the fixture was already stale);
- the guard **plus the value fix**, without release wiring, passes today and goes red **after the next release bump**, when `release-create-zudo-doc.sh` Step 2c advances `ZUDO_DOC_PIN` past the fixture.

## Changes

### Value realigned (#3305)

Fixture `@takazudo/zudo-doc`: `^4.5.0` → `^5.1.1`, read from the `ZUDO_DOC_PIN` literal rather than hard-coded. One line; no other key touched; file count unchanged (a slow test asserts 17).

### Lockstep rewrite behind a testable seam (#3306)

Step 2c rewrote only `scaffold.ts`, via an inline `node -e` regex, and **nothing** rewrote the fixture. That asymmetry was the drift source.

New `scripts/lib/rewrite-zudo-doc-pins.mjs` exports `rewriteZudoDocPins({ repoRoot, version })` plus a thin `main(argv)` CLI over it, and rewrites **both** surfaces. Taking `repoRoot` as a parameter is what makes it testable against a temp tree — `check-pin-parity.mjs` resolves paths relative to its own location, which makes scratch-copy simulation of the shell step fragile. Both files are read and validated **before either is written**, so a missing pin in the second cannot leave the tree half-rewritten. Missing file, missing `ZUDO_DOC_PIN`, missing dependency key, unparseable JSON, and a malformed version each fail loudly — a silent no-op is the exact failure class this epic removes.

Step 2c now calls the helper; no pin-rewrite regex remains inline. The Step 2c comment and the script's top-level "What it does" summary both name both files.

**Why the seam matters more than the code.** This change's failure mode is "the next release breaks", verifiable only by releasing. The seam converts that into permanent automated coverage — but only if the shipped path and the tested path are the same code. Three layers enforce that: the CLI is a thin argv parser over the exported function (no second implementation to drift); the test spawns the **real CLI** via `execFileSync` in the exact form Step 2c uses; and two wiring assertions read `release-create-zudo-doc.sh` itself — that it invokes the helper with `--repo-root "$ROOT_DIR" --version "$NEW_VERSION"`, and that no inline `node -e` block mentioning `ZUDO_DOC_PIN` survives. The second guard was checked non-vacuous: its regex still matches the 5 remaining `node -e` blocks, 0 of which mention `ZUDO_DOC_PIN`.

### Sixth guarded surface (#3307)

`scripts/check-pin-parity.mjs` now guards the fixture, asserting equality against `readScaffoldPin(...)` — the `ZUDO_DOC_PIN` literal, **not** root `version`. The five existing surfaces split into "external upstream pins, compared to root `dependencies[pkg]`" and "internal packages, compared to root `version`"; the fixture models *a consumer's package.json*, so the value it must mirror is what the scaffold emits. Header comment now enumerates six surfaces and records that this one is documentary, so drift is invisible to the test suite.

This landed in Wave 2 deliberately: with the value corrected and the release wired first, the guard was green the moment it merged, rather than leaving the epic base red.

## Verification (#3308 confirm pass)

The confirm sub-issue was verification-only — no commits, by design.

- **Positive end-to-end — GREEN.** Ran the real `rewriteZudoDocPins({ repoRoot, version })` against a temp copy, then `check-pin-parity.mjs` against that copy: exit 0, reporting `target-manifest fixture dependencies[@takazudo/zudo-doc] = ^5.9.9 (matches scaffold.ts ZUDO_DOC_PIN)`. A **same-major** synthetic version was used — a cross-major jump trips the pre-existing, intentionally-lagging `@takazudo/zudo-doc-history-server` peer floor, an unrelated publish-lag design already documented in the script.
- **Negative control 1 — RED.** With the fixture half of the rewrite disabled (mimicking pre-#3306 behaviour), parity goes red with `Fixture pin drift — target-manifest fixture pins ^5.1.1 but scaffold.ts ZUDO_DOC_PIN is ^5.9.9`. Proves the fixture rewrite is load-bearing, not redundant.
- **Negative control 2 — RED.** Hand-editing the fixture pin makes `pnpm check:pin-parity` exit 1. Durable coverage for this already ships in #3307's test, so it was run rather than duplicated; the real-tree reproduction was `trap`-guarded and restored (verified byte-identical).
- **Green run.** `pnpm check:pin-parity` exit 0 across all 6 surfaces · scripts tests 39/39 · `create-zudo-doc` 595/595 · `@takazudo/zudo-doc` 2074/2074 · `bash -n scripts/release-create-zudo-doc.sh` OK.

Nothing needed fixing — a verification that cannot fail proves nothing, and both controls demonstrably fail for the right reason and only the right reason.

Closes #3305, closes #3306, closes #3307, closes #3308.
