### PR TITLE
fix(deps): bump @takazudo/zdtp to 0.4.10 for the document-teardown-race fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     }
   },
   "dependencies": {
-    "@takazudo/zdtp": "0.4.9",
+    "@takazudo/zdtp": "0.4.10",
     "@takazudo/zfb": "2.2.0",
     "@takazudo/zfb-adapter-cloudflare": "2.2.0",
     "@takazudo/zfb-md-wasm": "2.2.0",

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -776,7 +776,7 @@ function generatePackageJson(choices: UserChoices) {
     // same reason. This is the ACCEPTED, permanent contract per #2668 — see
     // the "@takazudo/zdtp dep implication" note in
     // packages/zudo-doc/docs/adr/route-injection-seam.md.
-    "@takazudo/zdtp": "0.4.9",
+    "@takazudo/zdtp": "0.4.10",
     // (@takazudo/zudo-doc-history-server is NOT here — it is gated on the
     // docHistory feature, see the block below. It was briefly unconditional
     // (#3080) to work around doc-history-area importing its `/exclude` subpath

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -619,7 +619,7 @@
     "CHANGELOG.md"
   ],
   "peerDependencies": {
-    "@takazudo/zdtp": "^0.4.9",
+    "@takazudo/zdtp": "^0.4.10",
     "@takazudo/zfb": "^2.2.0",
     "@takazudo/zfb-md-wasm": "^2.2.0",
     "@takazudo/zfb-runtime": "^2.2.0",

--- a/packages/zudo-doc/src/design-token-panel-bootstrap.tsx
+++ b/packages/zudo-doc/src/design-token-panel-bootstrap.tsx
@@ -127,10 +127,10 @@ const TOGGLE_PANEL_EVENT = "toggle-design-token-panel";
  * default instance" for {@link resolveInstanceToggleEvent}. Not a value this
  * package ever configures (the package default is `zudo-doc-tweak`), but a
  * host is free to, and the rule below hinges on it. Verified against the
- * installed zdtp 0.4.9 bundle (`dist/panel-config-*.js`), which is also where
- * zdtp's exported `DEFAULT_TOGGLE_EVENT` / `toggleEventName()` live — we
- * cannot import either, because a value import of `@takazudo/zdtp` here would
- * defeat the whole lazy load (#3282).
+ * installed zdtp 0.4.9/0.4.10 bundle (`dist/panel-config-*.js`), which is
+ * also where zdtp's exported `DEFAULT_TOGGLE_EVENT` / `toggleEventName()`
+ * live — we cannot import either, because a value import of
+ * `@takazudo/zdtp` here would defeat the whole lazy load (#3282).
  */
 const ZDTP_DEFAULT_STORAGE_PREFIX = "zudo-design-token-panel";
 
@@ -185,7 +185,7 @@ function readOpenState(instancePrefix: string): boolean {
 }
 
 /**
- * zdtp's persisted activation-flag keys (verified against the zdtp 0.4.9
+ * zdtp's persisted activation-flag keys (verified against the zdtp 0.4.9/0.4.10
  * bundle). The owner-mode flags each make zdtp's parked post-configure hook
  * mount machinery even with the panel closed (autoload shell, element-path
  * inspector, DOM tweaker); `:visible` is the documented lazy-load gate that
@@ -367,10 +367,10 @@ function collectDeclaredTokenNames(config: PanelConfig): string[] {
  * through an `applySink`, the clear goes through the SAME sink
  * (`sink.clear(names)`, errors non-fatal per zdtp's own contract) — the
  * overrides live in the sink's target, not on the document root. Upstream
- * check (2026-07, zdtp 0.4.9): the package exposes no sanctioned
- * `clearApplied()`-style API on `PanelInstanceHandle` (only
- * instanceId/open/close/toggle/destroy), so this config-driven path is the
- * current mechanism; prefer a zdtp API if one lands
+ * check (2026-07 zdtp 0.4.9, re-checked 2026-08 zdtp 0.4.10): the package
+ * exposes no sanctioned `clearApplied()`-style API on `PanelInstanceHandle`
+ * (only instanceId/open/close/toggle/destroy), so this config-driven path is
+ * the current mechanism; prefer a zdtp API if one lands
  * (Takazudo/zudo-design-token-panel).
  */
 function clearAppliedTokenOverrides(config: PanelConfig): void {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
   .:
     dependencies:
       '@takazudo/zdtp':
-        specifier: 0.4.9
-        version: 0.4.9(preact@10.29.2)
+        specifier: 0.4.10
+        version: 0.4.10(preact@10.29.2)
       '@takazudo/zfb':
         specifier: 2.2.0
         version: 2.2.0(react@19.2.8)
@@ -196,8 +196,8 @@ importers:
         specifier: ^8.4.2
         version: 8.4.2(@types/node@25.3.5)
       '@takazudo/zdtp':
-        specifier: ^0.4.9
-        version: 0.4.9(preact@10.29.2)
+        specifier: ^0.4.10
+        version: 0.4.10(preact@10.29.2)
       diff:
         specifier: ^8.0.0
         version: 8.0.3
@@ -1621,8 +1621,8 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
-  '@takazudo/zdtp@0.4.9':
-    resolution: {integrity: sha512-1ZsEfls0I1jgn578LjSCKZ9OVoYEcjmGlbEdbcoO6oMnOXervixm3pkX+wQ/MoLS+bPX6zDKRM8O89Y++wXOMQ==}
+  '@takazudo/zdtp@0.4.10':
+    resolution: {integrity: sha512-vVYLTvMOxguAJ9yu26+y4KaV+z2A7IR5H8LTtSZzOLfw5oNso0sGc8DjQfrR/QbtHjV5zSE3HDV4t3xusOQzNw==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
     peerDependencies:
@@ -4798,7 +4798,7 @@ snapshots:
       tailwindcss: 4.3.3
       vite: 7.3.5(@types/node@25.3.5)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.11)
 
-  '@takazudo/zdtp@0.4.9(preact@10.29.2)':
+  '@takazudo/zdtp@0.4.10(preact@10.29.2)':
     dependencies:
       '@tailwindcss/browser': 4.3.2
       culori: 4.0.2


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3344

---

## Summary

Bumps `@takazudo/zdtp` 0.4.9 → 0.4.10 to pick up the upstream fix behind the flaky
`design-token-panel-bootstrap.test.ts` failure in #3344.

The upstream bug: zdtp's deferred continuations read the global `document` *after*
awaiting. Under parallel test load a vitest jsdom environment could tear down first,
so a straggler continuation found a `document` that was no longer a Document and threw
`document.getElementById is not a function` as an unhandled rejection.

0.4.10 fixes it by capturing the owning document *before* the await and cancelling
quietly when it is gone, swapped, or unusable — plus liveness guards on the public
entry points so a post-teardown straggler is a no-op that writes no storage state.
Upstream: `Takazudo/zudo-design-token-panel#568`, release `v0.4.10`.

## Changes

**Dependency pin — all three sites, because they are enforced together.**
`scripts/check-pin-parity.mjs` declares zdtp `comparison: "exact"`, so the peer floor
must be `^` + the root pin and `scaffold.ts` must equal the root pin. Moving only one
fails `pnpm check:pin-parity`.

| File | Field | Change |
|---|---|---|
| `package.json` | `dependencies` | `0.4.9` → `0.4.10` |
| `packages/zudo-doc/package.json` | `peerDependencies` | `^0.4.9` → `^0.4.10` |
| `packages/create-zudo-doc/src/scaffold.ts` | generated-project dep | `0.4.9` → `0.4.10` |
| `pnpm-lock.yaml` | — | zdtp entries only (7 ins / 7 del) |

A repo-wide sweep confirms these are the only version-carrying zdtp sites — the e2e
fixtures and the unit-test fixtures reference zdtp by import/CSS path only, with no
version literal, so nothing was missed.

**Comment re-dating** — `packages/zudo-doc/src/design-token-panel-bootstrap.tsx` carries
three "verified against the zdtp 0.4.9 bundle" notes documenting zdtp internals this file
reaches into. All three were re-verified against the installed 0.4.10 bundle and are
unchanged, so they are re-dated rather than rewritten:

- default `storagePrefix` (`zudo-design-token-panel`) and `DEFAULT_TOGGLE_EVENT`
  (`toggle-design-token-panel`) literals
- activation-flag key suffixes (`:autoload`, `-elpath-enabled`, `-domtweaker-enabled`,
  `-state*`)
- `PanelInstanceHandle` still exposes only `instanceId`/`open`/`close`/`toggle`/`destroy`,
  so there is still no sanctioned `clearApplied()`-style API and the config-driven clear
  path stands

Comment-only; no logic change.

## Test Plan

Green locally:

- `pnpm check:pin-parity` — all six surfaces, including the zdtp exact-match peer floor
- `pnpm check` — tsc + 3 collections
- `pnpm check:template-drift`, `pnpm check:fixture-settings-drift`, `pnpm check:compatibility-contract`
- `pnpm build:workspace`
- `pnpm test:packages` — zudo-doc 181 files / 2104 tests, create-zudo-doc 595, zudo-doc-online 747, zero unhandled rejections

**On what that does and does not prove:** a single green parallel run is weak evidence for
a flake fix — #3344 itself recorded a clean second run on 0.4.9. The actual fix evidence is
upstream's new deterministic `document-teardown-race.test.ts` (15 tests; 6–9 fail on 0.4.9,
all pass on 0.4.10), which swaps the global document mid-flight and asserts no unhandled
rejection. The local run here demonstrates no regression from the bump, nothing stronger.

Closes #3344