### PR TITLE
fix: retry coherent CSS gate fetch pairs

### DIFF
--- a/.github/actions/css-shape-smoke-gate/action.yml
+++ b/.github/actions/css-shape-smoke-gate/action.yml
@@ -20,38 +20,4 @@ runs:
       env:
         DEPLOY_URL: ${{ inputs.deploy-url }}
       run: |
-        set -euo pipefail
-        # Retry both fetches: right after deploy the homepage HTML can reference a new
-        # hashed styles-<hash>.css before that asset has propagated, so an immediate
-        # curl 404s. --retry-all-errors retries HTTP 4xx too (plain --retry does not) —
-        # this flag is load-bearing. 10 retries at a fixed 6s delay is ~60s of sleeping
-        # when failures are quick, against a 90s --retry-max-time budget (that flag only
-        # gates whether another retry may *start*, so an in-flight transfer can run past
-        # it — intentional, do not add --max-time). Propagation race, not a real failure
-        # (#2236, #3125).
-        HTML=$(curl -fsSL --retry 10 --retry-delay 6 --retry-max-time 90 --retry-all-errors "$DEPLOY_URL/") \
-          || { echo "::error::failed to fetch $DEPLOY_URL/ (curl exit $?)"; exit 1; }
-        # Use a here-string (not echo|grep) so head -1 exiting early cannot SIGPIPE an
-        # upstream echo and flip pipefail. grep exits 1 on no match, which would abort
-        # under set -e before the friendlier message below fires — `|| true` guards that.
-        CSS_PATH=$(grep -oE "href=[\"']?[^\"' >]*assets/styles-[^\"' >]*\.css" <<<"$HTML" | head -1 | sed -E "s/^href=[\"']?//") || true
-        # ${#HTML} is a character count, not a byte count — it is a diagnostic
-        # ("did we get an empty/short body?"), so say chars rather than pay for
-        # an extra `printf | wc -c` subshell.
-        [ -n "$CSS_PATH" ] || { echo "::error::no CSS link found in $DEPLOY_URL/ (fetched ${#HTML} chars)"; exit 1; }
-        curl -fsSL --retry 10 --retry-delay 6 --retry-max-time 90 --retry-all-errors "${DEPLOY_URL}${CSS_PATH}" -o /tmp/deployed-css.css \
-          || { echo "::error::failed to fetch ${DEPLOY_URL}${CSS_PATH} (curl exit $?)"; exit 1; }
-
-        CSS_BYTES=$(wc -c < /tmp/deployed-css.css)
-        MIN_CSS_BYTES=50000  # post-zfb#159 split-import fix (in pin 9239267) drops leaked Tailwind defaults; healthy baseline ~64-66 KB (down from pre-fix ~77.7 KB). Threshold sits well above the ~30-40 KB broken-scanner floor with headroom for future intentional shrinkage.
-        [ "$CSS_BYTES" -ge "$MIN_CSS_BYTES" ] || { echo "::error::deployed CSS is $CSS_BYTES bytes, below threshold $MIN_CSS_BYTES (broken scanner produces ~30-40 KB)"; exit 1; }
-
-        MEDIA_COUNT=$(grep -cE '^@media' /tmp/deployed-css.css || true)
-        MIN_MEDIA=3  # tuned from the Sub-2 manager-confirm baseline (post-fix has 4 @media; threshold 3 leaves one block of safety)
-        [ "$MEDIA_COUNT" -ge "$MIN_MEDIA" ] || { echo "::error::deployed CSS has $MEDIA_COUNT @media blocks, below threshold $MIN_MEDIA"; exit 1; }
-
-        LEAKED_DEFAULT_COLORS=$(grep -cE -- '--color-(gray|zinc|red|amber|green|cyan|blue|indigo|purple|slate)-[0-9]+:' /tmp/deployed-css.css || true)
-        MAX_DEFAULT_THEME_COLOR_TOKENS=2  # tuned from the Sub-2 manager-confirm baseline (post-fix has 0; broken state has 36)
-        [ "$LEAKED_DEFAULT_COLORS" -le "$MAX_DEFAULT_THEME_COLOR_TOKENS" ] || { echo "::error::deployed CSS has $LEAKED_DEFAULT_COLORS leaked Tailwind default color tokens, above threshold $MAX_DEFAULT_THEME_COLOR_TOKENS (zfb user_has_import blind-spot regression)"; exit 1; }
-
-        echo "OK: deployed CSS is $CSS_BYTES bytes, $MEDIA_COUNT @media blocks, $LEAKED_DEFAULT_COLORS leaked default color tokens"
+        bash "${{ github.action_path }}/run.sh"

--- a/.github/actions/css-shape-smoke-gate/run.sh
+++ b/.github/actions/css-shape-smoke-gate/run.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${DEPLOY_URL:?DEPLOY_URL is required}"
+
+MAX_ATTEMPTS="${CSS_FETCH_ATTEMPTS:-11}"
+RETRY_DELAY_SECONDS="${CSS_FETCH_RETRY_DELAY_SECONDS:-6}"
+CSS_OUTPUT_PATH="${CSS_OUTPUT_PATH:-${RUNNER_TEMP:-/tmp}/deployed-css.css}"
+
+# Retry the complete HTML -> referenced CSS transaction. Retrying a CSS URL
+# captured once can pin the gate to a deployment generation whose hashed asset
+# has already rotated away (#3321). Eleven attempts with at most ten 6-second
+# sleeps preserve the previous ~60-second propagation allowance without nested
+# curl retries or a blanket delay on healthy deploys.
+FETCHED_CSS=false
+LAST_FAILURE="not attempted"
+LAST_CSS_PATH=""
+
+for ((ATTEMPT = 1; ATTEMPT <= MAX_ATTEMPTS; ATTEMPT += 1)); do
+  HTML=""
+  CSS_PATH=""
+
+  if ! HTML=$(curl -fsSL "$DEPLOY_URL/"); then
+    LAST_FAILURE="homepage fetch failed: $DEPLOY_URL/"
+    echo "CSS-shape fetch attempt $ATTEMPT/$MAX_ATTEMPTS: $LAST_FAILURE"
+  else
+    # Use a here-string (not echo|grep) so head -1 exiting early cannot SIGPIPE
+    # an upstream echo and flip pipefail. The conditional makes grep's no-match
+    # status retryable instead of letting `set -e` abort the gate.
+    CSS_PATH=$(grep -oE "href=[\"']?[^\"' >]*assets/styles-[^\"' >]*\.css" <<<"$HTML" | head -1 | sed -E "s/^href=[\"']?//") || true
+
+    if [ -z "$CSS_PATH" ]; then
+      # ${#HTML} is a diagnostic character count, not a byte count.
+      LAST_FAILURE="no CSS link found in $DEPLOY_URL/ (fetched ${#HTML} chars)"
+      echo "CSS-shape fetch attempt $ATTEMPT/$MAX_ATTEMPTS: $LAST_FAILURE"
+    else
+      LAST_CSS_PATH="$CSS_PATH"
+      if curl -fsSL "${DEPLOY_URL}${CSS_PATH}" -o "$CSS_OUTPUT_PATH"; then
+        FETCHED_CSS=true
+        break
+      fi
+      LAST_FAILURE="stylesheet fetch failed: ${DEPLOY_URL}${CSS_PATH}"
+      echo "CSS-shape fetch attempt $ATTEMPT/$MAX_ATTEMPTS: $LAST_FAILURE"
+    fi
+  fi
+
+  if [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]; then
+    sleep "$RETRY_DELAY_SECONDS"
+  fi
+done
+
+if [ "$FETCHED_CSS" != true ]; then
+  if [ -n "$LAST_CSS_PATH" ]; then
+    echo "::error::failed to fetch coherent deployed CSS after $MAX_ATTEMPTS attempts; last failure: $LAST_FAILURE; last stylesheet path: $LAST_CSS_PATH"
+  else
+    echo "::error::failed to fetch coherent deployed CSS after $MAX_ATTEMPTS attempts; last failure: $LAST_FAILURE"
+  fi
+  exit 1
+fi
+
+CSS_BYTES=$(wc -c < "$CSS_OUTPUT_PATH")
+MIN_CSS_BYTES=50000  # post-zfb#159 split-import fix (in pin 9239267) drops leaked Tailwind defaults; healthy baseline ~64-66 KB (down from pre-fix ~77.7 KB). Threshold sits well above the ~30-40 KB broken-scanner floor with headroom for future intentional shrinkage.
+[ "$CSS_BYTES" -ge "$MIN_CSS_BYTES" ] || { echo "::error::deployed CSS is $CSS_BYTES bytes, below threshold $MIN_CSS_BYTES (broken scanner produces ~30-40 KB)"; exit 1; }
+
+MEDIA_COUNT=$(grep -cE '^@media' "$CSS_OUTPUT_PATH" || true)
+MIN_MEDIA=3  # tuned from the Sub-2 manager-confirm baseline (post-fix has 4 @media; threshold 3 leaves one block of safety)
+[ "$MEDIA_COUNT" -ge "$MIN_MEDIA" ] || { echo "::error::deployed CSS has $MEDIA_COUNT @media blocks, below threshold $MIN_MEDIA"; exit 1; }
+
+LEAKED_DEFAULT_COLORS=$(grep -cE -- '--color-(gray|zinc|red|amber|green|cyan|blue|indigo|purple|slate)-[0-9]+:' "$CSS_OUTPUT_PATH" || true)
+MAX_DEFAULT_THEME_COLOR_TOKENS=2  # tuned from the Sub-2 manager-confirm baseline (post-fix has 0; broken state has 36)
+[ "$LEAKED_DEFAULT_COLORS" -le "$MAX_DEFAULT_THEME_COLOR_TOKENS" ] || { echo "::error::deployed CSS has $LEAKED_DEFAULT_COLORS leaked Tailwind default color tokens, above threshold $MAX_DEFAULT_THEME_COLOR_TOKENS (zfb user_has_import blind-spot regression)"; exit 1; }
+
+echo "OK: deployed CSS is $CSS_BYTES bytes, $MEDIA_COUNT @media blocks, $LEAKED_DEFAULT_COLORS leaked default color tokens"

--- a/scripts/__tests__/css-shape-smoke-gate.test.ts
+++ b/scripts/__tests__/css-shape-smoke-gate.test.ts
@@ -1,0 +1,175 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const root = path.resolve(import.meta.dirname, "../..");
+const gate = path.join(root, ".github/actions/css-shape-smoke-gate/run.sh");
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { force: true, recursive: true });
+});
+
+const fakeCurl = String.raw`#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT=""
+URL=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o)
+      OUTPUT="$2"
+      shift 2
+      ;;
+    -*)
+      shift
+      ;;
+    *)
+      URL="$1"
+      shift
+      ;;
+  esac
+done
+
+printf '%s\n' "$URL" >> "$CALL_LOG"
+COUNT=$(wc -l < "$CALL_LOG")
+
+write_css() {
+  cp "$HEALTHY_CSS" "$OUTPUT"
+}
+
+case "$SCENARIO" in
+  recover-all-stages)
+    case "$COUNT" in
+      1) exit 22 ;;
+      2) printf '%s\n' '<html>no stylesheet yet</html>' ;;
+      3) printf '%s\n' '<link href="/assets/styles-old.css">' ;;
+      4) exit 22 ;;
+      5) printf '%s\n' '<link href="/assets/styles-new.css">' ;;
+      6) write_css ;;
+      *) exit 99 ;;
+    esac
+    ;;
+  homepage-failure)
+    exit 22
+    ;;
+  missing-link)
+    printf '%s\n' '<html>no stylesheet yet</html>'
+    ;;
+  stylesheet-failure)
+    if [[ "$URL" == */ ]]; then
+      printf '%s\n' '<link href="/assets/styles-stale.css">'
+    else
+      exit 22
+    fi
+    ;;
+  *)
+    exit 98
+    ;;
+esac
+`;
+
+type GateRun = {
+  calls: string[];
+  output: string;
+  sleeps: string[];
+  status: number | null;
+  stderr: string;
+  stdout: string;
+};
+
+function runGate(scenario: string, attempts = 11): GateRun {
+  const dir = mkdtempSync(path.join(tmpdir(), "css-shape-gate-"));
+  tempDirs.push(dir);
+  const bin = path.join(dir, "bin");
+  mkdirSync(bin);
+
+  const curl = path.join(bin, "curl");
+  const sleep = path.join(bin, "sleep");
+  const callLog = path.join(dir, "calls.log");
+  const sleepLog = path.join(dir, "sleeps.log");
+  const healthyCss = path.join(dir, "healthy.css");
+  const output = path.join(dir, "deployed.css");
+
+  writeFileSync(curl, fakeCurl, { mode: 0o755 });
+  writeFileSync(
+    sleep,
+    '#!/usr/bin/env bash\nprintf \'%s\\n\' "$1" >> "$SLEEP_LOG"\n',
+    { mode: 0o755 },
+  );
+  writeFileSync(
+    healthyCss,
+    `@media screen{a{color:red}}\n@media print{a{color:black}}\n@media (width > 1px){a{display:block}}\n${"x".repeat(50_000)}`,
+  );
+
+  const result = spawnSync("bash", [gate], {
+    cwd: root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CALL_LOG: callLog,
+      CSS_FETCH_ATTEMPTS: String(attempts),
+      CSS_FETCH_RETRY_DELAY_SECONDS: "6",
+      CSS_OUTPUT_PATH: output,
+      DEPLOY_URL: "https://deploy.example",
+      HEALTHY_CSS: healthyCss,
+      PATH: `${bin}:${process.env.PATH}`,
+      SCENARIO: scenario,
+      SLEEP_LOG: sleepLog,
+    },
+  });
+
+  const readLines = (file: string) => {
+    try {
+      return readFileSync(file, "utf8").trim().split("\n").filter(Boolean);
+    } catch {
+      return [];
+    }
+  };
+
+  return {
+    calls: readLines(callLog),
+    output,
+    sleeps: readLines(sleepLog),
+    status: result.status,
+    stderr: result.stderr,
+    stdout: result.stdout,
+  };
+}
+
+describe("CSS-shape smoke gate", () => {
+  it("retries the complete HTML-to-CSS transaction and recovers to a new hash", () => {
+    const result = runGate("recover-all-stages", 6);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.calls).toEqual([
+      "https://deploy.example/",
+      "https://deploy.example/",
+      "https://deploy.example/",
+      "https://deploy.example/assets/styles-old.css",
+      "https://deploy.example/",
+      "https://deploy.example/assets/styles-new.css",
+    ]);
+    expect(result.sleeps).toEqual(["6", "6", "6"]);
+    expect(readFileSync(result.output, "utf8")).toContain("@media screen");
+    expect(result.stdout).toContain("OK: deployed CSS is");
+  });
+
+  it.each([
+    ["homepage-failure", "homepage fetch failed: https://deploy.example/"],
+    ["missing-link", "no CSS link found in https://deploy.example/"],
+    [
+      "stylesheet-failure",
+      "stylesheet fetch failed: https://deploy.example/assets/styles-stale.css; last stylesheet path: /assets/styles-stale.css",
+    ],
+  ])("exhausts a bounded budget with an actionable %s diagnostic", (scenario, diagnostic) => {
+    const result = runGate(scenario, 3);
+
+    expect(result.status).toBe(1);
+    expect(result.sleeps).toEqual(["6", "6"]);
+    expect(result.stdout).toContain("after 3 attempts");
+    expect(result.stdout).toContain(diagnostic);
+  });
+});

--- a/scripts/__tests__/worker-entry-config.test.ts
+++ b/scripts/__tests__/worker-entry-config.test.ts
@@ -99,13 +99,11 @@ describe("custom Worker deployment contract", () => {
     }
   });
 
-  it("arms every post-deploy gate with the current propagation retry policy", () => {
+  it("keeps every post-deploy gate on a bounded propagation retry policy", () => {
     // #3125: after a deploy the edge can 404 a just-published URL for tens of
     // seconds. Every gate that fetches the deployed site must carry the same
     // retry policy, or it goes red on propagation rather than on a real defect.
     for (const [path, expected] of [
-      // Two retrying curls: the homepage HTML, then the hashed stylesheet.
-      [".github/actions/css-shape-smoke-gate/action.yml", 2],
       // Two per workflow: the root-asset-URL gate and the public-asset gate.
       // The third post-deploy curl (POST /api/ai-chat) deliberately omits both
       // -f and the retry flags — a JSON validation 4xx is a valid response.
@@ -132,6 +130,15 @@ describe("custom Worker deployment contract", () => {
       expect(source).not.toContain("--retry-delay 3");
       expect(source).not.toContain("--retry-delay 2");
     }
+
+    const cssAction = read(".github/actions/css-shape-smoke-gate/action.yml");
+    const cssGate = read(".github/actions/css-shape-smoke-gate/run.sh");
+    expect(cssAction).toContain('bash "${{ github.action_path }}/run.sh"');
+    expect(cssGate).toContain('MAX_ATTEMPTS="${CSS_FETCH_ATTEMPTS:-11}"');
+    expect(cssGate).toContain('RETRY_DELAY_SECONDS="${CSS_FETCH_RETRY_DELAY_SECONDS:-6}"');
+    expect(cssGate).toContain('for ((ATTEMPT = 1; ATTEMPT <= MAX_ATTEMPTS; ATTEMPT += 1))');
+    expect(cssGate).toContain('if [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]');
+    expect(cssGate).not.toContain("--retry");
 
     for (const workflow of [
       ".github/workflows/main-deploy.yml",


### PR DESCRIPTION
Closes #3323.

Parent epic: #3322

Source finding: #3321

**Difficulty:** high - deployment-generation races create subtle ordering and retry-budget correctness risks

## Summary

- move the CSS-shape gate into an executable adjacent script and retry the complete
  homepage HTML → referenced stylesheet transaction
- use 11 attempts with at most ten 6-second sleeps, refreshing the stylesheet hash after
  every failed homepage, missing-link, or asset fetch stage
- preserve the existing CSS byte, `@media`, and leaked Tailwind color-token thresholds
- add deterministic fake-network coverage for multi-stage recovery, stale-hash rotation,
  terminal diagnostics, retry count, request ordering, and no trailing sleep
- keep the other post-deploy workflow curls on their existing propagation policy

## Why

The previous asset-level curl retry captured one stylesheet hash and retried it for the
whole window. During deployment rotation that hash can become permanently stale, so more
retries cannot recover even when fresh HTML points to a healthy stylesheet. Retrying the
coherent pair preserves HTML/CSS agreement per attempt while allowing the gate to advance
to the current deployment generation.

## Test plan

- `pnpm vitest run scripts/__tests__/css-shape-smoke-gate.test.ts scripts/__tests__/worker-entry-config.test.ts`
- `pnpm test:unit` — 938 passed, 2 skipped
- `pnpm tsc --noEmit --pretty false`
- `bash -n .github/actions/css-shape-smoke-gate/run.sh`
- parse the composite action and all three consuming workflow YAML files with PyYAML
- one-attempt live production gate check — 148,430 CSS bytes, 10 `@media` blocks, zero
  leaked default color tokens

## Verification

- direct `codex-review`: no remaining findings
- UI verification: not applicable; this changes CI fetch orchestration only
