### PR TITLE
sweep-260810-online-hardening: DOMPurify sanitizer + Web Locks clientId

### DIFF
--- a/packages/zudo-doc-online/CLAUDE.md
+++ b/packages/zudo-doc-online/CLAUDE.md
@@ -264,30 +264,38 @@ implemented in `src/features/projects/`).
 
 ## Known limitations
 
-- **Duplicate-tab `clientId` collision.** `src/store/client-id.ts` stores the
-  per-tab id in `sessionStorage` (survives a reload, never shared with a
-  genuinely new tab) — but a browser's "duplicate tab" action copies
-  `sessionStorage` verbatim, so two tabs opened that way share one id until
-  one is closed and reopened. A mutation from either tab is misclassified as
-  the other's own SSE event, momentarily weakening the dirty-guard between
-  exactly those two tabs. Documented as a deliberate deferral in the file's
-  own header — fixing it needs live cross-tab coordination (Web Locks API or
-  a BroadcastChannel handshake at startup), a wider change than the
-  synchronous accessor should carry.
-- **Preview sanitizer is a hand-rolled allowlist, not a real sanitizer
-  library.** `src/features/preview/render-runtime.ts`'s `sanitizePreviewHtml`
-  walks a real parsed DOM (`DOMParser`) allowlisting tags/attributes before
-  `dangerouslySetInnerHTML` injection — necessary because `renderHtml`
-  preserves raw HTML from markdown verbatim (`<script>`, `onerror`,
-  `javascript:` URLs all survive), and this surface is designed for
-  AI-agent authoring, so the source of a page's markdown isn't always a
-  human. It has NOT had the adversarial scrutiny a battle-tested library
-  (e.g. DOMPurify) has; epic #3327 contract 4 forbids a child sub-issue from
-  adding a new dependency, so adopting a real sanitizer needs to go through
-  the bootstrap sub-issue's dependency-addition path in a future epic, not a
-  package-level patch here. Treat the current pass as a scoped mitigation
-  for this tool's actual threat model (loopback-bound, single-user local dev
-  server), not a substitute.
+- **Duplicate-tab `clientId` collision — fixed via Web Locks, except where
+  the API is missing.** `src/store/client-id.ts` still stores the per-tab id
+  in `sessionStorage`, which a browser's "duplicate tab" action copies
+  verbatim. Since #3360, `initClientId()` (awaited in `src/main.tsx` before
+  the pop-out import and `render()`, so it settles before any surface builds
+  an SSE client) claims a Web Lock named `zdo-client-id:{id}` and holds it
+  for the tab's lifetime; a duplicate loses the claim, mints a fresh id,
+  persists it, and re-claims — looping, since two duplicates can race. The
+  residual gap: an environment without `navigator.locks` (jsdom, older
+  engines) degrades to the old synchronous read, where two duplicated tabs
+  share one id until one is closed and reopened and a mutation from either is
+  misclassified as the other's own SSE event. The claim never rejects and
+  never blocks boot — a failed claim falls back rather than leaving a blank
+  SPA. Note `navigator.locks.request()`'s promise resolves only when its
+  callback settles, so holding a lock for the tab's lifetime means that
+  promise never resolves: the module resolves a separate handshake promise
+  from inside the callback and deliberately leaves the outer one unawaited.
+- **Preview sanitizer is DOMPurify with a narrowed policy.** Since #3359,
+  `src/features/preview/render-runtime.ts`'s `sanitizePreviewHtml` runs
+  DOMPurify — a battle-tested library — instead of the hand-rolled DOM walk
+  that preceded it (epic #3327's no-new-dependency contract was lifted for
+  this epic). Sanitizing at all is necessary because `renderHtml` preserves
+  raw HTML from markdown verbatim (`<script>`, `onerror`, `javascript:` URLs
+  all survive) and this surface is designed for AI-agent authoring, so the
+  markdown's author isn't always a human. Two deliberate deviations from
+  stock DOMPurify: its `ALLOWED_ATTR` is global-only, so the config passes
+  the union of every tag's attributes and an `uponSanitizeAttribute` hook
+  narrows it back down per tag (plus an `href`/`src` scheme check); and
+  `SANITIZE_DOM` is off, matching the prior sanitizer's behavior rather than
+  dropping `id`/`name` attributes the preview legitimately emits. When
+  DOMPurify reports its host environment unsupported (no DOM), sanitization
+  is a no-op — that path is server/test-side, never the browser preview.
 
 ## Directory map
 

--- a/packages/zudo-doc-online/package.json
+++ b/packages/zudo-doc-online/package.json
@@ -28,6 +28,7 @@
     "@takazudo/zfb-md-wasm": "2.2.0",
     "@takazudo/zudo-doc": "workspace:*",
     "codemirror": "^6.0.2",
+    "dompurify": "^3.4.13",
     "hono": "^4.13.1",
     "preact": "^10.29.1",
     "zod": "^4.4.3"

--- a/packages/zudo-doc-online/src/features/preview/__tests__/render-runtime.test.ts
+++ b/packages/zudo-doc-online/src/features/preview/__tests__/render-runtime.test.ts
@@ -144,16 +144,91 @@ describe("sanitizePreviewHtml", () => {
     expect(sanitizePreviewHtml(html)).toBe(html);
   });
 
-  it("is a no-op when DOMParser is unavailable", () => {
-    const original = globalThis.DOMParser;
-    // @ts-expect-error -- deliberately simulating a DOM-less environment
-    delete globalThis.DOMParser;
+  it("is a no-op when DOMPurify reports its host environment unsupported", async () => {
+    const DOMPurify = (await import("dompurify")).default;
+    const original = DOMPurify.isSupported;
+    DOMPurify.isSupported = false;
     try {
       const html = "<script>alert(1)</script>";
       expect(sanitizePreviewHtml(html)).toBe(html);
     } finally {
-      globalThis.DOMParser = original;
+      DOMPurify.isSupported = original;
     }
+  });
+
+  it("drops an <svg><script> nested payload entirely, including the nested script's content", () => {
+    const out = sanitizePreviewHtml('<p>x</p><svg><script>alert(1)</script></svg><p>y</p>');
+    expect(out).not.toContain("<svg");
+    expect(out).not.toContain("<script");
+    expect(out).not.toContain("alert(1)");
+    expect(out).toContain("<p>x</p>");
+    expect(out).toContain("<p>y</p>");
+  });
+
+  it("neutralizes a javascript: href obfuscated with uppercase casing", () => {
+    const out = sanitizePreviewHtml('<a href="JaVaScRiPt:alert(1)">bad</a>');
+    expect(out).not.toContain("javascript:");
+    expect(out).not.toContain("JaVaScRiPt");
+  });
+
+  it("neutralizes a javascript: href obfuscated with embedded control characters", () => {
+    const out = sanitizePreviewHtml('<a href="jav\tascript:alert(1)">bad</a>');
+    expect(out).not.toMatch(/href="[^"]*script:/i);
+  });
+
+  it("neutralizes a javascript: href obfuscated via HTML entities", () => {
+    // The browser/parser decodes `&#106;avascript:` to `javascript:` before
+    // the sanitizer ever sees the attribute value -- assert the decoded form
+    // is still caught.
+    const out = sanitizePreviewHtml('<a href="&#106;avascript:alert(1)">bad</a>');
+    expect(out).not.toMatch(/href="[^"]*script:/i);
+  });
+
+  it("rejects a data: URL on href and src", () => {
+    const out = sanitizePreviewHtml(
+      '<a href="data:text/html,<script>alert(1)</script>">bad</a>' +
+        '<img src="data:image/svg+xml;base64,QQ==">',
+    );
+    expect(out).not.toContain('href="data:');
+    expect(out).not.toContain('src="data:');
+  });
+
+  it("rejects a blob: URL on href and src", () => {
+    const out = sanitizePreviewHtml(
+      '<a href="blob:https://example.com/xyz">bad</a><img src="blob:https://example.com/xyz">',
+    );
+    expect(out).not.toContain('href="blob:');
+    expect(out).not.toContain('src="blob:');
+  });
+
+  it("drops a <math> payload entirely", () => {
+    const out = sanitizePreviewHtml(
+      '<p>x</p><math><mtext><script>alert(1)</script></mtext></math><p>y</p>',
+    );
+    expect(out).not.toContain("<math");
+    expect(out).not.toContain("<script");
+    expect(out).not.toContain("alert(1)");
+    expect(out).toContain("<p>x</p>");
+    expect(out).toContain("<p>y</p>");
+  });
+
+  it("strips a per-tag attribute when present on a tag it is not allowlisted for", () => {
+    // `href` is only valid on `a`; `colspan` is only valid on `th`/`td`.
+    const out = sanitizePreviewHtml('<div href="https://example.com" colspan="2">x</div>');
+    expect(out).not.toContain("href");
+    expect(out).not.toContain("colspan");
+    expect(out).toContain("<div>x</div>");
+  });
+
+  it("does not retain a drop-tag's content as text (unlike DOMPurify's own KEEP_CONTENT default)", () => {
+    const out = sanitizePreviewHtml("<style>body { color: red; }</style><p>after</p>");
+    expect(out).not.toContain("color: red");
+    expect(out).toContain("<p>after</p>");
+  });
+
+  it("passes admonition markup from postProcessAdmonitions through unchanged", () => {
+    const admonitionHtml = postProcessAdmonitions('<Note title="Heads up">Body text.</Note>');
+    expect(sanitizePreviewHtml(admonitionHtml)).toBe(admonitionHtml);
   });
 });
 

--- a/packages/zudo-doc-online/src/features/preview/__tests__/render-runtime.test.ts
+++ b/packages/zudo-doc-online/src/features/preview/__tests__/render-runtime.test.ts
@@ -230,6 +230,18 @@ describe("sanitizePreviewHtml", () => {
     const admonitionHtml = postProcessAdmonitions('<Note title="Heads up">Body text.</Note>');
     expect(sanitizePreviewHtml(admonitionHtml)).toBe(admonitionHtml);
   });
+
+  it("keeps a heading id that collides with a DOM/document property name (e.g. a heading literally titled 'Title')", () => {
+    // headingIds' hierarchical strategy slugifies heading text verbatim, so a
+    // page section titled "Title", "Name", "Location", etc. produces an id
+    // that collides with a same-named `document`/`window` property.
+    // DOMPurify's default DOM-clobbering guard (SANITIZE_DOM) silently drops
+    // such an id while leaving its `#title` hash-link href intact, breaking
+    // in-page navigation -- this policy trusts its own pipeline-generated
+    // ids, so that guard must not fire here.
+    const html = '<h2 id="title" class="hash-heading">Title<a class="hash-link" href="#title">#</a></h2>';
+    expect(sanitizePreviewHtml(html)).toBe(html);
+  });
 });
 
 describe("loadZfbMdWasm", () => {

--- a/packages/zudo-doc-online/src/features/preview/render-runtime.ts
+++ b/packages/zudo-doc-online/src/features/preview/render-runtime.ts
@@ -240,8 +240,15 @@ function isSafeUrl(value: string): boolean {
 /**
  * Registers the fixed policy hooks (per-tag attribute narrowing + the
  * `isSafeUrl` href/src check) on a DOMPurify instance. `addHook` appends
- * rather than replaces, so this must only ever be called once per instance
- * -- the module-level call right below is the only call site.
+ * rather than replaces, so this must only ever run once per instance --
+ * guarded by `hooksRegistered` below, called lazily from `sanitizePreviewHtml`
+ * rather than at module load. In a DOM-less environment (Node, no `window`)
+ * the imported `dompurify` default export is an uninitialized factory with
+ * `isSupported === false` and no `addHook` method at all -- calling this
+ * unconditionally at module scope would throw the instant this module is
+ * imported anywhere outside a real DOM (e.g. a future Node-environment test
+ * or server-side import), independent of and before the `isSupported`
+ * no-op check below ever gets a chance to run.
  */
 function registerSanitizeHooks(purify: typeof DOMPurify): void {
   purify.addHook("uponSanitizeAttribute", (node, event) => {
@@ -263,7 +270,7 @@ function registerSanitizeHooks(purify: typeof DOMPurify): void {
   });
 }
 
-registerSanitizeHooks(DOMPurify);
+let hooksRegistered = false;
 
 const SANITIZE_CONFIG: DOMPurifyConfig = {
   ALLOWED_TAGS: SANITIZE_ALLOWED_TAGS,
@@ -279,6 +286,17 @@ const SANITIZE_CONFIG: DOMPurifyConfig = {
   // SANITIZE_GLOBAL_ATTRS / ALLOWED_ATTR above) and no data-* attrs at all.
   ALLOW_ARIA_ATTR: false,
   ALLOW_DATA_ATTR: false,
+  // DOMPurify's default DOM-clobbering guard drops an `id`/`name` attribute
+  // whenever its value collides with an existing `document`/form property
+  // name (e.g. `id="title"`, since `document.title` exists) -- verified
+  // empirically against this pipeline's own output. `headingIds` slugifies
+  // heading TEXT verbatim, so a page section titled "Title", "Name",
+  // "Location", etc. produces exactly such a collision, silently dropping
+  // the id while leaving its `#title`-style hash-link href intact and
+  // breaking in-page navigation. This pane trusts its own pipeline-generated
+  // ids (not free-form attacker-chosen ones), so that guard is disabled --
+  // matching the prior hand-rolled sanitizer, which never had it.
+  SANITIZE_DOM: false,
 };
 
 /**
@@ -290,6 +308,10 @@ const SANITIZE_CONFIG: DOMPurifyConfig = {
  */
 export function sanitizePreviewHtml(html: string): string {
   if (!DOMPurify.isSupported) return html;
+  if (!hooksRegistered) {
+    registerSanitizeHooks(DOMPurify);
+    hooksRegistered = true;
+  }
   return DOMPurify.sanitize(html, SANITIZE_CONFIG);
 }
 

--- a/packages/zudo-doc-online/src/features/preview/render-runtime.ts
+++ b/packages/zudo-doc-online/src/features/preview/render-runtime.ts
@@ -30,6 +30,8 @@
  * line inside an otherwise correctly styled/colored admonition box.
  */
 
+import DOMPurify from "dompurify";
+import type { Config as DOMPurifyConfig } from "dompurify";
 import type { Diagnostic, PipelineOptions } from "@takazudo/zfb-md-wasm";
 
 type WasmModule = typeof import("@takazudo/zfb-md-wasm");
@@ -123,7 +125,7 @@ export function postProcessAdmonitions(html: string): string {
 }
 
 /* ============================================================================
- * Best-effort HTML sanitization before DOM injection
+ * HTML sanitization before DOM injection (DOMPurify-backed)
  *
  * `renderHtml` preserves raw HTML from the markdown source VERBATIM --
  * verified empirically (not documented in the package's own contract):
@@ -137,20 +139,19 @@ export function postProcessAdmonitions(html: string): string {
  * to see the raw `<Note>`-style tags) -- this pass runs last, right before
  * the trust boundary the HTML is about to cross.
  *
- * This is a hand-rolled allowlist walk over a real parsed DOM tree (native
- * `DOMParser`, zero new dependencies -- epic #3327 contract 4 forbids a
- * child sub-issue from adding one, e.g. DOMPurify), not a text-pattern
- * sanitizer -- a real parse tree closes most of the bypass classes a regex
- * sanitizer is prone to, but this has not had the adversarial scrutiny a
- * battle-tested library has. Treat this as a deliberate, scoped mitigation
- * for THIS tool's threat model (a loopback-bound single-user local dev
- * server -- epic non-goals), not a substitute for a real sanitizer library;
- * adopting one needs to go through the bootstrap sub-issue's
- * dependency-addition path, not a Wave-7 child.
+ * This wraps DOMPurify (a battle-tested sanitizer library -- the
+ * hand-rolled `DOMParser` allowlist walk this replaced never had the
+ * adversarial scrutiny DOMPurify has) with the same allowlist policy the
+ * previous implementation enforced: a fixed tag allowlist, whole-subtree
+ * dropping for a fixed set of dangerous tags, per-tag (not just global)
+ * attribute narrowing, and the existing `isSafeUrl` scheme check on
+ * `href`/`src`. DOMPurify's own config knobs are global-only (`ALLOWED_ATTR`
+ * has no per-tag concept), so the per-tag narrowing below still needs a
+ * `uponSanitizeAttribute` hook.
  * ========================================================================== */
 
 /** Tags whose entire subtree is dropped -- there is no safe way to keep their content. */
-const SANITIZE_DROP_TAGS = new Set([
+const SANITIZE_DROP_TAGS = [
   "script",
   "style",
   "iframe",
@@ -163,10 +164,10 @@ const SANITIZE_DROP_TAGS = new Set([
   "svg",
   "math",
   "noscript",
-]);
+];
 
 /** Tags this pane's own pipeline can legitimately produce -- everything else is unwrapped (kept as already-sanitized text/children, tag stripped). */
-const SANITIZE_ALLOWED_TAGS = new Set([
+const SANITIZE_ALLOWED_TAGS = [
   "a",
   "p",
   "br",
@@ -199,7 +200,7 @@ const SANITIZE_ALLOWED_TAGS = new Set([
   "div",
   "details",
   "summary",
-]);
+];
 
 const SANITIZE_GLOBAL_ATTRS = new Set(["class", "id", "title", "aria-label", "aria-hidden", "dir", "lang", "open"]);
 
@@ -211,6 +212,12 @@ const SANITIZE_TAG_ATTRS: Record<string, ReadonlySet<string>> = {
   th: new Set(["colspan", "rowspan"]),
   td: new Set(["colspan", "rowspan"]),
 };
+
+/** The full attribute vocabulary across every tag -- DOMPurify's `ALLOWED_ATTR` is global-only, so this is the union; the `uponSanitizeAttribute` hook below narrows it back down per tag. */
+const SANITIZE_ALLOWED_ATTR = [
+  ...SANITIZE_GLOBAL_ATTRS,
+  ...new Set(Object.values(SANITIZE_TAG_ATTRS).flatMap((set) => [...set])),
+];
 
 const SANITIZE_URL_ATTRS = new Set(["href", "src"]);
 
@@ -230,58 +237,60 @@ function isSafeUrl(value: string): boolean {
   return SAFE_URL_SCHEMES.has(scheme.toLowerCase());
 }
 
-function sanitizeElement(el: Element): void {
-  // Depth-first: children are fully sanitized before this element's own
-  // fate (drop / unwrap / keep) is decided, so an unwrap below re-parents
-  // already-safe nodes.
-  for (const child of [...el.children]) {
-    sanitizeElement(child);
-  }
+/**
+ * Registers the fixed policy hooks (per-tag attribute narrowing + the
+ * `isSafeUrl` href/src check) on a DOMPurify instance. `addHook` appends
+ * rather than replaces, so this must only ever be called once per instance
+ * -- the module-level call right below is the only call site.
+ */
+function registerSanitizeHooks(purify: typeof DOMPurify): void {
+  purify.addHook("uponSanitizeAttribute", (node, event) => {
+    const name = event.attrName;
+    const tag = node.tagName.toLowerCase();
 
-  const tag = el.tagName.toLowerCase();
-
-  if (SANITIZE_DROP_TAGS.has(tag)) {
-    el.remove();
-    return;
-  }
-
-  if (!SANITIZE_ALLOWED_TAGS.has(tag)) {
-    el.replaceWith(...el.childNodes);
-    return;
-  }
-
-  const tagAttrs = SANITIZE_TAG_ATTRS[tag];
-  for (const attr of [...el.attributes]) {
-    const name = attr.name.toLowerCase();
-    // Event-handler attributes are rejected unconditionally, ahead of the
-    // allowlist below -- a belt-and-suspenders check, since none of them
-    // appear in SANITIZE_GLOBAL_ATTRS/SANITIZE_TAG_ATTRS anyway.
-    if (name.startsWith("on")) {
-      el.removeAttribute(attr.name);
-      continue;
+    if (SANITIZE_URL_ATTRS.has(name) && !isSafeUrl(event.attrValue)) {
+      event.keepAttr = false;
+      return;
     }
-    if (SANITIZE_URL_ATTRS.has(name) && !isSafeUrl(attr.value)) {
-      el.removeAttribute(attr.name);
-      continue;
-    }
-    if (SANITIZE_GLOBAL_ATTRS.has(name) || tagAttrs?.has(name)) continue;
-    el.removeAttribute(attr.name);
-  }
+
+    if (SANITIZE_GLOBAL_ATTRS.has(name)) return; // already in ALLOWED_ATTR; valid on every allowed tag
+    if (SANITIZE_TAG_ATTRS[tag]?.has(name)) return; // valid on this specific tag
+
+    // Anything else that made it past the global ALLOWED_ATTR allowlist is a
+    // tag-attr pairing this policy never granted (e.g. `href` on a `div`) --
+    // narrow it back out.
+    event.keepAttr = false;
+  });
 }
 
+registerSanitizeHooks(DOMPurify);
+
+const SANITIZE_CONFIG: DOMPurifyConfig = {
+  ALLOWED_TAGS: SANITIZE_ALLOWED_TAGS,
+  ALLOWED_ATTR: SANITIZE_ALLOWED_ATTR,
+  // DOMPurify keeps a removed tag's TEXT content by default (`KEEP_CONTENT`).
+  // `ADD_FORBID_CONTENTS` layers the tags this policy needs the WHOLE
+  // subtree dropped for on top of DOMPurify's own defaults (which already
+  // include script/style/svg/math/iframe/noscript) rather than replacing
+  // them outright, so DOMPurify's other built-in drop-tags stay in effect too.
+  ADD_FORBID_CONTENTS: SANITIZE_DROP_TAGS,
+  // Both default to `true` in DOMPurify -- broader than this policy, which
+  // allows only the two explicitly-listed aria-* attrs (already present in
+  // SANITIZE_GLOBAL_ATTRS / ALLOWED_ATTR above) and no data-* attrs at all.
+  ALLOW_ARIA_ATTR: false,
+  ALLOW_DATA_ATTR: false,
+};
+
 /**
- * Best-effort sanitization pass -- see the section header above for scope
- * and rationale. A no-op outside a DOM environment (`DOMParser` absent):
+ * Sanitization pass -- see the section header above for scope and
+ * rationale. A no-op when DOMPurify reports its host environment
+ * unsupported (`DOMPurify.isSupported`, e.g. no `window`/DOM available):
  * this function is only ever meaningfully called from the browser, where
  * `preview-pane.tsx` is the sole caller right before `dangerouslySetInnerHTML`.
  */
 export function sanitizePreviewHtml(html: string): string {
-  if (typeof DOMParser === "undefined") return html;
-  const doc = new DOMParser().parseFromString(html, "text/html");
-  for (const child of [...doc.body.children]) {
-    sanitizeElement(child);
-  }
-  return doc.body.innerHTML;
+  if (!DOMPurify.isSupported) return html;
+  return DOMPurify.sanitize(html, SANITIZE_CONFIG);
 }
 
 /* ============================================================================

--- a/packages/zudo-doc-online/src/main.tsx
+++ b/packages/zudo-doc-online/src/main.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useState } from "preact/hooks";
 import "./styles/global.css";
 import { RouteView } from "./app/routes.js";
 import { Shell } from "./app/shell.js";
-import { getClientId } from "./store/client-id.js";
+import { getClientId, initClientId } from "./store/client-id.js";
 import { ProjectEventsClient } from "./store/events.js";
 import { createHttpProjectStore } from "./store/http-provider.js";
 import {
@@ -57,6 +57,13 @@ function ShellApp() {
     </Shell>
   );
 }
+
+// Settle this tab's client id BEFORE anything mounts: every surface builds
+// SSE/events clients during mount via the synchronous `getClientId()`, and a
+// duplicated tab only learns it must re-mint once the Web Lock claim resolves.
+// Awaiting here is the single point that covers every provider-construction
+// path. It never rejects — a failed claim degrades to the stored id.
+await initClientId();
 
 const root = document.getElementById("root");
 

--- a/packages/zudo-doc-online/src/store/__tests__/client-id.test.ts
+++ b/packages/zudo-doc-online/src/store/__tests__/client-id.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
-import { getClientId, type ClientIdStorage } from "../client-id";
+import {
+  getClientId,
+  initClientId,
+  resetClientIdState,
+  type ClientIdLockManager,
+  type ClientIdStorage,
+} from "../client-id";
 
 function fakeStorage(initial: Record<string, string> = {}): ClientIdStorage {
   const data = new Map(Object.entries(initial));
@@ -11,6 +17,67 @@ function fakeStorage(initial: Record<string, string> = {}): ClientIdStorage {
     },
   };
 }
+
+interface FakeLocks {
+  readonly manager: ClientIdLockManager;
+  /** Names currently held — by a simulated other tab, or by a successful claim. */
+  readonly held: Set<string>;
+  /** Names `request()` was called with, in order. */
+  readonly requested: string[];
+  /** Settle every callback still holding a lock, so no promise outlives the test. */
+  releaseAll(): void;
+}
+
+function fakeLocks(initiallyHeld: string[] = []): FakeLocks {
+  const held = new Set(initiallyHeld);
+  const requested: string[] = [];
+  const releases: Array<() => void> = [];
+
+  const manager: ClientIdLockManager = {
+    request(name, _options, callback) {
+      requested.push(name);
+      if (held.has(name)) return Promise.resolve(callback(null));
+      held.add(name);
+      // The real API keeps this promise pending for as long as the callback
+      // holds the lock — the callback we pass never resolves on a grant.
+      return Promise.race([
+        callback({ name }),
+        new Promise<void>((resolve) => {
+          releases.push(() => {
+            held.delete(name);
+            resolve();
+          });
+        }),
+      ]);
+    },
+  };
+
+  return {
+    manager,
+    held,
+    requested,
+    releaseAll() {
+      for (const release of releases.splice(0)) release();
+    },
+  };
+}
+
+/** Lets a pending-forever promise prove it is still pending. */
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function sequentialIds(prefix = "id"): () => string {
+  let calls = 0;
+  return () => {
+    calls += 1;
+    return `${prefix}-${calls}`;
+  };
+}
+
+afterEach(() => {
+  resetClientIdState();
+});
 
 describe("getClientId", () => {
   it("mints and persists an id on first call", () => {
@@ -47,15 +114,134 @@ describe("getClientId", () => {
   it("does not cross-contaminate two independent storages", () => {
     const storageA = fakeStorage();
     const storageB = fakeStorage();
-    let calls = 0;
-    const createId = () => {
-      calls += 1;
-      return `id-${calls}`;
-    };
+    const createId = sequentialIds();
 
     const a = getClientId({ storage: storageA, createId });
     const b = getClientId({ storage: storageB, createId });
 
     expect(a).not.toBe(b);
+  });
+});
+
+describe("initClientId", () => {
+  it("keeps the stored id and holds its lock when the lock is free", async () => {
+    const storage = fakeStorage({ "zdo-client-id": "stored-id" });
+    const locks = fakeLocks();
+
+    const id = await initClientId({
+      storage,
+      lockManager: locks.manager,
+      createId: () => "should-not-be-used",
+    });
+
+    expect(id).toBe("stored-id");
+    expect(storage.getItem("zdo-client-id")).toBe("stored-id");
+    expect(locks.held.has("zdo-client-id:stored-id")).toBe(true);
+
+    locks.releaseAll();
+  });
+
+  it("mints, stores and claims a fresh id when the stored one is held elsewhere", async () => {
+    const storage = fakeStorage({ "zdo-client-id": "duplicated-id" });
+    // The first mint also loses, forcing a second pass — two duplicates racing.
+    const locks = fakeLocks(["zdo-client-id:duplicated-id", "zdo-client-id:fresh-1"]);
+
+    const id = await initClientId({
+      storage,
+      lockManager: locks.manager,
+      createId: sequentialIds("fresh"),
+    });
+
+    expect(id).toBe("fresh-2");
+    expect(storage.getItem("zdo-client-id")).toBe("fresh-2");
+    expect(locks.requested).toEqual([
+      "zdo-client-id:duplicated-id",
+      "zdo-client-id:fresh-1",
+      "zdo-client-id:fresh-2",
+    ]);
+    expect(locks.held.has("zdo-client-id:fresh-2")).toBe(true);
+
+    locks.releaseAll();
+  });
+
+  it("falls back to the synchronous behavior when no lock manager exists", async () => {
+    const storage = fakeStorage({ "zdo-client-id": "stored-id" });
+
+    const id = await initClientId({ storage, lockManager: null });
+
+    expect(id).toBe("stored-id");
+  });
+
+  it("resolves while the underlying lock request stays pending", async () => {
+    const storage = fakeStorage({ "zdo-client-id": "stored-id" });
+    let requestSettled = false;
+    const locks = fakeLocks();
+    const manager: ClientIdLockManager = {
+      request(name, options, callback) {
+        const outcome = locks.manager.request(name, options, callback);
+        void outcome.then(
+          () => {
+            requestSettled = true;
+          },
+          () => {
+            requestSettled = true;
+          },
+        );
+        return outcome;
+      },
+    };
+
+    await expect(initClientId({ storage, lockManager: manager })).resolves.toBe("stored-id");
+    await flushMicrotasks();
+
+    expect(requestSettled).toBe(false);
+
+    locks.releaseAll();
+  });
+
+  it("claims once for concurrent and repeated calls", async () => {
+    const storage = fakeStorage({ "zdo-client-id": "stored-id" });
+    const locks = fakeLocks();
+
+    const [first, second] = await Promise.all([
+      initClientId({ storage, lockManager: locks.manager }),
+      initClientId({ storage, lockManager: locks.manager }),
+    ]);
+    const third = await initClientId({ storage, lockManager: locks.manager });
+
+    expect(first).toBe("stored-id");
+    expect(second).toBe("stored-id");
+    expect(third).toBe("stored-id");
+    expect(locks.requested).toEqual(["zdo-client-id:stored-id"]);
+
+    locks.releaseAll();
+  });
+
+  it("falls back to the stored id when the lock request rejects", async () => {
+    const storage = fakeStorage({ "zdo-client-id": "stored-id" });
+    const manager: ClientIdLockManager = {
+      request: () => Promise.reject(new Error("locks unavailable")),
+    };
+
+    await expect(initClientId({ storage, lockManager: manager })).resolves.toBe("stored-id");
+  });
+
+  it("mints an id when there is neither storage nor a lock manager", async () => {
+    const throwingStorage: ClientIdStorage = {
+      getItem: () => {
+        throw new Error("storage unavailable");
+      },
+      setItem: () => {
+        throw new Error("storage unavailable");
+      },
+    };
+
+    await expect(
+      initClientId({
+        storage: throwingStorage,
+        lockManager: null,
+        createId: () => "fallback-id",
+      }),
+    ).resolves.toBe("fallback-id");
   });
 });

--- a/packages/zudo-doc-online/src/store/client-id.ts
+++ b/packages/zudo-doc-online/src/store/client-id.ts
@@ -10,22 +10,52 @@
  * `sessionStorage` (not `localStorage`) is deliberate: the id survives a
  * reload of the same tab but is never shared with a genuinely new tab.
  *
- * KNOWN LIMITATION: a browser's "duplicate tab" action copies `sessionStorage`
- * verbatim into the new tab, so two tabs opened that way share one id until
- * one of them is closed and reopened — a mutation from either would be
- * misclassified as the other's own event, momentarily weakening the SSE
- * dirty-guard between exactly those two tabs. Detecting that reliably needs
- * live cross-tab coordination (e.g. the Web Locks API or a BroadcastChannel
- * handshake at startup), which is an async, wider-reaching change than this
- * synchronous accessor should carry — left for a follow-up rather than
- * fixed here.
+ * ## The duplicate-tab claim (Web Locks)
+ *
+ * A browser's "duplicate tab" action copies `sessionStorage` verbatim into
+ * the new tab, so the stored id alone cannot stay unique. `initClientId()`
+ * therefore claims a Web Lock named `zdo-client-id:{id}` at boot and holds it
+ * for the tab's lifetime: a duplicate finds the lock already held, mints a
+ * fresh id, and re-claims — looping until a claim actually succeeds, since
+ * two duplicates can race for the same name.
+ *
+ * KNOWN LIMITATION: an environment without `navigator.locks` (jsdom, older
+ * engines) keeps the pre-fix behavior — two duplicated tabs share one id
+ * until one is closed and reopened, and a mutation from either is
+ * misclassified as the other's own SSE event, momentarily weakening the
+ * dirty-guard between exactly those two tabs. The claim degrades to today's
+ * synchronous read rather than failing, so boot never blocks on it.
+ *
+ * ## Web Locks semantics that shape the code below
+ *
+ * `navigator.locks.request()`'s returned promise resolves only when the
+ * CALLBACK settles — holding a lock for the tab's lifetime means that outer
+ * promise NEVER resolves, so it must never be awaited. `claimLock()` instead
+ * resolves a separate handshake promise from inside the callback the moment
+ * the grant result is known, and returns a never-resolving promise from the
+ * callback to keep the lock held.
  */
 
 const STORAGE_KEY = "zdo-client-id";
+const LOCK_PREFIX = "zdo-client-id:";
 
 export interface ClientIdStorage {
   getItem(key: string): string | null;
   setItem(key: string, value: string): void;
+}
+
+/** The single `Lock` field this module reads; structurally satisfied by the real DOM `Lock`. */
+export interface ClientIdLockGrant {
+  readonly name: string;
+}
+
+/** The `navigator.locks` subset this module uses; injectable so tests need no real LockManager. */
+export interface ClientIdLockManager {
+  request(
+    name: string,
+    options: { mode: "exclusive"; ifAvailable: true },
+    callback: (lock: ClientIdLockGrant | null) => Promise<unknown>,
+  ): Promise<unknown>;
 }
 
 export interface ClientIdOptions {
@@ -33,6 +63,14 @@ export interface ClientIdOptions {
   storage?: ClientIdStorage;
   /** Injectable for tests; defaults to `crypto.randomUUID`. */
   createId?: () => string;
+}
+
+export interface InitClientIdOptions extends ClientIdOptions {
+  /**
+   * Injectable for tests; defaults to `navigator.locks`. Pass `null` to
+   * exercise the no-Web-Locks fallback explicitly.
+   */
+  lockManager?: ClientIdLockManager | null;
 }
 
 /**
@@ -43,6 +81,13 @@ export interface ClientIdOptions {
  * to call this in a process would poison every later test with its id.
  */
 let cachedId: string | undefined;
+
+/**
+ * The in-flight (or settled) claim, so repeated `initClientId()` calls share
+ * one result. Without this, a second call would find the tab's OWN held lock
+ * and needlessly re-mint.
+ */
+let initPromise: Promise<string> | undefined;
 
 export function getClientId(options: ClientIdOptions = {}): string {
   if (options.storage === undefined && cachedId !== undefined) return cachedId;
@@ -58,9 +103,87 @@ export function getClientId(options: ClientIdOptions = {}): string {
   return id;
 }
 
-/** Test-only: clears the module-level cache used by the zero-argument path. */
-export function resetClientIdCache(): void {
+/**
+ * Claims this tab's id under a Web Lock, minting a fresh one for as long as
+ * the claim keeps losing to a duplicate tab. Idempotent and concurrency-safe:
+ * every call after the first returns the same promise. Never rejects — any
+ * failure (no `navigator.locks`, a rejected request, unavailable storage)
+ * degrades to the synchronous behavior rather than leaving a blank SPA.
+ */
+export function initClientId(options: InitClientIdOptions = {}): Promise<string> {
+  if (initPromise === undefined) {
+    initPromise = runInit(options).then((id) => {
+      if (options.storage === undefined) cachedId = id;
+      return id;
+    });
+  }
+  return initPromise;
+}
+
+async function runInit(options: InitClientIdOptions): Promise<string> {
+  const createId = options.createId ?? (() => crypto.randomUUID());
+  let id: string | undefined;
+
+  try {
+    const storage = options.storage ?? resolveDefaultStorage();
+    const existing = storage.getItem(STORAGE_KEY);
+    id = existing ?? createId();
+    if (existing === null) storage.setItem(STORAGE_KEY, id);
+
+    const locks = resolveLockManager(options);
+    if (locks === null) return id;
+
+    // Loop rather than mint-once: two duplicated tabs can lose the same race,
+    // and the freshly minted id could itself already be claimed.
+    for (;;) {
+      const granted = await claimLock(locks, LOCK_PREFIX + id);
+      if (granted) return id;
+      id = createId();
+      storage.setItem(STORAGE_KEY, id);
+    }
+  } catch {
+    return id ?? createId();
+  }
+}
+
+/**
+ * Resolves `true` once the lock is held (kept for the tab's lifetime) or
+ * `false` when a duplicate tab already holds it. The `request()` promise is
+ * deliberately never awaited — see the file header.
+ */
+function claimLock(locks: ClientIdLockManager, name: string): Promise<boolean> {
+  return new Promise<boolean>((resolve, reject) => {
+    let granted = false;
+
+    const outcome = locks.request(name, { mode: "exclusive", ifAvailable: true }, (lock) => {
+      if (lock === null) {
+        resolve(false);
+        return Promise.resolve();
+      }
+      granted = true;
+      resolve(true);
+      return new Promise<never>(() => {});
+    });
+
+    // `request()` can reject before the callback ever runs (bad name,
+    // unsupported engine). Once the lock is granted the outer promise stays
+    // pending forever by design, so a late rejection cannot arrive there.
+    Promise.resolve(outcome).catch((error: unknown) => {
+      if (!granted) reject(error instanceof Error ? error : new Error(String(error)));
+    });
+  });
+}
+
+/** Test-only: clears the module-level id cache and any completed/in-flight claim. */
+export function resetClientIdState(): void {
   cachedId = undefined;
+  initPromise = undefined;
+}
+
+function resolveLockManager(options: InitClientIdOptions): ClientIdLockManager | null {
+  if (options.lockManager !== undefined) return options.lockManager;
+  if (typeof navigator === "undefined") return null;
+  return (navigator as Navigator & { locks?: ClientIdLockManager }).locks ?? null;
 }
 
 function resolveDefaultStorage(): ClientIdStorage {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -325,6 +325,9 @@ importers:
       codemirror:
         specifier: ^6.0.2
         version: 6.0.2
+      dompurify:
+        specifier: '>=3.4.11'
+        version: 3.4.13
       hono:
         specifier: ^4.13.1
         version: 4.13.1
@@ -1741,6 +1744,9 @@ packages:
   '@types/string-similarity@4.0.2':
     resolution: {integrity: sha512-LkJQ/jsXtCVMK+sKYAmX/8zEq+/46f1PTQw7YtmQwb74jemS1SlNLmARM2Zml9DgdDTWKAtc5L13WorpHPDjDA==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -2061,6 +2067,9 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -4909,6 +4918,9 @@ snapshots:
 
   '@types/string-similarity@4.0.2': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
@@ -5238,6 +5250,10 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.4.13:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@3.2.2:
     dependencies:


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3358
- parent PR
    - https://github.com/zudolab/zudo-doc/pull/3357

---

## Summary

Online Hardening epic (#3358): two security/robustness fixes in `packages/zudo-doc-online`.

1. **DOMPurify preview sanitizer** (#3359) — `sanitizePreviewHtml` in `src/features/preview/render-runtime.ts` now runs DOMPurify instead of the hand-rolled DOMParser allowlist walk. The prior policy is reproduced precisely: explicit whole-subtree dropping for the old drop-tag set via `FORBID_CONTENTS`, per-tag attribute narrowing via a `uponSanitizeAttribute` hook (DOMPurify's `ALLOWED_ATTR` is global-only), `ALLOW_ARIA_ATTR`/`ALLOW_DATA_ATTR` off with only `aria-label`/`aria-hidden` re-allowed, and the existing `isSafeUrl` scheme check kept as an `href`/`src` hook. Two review-driven fixes: hook registration is lazy (module import stays Node-safe), and `SANITIZE_DOM: false` preserves heading ids that collide with DOM property names (anchor navigation). New regression tests cover svg/script nesting, obfuscated `javascript:` variants, `data:`/`blob:` URLs, math payloads, per-tag narrowing, and admonition pass-through.
2. **Web Locks clientId claim** (#3360) — `src/store/client-id.ts` gains `initClientId()`: at boot each tab claims a Web Lock named after its stored id (`ifAvailable: true`); a duplicated tab loses the claim, mints a fresh id, and re-claims in a loop. The handshake resolves from inside the lock callback while the outer `request()` promise is deliberately never awaited (it never resolves for a lifetime-held lock). Idempotent via a cached in-flight promise; environments without `navigator.locks` (or a rejected request) degrade to the previous synchronous behavior. `main.tsx` awaits it before the pop-out import and `render()`. `CLAUDE.md`'s Known-limitations entries rewritten for both changes.

## Verification

- `pnpm --filter zudo-doc-online typecheck` clean, `test` 902/902, `build` clean — on the merged base.
- Codex review of the full epic diff: no actionable regressions.

## Topic PRs

Both topics were merged locally into this base (no separate PRs): `dompurify-sanitizer`, `weblocks-client-id`.
