### PR TITLE
site-schema: browser-safe subpath + chrome browser-safety fixes (epic #3394)

### DIFF
--- a/packages/zudo-doc/API.md
+++ b/packages/zudo-doc/API.md
@@ -226,7 +226,7 @@ or a non-zfb tool can compute the same answers the SSG build computes.
 `DocRouteEntry`, `BuildDocRouteEntriesArgs`, `DocRouteEntriesContext`,
 `DocRouteEntriesAPI`, `NavSourceDocs`, `BreadcrumbItem`, `HeadingItem`,
 `SidebarNode`, `CategoryMeta`, `SidebarFrontmatter`, `CollectionEntryLike`,
-`DocEntryLike`, `PaginationOverrides`, `BuildHref`, `BuildNavTreeOptions`,
+`DocEntryLike`, `PaginationOverrides`, `BuildHref`,
 `NavScopeNode`, `NavScopeHeaderNavItem`.
 
 `NavSourceDocs` + `DocNavNode` are the nav-manifest types. Every props/route

--- a/packages/zudo-doc/API.md
+++ b/packages/zudo-doc/API.md
@@ -18,7 +18,7 @@ New snapshot guards (added in `packages/zudo-doc/src/__tests__/public-api-snapsh
 
 ---
 
-## 1. Subpath Exports (147 total)
+## 1. Subpath Exports (149 total)
 
 The full `package.json#exports` keyset is the contract. Any addition or removal requires a deliberate, reviewed change that will fail the snapshot guard.
 
@@ -192,10 +192,61 @@ behavior change from the previous standalone-line-below-the-row placement,
 | `./nav-source-cache` | Navigation source cache |
 | `./nav-source-docs` | Navigation source for docs collections |
 | `./doc-route-paths` | Doc route path builders |
-| `./doc-route-entries` | Doc route entry generators |
+| `./doc-route-entries` | Doc route entry generators — the zfb-typed binding of `./site-schema`'s builder (`props.entry` is zfb's `CollectionEntry`) |
+| `./site-schema` | Browser-safe nav / breadcrumb / pager domain — see below |
 | `./route-enumerators` | Route enumeration utilities |
 | `./locale-merge` | Locale-aware content merging |
 | `./tree-nav-shared` | Shared tree navigation primitives |
+
+#### `./site-schema` — the browser-safe site-shape domain (#3395)
+
+Everything needed to answer "what is the shape of this documentation site?" —
+which routes exist, how they nest, what the previous/next page is, and what
+breadcrumb trail leads to a slug — with none of the rendering, disk access, or
+zfb engine coupling the rest of the package carries. A browser bundle, a Worker,
+or a non-zfb tool can compute the same answers the SSG build computes.
+
+**Exported functions**
+
+| Export | Contract |
+|---|---|
+| `createDocRouteEntries(ctx)` | The "which routes exist" builder: an entry with `category_no_page: true` emits NO route; every category with children but no `index.mdx` emits one auto-index route. Generic over the entry shape; its memo is scoped per factory instance |
+| `buildNavTree` | Flat doc list → recursive `DocNavNode[]`, including root-index node synthesis |
+| `buildBreadcrumbs` | THE blessed breadcrumb contract — the route-time slug-split walk over `DocNavNode` that produces `props.breadcrumbs`. (The component-side `findPath` / `buildBreadcrumbItems` pair stays presentation detail and is deliberately NOT exported) |
+| `collectAutoIndexNodes`, `groupSatelliteNodes`, `findNode`, `firstRoutedHref`, `isNavVisible` | Nav-tree walkers and the navigation visibility predicate |
+| `resolveDocPrevNext` | Pager resolution, including the "a category's last page has no next" rule and `pagination_prev`/`pagination_next` overrides |
+| `flattenTree`, `flattenSubtree`, `rewriteNavHref`, `remapNavChildHrefs` | Pre-order flattening and versioned-href remapping |
+| `getCategoryOrder`, `getNavSectionForSlug`, `getNavSubtree` | `headerNav` `categoryMatch` scoping |
+| `buildSidebarTree` | The underlying framework-agnostic tree builder |
+| `extractHeadings` | MDX body → TOC `HeadingItem[]` |
+| `schemaVersion` | Contract version (currently `1`) so consumers can fail closed on a change |
+
+**Exported types** — `DocNavNode`, `AutoIndexNode`, `DocPageFrontmatter`,
+`DocPageBaseProps` / `DocPageEntryProps` / `DocPageAutoIndexProps`,
+`DocRouteEntry`, `BuildDocRouteEntriesArgs`, `DocRouteEntriesContext`,
+`DocRouteEntriesAPI`, `NavSourceDocs`, `BreadcrumbItem`, `HeadingItem`,
+`SidebarNode`, `CategoryMeta`, `SidebarFrontmatter`, `CollectionEntryLike`,
+`DocEntryLike`, `PaginationOverrides`, `BuildHref`, `BuildNavTreeOptions`,
+`NavScopeNode`, `NavScopeHeaderNavItem`.
+
+`NavSourceDocs` + `DocNavNode` are the nav-manifest types. Every props/route
+type is generic over the entry shape and defaults to the structural
+`DocEntryLike`; `./doc-page-props` and `./doc-route-entries` re-bind them to
+zfb's `CollectionEntry` so engine-side consumers keep `entry.Content`.
+
+**Browser-safety contract, and the three guards that hold it.** Nothing
+reachable from this subpath — through the bundled JS graph OR the transitive
+`.d.ts` graph — may be a `node:*` builtin, `preact`, a `.css` file, a
+`virtual:` module, or an `@takazudo/zfb*` package.
+
+1. `src/__tests__/site-schema.test.ts` bundles the barrel with esbuild
+   `platform: "neutral"`, records every specifier at resolve time, and walks the
+   emitted declaration graph for the same violations.
+2. `scripts/check-site-schema.mjs` repeats the bundle check against the built
+   `dist/site-schema/index.js` in the `prepack` chain, so a publish cannot ship a
+   graph the source-level guard would have rejected.
+3. The `package.json#exports` keyset snapshot in
+   `src/__tests__/public-api-snapshot.test.ts`.
 
 ### Package-Owned Routes (A2)
 

--- a/packages/zudo-doc/README.md
+++ b/packages/zudo-doc/README.md
@@ -17,6 +17,45 @@ This package provides the missing-by-design framework concerns:
 - **View Transitions** (`./transitions`) — native View Transitions API shim (Chrome/Edge/Safari 18+); persistent regions via `view-transition-name`. No-op fallback in Firefox.
 - **Head injection** (`./head`) — canonical, og:\*, twitter:\*, robots, preload hints, RSS link, sitemap link, and theme-color output.
 - **SSR-skip wrappers** (`./ssr-skip`) — `<AiChatModalIsland>`, `<ImageEnlargeIsland>`, `<DesignTokenTweakPanelIsland>`, `<MockInitIsland>` — wrap zfb's `<Island ssrFallback>` with the right fallback markup so doc pages don't have to re-implement the SSR-skip pattern.
+- **Site schema** (`./site-schema`) — browser-safe nav tree / breadcrumb / pager domain, with zero zfb engine or filesystem coupling. See below.
+
+## `./site-schema` — the browser-safe site-shape domain
+
+Everything needed to answer "what is the shape of this documentation site?" — which routes exist, how they nest, what the previous/next page is, and what breadcrumb trail leads to a slug — without any of the rendering, disk access, or zfb engine coupling the rest of the package carries. A browser bundle, a Cloudflare Worker, or any non-zfb tool can compute the same answers the SSG build computes.
+
+**What it exports.** The route-existence builder `createDocRouteEntries`; the nav-tree builder `buildNavTree`; the blessed breadcrumb builder `buildBreadcrumbs`; the pager resolver `resolveDocPrevNext`; tree-walking helpers (`findNode`, `firstRoutedHref`, `flattenTree`, `flattenSubtree`, `collectAutoIndexNodes`, `groupSatelliteNodes`, `isNavVisible`, `rewriteNavHref`, `remapNavChildHrefs`); the `headerNav` scoping helpers `getCategoryOrder` / `getNavSectionForSlug` / `getNavSubtree`; the underlying `buildSidebarTree` primitive; the TOC helper `extractHeadings`; and the `schemaVersion` contract constant. Every props/route type is generic over the entry shape (defaulting to a structural `DocEntryLike`) so the subpath never needs to import zfb's `CollectionEntry` — see `API.md` for the full function and type reference.
+
+**Derivation contracts** — the rules a consumer relies on, not just the function names:
+
+- **Route emission.** An entry with `category_no_page: true` carries category metadata only and emits NO route. Every category with children but no `index.mdx` emits one synthesized auto-index route.
+- **The blessed breadcrumb rule.** `buildBreadcrumbs` is THE route-time slug-split walk that produces `props.breadcrumbs` — the same contract the SSG build uses. The presentation-layer `findPath` / `buildBreadcrumbItems` pair stays a component-side detail and is deliberately NOT exported; consumers reconstruct breadcrumbs through this function, not by re-walking the tree themselves.
+- **Category-scoped prev/next.** `resolveDocPrevNext` resolves prev/next against the route's OWN flattened subtree, not the whole site — so a category's last page has no `next` (and its first page has no `prev`). Frontmatter `pagination_prev` / `pagination_next` overrides resolve against that same caller-supplied tree, never a foreign one.
+
+**The `schemaVersion` fail-closed contract.** `schemaVersion` (currently `1`) is a contract-version constant, not a feature flag — check it before trusting the shape of anything else the subpath exports, and fail closed (refuse to render, or warn loudly) rather than silently mis-reading a shape change after a package upgrade. The pattern is deliberately the same one `@takazudo/zudo-doc/catalog` already established for its `ThemePacksIndexManifest.schemaVersion`.
+
+**Browser-safety guarantees.** Nothing reachable from `./site-schema` — through the bundled JS graph OR the transitive `.d.ts` graph — may be a `node:*` builtin, `preact`, a `.css` file, a `virtual:` module, or an `@takazudo/zfb*` package. Three guards hold that line:
+
+1. `src/__tests__/site-schema.test.ts` bundles the barrel with esbuild `platform: "neutral"` and walks the emitted declaration graph for the same violations.
+2. `scripts/check-site-schema.mjs` repeats the bundle check against the built `dist/site-schema/index.js` in the `prepack` chain, so a publish cannot ship a graph the source-level guard would have rejected.
+3. The `package.json#exports` keyset snapshot in `src/__tests__/public-api-snapshot.test.ts` pins the subpath's presence and shape.
+
+**Consumer story.** Import `@takazudo/zudo-doc/site-schema` anywhere you need zudo-doc's site semantics without a zfb build behind you — an SPA shell rendering its own nav chrome, a Worker computing breadcrumbs for an API response, or a script that needs to know what page comes next:
+
+```ts
+import {
+  schemaVersion,
+  buildNavTree,
+  buildBreadcrumbs,
+  resolveDocPrevNext,
+} from "@takazudo/zudo-doc/site-schema";
+
+if (schemaVersion !== 1) {
+  throw new Error(`Unsupported @takazudo/zudo-doc/site-schema version: ${schemaVersion}`);
+}
+
+const tree = buildNavTree(docs, "en", categoryMeta, buildHref);
+const breadcrumbs = buildBreadcrumbs(tree, "guides/color", homeHref);
+```
 
 ## Optional peer dependency: `@takazudo/zfb-md-wasm`
 

--- a/packages/zudo-doc/docs/adr/route-injection-seam.md
+++ b/packages/zudo-doc/docs/adr/route-injection-seam.md
@@ -291,13 +291,45 @@ the same `setup(ctx)` hook.
 - **Different from `chromeBindingsModule` in one important way: scanner
   reachability IS part of this contract.** Unlike the chrome-bindings channel
   (SSR-presentational only — see the caveat above), the real
-  `DesignTokenPanelBootstrap` **island component** is NOT itself carried
+  design-token-panel **island component** is NOT itself carried
   through the config virtual module — it is a separate, statically-imported
-  component (`@takazudo/zudo-doc/design-token-panel-bootstrap`). Only the
-  PanelConfig *data* (mode-scoped builder) travels through the
-  `designTokenPanelConfigModule` re-export; the component itself is always
+  component. Only the PanelConfig *data* (mode-scoped builder) travels through
+  the `designTokenPanelConfigModule` re-export; the component itself is always
   reachable by zfb's island scanner regardless of whether a host configured
   this setting.
+- **Where the virtual specifier is imported (revised by #3396, epic #3394).**
+  Originally `design-token-panel-bootstrap.tsx` imported
+  `virtual:zudo-doc-design-token-panel-config` directly, which made the whole
+  chrome graph un-bundleable without the routes plugin (see the amended bullet
+  below). It now imports the package-default builder as a plain module, and the
+  override channel lives in a **routes-only configured wrapper**,
+  `routes/_design-token-panel-bootstrap.tsx`:
+  - the wrapper is the only module in the package importing the virtual
+    specifier, and it lives in the routes graph, which zfb always bundles with
+    the plugin active (`routes-src/` copy is automatic — the copier takes every
+    non-test file in `src/routes/`);
+  - `routes/_chrome.tsx` threads it through the existing
+    `hostBindings.DesignTokenPanelBootstrap` slot, spread BEFORE
+    `...chromeBindings` so a host's own slot value still wins;
+  - it is a **component-level** seam, deliberately not a module-level setter.
+    The route/SSR module graph and the hydrated island bundle are separate
+    graphs, so a setter called during route evaluation would configure only the
+    server-side copy of the bootstrap module while the client re-evaluated it
+    and kept the default. Passing the builder as an argument from a component
+    that lives inside the island bundle is the only shape that survives that
+    boundary;
+  - the wrapper's exported identifier (`ConfiguredDesignTokenPanelBootstrap`)
+    is DISTINCT from `DesignTokenPanelBootstrap` on purpose. `chrome/derive.tsx`
+    still statically imports the package default as the slot default, so both
+    components sit in the scanned graph; sharing a name would trip zfb's
+    "island marker name collision" diagnostic and silently drop one of them.
+    The `displayName` must equal the export identifier — zfb registers islands
+    by the scanner-visible export name.
+  - **Known gap:** a host rendering docs through a self-contained `pages/` stub
+    (the locked-manifest shape, #2653) calls `createChrome` directly and so gets
+    the package default, not the wrapper — `designTokenPanelConfigModule` does
+    not apply to those pages. Such a host threads its own builder via
+    `chromeBindings.DesignTokenPanelBootstrap`.
 - **Slot default lives at the chrome seam (gate-2 fix, Wave-5 confirm
   #2659).** The static import + slot wiring sit in `chrome/derive.tsx`'s
   `deriveBodyEndIslands` — `hostBindings.DesignTokenPanelBootstrap` DEFAULTS
@@ -312,14 +344,17 @@ the same `setup(ctx)` hook.
   still accepts a host override. If a host supplies a whole `BodyEndIslands`
   override, the derive seam composes the package-owned panel island alongside
   it; the host override does not replace or duplicate the panel mount.
-  Consequence: `@takazudo/zudo-doc/chrome` now
-  transitively imports `virtual:zudo-doc-design-token-panel-config`, so a
-  `packageOwnedRoutes: false` host that bundles chrome must register/alias
-  that module itself (the package vitest config aliases it to the package
-  default for fast tests).
-- **`@takazudo/zdtp` dep implication:** the same static import that makes
-  `DesignTokenPanelBootstrap` the seam default (`chrome/derive.tsx`, ~line
-  65) makes `@takazudo/zdtp` an **unconditional build-time dependency** of
+  ~~Consequence: `@takazudo/zudo-doc/chrome` now transitively imports
+  `virtual:zudo-doc-design-token-panel-config`, so a `packageOwnedRoutes: false`
+  host that bundles chrome must register/alias that module itself (the package
+  vitest config aliases it to the package default for fast tests).~~ **Retired
+  by #3396** — the chrome graph carries no `virtual:` specifier any more, so no
+  alias is needed anywhere (the vitest alias was removed with it) and chrome
+  bundles outside a zfb build. See the "Where the virtual specifier is
+  imported" bullet above.
+- **`@takazudo/zdtp` dep implication (UNCHANGED by #3396):** the same static
+  import that makes `DesignTokenPanelBootstrap` the seam default
+  (`chrome/derive.tsx`) makes `@takazudo/zdtp` an **unconditional build-time dependency** of
   every `createChrome` consumer — even `designTokenPanel: false` projects
   (the "Could not resolve '@takazudo/zdtp'" failure class from #2660). Same
   shape as the `diff` peer implication above: only RENDERING is gated on the

--- a/packages/zudo-doc/docs/adr/theme-packs.md
+++ b/packages/zudo-doc/docs/adr/theme-packs.md
@@ -190,6 +190,10 @@ commit; only the active pack's CSS + fonts ever load.
 - `data-theme-pack` is appended to `<ClientRouter preserveHtmlAttrs>` in
   `src/doclayout/doc-layout.tsx` (alongside `data-sidebar-hidden`,
   `data-theme`, `style`).
+- `<html data-zd-theme-pack-loading>` — the transient hard-load anti-FOUC
+  latch (#3399). Present only while the initial pack stylesheet request is in
+  flight, bounded by a ~2s watchdog. Never persisted, never in
+  `preserveHtmlAttrs`.
 
 **Hard-load bootstrap (pre-paint, BEFORE the initial pack stylesheet
 request).** A correction to the sketch in #2822's original body: an inline
@@ -204,7 +208,16 @@ emits the (single, correct) link:
 JSON-literal style) is rendered by `src/head-with-defaults/index.tsx`
 IMMEDIATELY AFTER `<ColorSchemeProvider …/>`, and emits in order:
 
-1. An inline `<script>` (`buildThemePackBootstrap(configuredSlug, enabled,
+1. A build-static anti-FOUC latch `<style>` — emitted BEFORE the script so
+   the rule is live by the time the body parses:
+
+   ```css
+   html[data-zd-theme-pack-loading] body{visibility:hidden}
+   ```
+
+   Inert until the script arms it, so pages that load no pack stylesheet
+   (and every no-JS visitor) are unaffected.
+2. An inline `<script>` (`buildThemePackBootstrap(configuredSlug, enabled,
    base)` where `enabled` is the ordered `{ slug → version }` map from the
    registry):
 
@@ -216,27 +229,61 @@ IMMEDIATELY AFTER `<ColorSchemeProvider …/>`, and emits in order:
      var KEY = "zudo-doc-theme-pack";
      var stored = null; try { stored = localStorage.getItem(KEY); } catch (e) {}
      var slug = (stored && Object.prototype.hasOwnProperty.call(packs, stored))
-       ? stored : configured;
-     document.documentElement.setAttribute("data-theme-pack", slug);
+       ? stored : configured;   // …then a validated live html attribute, then configured
+     var root = document.documentElement;
+     root.setAttribute("data-theme-pack", slug);
      if (slug !== "default") {
-       document.write('<link rel="stylesheet" data-zd-theme-pack-css href="'
-         + base + 'theme-packs/' + slug + '/pack.css?v=' + packs[slug] + '">');
+       var href = base + 'theme-packs/' + slug + '/pack.css?v=' + packs[slug];
+       if (!hasPackLink(href)) {              // post-load re-evaluation is inert
+         root.setAttribute("data-zd-theme-pack-loading", "");
+         var release = function(){ root.removeAttribute("data-zd-theme-pack-loading"); };
+         var link = document.createElement("link");
+         /* rel=stylesheet, data-zd-theme-pack-css, href */
+         link.onload = release; link.onerror = release;
+         document.head.appendChild(link);
+         setTimeout(release, 2000);           // watchdog
+       }
      }
      document.addEventListener(BEFORE_SWAP_EVENT, /* pre-swap injection, PRIMARY — see SPA below */);
      document.addEventListener(AFTER_NAVIGATE_EVENT, /* re-apply, FALLBACK/cleanup — see SPA below */);
    })();
    ```
 
-   `document.write` during initial head parse is deliberate: the written
-   link is **parser-inserted**, therefore render-blocking in every browser —
-   the one mechanism with a hard cross-browser pre-paint guarantee AND
-   exactly one stylesheet request that is correct the first time (no
-   default-then-stored double fetch, no MutationObserver races). Chrome's
-   document.write intervention targets parser-blocking cross-origin
-   *scripts*, not stylesheets. The AFTER_NAVIGATE re-apply handler must use
-   `createElement`/`appendChild` (document.write after load would clobber the
-   document).
-2. A `<noscript><link rel="stylesheet" href="{base}theme-packs/<configured>/pack.css?v=…"></noscript>`
+   **Superseded mechanism (zudolab/zudo-doc#3399).** This step originally
+   `document.write`-d the link during head parse. A parser-inserted
+   stylesheet is render-blocking in every browser, so that was a HARD
+   cross-browser pre-paint guarantee (and Chrome's document.write
+   intervention targets parser-blocking cross-origin *scripts*, not
+   stylesheets — it was never at risk there). It was replaced because
+   `document.write` after page load implicitly `document.open()`s and
+   DESTROYS the live document, which makes any post-load re-evaluation of
+   the chrome — SPA embedding, #3393 — fatal rather than merely redundant.
+
+   **Latch contract (the explicit replacement guarantee).** A script-inserted
+   head stylesheet does not block the parser; Chromium and Firefox generally
+   still block paint on a pending head sheet, Safari is the soft spot. So the
+   compensation is stated rather than assumed: the script arms
+   `data-zd-theme-pack-loading` on `<html>` before appending the link and
+   clears it on the link's `load` OR `error`, with a ~2s watchdog clearing it
+   unconditionally. In words: **no FOUC for a pack stylesheet that loads
+   within the watchdog; a bounded flash beyond it** — past 2s,
+   blank-screen avoidance deliberately wins over strict no-FOUC, because a
+   hung stylesheet must never leave the page permanently blank. This is an
+   accepted weakening versus the parser-inserted link; do not restore
+   `document.write` to close it.
+
+   Everything else the old mechanism bought is preserved: exactly one
+   stylesheet request, correct the first time (no default-then-stored double
+   fetch, no MutationObserver races), and zero requests for `default`.
+   Post-load re-evaluation is inert because the insertion is guarded on an
+   existing `link[data-zd-theme-pack-css]` whose href matches the resolved
+   slug — present synchronously after the first evaluation, so a duplicate
+   run finds it whether the sheet is still pending or already loaded.
+   `data-zd-theme-pack-loading` is deliberately NOT in `preserveHtmlAttrs`:
+   it must never survive a soft navigation. The BEFORE_SWAP / AFTER_NAVIGATE
+   handlers use `createElement`/`appendChild` and never arm the latch (the
+   live link is already loaded — there is nothing to wait for).
+3. A `<noscript><link rel="stylesheet" href="{base}theme-packs/<configured>/pack.css?v=…"></noscript>`
    fallback (omitted when the configured pack is `default`) so a no-JS
    visitor gets the CONFIGURED pack (matching the SSR html attribute).
 
@@ -321,9 +368,9 @@ there is nothing to persist for the stock look). Idempotent when nothing
 changed.
 
 **Ordering note (MUST-verify in #2822):** the runtime-inserted link is
-appended to head end, hence after the main bundle stylesheet; the
-bootstrap-written link's position is wherever head-with-defaults renders the
-provider. Because all pack rules are attr-scoped (specificity ≥ (0,1,1) over
+appended to head end, hence after the main bundle stylesheet; since #3399 the
+bootstrap's own link is appended to head end too (it is no longer written at
+the provider's position during parse). Because all pack rules are attr-scoped (specificity ≥ (0,1,1) over
 the package's unlayered rules and the SSR `:root` token style at (0,1,0)),
 link order does not decide the cascade — but #2822 should still assert the
 provider renders after `<ColorSchemeProvider/>` in a jsdom test.

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -239,6 +239,10 @@
       "types": "./dist/catalog.d.ts",
       "default": "./dist/catalog.js"
     },
+    "./site-schema": {
+      "types": "./dist/site-schema/index.d.ts",
+      "default": "./dist/site-schema/index.js"
+    },
     "./theme.css": "./dist/theme.css",
     "./safelist.css": "./dist/safelist.css",
     "./content.css": "./dist/content.css",
@@ -605,7 +609,7 @@
     "dev:js": "tsup --watch",
     "dev:dts": "tsc -p tsconfig.build.json --watch --preserveWatchOutput",
     "prepare": "tsup --silent && tsc -p tsconfig.build.json",
-    "prepack": "pnpm --dir ../.. gen:changelog && node scripts/check-theme-css.mjs && node scripts/check-safelist.mjs && node scripts/check-content-css.mjs && node scripts/check-page-loading-css.mjs && node scripts/check-features-css.mjs && node scripts/check-theme-packs.mjs && node scripts/check-catalog.mjs && node scripts/check-plugins.mjs && node scripts/check-plugin-resolution.mjs && node scripts/check-eject-sources.mjs && node scripts/check-routes-src.mjs && node scripts/check-shim-artifacts.mjs && node scripts/check-virtual-modules.mjs && node bin/gen-component-tokens.mjs --check",
+    "prepack": "pnpm --dir ../.. gen:changelog && node scripts/check-theme-css.mjs && node scripts/check-safelist.mjs && node scripts/check-content-css.mjs && node scripts/check-page-loading-css.mjs && node scripts/check-features-css.mjs && node scripts/check-theme-packs.mjs && node scripts/check-catalog.mjs && node scripts/check-site-schema.mjs && node scripts/check-plugins.mjs && node scripts/check-plugin-resolution.mjs && node scripts/check-eject-sources.mjs && node scripts/check-routes-src.mjs && node scripts/check-shim-artifacts.mjs && node scripts/check-virtual-modules.mjs && node bin/gen-component-tokens.mjs --check",
     "test:plugin-resolution": "node scripts/check-plugin-resolution.mjs",
     "test": "vitest run --config vitest.config.ts",
     "test:slow": "vitest run --config vitest.slow.config.ts",

--- a/packages/zudo-doc/scripts/check-site-schema.mjs
+++ b/packages/zudo-doc/scripts/check-site-schema.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+// scripts/check-site-schema.mjs
+//
+// Publish-time browser-safety guard for the `@takazudo/zudo-doc/site-schema`
+// subpath (zudolab/zudo-doc#3395) — run in the `prepack` chain next to
+// check-catalog.mjs.
+//
+// The unit test in `src/__tests__/site-schema.test.ts` proves the SOURCE graph
+// is clean; this proves the SHIPPED graph is, which is not the same claim: a
+// stale `dist/`, a hand-edited artifact, or a build that ran with different
+// resolution would all slip past a source-only check and reach consumers.
+//
+// Asserts: dist/site-schema/index.js and index.d.ts exist, the barrel really
+// exports `schemaVersion`, and nothing reachable from the bundled JS is a
+// `node:*` builtin, preact, a stylesheet, a `virtual:` module, or an
+// `@takazudo/zfb*` package.
+//
+// Exit 0 → the shipped subpath is browser-safe.
+// Exit 1 → missing artifact or a forbidden dependency (with a clear diagnostic).
+
+import { existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { analyzeSiteSchemaGraph } from "./site-schema-graph.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = resolve(__dirname, "..");
+const DIST_JS = resolve(PKG_ROOT, "dist/site-schema/index.js");
+const DIST_DTS = resolve(PKG_ROOT, "dist/site-schema/index.d.ts");
+
+if (!existsSync(DIST_JS) || !existsSync(DIST_DTS)) {
+  process.stderr.write(
+    `\n[check-site-schema] ERROR: dist/site-schema/index.js and/or index.d.ts is missing.\n` +
+      `  Run \`pnpm --filter @takazudo/zudo-doc build\` first, then retry.\n\n`,
+  );
+  process.exit(1);
+}
+
+const mod = await import(DIST_JS);
+if (typeof mod.schemaVersion !== "number") {
+  process.stderr.write(
+    `[check-site-schema] ERROR: dist/site-schema/index.js does not export a numeric ` +
+      `schemaVersion (got ${JSON.stringify(mod.schemaVersion)}).\n`,
+  );
+  process.exit(1);
+}
+
+const { violations, specifiers } = await analyzeSiteSchemaGraph({
+  entry: DIST_JS,
+  resolveFrom: [PKG_ROOT, resolve(PKG_ROOT, "../..")],
+});
+
+if (violations.length > 0) {
+  process.stderr.write(
+    `\n[check-site-schema] ERROR: ./site-schema must stay browser-safe, but its\n` +
+      `  shipped graph reaches ${violations.length} forbidden specifier(s):\n` +
+      violations
+        .map((v) => `    ${v.specifier}  (${v.label})  imported by ${v.importer}\n`)
+        .join("") +
+      `\n  Move the offending code behind a subpath that is allowed to be\n` +
+      `  engine-bound (e.g. ./doc-route-entries, ./nav-source-docs), or import\n` +
+      `  the pure half directly (e.g. ../sidebar-tree/build-tree.js instead of\n` +
+      `  the sidebar-tree barrel).\n\n`,
+  );
+  process.exit(1);
+}
+
+process.stdout.write(
+  `[check-site-schema] dist/site-schema/index.js OK ` +
+    `(schemaVersion ${mod.schemaVersion}, ${specifiers.length} resolved specifier(s), 0 forbidden)\n`,
+);

--- a/packages/zudo-doc/scripts/site-schema-graph.mjs
+++ b/packages/zudo-doc/scripts/site-schema-graph.mjs
@@ -1,0 +1,98 @@
+// scripts/site-schema-graph.mjs
+//
+// The browser-safety detector shared by the two `site-schema` guards
+// (zudolab/zudo-doc#3395):
+//   - `scripts/check-site-schema.mjs` (prepack) runs it over `dist/site-schema/index.js`
+//   - `src/__tests__/site-schema.test.ts` runs it over `src/site-schema/index.ts`
+//
+// It bundles the entry with esbuild `platform: "neutral"` — the same mode zfb
+// evaluates config modules in (`loader.rs:277`) and the closest stand-in for a
+// browser bundler — and records every bare specifier reached along the way.
+// Anything matching FORBIDDEN_SPECIFIERS is a violation.
+//
+// Recording at RESOLVE time (rather than grepping the emitted bundle) is what
+// makes the check total: a forbidden dependency is caught whether it resolves,
+// fails to resolve, or gets inlined away.
+
+import { createRequire } from "node:module";
+
+/** Specifier classes that must never be reachable from `./site-schema`. */
+export const FORBIDDEN_SPECIFIERS = [
+  { pattern: /^node:/, label: "node builtin" },
+  { pattern: /^preact(\/|$)/, label: "preact" },
+  { pattern: /^@takazudo\/zfb/, label: "zfb engine package" },
+  { pattern: /^virtual:/, label: "zfb virtual module" },
+  { pattern: /\.css$/, label: "stylesheet" },
+];
+
+/** The forbidden class a specifier belongs to, or `undefined` when it is fine. */
+export function forbiddenLabel(specifier) {
+  return FORBIDDEN_SPECIFIERS.find((rule) => rule.pattern.test(specifier))?.label;
+}
+
+/**
+ * Resolve esbuild without adding it as a direct dependency — it rides in
+ * transitively via tsup (build/prepack) and vite/vitest (tests).
+ *
+ * @param {string[]} fromPaths - candidate resolution roots.
+ */
+export async function loadEsbuild(fromPaths) {
+  const require = createRequire(import.meta.url);
+  for (const via of ["tsup", "vite", "vitest", "esbuild"]) {
+    try {
+      const specifier = via === "esbuild" ? "esbuild" : `${via}/package.json`;
+      const pkgPath = require.resolve(specifier, { paths: fromPaths });
+      if (via === "esbuild") return await import(pkgPath);
+      return await import(createRequire(pkgPath).resolve("esbuild"));
+    } catch {
+      // try the next host package
+    }
+  }
+  throw new Error("[site-schema-graph] could not resolve esbuild via tsup / vite / vitest");
+}
+
+/**
+ * Bundle `entry` and report every forbidden specifier reachable from it.
+ *
+ * @param {object} args
+ * @param {string} args.entry - absolute path to the entry module (.ts or .js).
+ * @param {string[]} args.resolveFrom - roots used to locate esbuild.
+ * @returns {Promise<{ violations: Array<{ specifier: string, label: string, importer: string }>, specifiers: string[] }>}
+ */
+export async function analyzeSiteSchemaGraph({ entry, resolveFrom }) {
+  const esbuild = await loadEsbuild(resolveFrom);
+
+  /** @type {Map<string, { specifier: string, label: string, importer: string }>} */
+  const violations = new Map();
+  const specifiers = new Set();
+
+  const recorder = {
+    name: "site-schema-specifier-recorder",
+    setup(build) {
+      build.onResolve({ filter: /.*/ }, (args) => {
+        if (args.kind === "entry-point") return null;
+        specifiers.add(args.path);
+        const label = forbiddenLabel(args.path);
+        if (!label) return null;
+        if (!violations.has(args.path)) {
+          violations.set(args.path, { specifier: args.path, label, importer: args.importer });
+        }
+        // Stop here so a forbidden dependency is REPORTED rather than turned
+        // into an unrelated "could not resolve" build failure.
+        return { path: args.path, external: true };
+      });
+    },
+  };
+
+  await esbuild.build({
+    entryPoints: [entry],
+    bundle: true,
+    write: false,
+    platform: "neutral",
+    format: "esm",
+    logLevel: "silent",
+    plugins: [recorder],
+  });
+
+  return { violations: [...violations.values()], specifiers: [...specifiers].sort() };
+}

--- a/packages/zudo-doc/scripts/site-schema-graph.mjs
+++ b/packages/zudo-doc/scripts/site-schema-graph.mjs
@@ -38,12 +38,12 @@ export function forbiddenLabel(specifier) {
  */
 export async function loadEsbuild(fromPaths) {
   const require = createRequire(import.meta.url);
-  for (const via of ["tsup", "vite", "vitest", "esbuild"]) {
+  // Each host package is resolved first, then esbuild is resolved FROM it —
+  // pnpm's store keeps esbuild out of this package's own node_modules.
+  for (const host of ["tsup", "vite", "vitest"]) {
     try {
-      const specifier = via === "esbuild" ? "esbuild" : `${via}/package.json`;
-      const pkgPath = require.resolve(specifier, { paths: fromPaths });
-      if (via === "esbuild") return await import(pkgPath);
-      return await import(createRequire(pkgPath).resolve("esbuild"));
+      const hostPkg = require.resolve(`${host}/package.json`, { paths: fromPaths });
+      return await import(createRequire(hostPkg).resolve("esbuild"));
     } catch {
       // try the next host package
     }

--- a/packages/zudo-doc/src/__tests__/chrome-eval-graph.test.ts
+++ b/packages/zudo-doc/src/__tests__/chrome-eval-graph.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect } from "vitest";
+import { createRequire } from "node:module";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const srcRoot = resolve(__dirname, "..");
+const repoRoot = resolve(__dirname, "../../../..");
+
+// ── esbuild resolution (mirrors preset.test.ts) ─────────────────────────────
+// esbuild is not a direct dependency of this package — it rides in as a
+// transitive of vite/vitest. Resolve it via vite so the guard runs without
+// adding a dep.
+interface EsbuildBuildError extends Error {
+  errors?: Array<{ text?: string }>;
+}
+interface EsbuildLike {
+  build(opts: Record<string, unknown>): Promise<{
+    errors: unknown[];
+    outputFiles: Array<{ text: string }>;
+  }>;
+}
+
+function loadEsbuild(): EsbuildLike {
+  const vitePkg = require.resolve("vite/package.json", {
+    paths: [process.cwd(), __dirname, repoRoot],
+  });
+  const viteRequire = createRequire(vitePkg);
+  return viteRequire("esbuild") as EsbuildLike;
+}
+
+// (success-path) Match `node:*` / `virtual:*` only as a real module specifier
+// in BUNDLED CODE — in an import/export `from "..."`, a bare `import "..."`,
+// or a `require("...")` call — so a matching substring inside an unrelated
+// string literal or object-shorthand (`{ node: g6 }`) in the output can't
+// trip a false positive. Verified against this exact bundle: esbuild's own
+// tailwind engine embeds the string `"virtual:tailwindcss/index.css"` as a
+// plain data value, and preact/tailwind internals use `node:` as an object
+// key shorthand — neither is preceded by `from`/`import`/`require(`, so the
+// strict regex below correctly ignores both.
+const NODE_CODE_RE = /(?:\bfrom\s*|\bimport\s*|\brequire\s*\(\s*)["'](node:[^"']+)["']/g;
+const VIRTUAL_CODE_RE = /(?:\bfrom\s*|\bimport\s*|\brequire\s*\(\s*)["'](virtual:[^"']+)["']/g;
+
+function specifiersInCode(text: string, re: RegExp): string[] {
+  const found = new Set<string>();
+  for (const m of text.matchAll(re)) {
+    if (m[1]) found.add(m[1]);
+  }
+  return [...found];
+}
+
+// (throw-path) Match any quoted `node:*` / `virtual:*` in an esbuild
+// DIAGNOSTIC message (e.g. `Could not resolve "node:fs"`). These have no
+// import keyword, so the code regexes above would miss them.
+const NODE_DIAGNOSTIC_RE = /["'](node:[^"']+)["']/g;
+const VIRTUAL_DIAGNOSTIC_RE = /["'](virtual:[^"']+)["']/g;
+
+function specifiersInDiagnostics(text: string, re: RegExp): string[] {
+  const found = new Set<string>();
+  for (const m of text.matchAll(re)) {
+    if (m[1]) found.add(m[1]);
+  }
+  return [...found];
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// CHROME BROWSER-BUNDLE EVAL-GRAPH GUARD (#3401, epic #3394).
+//
+// `@takazudo/zudo-doc/chrome` (and its `./home-page` / `./sidebar-tree`
+// siblings) must bundle for the browser with zero shims/aliases (companion
+// issue #3393) — the zfb island scanner walks this exact graph to build
+// client bundles, and a host with `packageOwnedRoutes: false` bundles it
+// directly with no zfb build in the loop. Before wave 1 of epic #3394, that
+// graph carried two structural leaks:
+//   - a static `virtual:zudo-doc-design-token-panel-config` import, resolved
+//     only inside a zfb build (fixed by #3396 — the DTP bootstrap now binds
+//     the package-default builder directly; the virtual specifier only
+//     appears in the routes-only wrapper under `src/routes/`, which this
+//     graph does not reach).
+//   - a static `node:fs`/`node:path` import in `sidebar-tree/category-meta.ts`
+//     (fixed by #3397 — resolved at call time via
+//     `process.getBuiltinModule(...)` instead of a top-level import, so the
+//     literal string `"node:fs"` still appears in the bundle as a plain call
+//     argument, never as an import/require specifier — the strict
+//     `NODE_CODE_RE` below is what makes that distinction, mirroring
+//     `preset.test.ts`).
+// This guard is only possible now that both edges are gone — it locks them
+// out so they can't regrow silently.
+//
+// MECHANISM: identical to `preset.test.ts` — esbuild-bundle with
+// `--platform=neutral` (no shimming of `node:*`), scan the throw-path
+// diagnostics AND (defense-in-depth) the emitted bundle for a literal
+// `node:*`/`virtual:*` import/require specifier.
+//
+// EXTERNAL: unlike `preset.test.ts` (which bundles zod with no external at
+// all — the config eval graph has no third-party runtime deps of its own),
+// chrome's graph reaches real npm peer dependencies. Of those, only
+// `@takazudo/zfb-md-wasm` needs to be marked `external` here: it is an
+// OPTIONAL peer (`package.json#peerDependenciesMeta`) that
+// `html-preview-wrapper/highlight-runtime.ts` reaches through a genuine
+// `import("@takazudo/zfb-md-wasm")` (browser-time-only, per the project root
+// CLAUDE.md's "zfb semantic highlighting" note) — its OWN dist bundle
+// contains an internal Node/browser environment branch
+// (`node:fs/promises`/`node:url`) that is not part of THIS package's import
+// graph and would otherwise false-positive the guard when esbuild inlines
+// the dynamic-import target. `preact`, `@takazudo/zfb`, and `@takazudo/zdtp`
+// were tried and do NOT need to be external — they bundle in clean with zero
+// node:*/virtual:* leaks of their own, so excluding them would only narrow
+// the guard's coverage for no reason.
+//
+// ENTRY COVERAGE: `./home-page` and `./sidebar-tree` are covered here TOO,
+// alongside `./chrome` (which imports both). Before writing this test, all
+// three were probed independently: `sidebar-tree/index.ts` bundles clean
+// (the #3397 fix made the whole module node-free), and `home-page/index.tsx`
+// bundles clean even though its barrel re-exports `prepareHomeData` (which
+// statically imports `sidebar-tree`'s `loadCategoryMeta`) — because that
+// chain no longer carries a literal node:* import/require specifier either,
+// same reason. So, unlike the older `foundation-eval-graph.test.ts` guard
+// (whose header note anticipated this file would stay chrome-only), the
+// probe showed no reason to leave home-page/sidebar-tree uncovered.
+// ───────────────────────────────────────────────────────────────────────────
+
+const ENTRIES = [
+  "chrome/index.tsx",
+  "home-page/index.tsx",
+  "sidebar-tree/index.ts",
+] as const;
+
+const EXTERNAL = ["@takazudo/zfb-md-wasm"];
+
+describe("chrome browser-bundle graph is node-builtin- and virtual-module-free (--platform=neutral)", () => {
+  for (const rel of ENTRIES) {
+    it(`bundles ${rel} with no reachable node:* builtin or virtual:* module`, async () => {
+      const esbuild = loadEsbuild();
+      const entry = resolve(srcRoot, rel);
+
+      let result: Awaited<ReturnType<EsbuildLike["build"]>>;
+      try {
+        result = await esbuild.build({
+          entryPoints: [entry],
+          bundle: true,
+          write: false,
+          platform: "neutral",
+          format: "esm",
+          logLevel: "silent",
+          external: EXTERNAL,
+        });
+      } catch (err) {
+        // (1) Throw path. Inspect the build diagnostics for a node:*/virtual:*
+        // specifier.
+        const buildErr = err as EsbuildBuildError;
+        const diagnostics = (buildErr.errors ?? [])
+          .map((e) => e.text ?? "")
+          .join("\n");
+        const leakedNode = specifiersInDiagnostics(diagnostics, NODE_DIAGNOSTIC_RE);
+        const leakedVirtual = specifiersInDiagnostics(diagnostics, VIRTUAL_DIAGNOSTIC_RE);
+        if (leakedNode.length > 0 || leakedVirtual.length > 0) {
+          throw new Error(
+            `${rel} eval graph leaked unresolvable specifiers (platform=neutral): ` +
+              `${[...leakedNode, ...leakedVirtual].join(", ")}`,
+          );
+        }
+        // A build failure unrelated to node:*/virtual:* is a genuine test failure.
+        throw err;
+      }
+
+      // (2) Success path. No node:*/virtual:* import/require specifier in the
+      // emitted bundle.
+      expect(result.errors).toEqual([]);
+      expect(result.outputFiles.length).toBeGreaterThan(0);
+
+      const bundled = result.outputFiles.map((f: { text: string }) => f.text).join("\n");
+      const nodeOffenders = specifiersInCode(bundled, NODE_CODE_RE);
+      const virtualOffenders = specifiersInCode(bundled, VIRTUAL_CODE_RE);
+
+      expect(
+        nodeOffenders,
+        `${rel} leaked node:* builtins: ${nodeOffenders.join(", ")}`,
+      ).toEqual([]);
+      expect(
+        virtualOffenders,
+        `${rel} leaked virtual:* modules: ${virtualOffenders.join(", ")}`,
+      ).toEqual([]);
+    });
+  }
+
+  // Self-test: prove the detectors are LIVE, not dead code. A module that
+  // imports a node builtin or a virtual: specifier MUST be flagged by the
+  // same throw/scan logic the guard above uses. If this ever stops flagging,
+  // the guard has silently lost its teeth (mirrors preset.test.ts's
+  // equivalent self-test).
+  it("DETECTS a node:* import (guard is not dead code)", async () => {
+    const esbuild = loadEsbuild();
+    const probe = {
+      stdin: {
+        contents: `import { readFileSync } from "node:fs"; export const x = typeof readFileSync;`,
+        resolveDir: __dirname,
+        loader: "ts",
+      },
+      bundle: true,
+      write: false,
+      platform: "neutral",
+      format: "esm",
+      logLevel: "silent",
+    } as Record<string, unknown>;
+
+    let leaked: string[];
+    try {
+      const r = await esbuild.build(probe);
+      leaked = specifiersInCode(r.outputFiles.map((f: { text: string }) => f.text).join("\n"), NODE_CODE_RE);
+    } catch (err) {
+      const buildErr = err as EsbuildBuildError;
+      leaked = specifiersInDiagnostics(
+        (buildErr.errors ?? []).map((e) => e.text ?? "").join("\n"),
+        NODE_DIAGNOSTIC_RE,
+      );
+    }
+    expect(leaked).toContain("node:fs");
+  });
+
+  it("DETECTS a virtual:* import (guard is not dead code)", async () => {
+    const esbuild = loadEsbuild();
+    const probe = {
+      stdin: {
+        contents: `import { x } from "virtual:zudo-doc-route-context"; export const y = x;`,
+        resolveDir: __dirname,
+        loader: "ts",
+      },
+      bundle: true,
+      write: false,
+      platform: "neutral",
+      format: "esm",
+      logLevel: "silent",
+    } as Record<string, unknown>;
+
+    let leaked: string[];
+    try {
+      const r = await esbuild.build(probe);
+      leaked = specifiersInCode(r.outputFiles.map((f: { text: string }) => f.text).join("\n"), VIRTUAL_CODE_RE);
+    } catch (err) {
+      const buildErr = err as EsbuildBuildError;
+      leaked = specifiersInDiagnostics(
+        (buildErr.errors ?? []).map((e) => e.text ?? "").join("\n"),
+        VIRTUAL_DIAGNOSTIC_RE,
+      );
+    }
+    expect(leaked).toContain("virtual:zudo-doc-route-context");
+  });
+});

--- a/packages/zudo-doc/src/__tests__/foundation-eval-graph.test.ts
+++ b/packages/zudo-doc/src/__tests__/foundation-eval-graph.test.ts
@@ -90,6 +90,11 @@ const NODE_FREE_MODULES = [
   // BundleConfig) and `zod` (ZodType) imports are type-only and erased before
   // esbuild resolution.
   "config.ts",
+  // The browser-safe nav/breadcrumb/pager domain (#3395). Covered here for the
+  // node-free half of its contract; `site-schema.test.ts` additionally rejects
+  // preact, `.css`, `virtual:` and `@takazudo/zfb*`, which this list's shared
+  // `external: ["preact", …]` setting deliberately does not police.
+  "site-schema/index.ts",
 ] as const;
 
 describe("S1a foundation primitives are node-builtin-free (--platform=neutral)", () => {

--- a/packages/zudo-doc/src/__tests__/public-api-snapshot.test.ts
+++ b/packages/zudo-doc/src/__tests__/public-api-snapshot.test.ts
@@ -161,6 +161,7 @@ describe("package.json exports keyset snapshot", () => {
         "./sidebar-utils",
         "./sidebar-with-defaults",
         "./sidebar/types",
+        "./site-schema",
         "./site-tree-nav",
         "./site-tree-nav-island",
         "./slug",

--- a/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
+++ b/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
@@ -1051,8 +1051,19 @@ describe("CB chrome-bindings directory: build fails loudly when chromeBindingsMo
 // module (`virtual:zudo-doc-design-token-panel-config`, mirrors
 // `chromeBindingsModule` exactly).
 //
+// NOTE (#3396): on INJECTED routes the mounted component is the routes-only
+// configured wrapper `ConfiguredDesignTokenPanelBootstrap`
+// (`routes/_design-token-panel-bootstrap.tsx`), threaded through
+// `hostBindings.DesignTokenPanelBootstrap` by `routes/_chrome.tsx` — that is
+// the module that imports `virtual:zudo-doc-design-token-panel-config` now.
+// The package default `DesignTokenPanelBootstrap` remains the derive-level slot
+// default for bare `createChrome` callers (self-contained `pages/` stubs), and
+// its name must stay DISTINCT from the wrapper's or zfb's island-marker
+// collision diagnostic drops one of the two. Hence every marker assertion below
+// names the WRAPPER; `INJECTED_DTP_ISLAND` is that name.
+//
 //   1. designTokenPanel: true, NO designTokenPanelConfigModule → the injected
-//      doc route emits the `data-zfb-island="DesignTokenPanelBootstrap"`
+//      doc route emits the `data-zfb-island="ConfiguredDesignTokenPanelBootstrap"`
 //      marker AND the emitted islands client bundle registers the real
 //      component (marker <-> registry match => hydration, the same
 //      structural proof DH established for DocHistory) AND carries the
@@ -1067,10 +1078,10 @@ describe("CB chrome-bindings directory: build fails loudly when chromeBindingsMo
 //   4. designTokenPanel: false → no island marker reaches the SSR HTML (HARD
 //      GATE #3). NOTE: like the pre-existing aiAssistant/imageEnlarge gating
 //      (see `doc-body-end-islands/index.tsx`'s "KNOWN CAVEAT" comment), the
-//      island's SHELL CODE (`DesignTokenPanelBootstrap` itself) may still be
+//      island's SHELL CODE (the bootstrap component itself) may still be
 //      present in the emitted JS bundle even when its marker/render is gated
 //      off — zfb's scanner walks the STATIC "use client" import chain
-//      (`_chrome.tsx` always imports `DesignTokenPanelBootstrap` so it can
+//      (`_chrome.tsx` always imports the configured wrapper so it can
 //      thread it into `createChrome`), and bundle-stripping a
 //      statically-imported-but-conditionally-rendered island is explicitly
 //      out of scope for that established pattern. This case therefore
@@ -1092,6 +1103,15 @@ describe("CB chrome-bindings directory: build fails loudly when chromeBindingsMo
 //      entry via static edges alone, and only reachable by crossing a
 //      dynamic `import()` edge.
 // ---------------------------------------------------------------------------
+
+/** The island marker injected package routes emit for the design-token panel:
+ *  the routes-only configured wrapper, NOT the package default (#3396). */
+const INJECTED_DTP_ISLAND = "ConfiguredDesignTokenPanelBootstrap";
+
+/** The package-default island name — the derive-level slot default that bare
+ *  `createChrome` callers get. Never the marker on an injected route, and it
+ *  must never collide with {@link INJECTED_DTP_ISLAND}. */
+const DEFAULT_DTP_ISLAND = "DesignTokenPanelBootstrap";
 
 /** Flip `designTokenPanel` ON in a fixture's settings.ts (it ships OFF). */
 function enableDesignTokenPanel(dir: string): void {
@@ -1127,19 +1147,33 @@ function enableMissingDesignTokenPanelConfigModule(dir: string): void {
   writeFileSync(settingsPath, src);
 }
 
-describe("DTP design-token-panel: injected doc route registers the DesignTokenPanelBootstrap island (packageOwnedRoutes + designTokenPanel)", () => {
+describe("DTP design-token-panel: injected doc route registers the configured design-token-panel island (packageOwnedRoutes + designTokenPanel)", () => {
   let fixtureDir: string;
+  let buildOutput: string;
 
   it("setup: fixture builds with designTokenPanel enabled + empty pages/", { timeout: 180_000 }, () => {
     fixtureDir = setupFixture({ emptyPages: true });
     enableDesignTokenPanel(fixtureDir);
-    runZfbBuild(fixtureDir);
+    buildOutput = runZfbBuild(fixtureDir);
   });
 
-  it("marker: injected /docs/getting-started/ HTML carries the DesignTokenPanelBootstrap island marker (non-skip-ssr)", () => {
+  it("marker: injected /docs/getting-started/ HTML carries the configured island marker (non-skip-ssr)", () => {
     const html = readBuiltHtml(fixtureDir, "docs/getting-started/index.html");
-    expectHtmlAttr(html, "data-zfb-island", "DesignTokenPanelBootstrap");
-    expect(countHtmlAttr(html, "data-zfb-island", "DesignTokenPanelBootstrap")).toBe(1);
+    expectHtmlAttr(html, "data-zfb-island", INJECTED_DTP_ISLAND);
+    expect(countHtmlAttr(html, "data-zfb-island", INJECTED_DTP_ISLAND)).toBe(1);
+    // Exactly one panel island: the derive-level package default must NOT also
+    // mount alongside the routes wrapper (#3396 — the wrapper REPLACES it in
+    // the slot rather than composing with it).
+    expect(countHtmlAttr(html, "data-zfb-island", DEFAULT_DTP_ISLAND)).toBe(0);
+  });
+
+  it("no name collision: the package default and the routes wrapper both register (#3396)", () => {
+    // Both components are statically reachable from the injected route (the
+    // wrapper via `_chrome.tsx`, the package default via `chrome/derive.tsx`'s
+    // slot default). If they ever shared a marker name, zfb would drop one and
+    // say so — which would silently un-hydrate the panel.
+    expect(buildOutput).not.toMatch(/island marker name collision/i);
+    expect(buildOutput).not.toMatch(/has no matching registry entry/i);
   });
 
   it("shim: injected /docs/getting-started/ HTML carries the pre-hydration toggle-shim script", () => {
@@ -1148,11 +1182,11 @@ describe("DTP design-token-panel: injected doc route registers the DesignTokenPa
     expect(html).toContain("toggle-design-token-panel");
   });
 
-  it("bundle: the emitted islands client bundle registers DesignTokenPanelBootstrap (marker <-> registry match => hydration)", () => {
-    // Marker present (above) + DesignTokenPanelBootstrap in the client bundle
-    // = the marker has a matching registry entry, which is exactly what
-    // zfb's hydration requires (same structural proof as Case DH).
-    expect(readIslandsBundles(fixtureDir)).toContain("DesignTokenPanelBootstrap");
+  it("bundle: the emitted islands client bundle registers the configured island (marker <-> registry match => hydration)", () => {
+    // Marker present (above) + the same name in the client bundle = the marker
+    // has a matching registry entry, which is exactly what zfb's hydration
+    // requires (same structural proof as Case DH).
+    expect(readIslandsBundles(fixtureDir)).toContain(INJECTED_DTP_ISLAND);
   });
 
   it("package-default builder: the bundle carries the unchanged storagePrefix 'zudo-doc-tweak' (HARD GATE #4)", () => {
@@ -1205,7 +1239,7 @@ describe("DTP design-token-panel: injected doc route registers the DesignTokenPa
   });
 });
 
-describe("DTP host body-end override: package derive seam retains exactly one DesignTokenPanelBootstrap", () => {
+describe("DTP host body-end override: package derive seam retains exactly one design-token-panel island", () => {
   let fixtureDir: string;
   let buildOutput: string;
 
@@ -1219,25 +1253,28 @@ describe("DTP host body-end override: package derive seam retains exactly one De
   it("composes the host body-end content with exactly one package-owned marker", () => {
     const html = readBuiltHtml(fixtureDir, "docs/getting-started/index.html");
     expect(html).toContain("HOST-BODY-END-MARKER");
-    expect(countHtmlAttr(html, "data-zfb-island", "DesignTokenPanelBootstrap")).toBe(1);
+    expect(countHtmlAttr(html, "data-zfb-island", INJECTED_DTP_ISLAND)).toBe(1);
+    expect(countHtmlAttr(html, "data-zfb-island", DEFAULT_DTP_ISLAND)).toBe(0);
     expect(html).toContain("__zdtpToggleShimInstalled");
   });
 
   it("keeps a matching client registry entry without the duplicate-component warning", () => {
-    expect(readIslandsBundles(fixtureDir)).toContain("DesignTokenPanelBootstrap");
+    expect(readIslandsBundles(fixtureDir)).toContain(INJECTED_DTP_ISLAND);
     expect(buildOutput).not.toMatch(/cannot hydrate both components/i);
+    expect(buildOutput).not.toMatch(/island marker name collision/i);
   });
 });
 
 describe("DTP host override: designTokenPanelConfigModule wires the host's builder into the bundle", () => {
   let fixtureDir: string;
+  let buildOutput: string;
 
   it("setup: fixture builds with designTokenPanel + designTokenPanelConfigModule set", { timeout: 180_000 }, () => {
     fixtureDir = setupFixture({ emptyPages: true });
     enableDesignTokenPanel(fixtureDir);
     enableDesignTokenPanelConfigModule(fixtureDir);
     // Should not throw — the resolved file (src/design-token-panel-config.ts) exists.
-    runZfbBuild(fixtureDir);
+    buildOutput = runZfbBuild(fixtureDir);
   });
 
   it("bindings: the emitted islands client bundle carries the host-only token label (not the package default)", () => {
@@ -1245,9 +1282,40 @@ describe("DTP host override: designTokenPanelConfigModule wires the host's build
     expect(bundle).toContain("DTP-HOST-CONFIG-MODULE-MARKER");
   });
 
-  it("marker: injected /docs/getting-started/ HTML still carries the DesignTokenPanelBootstrap island marker", () => {
+  it("marker: injected /docs/getting-started/ HTML still carries the configured island marker", () => {
     const html = readBuiltHtml(fixtureDir, "docs/getting-started/index.html");
-    expectHtmlAttr(html, "data-zfb-island", "DesignTokenPanelBootstrap");
+    expectHtmlAttr(html, "data-zfb-island", INJECTED_DTP_ISLAND);
+  });
+
+  // -------------------------------------------------------------------------
+  // #3396 end-to-end proof. The two assertions above are each necessary but
+  // individually weak: the host label could sit in a dead chunk, and the marker
+  // could point at a component that never registers. Together with the two
+  // below they close the loop — the SAME island that carries the host builder
+  // is the one the marker names AND the one the client registry exposes, so the
+  // override genuinely reaches the panel that hydrates.
+  //
+  // This is the empirical answer to the #2480 question the issue raises: that
+  // lesson was about COMPONENT imports going dynamic and silently killing
+  // registration. Moving only the CONFIG import into the routes graph is
+  // exempt — registration is unaffected, as these assertions show.
+  // -------------------------------------------------------------------------
+
+  it("registration: the configured island is in the client registry alongside the host's builder", () => {
+    const bundle = readIslandsBundles(fixtureDir);
+    expect(bundle).toContain(INJECTED_DTP_ISLAND);
+    expect(bundle).toContain("DTP-HOST-CONFIG-MODULE-MARKER");
+    // The package default must NOT be what the page mounted — otherwise the
+    // host builder would be in the bundle but unreachable from the live panel.
+    const html = readBuiltHtml(fixtureDir, "docs/getting-started/index.html");
+    expect(countHtmlAttr(html, "data-zfb-island", DEFAULT_DTP_ISLAND)).toBe(0);
+    expect(countHtmlAttr(html, "data-zfb-island", INJECTED_DTP_ISLAND)).toBe(1);
+  });
+
+  it("scanner: the build reports no marker collision and no unmatched marker", () => {
+    expect(buildOutput).not.toMatch(/island marker name collision/i);
+    expect(buildOutput).not.toMatch(/has no matching registry entry/i);
+    expect(buildOutput).not.toMatch(/cannot hydrate both components/i);
   });
 });
 
@@ -1280,9 +1348,10 @@ describe("DTP off: designTokenPanel false emits no island marker on the page (HA
     runZfbBuild(fixtureDir);
   });
 
-  it("no marker: injected /docs/getting-started/ HTML carries no DesignTokenPanelBootstrap marker", () => {
+  it("no marker: injected /docs/getting-started/ HTML carries neither design-token-panel marker", () => {
     const html = readBuiltHtml(fixtureDir, "docs/getting-started/index.html");
-    expect(html).not.toMatch(htmlAttrPattern("data-zfb-island", "DesignTokenPanelBootstrap"));
+    expect(html).not.toMatch(htmlAttrPattern("data-zfb-island", INJECTED_DTP_ISLAND));
+    expect(html).not.toMatch(htmlAttrPattern("data-zfb-island", DEFAULT_DTP_ISLAND));
   });
 
   it("no shim: injected /docs/getting-started/ HTML carries no toggle-shim script", () => {
@@ -1968,6 +2037,26 @@ describe("TM build+check+css: the locked manifest builds, typechecks, and ships 
 // included — mounts the settings-gated island with no explicit wiring. The
 // cases below are the regression guard: the stub's island-marker set must
 // stay IDENTICAL to the injected-route baseline.
+//
+// *** #3396 AMENDMENT — the panel island now has TWO shapes ***
+// The gate-2 invariant above (both variants mount the settings-gated panel) is
+// intact, but the two variants no longer mount the SAME COMPONENT, so their raw
+// marker strings differ:
+//   - injected route → `ConfiguredDesignTokenPanelBootstrap`, the routes-only
+//     wrapper that reads `virtual:zudo-doc-design-token-panel-config` and so
+//     honors a host's `designTokenPanelConfigModule`;
+//   - self-contained stub → `DesignTokenPanelBootstrap`, the package default
+//     bound to the package-default builder.
+// This divergence is FORCED, not incidental: the virtual specifier cannot be
+// imported from a module whose realpath is under node_modules (zfb's bundler
+// does not run the virtual-module resolver there — the S1 #2370 gap), which is
+// why the wrapper must live in the staged `routes-src/` tree and cannot be a
+// public package subpath the stub could import. The two components must also
+// carry distinct names or zfb's island-marker collision diagnostic drops one.
+// The builder cannot be handed across as a prop either — it is a function, so
+// it cannot survive the SSR → hydration boundary.
+// The diff below therefore NORMALIZES the panel marker (strict everywhere else)
+// and asserts each variant's own shape explicitly.
 // ---------------------------------------------------------------------------
 
 describe("TM group 2: island-set diff — self-contained doc stub vs. injected-route baseline (designTokenPanel: true)", () => {
@@ -1988,25 +2077,36 @@ describe("TM group 2: island-set diff — self-contained doc stub vs. injected-r
     expect(html).toContain("TM-INDEX-MARKER: target-manifest-render-proof");
   });
 
-  it("baseline: injected /docs/getting-started/ carries the DesignTokenPanelBootstrap marker + a matching client-bundle registry entry", () => {
+  it("baseline: injected /docs/getting-started/ carries the configured panel marker + a matching client-bundle registry entry", () => {
     const html = readBuiltHtml(baselineDir, "docs/getting-started/index.html");
-    expectHtmlAttr(html, "data-zfb-island", "DesignTokenPanelBootstrap");
-    expect(readIslandsBundles(baselineDir)).toContain("DesignTokenPanelBootstrap");
+    expectHtmlAttr(html, "data-zfb-island", INJECTED_DTP_ISLAND);
+    expect(readIslandsBundles(baselineDir)).toContain(INJECTED_DTP_ISLAND);
   });
 
-  it("home route (both variants): / carries the DesignTokenPanelBootstrap marker via the re-export — unaffected by the doc-stub gap", () => {
+  it("home route (both variants): / carries the configured panel marker via the re-export — unaffected by the doc-stub gap", () => {
+    // `pages/index.tsx` is a 1-line re-export of `routes/index` in BOTH
+    // variants, so both reach the panel island through `routes/_chrome.tsx` —
+    // i.e. the configured wrapper, even in the with-stub fixture.
     for (const dir of [stubDir, baselineDir]) {
       const html = readBuiltHtml(dir, "index.html");
-      expectHtmlAttr(html, "data-zfb-island", "DesignTokenPanelBootstrap");
+      expectHtmlAttr(html, "data-zfb-island", INJECTED_DTP_ISLAND);
     }
-    expect(readIslandsBundles(stubDir)).toContain("DesignTokenPanelBootstrap");
+    expect(readIslandsBundles(stubDir)).toContain(INJECTED_DTP_ISLAND);
   });
 
-  it("island-set diff: the self-contained stub's marker set is IDENTICAL to the injected baseline (gate-2 fix: incl. DesignTokenPanelBootstrap)", () => {
-    const baselineMarkers = new Set(
+  it("island-set diff: the self-contained stub's marker set matches the injected baseline (gate-2 fix; panel marker normalized per #3396)", () => {
+    // Fold the two panel shapes onto one token so the set diff stays STRICT
+    // for every other island while tolerating the one divergence #3396 forces
+    // (see the block header). A stub page that mounted NO panel at all — the
+    // original #2658 gate-2 gap — still fails here, because normalization maps
+    // a name onto another name, it never invents one.
+    const normalize = (markers: string[]): Set<string> =>
+      new Set(markers.map((m) => m.split(INJECTED_DTP_ISLAND).join(DEFAULT_DTP_ISLAND)));
+
+    const baselineMarkers = normalize(
       extractIslandMarkers(readBuiltHtml(baselineDir, "docs/getting-started/index.html")),
     );
-    const stubMarkers = new Set(
+    const stubMarkers = normalize(
       extractIslandMarkers(readBuiltHtml(stubDir, "docs/getting-started/index.html")),
     );
     const missingFromStub = [...baselineMarkers].filter((m) => !stubMarkers.has(m)).sort();
@@ -2017,15 +2117,27 @@ describe("TM group 2: island-set diff — self-contained doc stub vs. injected-r
     // ["data-zfb-island=DesignTokenPanelBootstrap"] — the #2658 gate-2 gap.)
     expect(extraInStub).toEqual([]);
     expect(missingFromStub).toEqual([]);
+    // The normalization must not be silently doing nothing: the panel island
+    // has to be in the set at all, or both sides could be vacuously equal.
+    expect(baselineMarkers).toContain(`data-zfb-island=${DEFAULT_DTP_ISLAND}`);
   });
 
   // Was `it.fails` while the gate-2 gap was open (see the module-header note
   // above); flipped to a plain `it` by the #2658 gate-2 fix, per the marker's
   // own instruction. The registry pairing lives in the "home route" case above
   // (shared islands bundle) — this asserts the stub page's own marker.
-  it("doc route carries the DesignTokenPanelBootstrap marker, matching the baseline (#2658 gate-2 fix)", () => {
+  it("doc route carries the PACKAGE-DEFAULT panel marker + a matching registry entry (#2658 gate-2 fix, #3396 shape)", () => {
     const html = readBuiltHtml(stubDir, "docs/getting-started/index.html");
-    expectHtmlAttr(html, "data-zfb-island", "DesignTokenPanelBootstrap");
+    expectHtmlAttr(html, "data-zfb-island", DEFAULT_DTP_ISLAND);
+    // The stub reaches the package default, NOT the routes wrapper — the
+    // known #3396 gap: `designTokenPanelConfigModule` does not apply to pages
+    // rendered by a self-contained stub.
+    expect(countHtmlAttr(html, "data-zfb-island", INJECTED_DTP_ISLAND)).toBe(0);
+    // No bundle-substring assertion here: `ConfiguredDesignTokenPanelBootstrap`
+    // CONTAINS `DesignTokenPanelBootstrap`, so a `toContain` on the default's
+    // name cannot distinguish the two registry entries and would pass even if
+    // only the wrapper registered. The collision/unmatched-marker guards in the
+    // DTP blocks above are what prove both entries exist.
   });
 });
 

--- a/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
+++ b/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
@@ -616,20 +616,58 @@ describe("A2 no-stub: injected routes render correct HTML (packageOwnedRoutes:tr
   //
   // All of it traces to already-merged, intentional PRs; no unattributed
   // bytes.
+  //
+  // 2026-08-18 re-baseline (zudolab/zudo-doc#3401, epic #3394 wave-1 → base
+  // merge): pre-epic HEAD (3902f7f0) rebuilt in a scratch worktree and
+  // byte-diffed against this epic base's HEAD via the same
+  // `parity-html-normalize.mjs` helper this test uses. All three pages grew
+  // by IDENTICALLY 2040 bytes (no page-specific delta, unlike the #3277
+  // entry's TOC-only +11 bytes) and every changed line traces to exactly two
+  // already-merged, intentional wave-1 PRs:
+  //
+  //   - `zudolab/zudo-doc#3399` (theme-pack no-FOUC bootstrap rewrite,
+  //     `theme/theme-pack-provider.tsx`): adds the anti-FOUC latch
+  //     `<style>html[data-zd-theme-pack-loading] body{visibility:hidden}</style>`
+  //     immediately before the bootstrap `<script>`, and replaces the old
+  //     `document.write('<link ...>')` insertion with
+  //     `createElement`/`head.appendChild` plus a `LOADING_ATTR`/`WATCHDOG`
+  //     latch-release dance — present verbatim on every page (unconditional,
+  //     not gated on `themePack`).
+  //   - `zudolab/zudo-doc#3398` (explicit current-route input,
+  //     `header/nav-overflow-script.ts`): replaces the inlined
+  //     `isUnderPath`/raw `location.pathname` walk with a `getCurrentPath()`
+  //     override read plus `pathMatchesNavPath`/`computeActiveNavPath`
+  //     embedded verbatim from `nav-active.ts`, so the client script's
+  //     longest-match walk can't drift from the SSR header's own
+  //     `computeActiveNavPath` call — also unconditional, present on every
+  //     page.
+  //
+  // Both scripts are page-independent boilerplate emitted on every SSG page,
+  // which is exactly why all three otherwise-unrelated fixture pages moved by
+  // the same byte count. No other wave-1 sub-issue (category-meta-fs #3397 —
+  // this fixture has no `_category_.json` so `loadCategoryMeta` is an empty
+  // map either way; dtp-virtual-seam #3396 — `designTokenPanel` stays `false`
+  // in this fixture, so the DTP island markup is absent both before and
+  // after; site-schema subpath/active-nav-input plumbing — pure refactors of
+  // code this fixture's build doesn't exercise differently) touched a single
+  // byte of these three pages.
+  //
+  // All of it traces to already-merged, intentional PRs; no unattributed
+  // bytes.
 
   it("parity: /404.html normalized-HTML sha256 is stable (stub-defaults path)", () => {
     const html = readBuiltHtml(fixtureDir, "404.html");
-    expect(sha256Html(html)).toMatchInlineSnapshot(`"29f8ad2434e2c80e7ec084ce35d5403576c08d2efb14b64393fbdd822d429198"`);
+    expect(sha256Html(html)).toMatchInlineSnapshot(`"e8da2b7dfb3dd4f40819c45d1099f0f628425d3e7d1d8f6b1950087ca7b2dacc"`);
   });
 
   it("parity: /docs/getting-started/index.html normalized-HTML sha256 is stable (stub-defaults path)", () => {
     const html = readBuiltHtml(fixtureDir, "docs/getting-started/index.html");
-    expect(sha256Html(html)).toMatchInlineSnapshot(`"e433f30ab887391e7bf22dd1d6af24e80cbafba3530e95c076378b26c5a5a272"`);
+    expect(sha256Html(html)).toMatchInlineSnapshot(`"c7d1036b74679e01fba0de5291eead1e87ae102107081e34be5a580ebbdc53dd"`);
   });
 
   it("parity: /docs/getting-started/coverage/index.html normalized-HTML sha256 is stable (new page, #3179)", () => {
     const html = readBuiltHtml(fixtureDir, "docs/getting-started/coverage/index.html");
-    expect(sha256Html(html)).toMatchInlineSnapshot(`"c8cc832ab0d4f2771619be1fe06d2e962122f77705cc6c507df62e08d2853251"`);
+    expect(sha256Html(html)).toMatchInlineSnapshot(`"efdd372af488957c34c567eb779243c2b0c0ca8699d51644342a6acbc6cbb279"`);
   });
 });
 

--- a/packages/zudo-doc/src/__tests__/site-schema.test.ts
+++ b/packages/zudo-doc/src/__tests__/site-schema.test.ts
@@ -1,0 +1,418 @@
+// Contract suite for `@takazudo/zudo-doc/site-schema` (zudolab/zudo-doc#3395).
+//
+// Four things are pinned here:
+//   1. the subpath exists in package.json#exports and points at the built barrel;
+//   2. the exported symbol set (runtime functions + the type names in the
+//      emitted declaration);
+//   3. the pure domain behaves — nav tree, breadcrumbs, prev/next, auto-index,
+//      and the per-factory memo scope that keeps two route contexts from
+//      serving each other's cached routes;
+//   4. NOTHING reachable from the barrel — through the bundled JS graph OR the
+//      transitive `.d.ts` graph — is a `node:*` builtin, preact, a stylesheet,
+//      a `virtual:` module, or an `@takazudo/zfb*` package.
+//
+// The dist-reading cases assume a prior `pnpm --filter @takazudo/zudo-doc build`,
+// the same precondition catalog.test.ts relies on; they read artifacts only and
+// never trigger a build, so this stays in the fast unit tier.
+
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import {
+  schemaVersion,
+  buildNavTree,
+  buildBreadcrumbs,
+  collectAutoIndexNodes,
+  createDocRouteEntries,
+  findNode,
+  firstRoutedHref,
+  groupSatelliteNodes,
+  isNavVisible,
+  resolveDocPrevNext,
+  flattenTree,
+} from "../site-schema/index.js";
+import type {
+  AutoIndexNode,
+  DocEntryLike,
+  DocNavNode,
+  DocPageFrontmatter,
+  DocRouteEntriesContext,
+  NavSourceDocs,
+} from "../site-schema/index.js";
+import { toRouteSlug, toSlugParams } from "../slug/index.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = resolve(__dirname, "../..");
+const REPO_ROOT = resolve(PKG_ROOT, "../..");
+const SRC_ENTRY = resolve(PKG_ROOT, "src/site-schema/index.ts");
+const DIST_DTS = resolve(PKG_ROOT, "dist/site-schema/index.d.ts");
+
+// The detector is shared verbatim with the `prepack` guard
+// (`scripts/check-site-schema.mjs`) so the two can never disagree about what
+// counts as browser-unsafe. It is loaded through a runtime URL rather than a
+// literal specifier because it is plain `.mjs` with no declarations — node and
+// vitest both resolve it, and TypeScript never has to.
+interface SiteSchemaGraph {
+  forbiddenLabel(specifier: string): string | undefined;
+  analyzeSiteSchemaGraph(args: { entry: string; resolveFrom: string[] }): Promise<{
+    violations: Array<{ specifier: string; label: string; importer: string }>;
+    specifiers: string[];
+  }>;
+}
+
+async function loadGraphHelper(): Promise<SiteSchemaGraph> {
+  const url = pathToFileURL(resolve(PKG_ROOT, "scripts/site-schema-graph.mjs")).href;
+  return (await import(/* @vite-ignore */ url)) as SiteSchemaGraph;
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function entry(slug: string, data: Partial<DocPageFrontmatter> = {}): DocEntryLike {
+  return { slug, data: { title: slug, ...data }, body: "" };
+}
+
+const docsUrlFor = (base: string) => (slug: string) => (slug ? `${base}/docs/${slug}/` : `${base}/docs/`);
+
+/** A minimal but complete route context, parameterized on its URL space so two
+ *  instances are distinguishable in their output. */
+function makeContext(base: string): DocRouteEntriesContext {
+  const docsUrl = docsUrlFor(base);
+  return {
+    defaultLocale: "en",
+    buildNavTree: (docs, locale, categoryMeta, buildHref) =>
+      buildNavTree(docs, locale, categoryMeta, buildHref),
+    docsUrl: (slug) => docsUrl(slug),
+    withBase: (path) => `${base}${path}`,
+    collectAutoIndexNodes: (tree) => collectAutoIndexNodes(tree) as AutoIndexNode[],
+    getNavSectionForSlug: () => undefined,
+    getNavSubtree: (tree) => tree,
+    toRouteSlug,
+    toSlugParams,
+    extractHeadings: () => [],
+  };
+}
+
+function makeSource(docs: DocEntryLike[]): NavSourceDocs {
+  return { docs, navDocs: docs, categoryMeta: new Map(), localeSlugSet: new Set() };
+}
+
+// ---------------------------------------------------------------------------
+// (1) Exports-map entry
+// ---------------------------------------------------------------------------
+
+describe("./site-schema subpath export", () => {
+  it("points at the built barrel", () => {
+    const pkg = JSON.parse(readFileSync(resolve(PKG_ROOT, "package.json"), "utf8")) as {
+      exports: Record<string, unknown>;
+      scripts: Record<string, string>;
+    };
+    expect(pkg.exports["./site-schema"]).toEqual({
+      types: "./dist/site-schema/index.d.ts",
+      default: "./dist/site-schema/index.js",
+    });
+  });
+
+  it("is guarded at publish time by check-site-schema.mjs", () => {
+    const pkg = JSON.parse(readFileSync(resolve(PKG_ROOT, "package.json"), "utf8")) as {
+      scripts: Record<string, string>;
+    };
+    expect(pkg.scripts.prepack).toContain("check-site-schema.mjs");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (2) Exported symbol set
+// ---------------------------------------------------------------------------
+
+describe("site-schema exported symbols", () => {
+  it("freezes the runtime export set", async () => {
+    const mod = await import("../site-schema/index.js");
+    expect(Object.keys(mod).sort()).toMatchInlineSnapshot(`
+      [
+        "buildBreadcrumbs",
+        "buildNavTree",
+        "buildSidebarTree",
+        "collectAutoIndexNodes",
+        "createDocRouteEntries",
+        "extractHeadings",
+        "findNode",
+        "firstRoutedHref",
+        "flattenSubtree",
+        "flattenTree",
+        "getCategoryOrder",
+        "getNavSectionForSlug",
+        "getNavSubtree",
+        "groupSatelliteNodes",
+        "isNavVisible",
+        "remapNavChildHrefs",
+        "resolveDocPrevNext",
+        "rewriteNavHref",
+        "schemaVersion",
+      ]
+    `);
+  });
+
+  it("carries a schemaVersion so consumers can fail closed", () => {
+    expect(schemaVersion).toBe(1);
+  });
+
+  it("declares every documented type in the emitted declaration", () => {
+    expect(existsSync(DIST_DTS), `${DIST_DTS} missing — run \`pnpm --filter @takazudo/zudo-doc build\``).toBe(true);
+    const dts = readFileSync(DIST_DTS, "utf8");
+    for (const name of [
+      "DocNavNode",
+      "AutoIndexNode",
+      "DocPageFrontmatter",
+      "DocPageBaseProps",
+      "DocPageEntryProps",
+      "DocPageAutoIndexProps",
+      "DocRouteEntry",
+      "BuildDocRouteEntriesArgs",
+      "DocRouteEntriesContext",
+      "NavSourceDocs",
+      "BreadcrumbItem",
+      "HeadingItem",
+      "SidebarNode",
+      "CategoryMeta",
+      "SidebarFrontmatter",
+      "CollectionEntryLike",
+      "PaginationOverrides",
+    ]) {
+      expect(dts, `${name} is not exported from dist/site-schema/index.d.ts`).toContain(name);
+    }
+  });
+
+  it("keeps the component-side breadcrumb helpers out of the contract", async () => {
+    const mod = await import("../site-schema/index.js");
+    expect(mod).not.toHaveProperty("findPath");
+    expect(mod).not.toHaveProperty("buildBreadcrumbItems");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (3) The pure domain
+// ---------------------------------------------------------------------------
+
+describe("site-schema pure surface", () => {
+  const docs = [
+    entry("getting-started/index", { title: "Getting Started", sidebar_position: 1 }),
+    entry("getting-started/install", { title: "Install", sidebar_position: 2 }),
+    entry("guides/deep/nested", { title: "Nested", sidebar_position: 1 }),
+  ];
+
+  const tree = buildNavTree(docs, "en", undefined, (slug) => docsUrlFor("")(slug));
+
+  it("builds a nav tree with category nesting", () => {
+    expect(tree.map((n) => n.slug).sort()).toEqual(["getting-started", "guides"]);
+    expect(findNode(tree, "getting-started/install")?.hasPage).toBe(true);
+  });
+
+  it("treats a category without an index.mdx as an auto-index", () => {
+    const autoIndexes = collectAutoIndexNodes(tree).map((n) => n.slug);
+    expect(autoIndexes).toContain("guides");
+    // getting-started HAS an index.mdx, so it is a real route, not an auto-index.
+    expect(autoIndexes).not.toContain("getting-started");
+  });
+
+  it("walks the slug path to build breadcrumbs, leaving the last crumb unlinked", () => {
+    const crumbs = buildBreadcrumbs(tree, "getting-started/install", "/");
+    expect(crumbs.map((c) => c.label)).toEqual(["", "Getting Started", "Install"]);
+    expect(crumbs[0]?.href).toBe("/");
+    expect(crumbs.at(-1)?.href).toBeUndefined();
+  });
+
+  it("remaps intermediate crumbs through hrefFor but never the current page", () => {
+    const crumbs = buildBreadcrumbs(tree, "getting-started/install", "/", (slug) => `/v/1.0/${slug}/`);
+    expect(crumbs[1]?.href).toBe("/v/1.0/getting-started/");
+    expect(crumbs.at(-1)?.href).toBeUndefined();
+  });
+
+  it("resolves prev/next sequentially and honours frontmatter overrides", () => {
+    const flat = flattenTree(tree);
+    const plain = resolveDocPrevNext(tree, flat, "getting-started/install", {});
+    expect(plain.prev?.slug).toBe("getting-started");
+
+    const suppressed = resolveDocPrevNext(tree, flat, "getting-started/install", {
+      pagination_prev: null,
+    });
+    expect(suppressed.prev).toBeNull();
+
+    const redirected = resolveDocPrevNext(tree, flat, "getting-started/install", {
+      pagination_next: "guides/deep/nested",
+    });
+    expect(redirected.next?.slug).toBe("guides/deep/nested");
+  });
+
+  it("finds the first routed descendant href", () => {
+    const guides = findNode(tree, "guides");
+    expect(guides).toBeDefined();
+    expect(firstRoutedHref(guides as DocNavNode)).toBe("/docs/guides/deep/nested/");
+  });
+
+  it("groups slug-prefix satellites under their primary node", () => {
+    const flatTree: DocNavNode[] = [
+      { slug: "api", label: "API", position: 1, hasPage: true, children: [] },
+      { slug: "api-legacy", label: "Legacy", position: 2, hasPage: true, children: [] },
+      { slug: "guides", label: "Guides", position: 3, hasPage: true, children: [] },
+    ];
+    const grouped = groupSatelliteNodes(flatTree, ["api"]);
+    expect(grouped.map((n) => n.slug)).toEqual(["api", "guides"]);
+    expect(grouped[0]?.children.map((c) => c.slug)).toEqual(["api-legacy"]);
+  });
+
+  it("hides unlisted and standalone docs from navigation", () => {
+    expect(isNavVisible(entry("a"))).toBe(true);
+    expect(isNavVisible(entry("b", { unlisted: true }))).toBe(false);
+    expect(isNavVisible(entry("c", { standalone: true }))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (3b) createDocRouteEntries — route emission + memo scoping
+// ---------------------------------------------------------------------------
+
+describe("createDocRouteEntries", () => {
+  const docs = [
+    entry("index"),
+    entry("guides/index", { category_no_page: true }),
+    entry("guides/one"),
+    entry("orphans/child"),
+  ];
+
+  it("emits no route for a category_no_page entry and one for each auto-index", () => {
+    const { buildDocRouteEntries } = createDocRouteEntries(makeContext(""));
+    const routes = buildDocRouteEntries({
+      source: makeSource(docs),
+      locale: "en",
+      routeSig: "docs;en",
+    });
+    const slugs = routes.map((r) => r.slug);
+
+    expect(slugs).toContain("guides/one");
+    // `guides/index` carries category metadata only.
+    expect(slugs.filter((s) => s === "guides")).toHaveLength(0);
+    // `orphans` has a child but no index.mdx → one auto-index route.
+    expect(slugs).toContain("orphans");
+    expect(routes.find((r) => r.slug === "orphans")?.props.kind).toBe("autoIndex");
+    expect(routes.find((r) => r.slug === "guides/one")?.props.kind).toBe("entry");
+  });
+
+  it("memoizes repeat calls within one factory", () => {
+    const { buildDocRouteEntries } = createDocRouteEntries(makeContext(""));
+    const source = makeSource(docs);
+    const first = buildDocRouteEntries({ source, locale: "en", routeSig: "docs;en" });
+    const second = buildDocRouteEntries({ source, locale: "en", routeSig: "docs;en" });
+    expect(second).toBe(first);
+  });
+
+  // Regression for #3395: the memo used to be keyed on `source.docs` identity +
+  // routeSig alone, so two factories sharing a docs array and a routeSig but
+  // built over different URL/context closures served each other's cached routes.
+  it("scopes the memo per factory instance", () => {
+    const source = makeSource(docs);
+    const args = { source, locale: "en", routeSig: "docs;en" } as const;
+
+    const a = createDocRouteEntries(makeContext("/a")).buildDocRouteEntries({ ...args });
+    const b = createDocRouteEntries(makeContext("/b")).buildDocRouteEntries({ ...args });
+
+    expect(a).not.toBe(b);
+    expect(a[0]?.props.breadcrumbs[0]?.href).toBe("/a/");
+    expect(b[0]?.props.breadcrumbs[0]?.href).toBe("/b/");
+
+    const aHrefs = a.map((r) => r.props.autoIndex?.href ?? r.props.entry?.slug);
+    const bHrefs = b.map((r) => r.props.autoIndex?.href ?? r.props.entry?.slug);
+    expect(aHrefs).not.toEqual(bHrefs);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (4) Browser safety — bundled graph
+// ---------------------------------------------------------------------------
+
+describe("site-schema stays browser-safe", () => {
+  it("reaches no node:*, preact, .css, virtual:, or @takazudo/zfb specifier", async () => {
+    const { analyzeSiteSchemaGraph } = await loadGraphHelper();
+    const { violations, specifiers } = await analyzeSiteSchemaGraph({
+      entry: SRC_ENTRY,
+      resolveFrom: [PKG_ROOT, REPO_ROOT, __dirname],
+    });
+    expect(
+      violations,
+      violations.map((v) => `${v.specifier} (${v.label}) via ${v.importer}`).join("\n"),
+    ).toEqual([]);
+    // Sanity: the analysis actually walked a graph rather than short-circuiting.
+    expect(specifiers.length).toBeGreaterThan(0);
+  });
+
+  it("DETECTS a forbidden specifier (guard is not dead code)", async () => {
+    const { forbiddenLabel } = await loadGraphHelper();
+    expect(forbiddenLabel("node:fs")).toBe("node builtin");
+    expect(forbiddenLabel("preact/hooks")).toBe("preact");
+    expect(forbiddenLabel("@takazudo/zfb/content")).toBe("zfb engine package");
+    expect(forbiddenLabel("@takazudo/zfb-runtime")).toBe("zfb engine package");
+    expect(forbiddenLabel("virtual:zudo-doc-route-context")).toBe("zfb virtual module");
+    expect(forbiddenLabel("../theme.css")).toBe("stylesheet");
+    expect(forbiddenLabel("../slug/index.js")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (4b) Browser safety — TRANSITIVE declaration graph
+// ---------------------------------------------------------------------------
+
+/** Every `from "…"` specifier in a declaration file. */
+function declarationSpecifiers(source: string): string[] {
+  return [...source.matchAll(/\bfrom\s*["']([^"']+)["']/g)].map((m) => m[1] as string);
+}
+
+/** Resolve a relative `.js`/extensionless specifier to its emitted `.d.ts`. */
+function resolveDeclaration(fromFile: string, specifier: string): string | undefined {
+  const base = resolve(dirname(fromFile), specifier);
+  for (const candidate of [
+    base.replace(/\.js$/, ".d.ts"),
+    `${base}.d.ts`,
+    resolve(base, "index.d.ts"),
+  ]) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+describe("site-schema declaration graph", () => {
+  it("never reaches @takazudo/zfb (or any other forbidden package) transitively", async () => {
+    const { forbiddenLabel } = await loadGraphHelper();
+    expect(
+      existsSync(DIST_DTS),
+      `${DIST_DTS} missing — run \`pnpm --filter @takazudo/zudo-doc build\``,
+    ).toBe(true);
+
+    const seen = new Set<string>();
+    const violations: string[] = [];
+    const queue = [DIST_DTS];
+
+    while (queue.length > 0) {
+      const file = queue.pop() as string;
+      if (seen.has(file)) continue;
+      seen.add(file);
+
+      for (const specifier of declarationSpecifiers(readFileSync(file, "utf8"))) {
+        const label = forbiddenLabel(specifier);
+        if (label) {
+          violations.push(`${specifier} (${label}) declared in ${file}`);
+          continue;
+        }
+        if (!specifier.startsWith(".")) continue;
+        const next = resolveDeclaration(file, specifier);
+        if (next) queue.push(next);
+      }
+    }
+
+    expect(violations, violations.join("\n")).toEqual([]);
+    // The walk must have covered more than the barrel itself.
+    expect(seen.size).toBeGreaterThan(1);
+  });
+});

--- a/packages/zudo-doc/src/__tests__/site-schema.test.ts
+++ b/packages/zudo-doc/src/__tests__/site-schema.test.ts
@@ -80,12 +80,11 @@ const docsUrlFor = (base: string) => (slug: string) => (slug ? `${base}/docs/${s
 /** A minimal but complete route context, parameterized on its URL space so two
  *  instances are distinguishable in their output. */
 function makeContext(base: string): DocRouteEntriesContext {
-  const docsUrl = docsUrlFor(base);
   return {
     defaultLocale: "en",
     buildNavTree: (docs, locale, categoryMeta, buildHref) =>
       buildNavTree(docs, locale, categoryMeta, buildHref),
-    docsUrl: (slug) => docsUrl(slug),
+    docsUrl: docsUrlFor(base),
     withBase: (path) => `${base}${path}`,
     collectAutoIndexNodes: (tree) => collectAutoIndexNodes(tree) as AutoIndexNode[],
     getNavSectionForSlug: () => undefined,
@@ -323,9 +322,10 @@ describe("createDocRouteEntries", () => {
     expect(a[0]?.props.breadcrumbs[0]?.href).toBe("/a/");
     expect(b[0]?.props.breadcrumbs[0]?.href).toBe("/b/");
 
-    const aHrefs = a.map((r) => r.props.autoIndex?.href ?? r.props.entry?.slug);
-    const bHrefs = b.map((r) => r.props.autoIndex?.href ?? r.props.entry?.slug);
-    expect(aHrefs).not.toEqual(bHrefs);
+    const autoIndexHref = (routes: typeof a) =>
+      routes.find((r) => r.slug === "orphans")?.props.autoIndex?.href;
+    expect(autoIndexHref(a)).toBe("/a/docs/orphans/");
+    expect(autoIndexHref(b)).toBe("/b/docs/orphans/");
   });
 });
 

--- a/packages/zudo-doc/src/chrome/derive.tsx
+++ b/packages/zudo-doc/src/chrome/derive.tsx
@@ -45,14 +45,16 @@ import { createDesignTokenPanelIsland } from "../doc-body-end-islands/design-tok
 // (route → chrome → derive → bootstrap is the scanner-reachability chain; a
 // dynamic/type-only import silently kills island registration — #2480 lesson).
 //
-// COUPLING NOTE: this module (and therefore `@takazudo/zudo-doc/chrome`) now
-// transitively imports `virtual:zudo-doc-design-token-panel-config`, which
-// only the routes plugin registers (`settings.packageOwnedRoutes`, default
-// on). A `packageOwnedRoutes: false` host that bundles chrome must register
-// that virtual module (or alias it to
-// `@takazudo/zudo-doc/design-token-panel-config`) itself — see the KNOWN
-// COUPLING note in `../design-token-panel-bootstrap.tsx`. The package's own
-// vitest config aliases it for fast tests (vitest.config.ts).
+// COUPLING NOTE (resolved #3396, epic #3394): this module — and therefore
+// `@takazudo/zudo-doc/chrome` — used to transitively import
+// `virtual:zudo-doc-design-token-panel-config`, which only the routes plugin
+// registers, so a `packageOwnedRoutes: false` host had to alias the specifier
+// to bundle chrome at all (and the package's own vitest config carried a
+// matching alias). The bootstrap module now binds the package-default builder
+// directly; the host `designTokenPanelConfigModule` override enters through the
+// routes-only wrapper `routes/_design-token-panel-bootstrap.tsx`, which
+// `routes/_chrome.tsx` threads into the `DesignTokenPanelBootstrap` slot
+// consumed below. Keep this import free of `virtual:` specifiers.
 //
 // This same static import also makes `@takazudo/zdtp` an unconditional
 // build-time dependency of every `createChrome` consumer — accepted,
@@ -346,6 +348,13 @@ function deriveThemePackSwitcherProps(ctx: ChromeContext): ThemePackSwitcherProp
  * still replace the DTP component through
  * `hostBindings.DesignTokenPanelBootstrap`, but the package remains the sole
  * owner of the mounts and settings gates.
+ *
+ * Since #3396 the injected package routes use that same slot: `routes/_chrome.tsx`
+ * supplies `ConfiguredDesignTokenPanelBootstrap`, which is identical to the
+ * default except that its builder comes from
+ * `virtual:zudo-doc-design-token-panel-config` (i.e. a host's
+ * `designTokenPanelConfigModule`). The default below is what every non-routes
+ * `createChrome` caller keeps getting.
  */
 export function deriveBodyEndIslands(ctx: ChromeContext) {
   const designTokenPanelDeps = {

--- a/packages/zudo-doc/src/chrome/derive.tsx
+++ b/packages/zudo-doc/src/chrome/derive.tsx
@@ -23,7 +23,7 @@
 import type { JSX, VNode, ComponentChildren } from "preact";
 import type { ChromeContext, FactoryComponent } from "../factory-context/index.js";
 import type { Settings } from "../settings.js";
-import type { CategoryMeta } from "../routes/_docs-helpers.js";
+import type { CategoryMeta } from "../sidebar-tree/types.js";
 
 import { createComposeMetaTitle } from "../compose-meta-title/index.js";
 import {

--- a/packages/zudo-doc/src/design-token-panel-bootstrap.tsx
+++ b/packages/zudo-doc/src/design-token-panel-bootstrap.tsx
@@ -30,27 +30,41 @@
  *   bootstrapDesignTokenPanel(buildDesignTokenPanelConfig);
  *
  * `DesignTokenPanelBootstrap` (below) is the PACKAGE-OWNED island component
- * that wires the mode-scoped builder for package-owned routes with no host
- * config file — the #2658 "Approach (a)" package default. It resolves its
- * builder from the `virtual:zudo-doc-design-token-panel-config` virtual
- * module the routes plugin registers (`../plugins/routes.ts`): absent a host
- * `designTokenPanelConfigModule` override, that resolves to
- * `@takazudo/zudo-doc/design-token-panel-config`'s `buildDesignTokenPanelConfig`.
+ * that wires the mode-scoped builder for every `createChrome` consumer with no
+ * host config file — the #2658 "Approach (a)" package default. Since #3396 it
+ * binds the package-default builder DIRECTLY
+ * (`./design-token-panel-config/index.js`), not the routes plugin's
+ * `virtual:zudo-doc-design-token-panel-config` module.
  * `packages/zudo-doc/src/chrome/derive.tsx` statically imports it so zfb's
  * island scanner walks route → chrome → derive → here (mirrors the DocHistory
  * #2480 static-import contract). A host that ejects entirely can call
  * `bootstrapDesignTokenPanel` with its own builder, but current package-owned
  * routes use this component directly.
  *
- * KNOWN COUPLING: `DesignTokenPanelBootstrap`'s top-level import of
- * `virtual:zudo-doc-design-token-panel-config` requires the routes plugin
- * (`settings.packageOwnedRoutes`, default `true`) to be active in the
- * consuming project, since that plugin is what registers the virtual module.
- * A project that explicitly sets `packageOwnedRoutes: false` AND wants to
- * reuse the bare `bootstrapDesignTokenPanel` export for its own component is
- * unaffected — that import graph never reaches `DesignTokenPanelBootstrap` —
- * but a `packageOwnedRoutes: false` project must not import the package island
- * component itself.
+ * COUPLING REMOVED (#3396, epic #3394): this module no longer imports any
+ * `virtual:` specifier, so `@takazudo/zudo-doc/chrome` (which reaches here via
+ * `chrome/derive.tsx`) bundles OUTSIDE a zfb build with zero shims, and a
+ * `packageOwnedRoutes: false` host needs no alias for the config specifier.
+ *
+ * WHERE THE HOST OVERRIDE ENTERS NOW: `settings.designTokenPanelConfigModule`
+ * still travels through `virtual:zudo-doc-design-token-panel-config`, but the
+ * ONLY module that imports that specifier is the routes-only wrapper
+ * `routes/_design-token-panel-bootstrap.tsx`. It calls
+ * {@link runDesignTokenPanelBootstrapOnce} with the resolved builder and is
+ * threaded into `hostBindings.DesignTokenPanelBootstrap` by `routes/_chrome.tsx`,
+ * so `deriveBodyEndIslands` renders it instead of the package default on
+ * injected routes. The wrapper is a component-level seam INSIDE the client
+ * island bundle — deliberately NOT a module-level setter: the route/SSR graph
+ * and the hydrated island bundle are separate module graphs, so a setter called
+ * during route evaluation would configure only the server instance while the
+ * client re-evaluated this module and kept the default.
+ *
+ * KNOWN GAP (#3396): a host that renders docs through a SELF-CONTAINED
+ * `pages/` stub (the locked-manifest shape, #2653 — it calls `createChrome`
+ * directly rather than going through `routes/_chrome.tsx`) reaches the package
+ * default here, so `designTokenPanelConfigModule` does NOT apply to those
+ * pages. Such a host threads its own builder explicitly, via
+ * `chromeBindings.DesignTokenPanelBootstrap`.
  *
  * Package-first wiring landed in S9a zudolab/zudo-doc#2333; mode-scoped rebuild
  * wiring was added in zudolab/zudo-doc#2610 and the package-default island in
@@ -83,14 +97,15 @@ import {
   THEME_PACK_CHANGED_EVENT,
   readThemePackFromDom,
 } from "./theme-pack-switcher/theme-pack-sync.js";
-// Host-callables channel, third virtual module (#2658, mirrors #2501's
-// chromeBindingsModule): absent `settings.designTokenPanelConfigModule` →
-// re-exports the package default (`@takazudo/zudo-doc/design-token-panel-config`);
-// present → re-exports the host's module. Registered unconditionally by the
-// routes plugin (`../plugins/routes.ts`) whenever `packageOwnedRoutes` is on.
-// Not present on disk; the package ships ambient typings for it
-// (`routes/_virtual.d.ts`).
-import { buildDesignTokenPanelConfig } from "virtual:zudo-doc-design-token-panel-config";
+// PACKAGE-DEFAULT builder, imported as a plain on-disk module (#3396). This
+// was `virtual:zudo-doc-design-token-panel-config` until #3396; that static
+// import made every chrome consumer un-bundleable without the routes plugin
+// registering the specifier. The host-override channel now enters through the
+// routes-only wrapper (`routes/_design-token-panel-bootstrap.tsx`), so this
+// module — and therefore `@takazudo/zudo-doc/chrome` — needs no alias or shim
+// outside a zfb build. The builder module is zdtp-runtime-free (type-only zdtp
+// imports), so importing it statically does not defeat the #3282 lazy load.
+import { buildDesignTokenPanelConfig } from "./design-token-panel-config/index.js";
 
 /** The zdtp module namespace, typed without importing any runtime code. */
 type ZdtpModule = typeof import("@takazudo/zdtp");
@@ -758,25 +773,46 @@ export function bootstrapDesignTokenPanel(
 let bootstrapped = false;
 
 /**
+ * Run {@link bootstrapDesignTokenPanel} at most once per module instance, with
+ * whichever mode-scoped builder the caller supplies.
+ *
+ * Exists so the routes-only configured wrapper
+ * (`routes/_design-token-panel-bootstrap.tsx`, #3396) gets byte-identical
+ * one-shot semantics to {@link DesignTokenPanelBootstrap} while supplying the
+ * host-overridable builder from `virtual:zudo-doc-design-token-panel-config`.
+ * The guard is deliberately shared across both callers: `deriveBodyEndIslands`
+ * renders exactly ONE of them, and if a host ever mounted both, configuring the
+ * panel twice would re-mount it rather than layer the two configs.
+ *
+ * This is a CALL, not a module-level setter — the builder is passed in at
+ * render time inside whichever bundle the island actually hydrates in, so it
+ * never has to cross the route-graph → island-bundle boundary.
+ */
+export function runDesignTokenPanelBootstrapOnce(build: PanelConfigBuilder): void {
+  if (bootstrapped) return;
+  bootstrapped = true;
+  bootstrapDesignTokenPanel(build);
+}
+
+/**
  * The package-default `<DesignTokenPanelBootstrap/>` island: mounted (via
  * `Island({ when: "load" })`, no `ssrFallback` — it renders nothing on either
  * side) by `../doc-body-end-islands/index.tsx` when `settings.designTokenPanel`
  * is on, gated the same way `AiChatModal`/`ImageEnlarge`/`MermaidEnlarge` are.
- * On first render, calls `bootstrapDesignTokenPanel` with the mode-scoped
- * `buildDesignTokenPanelConfig` builder resolved from
- * `virtual:zudo-doc-design-token-panel-config` (package default, or the
- * host's `designTokenPanelConfigModule` override).
+ * On first render, calls `bootstrapDesignTokenPanel` with the PACKAGE-DEFAULT
+ * mode-scoped `buildDesignTokenPanelConfig` builder. A host's
+ * `designTokenPanelConfigModule` override does not reach this component — it
+ * arrives through the routes-only wrapper described in the module docblock.
  *
  * `displayName` pinned explicitly (belt-and-braces, matching
  * `AiChatModal`/`ImageEnlarge`/`MermaidEnlarge`/`DocHistory`) so zfb's
  * `captureComponentName` emits a stable `data-zfb-island="DesignTokenPanelBootstrap"`
- * marker independent of minification.
+ * marker independent of minification. It MUST keep matching the exported
+ * binding identifier — zfb's island scanner registers by the scanner-visible
+ * export name and warns when a `displayName` diverges from it.
  */
 export function DesignTokenPanelBootstrap(): JSX.Element | null {
-  if (!bootstrapped) {
-    bootstrapped = true;
-    bootstrapDesignTokenPanel(buildDesignTokenPanelConfig);
-  }
+  runDesignTokenPanelBootstrapOnce(buildDesignTokenPanelConfig);
   return null;
 }
 DesignTokenPanelBootstrap.displayName = "DesignTokenPanelBootstrap";

--- a/packages/zudo-doc/src/design-token-panel-bootstrap.tsx
+++ b/packages/zudo-doc/src/design-token-panel-bootstrap.tsx
@@ -38,8 +38,9 @@
  * `packages/zudo-doc/src/chrome/derive.tsx` statically imports it so zfb's
  * island scanner walks route → chrome → derive → here (mirrors the DocHistory
  * #2480 static-import contract). A host that ejects entirely can call
- * `bootstrapDesignTokenPanel` with its own builder, but current package-owned
- * routes use this component directly.
+ * `bootstrapDesignTokenPanel` with its own builder. Package-owned INJECTED
+ * routes do not render this component — they render the configured wrapper
+ * described below — but every other `createChrome` caller does.
  *
  * COUPLING REMOVED (#3396, epic #3394): this module no longer imports any
  * `virtual:` specifier, so `@takazudo/zudo-doc/chrome` (which reaches here via
@@ -777,8 +778,8 @@ let bootstrapped = false;
  * whichever mode-scoped builder the caller supplies.
  *
  * Exists so the routes-only configured wrapper
- * (`routes/_design-token-panel-bootstrap.tsx`, #3396) gets byte-identical
- * one-shot semantics to {@link DesignTokenPanelBootstrap} while supplying the
+ * (`routes/_design-token-panel-bootstrap.tsx`, #3396) gets the same one-shot
+ * semantics as {@link DesignTokenPanelBootstrap} while supplying the
  * host-overridable builder from `virtual:zudo-doc-design-token-panel-config`.
  * The guard is deliberately shared across both callers: `deriveBodyEndIslands`
  * renders exactly ONE of them, and if a host ever mounted both, configuring the

--- a/packages/zudo-doc/src/doc-body-end-islands/index.tsx
+++ b/packages/zudo-doc/src/doc-body-end-islands/index.tsx
@@ -35,19 +35,21 @@
 //
 // `designTokenPanel` (#2658) is DIFFERENT from the AiChatModal/ImageEnlarge/
 // MermaidEnlarge trio above: the real `DesignTokenPanelBootstrap` component is
-// itself a package component (`@takazudo/zudo-doc/design-token-panel-bootstrap`,
-// self-contained via the `virtual:zudo-doc-design-token-panel-config` virtual
-// module), but importing it here directly would leak that virtual-module
-// dependency into `createBodyEndIslands`'s generic, routes-plugin-independent
-// reachability graph (this factory is also called by `chrome/derive.tsx` for a
-// FUTURE host calling `createChrome` directly, without `packageOwnedRoutes`).
-// So it is injected as an explicit `DesignTokenPanelBootstrap` dependency
-// (`BodyEndIslandsDeps`) instead of imported at module top-level —
-// `chrome/derive.tsx`'s `deriveBodyEndIslands` statically imports the real
-// component and supplies it as the slot DEFAULT for every `createChrome`
+// itself a package component (`@takazudo/zudo-doc/design-token-panel-bootstrap`),
+// but it is injected as an explicit `DesignTokenPanelBootstrap` dependency
+// (`BodyEndIslandsDeps`) rather than imported at module top-level, so this
+// factory keeps a single injection point for the two shapes the component can
+// take. `chrome/derive.tsx`'s `deriveBodyEndIslands` statically imports the
+// package default and supplies it as the slot DEFAULT for every `createChrome`
 // consumer (#2659 gate-2 fix; the scanner walks route → chrome → derive →
-// component, mirroring the DocHistory #2480 chain). See
-// `../design-token-panel-bootstrap.tsx` for the full coupling note. *Not skip-ssr in the zfb-marker sense — it renders
+// component, mirroring the DocHistory #2480 chain); on injected routes
+// `routes/_chrome.tsx` overrides that slot with the configured wrapper that
+// carries a host's `designTokenPanelConfigModule` (#3396). Neither module
+// imports a `virtual:` specifier any more — the original reason for the deps
+// injection (keeping `virtual:zudo-doc-design-token-panel-config` out of this
+// factory's routes-plugin-independent reachability graph) was retired by #3396,
+// but the injection stays because it is now what lets the routes graph swap the
+// component. See `../design-token-panel-bootstrap.tsx` for the full contract. *Not skip-ssr in the zfb-marker sense — it renders
 // `null` on both SSR and client, so it uses `Island({ when })` with no
 // `ssrFallback` (matches `ClientRouterBootstrap`'s host-side precedent), which
 // zfb marks `data-zfb-island` (no `-skip-ssr` suffix).

--- a/packages/zudo-doc/src/doc-page-props/index.ts
+++ b/packages/zudo-doc/src/doc-page-props/index.ts
@@ -1,63 +1,24 @@
-// Shared current zfb entry and discriminated-union props types for all four
-// doc-route variants.
+// The current zfb entry type and the discriminated-union props types for all
+// four doc-route variants.
+//
+// The SHAPES live in `../site-schema/types.js`, which is browser-safe and
+// carries no zfb edge (#3395). This module is the one place that binds them to
+// zfb's real `CollectionEntry`, so route and renderer code keeps reading
+// `entry.Content` / `entry.module_specifier` exactly as before while the pure
+// domain stays publishable on its own.
 
 export type { HeadingItem } from "../extract-headings/index.js";
-import type { HeadingItem } from "../extract-headings/index.js";
-import type { BreadcrumbItem } from "../breadcrumb/types.js";
 import type { CollectionEntry } from "@takazudo/zfb/content";
+import type {
+  AutoIndexNode,
+  DocNavNode,
+  DocPageAutoIndexProps as DocPageAutoIndexPropsBase,
+  DocPageBaseProps as DocPageBasePropsGeneric,
+  DocPageEntryProps as DocPageEntryPropsGeneric,
+  DocPageFrontmatter,
+} from "../site-schema/types.js";
 
-// ---------------------------------------------------------------------------
-// Structural navigation node
-// ---------------------------------------------------------------------------
-
-/**
- * Nav tree node shape as consumed by doc-route pages.
- *
- * Structurally identical to the host project's `NavNode` from
- * `src/utils/docs.ts`. Defined here so the package types do not import
- * the host `@/` alias. The host's `NavNode` is a structural subtype and
- * assignable wherever `DocNavNode` is expected.
- */
-export interface DocNavNode {
-  slug: string;
-  label: string;
-  description?: string;
-  position: number;
-  href?: string;
-  hasPage: boolean;
-  children: DocNavNode[];
-  sortOrder?: "asc" | "desc";
-  collapsed?: boolean;
-}
-
-// ---------------------------------------------------------------------------
-// Current zfb docs entry
-// ---------------------------------------------------------------------------
-
-/**
- * Minimal docs frontmatter shape consumed by the doc-page types.
- *
- * A structural subset of the host's `DocsData` — only the fields that
- * `DocPageEntry` and `DocPageBaseProps` actually read. The full `DocsData`
- * (from `src/config/docs-schema.ts`) is a structural supertype and is
- * assignable here.
- */
-export interface DocPageFrontmatter {
-  title: string;
-  description?: string;
-  slug?: string;
-  draft?: boolean;
-  unlisted?: boolean;
-  standalone?: boolean;
-  sidebar_position?: number;
-  sidebar_label?: string;
-  category_no_page?: boolean;
-  category_sort_order?: "asc" | "desc";
-  pagination_prev?: string | null;
-  pagination_next?: string | null;
-  tags?: string[];
-  [key: string]: unknown;
-}
+export type { AutoIndexNode, DocNavNode, DocPageFrontmatter };
 
 // ---------------------------------------------------------------------------
 // DocPageEntry — entry shape for all 4 doc-route paths()
@@ -70,39 +31,14 @@ export interface DocPageFrontmatter {
 export type DocPageEntry = CollectionEntry<DocPageFrontmatter>;
 
 // ---------------------------------------------------------------------------
-// AutoIndexNode — auto-generated category index page node
+// Doc-page props — the site-schema shapes bound to the zfb entry
 // ---------------------------------------------------------------------------
-
-export interface AutoIndexNode extends DocNavNode {
-  children: DocNavNode[];
-}
-
-// ---------------------------------------------------------------------------
-// DocPageBaseProps — shared base for all doc-page prop shapes
-// ---------------------------------------------------------------------------
-
-/** Shared fields present in every doc-page route. */
-interface DocPagePropsBase {
-  breadcrumbs: BreadcrumbItem[];
-  prev: DocNavNode | null;
-  next: DocNavNode | null;
-  /** Depth-2/3/4 headings extracted from the MDX body, for SSG TOC links. */
-  headings: HeadingItem[];
-}
 
 /** Branch: a real content entry. `autoIndex` is absent. */
-export interface DocPageEntryProps extends DocPagePropsBase {
-  kind: "entry";
-  entry: DocPageEntry;
-  autoIndex?: undefined;
-}
+export type DocPageEntryProps = DocPageEntryPropsGeneric<DocPageEntry>;
 
 /** Branch: an auto-generated category index. `entry` is absent. */
-export interface DocPageAutoIndexProps extends DocPagePropsBase {
-  kind: "autoIndex";
-  autoIndex: AutoIndexNode;
-  entry?: undefined;
-}
+export type DocPageAutoIndexProps = DocPageAutoIndexPropsBase;
 
 /** Discriminated union for the `kind` prop. Narrow via `props.kind === "entry"`. */
-export type DocPageBaseProps = DocPageEntryProps | DocPageAutoIndexProps;
+export type DocPageBaseProps = DocPageBasePropsGeneric<DocPageEntry>;

--- a/packages/zudo-doc/src/doc-route-entries/index.ts
+++ b/packages/zudo-doc/src/doc-route-entries/index.ts
@@ -1,260 +1,40 @@
-// doc-route-entries — shared, memoized route-entry builder for the 4 doc
-// catch-all routes (epic #2344, S6).
+// doc-route-entries — the zfb-typed binding of the shared route-entry builder
+// (epic #2344, S6; relocated by #3395).
 //
-// Moved from the showcase's `pages/lib/_doc-route-entries.ts` into the shared
-// package. Previously this imported host utilities (`@/utils/docs`,
-// `@/utils/nav-scope`, the package slug helpers, `@/config/i18n`) directly — imports
-// that would not resolve in downstream consumers. The package version accepts
-// all host-specific functions via injected context through
-// `createDocRouteEntries(ctx)`.
+// The builder itself now lives in `../site-schema/doc-route-entries.js`, where
+// it is generic over the entry shape and free of any `@takazudo/zfb`
+// declaration edge. This module re-exports it and pins every type parameter to
+// the zfb-typed `DocPageEntry`, so `./doc-route-entries` consumers — the route
+// entrypoints, `route-context`, `factory-context` — see exactly the types they
+// saw before the split, including `props.entry.Content`.
 //
-// MEMOIZATION: the result is memoized with the #1902 WeakMap pattern
-// (memoizeDerived keyed on the identity-stable `source.docs` array + a
-// per-route signature), so the expensive per-entry work — extractHeadings,
-// buildBreadcrumbs, prev/next resolution — runs ONCE per entry per build, not
-// once per entry per page (zfb re-invokes paths() once per built page).
+// Prefer `@takazudo/zudo-doc/site-schema` when you do not need the zfb entry:
+// same function, browser-safe graph.
 
 import type { DocPageEntry, DocNavNode, AutoIndexNode, DocPageBaseProps } from "../doc-page-props/index.js";
 import type { NavSourceDocs } from "../nav-source-docs/index.js";
-import { memoizeDerived } from "../nav-source-cache/index.js";
 import type { BreadcrumbItem } from "../breadcrumb/types.js";
 import type { HeadingItem } from "../extract-headings/index.js";
-import type { CategoryMeta } from "../sidebar-tree/index.js";
-import { buildBreadcrumbs as buildBreadcrumbsImpl } from "../routes/_docs-helpers.js";
-import {
-  resolveDocPrevNext,
-  flattenSubtree,
-  rewriteNavHref,
-  remapNavChildHrefs,
-} from "../doc-route-paths/index.js";
+import type {
+  BuildDocRouteEntriesArgs as BuildDocRouteEntriesArgsGeneric,
+  DocRouteEntriesAPI as DocRouteEntriesAPIGeneric,
+  DocRouteEntriesContext as DocRouteEntriesContextGeneric,
+  DocRouteEntry as DocRouteEntryGeneric,
+} from "../site-schema/doc-route-entries.js";
+
+export { createDocRouteEntries } from "../site-schema/doc-route-entries.js";
 
 export type { DocPageEntry, DocNavNode, AutoIndexNode, DocPageBaseProps, NavSourceDocs };
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-/** One enumerated doc route: a content entry or an auto-generated category
- *  index, with all per-page derived data pre-computed. */
-export interface DocRouteEntry {
-  /** Canonical route slug ("" for the docs root index — #1891). */
-  slug: string;
-  /** Optional-catchall params array — `toSlugParams(slug)` ([] for the root). */
-  slugParams: string[];
-  /**
-   * True when the entry came from the base collection rather than the locale
-   * collection (`!localeSlugSet.has(slug)`). Only meaningful on routes whose
-   * nav source performs a locale merge — routes without one (default-locale /
-   * versioned-EN, where `localeSlugSet` is empty) must ignore this field.
-   * Always false for autoIndex items.
-   */
-  isFallback: boolean;
-  /** Shared page props (kind/entry/autoIndex/breadcrumbs/prev/next/headings). */
-  props: DocPageBaseProps;
-}
-
-export interface BuildDocRouteEntriesArgs {
-  /** Identity-stable nav source for this route's (locale, version) context. */
-  source: NavSourceDocs;
-  /** Active locale for nav-tree labels and breadcrumbs. */
-  locale: string;
-  /**
-   * Unique memo signature for this route context. Each route file passes its
-   * own prefix plus the loop variables (version slug / locale), e.g.
-   * "docs;en", "locale-docs;ja", "v-docs;1.0", "v-locale-docs;1.0;ja" —
-   * call sites that share a docs array identity must never collide on a key.
-   */
-  routeSig: string;
-  /** Versioned URL closure bound to the route's version (+ locale). Presence
-   *  switches the versioned behaviors (breadcrumbs, prev/next, child hrefs). */
-  urlFor?: (slug: string) => string;
-}
-
-// ---------------------------------------------------------------------------
-// Injected context for createDocRouteEntries
-// ---------------------------------------------------------------------------
-
-// BreadcrumbItem and HeadingItem are imported from the package's own intra-package
-// paths above (breadcrumb/types.js and extract-headings/index.js) — no local
-// re-declarations needed.
 export type { BreadcrumbItem, HeadingItem };
 
-/**
- * Context slice `createDocRouteEntries` derives its bag from (epic Collapse
- * Wiring Shells #2420, FACTORIES #2424 — breaking signature). STRUCTURAL SUBSET
- * of the unified `RouteContext`/`ChromeContext` — the nav-tree builder is
- * reconstructed by binding the context's 4-arg `buildNavTree` to `docsUrl`, and
- * the breadcrumb trail by binding the package `buildBreadcrumbs` to the
- * locale-prefixed `withBase` base, exactly as the pre-collapse wiring did.
- */
-export interface DocRouteEntriesContext {
-  /** Default locale code (drives the breadcrumb base-prefix selection). */
-  defaultLocale: string;
-  /** Build the nav tree for a locale (4-arg form with an explicit href builder). */
-  buildNavTree: (
-    docs: DocPageEntry[],
-    locale: string,
-    categoryMeta: Map<string, CategoryMeta> | undefined,
-    buildHref: (slug: string, locale: string) => string,
-  ) => DocNavNode[];
-  /** Build a docs URL for the given slug and locale. */
-  docsUrl: (slug: string, locale?: string) => string;
-  /** Prefix a path with the configured base directory. */
-  withBase: (path: string) => string;
-  /** Collect all auto-generated index nodes (categories without index.mdx). */
-  collectAutoIndexNodes: (tree: DocNavNode[]) => AutoIndexNode[];
-  /** Determine the nav section (categoryMatch) for a slug. */
-  getNavSectionForSlug: (slug: string) => string | undefined;
-  /** Filter top-level nav nodes by a categoryMatch value. */
-  getNavSubtree: (tree: DocNavNode[], categoryMatch?: string) => DocNavNode[];
-  /** Convert a content entry slug to a canonical route slug. */
-  toRouteSlug: (entrySlug: string) => string;
-  /** Convert a canonical route slug to an optional-catchall params array. */
-  toSlugParams: (slug: string) => string[];
-  /** Extract headings from a raw MDX body (bound to settings depth/strategy). */
-  extractHeadings: (body: string) => HeadingItem[];
-}
+/** One enumerated doc route, carrying a zfb collection entry. */
+export type DocRouteEntry = DocRouteEntryGeneric<DocPageEntry>;
 
-// ---------------------------------------------------------------------------
-// createDocRouteEntries factory
-// ---------------------------------------------------------------------------
+/** Arguments to `buildDocRouteEntries` for one (locale, version) context. */
+export type BuildDocRouteEntriesArgs = BuildDocRouteEntriesArgsGeneric<DocPageEntry>;
 
-/**
- * Result of `createDocRouteEntries`. Contains the `buildDocRouteEntries`
- * function bound to the injected context.
- */
-export interface DocRouteEntriesAPI {
-  /**
-   * Enumerate all doc routes for one (locale, version) context, with per-entry
-   * derived data pre-computed. Memoized per build on the identity-stable
-   * `source.docs` array.
-   */
-  buildDocRouteEntries: (args: BuildDocRouteEntriesArgs) => DocRouteEntry[];
-}
+/** The context slice `createDocRouteEntries` derives its bag from. */
+export type DocRouteEntriesContext = DocRouteEntriesContextGeneric<DocPageEntry>;
 
-/**
- * Create the `buildDocRouteEntries` function bound to the host's injected
- * context.
- *
- * @example
- * ```ts
- * // pages/lib/_doc-route-entries.ts (thin stub)
- * import { createDocRouteEntries } from "@takazudo/zudo-doc/doc-route-entries";
- * import { buildNavTree, buildBreadcrumbs, collectAutoIndexNodes } from "@/utils/docs";
- * import { getNavSectionForSlug, getNavSubtree } from "@/utils/nav-scope";
- * import { toRouteSlug, toSlugParams } from "@takazudo/zudo-doc/slug";
- * import { extractHeadings } from "./_extract-headings";
- *
- * export const { buildDocRouteEntries } = createDocRouteEntries(routeContext);
- * export type { DocRouteEntry, BuildDocRouteEntriesArgs };
- * ```
- */
-export function createDocRouteEntries(
-  ctx: DocRouteEntriesContext,
-): DocRouteEntriesAPI {
-  // Derive the old narrow bag from the unified context: bind the 4-arg
-  // `buildNavTree` to `docsUrl` for the 3-arg form the body uses, and bind the
-  // package `buildBreadcrumbs` to the locale-prefixed `withBase` base.
-  const defaultLocale = ctx.defaultLocale;
-  const buildNavTree = (
-    docs: DocPageEntry[],
-    locale: string,
-    categoryMeta: Map<string, CategoryMeta>,
-  ): DocNavNode[] =>
-    ctx.buildNavTree(docs, locale, categoryMeta, (slug, loc) => ctx.docsUrl(slug, loc));
-  const buildBreadcrumbs = (
-    tree: DocNavNode[],
-    slug: string,
-    locale: string,
-    urlFor?: (slug: string) => string,
-  ): BreadcrumbItem[] =>
-    buildBreadcrumbsImpl(
-      tree,
-      slug,
-      locale === defaultLocale ? ctx.withBase("/") : ctx.withBase(`/${locale}/`),
-      urlFor,
-    );
-  const collectAutoIndexNodes = ctx.collectAutoIndexNodes;
-  const getNavSectionForSlug = ctx.getNavSectionForSlug;
-  const getNavSubtree = ctx.getNavSubtree;
-  const toRouteSlug = ctx.toRouteSlug;
-  const toSlugParams = ctx.toSlugParams;
-  const extractHeadings = ctx.extractHeadings;
-
-  function buildDocRouteEntries(args: BuildDocRouteEntriesArgs): DocRouteEntry[] {
-    const { source, locale, routeSig, urlFor } = args;
-
-    return memoizeDerived([source.docs], `docRouteEntries;${routeSig}`, () => {
-      const { docs, navDocs, categoryMeta, localeSlugSet } = source;
-
-      // Nav docs: exclude unlisted (for sidebar/prev-next) but keep for breadcrumbs
-      const tree = buildNavTree(navDocs, locale, categoryMeta);
-      // Breadcrumb tree: latest routes use the full tree (including unlisted)
-      // for accurate crumbs; versioned routes resolve crumbs against the nav
-      // tree itself (#1916 #1).
-      const breadcrumbTree = urlFor
-        ? tree
-        : buildNavTree(docs, locale, categoryMeta);
-
-      const result: DocRouteEntry[] = [];
-
-      // Regular doc pages
-      for (const entry of docs) {
-        // A `category_no_page` index.mdx carries category metadata only — keep
-        // it in the nav tree but emit NO route for it.
-        if (entry.data.category_no_page === true) continue;
-
-        const slug = entry.data.slug ?? toRouteSlug(entry.slug);
-        const navSection = getNavSectionForSlug(slug);
-        const subtree = getNavSubtree(tree, navSection);
-
-        const { prev: prevNode, next: nextNode } = resolveDocPrevNext(
-          tree,
-          flattenSubtree(subtree),
-          slug,
-          entry.data as { pagination_prev?: string | null; pagination_next?: string | null },
-        );
-
-        result.push({
-          slug,
-          slugParams: toSlugParams(slug),
-          isFallback: !localeSlugSet.has(slug),
-          props: {
-            kind: "entry",
-            entry,
-            breadcrumbs: buildBreadcrumbs(breadcrumbTree, slug, locale, urlFor),
-            prev: rewriteNavHref(prevNode, urlFor),
-            next: rewriteNavHref(nextNode, urlFor),
-            headings: extractHeadings(entry.body ?? ""),
-          },
-        });
-      }
-
-      // Auto-generated index pages for categories without index.mdx
-      for (const node of collectAutoIndexNodes(tree)) {
-        result.push({
-          slug: node.slug,
-          slugParams: toSlugParams(node.slug),
-          isFallback: false,
-          props: {
-            kind: "autoIndex",
-            autoIndex: urlFor
-              ? {
-                  ...node,
-                  children: remapNavChildHrefs(node.children, urlFor) as DocNavNode[],
-                }
-              : node,
-            breadcrumbs: buildBreadcrumbs(breadcrumbTree, node.slug, locale, urlFor),
-            prev: null,
-            next: null,
-            headings: [],
-          },
-        });
-      }
-
-      return result;
-    });
-  }
-
-  return { buildDocRouteEntries };
-}
+/** The functions `createDocRouteEntries` returns. */
+export type DocRouteEntriesAPI = DocRouteEntriesAPIGeneric<DocPageEntry>;

--- a/packages/zudo-doc/src/doc-route-paths/index.ts
+++ b/packages/zudo-doc/src/doc-route-paths/index.ts
@@ -16,7 +16,10 @@
 // `urlFor(slug) => string` closure, so the same code serves latest, locale,
 // versioned, and versioned-locale routes without branching on context.
 
-import type { DocNavNode } from "../doc-page-props/index.js";
+// `DocNavNode` comes from the browser-safe `site-schema` types (#3395) rather
+// than `doc-page-props` — the latter aliases zfb's `CollectionEntry`, and that
+// declaration edge would follow this module into every graph that imports it.
+import type { DocNavNode } from "../site-schema/types.js";
 
 // Re-export DocNavNode so callers can import it from this subpath.
 export type { DocNavNode };

--- a/packages/zudo-doc/src/doclayout/doc-layout.tsx
+++ b/packages/zudo-doc/src/doclayout/doc-layout.tsx
@@ -61,6 +61,13 @@ import type { ComponentChildren, JSX } from "preact";
 // swaps the DOM via document.startViewTransition — same behaviour as
 // Astro's <ClientRouter />. Mounted here so it lands in <head> on every
 // page that uses this shell. Closes zudolab/zudo-doc#1522.
+//
+// KNOWN COUPLING: this import is NOT side-effect-free — @takazudo/zfb-runtime
+// wires document/window listeners at module scope on import, before this
+// component ever mounts. Upstream fix tracked at
+// https://github.com/Takazudo/zudo-front-builder/issues/2429 (component/
+// activation split). Switching to a side-effect-free import is deferred to a
+// future @takazudo/zfb-runtime pin bump once that split ships.
 import { ClientRouter } from "@takazudo/zfb-runtime";
 
 /**

--- a/packages/zudo-doc/src/head-with-defaults/__tests__/theme-pack-head.test.tsx
+++ b/packages/zudo-doc/src/head-with-defaults/__tests__/theme-pack-head.test.tsx
@@ -6,12 +6,13 @@
 // The ADR's "Ordering note (MUST-verify in #2822)": assert the theme-pack
 // provider renders IMMEDIATELY AFTER <ColorSchemeProvider/> in the
 // head-with-defaults output, and that the emitted bootstrap contains the
-// document.write + noscript shapes.
+// inlined-map + noscript shapes.
 
 import { describe, expect, it } from "vitest";
 import { render } from "preact-render-to-string";
 import { createHeadWithDefaults } from "../index.js";
 import { makeFakeChromeContext } from "../../__tests__/fixtures/fake-chrome-context.js";
+import { THEME_PACK_LATCH_CSS } from "../../theme/theme-pack-provider.js";
 import type { ThemePackRegistry } from "../../theme-packs-registry/index.js";
 
 const REGISTRY = [
@@ -53,13 +54,15 @@ describe("HeadWithDefaults — theme-pack bootstrap emission", () => {
     const themePackIdx = out.indexOf(THEME_PACK_MARKER);
     expect(colorSchemeIdx).toBeGreaterThan(-1);
     expect(themePackIdx).toBeGreaterThan(colorSchemeIdx);
-    // "Immediately after": nothing but the script boundary sits between the
-    // color-scheme bootstrap's closing </script> and the theme-pack script.
+    // "Immediately after": between the color-scheme bootstrap's closing
+    // </script> and the theme-pack script sits EXACTLY the theme-pack anti-FOUC
+    // latch <style> — the provider's own first child, which must precede its
+    // script (#3399) — and nothing else.
     const between = out.slice(
       out.indexOf("</script>", colorSchemeIdx) + "</script>".length,
       out.lastIndexOf("<script>", themePackIdx),
     );
-    expect(between).toBe("");
+    expect(between).toBe(`<style>${THEME_PACK_LATCH_CSS}</style>`);
   });
 
   it("inlines the enabled {slug → version} map and the base prefix", () => {

--- a/packages/zudo-doc/src/head-with-defaults/index.tsx
+++ b/packages/zudo-doc/src/head-with-defaults/index.tsx
@@ -158,9 +158,10 @@ export function createHeadWithDefaults<S extends Settings = Settings>(
         <ColorSchemeProvider cssText={cssText} colorMode={colorMode} />
         {/* Theme-pack bootstrap — MUST render immediately after
             <ColorSchemeProvider/> (ADR theme-packs.md Decision 3 ordering
-            note, #2822). Emits the pre-paint slug-resolution script (which
-            document.writes the render-blocking pack link for a non-default
-            active pack) plus the no-JS <noscript> fallback link for the
+            note, #2822). Emits the anti-FOUC latch <style>, then the pre-paint
+            slug-resolution script (which head-appends the pack link for a
+            non-default active pack, hiding the body behind the latch until it
+            loads — #3399), plus the no-JS <noscript> fallback link for the
             configured pack. */}
         {themePackEnabled !== null && (
           <ThemePackProvider

--- a/packages/zudo-doc/src/header/__tests__/nav-overflow-active-exec.test.ts
+++ b/packages/zudo-doc/src/header/__tests__/nav-overflow-active-exec.test.ts
@@ -1,0 +1,94 @@
+/** @vitest-environment happy-dom */
+// Executes the generated NAV_OVERFLOW_SCRIPT in a real DOM (zudolab/zudo-doc#3398),
+// rather than only asserting its string contents (nav-class-tokens.test.ts
+// covers that). Proves the consolidated matching core — embedded from
+// nav-active.ts via `computeActiveNavPath.toString()` / `pathMatchesNavPath.toString()`,
+// replacing the script's former hand-duplicated longest-match walk — still
+// produces the correct aria-current / active-class output end-to-end, and
+// that the explicit current-route override
+// (`document.documentElement.dataset.zdCurrentPath`) takes priority over
+// `location.pathname`.
+
+import { afterEach, describe, expect, it } from "vitest";
+import { NAV_OVERFLOW_SCRIPT } from "../nav-overflow-script.js";
+import { NAV_TOP_ACTIVE } from "../nav-class-tokens.js";
+
+function setLocation(pathname: string): void {
+  (window as unknown as { happyDOM?: { setURL: (url: string) => void } }).happyDOM?.setURL(
+    `http://localhost${pathname}`,
+  );
+}
+
+function buildNav(): HTMLElement {
+  const nav = document.createElement("nav");
+  nav.setAttribute("data-header-nav", "");
+  nav.innerHTML = `
+    <a data-nav-item href="/docs/">Docs</a>
+    <div data-nav-item data-nav-item-dropdown>
+      <a href="/learn/">Learn</a>
+      <div>
+        <a href="/learn/getting-started/">Getting Started</a>
+        <a href="/learn/advanced/">Advanced</a>
+      </div>
+    </div>
+    <a data-nav-item href="/blog/">Blog</a>
+  `;
+  document.body.appendChild(nav);
+  return nav;
+}
+
+describe("NAV_OVERFLOW_SCRIPT — executed in jsdom (applyActiveNav)", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    delete document.documentElement.dataset.zdCurrentPath;
+  });
+
+  it("marks the matching top-level item active from location.pathname", () => {
+    setLocation("/docs/introduction");
+    const nav = buildNav();
+
+    new Function(NAV_OVERFLOW_SCRIPT)();
+
+    const docsLink = nav.querySelector('a[href="/docs/"]');
+    const blogLink = nav.querySelector('a[href="/blog/"]');
+    expect(docsLink?.getAttribute("aria-current")).toBe("page");
+    expect(docsLink?.className).toContain(NAV_TOP_ACTIVE.join(" "));
+    expect(blogLink?.getAttribute("aria-current")).toBeNull();
+  });
+
+  it("marks the matching dropdown child active and the parent as active-by-child", () => {
+    setLocation("/learn/getting-started/setup");
+    const nav = buildNav();
+
+    new Function(NAV_OVERFLOW_SCRIPT)();
+
+    const learnLink = nav.querySelector('a[href="/learn/"]');
+    const activeChild = nav.querySelector('a[href="/learn/getting-started/"]');
+    const inactiveChild = nav.querySelector('a[href="/learn/advanced/"]');
+    expect(learnLink?.getAttribute("aria-current")).toBe("page");
+    expect(activeChild?.getAttribute("data-active")).toBe("");
+    expect(inactiveChild?.hasAttribute("data-active")).toBe(false);
+  });
+
+  it("prefers document.documentElement.dataset.zdCurrentPath over location.pathname", () => {
+    setLocation("/blog/post-1");
+    document.documentElement.dataset.zdCurrentPath = "/docs/introduction";
+    const nav = buildNav();
+
+    new Function(NAV_OVERFLOW_SCRIPT)();
+
+    const docsLink = nav.querySelector('a[href="/docs/"]');
+    const blogLink = nav.querySelector('a[href="/blog/"]');
+    expect(docsLink?.getAttribute("aria-current")).toBe("page");
+    expect(blogLink?.getAttribute("aria-current")).toBeNull();
+  });
+
+  it("clears every active marker when the current path matches no nav entry", () => {
+    setLocation("/about/");
+    const nav = buildNav();
+
+    new Function(NAV_OVERFLOW_SCRIPT)();
+
+    expect(nav.querySelector('a[aria-current="page"]')).toBeNull();
+  });
+});

--- a/packages/zudo-doc/src/header/nav-active.ts
+++ b/packages/zudo-doc/src/header/nav-active.ts
@@ -53,13 +53,25 @@ export function pathForMatch(
 /**
  * Segment-aware prefix test: nav path `/docs/guides` matches `/docs/guides`
  * and `/docs/guides/...` but NOT `/docs/guideship`.
+ *
+ * Exported (not just module-private) so `nav-overflow-script.ts` can embed it
+ * verbatim via `.toString()` alongside `computeActiveNavPath` — that function
+ * closes over this one, so a bare `computeActiveNavPath.toString()` embed
+ * would reference an undefined `pathMatchesNavPath` in the browser (see the
+ * caution note on `computeActiveNavPath` below). Kept self-contained (no
+ * outer references) for the same reason.
  */
-function pathMatchesNavPath(currentPath: string, navPath: string): boolean {
+export function pathMatchesNavPath(currentPath: string, navPath: string): boolean {
   if (currentPath === navPath) return true;
   const prefix = navPath.endsWith("/") ? navPath : `${navPath}/`;
   return currentPath.startsWith(prefix);
 }
 
+/**
+ * CAUTION (zudolab/zudo-doc#3398): this closes over `pathMatchesNavPath`
+ * above. `nav-overflow-script.ts` embeds both via `.toString()` (never this
+ * one alone) so the generated browser script is self-contained.
+ */
 export function computeActiveNavPath(
   navItems: readonly NavItemLike[],
   pathForMatchValue: string,

--- a/packages/zudo-doc/src/header/nav-overflow-script.ts
+++ b/packages/zudo-doc/src/header/nav-overflow-script.ts
@@ -31,6 +31,7 @@
 // script can be reviewed in isolation.
 
 import { AFTER_NAVIGATE_EVENT } from "../transitions/page-events.js";
+import { computeActiveNavPath, pathMatchesNavPath } from "./nav-active.js";
 import {
   NAV_CHEVRON_ACTIVE,
   NAV_CHEVRON_INACTIVE,
@@ -45,6 +46,17 @@ import {
   NAV_TOP_ACTIVE,
   NAV_TOP_INACTIVE,
 } from "./nav-class-tokens.js";
+
+// Explicit current-route override read order, shared by all four active-nav
+// read sites (sidebar-tree-island, this script, version-switcher,
+// language-switcher — zudolab/zudo-doc#3398): an embedding host may set
+// `document.documentElement.dataset.zdCurrentPath` before `location.pathname`
+// is trustworthy. Inside an iframe `srcdoc` document, `location.pathname` is
+// the literal string "srcdoc" (matches no route) and Chromium refuses
+// `history.replaceState` there, so the page can't self-correct via
+// navigation (spike ledger adl-0005). Written inline into the script string
+// below (rather than a `.toString()`-embedded helper) since the whole
+// NAV_OVERFLOW_SCRIPT body is already hand-authored plain JS.
 
 // The class lists spliced into the script below are the SSR ↔ runtime
 // lockstep: they must match the strings header.tsx renders. Both files import
@@ -78,20 +90,28 @@ export const NAV_OVERFLOW_SCRIPT = `(function () {
     catch (e) { return ""; }
   }
 
-  function isUnderPath(cur, p) {
-    if (!p) return false;
-    if (cur === p) return true;
-    return p !== "/" && cur.indexOf(p + "/") === 0;
+  // Explicit current-route override — see the module-level comment in
+  // nav-overflow-script.ts for the full rationale (zudolab/zudo-doc#3398).
+  function getCurrentPath() {
+    var override = document.documentElement.dataset.zdCurrentPath;
+    return override || location.pathname;
   }
+
+  // Shared matching core (zudolab/zudo-doc#3398): embedded verbatim from
+  // nav-active.ts so this script's longest-match walk cannot drift from the
+  // SSR header's own computeActiveNavPath call (header.tsx). computeActiveNavPath
+  // closes over pathMatchesNavPath, so both are embedded together.
+  var pathMatchesNavPath = ${pathMatchesNavPath.toString()};
+  var computeActiveNavPath = ${computeActiveNavPath.toString()};
 
   // Recompute which header nav item is "active" from the CURRENT URL and
   // repaint the highlight. SSR sets the active item on first paint, but the
   // header is persisted across same-locale client-router swaps
   // (data-zfb-transition-persist), so without this the highlight would stay
   // frozen on the page where the header was first rendered. Mirrors the
-  // sidebar island's client-side approach (match location.pathname against
+  // sidebar island's client-side approach (match the current path against
   // each entry's href) and the SSR longest-match + dropdown-parent rules.
-  // URL-based: hrefs and location.pathname both carry the base + locale
+  // URL-based: hrefs and the current path both carry the base + locale
   // prefix, so they compare directly without stripping.
   function applyActiveNav() {
     var nav = document.querySelector("[data-header-nav]");
@@ -99,25 +119,30 @@ export const NAV_OVERFLOW_SCRIPT = `(function () {
     var topItems = Array.from(nav.querySelectorAll(":scope > [data-nav-item]"));
     if (topItems.length === 0) return;
 
-    var cur = trimSlashes(location.pathname);
+    var cur = trimSlashes(getCurrentPath());
 
-    // Deepest (longest) nav path the current URL lives under, across both
-    // top-level and dropdown-child paths — matches computeActiveNavPath.
-    var activePath = "";
+    // Build NavItemLike-shaped entries from the live DOM so the shared
+    // computeActiveNavPath can do the deepest-match walk — the same call
+    // shape the SSR header uses (matches computeActiveNavPath). A dropdown
+    // missing its own top-level anchor is skipped entirely (path "" would
+    // otherwise match every current path — pathMatchesNavPath treats "" as
+    // the root "/"), mirroring the parentLink guard used below for the same
+    // malformed-markup case.
+    var navItems = [];
     topItems.forEach(function (it) {
       var isDropdown = it.hasAttribute("data-nav-item-dropdown");
       var topA = isDropdown ? it.querySelector(":scope > a") : it;
-      if (topA) {
-        var tp = navPathname(topA);
-        if (isUnderPath(cur, tp) && tp.length > activePath.length) activePath = tp;
-      }
+      if (!topA) return;
+      var children = [];
       if (isDropdown) {
         it.querySelectorAll(":scope > div a").forEach(function (c) {
-          var cp = navPathname(c);
-          if (isUnderPath(cur, cp) && cp.length > activePath.length) activePath = cp;
+          children.push({ path: navPathname(c) });
         });
       }
+      navItems.push({ path: navPathname(topA), children: children });
     });
+
+    var activePath = computeActiveNavPath(navItems, cur) || "";
 
     function setTopActive(a, active) {
       if (!a) return;

--- a/packages/zudo-doc/src/i18n-version/__tests__/language-switcher.test.tsx
+++ b/packages/zudo-doc/src/i18n-version/__tests__/language-switcher.test.tsx
@@ -193,7 +193,10 @@ describe("LANGUAGE_SWITCHER_INIT_SCRIPT", () => {
     expect(LANGUAGE_SWITCHER_INIT_SCRIPT).toContain(JSON.stringify(AFTER_NAVIGATE_EVENT));
     expect(LANGUAGE_SWITCHER_INIT_SCRIPT).toContain("data-language-switcher");
     expect(LANGUAGE_SWITCHER_INIT_SCRIPT).toContain("switchLocaleHref");
-    expect(LANGUAGE_SWITCHER_INIT_SCRIPT).toContain("window.location.pathname");
+    // Explicit current-route override read order (zudolab/zudo-doc#3398):
+    // dataset attribute first, location.pathname as the fallback default.
+    expect(LANGUAGE_SWITCHER_INIT_SCRIPT).toContain("dataset.zdCurrentPath");
+    expect(LANGUAGE_SWITCHER_INIT_SCRIPT).toContain("location.pathname");
     // idempotency guard (single document-level listener per page lifetime)
     expect(LANGUAGE_SWITCHER_INIT_SCRIPT).toContain("__zdLanguageSwitcherInit");
   });

--- a/packages/zudo-doc/src/i18n-version/__tests__/version-switcher.test.tsx
+++ b/packages/zudo-doc/src/i18n-version/__tests__/version-switcher.test.tsx
@@ -445,7 +445,10 @@ describe("VERSION_SWITCHER_REWIRE_SCRIPT", () => {
     expect(VERSION_SWITCHER_REWIRE_SCRIPT).toContain(JSON.stringify(AFTER_NAVIGATE_EVENT));
     expect(VERSION_SWITCHER_REWIRE_SCRIPT).toContain("data-version-rewire");
     expect(VERSION_SWITCHER_REWIRE_SCRIPT).toContain("computeVersionSwitcherState");
-    expect(VERSION_SWITCHER_REWIRE_SCRIPT).toContain("window.location.pathname");
+    // Explicit current-route override read order (zudolab/zudo-doc#3398):
+    // dataset attribute first, location.pathname as the fallback default.
+    expect(VERSION_SWITCHER_REWIRE_SCRIPT).toContain("dataset.zdCurrentPath");
+    expect(VERSION_SWITCHER_REWIRE_SCRIPT).toContain("location.pathname");
     // idempotency guard (single document-level listener per page lifetime)
     expect(VERSION_SWITCHER_REWIRE_SCRIPT).toContain("__zdVersionSwitcherRewire");
   });

--- a/packages/zudo-doc/src/i18n-version/language-switcher.tsx
+++ b/packages/zudo-doc/src/i18n-version/language-switcher.tsx
@@ -123,6 +123,11 @@ export function switchLocaleHref(
  * `window[FLAG]` makes it idempotent: the tag may re-execute on a hard reload
  * or a cross-locale header repaint, but the listener is registered exactly
  * once per page lifetime.
+ *
+ * The pathname fed to `switchLocaleHref` prefers
+ * `document.documentElement.dataset.zdCurrentPath` over `location.pathname` —
+ * the same explicit current-route override `nav-overflow-script.ts` /
+ * `sidebar-tree-island` / `version-switcher.tsx` read (zudolab/zudo-doc#3398).
  */
 export const LANGUAGE_SWITCHER_INIT_SCRIPT = `(function(){
 var FLAG="__zdLanguageSwitcherInit";
@@ -140,7 +145,7 @@ for(var j=0;j<anchors.length;j++){
 var a=anchors[j];
 var target=a.getAttribute("lang");
 if(!target)continue;
-a.setAttribute("href",switchLocaleHref(window.location.pathname,config,currentLang,target));
+a.setAttribute("href",switchLocaleHref(document.documentElement.dataset.zdCurrentPath||location.pathname,config,currentLang,target));
 }
 }
 }

--- a/packages/zudo-doc/src/i18n-version/version-switcher.tsx
+++ b/packages/zudo-doc/src/i18n-version/version-switcher.tsx
@@ -552,6 +552,11 @@ document.addEventListener(${JSON.stringify(AFTER_NAVIGATE_EVENT)},initVersionSwi
  * `window[FLAG]` makes it idempotent: the tag may re-execute on a hard reload or
  * a cross-locale header repaint, but the listener registers exactly once per
  * page lifetime.
+ *
+ * The pathname fed to `computeVersionSwitcherState` prefers
+ * `document.documentElement.dataset.zdCurrentPath` over `location.pathname` —
+ * the same explicit current-route override `nav-overflow-script.ts` /
+ * `sidebar-tree-island` / `language-switcher.tsx` read (zudolab/zudo-doc#3398).
  */
 export const VERSION_SWITCHER_REWIRE_SCRIPT = `(function(){
 var FLAG="__zdVersionSwitcherRewire";
@@ -599,7 +604,7 @@ for(var j=0;j<versionAnchors.length;j++){
 var s=versionAnchors[j].getAttribute("data-version-slug");
 if(s)slugs.push(s);
 }
-var state=computeVersionSwitcherState(window.location.pathname,config,slugs);
+var state=computeVersionSwitcherState(document.documentElement.dataset.zdCurrentPath||location.pathname,config,slugs);
 var latest=c.querySelector("[data-version-latest]");
 if(latest){
 latest.setAttribute("href",state.latestHref);

--- a/packages/zudo-doc/src/nav-source-docs/index.ts
+++ b/packages/zudo-doc/src/nav-source-docs/index.ts
@@ -22,6 +22,7 @@
 import type { CategoryMeta } from "../sidebar-tree/index.js";
 import { loadCategoryMeta as loadCategoryMetaImpl } from "../sidebar-tree/index.js";
 import type { DocPageEntry } from "../doc-page-props/index.js";
+import type { NavSourceDocs as NavSourceDocsShape } from "../site-schema/types.js";
 import { memoizeDerived } from "../nav-source-cache/index.js";
 import { mergeLocaleDocs } from "../locale-merge/index.js";
 import type { Settings } from "../settings.js";
@@ -32,17 +33,12 @@ import type { Settings } from "../settings.js";
 
 export type { CategoryMeta, DocPageEntry };
 
-export interface NavSourceDocs {
-  /** Full doc list (merged + draft-filtered; unlisted retained per options). */
-  docs: DocPageEntry[];
-  /** `docs.filter(isNavVisible)` — stable instance for buildNavTree. */
-  navDocs: DocPageEntry[];
-  /** Stable category-meta Map for the active (locale, version). */
-  categoryMeta: Map<string, CategoryMeta>;
-  /** Slugs that came from the locale collection (for isFallback). Empty for
-   *  default-locale / single-collection cases. */
-  localeSlugSet: ReadonlySet<string>;
-}
+/**
+ * The resolved nav source for one (locale, version) context, carrying zfb
+ * collection entries. The shape itself is browser-safe and declared in
+ * `../site-schema/types.js` (#3395); this alias pins it to `DocPageEntry`.
+ */
+export type NavSourceDocs = NavSourceDocsShape<DocPageEntry>;
 
 /**
  * How to filter the merged doc list.

--- a/packages/zudo-doc/src/plugins/__tests__/routes.test.ts
+++ b/packages/zudo-doc/src/plugins/__tests__/routes.test.ts
@@ -19,10 +19,16 @@
 // built HTML + client bundle registration + a real build failure) lives in
 // the slow-tier `__tests__/route-injection-build.slow.test.ts` (Case DTP),
 // per the project's fast/slow test-tier split (zudolab/zudo-doc#2530).
+//
+// The loader contract below is UNCHANGED by #3396 — what changed is WHO
+// imports the specifier the loader serves. The second describe block is the
+// fast guard for that: the routes-only wrapper must be the sole importer, or
+// `@takazudo/zudo-doc/chrome` silently regains its routes-plugin coupling.
 
 import { describe, expect, it, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readdirSync, readFileSync } from "node:fs";
+import { join, relative, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { tmpdir } from "node:os";
 import routesPlugin from "../routes.js";
 
@@ -149,5 +155,58 @@ describe("routes plugin — virtual:zudo-doc-design-token-panel-config (#2658)",
     expect(thrown).toBeDefined();
     expect(thrown!.message).toContain("designTokenPanelConfigModule");
     expect(thrown!.message).toContain("directory, not a module file");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #3396 seam guard — the routes-only wrapper is the SOLE importer of the
+// design-token-panel-config virtual specifier.
+//
+// This automates the acceptance-criteria grep. The regression it catches is
+// invisible to every other fast test: re-adding the import to
+// `design-token-panel-bootstrap.tsx` (or anywhere else in the chrome graph)
+// still typechecks and still builds under zfb, and only breaks the ONE thing
+// the epic is about — bundling `@takazudo/zudo-doc/chrome` outside a zfb build,
+// where nothing registers the specifier.
+// ---------------------------------------------------------------------------
+
+const SRC_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const DTP_CONFIG_SPECIFIER = "virtual:zudo-doc-design-token-panel-config";
+
+/** Every compiled `.ts`/`.tsx` source under `src/`, excluding tests and the
+ *  ambient `.d.ts` declarations (which must keep naming the specifier). */
+function collectSourceFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "__tests__") continue;
+      collectSourceFiles(full, out);
+      continue;
+    }
+    if (!/\.tsx?$/.test(entry.name)) continue;
+    if (/\.d\.ts$/.test(entry.name)) continue;
+    if (/\.test\.tsx?$/.test(entry.name)) continue;
+    out.push(full);
+  }
+  return out;
+}
+
+describe("routes plugin — design-token-panel-config specifier is routes-only (#3396)", () => {
+  const importers = collectSourceFiles(SRC_ROOT)
+    .filter((file) =>
+      new RegExp(String.raw`\bfrom\s+(["'])${DTP_CONFIG_SPECIFIER}\1`).test(
+        readFileSync(file, "utf8"),
+      ),
+    )
+    .map((file) => relative(SRC_ROOT, file).split("\\").join("/"));
+
+  it("exactly one source module imports the specifier", () => {
+    expect(importers).toEqual(["routes/_design-token-panel-bootstrap.tsx"]);
+  });
+
+  it("the generic bootstrap module binds the package-default builder instead", () => {
+    const source = readFileSync(join(SRC_ROOT, "design-token-panel-bootstrap.tsx"), "utf8");
+    expect(source).toContain('from "./design-token-panel-config/index.js"');
+    expect(source).not.toContain(`from "${DTP_CONFIG_SPECIFIER}"`);
   });
 });

--- a/packages/zudo-doc/src/plugins/routes.ts
+++ b/packages/zudo-doc/src/plugins/routes.ts
@@ -41,8 +41,10 @@
 //      SECOND host-callables channel, identical mechanics to #2 above (#2658).
 //      `settings.designTokenPanelConfigModule` carries a project-root-relative
 //      PATH to a host module exporting a named `buildDesignTokenPanelConfig`.
-//      `design-token-panel-bootstrap.tsx`'s `DesignTokenPanelBootstrap` island
-//      imports this virtual module. Registered UNCONDITIONALLY: absent setting
+//      `routes/_design-token-panel-bootstrap.tsx`'s configured island wrapper
+//      is the SOLE importer of this virtual module (#3396 moved it out of
+//      `design-token-panel-bootstrap.tsx` so the generic chrome graph carries
+//      no `virtual:` specifier). Registered UNCONDITIONALLY: absent setting
 //      → re-exports the PACKAGE DEFAULT (`@takazudo/zudo-doc/design-token-panel-config`,
 //      not an empty fallback — there is no meaningful "empty" builder);
 //      present-but-missing file → a loud Error at plugin setup naming the
@@ -327,7 +329,7 @@ const plugin = definePlugin({
     // (3) Design-token-panel-config virtual module — the THIRD virtual module
     // (#2658, mirrors the chromeBindingsModule contract above exactly, via the
     // same `resolveHostModuleOverride` guards). Registered UNCONDITIONALLY:
-    // `design-token-panel-bootstrap.tsx`'s `DesignTokenPanelBootstrap` island
+    // `routes/_design-token-panel-bootstrap.tsx`'s configured island wrapper
     // always imports this specifier, so the module must exist even when the
     // setting is absent — in that case the loader re-exports the PACKAGE
     // DEFAULT builder (`@takazudo/zudo-doc/design-token-panel-config`) instead

--- a/packages/zudo-doc/src/route-context/index.ts
+++ b/packages/zudo-doc/src/route-context/index.ts
@@ -47,8 +47,8 @@ import {
 } from "../route-enumerators/index.js";
 import type { DocNavNode, DocPageEntry } from "../doc-page-props/index.js";
 import type { HeadingItem } from "../extract-headings/index.js";
+import { stableDocs as defaultStableDocs } from "../routes/_docs-helpers.js";
 import {
-  stableDocs as defaultStableDocs,
   isNavVisible,
   buildNavTree,
   buildBreadcrumbs,
@@ -56,7 +56,7 @@ import {
   groupSatelliteNodes,
   findNode,
   firstRoutedHref,
-} from "../routes/_docs-helpers.js";
+} from "../site-schema/nav-tree.js";
 
 export type {
   RouteContext,

--- a/packages/zudo-doc/src/routes/_chrome.tsx
+++ b/packages/zudo-doc/src/routes/_chrome.tsx
@@ -13,7 +13,7 @@
 import { routeCtx } from "./_context.js";
 import { createChrome } from "../chrome/index.js";
 import { DocHistory } from "../doc-history/index.js";
-import type { DocNavNode } from "./_docs-helpers.js";
+import type { DocNavNode } from "../site-schema/types.js";
 // Imported via the BARE published subpath rather than a relative
 // `../chrome-bindings.js`. This file is copied into consumer projects by the
 // routes-src mechanism (`scripts/copy-routes-src.mjs`), which rewrites relative

--- a/packages/zudo-doc/src/routes/_chrome.tsx
+++ b/packages/zudo-doc/src/routes/_chrome.tsx
@@ -27,6 +27,10 @@ import { defineChromeBindings } from "@takazudo/zudo-doc/chrome-bindings";
 // ("Host-callables channel — chromeBindingsModule"). Not present on disk; the
 // package ships ambient typings for it (`routes/_virtual.d.ts`).
 import { chromeBindings } from "virtual:zudo-doc-chrome-bindings";
+// Routes-only configured design-token-panel island (#3396) — the ONLY importer
+// of `virtual:zudo-doc-design-token-panel-config` in the package. Static, for
+// the same island-scanner reason as `DocHistory` above.
+import { ConfiguredDesignTokenPanelBootstrap } from "./_design-token-panel-bootstrap.js";
 
 // Island-scanner contract (load-bearing): the injected doc routes reach the real
 // DocHistory client island ONLY through this static import → `createChrome`
@@ -57,15 +61,23 @@ import { chromeBindings } from "virtual:zudo-doc-chrome-bindings";
 // the way the static `DocHistory` import above is (the virtual re-export sits
 // outside zfb's static-import scanner reachability graph) — see the ADR.
 //
-// `DesignTokenPanelBootstrap` (#2658) is NOT threaded here: unlike DocHistory
-// (whose derive-level default is a no-op stub), the package-default island IS
-// the derive-level default (`chrome/derive.tsx`'s `deriveBodyEndIslands`,
-// gate-2 fix from the Wave-5 confirm #2659) — so this shim, the locked-manifest
-// self-contained doc stub (#2653), and every other bare `createChrome` caller
-// all get it without explicit wiring. Scanner reachability holds through the
-// static chain route → this shim → `createChrome` → `chrome/derive` →
-// `design-token-panel-bootstrap`.
+// `DesignTokenPanelBootstrap` IS threaded here since #3396, but only to swap
+// the BUILDER — the mount, the settings gate, and the slot default all still
+// belong to `chrome/derive.tsx`'s `deriveBodyEndIslands` (gate-2 fix from the
+// Wave-5 confirm #2659), so the locked-manifest self-contained doc stub (#2653)
+// and every other bare `createChrome` caller keep getting the package-default
+// island with no explicit wiring. On THESE injected routes the configured
+// wrapper wins, which is what carries a host's
+// `settings.designTokenPanelConfigModule` through. Scanner reachability holds
+// through the static chain route → this shim → `_design-token-panel-bootstrap`.
+//
+// It is spread BEFORE `...chromeBindings` (unlike `DocHistory`, which is spread
+// after): a host's own `DesignTokenPanelBootstrap` slot value must still win,
+// exactly as it did when the derive-level default was the only package wiring.
 const chrome = createChrome(routeCtx, {
+  ...defineChromeBindings({
+    DesignTokenPanelBootstrap: ConfiguredDesignTokenPanelBootstrap,
+  }),
   ...chromeBindings,
   ...defineChromeBindings({ DocHistory }),
 });

--- a/packages/zudo-doc/src/routes/_design-token-panel-bootstrap.tsx
+++ b/packages/zudo-doc/src/routes/_design-token-panel-bootstrap.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+// routes/_design-token-panel-bootstrap — the ROUTES-ONLY configured
+// design-token-panel island (#3396, epic #3394).
+//
+// WHY THIS FILE EXISTS: `virtual:zudo-doc-design-token-panel-config` is
+// registered by the routes plugin, so any module that imports it statically
+// drags the plugin along as a hard requirement. Until #3396 that importer was
+// `../design-token-panel-bootstrap.tsx`, which `chrome/derive.tsx` imports —
+// meaning `@takazudo/zudo-doc/chrome` could not be bundled outside a zfb build
+// (or by a `packageOwnedRoutes: false` host) without aliasing the specifier.
+// Moving the import HERE confines it to the routes graph, which zfb always
+// bundles with the plugin active.
+//
+// WHY A COMPONENT AND NOT A SETTER: the route/SSR module graph and the
+// hydrated island bundle are SEPARATE graphs. A `setPanelConfigBuilder(...)`
+// called while `_chrome.tsx` evaluates would configure only the server-side
+// copy of the bootstrap module; the client bundle re-evaluates that module
+// independently and would keep the package default. Passing the builder as an
+// argument from a component that lives INSIDE the island bundle is the only
+// shape that survives the boundary.
+//
+// ISLAND-SCANNER CONTRACT (#2480 lesson): `_chrome.tsx` imports this module
+// STATICALLY and threads the component into `hostBindings`, so the scanner
+// walks route → _chrome → here. The exported binding identifier and the
+// `displayName` must stay IDENTICAL — zfb registers islands by the
+// scanner-visible export name, and a marker whose name has no registry entry
+// silently never hydrates. The name must also stay DISTINCT from
+// `DesignTokenPanelBootstrap`: `chrome/derive.tsx` still statically imports
+// that package default (it is the slot default for bare `createChrome`
+// callers), so both components are in the scanned graph and a shared name
+// would trip zfb's "island marker name collision" warning and drop one of them.
+
+import type { JSX } from "preact";
+import { runDesignTokenPanelBootstrapOnce } from "../design-token-panel-bootstrap.js";
+// Host-callables channel, third virtual module (#2658, mirrors #2501's
+// chromeBindingsModule): absent `settings.designTokenPanelConfigModule` →
+// re-exports the package default (`@takazudo/zudo-doc/design-token-panel-config`);
+// present → re-exports the host's module. Registered unconditionally by the
+// routes plugin (`../plugins/routes.ts`) whenever `packageOwnedRoutes` is on.
+// Not present on disk; the package ships ambient typings for it
+// (`./_virtual.d.ts`).
+import { buildDesignTokenPanelConfig } from "virtual:zudo-doc-design-token-panel-config";
+
+/**
+ * The design-token-panel island injected routes mount instead of the package
+ * default: identical behavior, except the mode-scoped `PanelConfig` builder is
+ * the one the routes plugin resolved — the host's
+ * `settings.designTokenPanelConfigModule` when set, the package default
+ * otherwise.
+ *
+ * Renders `null` on both SSR and client (the panel self-mounts as a side
+ * effect of `bootstrapDesignTokenPanel`), matching the package default's
+ * non-`ssrFallback` `Island({ when: "load" })` shape.
+ */
+export function ConfiguredDesignTokenPanelBootstrap(): JSX.Element | null {
+  runDesignTokenPanelBootstrapOnce(buildDesignTokenPanelConfig);
+  return null;
+}
+ConfiguredDesignTokenPanelBootstrap.displayName = "ConfiguredDesignTokenPanelBootstrap";

--- a/packages/zudo-doc/src/routes/_docs-helpers.ts
+++ b/packages/zudo-doc/src/routes/_docs-helpers.ts
@@ -11,30 +11,18 @@
 // WHAT MOVED: every pure nav helper this file used to define — `buildNavTree`,
 // `groupSatelliteNodes`, `findNode`, `firstRoutedHref`, `collectAutoIndexNodes`,
 // `buildBreadcrumbs`, `isNavVisible` — now lives in `../site-schema/nav-tree.js`
-// and is re-exported below unchanged (#3395). Cutting them loose is what lets
-// `createDocRouteEntries` reach `buildBreadcrumbs` without dragging
-// `@takazudo/zfb/content` into an otherwise browser-safe graph.
+// (#3395); import them from there, not from here. Cutting them loose is what
+// lets `createDocRouteEntries` reach `buildBreadcrumbs` without dragging
+// `@takazudo/zfb/content` into an otherwise browser-safe graph. This module
+// deliberately re-exports NOTHING: a second import path for the nav helpers
+// through this file would put them one hop from the `@takazudo/zfb/content`
+// edge this file exists to carry.
 
 import {
   getCollection,
   getContentSnapshot,
 } from "@takazudo/zfb/content";
-import type { CategoryMeta } from "../sidebar-tree/types.js";
-import type { DocNavNode, DocPageEntry, DocPageFrontmatter } from "../doc-page-props/index.js";
-
-export type { CategoryMeta, DocNavNode, DocPageEntry };
-export type { BreadcrumbItem } from "../site-schema/types.js";
-export type { BuildHref, BuildNavTreeOptions } from "../site-schema/nav-tree.js";
-
-export {
-  buildBreadcrumbs,
-  buildNavTree,
-  collectAutoIndexNodes,
-  findNode,
-  firstRoutedHref,
-  groupSatelliteNodes,
-  isNavVisible,
-} from "../site-schema/nav-tree.js";
+import type { DocPageEntry, DocPageFrontmatter } from "../doc-page-props/index.js";
 
 // ---------------------------------------------------------------------------
 // Content bridge — snapshot-anchored stable docs (Decision 5)

--- a/packages/zudo-doc/src/routes/_docs-helpers.ts
+++ b/packages/zudo-doc/src/routes/_docs-helpers.ts
@@ -1,37 +1,40 @@
-// routes/_docs-helpers — package-side nav-tree helpers for the package-owned
-// route entrypoints (epic Package-First Finale #2356, A1 #2361).
+// routes/_docs-helpers — the content bridge for the package-owned route
+// entrypoints (epic Package-First Finale #2356, A1 #2361).
 //
-// The host's `src/utils/docs.ts` `buildNavTree` / `buildBreadcrumbs` /
-// `collectAutoIndexNodes` / `groupSatelliteNodes` / `findNode` /
-// `firstRoutedHref` are host-only wrappers around the package primitive
-// `buildSidebarTree` (`@takazudo/zudo-doc/sidebar-tree`). The package route
-// entrypoints inject these same helpers into the doc-route / nav-source /
-// nav-wrapper factories, so this module reproduces them WITHOUT the host `@/`
-// alias — the "+ package `docs` helpers" note in the ADR's host-dep table.
+// WHAT IS LEFT HERE: `stableDocs`, and only `stableDocs`. It is the one piece
+// of this module that cannot be browser-safe — it imports `@takazudo/zfb/content`
+// directly (NOT the host `zfb/content` tsconfig alias — Decision 2) to anchor
+// the bridged + draft-filtered array on the build snapshot, so repeat callers
+// within a build get the SAME instance and the nav-tree / doc-route memos
+// short-circuit (the content bridge — Decision 5).
 //
-// Faithful to the host derivation (root-index node synthesis, NavNode shape,
-// satellite grouping, breadcrumb walk) but without the host-only LRU /
-// identity caches: build-time array-identity stability already comes from the
-// snapshot-anchored `stableDocs` (below) + `memoizeDerived` in the factories.
-//
-// `stableDocs` (the content bridge — Decision 5) imports `@takazudo/zfb/content`
-// directly (NOT the host `zfb/content` tsconfig alias — Decision 2), anchoring
-// the bridged + draft-filtered array on the snapshot so repeat callers within a
-// build get the SAME instance and the nav-tree / doc-route memos short-circuit.
+// WHAT MOVED: every pure nav helper this file used to define — `buildNavTree`,
+// `groupSatelliteNodes`, `findNode`, `firstRoutedHref`, `collectAutoIndexNodes`,
+// `buildBreadcrumbs`, `isNavVisible` — now lives in `../site-schema/nav-tree.js`
+// and is re-exported below unchanged (#3395). Cutting them loose is what lets
+// `createDocRouteEntries` reach `buildBreadcrumbs` without dragging
+// `@takazudo/zfb/content` into an otherwise browser-safe graph.
 
 import {
   getCollection,
   getContentSnapshot,
 } from "@takazudo/zfb/content";
-import {
-  buildSidebarTree,
-  type CategoryMeta,
-  type SidebarNode,
-} from "../sidebar-tree/index.js";
-import { toRouteSlug } from "../slug/index.js";
+import type { CategoryMeta } from "../sidebar-tree/types.js";
 import type { DocNavNode, DocPageEntry, DocPageFrontmatter } from "../doc-page-props/index.js";
 
 export type { CategoryMeta, DocNavNode, DocPageEntry };
+export type { BreadcrumbItem } from "../site-schema/types.js";
+export type { BuildHref, BuildNavTreeOptions } from "../site-schema/nav-tree.js";
+
+export {
+  buildBreadcrumbs,
+  buildNavTree,
+  collectAutoIndexNodes,
+  findNode,
+  firstRoutedHref,
+  groupSatelliteNodes,
+  isNavVisible,
+} from "../site-schema/nav-tree.js";
 
 // ---------------------------------------------------------------------------
 // Content bridge — snapshot-anchored stable docs (Decision 5)
@@ -63,202 +66,4 @@ export function stableDocs(collectionName: string): DocPageEntry[] {
   const built = buildDocs(collectionName);
   docsByAnchor.set(anchor, built);
   return built;
-}
-
-// ---------------------------------------------------------------------------
-// Nav-tree helpers — ported from src/utils/docs.ts onto buildSidebarTree
-// ---------------------------------------------------------------------------
-
-/** Filter predicate: true when a doc should appear in navigation. */
-export function isNavVisible(doc: DocPageEntry): boolean {
-  return !doc.data.unlisted && !doc.data.standalone;
-}
-
-/** A docs-href builder: `(slug, locale) => url`. */
-export type BuildHref = (slug: string, locale: string) => string;
-
-export interface BuildNavTreeOptions {
-  buildHref?: BuildHref;
-}
-
-function toNavNode(node: SidebarNode): DocNavNode {
-  return {
-    slug: node.id,
-    label: node.label,
-    description: node.description,
-    position: node.sidebar_position ?? 999,
-    href: node.href,
-    hasPage: node.hasPage,
-    children: node.children.map(toNavNode),
-    sortOrder: node.sortOrder ?? "asc",
-  };
-}
-
-/** Last entry whose package-derived slug is empty ("") — the entry the shared
- *  builder skips. Last one wins (mirrors the host builder's overwrite). */
-function findRootIndexDoc(docs: DocPageEntry[]): DocPageEntry | undefined {
-  let found: DocPageEntry | undefined;
-  for (const d of docs) {
-    const slug = d.data.slug ?? toRouteSlug(d.slug);
-    if (slug === "") found = d;
-  }
-  return found;
-}
-
-function toRootNavNode(
-  doc: DocPageEntry,
-  locale: string,
-  buildHref: BuildHref,
-  categoryMeta?: Map<string, CategoryMeta>,
-): DocNavNode {
-  const meta = categoryMeta?.get("");
-  const noPage = doc.data.category_no_page ?? meta?.noPage;
-  const sortOrder =
-    (doc.data.category_sort_order as "asc" | "desc" | undefined) ?? meta?.sortOrder ?? "asc";
-  return {
-    slug: "",
-    label:
-      (doc.data.sidebar_label as string | undefined) ??
-      doc.data.title ??
-      meta?.label ??
-      "",
-    description: doc.data.description ?? meta?.description,
-    position: (doc.data.sidebar_position as number | undefined) ?? meta?.position ?? 999,
-    href: noPage ? undefined : buildHref("", locale),
-    hasPage: noPage !== true,
-    children: [],
-    sortOrder,
-  };
-}
-
-/**
- * Build a recursive navigation tree from a flat doc collection. Delegates tree
- * construction to the shared `buildSidebarTree`; keeps the host-side concerns
- * (DocNavNode shape, root-index node synthesis). `buildHref` parameterizes the
- * href space (default: the injected `docsUrl`). Unlike the host copy this drops
- * the LRU / identity caches — the snapshot-anchored `stableDocs` already makes
- * the input arrays identity-stable so the factory-level `memoizeDerived` short-
- * circuits per build.
- */
-export function buildNavTree(
-  docs: DocPageEntry[],
-  locale: string,
-  categoryMeta: Map<string, CategoryMeta> | undefined,
-  buildHref: BuildHref,
-  options?: BuildNavTreeOptions,
-): DocNavNode[] {
-  const href: BuildHref = options?.buildHref ?? buildHref;
-  const sidebarTree = buildSidebarTree(
-    docs,
-    locale,
-    {
-      categoryMeta,
-      buildHref: (slug, loc) => href(slug, loc),
-      // Host call sites own visibility; disable the builder's default filter so
-      // breadcrumb (unfiltered) and nav (pre-filtered) paths are unchanged.
-      isNavVisible: () => true,
-    },
-  );
-  const result = sidebarTree.map(toNavNode);
-
-  const rootDoc = findRootIndexDoc(docs);
-  if (rootDoc) {
-    result.push(toRootNavNode(rootDoc, locale, href, categoryMeta));
-    result.sort((a, b) => {
-      const posCompare = a.position - b.position;
-      if (posCompare !== 0) return posCompare;
-      return a.slug.localeCompare(b.slug);
-    });
-  }
-  return result;
-}
-
-/** Group "satellite" nodes (slug-prefix siblings) under their primary node. */
-export function groupSatelliteNodes(tree: DocNavNode[], prefixes: string[]): DocNavNode[] {
-  const result = [...tree];
-  for (const prefix of prefixes) {
-    const primaryIdx = result.findIndex((n) => n.slug === prefix);
-    if (primaryIdx < 0) continue;
-    const primary = result[primaryIdx];
-    if (!primary) continue;
-    const satelliteIdxs: number[] = [];
-    for (let i = 0; i < result.length; i++) {
-      const node = result[i];
-      if (node && i !== primaryIdx && node.slug.startsWith(`${prefix}-`)) {
-        satelliteIdxs.push(i);
-      }
-    }
-    if (satelliteIdxs.length === 0) continue;
-    const extraChildren: DocNavNode[] = [];
-    for (const idx of satelliteIdxs) {
-      const node = result[idx];
-      if (node) extraChildren.push(node);
-    }
-    result[primaryIdx] = { ...primary, children: [...primary.children, ...extraChildren] };
-    for (const idx of satelliteIdxs.reverse()) result.splice(idx, 1);
-  }
-  return result;
-}
-
-/** Find a node by slug anywhere in the tree. */
-export function findNode(nodes: DocNavNode[], slug: string): DocNavNode | undefined {
-  for (const node of nodes) {
-    if (node.slug === slug) return node;
-    const found = findNode(node.children, slug);
-    if (found) return found;
-  }
-  return undefined;
-}
-
-/** Href of the first routed descendant, walking children depth-first. */
-export function firstRoutedHref(node: DocNavNode): string | undefined {
-  for (const child of node.children) {
-    if (child.hasPage && child.href) return child.href;
-    const nested = firstRoutedHref(child);
-    if (nested) return nested;
-  }
-  return undefined;
-}
-
-/** Collect all category nodes that have children but no page (no index.mdx). */
-export function collectAutoIndexNodes(nodes: DocNavNode[]): DocNavNode[] {
-  const result: DocNavNode[] = [];
-  for (const node of nodes) {
-    if (!node.hasPage && node.children.length > 0 && node.href) result.push(node);
-    result.push(...collectAutoIndexNodes(node.children));
-  }
-  return result;
-}
-
-export interface BreadcrumbItem {
-  label: string;
-  href?: string;
-}
-
-/** Build breadcrumb trail by walking the nav tree. `homeHref` is the locale
- *  docs root (injected). `hrefFor` optionally remaps intermediate crumbs into
- *  a versioned URL space. */
-export function buildBreadcrumbs(
-  tree: DocNavNode[],
-  slug: string,
-  homeHref: string,
-  hrefFor?: (slug: string) => string,
-): BreadcrumbItem[] {
-  const parts = slug.split("/");
-  const crumbs: BreadcrumbItem[] = [{ label: "", href: homeHref }];
-  let nodes = tree;
-  for (let i = 0; i < parts.length; i++) {
-    const partialSlug = parts.slice(0, i + 1).join("/");
-    const node = nodes.find((n) => n.slug === partialSlug);
-    if (!node) break;
-    const isLast = i === parts.length - 1;
-    const href = isLast
-      ? undefined
-      : hrefFor && node.href !== undefined
-        ? hrefFor(node.slug)
-        : node.href;
-    crumbs.push({ label: node.label, href });
-    nodes = node.children;
-  }
-  return crumbs;
 }

--- a/packages/zudo-doc/src/routes/_virtual.d.ts
+++ b/packages/zudo-doc/src/routes/_virtual.d.ts
@@ -57,8 +57,11 @@ declare module "virtual:zudo-doc-chrome-bindings" {
 // …)`, #2658). No on-disk source — materialised at build, either as a
 // re-export of the host's `settings.designTokenPanelConfigModule` file or as
 // a re-export of the package default (`@takazudo/zudo-doc/design-token-panel-config`)
-// when the setting is absent. See `plugins/routes.ts` and this package's
-// `design-token-panel-bootstrap.tsx` for the full contract.
+// when the setting is absent. Since #3396 its SOLE importer is the
+// routes-only wrapper `./_design-token-panel-bootstrap.tsx` — the generic
+// `design-token-panel-bootstrap.tsx` binds the package default directly, so
+// `@takazudo/zudo-doc/chrome` bundles without the routes plugin. See
+// `plugins/routes.ts` and that bootstrap module for the full contract.
 //
 // Typed via an inline `import(...)` type (not a top-level import, for the
 // same ambient-module-declaration reason as `chromeBindings` above) — see

--- a/packages/zudo-doc/src/settings.ts
+++ b/packages/zudo-doc/src/settings.ts
@@ -450,6 +450,13 @@ export interface Settings {
    * Only the PATH travels through `settings` (a string is serializable
    * data) — the bundler imports the actual builder from the re-exported
    * module. Irrelevant when `designTokenPanel` is `false`.
+   *
+   * KNOWN GAP (#3396): this setting applies only to pages rendered through the
+   * package-injected routes. A doc page rendered by a SELF-CONTAINED host
+   * `pages/` stub mounts the package-default bootstrap and silently ignores
+   * this module — such a host must override the panel through
+   * `chromeBindings.DesignTokenPanelBootstrap` instead (see
+   * `docs/adr/route-injection-seam.md`).
    */
   designTokenPanelConfigModule?: string;
   /**

--- a/packages/zudo-doc/src/sidebar-tree-island/__tests__/sidebar-tree-active-path.test.tsx
+++ b/packages/zudo-doc/src/sidebar-tree-island/__tests__/sidebar-tree-active-path.test.tsx
@@ -1,0 +1,107 @@
+/** @vitest-environment happy-dom */
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+// Real-DOM regression tests for the explicit current-route override threaded
+// through SidebarTree's active-slug derivation (zudolab/zudo-doc#3398).
+//
+// Covers the override priority — `currentPath` prop >
+// `document.documentElement.dataset.zdCurrentPath` > `window.location.pathname`
+// — and the srcdoc/unusable-pathname case: inside an iframe `srcdoc` document,
+// `location.pathname` is the literal string "srcdoc", which matches no route
+// (spike ledger adl-0005). `deriveActiveSlug` must return `undefined` for
+// such a pathname, and the caller (`useActiveSlug`) must PRESERVE the
+// existing (SSR-supplied) active slug instead of clearing it.
+
+import { afterEach, describe, expect, it } from "vitest";
+import { render } from "preact";
+import { act } from "preact/test-utils";
+import { SidebarTree, type SidebarTreeProps } from "../index.js";
+import type { SidebarNavNode } from "../../sidebar/types.js";
+
+const NODES: SidebarNavNode[] = [
+  {
+    slug: "introduction",
+    label: "Introduction",
+    position: 0,
+    href: "/docs/introduction",
+    hasPage: true,
+    children: [],
+  },
+  {
+    slug: "guides",
+    label: "Guides",
+    position: 1,
+    hasPage: false,
+    children: [
+      {
+        slug: "guides/getting-started",
+        label: "Getting Started",
+        position: 0,
+        href: "/docs/guides/getting-started",
+        hasPage: true,
+        children: [],
+      },
+    ],
+  },
+];
+
+let mounted: HTMLDivElement | null = null;
+
+function mount(props: SidebarTreeProps): HTMLDivElement {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  act(() => {
+    render(<SidebarTree {...props} />, container);
+  });
+  mounted = container;
+  return container;
+}
+
+afterEach(() => {
+  if (mounted) {
+    act(() => {
+      render(null, mounted!);
+    });
+    mounted.remove();
+    mounted = null;
+  }
+  delete document.documentElement.dataset.zdCurrentPath;
+});
+
+describe("SidebarTree — explicit current-route override", () => {
+  it("prefers the explicit currentPath prop over the dataset override", () => {
+    document.documentElement.dataset.zdCurrentPath = "/docs/introduction";
+    const container = mount({ nodes: NODES, currentPath: "/docs/guides/getting-started" });
+
+    const active = container.querySelector('a[aria-current="page"]');
+    expect(active?.getAttribute("href")).toBe("/docs/guides/getting-started");
+  });
+
+  it("falls back to document.documentElement.dataset.zdCurrentPath when no currentPath prop is given", () => {
+    document.documentElement.dataset.zdCurrentPath = "/docs/introduction";
+    const container = mount({ nodes: NODES });
+
+    const active = container.querySelector('a[aria-current="page"]');
+    expect(active?.getAttribute("href")).toBe("/docs/introduction");
+  });
+});
+
+describe("SidebarTree — srcdoc / unusable pathname preserves SSR markers", () => {
+  it("keeps the SSR-supplied active slug when the resolved pathname matches no route", () => {
+    const container = mount({
+      nodes: NODES,
+      currentSlug: "guides/getting-started",
+      currentPath: "srcdoc",
+    });
+
+    const activeLinks = container.querySelectorAll('a[aria-current="page"]');
+    expect(activeLinks).toHaveLength(1);
+    expect(activeLinks[0]?.getAttribute("href")).toBe("/docs/guides/getting-started");
+  });
+
+  it("renders with no active marker (nothing cleared, nothing wrongly matched) when there is no SSR slug either", () => {
+    const container = mount({ nodes: NODES, currentPath: "srcdoc" });
+
+    expect(container.querySelector('a[aria-current="page"]')).toBeNull();
+  });
+});

--- a/packages/zudo-doc/src/sidebar-tree-island/index.tsx
+++ b/packages/zudo-doc/src/sidebar-tree-island/index.tsx
@@ -61,38 +61,60 @@ function saveOpenSet(set: Set<string>) {
 }
 
 /**
- * Derive the active slug from the current document URL. Used as a hydration-
- * time fallback when the parent island does not forward `currentSlug` through
- * its prop boundary, and at every View Transition to keep the highlight in
- * sync.
+ * Explicit current-route override, checked before `window.location.pathname`.
+ * An embedding host (e.g. an iframe `srcdoc` preview shell) sets
+ * `document.documentElement.dataset.zdCurrentPath` because inside
+ * `about:srcdoc`, `location.pathname` is the literal string "srcdoc" (matches
+ * no route) and Chromium refuses `history.replaceState` there, so the page
+ * cannot self-correct via navigation (zudolab/zudo-doc#3398, spike ledger
+ * adl-0005). This is the same override source `nav-overflow-script.ts` /
+ * `version-switcher.tsx` / `language-switcher.tsx` read.
  */
-function deriveActiveSlugFromUrl(nodes: SidebarNavNode[]): string | undefined {
-  if (typeof window === "undefined") return undefined;
-  const pathname = normalizePath(window.location.pathname);
-  return findActiveSlug(nodes, pathname);
+function currentPathOverride(): string | undefined {
+  if (typeof document === "undefined") return undefined;
+  return document.documentElement.dataset.zdCurrentPath || undefined;
+}
+
+/**
+ * Derive the active slug from an explicit current-route input. Resolution
+ * order: the `pathname` argument, then `currentPathOverride()`, then
+ * `window.location.pathname`. Used as a hydration-time fallback when the
+ * parent island does not forward `currentSlug` through its prop boundary,
+ * and at every View Transition to keep the highlight in sync.
+ *
+ * Returns `undefined` both when no pathname is resolvable AND when the
+ * resolved pathname matches no route (e.g. the literal "srcdoc") — callers
+ * must treat `undefined` as "no update," preserving whatever active slug is
+ * already set rather than clearing it.
+ */
+function deriveActiveSlug(nodes: SidebarNavNode[], pathname?: string): string | undefined {
+  const resolved =
+    pathname ?? currentPathOverride() ?? (typeof window !== "undefined" ? window.location.pathname : undefined);
+  if (!resolved) return undefined;
+  return findActiveSlug(nodes, normalizePath(resolved));
 }
 
 /**
  * Track the current active slug, updating on View Transition navigations.
  *
  * The initial-state initialiser prefers the SSR-supplied `initial` prop, but
- * falls back to deriving the slug from `window.location.pathname` when the
- * prop is missing.
+ * falls back to `deriveActiveSlug` (explicit `currentPath` input, then the
+ * override/location fallbacks) when the prop is missing.
  */
-function useActiveSlug(nodes: SidebarNavNode[], initial?: string): string | undefined {
+function useActiveSlug(nodes: SidebarNavNode[], initial?: string, currentPath?: string): string | undefined {
   const [slug, setSlug] = useState<string | undefined>(() =>
-    initial !== undefined ? initial : deriveActiveSlugFromUrl(nodes),
+    initial !== undefined ? initial : deriveActiveSlug(nodes, currentPath),
   );
 
   useEffect(() => {
     const update = () => {
-      const found = deriveActiveSlugFromUrl(nodes);
+      const found = deriveActiveSlug(nodes, currentPath);
       if (found !== undefined) setSlug(found);
     };
     update();
     document.addEventListener(AFTER_NAVIGATE_EVENT, update);
     return () => document.removeEventListener(AFTER_NAVIGATE_EVENT, update);
-  }, [nodes]);
+  }, [nodes, currentPath]);
 
   return slug;
 }
@@ -143,6 +165,13 @@ function RootMenuItemEntry({ item }: { item: SidebarRootMenuItem }) {
 export interface SidebarTreeProps {
   nodes: SidebarNavNode[];
   currentSlug?: string;
+  /**
+   * Explicit current-route override, checked before
+   * `document.documentElement.dataset.zdCurrentPath` and
+   * `window.location.pathname` when deriving the active slug on hydration
+   * and at every View Transition. See `deriveActiveSlug` (zudolab/zudo-doc#3398).
+   */
+  currentPath?: string;
   rootMenuItems?: SidebarRootMenuItem[];
   backToMenuLabel?: string;
   localeLinks?: SidebarLocaleLink[];
@@ -171,8 +200,8 @@ function SidebarFooter({ links, themeDefaultMode }: { links?: SidebarLocaleLink[
   );
 }
 
-export function SidebarTree({ nodes, currentSlug, rootMenuItems, backToMenuLabel, localeLinks, themeDefaultMode }: SidebarTreeProps) {
-  const activeSlug = useActiveSlug(nodes, currentSlug);
+export function SidebarTree({ nodes, currentSlug, currentPath, rootMenuItems, backToMenuLabel, localeLinks, themeDefaultMode }: SidebarTreeProps) {
+  const activeSlug = useActiveSlug(nodes, currentSlug, currentPath);
   const [query, setQuery] = useState("");
   const [showingRootMenu, setShowingRootMenu] = useState(false);
   const filterRef = useRef<HTMLInputElement>(null);

--- a/packages/zudo-doc/src/sidebar-tree-island/index.tsx
+++ b/packages/zudo-doc/src/sidebar-tree-island/index.tsx
@@ -88,8 +88,11 @@ function currentPathOverride(): string | undefined {
  * already set rather than clearing it.
  */
 function deriveActiveSlug(nodes: SidebarNavNode[], pathname?: string): string | undefined {
+  // `||` (not `??`) so an empty-string `pathname` falls through to the live
+  // sources instead of silently disabling derivation — SidebarWithDefaults
+  // defaults its own currentPath to "", so "" is the natural absent shape.
   const resolved =
-    pathname ?? currentPathOverride() ?? (typeof window !== "undefined" ? window.location.pathname : undefined);
+    pathname || currentPathOverride() || (typeof window !== "undefined" ? window.location.pathname : undefined);
   if (!resolved) return undefined;
   return findActiveSlug(nodes, normalizePath(resolved));
 }
@@ -107,13 +110,19 @@ function useActiveSlug(nodes: SidebarNavNode[], initial?: string, currentPath?: 
   );
 
   useEffect(() => {
-    const update = () => {
-      const found = deriveActiveSlug(nodes, currentPath);
+    const update = (pathname?: string) => {
+      const found = deriveActiveSlug(nodes, pathname);
       if (found !== undefined) setSlug(found);
     };
-    update();
-    document.addEventListener(AFTER_NAVIGATE_EVENT, update);
-    return () => document.removeEventListener(AFTER_NAVIGATE_EVENT, update);
+    // The static `currentPath` prop is an SSR-serialized value for the page the
+    // island first hydrated on — valid at hydration time only. Post-navigation
+    // updates must re-read the LIVE sources (dataset override, then
+    // location.pathname); recomputing from the frozen prop would pin the
+    // highlight to the first-loaded page across client-router navigations.
+    const onNavigate = () => update();
+    update(currentPath);
+    document.addEventListener(AFTER_NAVIGATE_EVENT, onNavigate);
+    return () => document.removeEventListener(AFTER_NAVIGATE_EVENT, onNavigate);
   }, [nodes, currentPath]);
 
   return slug;

--- a/packages/zudo-doc/src/sidebar-tree/__tests__/category-meta.test.ts
+++ b/packages/zudo-doc/src/sidebar-tree/__tests__/category-meta.test.ts
@@ -89,4 +89,19 @@ describe("loadCategoryMeta", () => {
     const b = loadCategoryMeta(dir);
     expect(a).toBe(b);
   });
+
+  it("degrades to an empty map without throwing when process.getBuiltinModule is unavailable", () => {
+    const dir = makeFixture();
+    const original = process.getBuiltinModule;
+    // Simulate a runtime (or a future SSG stub) where the builtin resolver
+    // this module depends on is absent — mirrors the #2030 degrade path.
+    // @ts-expect-error test-only removal to simulate an unavailable resolver
+    delete process.getBuiltinModule;
+    try {
+      const meta = loadCategoryMeta(dir);
+      expect(meta.size).toBe(0);
+    } finally {
+      process.getBuiltinModule = original;
+    }
+  });
 });

--- a/packages/zudo-doc/src/sidebar-tree/category-meta.ts
+++ b/packages/zudo-doc/src/sidebar-tree/category-meta.ts
@@ -7,11 +7,71 @@
  * from the consumer project (`@/utils/...`). Behaviour is intentionally
  * identical to the original so call sites can swap implementations 1:1.
  */
-import fs from "node:fs";
-import path from "node:path";
 import type { CategoryMeta } from "./types.js";
 
 const cache = new Map<string, Map<string, CategoryMeta>>();
+
+/** Structural stand-in for `fs.Dirent` — only the members this module reads. */
+interface DirEntry {
+  isDirectory(): boolean;
+  name: string;
+}
+
+interface FsBuiltin {
+  readdirSync(dir: string, options: { withFileTypes: true }): DirEntry[];
+  existsSync(path: string): boolean;
+  readFileSync(path: string, encoding: "utf-8"): string;
+}
+
+interface PathBuiltin {
+  resolve(...segments: string[]): string;
+  join(...segments: string[]): string;
+  relative(from: string, to: string): string;
+}
+
+interface Builtins {
+  fs: FsBuiltin;
+  path: PathBuiltin;
+}
+
+/**
+ * Resolve `node:fs`/`node:path` at call time via `process.getBuiltinModule`
+ * (Node >= 22.3; CI's setup-node 22 and local dev Node 24 both satisfy this)
+ * instead of top-level `import fs from "node:fs"`. This was this module's
+ * only static `node:*` import in the chrome render graph (#3394 companion 2).
+ *
+ * IMPORTANT — mechanism change vs. the old degrade path (#2030): the legacy
+ * static-import version relied on zfb's SSG runtime *stubbing the `node:fs`/
+ * `node:path` import specifiers themselves* — any property access on the
+ * stub threw, so `loadCategoryMeta` silently fell back to an empty map.
+ * `process.getBuiltinModule` does not go through specifier resolution at
+ * all — it asks the running Node process directly for the real builtin — so
+ * it most likely BYPASSES that stub and returns the genuine `fs`/`path`
+ * modules even under the SSG runtime, meaning this code may now actually
+ * read `_category_.json` from disk at build time where it previously
+ * degraded to empty. This is a call-site-level analysis only; it has not
+ * been confirmed against a real `pnpm build` output diff (deferred — see
+ * PR discussion / issue #3397). The try/catch below is kept as a defensive
+ * fallback (older Node without `getBuiltinModule`, or a future stub that
+ * targets `process.getBuiltinModule` itself) so the #2030 empty-map
+ * degradation still fires if builtins genuinely cannot be resolved.
+ */
+function resolveBuiltins(): Builtins | undefined {
+  const getBuiltinModule = (
+    globalThis as {
+      process?: { getBuiltinModule?: (id: string) => unknown };
+    }
+  ).process?.getBuiltinModule;
+  if (typeof getBuiltinModule !== "function") return undefined;
+  try {
+    const fs = getBuiltinModule("node:fs") as FsBuiltin | undefined;
+    const path = getBuiltinModule("node:path") as PathBuiltin | undefined;
+    if (!fs || !path) return undefined;
+    return { fs, path };
+  } catch {
+    return undefined;
+  }
+}
 
 /**
  * Scan `contentDir` recursively for `_category_.json` files. Each file's
@@ -26,23 +86,22 @@ const cache = new Map<string, Map<string, CategoryMeta>>();
  * files for each page is wasteful.
  */
 export function loadCategoryMeta(contentDir: string): Map<string, CategoryMeta> {
-  // zfb's SSG runtime stubs node:* — ANY property access on fs/path throws
-  // ("node:* is not available under the SSG runtime"). The legacy host
-  // implementation only touched node APIs inside scanDir's try/catch, so under
-  // that runtime it silently yielded an empty map (routes still enumerate;
-  // sidecar meta just doesn't apply). Preserve that exact degradation: fall
-  // back to the raw string as the cache key and let scanDir's try/catch
-  // produce the empty result (#2030).
+  const builtins = resolveBuiltins();
+  // Builtins unavailable: preserve the #2030 degrade-to-empty-map behaviour
+  // verbatim — cache the raw (unresolved) contentDir key, skip the scan, and
+  // return an empty map. Routes still enumerate; sidecar meta just doesn't apply.
   let absolute: string;
   try {
-    absolute = path.resolve(contentDir);
+    absolute = builtins ? builtins.path.resolve(contentDir) : contentDir;
   } catch {
     absolute = contentDir;
   }
   const cached = cache.get(absolute);
   if (cached) return cached;
   const result = new Map<string, CategoryMeta>();
-  scanDir(absolute, absolute, result);
+  if (builtins) {
+    scanDir(builtins, absolute, absolute, result);
+  }
   cache.set(absolute, result);
   return result;
 }
@@ -53,11 +112,13 @@ export function clearCategoryMetaCache(): void {
 }
 
 function scanDir(
+  builtins: Builtins,
   baseDir: string,
   currentDir: string,
   result: Map<string, CategoryMeta>,
 ): void {
-  let entries: fs.Dirent[];
+  const { fs, path } = builtins;
+  let entries: DirEntry[];
   try {
     entries = fs.readdirSync(currentDir, { withFileTypes: true });
   } catch {
@@ -70,13 +131,13 @@ function scanDir(
     const fullPath = path.join(currentDir, entry.name);
     const categoryFile = path.join(fullPath, "_category_.json");
     if (fs.existsSync(categoryFile)) {
-      const meta = readCategoryFile(categoryFile);
+      const meta = readCategoryFile(builtins, categoryFile);
       if (meta) {
         const relativePath = path.relative(baseDir, fullPath);
         result.set(relativePath, meta);
       }
     }
-    scanDir(baseDir, fullPath, result);
+    scanDir(builtins, baseDir, fullPath, result);
   }
 }
 
@@ -86,10 +147,10 @@ function scanDir(
  * the builder treats absence as "no metadata for this directory" rather
  * than crashing the whole build over a stray comma.
  */
-function readCategoryFile(filePath: string): CategoryMeta | undefined {
+function readCategoryFile(builtins: Builtins, filePath: string): CategoryMeta | undefined {
   let raw: string;
   try {
-    raw = fs.readFileSync(filePath, "utf-8");
+    raw = builtins.fs.readFileSync(filePath, "utf-8");
   } catch {
     return undefined;
   }

--- a/packages/zudo-doc/src/sidebar-tree/category-meta.ts
+++ b/packages/zudo-doc/src/sidebar-tree/category-meta.ts
@@ -90,12 +90,7 @@ export function loadCategoryMeta(contentDir: string): Map<string, CategoryMeta> 
   // Builtins unavailable: preserve the #2030 degrade-to-empty-map behaviour
   // verbatim — cache the raw (unresolved) contentDir key, skip the scan, and
   // return an empty map. Routes still enumerate; sidecar meta just doesn't apply.
-  let absolute: string;
-  try {
-    absolute = builtins ? builtins.path.resolve(contentDir) : contentDir;
-  } catch {
-    absolute = contentDir;
-  }
+  const absolute = builtins ? builtins.path.resolve(contentDir) : contentDir;
   const cached = cache.get(absolute);
   if (cached) return cached;
   const result = new Map<string, CategoryMeta>();

--- a/packages/zudo-doc/src/site-schema/doc-route-entries.ts
+++ b/packages/zudo-doc/src/site-schema/doc-route-entries.ts
@@ -1,0 +1,269 @@
+// site-schema/doc-route-entries — the "which doc routes exist" contract
+// (zudolab/zudo-doc#3395; originally epic #2344, S6).
+//
+// This is the SAME builder `@takazudo/zudo-doc/doc-route-entries` has always
+// exported, relocated here and made generic over the entry shape so its
+// declaration graph carries no `@takazudo/zfb` edge. `../doc-route-entries`
+// re-exports it and re-binds every type to the zfb-typed `DocPageEntry`, so
+// existing importers keep the exact types they had.
+//
+// The contract it pins:
+//   - an entry with `category_no_page: true` carries category metadata only and
+//     emits NO route;
+//   - every category with children but no `index.mdx` emits one auto-index route;
+//   - each emitted route carries its breadcrumbs, prev/next, and headings
+//     already computed.
+//
+// MEMOIZATION: the result is memoized with the #1902 WeakMap pattern
+// (memoizeDerived keyed on the identity-stable `source.docs` array + a
+// per-route signature), so the expensive per-entry work — extractHeadings,
+// buildBreadcrumbs, prev/next resolution — runs ONCE per entry per build, not
+// once per entry per page (zfb re-invokes paths() once per built page).
+
+import { memoizeDerived } from "../nav-source-cache/index.js";
+import {
+  resolveDocPrevNext,
+  flattenSubtree,
+  rewriteNavHref,
+  remapNavChildHrefs,
+} from "../doc-route-paths/index.js";
+import { buildBreadcrumbs as buildBreadcrumbsImpl } from "./nav-tree.js";
+import type {
+  AutoIndexNode,
+  BreadcrumbItem,
+  CategoryMeta,
+  DocEntryLike,
+  DocNavNode,
+  DocPageBaseProps,
+  HeadingItem,
+  NavSourceDocs,
+} from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** One enumerated doc route: a content entry or an auto-generated category
+ *  index, with all per-page derived data pre-computed. */
+export interface DocRouteEntry<E extends DocEntryLike = DocEntryLike> {
+  /** Canonical route slug ("" for the docs root index — #1891). */
+  slug: string;
+  /** Optional-catchall params array — `toSlugParams(slug)` ([] for the root). */
+  slugParams: string[];
+  /**
+   * True when the entry came from the base collection rather than the locale
+   * collection (`!localeSlugSet.has(slug)`). Only meaningful on routes whose
+   * nav source performs a locale merge — routes without one (default-locale /
+   * versioned-EN, where `localeSlugSet` is empty) must ignore this field.
+   * Always false for autoIndex items.
+   */
+  isFallback: boolean;
+  /** Shared page props (kind/entry/autoIndex/breadcrumbs/prev/next/headings). */
+  props: DocPageBaseProps<E>;
+}
+
+export interface BuildDocRouteEntriesArgs<E extends DocEntryLike = DocEntryLike> {
+  /** Identity-stable nav source for this route's (locale, version) context. */
+  source: NavSourceDocs<E>;
+  /** Active locale for nav-tree labels and breadcrumbs. */
+  locale: string;
+  /**
+   * Unique memo signature for this route context. Each route file passes its
+   * own prefix plus the loop variables (version slug / locale), e.g.
+   * "docs;en", "locale-docs;ja", "v-docs;1.0", "v-locale-docs;1.0;ja" —
+   * call sites that share a docs array identity must never collide on a key.
+   */
+  routeSig: string;
+  /** Versioned URL closure bound to the route's version (+ locale). Presence
+   *  switches the versioned behaviors (breadcrumbs, prev/next, child hrefs). */
+  urlFor?: (slug: string) => string;
+}
+
+// ---------------------------------------------------------------------------
+// Injected context for createDocRouteEntries
+// ---------------------------------------------------------------------------
+
+/**
+ * Context slice `createDocRouteEntries` derives its bag from (epic Collapse
+ * Wiring Shells #2420, FACTORIES #2424 — breaking signature). STRUCTURAL SUBSET
+ * of the unified `RouteContext`/`ChromeContext` — the nav-tree builder is
+ * reconstructed by binding the context's 4-arg `buildNavTree` to `docsUrl`, and
+ * the breadcrumb trail by binding the package `buildBreadcrumbs` to the
+ * locale-prefixed `withBase` base, exactly as the pre-collapse wiring did.
+ */
+export interface DocRouteEntriesContext<E extends DocEntryLike = DocEntryLike> {
+  /** Default locale code (drives the breadcrumb base-prefix selection). */
+  defaultLocale: string;
+  /** Build the nav tree for a locale (4-arg form with an explicit href builder). */
+  buildNavTree: (
+    docs: E[],
+    locale: string,
+    categoryMeta: Map<string, CategoryMeta> | undefined,
+    buildHref: (slug: string, locale: string) => string,
+  ) => DocNavNode[];
+  /** Build a docs URL for the given slug and locale. */
+  docsUrl: (slug: string, locale?: string) => string;
+  /** Prefix a path with the configured base directory. */
+  withBase: (path: string) => string;
+  /** Collect all auto-generated index nodes (categories without index.mdx). */
+  collectAutoIndexNodes: (tree: DocNavNode[]) => AutoIndexNode[];
+  /** Determine the nav section (categoryMatch) for a slug. */
+  getNavSectionForSlug: (slug: string) => string | undefined;
+  /** Filter top-level nav nodes by a categoryMatch value. */
+  getNavSubtree: (tree: DocNavNode[], categoryMatch?: string) => DocNavNode[];
+  /** Convert a content entry slug to a canonical route slug. */
+  toRouteSlug: (entrySlug: string) => string;
+  /** Convert a canonical route slug to an optional-catchall params array. */
+  toSlugParams: (slug: string) => string[];
+  /** Extract headings from a raw MDX body (bound to settings depth/strategy). */
+  extractHeadings: (body: string) => HeadingItem[];
+}
+
+/**
+ * Result of `createDocRouteEntries`. Contains the `buildDocRouteEntries`
+ * function bound to the injected context.
+ */
+export interface DocRouteEntriesAPI<E extends DocEntryLike = DocEntryLike> {
+  /**
+   * Enumerate all doc routes for one (locale, version) context, with per-entry
+   * derived data pre-computed. Memoized per build on the identity-stable
+   * `source.docs` array.
+   */
+  buildDocRouteEntries: (args: BuildDocRouteEntriesArgs<E>) => DocRouteEntry<E>[];
+}
+
+// ---------------------------------------------------------------------------
+// createDocRouteEntries factory
+// ---------------------------------------------------------------------------
+
+// Per-factory memo namespace. `source.docs` identity + `routeSig` alone do NOT
+// identify a result: two factories built over the same docs and the same
+// routeSig but different `docsUrl` / `withBase` / `urlFor` closures produce
+// DIFFERENT hrefs and breadcrumbs, and would otherwise serve each other's
+// cached output. Prefixing the memo key with a per-instance id scopes the cache
+// to the factory that computed it. A build creates the factory once
+// (`createRouteContext` is called once per build), so this costs no hit rate.
+let nextFactoryId = 1;
+
+/**
+ * Create the `buildDocRouteEntries` function bound to the host's injected
+ * context.
+ *
+ * @example
+ * ```ts
+ * import { createDocRouteEntries } from "@takazudo/zudo-doc/site-schema";
+ *
+ * export const { buildDocRouteEntries } = createDocRouteEntries(routeContext);
+ * ```
+ */
+export function createDocRouteEntries<E extends DocEntryLike = DocEntryLike>(
+  ctx: DocRouteEntriesContext<E>,
+): DocRouteEntriesAPI<E> {
+  const factoryId = nextFactoryId++;
+
+  // Derive the old narrow bag from the unified context: bind the 4-arg
+  // `buildNavTree` to `docsUrl` for the 3-arg form the body uses, and bind the
+  // package `buildBreadcrumbs` to the locale-prefixed `withBase` base.
+  const defaultLocale = ctx.defaultLocale;
+  const buildNavTree = (
+    docs: E[],
+    locale: string,
+    categoryMeta: Map<string, CategoryMeta>,
+  ): DocNavNode[] =>
+    ctx.buildNavTree(docs, locale, categoryMeta, (slug, loc) => ctx.docsUrl(slug, loc));
+  const buildBreadcrumbs = (
+    tree: DocNavNode[],
+    slug: string,
+    locale: string,
+    urlFor?: (slug: string) => string,
+  ): BreadcrumbItem[] =>
+    buildBreadcrumbsImpl(
+      tree,
+      slug,
+      locale === defaultLocale ? ctx.withBase("/") : ctx.withBase(`/${locale}/`),
+      urlFor,
+    );
+  const collectAutoIndexNodes = ctx.collectAutoIndexNodes;
+  const getNavSectionForSlug = ctx.getNavSectionForSlug;
+  const getNavSubtree = ctx.getNavSubtree;
+  const toRouteSlug = ctx.toRouteSlug;
+  const toSlugParams = ctx.toSlugParams;
+  const extractHeadings = ctx.extractHeadings;
+
+  function buildDocRouteEntries(args: BuildDocRouteEntriesArgs<E>): DocRouteEntry<E>[] {
+    const { source, locale, routeSig, urlFor } = args;
+
+    return memoizeDerived([source.docs], `docRouteEntries;${factoryId};${routeSig}`, () => {
+      const { docs, navDocs, categoryMeta, localeSlugSet } = source;
+
+      // Nav docs: exclude unlisted (for sidebar/prev-next) but keep for breadcrumbs
+      const tree = buildNavTree(navDocs, locale, categoryMeta);
+      // Breadcrumb tree: latest routes use the full tree (including unlisted)
+      // for accurate crumbs; versioned routes resolve crumbs against the nav
+      // tree itself (#1916 #1).
+      const breadcrumbTree = urlFor
+        ? tree
+        : buildNavTree(docs, locale, categoryMeta);
+
+      const result: DocRouteEntry<E>[] = [];
+
+      // Regular doc pages
+      for (const entry of docs) {
+        // A `category_no_page` index.mdx carries category metadata only — keep
+        // it in the nav tree but emit NO route for it.
+        if (entry.data.category_no_page === true) continue;
+
+        const slug = entry.data.slug ?? toRouteSlug(entry.slug);
+        const navSection = getNavSectionForSlug(slug);
+        const subtree = getNavSubtree(tree, navSection);
+
+        const { prev: prevNode, next: nextNode } = resolveDocPrevNext(
+          tree,
+          flattenSubtree(subtree),
+          slug,
+          entry.data as { pagination_prev?: string | null; pagination_next?: string | null },
+        );
+
+        result.push({
+          slug,
+          slugParams: toSlugParams(slug),
+          isFallback: !localeSlugSet.has(slug),
+          props: {
+            kind: "entry",
+            entry,
+            breadcrumbs: buildBreadcrumbs(breadcrumbTree, slug, locale, urlFor),
+            prev: rewriteNavHref(prevNode, urlFor),
+            next: rewriteNavHref(nextNode, urlFor),
+            headings: extractHeadings(entry.body ?? ""),
+          },
+        });
+      }
+
+      // Auto-generated index pages for categories without index.mdx
+      for (const node of collectAutoIndexNodes(tree)) {
+        result.push({
+          slug: node.slug,
+          slugParams: toSlugParams(node.slug),
+          isFallback: false,
+          props: {
+            kind: "autoIndex",
+            autoIndex: urlFor
+              ? {
+                  ...node,
+                  children: remapNavChildHrefs(node.children, urlFor) as DocNavNode[],
+                }
+              : node,
+            breadcrumbs: buildBreadcrumbs(breadcrumbTree, node.slug, locale, urlFor),
+            prev: null,
+            next: null,
+            headings: [],
+          },
+        });
+      }
+
+      return result;
+    });
+  }
+
+  return { buildDocRouteEntries };
+}

--- a/packages/zudo-doc/src/site-schema/index.ts
+++ b/packages/zudo-doc/src/site-schema/index.ts
@@ -1,0 +1,112 @@
+// @takazudo/zudo-doc/site-schema — the browser-safe nav / breadcrumb / pager
+// domain (zudolab/zudo-doc#3395).
+//
+// Everything here answers "what is the shape of this documentation site?":
+// which routes exist, how they nest, what the previous/next page is, and what
+// trail leads to a given slug. It is deliberately free of rendering, of disk
+// access, and of the zfb engine, so a browser bundle, a Worker, or a non-zfb
+// tool can compute the same answers the SSG build computes.
+//
+// THREE GUARDS keep that promise (all must stay green):
+//   1. `src/__tests__/site-schema.test.ts` bundles this barrel with esbuild
+//      `platform: "neutral"` and fails on any reachable `node:*`, `preact`,
+//      `.css`, `virtual:`, or `@takazudo/zfb*` specifier — and walks the
+//      emitted TRANSITIVE `.d.ts` graph for the same.
+//   2. `scripts/check-site-schema.mjs` repeats the bundle check against the
+//      built `dist/site-schema/index.js` in the `prepack` chain, so a publish
+//      cannot ship a graph the source-level guard would have rejected.
+//   3. The `package.json#exports` keyset snapshot in
+//      `src/__tests__/public-api-snapshot.test.ts`.
+//
+// NOT exported, on purpose: the component-side `findPath` / `buildBreadcrumbItems`
+// pair in `../breadcrumb` is presentation detail. The blessed breadcrumb
+// contract is the route-time `buildBreadcrumbs` below — the slug-split walk over
+// `DocNavNode` that produces `props.breadcrumbs`.
+
+/**
+ * Contract version of this module's shape. Bump on any breaking change to the
+ * exported types or functions so a consumer can fail closed rather than
+ * silently mis-read a newer schema (`@takazudo/zudo-doc/catalog` precedent).
+ */
+export const schemaVersion = 1;
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export type {
+  AutoIndexNode,
+  BreadcrumbItem,
+  CategoryMeta,
+  CollectionEntryLike,
+  DocEntryLike,
+  DocNavNode,
+  DocPageAutoIndexProps,
+  DocPageBaseProps,
+  DocPageEntryProps,
+  DocPageFrontmatter,
+  HeadingItem,
+  NavSourceDocs,
+  SidebarFrontmatter,
+  SidebarNode,
+} from "./types.js";
+
+export type {
+  BuildDocRouteEntriesArgs,
+  DocRouteEntriesAPI,
+  DocRouteEntriesContext,
+  DocRouteEntry,
+} from "./doc-route-entries.js";
+
+export type { BuildHref, BuildNavTreeOptions } from "./nav-tree.js";
+
+export type { PaginationOverrides } from "../doc-route-paths/index.js";
+
+// ── Nav tree, breadcrumbs, auto-index ───────────────────────────────────────
+
+export {
+  buildBreadcrumbs,
+  buildNavTree,
+  collectAutoIndexNodes,
+  findNode,
+  firstRoutedHref,
+  groupSatelliteNodes,
+  isNavVisible,
+} from "./nav-tree.js";
+
+// ── Prev/next and href remapping ────────────────────────────────────────────
+//
+// `findNode` is exported from `./nav-tree.js` above; `doc-route-paths` carries
+// a structurally identical copy that this barrel deliberately does not
+// re-export a second time under the same name.
+
+export {
+  flattenSubtree,
+  flattenTree,
+  remapNavChildHrefs,
+  resolveDocPrevNext,
+  rewriteNavHref,
+} from "../doc-route-paths/index.js";
+
+// ── Nav scoping (headerNav categoryMatch) ───────────────────────────────────
+
+export {
+  getCategoryOrder,
+  getNavSectionForSlug,
+  getNavSubtree,
+} from "../nav-scope/index.js";
+
+export type { NavScopeHeaderNavItem, NavScopeNode } from "../nav-scope/index.js";
+
+// ── Sidebar tree primitive ──────────────────────────────────────────────────
+//
+// From `build-tree.js`, NOT the `sidebar-tree` barrel: the barrel also exports
+// `loadCategoryMeta`, which reads sidecar files through `node:fs`.
+
+export { buildSidebarTree } from "../sidebar-tree/build-tree.js";
+
+// ── Headings ────────────────────────────────────────────────────────────────
+
+export { extractHeadings } from "../extract-headings/index.js";
+
+// ── Route enumeration ───────────────────────────────────────────────────────
+
+export { createDocRouteEntries } from "./doc-route-entries.js";

--- a/packages/zudo-doc/src/site-schema/index.ts
+++ b/packages/zudo-doc/src/site-schema/index.ts
@@ -56,7 +56,7 @@ export type {
   DocRouteEntry,
 } from "./doc-route-entries.js";
 
-export type { BuildHref, BuildNavTreeOptions } from "./nav-tree.js";
+export type { BuildHref } from "./nav-tree.js";
 
 export type { PaginationOverrides } from "../doc-route-paths/index.js";
 

--- a/packages/zudo-doc/src/site-schema/nav-tree.ts
+++ b/packages/zudo-doc/src/site-schema/nav-tree.ts
@@ -32,10 +32,6 @@ export function isNavVisible(doc: DocEntryLike): boolean {
 /** A docs-href builder: `(slug, locale) => url`. */
 export type BuildHref = (slug: string, locale: string) => string;
 
-export interface BuildNavTreeOptions {
-  buildHref?: BuildHref;
-}
-
 function toNavNode(node: SidebarNode): DocNavNode {
   return {
     slug: node.id,
@@ -100,9 +96,8 @@ export function buildNavTree(
   locale: string,
   categoryMeta: Map<string, CategoryMeta> | undefined,
   buildHref: BuildHref,
-  options?: BuildNavTreeOptions,
 ): DocNavNode[] {
-  const href: BuildHref = options?.buildHref ?? buildHref;
+  const href: BuildHref = buildHref;
   const sidebarTree = buildSidebarTree(
     docs,
     locale,

--- a/packages/zudo-doc/src/site-schema/nav-tree.ts
+++ b/packages/zudo-doc/src/site-schema/nav-tree.ts
@@ -1,0 +1,214 @@
+// site-schema/nav-tree — the pure nav-tree / breadcrumb helpers, moved
+// verbatim out of `routes/_docs-helpers.ts` (zudolab/zudo-doc#3395).
+//
+// These reproduce a host project's `buildNavTree` / `buildBreadcrumbs` /
+// `collectAutoIndexNodes` / `groupSatelliteNodes` / `findNode` /
+// `firstRoutedHref` on top of the package primitive `buildSidebarTree`.
+// Faithful to the host derivation (root-index node synthesis, DocNavNode shape,
+// satellite grouping, breadcrumb walk) but without the host-only LRU / identity
+// caches: build-time array-identity stability already comes from the
+// snapshot-anchored `stableDocs` (`routes/_docs-helpers.ts`) plus
+// `memoizeDerived` in the factories.
+//
+// `buildSidebarTree` is imported from `../sidebar-tree/build-tree.js` and NOT
+// from the `../sidebar-tree/index.js` barrel — the barrel also re-exports
+// `loadCategoryMeta`, which reads `_category_.json` sidecars through `node:fs`
+// and would drag a node builtin into this module's browser-safe graph.
+
+import { buildSidebarTree } from "../sidebar-tree/build-tree.js";
+import type { CategoryMeta, SidebarNode } from "../sidebar-tree/types.js";
+import { toRouteSlug } from "../slug/index.js";
+import type {
+  BreadcrumbItem,
+  DocEntryLike,
+  DocNavNode,
+} from "./types.js";
+
+/** Filter predicate: true when a doc should appear in navigation. */
+export function isNavVisible(doc: DocEntryLike): boolean {
+  return !doc.data.unlisted && !doc.data.standalone;
+}
+
+/** A docs-href builder: `(slug, locale) => url`. */
+export type BuildHref = (slug: string, locale: string) => string;
+
+export interface BuildNavTreeOptions {
+  buildHref?: BuildHref;
+}
+
+function toNavNode(node: SidebarNode): DocNavNode {
+  return {
+    slug: node.id,
+    label: node.label,
+    description: node.description,
+    position: node.sidebar_position ?? 999,
+    href: node.href,
+    hasPage: node.hasPage,
+    children: node.children.map(toNavNode),
+    sortOrder: node.sortOrder ?? "asc",
+  };
+}
+
+/** Last entry whose package-derived slug is empty ("") — the entry the shared
+ *  builder skips. Last one wins (mirrors the host builder's overwrite). */
+function findRootIndexDoc(docs: DocEntryLike[]): DocEntryLike | undefined {
+  let found: DocEntryLike | undefined;
+  for (const d of docs) {
+    const slug = d.data.slug ?? toRouteSlug(d.slug);
+    if (slug === "") found = d;
+  }
+  return found;
+}
+
+function toRootNavNode(
+  doc: DocEntryLike,
+  locale: string,
+  buildHref: BuildHref,
+  categoryMeta?: Map<string, CategoryMeta>,
+): DocNavNode {
+  const meta = categoryMeta?.get("");
+  const noPage = doc.data.category_no_page ?? meta?.noPage;
+  const sortOrder =
+    (doc.data.category_sort_order as "asc" | "desc" | undefined) ?? meta?.sortOrder ?? "asc";
+  return {
+    slug: "",
+    label:
+      (doc.data.sidebar_label as string | undefined) ??
+      doc.data.title ??
+      meta?.label ??
+      "",
+    description: doc.data.description ?? meta?.description,
+    position: (doc.data.sidebar_position as number | undefined) ?? meta?.position ?? 999,
+    href: noPage ? undefined : buildHref("", locale),
+    hasPage: noPage !== true,
+    children: [],
+    sortOrder,
+  };
+}
+
+/**
+ * Build a recursive navigation tree from a flat doc collection. Delegates tree
+ * construction to the shared `buildSidebarTree`; keeps the host-side concerns
+ * (DocNavNode shape, root-index node synthesis). `buildHref` parameterizes the
+ * href space (default: the injected `docsUrl`). Unlike the host copy this drops
+ * the LRU / identity caches — the snapshot-anchored `stableDocs` already makes
+ * the input arrays identity-stable so the factory-level `memoizeDerived` short-
+ * circuits per build.
+ */
+export function buildNavTree(
+  docs: DocEntryLike[],
+  locale: string,
+  categoryMeta: Map<string, CategoryMeta> | undefined,
+  buildHref: BuildHref,
+  options?: BuildNavTreeOptions,
+): DocNavNode[] {
+  const href: BuildHref = options?.buildHref ?? buildHref;
+  const sidebarTree = buildSidebarTree(
+    docs,
+    locale,
+    {
+      categoryMeta,
+      buildHref: (slug, loc) => href(slug, loc),
+      // Host call sites own visibility; disable the builder's default filter so
+      // breadcrumb (unfiltered) and nav (pre-filtered) paths are unchanged.
+      isNavVisible: () => true,
+    },
+  );
+  const result = sidebarTree.map(toNavNode);
+
+  const rootDoc = findRootIndexDoc(docs);
+  if (rootDoc) {
+    result.push(toRootNavNode(rootDoc, locale, href, categoryMeta));
+    result.sort((a, b) => {
+      const posCompare = a.position - b.position;
+      if (posCompare !== 0) return posCompare;
+      return a.slug.localeCompare(b.slug);
+    });
+  }
+  return result;
+}
+
+/** Group "satellite" nodes (slug-prefix siblings) under their primary node. */
+export function groupSatelliteNodes(tree: DocNavNode[], prefixes: string[]): DocNavNode[] {
+  const result = [...tree];
+  for (const prefix of prefixes) {
+    const primaryIdx = result.findIndex((n) => n.slug === prefix);
+    if (primaryIdx < 0) continue;
+    const primary = result[primaryIdx];
+    if (!primary) continue;
+    const satelliteIdxs: number[] = [];
+    for (let i = 0; i < result.length; i++) {
+      const node = result[i];
+      if (node && i !== primaryIdx && node.slug.startsWith(`${prefix}-`)) {
+        satelliteIdxs.push(i);
+      }
+    }
+    if (satelliteIdxs.length === 0) continue;
+    const extraChildren: DocNavNode[] = [];
+    for (const idx of satelliteIdxs) {
+      const node = result[idx];
+      if (node) extraChildren.push(node);
+    }
+    result[primaryIdx] = { ...primary, children: [...primary.children, ...extraChildren] };
+    for (const idx of satelliteIdxs.reverse()) result.splice(idx, 1);
+  }
+  return result;
+}
+
+/** Find a node by slug anywhere in the tree. */
+export function findNode(nodes: DocNavNode[], slug: string): DocNavNode | undefined {
+  for (const node of nodes) {
+    if (node.slug === slug) return node;
+    const found = findNode(node.children, slug);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+/** Href of the first routed descendant, walking children depth-first. */
+export function firstRoutedHref(node: DocNavNode): string | undefined {
+  for (const child of node.children) {
+    if (child.hasPage && child.href) return child.href;
+    const nested = firstRoutedHref(child);
+    if (nested) return nested;
+  }
+  return undefined;
+}
+
+/** Collect all category nodes that have children but no page (no index.mdx). */
+export function collectAutoIndexNodes(nodes: DocNavNode[]): DocNavNode[] {
+  const result: DocNavNode[] = [];
+  for (const node of nodes) {
+    if (!node.hasPage && node.children.length > 0 && node.href) result.push(node);
+    result.push(...collectAutoIndexNodes(node.children));
+  }
+  return result;
+}
+
+/** Build breadcrumb trail by walking the nav tree. `homeHref` is the locale
+ *  docs root (injected). `hrefFor` optionally remaps intermediate crumbs into
+ *  a versioned URL space. */
+export function buildBreadcrumbs(
+  tree: DocNavNode[],
+  slug: string,
+  homeHref: string,
+  hrefFor?: (slug: string) => string,
+): BreadcrumbItem[] {
+  const parts = slug.split("/");
+  const crumbs: BreadcrumbItem[] = [{ label: "", href: homeHref }];
+  let nodes = tree;
+  for (let i = 0; i < parts.length; i++) {
+    const partialSlug = parts.slice(0, i + 1).join("/");
+    const node = nodes.find((n) => n.slug === partialSlug);
+    if (!node) break;
+    const isLast = i === parts.length - 1;
+    const href = isLast
+      ? undefined
+      : hrefFor && node.href !== undefined
+        ? hrefFor(node.slug)
+        : node.href;
+    crumbs.push({ label: node.label, href });
+    nodes = node.children;
+  }
+  return crumbs;
+}

--- a/packages/zudo-doc/src/site-schema/types.ts
+++ b/packages/zudo-doc/src/site-schema/types.ts
@@ -1,0 +1,155 @@
+// site-schema/types — the canonical, browser-safe type surface for the
+// nav / breadcrumb / pager domain (zudolab/zudo-doc#3395).
+//
+// THE CONTRACT: nothing reachable from this module — at runtime OR through the
+// emitted `.d.ts` graph — may import `@takazudo/zfb*`, a `node:*` builtin,
+// preact, a stylesheet, or a `virtual:` module. That is what makes
+// `@takazudo/zudo-doc/site-schema` consumable from a browser bundle, a Worker,
+// or any non-zfb toolchain.
+//
+// WHY THE ENTRY TYPE IS GENERIC: the renderer-side entry type
+// (`DocPageEntry` in `../doc-page-props`) is an alias of zfb's
+// `CollectionEntry`, so naming it here would re-introduce the zfb declaration
+// edge this module exists to cut. Instead the props/route types below are
+// generic over the entry shape and default to the structural
+// {@link DocEntryLike}; `../doc-page-props` re-binds them to the zfb entry so
+// its own importers keep the exact types they have today.
+
+import type {
+  CategoryMeta,
+  CollectionEntryLike,
+  SidebarFrontmatter,
+  SidebarNode,
+} from "../sidebar-tree/types.js";
+import type { BreadcrumbItem } from "../breadcrumb/types.js";
+import type { HeadingItem } from "../extract-headings/index.js";
+
+export type {
+  BreadcrumbItem,
+  CategoryMeta,
+  CollectionEntryLike,
+  HeadingItem,
+  SidebarFrontmatter,
+  SidebarNode,
+};
+
+// ---------------------------------------------------------------------------
+// Structural navigation node
+// ---------------------------------------------------------------------------
+
+/**
+ * Nav tree node shape as consumed by doc-route pages.
+ *
+ * Structurally identical to a host project's `NavNode`. Defined here so the
+ * package types depend on no host alias and no engine package; a host `NavNode`
+ * is a structural subtype and assignable wherever `DocNavNode` is expected.
+ */
+export interface DocNavNode {
+  slug: string;
+  label: string;
+  description?: string;
+  position: number;
+  href?: string;
+  hasPage: boolean;
+  children: DocNavNode[];
+  sortOrder?: "asc" | "desc";
+  collapsed?: boolean;
+}
+
+/** A category node with children but no page of its own — an auto-index. */
+export interface AutoIndexNode extends DocNavNode {
+  children: DocNavNode[];
+}
+
+// ---------------------------------------------------------------------------
+// Frontmatter + entry shapes
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal docs frontmatter shape consumed by the doc-page types.
+ *
+ * A structural subset of a project's full docs schema — only the fields the
+ * nav/route domain actually reads. A richer `DocsData` is a structural
+ * supertype and is assignable here.
+ */
+export interface DocPageFrontmatter {
+  title: string;
+  description?: string;
+  slug?: string;
+  draft?: boolean;
+  unlisted?: boolean;
+  standalone?: boolean;
+  sidebar_position?: number;
+  sidebar_label?: string;
+  category_no_page?: boolean;
+  category_sort_order?: "asc" | "desc";
+  pagination_prev?: string | null;
+  pagination_next?: string | null;
+  tags?: string[];
+  [key: string]: unknown;
+}
+
+/**
+ * The structural doc-collection entry this domain reads: a slug, docs
+ * frontmatter, and an optional raw body. zfb's `CollectionEntry<DocPageFrontmatter>`
+ * (exported as `DocPageEntry` from `@takazudo/zudo-doc/doc-page-props`) is
+ * assignable to it, as is any plain fixture object of the same shape.
+ */
+export type DocEntryLike = CollectionEntryLike<DocPageFrontmatter>;
+
+// ---------------------------------------------------------------------------
+// Doc-page props — generic over the entry shape
+// ---------------------------------------------------------------------------
+
+/** Shared fields present in every doc-page route. */
+interface DocPagePropsBase {
+  breadcrumbs: BreadcrumbItem[];
+  prev: DocNavNode | null;
+  next: DocNavNode | null;
+  /** Depth-2/3/4 headings extracted from the MDX body, for SSG TOC links. */
+  headings: HeadingItem[];
+}
+
+/** Branch: a real content entry. `autoIndex` is absent. */
+export interface DocPageEntryProps<E extends DocEntryLike = DocEntryLike>
+  extends DocPagePropsBase {
+  kind: "entry";
+  entry: E;
+  autoIndex?: undefined;
+}
+
+/** Branch: an auto-generated category index. `entry` is absent. */
+export interface DocPageAutoIndexProps extends DocPagePropsBase {
+  kind: "autoIndex";
+  autoIndex: AutoIndexNode;
+  entry?: undefined;
+}
+
+/** Discriminated union for the `kind` prop. Narrow via `props.kind === "entry"`. */
+export type DocPageBaseProps<E extends DocEntryLike = DocEntryLike> =
+  | DocPageEntryProps<E>
+  | DocPageAutoIndexProps;
+
+// ---------------------------------------------------------------------------
+// Nav source
+// ---------------------------------------------------------------------------
+
+/**
+ * The resolved, identity-stable doc set for one (locale, version) context —
+ * the input every route-entry enumeration starts from.
+ *
+ * The concrete resolver that PRODUCES one (`createNavSourceDocs`) reads
+ * `_category_.json` sidecars off disk and therefore stays in
+ * `@takazudo/zudo-doc/nav-source-docs`; only the shape is browser-safe.
+ */
+export interface NavSourceDocs<E extends DocEntryLike = DocEntryLike> {
+  /** Full doc list (merged + draft-filtered; unlisted retained per options). */
+  docs: E[];
+  /** `docs.filter(isNavVisible)` — stable instance for buildNavTree. */
+  navDocs: E[];
+  /** Stable category-meta Map for the active (locale, version). */
+  categoryMeta: Map<string, CategoryMeta>;
+  /** Slugs that came from the locale collection (for isFallback). Empty for
+   *  default-locale / single-collection cases. */
+  localeSlugSet: ReadonlySet<string>;
+}

--- a/packages/zudo-doc/src/theme/__tests__/theme-pack-provider.test.tsx
+++ b/packages/zudo-doc/src/theme/__tests__/theme-pack-provider.test.tsx
@@ -1,23 +1,29 @@
 /** @jsxRuntime automatic */
 /** @jsxImportSource preact */
 // Unit tests for the theme-pack FOUC-safe bootstrap (ADR
-// `docs/adr/theme-packs.md` Decision 3 "Hard-load bootstrap"; #2822).
+// `docs/adr/theme-packs.md` Decision 3 "Hard-load bootstrap"; #2822;
+// document.write → head appendChild + explicit latch, #3399).
 //
 // Two layers of coverage:
-//   1. RENDER — `ThemePackProvider` emits the inline script + the configured-
-//      pack <noscript> fallback (omitted for "default") via
-//      preact-render-to-string.
+//   1. RENDER — `ThemePackProvider` emits the latch <style>, the inline
+//      script, and the configured-pack <noscript> fallback (omitted for
+//      "default") via preact-render-to-string.
 //   2. BEHAVIOR — the emitted script STRING is executed against a fake
-//      document/localStorage/window (the script only references those three
-//      globals, so `new Function` parameter shadowing injects the fakes),
-//      proving the stored-slug resolution, validation fallback, base-prefixed
-//      document.write, runtime-global publication, and the AFTER_NAVIGATE
-//      re-apply handler (createElement/appendChild — NEVER document.write
-//      after load).
+//      document/localStorage/window (the script references those three globals
+//      plus `setTimeout`, so `new Function` parameter shadowing injects the
+//      fakes and vitest's fake timers drive the watchdog), proving the
+//      stored-slug resolution, validation fallback, base-prefixed single link
+//      insertion, the latch lifecycle (armed before insertion; released on
+//      load, on error, and by the watchdog), inertness of a post-load
+//      re-evaluation, runtime-global publication, and the AFTER_NAVIGATE
+//      re-apply handler.
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render } from "preact-render-to-string";
 import ThemePackProvider, {
+  THEME_PACK_LATCH_CSS,
+  THEME_PACK_LOADING_ATTR,
+  THEME_PACK_LOAD_WATCHDOG_MS,
   buildThemePackBootstrap,
   resolveThemePackSsrSlug,
   themePackVersionMap,
@@ -38,6 +44,10 @@ const ENABLED = { default: "0.0.0", foundry: "1.2.3" };
 
 class FakeBootstrapLink {
   parentNode: FakeBootstrapHead | null = null;
+  // The bootstrap assigns these directly (the on* property form, so the fake
+  // needs no addEventListener); tests fire them to drive the latch lifecycle.
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
   private attrs = new Map<string, string>();
   setAttribute(name: string, value: string): void {
     this.attrs.set(name, value);
@@ -91,7 +101,11 @@ type BootstrapEventHandler = (event?: { newDocument?: unknown }) => void;
 
 interface BootstrapEnv {
   document: {
-    documentElement: { getAttribute(n: string): string | null };
+    documentElement: {
+      getAttribute(n: string): string | null;
+      setAttribute(n: string, v: string): void;
+      removeAttribute(n: string): void;
+    };
     write: ReturnType<typeof vi.fn>;
     addEventListener: (type: string, handler: BootstrapEventHandler) => void;
     createElement: (tag: string) => FakeBootstrapLink;
@@ -100,6 +114,7 @@ interface BootstrapEnv {
   };
   window: Record<string, unknown>;
   attr: (name: string) => string | null;
+  hasAttr: (name: string) => boolean;
   head: FakeBootstrapHead;
   listeners: Map<string, BootstrapEventHandler[]>;
   fireAfterNavigate: () => void;
@@ -113,11 +128,16 @@ function makeBootstrapEnv(stored: string | null, storageThrows = false): Bootstr
   const doc: BootstrapEnv["document"] = {
     documentElement: {
       getAttribute: (n: string) => attrs.get(n) ?? null,
-      // @ts-expect-error — setAttribute lives on the same object literal.
       setAttribute: (n: string, v: string) => {
         attrs.set(n, v);
       },
+      removeAttribute: (n: string) => {
+        attrs.delete(n);
+      },
     },
+    // Retained purely as a regression guard: the bootstrap must NEVER call it
+    // (a post-load document.write implicitly document.open()s and destroys the
+    // live document — the whole reason for #3399).
     write: vi.fn(),
     addEventListener: (type, handler) => {
       const arr = listeners.get(type) ?? [];
@@ -144,6 +164,7 @@ function makeBootstrapEnv(stored: string | null, storageThrows = false): Bootstr
     document: doc,
     window: win,
     attr: (name) => attrs.get(name) ?? null,
+    hasAttr: (name) => attrs.has(name),
     head,
     listeners,
     fireAfterNavigate: () => {
@@ -161,8 +182,9 @@ function makeBootstrapEnv(stored: string | null, storageThrows = false): Bootstr
 
 function runBootstrap(script: string, env: BootstrapEnv): void {
   const storage = (env as unknown as { __storage: unknown }).__storage;
-  // The script references exactly these three globals; parameter shadowing
-  // injects the fakes.
+  // The script references exactly these three globals (plus `setTimeout`,
+  // which resolves to the ambient one — vitest's fake timers drive the
+  // watchdog); parameter shadowing injects the fakes.
   new Function("document", "localStorage", "window", script)(
     env.document,
     storage,
@@ -170,28 +192,46 @@ function runBootstrap(script: string, env: BootstrapEnv): void {
   );
 }
 
+/** The single pack link the bootstrap inserted into the live head. */
+function onlyPackLink(env: BootstrapEnv): FakeBootstrapLink {
+  expect(env.head.children).toHaveLength(1);
+  return env.head.children[0]!;
+}
+
+function expectPackLink(link: FakeBootstrapLink, href: string): void {
+  expect(link.getAttribute("rel")).toBe("stylesheet");
+  expect(link.hasAttribute(THEME_PACK_LINK_ATTR)).toBe(true);
+  expect(link.getAttribute("href")).toBe(href);
+}
+
 // ---------------------------------------------------------------------------
 // Behavior — executing the emitted script
 // ---------------------------------------------------------------------------
 
 describe("buildThemePackBootstrap (executed)", () => {
-  it("uses a VALID persisted slug over the configured one and document.writes exactly one render-blocking link", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("uses a VALID persisted slug over the configured one and head-appends exactly one link", () => {
     const env = makeBootstrapEnv("foundry");
     runBootstrap(buildThemePackBootstrap("default", ENABLED, "/"), env);
 
     expect(env.attr(THEME_PACK_ATTR)).toBe("foundry");
-    expect(env.document.write).toHaveBeenCalledTimes(1);
-    expect(env.document.write).toHaveBeenCalledWith(
-      `<link rel="stylesheet" ${THEME_PACK_LINK_ATTR} href="/theme-packs/foundry/pack.css?v=1.2.3">`,
-    );
+    expectPackLink(onlyPackLink(env), "/theme-packs/foundry/pack.css?v=1.2.3");
+    // The mechanism #3399 removed: document.write after load destroys the doc.
+    expect(env.document.write).not.toHaveBeenCalled();
   });
 
-  it("falls back to the configured slug on an INVALID stored slug (no crash, no write for default)", () => {
+  it("falls back to the configured slug on an INVALID stored slug (no crash, no link for default)", () => {
     const env = makeBootstrapEnv("no-such-pack");
     runBootstrap(buildThemePackBootstrap("default", ENABLED, "/"), env);
 
     expect(env.attr(THEME_PACK_ATTR)).toBe("default");
-    expect(env.document.write).not.toHaveBeenCalled();
+    expect(env.head.children).toHaveLength(0);
   });
 
   it("survives a throwing localStorage (falls back to configured)", () => {
@@ -199,14 +239,16 @@ describe("buildThemePackBootstrap (executed)", () => {
     runBootstrap(buildThemePackBootstrap("foundry", ENABLED, "/"), env);
 
     expect(env.attr(THEME_PACK_ATTR)).toBe("foundry");
-    expect(env.document.write).toHaveBeenCalledTimes(1);
+    expectPackLink(onlyPackLink(env), "/theme-packs/foundry/pack.css?v=1.2.3");
   });
 
-  it("emits no stylesheet write when the resolved pack is default (stock look = zero requests)", () => {
+  it("inserts no stylesheet AND never arms the latch when the resolved pack is default (stock look = zero requests)", () => {
     const env = makeBootstrapEnv(null);
     runBootstrap(buildThemePackBootstrap("default", ENABLED, "/"), env);
 
     expect(env.attr(THEME_PACK_ATTR)).toBe("default");
+    expect(env.head.children).toHaveLength(0);
+    expect(env.hasAttr(THEME_PACK_LOADING_ATTR)).toBe(false);
     expect(env.document.write).not.toHaveBeenCalled();
   });
 
@@ -214,9 +256,138 @@ describe("buildThemePackBootstrap (executed)", () => {
     const env = makeBootstrapEnv("foundry");
     runBootstrap(buildThemePackBootstrap("default", ENABLED, "/sub/"), env);
 
-    expect(env.document.write).toHaveBeenCalledWith(
-      `<link rel="stylesheet" ${THEME_PACK_LINK_ATTR} href="/sub/theme-packs/foundry/pack.css?v=1.2.3">`,
-    );
+    expectPackLink(onlyPackLink(env), "/sub/theme-packs/foundry/pack.css?v=1.2.3");
+  });
+
+  // -------------------------------------------------------------------------
+  // Anti-FOUC latch lifecycle (#3399)
+  // -------------------------------------------------------------------------
+
+  describe("anti-FOUC latch", () => {
+    it("is armed BEFORE the link is appended and stays set while the sheet is pending", () => {
+      const env = makeBootstrapEnv("foundry");
+      let attrAtAppend: string | null = null;
+      const realAppend = env.head.appendChild.bind(env.head);
+      env.head.appendChild = (el: FakeBootstrapLink) => {
+        attrAtAppend = env.attr(THEME_PACK_LOADING_ATTR);
+        realAppend(el);
+      };
+
+      runBootstrap(buildThemePackBootstrap("default", ENABLED, "/"), env);
+
+      // Ordering is the whole point: arming after the append would race the
+      // request it is supposed to cover.
+      expect(attrAtAppend).toBe("");
+      expect(env.hasAttr(THEME_PACK_LOADING_ATTR)).toBe(true);
+    });
+
+    it("is cleared when the stylesheet loads", () => {
+      const env = makeBootstrapEnv("foundry");
+      runBootstrap(buildThemePackBootstrap("default", ENABLED, "/"), env);
+
+      onlyPackLink(env).onload!();
+
+      expect(env.hasAttr(THEME_PACK_LOADING_ATTR)).toBe(false);
+      // The pack attribute itself is untouched by the release.
+      expect(env.attr(THEME_PACK_ATTR)).toBe("foundry");
+    });
+
+    it("is cleared when the stylesheet errors (a 404 pack must not blank the page)", () => {
+      const env = makeBootstrapEnv("foundry");
+      runBootstrap(buildThemePackBootstrap("default", ENABLED, "/"), env);
+
+      onlyPackLink(env).onerror!();
+
+      expect(env.hasAttr(THEME_PACK_LOADING_ATTR)).toBe(false);
+    });
+
+    it("is cleared by the watchdog on a sheet that never resolves — blank-screen avoidance wins", () => {
+      const env = makeBootstrapEnv("foundry");
+      runBootstrap(buildThemePackBootstrap("default", ENABLED, "/"), env);
+
+      // Still latched right up to the deadline (the contract is "no FOUC
+      // within the watchdog", not "clear early").
+      vi.advanceTimersByTime(THEME_PACK_LOAD_WATCHDOG_MS - 1);
+      expect(env.hasAttr(THEME_PACK_LOADING_ATTR)).toBe(true);
+
+      vi.advanceTimersByTime(1);
+      expect(env.hasAttr(THEME_PACK_LOADING_ATTR)).toBe(false);
+    });
+
+    it("survives the watchdog firing after an ordinary load (release is idempotent)", () => {
+      const env = makeBootstrapEnv("foundry");
+      runBootstrap(buildThemePackBootstrap("default", ENABLED, "/"), env);
+
+      onlyPackLink(env).onload!();
+      // The watchdog still fires; clearing an already-cleared latch must be a
+      // harmless no-op rather than an error or a state reset.
+      vi.advanceTimersByTime(THEME_PACK_LOAD_WATCHDOG_MS);
+
+      expect(env.hasAttr(THEME_PACK_LOADING_ATTR)).toBe(false);
+      expect(env.attr(THEME_PACK_ATTR)).toBe("foundry");
+      expect(env.head.children).toHaveLength(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Post-load re-evaluation (SPA embedding — #3393 companion)
+  // -------------------------------------------------------------------------
+
+  describe("duplicate evaluation is inert", () => {
+    it("does not re-request or re-latch while the FIRST link is still pending", () => {
+      const env = makeBootstrapEnv("foundry");
+      const script = buildThemePackBootstrap("default", ENABLED, "/");
+      runBootstrap(script, env);
+      const first = onlyPackLink(env);
+
+      // Second evaluation with the sheet still in flight (latch still armed).
+      runBootstrap(script, env);
+
+      expect(env.head.children).toEqual([first]);
+      expect(env.document.write).not.toHaveBeenCalled();
+
+      // The FIRST link's load still releases the latch — the second run must
+      // not have replaced the handler or armed a second, unreleasable latch.
+      first.onload!();
+      expect(env.hasAttr(THEME_PACK_LOADING_ATTR)).toBe(false);
+      vi.advanceTimersByTime(THEME_PACK_LOAD_WATCHDOG_MS * 2);
+      expect(env.hasAttr(THEME_PACK_LOADING_ATTR)).toBe(false);
+    });
+
+    it("does not re-request or arm the latch when a matching link is ALREADY LOADED", () => {
+      const env = makeBootstrapEnv("foundry");
+      const script = buildThemePackBootstrap("default", ENABLED, "/");
+      runBootstrap(script, env);
+      const first = onlyPackLink(env);
+      first.onload!();
+      expect(env.hasAttr(THEME_PACK_LOADING_ATTR)).toBe(false);
+
+      runBootstrap(script, env);
+
+      expect(env.head.children).toEqual([first]);
+      // Re-arming here would hide the body of an already-styled page for 2s.
+      expect(env.hasAttr(THEME_PACK_LOADING_ATTR)).toBe(false);
+      expect(env.document.write).not.toHaveBeenCalled();
+    });
+
+    it("DOES insert when only a STALE (wrong-slug) pack link is present", () => {
+      // The guard keys on the resolved slug's href, not on the marker alone —
+      // otherwise a leftover link from another pack would suppress the
+      // correct one.
+      const env = makeBootstrapEnv("foundry");
+      const stale = new FakeBootstrapLink();
+      stale.setAttribute("rel", "stylesheet");
+      stale.setAttribute(THEME_PACK_LINK_ATTR, "");
+      stale.setAttribute("href", "/theme-packs/foundry/pack.css?v=0.0.1");
+      env.head.appendChild(stale);
+
+      runBootstrap(buildThemePackBootstrap("default", ENABLED, "/"), env);
+
+      expect(env.head.children).toHaveLength(2);
+      const inserted = env.head.children.find((l) => l !== stale)!;
+      expectPackLink(inserted, "/theme-packs/foundry/pack.css?v=1.2.3");
+      expect(env.hasAttr(THEME_PACK_LOADING_ATTR)).toBe(true);
+    });
   });
 
   it("publishes the runtime global applyThemePack validates against", () => {
@@ -240,41 +411,32 @@ describe("buildThemePackBootstrap (executed)", () => {
     it("re-asserts the attribute and re-inserts a dropped link via appendChild — never document.write", () => {
       const env = makeBootstrapEnv("foundry");
       runBootstrap(buildThemePackBootstrap("default", ENABLED, "/"), env);
-      expect(env.document.write).toHaveBeenCalledTimes(1);
+      onlyPackLink(env).onload!();
 
       // Simulate zfb's head swap dropping the pack link + the root-attribute
       // reset a missing preserve-list would cause.
       env.head.children.length = 0;
-      (env.document.documentElement as unknown as {
-        setAttribute(n: string, v: string): void;
-      }).setAttribute(THEME_PACK_ATTR, "default");
+      env.document.documentElement.setAttribute(THEME_PACK_ATTR, "default");
 
       env.fireAfterNavigate();
 
       expect(env.attr(THEME_PACK_ATTR)).toBe("foundry");
-      expect(env.head.children).toHaveLength(1);
-      const link = env.head.children[0]!;
-      expect(link.getAttribute("rel")).toBe("stylesheet");
-      expect(link.hasAttribute(THEME_PACK_LINK_ATTR)).toBe(true);
-      expect(link.getAttribute("href")).toBe("/theme-packs/foundry/pack.css?v=1.2.3");
-      // Post-load re-apply must never document.write (it would clobber the doc).
-      expect(env.document.write).toHaveBeenCalledTimes(1);
+      expectPackLink(onlyPackLink(env), "/theme-packs/foundry/pack.css?v=1.2.3");
+      // Post-load re-apply must never document.write (it would clobber the doc)
+      // and must not re-arm the hard-load latch.
+      expect(env.document.write).not.toHaveBeenCalled();
+      expect(env.hasAttr(THEME_PACK_LOADING_ATTR)).toBe(false);
     });
 
     it("is idempotent when the correct link survived the swap", () => {
       const env = makeBootstrapEnv("foundry");
       runBootstrap(buildThemePackBootstrap("default", ENABLED, "/"), env);
-
-      // Seed the head with the exact link the bootstrap would have written.
-      const existing = new FakeBootstrapLink();
-      existing.setAttribute("rel", "stylesheet");
-      existing.setAttribute(THEME_PACK_LINK_ATTR, "");
-      existing.setAttribute("href", "/theme-packs/foundry/pack.css?v=1.2.3");
-      env.head.appendChild(existing);
+      const bootstrapped = onlyPackLink(env);
+      bootstrapped.onload!();
 
       env.fireAfterNavigate();
 
-      expect(env.head.children).toEqual([existing]);
+      expect(env.head.children).toEqual([bootstrapped]);
     });
 
     it("keeps a live (unpersisted) pack across soft navigation when storage has nothing", () => {
@@ -283,9 +445,7 @@ describe("buildThemePackBootstrap (executed)", () => {
       // (which rides preserveHtmlAttrs) is the only surviving record.
       const env = makeBootstrapEnv(null);
       runBootstrap(buildThemePackBootstrap("default", ENABLED, "/"), env);
-      (env.document.documentElement as unknown as {
-        setAttribute(n: string, v: string): void;
-      }).setAttribute(THEME_PACK_ATTR, "foundry");
+      env.document.documentElement.setAttribute(THEME_PACK_ATTR, "foundry");
       // The head swap dropped the runtime link.
       env.head.children.length = 0;
 
@@ -331,7 +491,7 @@ describe("buildThemePackBootstrap (executed)", () => {
       // switcher, no stored preference — just settings.themePack != "default".
       const env = makeBootstrapEnv(null);
       runBootstrap(buildThemePackBootstrap("foundry", ENABLED, "/"), env);
-      expect(env.document.write).toHaveBeenCalledTimes(1);
+      expectPackLink(onlyPackLink(env), "/theme-packs/foundry/pack.css?v=1.2.3");
 
       const newDoc = new FakeNewDocument();
       env.fireBeforeSwap(newDoc);
@@ -356,7 +516,7 @@ describe("buildThemePackBootstrap (executed)", () => {
     it("does nothing when newDocument is the live document (defensive no-op)", () => {
       const env = makeBootstrapEnv("foundry");
       runBootstrap(buildThemePackBootstrap("default", ENABLED, "/"), env);
-      expect(env.head.children).toHaveLength(0);
+      const live = onlyPackLink(env);
 
       // Fire with the SAME reference used as the shadowed `document` global.
       // Without the `newDocument === document` guard this would append a
@@ -364,7 +524,7 @@ describe("buildThemePackBootstrap (executed)", () => {
       // / env.head.appendChild — corrupting the live document.
       env.fireBeforeSwap(env.document);
 
-      expect(env.head.children).toHaveLength(0);
+      expect(env.head.children).toEqual([live]);
     });
 
     it("does nothing when newDocument.head already has a stylesheet link with the exact href", () => {
@@ -415,25 +575,38 @@ describe("buildThemePackBootstrap (executed)", () => {
 // ---------------------------------------------------------------------------
 
 describe("ThemePackProvider (rendered)", () => {
-  it("emits the bootstrap script and the configured-pack noscript fallback", () => {
+  it("emits the latch style, the bootstrap script and the configured-pack noscript fallback", () => {
     const out = render(
       <ThemePackProvider configuredSlug="foundry" enabled={ENABLED} base="/" />,
     );
+    expect(out).toContain(`<style>${THEME_PACK_LATCH_CSS}</style>`);
     expect(out).toContain("<script>");
     expect(out).toContain('"zudo-doc-theme-pack"');
     expect(out).toContain(
       '<noscript><link rel="stylesheet" href="/theme-packs/foundry/pack.css?v=1.2.3"/></noscript>',
     );
-    // The script must precede the noscript (ADR emission order).
+    // Emission order (ADR Decision 3): latch style → script → noscript. The
+    // latch MUST precede the script that arms it, or the rule would not be
+    // live when the body parses.
+    expect(out.indexOf("<style>")).toBeLessThan(out.indexOf("<script>"));
     expect(out.indexOf("<script>")).toBeLessThan(out.indexOf("<noscript>"));
   });
 
-  it("omits the noscript fallback when the configured pack is default", () => {
+  it("emits the latch style even for the default pack (build-static, inert until armed)", () => {
     const out = render(
       <ThemePackProvider configuredSlug="default" enabled={ENABLED} base="/" />,
     );
+    expect(out).toContain(`<style>${THEME_PACK_LATCH_CSS}</style>`);
     expect(out).toContain("<script>");
     expect(out).not.toContain("<noscript>");
+  });
+
+  it("keeps the latch rule scoped to the loading attribute (never a bare body rule)", () => {
+    // A latch that hid the body unconditionally would blank every page the
+    // instant the stylesheet failed to ship.
+    expect(THEME_PACK_LATCH_CSS).toBe(
+      `html[${THEME_PACK_LOADING_ATTR}] body{visibility:hidden}`,
+    );
   });
 });
 

--- a/packages/zudo-doc/src/theme/__tests__/theme-pack-provider.test.tsx
+++ b/packages/zudo-doc/src/theme/__tests__/theme-pack-provider.test.tsx
@@ -560,6 +560,20 @@ describe("buildThemePackBootstrap (executed)", () => {
     });
   });
 
+  it("contains no document.write anywhere in the emitted text (all branches, not just the exercised ones)", () => {
+    // The behavior tests above prove the paths they exercise; this pins the
+    // whole string, so a document.write reintroduced on a branch no test walks
+    // still fails. It is the single defect #3399 exists to prevent.
+    for (const configured of ["default", "foundry"]) {
+      const script = buildThemePackBootstrap(configured, ENABLED, "/sub/");
+      expect(script).not.toContain("document.write");
+      expect(script).not.toContain("document.open");
+      // …and the latch attribute IS inlined (a build-static JSON literal).
+      expect(script).toContain(`"${THEME_PACK_LOADING_ATTR}"`);
+      expect(script).toContain(`=${THEME_PACK_LOAD_WATCHDOG_MS};`);
+    }
+  });
+
   it("emits identical script text across repeated calls with the same arguments (build-static contract)", () => {
     // zfb's scriptsAlreadyRan dedupe is keyed on textContent — the bootstrap
     // must be a pure function of its inputs so every page's inline script is

--- a/packages/zudo-doc/src/theme/theme-pack-provider.tsx
+++ b/packages/zudo-doc/src/theme/theme-pack-provider.tsx
@@ -1,26 +1,63 @@
 // ThemePackProvider — the FOUC-safe theme-pack bootstrap, sibling of
 // `color-scheme-provider.tsx` (ADR `docs/adr/theme-packs.md`, Decision 3
 // "Hard-load bootstrap"; epic Theme Core #2812, sub-issue #2822; soft-nav FOUC
-// fix zudolab/zudo-doc#3136, sub-issue #3137).
+// fix zudolab/zudo-doc#3136, sub-issue #3137; document.write removal +
+// explicit latch zudolab/zudo-doc#3399).
 //
 // Rendered by `head-with-defaults` IMMEDIATELY AFTER `<ColorSchemeProvider/>`.
 // Emits, in order:
 //
-//   1. An inline `<script>` that resolves the active pack slug
-//      (validated localStorage value, else the configured slug) BEFORE first
-//      paint, sets `<html data-theme-pack>`, and — for a non-default pack —
-//      `document.write`s the single pack stylesheet link. The written link is
-//      parser-inserted, therefore render-blocking in every browser: the one
-//      mechanism with a hard cross-browser pre-paint guarantee AND exactly one
-//      stylesheet request that is correct the first time (no default-then-
-//      stored double fetch, no MutationObserver races). Chrome's
-//      document.write intervention targets parser-blocking cross-origin
-//      *scripts*, not stylesheets. There is deliberately NO eager SSR link —
-//      an inline script cannot rewrite an SSR link's href "before the
-//      request" (by the time the element is scriptable its fetch has started).
-//   2. A `<noscript>` fallback link for the CONFIGURED pack (omitted when the
+//   1. A build-static anti-FOUC latch `<style>` (`THEME_PACK_LATCH_CSS`) —
+//      `html[data-zd-theme-pack-loading] body{visibility:hidden}`. It MUST
+//      precede the script so the rule is already live when the body parses;
+//      it is inert until the script sets the attribute, so pages that load no
+//      pack stylesheet are unaffected.
+//   2. An inline `<script>` that resolves the active pack slug
+//      (validated localStorage value, else the validated live html attribute,
+//      else the configured slug) BEFORE first paint, sets
+//      `<html data-theme-pack>`, and — for a non-default pack — inserts the
+//      single pack stylesheet link via `createElement`/`head.appendChild`
+//      under the latch (see the contract below). Still exactly one stylesheet
+//      request that is correct the first time (no default-then-stored double
+//      fetch, no MutationObserver races) and zero requests for `default`.
+//      There is deliberately NO eager SSR link — an inline script cannot
+//      rewrite an SSR link's href "before the request" (by the time the
+//      element is scriptable its fetch has started).
+//   3. A `<noscript>` fallback link for the CONFIGURED pack (omitted when the
 //      configured pack is `default`) so a no-JS visitor gets the configured
-//      look, matching the SSR `data-theme-pack` html attribute.
+//      look, matching the SSR `data-theme-pack` html attribute. The latch is
+//      never armed on the no-JS path (only the script sets it), so a no-JS
+//      visitor can never end up staring at a hidden body.
+//
+// ANTI-FOUC LATCH CONTRACT (#3399 — read before touching the insertion path).
+// The bootstrap used to `document.write` the link during head parse: a
+// parser-inserted stylesheet is render-blocking in every browser, which was a
+// HARD pre-paint guarantee. That mechanism had to go, because `document.write`
+// after page load implicitly `document.open()`s and DESTROYS the live document
+// — fatal the moment the chrome is evaluated a second time (SPA embedding).
+// A script-inserted head stylesheet does NOT block the parser; Chromium and
+// Firefox generally still block paint on a pending head sheet, Safari is the
+// soft spot. So the guarantee is replaced by an EXPLICIT, bounded one:
+//
+//   - Before inserting the link the script sets `data-zd-theme-pack-loading`
+//     on `<html>`, which the latch `<style>` turns into a hidden body.
+//   - The attribute is cleared on the link's `load` OR `error`.
+//   - A `THEME_PACK_LOAD_WATCHDOG_MS` (2s) timer clears it unconditionally.
+//
+// In words: **no FOUC for a pack stylesheet that loads within the watchdog;
+// a bounded flash beyond it.** Past 2s, blank-screen avoidance deliberately
+// wins over strict no-FOUC — a hung or very slow stylesheet must never leave
+// the page permanently blank. This is a real (accepted) weakening versus the
+// parser-inserted link; do not "restore" `document.write` to close it.
+//
+// Re-evaluating the script after load is INERT with respect to the stylesheet:
+// the insertion is guarded on an existing `link[data-zd-theme-pack-css]` whose
+// href matches the resolved slug, which is already in the head synchronously
+// after the first evaluation — so a duplicate run finds it whether the sheet
+// is still pending or already loaded, and neither re-requests it nor re-arms
+// the latch. (The two soft-nav handlers below are each individually
+// idempotent, so a duplicate registration would also be harmless; zfb's
+// `scriptsAlreadyRan` textContent dedupe prevents one in the first place.)
 //
 // SPA soft navigation (zfb Strategy B) — PRIMARY mechanism is a
 // `BEFORE_SWAP_EVENT` ("zfb:before-swap") listener. zfb dispatches this event
@@ -45,8 +82,9 @@
 // `createElement`/`appendChild`, and removes stale/wrong-slug links (including
 // dropping the link entirely when the resolved slug is `default`). It also
 // covers the default-pack case, which the before-swap handler intentionally
-// skips (there is nothing to persist for `default`). Neither handler EVER
-// uses `document.write` after load — that would clobber the live document.
+// skips (there is nothing to persist for `default`). Neither handler arms the
+// latch: a soft navigation keeps the already-loaded live link (that is the
+// whole point of the before-swap injection), so there is nothing to wait for.
 // Slug resolution is stored-first (validated) per the ADR, with a validated
 // LIVE `<html data-theme-pack>` fallback before the configured default:
 // `data-theme-pack` rides `preserveHtmlAttrs`, so when persistence failed
@@ -80,6 +118,35 @@ import {
   buildPackCssUrl,
 } from "../theme-pack-switcher/theme-pack-sync.js";
 import type { ThemePackRegistry } from "../theme-packs-registry/index.js";
+
+/**
+ * Transient `<html>` attribute the hard-load bootstrap sets while the pack
+ * stylesheet request is in flight. Paired with {@link THEME_PACK_LATCH_CSS};
+ * cleared on the link's load/error or by the watchdog. Deliberately NOT part
+ * of `preserveHtmlAttrs` — it must never survive a soft navigation.
+ *
+ * Not to be confused with `THEME_PACK_LINK_LOADING_ATTR`
+ * (`data-zd-theme-pack-css-loading`), which marks the in-flight `<link>`
+ * during a RUNTIME `applyThemePack` swap. Different element, different
+ * mechanism — a runtime swap awaits the sheet off-screen and never hides
+ * the body.
+ */
+export const THEME_PACK_LOADING_ATTR = "data-zd-theme-pack-loading";
+
+/**
+ * Upper bound (ms) on how long the latch may hide the body. Past this the
+ * attribute is cleared regardless of the stylesheet's state: blank-screen
+ * avoidance wins over strict no-FOUC (see the latch contract in the file
+ * header).
+ */
+export const THEME_PACK_LOAD_WATCHDOG_MS = 2000;
+
+/**
+ * The latch rule, emitted as a build-static `<style>` BEFORE the bootstrap
+ * script so it is live by the time the body parses. Inert until the script
+ * sets {@link THEME_PACK_LOADING_ATTR}.
+ */
+export const THEME_PACK_LATCH_CSS = `html[${THEME_PACK_LOADING_ATTR}] body{visibility:hidden}`;
 
 export interface ThemePackProviderProps {
   /** The build-configured pack slug (`settings.themePack`, default `"default"`). */
@@ -144,6 +211,8 @@ export function buildThemePackBootstrap(
   const runtimeGlobal = JSON.stringify(THEME_PACK_RUNTIME_GLOBAL);
   const afterNav = JSON.stringify(AFTER_NAVIGATE_EVENT);
   const beforeSwap = JSON.stringify(BEFORE_SWAP_EVENT);
+  const loadingAttr = JSON.stringify(THEME_PACK_LOADING_ATTR);
+  const watchdog = JSON.stringify(THEME_PACK_LOAD_WATCHDOG_MS);
   return `(function(){
 var configured=${configured};
 var packs=${packs};
@@ -151,12 +220,30 @@ var base=${b};
 var KEY=${key};
 var ATTR=${attr};
 var LINK_ATTR=${linkAttr};
+var LOADING_ATTR=${loadingAttr};
+var WATCHDOG=${watchdog};
 var DEFAULT_SLUG=${defaultSlug};
 function resolveSlug(){var stored=null;try{stored=localStorage.getItem(KEY);}catch(e){}if(stored&&Object.prototype.hasOwnProperty.call(packs,stored))return stored;var live=document.documentElement.getAttribute(ATTR);if(live&&Object.prototype.hasOwnProperty.call(packs,live))return live;return configured;}
 function packHref(slug){return base+"theme-packs/"+slug+"/pack.css?v="+packs[slug];}
+function hasPackLink(href){var ls=document.querySelectorAll("link["+LINK_ATTR+"]");for(var i=0;i<ls.length;i++){if(ls[i].getAttribute("href")===href)return true;}return false;}
 var slug=resolveSlug();
-document.documentElement.setAttribute(ATTR,slug);
-if(slug!==DEFAULT_SLUG){document.write('<link rel="stylesheet" '+LINK_ATTR+' href="'+packHref(slug)+'">');}
+var root=document.documentElement;
+root.setAttribute(ATTR,slug);
+if(slug!==DEFAULT_SLUG){
+var href=packHref(slug);
+if(!hasPackLink(href)){
+root.setAttribute(LOADING_ATTR,"");
+var release=function(){root.removeAttribute(LOADING_ATTR);};
+var link=document.createElement("link");
+link.setAttribute("rel","stylesheet");
+link.setAttribute(LINK_ATTR,"");
+link.setAttribute("href",href);
+link.onload=release;
+link.onerror=release;
+document.head.appendChild(link);
+setTimeout(release,WATCHDOG);
+}
+}
 window[${runtimeGlobal}]={base:base,packs:packs,configured:configured};
 document.addEventListener(${beforeSwap},function(e){
 var s=resolveSlug();
@@ -185,9 +272,11 @@ if(want!==null&&!found){var nl=document.createElement("link");nl.setAttribute("r
 }
 
 /**
- * Server-rendered head fragment: the pre-paint bootstrap `<script>` plus the
- * `<noscript>` configured-pack fallback. No hydration — like
- * `ColorSchemeProvider` it just emits markup the engine streams into `<head>`.
+ * Server-rendered head fragment: the anti-FOUC latch `<style>`, the pre-paint
+ * bootstrap `<script>`, and the `<noscript>` configured-pack fallback. No
+ * hydration — like `ColorSchemeProvider` it just emits markup the engine
+ * streams into `<head>`. The latch style MUST stay first (see the contract in
+ * the file header).
  */
 export default function ThemePackProvider({
   configuredSlug,
@@ -203,6 +292,7 @@ export default function ThemePackProvider({
 
   return (
     <>
+      <style dangerouslySetInnerHTML={{ __html: THEME_PACK_LATCH_CSS }} />
       <script dangerouslySetInnerHTML={{ __html: bootstrap }} />
       {noscriptHref !== null && (
         <noscript>

--- a/packages/zudo-doc/vitest.config.ts
+++ b/packages/zudo-doc/vitest.config.ts
@@ -49,16 +49,14 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      // The routes plugin's design-token-panel-config virtual module (#2658).
-      // `chrome/derive.tsx` statically imports the DesignTokenPanelBootstrap
-      // island (whose module imports this virtual specifier), so any fast test
-      // that touches the chrome graph needs it resolvable. Alias it to the
-      // package default builder — exactly what the plugin's loader emits when
-      // `settings.designTokenPanelConfigModule` is absent (plugins/routes.ts).
-      "virtual:zudo-doc-design-token-panel-config": resolve(
-        pkgRoot,
-        "src/design-token-panel-config/index.ts",
-      ),
+      // NOTE (#3396): there is deliberately NO alias for
+      // `virtual:zudo-doc-design-token-panel-config` here any more. The chrome
+      // graph no longer imports that specifier — `design-token-panel-bootstrap.tsx`
+      // binds the package-default builder directly, and the only importer left
+      // is `src/routes/_design-token-panel-bootstrap.tsx`, which no fast test
+      // loads. Re-adding an alias would mask a regression that reintroduced the
+      // routes-plugin coupling into the chrome graph.
+      //
       // preact-render-to-string is hoisted into the workspace root pnpm store
       // but not surfaced at root or package node_modules. Pin it explicitly so
       // JSX rendering tests work without bloating the package's own deps.


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3394

---

## Summary

- Adds the browser-safe `@takazudo/zudo-doc/site-schema` subpath: nav-manifest + route-entry types and the breadcrumb / prev-next / route-emission derivation rules as pure functions, guarded by the /catalog-precedent trio (node-free eval-graph test, `check-site-schema.mjs` prepack guard, exports-snapshot) plus a transitive-`.d.ts` zfb-free check and a `schemaVersion` fail-closed constant (#3395).
- Makes the chrome graph bundleable outside a zfb build: the `virtual:zudo-doc-design-token-panel-config` import moved into a routes-only configured wrapper (#3396), and `category-meta`'s static `node:fs`/`node:path` edge replaced with call-time `process.getBuiltinModule` resolution (#3397) — enforced going forward by a new `chrome-eval-graph` guard covering `./chrome`, `./home-page`, and `./sidebar-tree` (#3401).
- Active-nav derivation now accepts an explicit current-route input (`data-zd-current-path` dataset override → `location.pathname`) across all four read sites; an unusable pathname (iframe `srcdoc`) preserves SSR markers instead of clearing them (#3398).
- Theme-pack head bootstrap no longer uses `document.write`: head `appendChild` + an SSR-emitted anti-FOUC latch with a 2s watchdog, so a post-load re-evaluation is inert instead of destructive (#3399). Verified in real Chromium: no-FOUC hold during a delayed stylesheet, single request, zero requests for the default pack, post-load re-run inert, watchdog fires.
- ClientRouter's module-scope wiring is upstream zfb work — filed as Takazudo/zudo-front-builder#2429 with a containment comment at the import site; the fix arrives via a future pin bump (#3400).

## Changes

- **New** `packages/zudo-doc/src/site-schema/` (`index.ts`, `types.ts`, `nav-tree.ts`, `doc-route-entries.ts`) + `./site-schema` exports entry + `scripts/check-site-schema.mjs` in the prepack chain. The route-entry factory's memo is scoped per factory instance (fixes a cross-factory cache-collision) and its public types are structural (`CollectionEntryLike`) — no `@takazudo/zfb` in the subpath's declaration graph.
- `routes/_docs-helpers.ts` reduced to `stableDocs`; nav helpers moved to site-schema and importers re-pointed directly (no re-export shell).
- `design-token-panel-bootstrap.tsx` binds the package-default builder statically; new `routes/_design-token-panel-bootstrap.tsx` wrapper is the sole importer of the virtual module; vitest alias removed. Known gap for locked-manifest `pages/` stubs documented in `settings.ts` + ADR (follow-up: #3406).
- `sidebar-tree/category-meta.ts`: call-time builtin resolution, structural `DirEntry` type, builtins-unavailable test.
- `sidebar-tree-island`, `header/nav-overflow-script`, `i18n-version` switchers: shared current-route read order, executing jsdom test for the generated nav-overflow script.
- `theme/theme-pack-provider.tsx`: appendChild + latch + watchdog, test suite rewritten around the latch lifecycle, ADR Decision 3 amended.
- Docs: README `./site-schema` section (matching /catalog's documentation level), API.md entry.
- Snapshots: 3 route-injection inline sha256 baselines re-derived and attributed byte-for-byte to the script changes (#3399/#3398).

## Test Plan

- `pnpm --filter @takazudo/zudo-doc test` — 188 files / 2164 tests green (includes the new site-schema, chrome-eval-graph, memo-collision, latch-lifecycle, and script-executing tests).
- Full `pnpm build` (453 pages) + `pnpm test` (root + all workspace packages) green on the merged base.
- `route-injection-build.slow.test.ts` 97/97 (host DTP override reaches the hydrated panel; island registration intact).
- Browser-import proof: `import('@takazudo/zudo-doc/site-schema')` works on the built package; esbuild `platform:browser` bundle needs zero shims.
- Headless-Chromium verification of the theme-pack bootstrap (no-FOUC hold, single request, default-pack zero requests, post-load inertness, watchdog).