### PR TITLE
Fix task-list rendering and sidebar scroll preservation

### DIFF
--- a/e2e/fixtures/smoke/src/content/docs/guides/task-lists-test.mdx
+++ b/e2e/fixtures/smoke/src/content/docs/guides/task-lists-test.mdx
@@ -1,0 +1,25 @@
+---
+title: Task Lists Test
+sidebar_position: 24
+description: A page for GFM task-list rendering coverage.
+---
+
+## Tight task list
+
+- [x] Tight checked item
+- [ ] Tight unchecked item
+
+## Loose task list
+
+- [x] Loose checked item
+
+  {/* Keep this item loose without adding visible fixture text. */}
+
+- [ ] Loose unchecked item
+
+  {/* Keep this item loose without adding visible fixture text. */}
+
+## Ordinary unordered list
+
+- Ordinary unordered item
+- Another ordinary item

--- a/e2e/smoke-markdown-features.spec.ts
+++ b/e2e/smoke-markdown-features.spec.ts
@@ -224,3 +224,62 @@ test.describe("Math: KaTeX rendering via <MathBlock>", () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// GFM task-list marker reset
+// ---------------------------------------------------------------------------
+
+test.describe("GFM task lists: disabled checkbox marker reset", () => {
+  test("tight and loose task rows have no disc marker while ordinary lists retain one", async ({
+    page,
+  }) => {
+    await page.goto("/docs/guides/task-lists-test", {
+      waitUntil: "networkidle",
+    });
+
+    const rows = await page.locator(".zd-content li").evaluateAll((items) =>
+      items.map((item) => ({
+        text: item.textContent?.replace(/\s+/g, " ").trim() ?? "",
+        listStyleType: getComputedStyle(item).listStyleType,
+        checkboxes: Array.from(
+          item.querySelectorAll<HTMLInputElement>(
+            ':scope > input[type="checkbox"], :scope > p > input[type="checkbox"]',
+          ),
+        ).map((checkbox) => ({
+          checked: checkbox.checked,
+          disabled: checkbox.disabled,
+        })),
+      })),
+    );
+
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        {
+          text: "Tight checked item",
+          listStyleType: "none",
+          checkboxes: [{ checked: true, disabled: true }],
+        },
+        {
+          text: "Tight unchecked item",
+          listStyleType: "none",
+          checkboxes: [{ checked: false, disabled: true }],
+        },
+        {
+          text: "Loose checked item",
+          listStyleType: "none",
+          checkboxes: [{ checked: true, disabled: true }],
+        },
+        {
+          text: "Loose unchecked item",
+          listStyleType: "none",
+          checkboxes: [{ checked: false, disabled: true }],
+        },
+        {
+          text: "Ordinary unordered item",
+          listStyleType: "disc",
+          checkboxes: [],
+        },
+      ]),
+    );
+  });
+});

--- a/e2e/smoke-vt-chrome-persist.spec.ts
+++ b/e2e/smoke-vt-chrome-persist.spec.ts
@@ -202,7 +202,7 @@ test.describe("VT Chrome Persist: sidebar scroll preservation", () => {
     // Wait beyond the old delayed 50 ms reset. An early-success poll could
     // otherwise pass before the regression fires.
     await page.locator("#desktop-sidebar").waitFor({ state: "attached", timeout: 5000 });
-    await page.waitForTimeout(100);
+    await page.waitForTimeout(100); // wait-ok: observe past the legacy 50 ms delayed reset before asserting
 
     const scrollTopAfter = await page.evaluate(() => {
       const aside = document.querySelector("#desktop-sidebar");

--- a/e2e/smoke-vt-chrome-persist.spec.ts
+++ b/e2e/smoke-vt-chrome-persist.spec.ts
@@ -170,42 +170,47 @@ test.describe("VT Chrome Persist: sidebar scroll preservation", () => {
     await page.goto(GUIDES_INDEX, { waitUntil: "domcontentloaded" });
     await waitForSidebarHydration(page);
 
-    // Attempt to scroll the sidebar; note whether it is actually scrollable.
+    // Give this regression a deterministic scroll container independent of
+    // fixture content and host viewport changes.
     const scrollInfo = await page.evaluate(() => {
-      const aside = document.querySelector("#desktop-sidebar");
-      if (!aside) return { scrollable: false, scrollTop: 0 };
-      const scrollable = aside.scrollHeight > aside.clientHeight;
-      if (scrollable) aside.scrollTop = 60;
-      return { scrollable, scrollTop: aside.scrollTop };
+      const aside = document.querySelector<HTMLElement>("#desktop-sidebar");
+      if (!aside) return null;
+      aside.style.height = "160px";
+      aside.style.maxHeight = "160px";
+      aside.style.overflowY = "auto";
+      aside.scrollTop = 60;
+      return {
+        scrollHeight: aside.scrollHeight,
+        clientHeight: aside.clientHeight,
+        scrollTop: aside.scrollTop,
+      };
     });
+
+    expect(scrollInfo, "Expected #desktop-sidebar to exist").not.toBeNull();
+    expect(
+      scrollInfo!.scrollHeight,
+      "Sidebar fixture must overflow for the scroll preservation regression",
+    ).toBeGreaterThan(scrollInfo!.clientHeight);
+    expect(
+      scrollInfo!.scrollTop,
+      "Browser must accept the requested nonzero sidebar scroll position",
+    ).toBe(60);
 
     const swapFired = await spaClick(page, GUIDES_PAGE_1);
     expect(swapFired, "zfb:after-swap did not fire within 10 s").toBe(true);
 
-    // Wait for the sidebar to remain attached after the swap (persisted node).
+    // Wait beyond the old delayed 50 ms reset. An early-success poll could
+    // otherwise pass before the regression fires.
     await page.locator("#desktop-sidebar").waitFor({ state: "attached", timeout: 5000 });
+    await page.waitForTimeout(100);
 
     const scrollTopAfter = await page.evaluate(() => {
       const aside = document.querySelector("#desktop-sidebar");
       return aside ? aside.scrollTop : -1;
     });
 
-    if (scrollInfo.scrollable && scrollInfo.scrollTop > 0) {
-      // Sidebar was scrollable and we actually moved it: assert preservation.
-      // Allow a ±30 px tolerance in case the island adjusted to show the
-      // active item.
-      expect(
-        scrollTopAfter,
-        "aside scrollTop should be preserved after SPA swap (within ±30 px tolerance)",
-      ).toBeGreaterThanOrEqual(scrollInfo.scrollTop - 30);
-    } else {
-      // Sidebar was not scrollable (content shorter than viewport) or
-      // scrollTop stayed at 0 — just verify it did not reset to a negative
-      // value (element gone).
-      expect(
-        scrollTopAfter,
-        "aside should still be present in DOM after swap (scrollTop ≥ 0)",
-      ).toBeGreaterThanOrEqual(0);
-    }
+    expect(scrollTopAfter, "aside scrollTop should be preserved exactly after SPA swap").toBe(
+      scrollInfo!.scrollTop,
+    );
   });
 });

--- a/packages/zudo-doc/src/__tests__/content-css.test.ts
+++ b/packages/zudo-doc/src/__tests__/content-css.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const css = readFileSync(resolve(__dirname, "../content.css"), "utf8");
+
+describe("src/content.css GFM task-list marker contract", () => {
+  it("resets markers for the generated tight and loose task-item shapes", () => {
+    expect(css).toContain('li:has(> input[type="checkbox"][disabled])');
+    expect(css).toContain(
+      'li:has(> p > input[type="checkbox"][disabled])',
+    );
+    expect(css).toMatch(
+      /\.zd-content\s*:where\([\s\S]*?\)\s*\{\s*list-style-type:\s*none;/,
+    );
+  });
+
+  it("keeps the selector on li and requires a disabled checkbox", () => {
+    const taskListRule = css.match(
+      /\.zd-content\s*:where\([\s\S]*?\)\s*\{\s*list-style-type:\s*none;\s*\}/,
+    )?.[0];
+
+    expect(taskListRule).toBeDefined();
+    expect(taskListRule).toContain("li:has(");
+    expect(taskListRule).toContain('[type="checkbox"][disabled]');
+    expect(taskListRule).not.toContain("input) ");
+    expect(taskListRule).not.toMatch(/li:has\(\s*input\b/);
+    expect(taskListRule).not.toMatch(/:where\(\s*input\b/);
+  });
+
+  it("does not add a broad li:has(input) marker reset", () => {
+    expect(css).not.toMatch(/li:has\(\s*input\b/);
+  });
+});

--- a/packages/zudo-doc/src/content.css
+++ b/packages/zudo-doc/src/content.css
@@ -164,6 +164,19 @@
   color: var(--color-muted);
 }
 
+/* GFM task-list inputs are emitted as disabled direct children of a tight
+ * item, or as children of the item's paragraph in a loose list. The
+ * component-rendered ancestor `ul` carries an inline disc marker, so reset
+ * only those generated task rows on the `li` itself. Keep the direct-child
+ * shape and disabled constraint narrow so authored/nested checkboxes remain
+ * ordinary list content. */
+.zd-content :where(
+  li:has(> input[type="checkbox"][disabled]),
+  li:has(> p > input[type="checkbox"][disabled])
+) {
+  list-style-type: none;
+}
+
 .zd-content :where(li > ul, li > ol) {
   margin-top: var(--spacing-vsp-xs);
   margin-bottom: 0;

--- a/packages/zudo-doc/src/sidebar-tree-island/__tests__/sidebar-scroll-preserve.test.ts
+++ b/packages/zudo-doc/src/sidebar-tree-island/__tests__/sidebar-scroll-preserve.test.ts
@@ -2,7 +2,11 @@
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AFTER_NAVIGATE_EVENT, BEFORE_NAVIGATE_EVENT } from "../../transitions/index.js";
-import { installSidebarScrollPreserve } from "../sidebar-scroll-preserve.js";
+import {
+  disposeSidebarScrollPreserve,
+  ensureSidebarScrollPreserve,
+  installSidebarScrollPreserve,
+} from "../sidebar-scroll-preserve.js";
 
 interface ControlledScrollTop {
   element: HTMLElement;
@@ -68,9 +72,8 @@ beforeEach(() => {
   document.body.innerHTML = "";
 });
 
-afterEach(async () => {
+afterEach(() => {
   document.body.innerHTML = "";
-  await Promise.resolve();
 });
 
 describe("desktop sidebar scroll preservation", () => {
@@ -160,7 +163,7 @@ describe("desktop sidebar scroll preservation", () => {
     cleanup();
   });
 
-  it("cancels a pending restore and invalidates saved state on cleanup", async () => {
+  it("cancels a pending restore and invalidates saved state on cleanup", () => {
     const frames = createFrameScheduler();
     const sidebar = createSidebar(34);
     const cleanup = installSidebarScrollPreserve({ document, ...frames });
@@ -169,7 +172,6 @@ describe("desktop sidebar scroll preservation", () => {
     dispatch(AFTER_NAVIGATE_EVENT);
     cleanup();
     sidebar.setValue(3);
-    await Promise.resolve();
     frames.flush();
     dispatch(AFTER_NAVIGATE_EVENT);
     frames.flush();
@@ -179,22 +181,22 @@ describe("desktop sidebar scroll preservation", () => {
     expect(sidebar.getValue()).toBe(3);
   });
 
-  it("carries the navigation snapshot across a synchronous island reinstall", () => {
+  it("keeps the snapshot in the duplicate-safe document singleton", () => {
     const frames = createFrameScheduler();
     const sidebar = createSidebar(60);
-    const cleanupOldInstall = installSidebarScrollPreserve({ document, ...frames });
+    ensureSidebarScrollPreserve({ document, ...frames });
 
     dispatch(BEFORE_NAVIGATE_EVENT);
-    // The router temporarily lifts the persisted aside while its island is
-    // re-rendered. Chromium clamps scrollTop while the content height is gone.
+    // Chromium clamps scrollTop while the persisted aside's island content is
+    // temporarily gone. A later component/module boot call must neither replace
+    // the controller nor lose the snapshot captured before that collapse.
     sidebar.setValue(0);
-    cleanupOldInstall();
-    const cleanupNewInstall = installSidebarScrollPreserve({ document, ...frames });
+    ensureSidebarScrollPreserve({ document, ...frames });
     dispatch(AFTER_NAVIGATE_EVENT);
     frames.flush();
 
     expect(sidebar.getValue()).toBe(60);
     expect(sidebar.getWrites()).toBe(1);
-    cleanupNewInstall();
+    disposeSidebarScrollPreserve(document);
   });
 });

--- a/packages/zudo-doc/src/sidebar-tree-island/__tests__/sidebar-scroll-preserve.test.ts
+++ b/packages/zudo-doc/src/sidebar-tree-island/__tests__/sidebar-scroll-preserve.test.ts
@@ -68,8 +68,9 @@ beforeEach(() => {
   document.body.innerHTML = "";
 });
 
-afterEach(() => {
+afterEach(async () => {
   document.body.innerHTML = "";
+  await Promise.resolve();
 });
 
 describe("desktop sidebar scroll preservation", () => {
@@ -159,7 +160,7 @@ describe("desktop sidebar scroll preservation", () => {
     cleanup();
   });
 
-  it("cancels a pending restore and invalidates saved state on cleanup", () => {
+  it("cancels a pending restore and invalidates saved state on cleanup", async () => {
     const frames = createFrameScheduler();
     const sidebar = createSidebar(34);
     const cleanup = installSidebarScrollPreserve({ document, ...frames });
@@ -168,6 +169,7 @@ describe("desktop sidebar scroll preservation", () => {
     dispatch(AFTER_NAVIGATE_EVENT);
     cleanup();
     sidebar.setValue(3);
+    await Promise.resolve();
     frames.flush();
     dispatch(AFTER_NAVIGATE_EVENT);
     frames.flush();
@@ -175,5 +177,24 @@ describe("desktop sidebar scroll preservation", () => {
     expect(frames.canceled).toEqual([1]);
     expect(sidebar.getWrites()).toBe(0);
     expect(sidebar.getValue()).toBe(3);
+  });
+
+  it("carries the navigation snapshot across a synchronous island reinstall", () => {
+    const frames = createFrameScheduler();
+    const sidebar = createSidebar(60);
+    const cleanupOldInstall = installSidebarScrollPreserve({ document, ...frames });
+
+    dispatch(BEFORE_NAVIGATE_EVENT);
+    // The router temporarily lifts the persisted aside while its island is
+    // re-rendered. Chromium clamps scrollTop while the content height is gone.
+    sidebar.setValue(0);
+    cleanupOldInstall();
+    const cleanupNewInstall = installSidebarScrollPreserve({ document, ...frames });
+    dispatch(AFTER_NAVIGATE_EVENT);
+    frames.flush();
+
+    expect(sidebar.getValue()).toBe(60);
+    expect(sidebar.getWrites()).toBe(1);
+    cleanupNewInstall();
   });
 });

--- a/packages/zudo-doc/src/sidebar-tree-island/__tests__/sidebar-scroll-preserve.test.ts
+++ b/packages/zudo-doc/src/sidebar-tree-island/__tests__/sidebar-scroll-preserve.test.ts
@@ -75,8 +75,13 @@ afterEach(() => {
 describe("desktop sidebar scroll preservation", () => {
   it("does not schedule or write when the navigation had no saved sidebar", () => {
     const frames = createFrameScheduler();
+    const staleSidebar = createSidebar(91);
     const cleanup = installSidebarScrollPreserve({ document, ...frames });
 
+    // Seed an older snapshot, then prove that a before-navigation with no
+    // live sidebar clears it instead of leaking it into the next swap.
+    dispatch(BEFORE_NAVIGATE_EVENT);
+    staleSidebar.element.remove();
     dispatch(BEFORE_NAVIGATE_EVENT);
     const sidebar = createSidebar(17);
     dispatch(AFTER_NAVIGATE_EVENT);

--- a/packages/zudo-doc/src/sidebar-tree-island/__tests__/sidebar-scroll-preserve.test.ts
+++ b/packages/zudo-doc/src/sidebar-tree-island/__tests__/sidebar-scroll-preserve.test.ts
@@ -1,0 +1,174 @@
+/** @vitest-environment happy-dom */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AFTER_NAVIGATE_EVENT, BEFORE_NAVIGATE_EVENT } from "../../transitions/index.js";
+import { installSidebarScrollPreserve } from "../sidebar-scroll-preserve.js";
+
+interface ControlledScrollTop {
+  element: HTMLElement;
+  getValue: () => number;
+  setValue: (value: number) => void;
+  getWrites: () => number;
+}
+
+function createSidebar(initialScrollTop: number): ControlledScrollTop {
+  const element = document.createElement("aside");
+  element.id = "desktop-sidebar";
+  let value = initialScrollTop;
+  let writes = 0;
+  Object.defineProperty(element, "scrollTop", {
+    configurable: true,
+    get: () => value,
+    set: (next: number) => {
+      writes += 1;
+      value = next;
+    },
+  });
+  document.body.append(element);
+  return {
+    element,
+    getValue: () => value,
+    setValue: (next) => {
+      value = next;
+    },
+    getWrites: () => writes,
+  };
+}
+
+function createFrameScheduler() {
+  let nextHandle = 1;
+  const callbacks = new Map<number, FrameRequestCallback>();
+  const canceled: number[] = [];
+
+  return {
+    requestAnimationFrame(callback: FrameRequestCallback): number {
+      const handle = nextHandle++;
+      callbacks.set(handle, callback);
+      return handle;
+    },
+    cancelAnimationFrame(handle: number): void {
+      canceled.push(handle);
+      callbacks.delete(handle);
+    },
+    flush(): void {
+      const pending = [...callbacks.entries()];
+      callbacks.clear();
+      for (const [, callback] of pending) callback(0);
+    },
+    pendingCount: () => callbacks.size,
+    canceled,
+  };
+}
+
+function dispatch(type: string): void {
+  document.dispatchEvent(new Event(type));
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("desktop sidebar scroll preservation", () => {
+  it("does not schedule or write when the navigation had no saved sidebar", () => {
+    const frames = createFrameScheduler();
+    const cleanup = installSidebarScrollPreserve({ document, ...frames });
+
+    dispatch(BEFORE_NAVIGATE_EVENT);
+    const sidebar = createSidebar(17);
+    dispatch(AFTER_NAVIGATE_EVENT);
+    frames.flush();
+
+    expect(frames.pendingCount()).toBe(0);
+    expect(sidebar.getWrites()).toBe(0);
+    expect(sidebar.getValue()).toBe(17);
+    cleanup();
+  });
+
+  it("treats zero as a valid saved position and restores it", () => {
+    const frames = createFrameScheduler();
+    const sidebar = createSidebar(0);
+    const cleanup = installSidebarScrollPreserve({ document, ...frames });
+
+    dispatch(BEFORE_NAVIGATE_EVENT);
+    sidebar.setValue(42);
+    dispatch(AFTER_NAVIGATE_EVENT);
+    frames.flush();
+
+    expect(sidebar.getValue()).toBe(0);
+    expect(sidebar.getWrites()).toBe(1);
+    cleanup();
+  });
+
+  it("restores a nonzero position once and consumes the snapshot", () => {
+    const frames = createFrameScheduler();
+    const sidebar = createSidebar(73);
+    const cleanup = installSidebarScrollPreserve({ document, ...frames });
+
+    dispatch(BEFORE_NAVIGATE_EVENT);
+    sidebar.setValue(0);
+    dispatch(AFTER_NAVIGATE_EVENT);
+    dispatch(AFTER_NAVIGATE_EVENT);
+    frames.flush();
+
+    expect(sidebar.getValue()).toBe(73);
+    expect(sidebar.getWrites()).toBe(1);
+    cleanup();
+  });
+
+  it("does not write to a replacement sidebar from a stale snapshot", () => {
+    const frames = createFrameScheduler();
+    const original = createSidebar(61);
+    const cleanup = installSidebarScrollPreserve({ document, ...frames });
+
+    dispatch(BEFORE_NAVIGATE_EVENT);
+    const replacement = createSidebar(12);
+    original.element.remove();
+    dispatch(AFTER_NAVIGATE_EVENT);
+    frames.flush();
+
+    expect(original.getWrites()).toBe(0);
+    expect(replacement.getWrites()).toBe(0);
+    expect(replacement.getValue()).toBe(12);
+    cleanup();
+  });
+
+  it("cancels an overlapping restore and uses only the latest cycle", () => {
+    const frames = createFrameScheduler();
+    const sidebar = createSidebar(15);
+    const cleanup = installSidebarScrollPreserve({ document, ...frames });
+
+    dispatch(BEFORE_NAVIGATE_EVENT);
+    dispatch(AFTER_NAVIGATE_EVENT);
+    sidebar.setValue(28);
+    dispatch(BEFORE_NAVIGATE_EVENT);
+    dispatch(AFTER_NAVIGATE_EVENT);
+    frames.flush();
+
+    expect(frames.canceled).toEqual([1]);
+    expect(sidebar.getValue()).toBe(28);
+    expect(sidebar.getWrites()).toBe(1);
+    cleanup();
+  });
+
+  it("cancels a pending restore and invalidates saved state on cleanup", () => {
+    const frames = createFrameScheduler();
+    const sidebar = createSidebar(34);
+    const cleanup = installSidebarScrollPreserve({ document, ...frames });
+
+    dispatch(BEFORE_NAVIGATE_EVENT);
+    dispatch(AFTER_NAVIGATE_EVENT);
+    cleanup();
+    sidebar.setValue(3);
+    frames.flush();
+    dispatch(AFTER_NAVIGATE_EVENT);
+    frames.flush();
+
+    expect(frames.canceled).toEqual([1]);
+    expect(sidebar.getWrites()).toBe(0);
+    expect(sidebar.getValue()).toBe(3);
+  });
+});

--- a/packages/zudo-doc/src/sidebar-tree-island/index.tsx
+++ b/packages/zudo-doc/src/sidebar-tree-island/index.tsx
@@ -18,6 +18,7 @@ import { smartBreakToHtml } from "../smart-break/index.js";
 import { AFTER_NAVIGATE_EVENT, BEFORE_NAVIGATE_EVENT } from "../transitions/index.js";
 import { filterTree } from "../sidebar-filter/index.js";
 import { findActiveSlug, normalizePath } from "../sidebar-active-slug/index.js";
+import { installSidebarScrollPreserve } from "./sidebar-scroll-preserve.js";
 
 function ToggleChevron({ isExpanded, className }: { isExpanded: boolean; className?: string }) {
   return (
@@ -94,36 +95,15 @@ function useActiveSlug(nodes: SidebarNavNode[], initial?: string): string | unde
  * Preserve `#desktop-sidebar` scrollTop across SPA navigations.
  */
 function useSidebarScrollPreserve() {
-  useEffect(() => {
-    let savedScrollTop = 0;
-    let restoreTimer: ReturnType<typeof setTimeout> | undefined;
-
-    const onBefore = () => {
-      if (restoreTimer !== undefined) {
-        clearTimeout(restoreTimer);
-        restoreTimer = undefined;
-      }
-      const aside = document.querySelector<HTMLElement>("#desktop-sidebar");
-      if (aside) savedScrollTop = aside.scrollTop;
-    };
-
-    const onAfter = () => {
-      const aside = document.querySelector<HTMLElement>("#desktop-sidebar");
-      if (!aside) return;
-      restoreTimer = setTimeout(() => {
-        restoreTimer = undefined;
-        aside.scrollTop = savedScrollTop;
-      }, 50);
-    };
-
-    document.addEventListener(BEFORE_NAVIGATE_EVENT, onBefore);
-    document.addEventListener(AFTER_NAVIGATE_EVENT, onAfter);
-    return () => {
-      document.removeEventListener(BEFORE_NAVIGATE_EVENT, onBefore);
-      document.removeEventListener(AFTER_NAVIGATE_EVENT, onAfter);
-      if (restoreTimer !== undefined) clearTimeout(restoreTimer);
-    };
-  }, []);
+  useEffect(
+    () =>
+      installSidebarScrollPreserve({
+        document,
+        requestAnimationFrame: window.requestAnimationFrame.bind(window),
+        cancelAnimationFrame: window.cancelAnimationFrame.bind(window),
+      }),
+    [],
+  );
 }
 
 function RootMenuItemEntry({ item }: { item: SidebarRootMenuItem }) {

--- a/packages/zudo-doc/src/sidebar-tree-island/index.tsx
+++ b/packages/zudo-doc/src/sidebar-tree-island/index.tsx
@@ -18,7 +18,13 @@ import { smartBreakToHtml } from "../smart-break/index.js";
 import { AFTER_NAVIGATE_EVENT, BEFORE_NAVIGATE_EVENT } from "../transitions/index.js";
 import { filterTree } from "../sidebar-filter/index.js";
 import { findActiveSlug, normalizePath } from "../sidebar-active-slug/index.js";
-import { installSidebarScrollPreserve } from "./sidebar-scroll-preserve.js";
+import { ensureSidebarScrollPreserve } from "./sidebar-scroll-preserve.js";
+
+// The persisted aside can transiently tear down and re-mount its SidebarTree
+// effect during a body swap. Keep navigation snapshot ownership at browser
+// module/document lifetime so that island lifecycle cannot discard it between
+// before-preparation and after-swap. SSR evaluation is a safe no-op.
+ensureSidebarScrollPreserve();
 
 function ToggleChevron({ isExpanded, className }: { isExpanded: boolean; className?: string }) {
   return (
@@ -89,21 +95,6 @@ function useActiveSlug(nodes: SidebarNavNode[], initial?: string): string | unde
   }, [nodes]);
 
   return slug;
-}
-
-/**
- * Preserve `#desktop-sidebar` scrollTop across SPA navigations.
- */
-function useSidebarScrollPreserve() {
-  useEffect(
-    () =>
-      installSidebarScrollPreserve({
-        document,
-        requestAnimationFrame: window.requestAnimationFrame.bind(window),
-        cancelAnimationFrame: window.cancelAnimationFrame.bind(window),
-      }),
-    [],
-  );
 }
 
 function RootMenuItemEntry({ item }: { item: SidebarRootMenuItem }) {
@@ -182,7 +173,6 @@ function SidebarFooter({ links, themeDefaultMode }: { links?: SidebarLocaleLink[
 
 export function SidebarTree({ nodes, currentSlug, rootMenuItems, backToMenuLabel, localeLinks, themeDefaultMode }: SidebarTreeProps) {
   const activeSlug = useActiveSlug(nodes, currentSlug);
-  useSidebarScrollPreserve();
   const [query, setQuery] = useState("");
   const [showingRootMenu, setShowingRootMenu] = useState(false);
   const filterRef = useRef<HTMLInputElement>(null);

--- a/packages/zudo-doc/src/sidebar-tree-island/sidebar-scroll-preserve.ts
+++ b/packages/zudo-doc/src/sidebar-tree-island/sidebar-scroll-preserve.ts
@@ -6,16 +6,20 @@ interface SidebarScrollPreserveOptions {
   cancelAnimationFrame: (handle: number) => void;
 }
 
-/**
- * Install navigation-scoped scroll preservation for the persisted desktop
- * sidebar. Exposed separately from the hook so the browser lifecycle itself
- * can be exercised without duplicating this state machine in tests.
- */
-export function installSidebarScrollPreserve({
+interface SidebarScrollPreserveController {
+  retain: () => void;
+  release: () => void;
+}
+
+const controllers = new WeakMap<Document, SidebarScrollPreserveController>();
+
+function createController({
   document,
   requestAnimationFrame,
   cancelAnimationFrame,
-}: SidebarScrollPreserveOptions): () => void {
+}: SidebarScrollPreserveOptions): SidebarScrollPreserveController {
+  let leases = 0;
+  let disposalGeneration = 0;
   let snapshot: { element: HTMLElement; scrollTop: number } | undefined;
   let restoreFrame: number | undefined;
 
@@ -26,6 +30,7 @@ export function installSidebarScrollPreserve({
   };
 
   const onBefore = () => {
+    if (leases === 0) return;
     cancelPendingRestore();
 
     const element = document.querySelector<HTMLElement>("#desktop-sidebar");
@@ -33,7 +38,7 @@ export function installSidebarScrollPreserve({
   };
 
   const onAfter = () => {
-    if (!snapshot) return;
+    if (leases === 0 || !snapshot) return;
 
     const saved = snapshot;
     snapshot = undefined;
@@ -47,10 +52,57 @@ export function installSidebarScrollPreserve({
   document.addEventListener(BEFORE_NAVIGATE_EVENT, onBefore);
   document.addEventListener(AFTER_NAVIGATE_EVENT, onAfter);
 
+  const controller: SidebarScrollPreserveController = {
+    retain() {
+      leases += 1;
+      disposalGeneration += 1;
+    },
+    release() {
+      if (leases === 0) return;
+      leases -= 1;
+      if (leases !== 0) return;
+
+      // A persisted sidebar island is synchronously unmounted and re-mounted
+      // during a body swap. Suspend writes and cancel queued work immediately,
+      // but keep the current-navigation snapshot for one microtask so that the
+      // replacement effect can retain this controller before after-swap. A true
+      // unmount has no matching retain, so its stale state and listeners are
+      // still discarded before the next task.
+      cancelPendingRestore();
+      const generation = ++disposalGeneration;
+      queueMicrotask(() => {
+        if (leases !== 0 || disposalGeneration !== generation) return;
+        snapshot = undefined;
+        document.removeEventListener(BEFORE_NAVIGATE_EVENT, onBefore);
+        document.removeEventListener(AFTER_NAVIGATE_EVENT, onAfter);
+        controllers.delete(document);
+      });
+    },
+  };
+
+  return controller;
+}
+
+/**
+ * Install navigation-scoped scroll preservation for the persisted desktop
+ * sidebar. Exposed separately from the hook so the browser lifecycle itself
+ * can be exercised without duplicating this state machine in tests.
+ */
+export function installSidebarScrollPreserve({
+  document,
+  requestAnimationFrame,
+  cancelAnimationFrame,
+}: SidebarScrollPreserveOptions): () => void {
+  let controller = controllers.get(document);
+  if (!controller) {
+    controller = createController({ document, requestAnimationFrame, cancelAnimationFrame });
+    controllers.set(document, controller);
+  }
+  controller.retain();
+  let released = false;
   return () => {
-    document.removeEventListener(BEFORE_NAVIGATE_EVENT, onBefore);
-    document.removeEventListener(AFTER_NAVIGATE_EVENT, onAfter);
-    cancelPendingRestore();
-    snapshot = undefined;
+    if (released) return;
+    released = true;
+    controller.release();
   };
 }

--- a/packages/zudo-doc/src/sidebar-tree-island/sidebar-scroll-preserve.ts
+++ b/packages/zudo-doc/src/sidebar-tree-island/sidebar-scroll-preserve.ts
@@ -1,0 +1,56 @@
+import { AFTER_NAVIGATE_EVENT, BEFORE_NAVIGATE_EVENT } from "../transitions/index.js";
+
+interface SidebarScrollPreserveOptions {
+  document: Document;
+  requestAnimationFrame: (callback: FrameRequestCallback) => number;
+  cancelAnimationFrame: (handle: number) => void;
+}
+
+/**
+ * Install navigation-scoped scroll preservation for the persisted desktop
+ * sidebar. Exposed separately from the hook so the browser lifecycle itself
+ * can be exercised without duplicating this state machine in tests.
+ */
+export function installSidebarScrollPreserve({
+  document,
+  requestAnimationFrame,
+  cancelAnimationFrame,
+}: SidebarScrollPreserveOptions): () => void {
+  let snapshot: { element: HTMLElement; scrollTop: number } | undefined;
+  let restoreFrame: number | undefined;
+
+  const cancelPendingRestore = () => {
+    if (restoreFrame === undefined) return;
+    cancelAnimationFrame(restoreFrame);
+    restoreFrame = undefined;
+  };
+
+  const onBefore = () => {
+    cancelPendingRestore();
+
+    const element = document.querySelector<HTMLElement>("#desktop-sidebar");
+    snapshot = element ? { element, scrollTop: element.scrollTop } : undefined;
+  };
+
+  const onAfter = () => {
+    if (!snapshot) return;
+
+    const saved = snapshot;
+    snapshot = undefined;
+    restoreFrame = requestAnimationFrame(() => {
+      restoreFrame = undefined;
+      const current = document.querySelector<HTMLElement>("#desktop-sidebar");
+      if (current === saved.element) current.scrollTop = saved.scrollTop;
+    });
+  };
+
+  document.addEventListener(BEFORE_NAVIGATE_EVENT, onBefore);
+  document.addEventListener(AFTER_NAVIGATE_EVENT, onAfter);
+
+  return () => {
+    document.removeEventListener(BEFORE_NAVIGATE_EVENT, onBefore);
+    document.removeEventListener(AFTER_NAVIGATE_EVENT, onAfter);
+    cancelPendingRestore();
+    snapshot = undefined;
+  };
+}

--- a/packages/zudo-doc/src/sidebar-tree-island/sidebar-scroll-preserve.ts
+++ b/packages/zudo-doc/src/sidebar-tree-island/sidebar-scroll-preserve.ts
@@ -6,20 +6,20 @@ interface SidebarScrollPreserveOptions {
   cancelAnimationFrame: (handle: number) => void;
 }
 
-interface SidebarScrollPreserveController {
-  retain: () => void;
-  release: () => void;
-}
+const installedControllers = new WeakMap<Document, () => void>();
 
-const controllers = new WeakMap<Document, SidebarScrollPreserveController>();
-
-function createController({
+/**
+ * Install the scroll-preservation state machine on a document.
+ *
+ * This low-level entrypoint owns an explicit cleanup for focused tests and
+ * non-singleton hosts. The sidebar's browser module uses the durable,
+ * duplicate-safe `ensureSidebarScrollPreserve` wrapper below instead.
+ */
+export function installSidebarScrollPreserve({
   document,
   requestAnimationFrame,
   cancelAnimationFrame,
-}: SidebarScrollPreserveOptions): SidebarScrollPreserveController {
-  let leases = 0;
-  let disposalGeneration = 0;
+}: SidebarScrollPreserveOptions): () => void {
   let snapshot: { element: HTMLElement; scrollTop: number } | undefined;
   let restoreFrame: number | undefined;
 
@@ -30,16 +30,13 @@ function createController({
   };
 
   const onBefore = () => {
-    if (leases === 0) return;
     cancelPendingRestore();
-
     const element = document.querySelector<HTMLElement>("#desktop-sidebar");
     snapshot = element ? { element, scrollTop: element.scrollTop } : undefined;
   };
 
   const onAfter = () => {
-    if (leases === 0 || !snapshot) return;
-
+    if (!snapshot) return;
     const saved = snapshot;
     snapshot = undefined;
     restoreFrame = requestAnimationFrame(() => {
@@ -52,57 +49,40 @@ function createController({
   document.addEventListener(BEFORE_NAVIGATE_EVENT, onBefore);
   document.addEventListener(AFTER_NAVIGATE_EVENT, onAfter);
 
-  const controller: SidebarScrollPreserveController = {
-    retain() {
-      leases += 1;
-      disposalGeneration += 1;
-    },
-    release() {
-      if (leases === 0) return;
-      leases -= 1;
-      if (leases !== 0) return;
-
-      // A persisted sidebar island is synchronously unmounted and re-mounted
-      // during a body swap. Suspend writes and cancel queued work immediately,
-      // but keep the current-navigation snapshot for one microtask so that the
-      // replacement effect can retain this controller before after-swap. A true
-      // unmount has no matching retain, so its stale state and listeners are
-      // still discarded before the next task.
-      cancelPendingRestore();
-      const generation = ++disposalGeneration;
-      queueMicrotask(() => {
-        if (leases !== 0 || disposalGeneration !== generation) return;
-        snapshot = undefined;
-        document.removeEventListener(BEFORE_NAVIGATE_EVENT, onBefore);
-        document.removeEventListener(AFTER_NAVIGATE_EVENT, onAfter);
-        controllers.delete(document);
-      });
-    },
+  return () => {
+    document.removeEventListener(BEFORE_NAVIGATE_EVENT, onBefore);
+    document.removeEventListener(AFTER_NAVIGATE_EVENT, onAfter);
+    cancelPendingRestore();
+    snapshot = undefined;
   };
-
-  return controller;
 }
 
 /**
- * Install navigation-scoped scroll preservation for the persisted desktop
- * sidebar. Exposed separately from the hook so the browser lifecycle itself
- * can be exercised without duplicating this state machine in tests.
+ * Install exactly one module-lifetime controller for a browser document.
+ * Repeated calls from component renders or duplicate boot paths are no-ops.
  */
-export function installSidebarScrollPreserve({
-  document,
-  requestAnimationFrame,
-  cancelAnimationFrame,
-}: SidebarScrollPreserveOptions): () => void {
-  let controller = controllers.get(document);
-  if (!controller) {
-    controller = createController({ document, requestAnimationFrame, cancelAnimationFrame });
-    controllers.set(document, controller);
-  }
-  controller.retain();
-  let released = false;
-  return () => {
-    if (released) return;
-    released = true;
-    controller.release();
+export function ensureSidebarScrollPreserve(
+  options?: SidebarScrollPreserveOptions,
+): void {
+  const resolved = options ?? resolveBrowserOptions();
+  if (!resolved || installedControllers.has(resolved.document)) return;
+  installedControllers.set(
+    resolved.document,
+    installSidebarScrollPreserve(resolved),
+  );
+}
+
+function resolveBrowserOptions(): SidebarScrollPreserveOptions | undefined {
+  if (typeof document === "undefined" || typeof window === "undefined") return undefined;
+  return {
+    document,
+    requestAnimationFrame: window.requestAnimationFrame.bind(window),
+    cancelAnimationFrame: window.cancelAnimationFrame.bind(window),
   };
+}
+
+/** Test/HMR teardown for a controller installed through the singleton wrapper. */
+export function disposeSidebarScrollPreserve(document: Document): void {
+  installedControllers.get(document)?.();
+  installedControllers.delete(document);
 }


### PR DESCRIPTION
Parent: #3389

## Summary

- suppress inherited disc markers only for generated disabled GFM task-list checkbox shapes while leaving ordinary lists unchanged
- move sidebar scroll preservation to a document-lifetime controller so valid navigation snapshots survive transient island teardown during SPA swaps
- restore only onto the same persisted sidebar node after its scroll range returns, with current-cycle snapshot, cancellation, and no-save safeguards

## Changes

### GFM task lists

- add the package-owned `content.css` marker reset for tight and loose task-item markup
- add a fast selector-contract test and a smoke fixture covering checked, unchecked, tight, loose, and ordinary list rows
- add a Chromium computed-style regression

### Sidebar scroll preservation

- replace the fixed 50 ms effect-owned restore with a duplicate-safe document/module singleton and animation-frame restoration
- add production-path tests for no-save, zero, nonzero, consumption, replacement nodes, overlapping cycles, cleanup, and duplicate boot behavior
- make the Playwright regression deterministically overflow the sidebar and require exact nonzero preservation after the old failure window

## Test plan

- `pnpm --filter @takazudo/zudo-doc exec vitest run --config vitest.config.ts src/__tests__/content-css.test.ts src/sidebar-tree-island/__tests__/sidebar-scroll-preserve.test.ts src/sidebar-tree-island/__tests__/sidebar-tree-ssg.test.tsx` — 17 passed
- `pnpm --filter @takazudo/zudo-doc typecheck` — passed
- `pnpm --filter @takazudo/zudo-doc build` — passed
- `E2E_FIXTURES=smoke E2E_FORCE_REBUILD=1 bash e2e/setup-fixtures.sh` — passed
- focused Chromium task-list and sidebar-scroll regressions — 2 passed

Closes #3389
