### PR TITLE
Zdtp Lazy Load Triggers: settle autoload semantics, fix empty-envelope over-trigger, cover the resolved toggle channel

### DIFF
--- a/packages/zudo-doc/src/__tests__/design-token-panel-bootstrap.test.ts
+++ b/packages/zudo-doc/src/__tests__/design-token-panel-bootstrap.test.ts
@@ -127,6 +127,11 @@ function dispatchToggle(target: EventTarget): void {
   target.dispatchEvent(new Event("toggle-design-token-panel"));
 }
 
+/** Dispatch on an arbitrary toggle channel (custom / derived / shared). */
+function dispatchOn(target: EventTarget, channel: string): void {
+  target.dispatchEvent(new Event(channel));
+}
+
 /**
  * Flush the interim-listener → dynamic-import → configure promise chain
  * (REAL timers only). Used where nothing is expected to happen — positive
@@ -783,6 +788,284 @@ describe("bootstrapDesignTokenPanel — persisted-state probe envelope policy", 
 
     expect(zdtp.evaluations).toBe(0);
     expect(zdtp.configurePanel).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Resolved toggle channel (#3315, fixing #3292): the interim pre-import
+// listener binds the shared `toggle-design-token-panel` constant PLUS exactly
+// one resolved instance channel — `config.toggleEvent ?? toggle-${prefix}`,
+// mirroring zdtp's own `toggleEventName()` (README §5.3). A configured
+// `toggleEvent` REPLACES the derived name; the pair is never a union.
+// ---------------------------------------------------------------------------
+
+describe("bootstrapDesignTokenPanel — resolved toggle channel", () => {
+  function makeBuilder(config: Record<string, unknown>) {
+    return vi.fn<PanelConfigBuilder>(() => config as unknown as PanelConfig);
+  }
+
+  /** A builder whose prefix (and therefore derived channel) follows the mode. */
+  function makeModeBuilder() {
+    return vi.fn<PanelConfigBuilder>(
+      (mode) => ({ storagePrefix: `test-panel-${mode}` }) as unknown as PanelConfig,
+    );
+  }
+
+  beforeEach(() => {
+    zdtp.configurePanel.mockImplementation((cfg: PanelConfig) => ({
+      instanceId: cfg.storagePrefix,
+      destroy: vi.fn(),
+    }));
+  });
+
+  it("a host-configured custom toggleEvent triggers the dynamic import before load", async () => {
+    const browser = installBrowser();
+
+    bootstrapDesignTokenPanel(
+      makeBuilder({ storagePrefix: "test-panel", toggleEvent: "acme-open-tokens" }),
+    );
+    dispatchOn(browser.windowTarget, "acme-open-tokens");
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+
+    expect(zdtp.evaluations).toBe(1);
+    expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce();
+  });
+
+  it("the derived toggle-<storagePrefix> channel triggers it when no toggleEvent is configured", async () => {
+    const browser = installBrowser();
+
+    bootstrapDesignTokenPanel(makeBuilder({ storagePrefix: "test-panel" }));
+    dispatchOn(browser.windowTarget, "toggle-test-panel");
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+
+    expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce();
+  });
+
+  it("derives the channel from the PACK-SCOPED prefix when a non-default pack is active at boot", async () => {
+    const browser = installBrowser("light", "foundry");
+
+    bootstrapDesignTokenPanel(makeBuilder({ storagePrefix: "test-panel" }));
+    // The unscoped name belongs to a namespace that is not active — inert.
+    dispatchOn(browser.windowTarget, "toggle-test-panel");
+    await settle();
+    expect(zdtp.evaluations).toBe(0);
+
+    dispatchOn(browser.windowTarget, "toggle-test-panel--foundry");
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+  });
+
+  it("a configured toggleEvent REPLACES the derived name: the derived channel is not registered", async () => {
+    const browser = installBrowser();
+
+    bootstrapDesignTokenPanel(
+      makeBuilder({ storagePrefix: "test-panel", toggleEvent: "acme-open-tokens" }),
+    );
+    // zdtp would not honour `toggle-test-panel` for this instance either, so
+    // activating on it here would make the pre- and post-import channels
+    // disagree (the union hazard #3315 rules out).
+    dispatchOn(browser.windowTarget, "toggle-test-panel");
+    await settle();
+
+    expect(zdtp.evaluations).toBe(0);
+    expect(zdtp.configurePanel).not.toHaveBeenCalled();
+  });
+
+  it("keeps the shared channel live alongside a custom toggleEvent (no regression)", async () => {
+    const browser = installBrowser();
+
+    bootstrapDesignTokenPanel(
+      makeBuilder({ storagePrefix: "test-panel", toggleEvent: "acme-open-tokens" }),
+    );
+    dispatchToggle(browser.windowTarget);
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+
+    expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce();
+  });
+
+  it("ignores a custom toggleEvent for zdtp's OWN default prefix — that instance keeps the shared name", async () => {
+    const browser = installBrowser();
+    // zdtp's `toggleEventName()` short-circuits on the default storagePrefix
+    // and returns the historical shared name, discarding `toggleEvent`
+    // entirely (README §5.3; verified against the 0.4.9 bundle).
+    bootstrapDesignTokenPanel(
+      makeBuilder({
+        storagePrefix: "zudo-design-token-panel",
+        toggleEvent: "acme-open-tokens",
+      }),
+    );
+
+    dispatchOn(browser.windowTarget, "acme-open-tokens");
+    await settle();
+    expect(zdtp.evaluations).toBe(0);
+
+    dispatchToggle(browser.windowTarget);
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce();
+  });
+
+  it("a toggleEvent equal to the shared constant binds ONE listener: one dispatch, one net show", async () => {
+    const browser = installBrowser();
+    // The observable discriminator for double registration, asserted instead
+    // of the closure-local `pendingToggles`: two bindings would count ONE
+    // dispatch as TWO intents, making the net intent EVEN — configure would
+    // still run, but the panel would never be shown.
+    bootstrapDesignTokenPanel(
+      makeBuilder({
+        storagePrefix: "test-panel",
+        toggleEvent: "toggle-design-token-panel",
+      }),
+    );
+    dispatchToggle(browser.windowTarget);
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    await settle();
+
+    expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce();
+  });
+
+  it("two dispatches on two DISTINCT channels stay two intents (net even → no show)", async () => {
+    const browser = installBrowser();
+
+    bootstrapDesignTokenPanel(makeBuilder({ storagePrefix: "test-panel" }));
+    // Genuinely two toggle intents — the dedupe Set guards registration, never
+    // dispatch counting, so these must NOT collapse into one.
+    dispatchToggle(browser.windowTarget);
+    dispatchOn(browser.windowTarget, "toggle-test-panel");
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    await settle();
+
+    expect(zdtp.showDesignTokenPanel).not.toHaveBeenCalled();
+  });
+
+  it("a pack switch while pending rebinds the instance channel AND unbinds the old pack's", async () => {
+    const browser = installBrowser("light", "default");
+    const builder = makeBuilder({ storagePrefix: "test-panel" });
+
+    bootstrapDesignTokenPanel(builder);
+    browser.setPack("foundry");
+    browser.windowTarget.dispatchEvent(new Event("theme-pack-changed"));
+    await settle();
+    // Clean storage: the pack switch refreshed the channel without activating.
+    expect(zdtp.evaluations).toBe(0);
+
+    // STALE-CHANNEL REMOVAL, asserted explicitly: the pre-switch pack's channel
+    // must be gone, or it would keep starting an import for a namespace the
+    // user has left.
+    dispatchOn(browser.windowTarget, "toggle-test-panel");
+    await settle();
+    expect(zdtp.evaluations).toBe(0);
+    expect(zdtp.configurePanel).not.toHaveBeenCalled();
+
+    dispatchOn(browser.windowTarget, "toggle-test-panel--foundry");
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    expect(zdtp.configurePanel).toHaveBeenCalledWith(
+      expect.objectContaining({ storagePrefix: "test-panel--foundry" }),
+    );
+  });
+
+  it("a color-scheme change while pending rebinds a mode-dependent channel AND unbinds the old mode's", async () => {
+    const browser = installBrowser("light");
+    const builder = makeModeBuilder();
+
+    bootstrapDesignTokenPanel(builder);
+    browser.setMode("dark");
+    browser.windowTarget.dispatchEvent(new Event("color-scheme-changed"));
+    await settle();
+    expect(zdtp.evaluations).toBe(0);
+
+    dispatchOn(browser.windowTarget, "toggle-test-panel-light");
+    await settle();
+    expect(zdtp.evaluations).toBe(0);
+    expect(zdtp.configurePanel).not.toHaveBeenCalled();
+
+    dispatchOn(browser.windowTarget, "toggle-test-panel-dark");
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    expect(zdtp.configurePanel).toHaveBeenCalledWith(
+      expect.objectContaining({ storagePrefix: "test-panel-dark" }),
+    );
+  });
+
+  it("switching back to the boot pack rebinds its channel rather than accumulating a third", async () => {
+    const browser = installBrowser("light", "default");
+
+    bootstrapDesignTokenPanel(makeBuilder({ storagePrefix: "test-panel" }));
+    browser.setPack("foundry");
+    browser.windowTarget.dispatchEvent(new Event("theme-pack-changed"));
+    browser.setPack("default");
+    browser.windowTarget.dispatchEvent(new Event("theme-pack-changed"));
+    await settle();
+
+    dispatchOn(browser.windowTarget, "toggle-test-panel--foundry");
+    await settle();
+    expect(zdtp.evaluations).toBe(0);
+
+    dispatchOn(browser.windowTarget, "toggle-test-panel");
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    // One dispatch reached exactly one live binding → odd net intent.
+    expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce();
+  });
+
+  it("the shared channel survives a refresh whose resolved name equals it", async () => {
+    const browser = installBrowser("light", "default");
+    // The instance channel resolves to the shared constant at boot, then moves
+    // away on the pack switch. The removal branch must leave the shared
+    // registration alone — it is bound for the whole pending phase.
+    let hostToggleEvent = "toggle-design-token-panel";
+    const builder = vi.fn<PanelConfigBuilder>(
+      () =>
+        ({
+          storagePrefix: "test-panel",
+          toggleEvent: hostToggleEvent,
+        }) as unknown as PanelConfig,
+    );
+
+    bootstrapDesignTokenPanel(builder);
+    hostToggleEvent = "acme-open-tokens";
+    browser.setPack("foundry");
+    browser.windowTarget.dispatchEvent(new Event("theme-pack-changed"));
+    await settle();
+
+    dispatchToggle(browser.windowTarget);
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce();
+  });
+
+  it("the pre-hydration click-queue drain still counts exactly one toggle with both channels bound", async () => {
+    const browser = installBrowser();
+    // The drain re-dispatches the shared event synchronously — both channels
+    // are already bound by then (registration precedes the drain), and the
+    // single dispatch must still net exactly one show.
+    browser.windowTarget.__zdtpReadyClicks = () =>
+      dispatchToggle(browser.windowTarget);
+
+    bootstrapDesignTokenPanel(makeBuilder({ storagePrefix: "test-panel" }));
+    await vi.waitFor(() =>
+      expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce(),
+    );
+
+    expect(zdtp.configurePanel).toHaveBeenCalledOnce();
+  });
+
+  it("every channel becomes a no-op once configurePhase leaves pending", async () => {
+    const browser = installBrowser();
+
+    bootstrapDesignTokenPanel(
+      makeBuilder({ storagePrefix: "test-panel", toggleEvent: "acme-open-tokens" }),
+    );
+    dispatchToggle(browser.windowTarget);
+    await vi.waitFor(() =>
+      expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce(),
+    );
+
+    // Post-configure dispatches belong to the listeners zdtp binds itself;
+    // handling them here too would double-toggle every click.
+    dispatchToggle(browser.windowTarget);
+    dispatchOn(browser.windowTarget, "acme-open-tokens");
+    dispatchOn(browser.windowTarget, "toggle-test-panel");
+    await settle();
+
+    expect(zdtp.configurePanel).toHaveBeenCalledOnce();
+    expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce();
+    expect(zdtp.evaluations).toBe(1);
   });
 });
 

--- a/packages/zudo-doc/src/__tests__/design-token-panel-bootstrap.test.ts
+++ b/packages/zudo-doc/src/__tests__/design-token-panel-bootstrap.test.ts
@@ -402,6 +402,14 @@ describe("bootstrapDesignTokenPanel — lazy zdtp load", () => {
 // zdtp eagerly at mount so overrides do not silently revert.
 // ---------------------------------------------------------------------------
 
+/**
+ * A `-state*` envelope carrying at least one override. Seeded wherever a test
+ * needs the probe's state branch to FIRE: since #3314 the branch is
+ * content-based, so `"{}"` no longer triggers it and would silently turn any
+ * such test into a no-op assertion.
+ */
+const NON_EMPTY_ENVELOPE = '{"--zd-accent":"#f00"}';
+
 describe("bootstrapDesignTokenPanel — persisted-state probe", () => {
   function makeBuilder(prefix = "test-panel") {
     return vi.fn<PanelConfigBuilder>(
@@ -416,9 +424,9 @@ describe("bootstrapDesignTokenPanel — persisted-state probe", () => {
     }));
   });
 
-  it("a seeded -state-v4 key triggers an eager configure without any toggle (and no show)", async () => {
+  it("a seeded non-empty -state-v4 key triggers an eager configure without any toggle (and no show)", async () => {
     const browser = installBrowser();
-    browser.values.set("test-panel-state-v4", "{}");
+    browser.values.set("test-panel-state-v4", NON_EMPTY_ENVELOPE);
 
     bootstrapDesignTokenPanel(makeBuilder());
     await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
@@ -434,7 +442,7 @@ describe("bootstrapDesignTokenPanel — persisted-state probe", () => {
 
   it("an unversioned -state key triggers the eager configure (version-agnostic stem match)", async () => {
     const browser = installBrowser();
-    browser.values.set("test-panel-state", "{}");
+    browser.values.set("test-panel-state", NON_EMPTY_ENVELOPE);
 
     bootstrapDesignTokenPanel(makeBuilder());
     await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
@@ -452,7 +460,7 @@ describe("bootstrapDesignTokenPanel — persisted-state probe", () => {
 
   it("probes the pack-scoped prefix when a non-default pack is active", async () => {
     const browser = installBrowser("light", "foundry");
-    browser.values.set("test-panel--foundry-state-v4", "{}");
+    browser.values.set("test-panel--foundry-state-v4", NON_EMPTY_ENVELOPE);
 
     bootstrapDesignTokenPanel(makeBuilder());
     await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
@@ -516,11 +524,29 @@ describe("bootstrapDesignTokenPanel — persisted-state probe", () => {
     await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
   });
 
+  it(":autoload == \"1\" with :visible == \"0\" still triggers — the documented owner-mode-armed steady state", async () => {
+    const browser = installBrowser();
+    // zdtp README §10.1: `disableAutoload()` clears `:autoload`, `:visible`,
+    // `-elpath-enabled` and the open-state key TOGETHER, so this pair is an
+    // owner with the panel mounted closed — not a stale flag. Reviewed and
+    // deliberately left triggering in #3313; a `:visible=0` veto would break
+    // exactly this case (upstream: Takazudo/zudo-design-token-panel#565).
+    browser.values.set("test-panel:autoload", "1");
+    browser.values.set("test-panel:visible", "0");
+
+    bootstrapDesignTokenPanel(makeBuilder());
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    await settle();
+
+    // Armed, not opened: the probe never issues an explicit show().
+    expect(zdtp.showDesignTokenPanel).not.toHaveBeenCalled();
+  });
+
   it("a pre-load pack switch onto a namespace with saved state triggers the eager load", async () => {
     const browser = installBrowser("light", "default");
     // The boot-time (default-pack) namespace is clean, but the foundry
     // namespace has saved overrides.
-    browser.values.set("test-panel--foundry-state-v4", "{}");
+    browser.values.set("test-panel--foundry-state-v4", NON_EMPTY_ENVELOPE);
 
     bootstrapDesignTokenPanel(makeBuilder());
     await settle();
@@ -555,7 +581,7 @@ describe("bootstrapDesignTokenPanel — persisted-state probe", () => {
     const browser = installBrowser("light", "foundry");
     // Saved tweaks exist, but only under the DEFAULT pack's namespace — the
     // active (foundry-scoped) namespace has nothing to restore.
-    browser.values.set("test-panel-state-v4", "{}");
+    browser.values.set("test-panel-state-v4", NON_EMPTY_ENVELOPE);
 
     bootstrapDesignTokenPanel(makeBuilder());
     await settle();
@@ -567,7 +593,7 @@ describe("bootstrapDesignTokenPanel — persisted-state probe", () => {
   it("ignores unrelated apps' keys — no whole-localStorage suffix scan", async () => {
     installBrowser();
     const browser = installBrowser();
-    browser.values.set("other-app-state-v4", "{}");
+    browser.values.set("other-app-state-v4", NON_EMPTY_ENVELOPE);
     browser.values.set("test-panel-open", "0");
 
     bootstrapDesignTokenPanel(makeBuilder());
@@ -579,7 +605,7 @@ describe("bootstrapDesignTokenPanel — persisted-state probe", () => {
 
   it("a toggle while the probe-initiated import is in flight coalesces into the same configure", async () => {
     const browser = installBrowser();
-    browser.values.set("test-panel-state-v4", "{}");
+    browser.values.set("test-panel-state-v4", NON_EMPTY_ENVELOPE);
 
     bootstrapDesignTokenPanel(makeBuilder());
     dispatchToggle(browser.windowTarget);
@@ -613,6 +639,150 @@ describe("bootstrapDesignTokenPanel — persisted-state probe", () => {
     // The lazy toggle path must still work with storage disabled.
     dispatchToggle(browser.windowTarget);
     await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Envelope-content policy (#3314, locked by the #3313 decision): the
+// `${prefix}-state*` branch of the probe tests CONTENT, not key presence.
+// Organizing principle — trigger unless the value is PROVABLY empty, where
+// provably empty is exactly `{}`, `[]`, and the literal `null`.
+// ---------------------------------------------------------------------------
+
+describe("bootstrapDesignTokenPanel — persisted-state probe envelope policy", () => {
+  function makeBuilder(prefix = "test-panel") {
+    return vi.fn<PanelConfigBuilder>(
+      () => ({ storagePrefix: prefix }) as unknown as PanelConfig,
+    );
+  }
+
+  beforeEach(() => {
+    zdtp.configurePanel.mockImplementation((cfg: PanelConfig) => ({
+      instanceId: cfg.storagePrefix,
+      destroy: vi.fn(),
+    }));
+  });
+
+  /** Every row of the locked table, keyed by the RAW persisted value. */
+  const ENVELOPE_TRUTH_TABLE: ReadonlyArray<{
+    label: string;
+    raw: string;
+    triggers: boolean;
+  }> = [
+    { label: "an empty object", raw: "{}", triggers: false },
+    { label: "an empty array", raw: "[]", triggers: false },
+    { label: "the literal null", raw: "null", triggers: false },
+    { label: "a non-empty object", raw: '{"--zd-accent":"#f00"}', triggers: true },
+    { label: "a non-empty array", raw: '["--zd-accent"]', triggers: true },
+    { label: "a string primitive", raw: '"x"', triggers: true },
+    // `0` and `false` are the traps: falsy, but not containers we can PROVE
+    // are empty, so the conservative branch keeps them triggering.
+    { label: "the number 0", raw: "0", triggers: true },
+    { label: "the boolean false", raw: "false", triggers: true },
+    // Malformed values are handed to zdtp to migrate or reject rather than
+    // silently discarded here — the `catch` returns "not empty". Inverting
+    // this branch is the single easiest mistake to make in the predicate.
+    { label: "malformed JSON", raw: "{not json", triggers: true },
+    { label: "the empty string (malformed JSON)", raw: "", triggers: true },
+  ];
+
+  it.each(ENVELOPE_TRUTH_TABLE.filter((row) => row.triggers))(
+    "a -state-v4 envelope holding $label triggers the eager configure",
+    async ({ raw }) => {
+      const browser = installBrowser();
+      browser.values.set("test-panel-state-v4", raw);
+
+      bootstrapDesignTokenPanel(makeBuilder());
+      await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    },
+  );
+
+  it.each(ENVELOPE_TRUTH_TABLE.filter((row) => !row.triggers))(
+    "a -state-v4 envelope holding $label stays lazy until a toggle",
+    async ({ raw }) => {
+      const browser = installBrowser();
+      browser.values.set("test-panel-state-v4", raw);
+
+      bootstrapDesignTokenPanel(makeBuilder());
+      await settle();
+
+      expect(zdtp.evaluations).toBe(0);
+      expect(zdtp.configurePanel).not.toHaveBeenCalled();
+
+      // Narrowed, not disabled: the toggle path still activates.
+      dispatchToggle(browser.windowTarget);
+      await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    },
+  );
+
+  it("nothing persisted at all stays lazy (the absent-key row)", async () => {
+    installBrowser();
+
+    bootstrapDesignTokenPanel(makeBuilder());
+    await settle();
+
+    expect(zdtp.evaluations).toBe(0);
+    expect(zdtp.configurePanel).not.toHaveBeenCalled();
+  });
+
+  it("ORs across every matching key: an empty -state-v4 does not stop the scan reaching a non-empty -state-v3", async () => {
+    const browser = installBrowser();
+    // ACCEPTED FALSE POSITIVE, asserted as INTENDED behaviour so it cannot be
+    // silently "fixed": zdtp README §9 says an empty v4 key shadows the legacy
+    // v3 chain, so nothing would actually be applied here. Recognising that
+    // would require the probe to learn the version precedence, which the
+    // #3282 schema-agnostic mandate forbids — the OR stays version-blind.
+    // Insertion order matters: the empty v4 key is scanned FIRST.
+    browser.values.set("test-panel-state-v4", "{}");
+    browser.values.set("test-panel-state-v3", NON_EMPTY_ENVELOPE);
+
+    bootstrapDesignTokenPanel(makeBuilder());
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+  });
+
+  it("several empty envelopes across versions still stay lazy", async () => {
+    const browser = installBrowser();
+    browser.values.set("test-panel-state-v4", "{}");
+    browser.values.set("test-panel-state-v3", "{}");
+
+    bootstrapDesignTokenPanel(makeBuilder());
+    await settle();
+
+    expect(zdtp.evaluations).toBe(0);
+    expect(zdtp.configurePanel).not.toHaveBeenCalled();
+  });
+
+  it("a sibling pack's non-empty envelope never matches the base prefix stem", async () => {
+    const browser = installBrowser("light", "default");
+    // The `--<slug>` separator keeps sibling namespaces out of the
+    // `<prefix>-state` stem — unchanged by the content narrowing, so a
+    // NON-EMPTY value is what makes this assertion meaningful.
+    browser.values.set("test-panel--foundry-state-v4", NON_EMPTY_ENVELOPE);
+
+    bootstrapDesignTokenPanel(makeBuilder());
+    await settle();
+
+    expect(zdtp.evaluations).toBe(0);
+    expect(zdtp.configurePanel).not.toHaveBeenCalled();
+  });
+
+  it("a non-empty envelope is still ignored when storage throws", async () => {
+    installBrowser();
+    vi.stubGlobal("localStorage", {
+      getItem: () => NON_EMPTY_ENVELOPE,
+      key: () => {
+        throw new Error("storage access denied");
+      },
+      get length(): number {
+        throw new Error("storage access denied");
+      },
+    });
+
+    bootstrapDesignTokenPanel(makeBuilder());
+    await settle();
+
+    expect(zdtp.evaluations).toBe(0);
+    expect(zdtp.configurePanel).not.toHaveBeenCalled();
   });
 });
 
@@ -750,7 +920,7 @@ describe("bootstrapDesignTokenPanel — theme-pack interplay", () => {
     builder: PanelConfigBuilder,
     activePrefix: string,
   ): Promise<void> {
-    browser.values.set(`${activePrefix}-state-v4`, "{}");
+    browser.values.set(`${activePrefix}-state-v4`, NON_EMPTY_ENVELOPE);
     bootstrapDesignTokenPanel(builder);
     await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
   }

--- a/packages/zudo-doc/src/design-token-panel-bootstrap.tsx
+++ b/packages/zudo-doc/src/design-token-panel-bootstrap.tsx
@@ -7,9 +7,11 @@
  * Design-token panel (zdtp) WIRING MECHANISM + PACKAGE-DEFAULT ISLAND (#2658,
  * epic Minimal Scaffold #2651). zdtp itself is LAZY-LOADED (#3282, epic
  * #3261): this module carries NO top-level value import of `@takazudo/zdtp` —
- * the package is `import()`ed on the first `toggle-design-token-panel`
- * dispatch, or eagerly when the persisted-state probe finds saved tweaks / a
- * previously-open panel, so zdtp's bundle stays out of the initial page load.
+ * the package is `import()`ed on the first dispatch on either resolved toggle
+ * channel (the shared `toggle-design-token-panel`, or this instance's own —
+ * see {@link resolveInstanceToggleEvent}), or eagerly when the persisted-state
+ * probe finds saved tweaks / a previously-open panel, so zdtp's bundle stays
+ * out of the initial page load.
  *
  * `bootstrapDesignTokenPanel` is a callable that configures zdtp's panel and
  * wires its lifecycle hooks to zfb's navigation events via
@@ -112,12 +114,47 @@ const COLOR_SCHEME_CHANGED_EVENT = "color-scheme-changed";
 /**
  * The shared panel-toggle window event: dispatched by the header palette
  * button and re-dispatched by the SSR pre-hydration shim's `__zdtpReadyClicks`
- * drain. Once `@takazudo/zdtp` has loaded, its own module-scope listener owns
- * this channel; before that, the interim listener in
+ * drain. Once `@takazudo/zdtp` has loaded, the module-scope listener it binds
+ * for its DEFAULT instance owns this channel (and routes the dispatch to
+ * whichever instance is active); before that, the interim listener in
  * {@link bootstrapDesignTokenPanel} uses it to trigger the lazy load.
  * Cross-package contract — do not rename.
  */
 const TOGGLE_PANEL_EVENT = "toggle-design-token-panel";
+
+/**
+ * zdtp's OWN default `storagePrefix` — the value that makes an instance "the
+ * default instance" for {@link resolveInstanceToggleEvent}. Not a value this
+ * package ever configures (the package default is `zudo-doc-tweak`), but a
+ * host is free to, and the rule below hinges on it. Verified against the
+ * installed zdtp 0.4.9 bundle (`dist/panel-config-*.js`), which is also where
+ * zdtp's exported `DEFAULT_TOGGLE_EVENT` / `toggleEventName()` live — we
+ * cannot import either, because a value import of `@takazudo/zdtp` here would
+ * defeat the whole lazy load (#3282).
+ */
+const ZDTP_DEFAULT_STORAGE_PREFIX = "zudo-design-token-panel";
+
+/**
+ * The window-event name that toggles THIS instance once zdtp has loaded — a
+ * verbatim mirror of zdtp's `toggleEventName(cfg)` (README §5.3's config
+ * table, and the same three-branch expression in the installed 0.4.9 bundle):
+ *
+ * - default instance (prefix === {@link ZDTP_DEFAULT_STORAGE_PREFIX}) → the
+ *   historical shared name, and a configured `toggleEvent` is IGNORED;
+ * - otherwise → `config.toggleEvent` when supplied,
+ * - else the derived `toggle-${storagePrefix}`.
+ *
+ * A configured `toggleEvent` REPLACES the derived name rather than coexisting
+ * with it (#3315) — registering shared + custom + derived as a union would let
+ * the interim listener activate on a derived name zdtp itself would not honour
+ * after configure, so the pre-import and post-import channels would disagree.
+ */
+function resolveInstanceToggleEvent(config: PanelConfig): string {
+  if (config.storagePrefix === ZDTP_DEFAULT_STORAGE_PREFIX) {
+    return TOGGLE_PANEL_EVENT;
+  }
+  return config.toggleEvent ?? `toggle-${config.storagePrefix}`;
+}
 
 /**
  * The panel's own open-state key for a given instance (`${storagePrefix}-open`,
@@ -356,9 +393,10 @@ function clearAppliedTokenOverrides(config: PanelConfig): void {
 }
 
 /**
- * Bootstrap zdtp for a project — LAZILY (#3282). At mount this registers an
- * interim `toggle-design-token-panel` listener, drains the pre-hydration
- * click queue, and probes localStorage for persisted panel state; the actual
+ * Bootstrap zdtp for a project — LAZILY (#3282). At mount this registers the
+ * interim toggle listener on both resolved channels (#3315), drains the
+ * pre-hydration click queue, and probes localStorage for persisted panel
+ * state; the actual
  * `import("@takazudo/zdtp")` + configure happen on the first toggle (or
  * immediately on a probe hit). The configure body then wires everything the
  * pre-lazy version wired eagerly: `configurePanel` with the pack-scoped
@@ -571,58 +609,136 @@ export function bootstrapDesignTokenPanel(
     pendingToggles = 0;
   }
 
-  // Interim toggle listener, registered BEFORE the click-queue drain below so
+  /**
+   * The pack-scoped PanelConfig for the LIVE mode + pack — byte-identical to
+   * what the configure body builds, so the interim listener's channel and the
+   * probe's namespace can never disagree with the eventual instance. Each call
+   * invokes the host builder once; callers needing both the toggle channel and
+   * the probe prefix share ONE call rather than building twice.
+   */
+  function readActiveConfig(): PanelConfig {
+    return withPackScopedStoragePrefix(
+      buildConfig(readMode()),
+      readThemePackFromDom(),
+    );
+  }
+
+  // Interim toggle handler, registered BEFORE the click-queue drain below so
   // the drain's synchronous re-dispatch of a queued pre-hydration click lands
   // here (counting as toggle intent and starting the lazy load). Once
-  // configure completes, zdtp's own module-scope listener — installed when
-  // the dynamic import evaluated — owns every subsequent dispatch; handling
-  // them here too would double-toggle each click, so this listener becomes a
-  // permanent no-op the moment configurePhase leaves "pending".
-  window.addEventListener(TOGGLE_PANEL_EVENT, () => {
+  // configure completes, the listeners zdtp binds itself — when the dynamic
+  // import evaluated, and again inside configurePanel — own every subsequent
+  // dispatch on both channels; handling them here too would double-toggle each
+  // click, so this handler becomes a permanent no-op the moment configurePhase
+  // leaves "pending".
+  const onInterimToggle = (): void => {
     if (configurePhase !== "pending") return;
     pendingToggles += 1;
     void activate();
-  });
+  };
+
+  // Channel names `onInterimToggle` is currently bound to (#3315) — the
+  // double-registration guard. A host whose `toggleEvent` equals the shared
+  // constant (or whose derived channel does) must bind ONE listener, not two,
+  // or a single dispatch would count as two toggle intents and flip the net
+  // odd/even result — configure would run, but the panel would never open.
+  //
+  // It does NOT collapse two dispatches of two DISTINCT events: those are
+  // genuinely two intents. (A DOM `Event` carries exactly one `type`, so one
+  // dispatch can never reach two channel names — binding the same name twice
+  // is the only double-count path there is.)
+  //
+  // Belt-and-braces, deliberately: `addEventListener` already ignores a repeat
+  // registration of an identical (type, callback, capture) triple, and every
+  // call here shares the one `onInterimToggle` reference, so the DOM alone
+  // would cover today's code. The Set states the invariant explicitly and
+  // keeps it holding if a future edit ever wraps the handler per channel — at
+  // which point the DOM's dedupe silently stops applying.
+  const boundToggleChannels = new Set<string>();
+  // The instance channel currently bound, so a refresh can REPLACE it.
+  let instanceToggleChannel: string | null = null;
+
+  function bindToggleChannel(name: string): void {
+    if (boundToggleChannels.has(name)) return;
+    boundToggleChannels.add(name);
+    window.addEventListener(name, onInterimToggle);
+  }
+
+  /**
+   * Re-resolve the per-instance channel and swap the binding — REPLACE, never
+   * accumulate. The resolved name derives from `storagePrefix`, which changes
+   * with the active theme pack (and, for a mode-dependent builder, with the
+   * color scheme); merely adding the new name would leave a stale listener that
+   * still starts an import for a pack the user has already left. The shared
+   * constant is exempt from removal: it is bound unconditionally for the whole
+   * pending phase, so a host whose resolved channel happens to equal it must
+   * not have it unbound out from under the shared registration.
+   */
+  function refreshInstanceToggleChannel(config: PanelConfig): void {
+    const resolved = resolveInstanceToggleEvent(config);
+    if (resolved === instanceToggleChannel) return;
+    if (
+      instanceToggleChannel !== null &&
+      instanceToggleChannel !== TOGGLE_PANEL_EVENT
+    ) {
+      window.removeEventListener(instanceToggleChannel, onInterimToggle);
+      boundToggleChannels.delete(instanceToggleChannel);
+    }
+    instanceToggleChannel = resolved;
+    bindToggleChannel(resolved);
+  }
+
+  const bootConfig = readActiveConfig();
+  bindToggleChannel(TOGGLE_PANEL_EVENT);
+  refreshInstanceToggleChannel(bootConfig);
 
   // Drain the pre-hydration click queue. If the user clicked the palette
   // button before this Island evaluated, the SSR shim (see
   // `doc-body-end-islands/design-token-panel-island.tsx`) captured the event
   // as a single boolean flag. Calling __zdtpReadyClicks() here removes the
-  // shim listener and re-dispatches once (at most) so the interim listener
+  // shim listener and re-dispatches once (at most) so the interim handler
   // above picks it up.
   (window as { __zdtpReadyClicks?: () => void }).__zdtpReadyClicks?.();
 
   // Persisted-state PROBE (#3282): a returning user with saved tweaks or a
   // previously-open panel must not wait for a toggle — without this eager
   // load their overrides would silently revert until they opened the panel.
-  // The probed prefix is computed from the statically-available builder plus
-  // the SAME pack scoping configure applies, so it names EXACTLY the active
-  // namespace (including the `<prefix>--<slug>` pack-scoped variant; package
-  // default `zudo-doc-tweak`, host-overridable). On a hit, zdtp's parked
-  // post-configure hook re-applies the overrides and re-opens a
-  // previously-open panel once configure runs.
-  const probePrefix = withPackScopedStoragePrefix(
-    buildConfig(readMode()),
-    readThemePackFromDom(),
-  ).storagePrefix;
-  if (hasPersistedPanelState(probePrefix)) void activate();
+  // The probed prefix comes from the same `readActiveConfig()` result the
+  // toggle channel resolved from, so it names EXACTLY the active namespace
+  // (including the `<prefix>--<slug>` pack-scoped variant; package default
+  // `zudo-doc-tweak`, host-overridable). On a hit, zdtp's parked post-configure
+  // hook re-applies the overrides and re-opens a previously-open panel once
+  // configure runs.
+  if (hasPersistedPanelState(bootConfig.storagePrefix)) void activate();
 
-  // Pre-load pack-change probe (review finding): switching to a pack whose
-  // namespace holds persisted state must trigger the same eager load — the
-  // post-import theme-pack-changed rebuild listener does not exist yet, so
-  // without this the incoming pack's saved overrides would sit unapplied
-  // until a toggle (parity with the eager era, where the rebuild listener ran
-  // from boot). Permanently no-ops once configurePhase leaves "pending": from
-  // then on the configure body's own listener owns the event, and configure
-  // itself always reads the pack live, so an in-flight activation needs no
-  // help from this handler either.
+  // Pre-load pack-change handling, folded into ONE listener (review finding +
+  // #3315): switching to a pack whose namespace holds persisted state must
+  // trigger the same eager load — the post-import theme-pack-changed rebuild
+  // listener does not exist yet, so without this the incoming pack's saved
+  // overrides would sit unapplied until a toggle (parity with the eager era,
+  // where the rebuild listener ran from boot) — AND the new pack's namespace
+  // resolves a different instance toggle channel, which must replace the old
+  // pack's. Permanently no-ops once configurePhase leaves "pending": from then
+  // on the configure body's own listener owns the event, and configure itself
+  // always reads the pack live, so an in-flight activation needs no help from
+  // this handler either.
   window.addEventListener(THEME_PACK_CHANGED_EVENT, () => {
     if (configurePhase !== "pending") return;
-    const packScopedPrefix = withPackScopedStoragePrefix(
-      buildConfig(readMode()),
-      readThemePackFromDom(),
-    ).storagePrefix;
-    if (hasPersistedPanelState(packScopedPrefix)) void activate();
+    const activeConfig = readActiveConfig();
+    refreshInstanceToggleChannel(activeConfig);
+    if (hasPersistedPanelState(activeConfig.storagePrefix)) void activate();
+  });
+
+  // The color-scheme twin of the refresh above (#3315). `buildConfig(mode)` may
+  // make `storagePrefix` — and therefore the derived channel — mode-dependent,
+  // so a light/dark toggle during the pending phase can retarget the instance
+  // channel exactly like a pack switch does. It deliberately does NOT re-run
+  // the persisted-state probe: which namespaces are worth an eager load is the
+  // probe's own contract (#3313/#3314), and widening its trigger set is out of
+  // scope here. Same permanent no-op after configure, for the same reason.
+  window.addEventListener(COLOR_SCHEME_CHANGED_EVENT, () => {
+    if (configurePhase !== "pending") return;
+    refreshInstanceToggleChannel(readActiveConfig());
   });
 }
 

--- a/packages/zudo-doc/src/design-token-panel-bootstrap.tsx
+++ b/packages/zudo-doc/src/design-token-panel-bootstrap.tsx
@@ -167,17 +167,76 @@ const ACTIVATION_FLAG_KEY_SUFFIXES = [
 ] as const;
 
 /**
- * Persisted-state probe predicate (#3282): does the ACTIVE storage namespace
- * hold zdtp state worth an eager load? True when the public `${prefix}-open`
- * mirror or any {@link ACTIVATION_FLAG_KEY_SUFFIXES} flag reads `"1"`, or any
- * `${prefix}-state*` key exists — the bare stem match keeps it
- * version-agnostic across `-state`, `-state-v2`/`-v3`/`-v4`, and future
- * schema revisions without enumerating them. The scan is anchored to the
- * EXACT active prefix; a whole-localStorage suffix scan is deliberately off
- * the table (it would false-positive on unrelated apps' `*-state` keys).
- * Note the pack-scoped `--<slug>` separator keeps sibling namespaces out:
- * `<prefix>--<pack>-state` never matches the `<prefix>-state` stem.
- * Guarded: disabled/throwing storage reads as "no persisted state".
+ * Is a persisted `${prefix}-state*` envelope PROVABLY empty — i.e. does it
+ * carry zero overrides for zdtp's `reapplyPersistedOverrides()` to apply?
+ * Organizing principle (#3314, locked by #3313): **trigger unless provably
+ * empty**, and provably empty is exactly three values — `{}`, `[]`, and the
+ * literal `null`. Everything else counts as content: a non-empty object or
+ * array, any primitive (including `0` / `false` / `""`-as-JSON-string), and
+ * anything that does not parse at all.
+ *
+ * Note the inversion in the `catch`: malformed JSON returns `false` (NOT
+ * empty → the caller triggers the eager load), so zdtp gets the chance to
+ * migrate or reject the value rather than this probe silently discarding a
+ * returning user's overrides. This stays schema-agnostic per #3282 — it never
+ * looks inside the envelope beyond "does it hold anything at all".
+ */
+function isEmptyEnvelope(raw: string | null): boolean {
+  if (raw === null) return true;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return false;
+  }
+  if (parsed === null) return true;
+  if (Array.isArray(parsed)) return parsed.length === 0;
+  if (typeof parsed === "object") return Object.keys(parsed).length === 0;
+  return false;
+}
+
+/**
+ * Persisted-state probe predicate (#3282, narrowed in #3314): does the ACTIVE
+ * storage namespace hold zdtp state worth an eager load? True when the public
+ * `${prefix}-open` mirror or any {@link ACTIVATION_FLAG_KEY_SUFFIXES} flag
+ * reads `"1"`, or any `${prefix}-state*` key holds a NON-EMPTY envelope
+ * ({@link isEmptyEnvelope}). The bare stem match keeps it version-agnostic
+ * across `-state`, `-state-v2`/`-v3`/`-v4`, and future schema revisions
+ * without enumerating them. The scan is anchored to the EXACT active prefix;
+ * a whole-localStorage suffix scan is deliberately off the table (it would
+ * false-positive on unrelated apps' `*-state` keys). Note the pack-scoped
+ * `--<slug>` separator keeps sibling namespaces out: `<prefix>--<pack>-state`
+ * never matches the `<prefix>-state` stem. Guarded: disabled/throwing storage
+ * reads as "no persisted state".
+ *
+ * Three pieces of context a future reader cannot recover from the code:
+ *
+ * 1. **Content, not presence — a deliberate divergence from zdtp's own gate.**
+ *    zdtp's reference lazy-load gate (`dist/astro/host-adapter.js`) presence-
+ *    checks its state keys (`getItem(...) !== null`), so an empty `{}` there
+ *    still fetches the bundle. zdtp README §10.1 states the third eager-load
+ *    trigger as "overrides are persisted", not "a state key exists", so the
+ *    content check is the closer implementation of the documented contract.
+ *    Filed upstream as Takazudo/zudo-design-token-panel#566.
+ * 2. **`:autoload` triggering the eager load is INTENDED, not a stale flag.**
+ *    Reviewed against the installed zdtp contract in #3313 and deliberately
+ *    kept: README §9 (the `autoload` row) *defines* `'1'` as "fetches eagerly
+ *    on every page load and mounts CLOSED", and §10.1's `disableAutoload()`
+ *    clears `:autoload`, `:visible`, `-elpath-enabled` and the open-state key
+ *    together — so `:autoload=1` with `:visible=0` is the documented
+ *    owner-mode-armed steady state. A `:visible=0` veto would break exactly
+ *    that case; do not add one. The real defect (no provenance bit separating
+ *    an explicit `enableAutoload()` from a curious click, per §10.1's
+ *    auto-remember footgun) is upstream:
+ *    Takazudo/zudo-design-token-panel#565.
+ * 3. **The scan ORs across EVERY matching key and must not stop early.** §9
+ *    documents that the v4 migration leaves the legacy v1/v2/v3 keys in
+ *    place, so one user can hold several `-state*` keys at once. That yields
+ *    one ACCEPTED false positive: `-state-v4 = {}` alongside a non-empty
+ *    `-state-v3` triggers, even though the empty v4 key shadows v3 and zdtp
+ *    would apply nothing. Avoiding it would require the probe to know the
+ *    version precedence, which the #3282 schema-agnostic mandate forbids —
+ *    leave it, and do not "fix" it by learning the version ordering.
  */
 function hasPersistedPanelState(instancePrefix: string): boolean {
   try {
@@ -188,7 +247,8 @@ function hasPersistedPanelState(instancePrefix: string): boolean {
     const stateKeyStem = `${instancePrefix}-state`;
     for (let i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i);
-      if (key !== null && key.startsWith(stateKeyStem)) return true;
+      if (key === null || !key.startsWith(stateKeyStem)) continue;
+      if (!isEmptyEnvelope(localStorage.getItem(key))) return true;
     }
   } catch {
     // Storage unavailable → nothing persisted to restore → no eager load.


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3312
- parent PR
    - https://github.com/zudolab/zudo-doc/pull/3300

---

## Summary

Two defects on the same surface, on opposite sides of the same trade-off, both inside `bootstrapDesignTokenPanel` (`packages/zudo-doc/src/design-token-panel-bootstrap.tsx`) — paired because planning them apart would have guaranteed a merge conflict for no benefit.

- **#3293 — over-triggering.** The persisted-state probe fired an eager `import("@takazudo/zdtp")` on an **empty** `-state*` envelope (`{}`), because it tested key *presence* rather than *content*.
- **#3292 — under-triggering.** The interim pre-import listener was pinned to the shared `toggle-design-token-panel` event, so a host configuring `PanelConfig.toggleEvent` — or dispatching zdtp's per-instance channel — could not trigger the initial dynamic import at all.

## The `:autoload` half was not a bug (#3313)

The obvious fix — veto the eager load when `:visible === "0"` — was proposed during planning and is **wrong**. The decision sub-issue settled it against the installed contract, and found decisive evidence beyond the README:

- **README §9 (line 956)** *defines* the flag as the eager fetch: "When `'1'`, the panel bundle fetches eagerly on every page load and **mounts CLOSED** so the Alt+click element-path inspector is armed without opening the panel UI." A host that reads it and declines to fetch has redefined the key, not implemented it.
- **§10.1 (line 1081)** assigns the gate to the host adapter and enumerates the trigger conditions as an OR — "loads eagerly (the same as when the panel was previously visible or **overrides are persisted**)".
- **§10.1 (line 1074)** shows `disableAutoload()` clears `:autoload`, `:visible`, `-elpath-enabled` and the open-state key **together** — so `:autoload=1` + `:visible=0` is precisely **owner mode armed**, not a stale flag. The veto would have broken the primary documented owner use case.
- **New evidence:** zdtp's own reference gate in `dist/astro/host-adapter.js` ORs the same five conditions this probe does. Our implementation is faithful *plus* two supersets — it also checks `-open`, and its stem scan covers §9's v1 key and future revisions that upstream's hardcoded triple misses.

The real defect is upstream and **structurally inexpressible downstream**: §10.1 (line 1085) documents the auto-remember footgun — opening the panel by any means sets `:autoload` — and §9's key set carries no provenance bit distinguishing that from an explicit `enableAutoload()`. Filed upstream against zdtp: [#565](https://github.com/Takazudo/zudo-design-token-panel/issues/565) (missing provenance bit, carrying #3293's measured cost), [#566](https://github.com/Takazudo/zudo-design-token-panel/issues/566) (the reference gate has the same presence-check defect), [#567](https://github.com/Takazudo/zudo-design-token-panel/issues/567) (`PORTABLE-CONTRACT.md` missing from `files[]`). #3293 annotated with the link.

**"No local change to the autoload trigger" is the successful outcome here** — the finding did not evaporate, it moved to where it can actually be fixed.

## Changes

### Content-based envelope check (#3314)

`hasPersistedPanelState` now decides on content, not presence. The justification is stronger than "empty buys nothing": §10.1 words the trigger as **"overrides are persisted"**, not "a state key exists" — presence was only ever a proxy.

Principle: **trigger unless provably empty**, where provably empty is exactly `{}`, `[]`, `null`.

| Raw value | Trigger? |
| --- | --- |
| `{}` / `[]` / `null` | no |
| non-empty object / array | yes |
| primitive (incl. `0`, `false`) | yes — not provably empty |
| malformed JSON (incl. `""`) | yes — let zdtp migrate or reject it |
| key absent | no |

The probe stays **schema-agnostic** per the #3282 spec — it parses for emptiness, it does not learn the schema. The scan ORs across every matching key (§9 line 1001: the v4 migration leaves legacy keys in place), producing one **accepted** false positive — `-state-v4={}` plus a non-empty `-state-v3` triggers. Avoiding it would need version precedence, which the schema-agnostic mandate forbids; it is asserted in a test as intended and recorded in the doc comment.

Preserved: the storage guard (throwing/disabled `localStorage` reads as nothing persisted), the exact-prefix anchoring, and the `<prefix>--<pack>-state` vs `<prefix>-state` separator property.

### Resolved toggle channel (#3315)

Registers the shared `TOGGLE_PANEL_EVENT` **plus exactly one** resolved instance channel — `config.toggleEvent ?? "toggle-" + pack-scoped storagePrefix`. Not a union: per README §5.3's field summary (line 509), a configured `toggleEvent` **replaces** the derived name, so a shared+custom+derived union would let the bootstrap activate on a channel zdtp itself would not honour after configuration.

**Replace, don't accumulate.** The instance channel derives from `storagePrefix`, which changes on theme-pack switch — so the previously-registered dynamic channel is *removed*, not merely supplemented. A lingering old-pack listener would trigger an import for a pack the user has left. Both `THEME_PACK_CHANGED_EVENT` and `COLOR_SCHEME_CHANGED_EVENT` are hooked, because `buildConfig(mode)` can make the prefix mode-dependent; the existing pending-phase listeners are reused rather than adding new ones.

Preserved: registration stays **before** the `__zdtpReadyClicks()` drain (a queued pre-hydration click still counts as intent), and the listener becomes a permanent no-op once `configurePhase` leaves `"pending"` (zdtp's module-scope listener owns dispatches after that; handling them here too would double-toggle).

One addition beyond the literal brief: zdtp's **default-prefix short-circuit**, verified in the 0.4.9 bundle — `toggleEventName` returns the shared name and *discards* `toggleEvent` when `storagePrefix === "zudo-design-token-panel"`. Without it, a host on zdtp's own default prefix with a custom `toggleEvent` would register a channel zdtp will not honour post-configure — the same pre/post-import disagreement this epic rules out, applied to a case the brief did not enumerate.

## Verification (#3316) — network-level, on a real browser

**18/18 rows PASS, reproduced identically across two independent runs.** A fresh browser context per row, state seeded via `addInitScript` **before** page scripts run, and `page.on("request")` recording actual fetches of the zdtp chunk. A cheaper proxy ("the module wasn't imported") would not have caught the original bug, which was visible only as a real chunk fetch.

Chunk identified **by content**, not by #3293's hash: `islands-chunk-5D6WRUDM.js` (248,866 B) is the only chunk carrying zdtp's own `zudo-design-token-panel` prefix, and no HTML references it — it is genuinely lazy.

| Seeded state / action | Expected | Observed |
| --- | --- | --- |
| nothing · `:visible=0` · `-state-v4={}` · `-state-v4=null` | no fetch | no fetch |
| `:visible=1` · `-open=1` · `-elpath-enabled=1` · `-domtweaker-enabled=1` | fetch | fetch |
| `:autoload=1` · `:autoload=1`+`:visible=0` | fetch (#3313) | fetch |
| `-state-v4` real overrides · malformed | fetch | fetch |
| click the palette trigger | fetch | fetch |
| dispatch derived `toggle-zudo-doc-tweak` | fetch (#3315) | fetch |
| dispatch shared `toggle-design-token-panel` | fetch | fetch |
| pack switch → `toggle-zudo-doc-tweak--academia` | fetch | fetch |
| pack switch → stale `toggle-zudo-doc-tweak` | **no fetch** (#3315) | no fetch |

**The last two rows only carry weight as a pair.** The derived-channel row proves `toggle-zudo-doc-tweak` *is* bound while the default pack is active — so the stale-channel row's silence after switching to `academia` demonstrates the binding was **removed**, not merely never present. Pack switches were driven through the real switcher UI, not by faking the attribute and event.

**Parity confirmed** — a fetch-count matrix alone would pass even if overrides silently stopped applying, which is the regression this narrowing could plausibly introduce. Using an envelope **captured from the real panel** (opened via the trigger, `--spacing-hsp-2xs` set to `0.6rem` through the panel's own input, then read back): overrides still apply on load (inline `--spacing-hsp-2xs: 0.6rem` on `<html>`), and a previously-open panel still re-opens.

Nuance worth recording: `-open=1` **alone** fetches the chunk but does not mount or re-open the panel — zdtp's re-open path keys off `:visible`, not the `-open` mirror. So "re-opens" is only assertable for the realistic quartet a genuinely-open panel persists.

**One row uncovered, as the sub-issue permits:** no fixture and not the host declares a custom `toggleEvent`, so there is no build in which that row can be exercised. Building one was out of scope for a verification pass. The path is covered by unit tests.

### Gates

`pnpm --filter @takazudo/zudo-doc test` → **2104/2104** (2090 before Wave 3) · `pnpm check` clean · `pnpm build` 438 pages. Each wave was mutation-checked: dropping the stale-channel removal fails 3 cases, dropping the instance-channel registration fails 4, inverting the malformed-JSON `catch` fails exactly the 2 malformed rows.

Closes #3313, closes #3314, closes #3315, closes #3316.
