### PR TITLE
docs: correct stale frontmatter-passthrough and admonition-set claims

### DIFF
--- a/.claude/skills/zudo-doc-writing-rules/SKILL.md
+++ b/.claude/skills/zudo-doc-writing-rules/SKILL.md
@@ -76,7 +76,7 @@ The schema is package-owned (`@takazudo/zudo-doc/docs-schema`, source `packages/
 | `hide_sidebar` | boolean | no | Hide the left sidebar on this page |
 | `hide_toc` | boolean | no | Hide the right-side table of contents |
 
-Unknown fields are rejected by the Zod schema — do not invent new ones without updating the schema.
+The schema ends with `.passthrough()`, so custom keys (e.g. `author`, `status`) are preserved rather than rejected — they simply carry no built-in behavior. Consequence: a typo in a framework field name (`sidebar_postion`) does NOT error at build time; double-check spellings against the table above.
 
 ## Linking Between Docs
 
@@ -112,9 +112,10 @@ Body content.
 <Info>...</Info>
 <Warning>...</Warning>
 <Danger>...</Danger>
+<Caution>...</Caution>
 ```
 
-All five components accept an optional `title` prop.
+All admonition components accept an optional `title` prop. (`caution` is danger-adjacent, used by GitHub-style `[!CAUTION]` alerts; JSX additionally registers `<Important>` for `[!IMPORTANT]`.)
 
 ## Common Mistakes (Do Not Do)
 
@@ -125,7 +126,7 @@ All five components accept an optional `title` prop.
 - **Updating only the EN or only the JA version** — breaks the bilingual mirror (except for pages under `defaultLocaleOnlyPrefixes` or with `generated: true`).
 - **Absolute `/docs/...` links in prose** — the resolver cannot verify them; use relative `./page.mdx` instead.
 - **Omitting the `.mdx` extension in links** — the resolver requires it.
-- **Inventing frontmatter fields** — the Zod schema will reject them at build time.
+- **Misspelling framework frontmatter fields** — the schema passes unknown keys through, so a typo'd `sidebar_position` silently does nothing instead of erroring.
 - **Translating code inside code blocks** — the bilingual rule says code stays identical.
 
 ## Recommended Workflow

--- a/src/content/docs-ja/getting-started/writing-docs.mdx
+++ b/src/content/docs-ja/getting-started/writing-docs.mdx
@@ -121,6 +121,12 @@ zudo-docはDocusaurusスタイルのアドモニションをサポートして�
 
 </Danger>
 
+<Caution>
+
+これは**注意（caution）**アラートです — 高深刻度で danger に準じる位置づけです。GitHubスタイルの `[!CAUTION]` アラートもこの表示になります。
+
+</Caution>
+
 ### カスタムタイトル
 
 <Note title="カスタムタイトル">
@@ -164,6 +170,7 @@ Warning with a custom title.
 | Info | info | 青 |
 | Warning | warning | 黄 |
 | Danger | danger | 赤 |
+| Caution | danger | 赤 |
 
 <Tip>
 

--- a/src/content/docs/getting-started/writing-docs.mdx
+++ b/src/content/docs/getting-started/writing-docs.mdx
@@ -121,6 +121,12 @@ This is a **danger** alert — use it for critical warnings about data loss or b
 
 </Danger>
 
+<Caution>
+
+This is a **caution** alert — high-severity and danger-adjacent; it is also what GitHub-style `[!CAUTION]` alerts render as.
+
+</Caution>
+
 ### Custom Titles
 
 <Note title="Custom Title">
@@ -164,6 +170,7 @@ Each admonition type maps to a semantic color token for its border and title col
 | Info | info | Blue |
 | Warning | warning | Yellow |
 | Danger | danger | Red |
+| Caution | danger | Red |
 
 <Tip>
 


### PR DESCRIPTION
## Summary

Auto-fix for the `agent-found` issue #3384 (raised during the PR 3383 workflow): three pre-existing doc-authoring claims were factually wrong.

## Changes

- `.claude/skills/zudo-doc-writing-rules/SKILL.md`: the default docs schema is `.passthrough()` — custom frontmatter keys are preserved, not rejected (and the real hazard is a silently-ignored typo in a framework field); the admonition set includes `caution`/`<Caution>` (+ JSX `<Important>`).
- `src/content/docs/getting-started/writing-docs.mdx` + JA mirror: added the `<Caution>` demo and its color-table row (danger token).

Since `.claude/skills/` regenerates the published `/docs/claude-skills/` pages, the skill fix also corrects its published page.

Closes #3384

## Test Plan

- Claims verified against `packages/zudo-doc/src/docs-schema/index.ts` (`.passthrough()`), `mdx-components/index.ts` (Caution/Important registration), and `content.css` (caution → danger token).
- CI build + link check cover the edited pages.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/3385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789161781&installation_model_id=20910&pr_number=3385&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F3385&signature=4cb7bae94892f0943ecd925c2f5fb3207d4ebea1ff8ec1ed8d1d830b6f6f999a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->