### PR TITLE
refactor(zudo-doc): single shared constant for the zdCurrentPath route override

### DIFF
--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -557,6 +557,10 @@
       "types": "./dist/sidebar-active-slug/index.d.ts",
       "default": "./dist/sidebar-active-slug/index.js"
     },
+    "./current-path": {
+      "types": "./dist/current-path/index.d.ts",
+      "default": "./dist/current-path/index.js"
+    },
     "./i18n-defaults": {
       "types": "./dist/i18n-defaults/index.d.ts",
       "default": "./dist/i18n-defaults/index.js"

--- a/packages/zudo-doc/src/__tests__/public-api-snapshot.test.ts
+++ b/packages/zudo-doc/src/__tests__/public-api-snapshot.test.ts
@@ -59,6 +59,7 @@ describe("package.json exports keyset snapshot", () => {
         "./content",
         "./content-admonition",
         "./content.css",
+        "./current-path",
         "./design-token-panel-bootstrap",
         "./design-token-panel-config",
         "./desktop-sidebar-toggle-island",

--- a/packages/zudo-doc/src/current-path/__tests__/current-path-surfaces.test.tsx
+++ b/packages/zudo-doc/src/current-path/__tests__/current-path-surfaces.test.tsx
@@ -1,0 +1,197 @@
+/** @vitest-environment happy-dom */
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+// Cross-surface proof that ONE dataset key drives every current-route reader
+// (zudolab/zudo-doc#3408). Each of the four surfaces is exercised through
+// `document.documentElement.dataset[CURRENT_PATH_DATASET_KEY]` — never a
+// hand-written "zdCurrentPath" literal — so renaming the constant either moves
+// all four together or fails here. Two of the surfaces are string-embedded
+// client scripts, which is exactly where a literal could rot unnoticed: they
+// are executed, not string-matched.
+
+import { afterEach, describe, expect, it } from "vitest";
+import { render } from "preact";
+import { act } from "preact/test-utils";
+import { CURRENT_PATH_DATASET_KEY, CURRENT_PATH_SCRIPT_PRELUDE, readCurrentPath } from "../index.js";
+import { NAV_OVERFLOW_SCRIPT } from "../../header/nav-overflow-script.js";
+import { LANGUAGE_SWITCHER_INIT_SCRIPT } from "../../i18n-version/language-switcher.js";
+import { VERSION_SWITCHER_REWIRE_SCRIPT } from "../../i18n-version/version-switcher.js";
+import { SidebarTree } from "../../sidebar-tree-island/index.js";
+import type { SidebarNavNode } from "../../sidebar/types.js";
+
+function setLocation(pathname: string): void {
+  (window as unknown as { happyDOM?: { setURL: (url: string) => void } }).happyDOM?.setURL(
+    `http://localhost${pathname}`,
+  );
+}
+
+function setOverride(pathname: string): void {
+  document.documentElement.dataset[CURRENT_PATH_DATASET_KEY] = pathname;
+}
+
+let mounted: HTMLDivElement | null = null;
+
+function mountSidebar(nodes: SidebarNavNode[]): HTMLDivElement {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  act(() => {
+    render(<SidebarTree nodes={nodes} />, container);
+  });
+  mounted = container;
+  return container;
+}
+
+afterEach(() => {
+  if (mounted) {
+    act(() => {
+      render(null, mounted!);
+    });
+    mounted = null;
+  }
+  document.body.innerHTML = "";
+  delete document.documentElement.dataset[CURRENT_PATH_DATASET_KEY];
+});
+
+describe("readCurrentPath", () => {
+  it("prefers the explicit argument over the dataset override and location", () => {
+    setLocation("/from-location");
+    setOverride("/from-dataset");
+    expect(readCurrentPath(CURRENT_PATH_DATASET_KEY, "/explicit")).toBe("/explicit");
+  });
+
+  it("prefers the dataset override over location.pathname", () => {
+    setLocation("/from-location");
+    setOverride("/from-dataset");
+    expect(readCurrentPath(CURRENT_PATH_DATASET_KEY)).toBe("/from-dataset");
+  });
+
+  it("falls through empty strings at every step", () => {
+    setLocation("/from-location");
+    setOverride("");
+    expect(readCurrentPath(CURRENT_PATH_DATASET_KEY, "")).toBe("/from-location");
+  });
+
+  it("falls back to location.pathname when no override is set", () => {
+    setLocation("/from-location");
+    expect(readCurrentPath(CURRENT_PATH_DATASET_KEY)).toBe("/from-location");
+  });
+});
+
+describe("CURRENT_PATH_SCRIPT_PRELUDE", () => {
+  it("carries the key as a literal so embedded scripts need no closure", () => {
+    expect(CURRENT_PATH_SCRIPT_PRELUDE).toContain(JSON.stringify(CURRENT_PATH_DATASET_KEY));
+    expect(new Function(`${CURRENT_PATH_SCRIPT_PRELUDE}return CURRENT_PATH_DATASET_KEY;`)()).toBe(
+      CURRENT_PATH_DATASET_KEY,
+    );
+  });
+
+  it("is spliced into all three string-embedded client scripts", () => {
+    for (const script of [
+      NAV_OVERFLOW_SCRIPT,
+      LANGUAGE_SWITCHER_INIT_SCRIPT,
+      VERSION_SWITCHER_REWIRE_SCRIPT,
+    ]) {
+      expect(script).toContain(CURRENT_PATH_SCRIPT_PRELUDE);
+    }
+  });
+});
+
+describe("SidebarTree island reads the shared dataset key", () => {
+  const nodes: SidebarNavNode[] = [
+    {
+      slug: "introduction",
+      label: "Introduction",
+      position: 0,
+      href: "/docs/introduction",
+      hasPage: true,
+      children: [],
+    },
+    {
+      slug: "advanced",
+      label: "Advanced",
+      position: 1,
+      href: "/docs/advanced",
+      hasPage: true,
+      children: [],
+    },
+  ];
+
+  it("derives the active slug from the dataset override", () => {
+    setLocation("/docs/advanced");
+    setOverride("/docs/introduction");
+
+    const container = mountSidebar(nodes);
+
+    expect(container.querySelector('a[aria-current="page"]')?.getAttribute("href")).toBe(
+      "/docs/introduction",
+    );
+  });
+});
+
+describe("NAV_OVERFLOW_SCRIPT reads the shared dataset key", () => {
+  it("highlights the nav item matching the dataset override", () => {
+    setLocation("/blog/post-1");
+    setOverride("/docs/introduction");
+    const nav = document.createElement("nav");
+    nav.setAttribute("data-header-nav", "");
+    nav.innerHTML = `
+      <a data-nav-item href="/docs/">Docs</a>
+      <a data-nav-item href="/blog/">Blog</a>
+    `;
+    document.body.appendChild(nav);
+
+    new Function(NAV_OVERFLOW_SCRIPT)();
+
+    expect(nav.querySelector('a[href="/docs/"]')?.getAttribute("aria-current")).toBe("page");
+    expect(nav.querySelector('a[href="/blog/"]')?.getAttribute("aria-current")).toBeNull();
+  });
+});
+
+describe("LANGUAGE_SWITCHER_INIT_SCRIPT reads the shared dataset key", () => {
+  it("rewrites locale hrefs from the dataset override", () => {
+    setLocation("/ja/docs/unrelated");
+    setOverride("/ja/docs/introduction");
+    const container = document.createElement("div");
+    container.setAttribute("data-language-switcher", "");
+    container.setAttribute("data-base", "");
+    container.setAttribute("data-default-locale", "en");
+    container.setAttribute("data-trailing-slash", "false");
+    container.setAttribute("data-current-locale", "ja");
+    container.innerHTML = `<a lang="en" href="#">EN</a><a lang="ja" href="#">JA</a>`;
+    document.body.appendChild(container);
+
+    new Function(LANGUAGE_SWITCHER_INIT_SCRIPT)();
+
+    expect(container.querySelector('a[lang="en"]')?.getAttribute("href")).toBe(
+      "/docs/introduction",
+    );
+    expect(container.querySelector('a[lang="ja"]')?.getAttribute("href")).toBe(
+      "/ja/docs/introduction",
+    );
+  });
+});
+
+describe("VERSION_SWITCHER_REWIRE_SCRIPT reads the shared dataset key", () => {
+  it("resolves the active version from the dataset override", () => {
+    setLocation("/docs/introduction");
+    setOverride("/v/1-0/docs/introduction");
+    const container = document.createElement("div");
+    container.setAttribute("data-version-rewire", "");
+    container.setAttribute("data-base", "");
+    container.setAttribute("data-default-locale", "en");
+    container.setAttribute("data-trailing-slash", "false");
+    container.setAttribute("data-current-locale", "en");
+    container.innerHTML = `
+      <a data-version-latest href="#">Latest</a>
+      <a data-version-slug="1-0" href="#">1.0</a>
+    `;
+    document.body.appendChild(container);
+
+    new Function(VERSION_SWITCHER_REWIRE_SCRIPT)();
+
+    expect(container.querySelector('[data-version-slug="1-0"]')?.getAttribute("aria-current")).toBe(
+      "page",
+    );
+    expect(container.querySelector("[data-version-latest]")?.getAttribute("aria-current")).toBeNull();
+  });
+});

--- a/packages/zudo-doc/src/current-path/index.ts
+++ b/packages/zudo-doc/src/current-path/index.ts
@@ -1,0 +1,53 @@
+// Single source of truth for the explicit current-route override
+// (zudolab/zudo-doc#3398, consolidated by #3408).
+//
+// An embedding host may set `document.documentElement.dataset.zdCurrentPath`
+// before `location.pathname` is trustworthy: inside an iframe `srcdoc`
+// document, `location.pathname` is the literal string "srcdoc" (matches no
+// route) and Chromium refuses `history.replaceState` there, so the page cannot
+// self-correct via navigation (spike ledger adl-0005).
+//
+// Four surfaces read it — `sidebar-tree-island/index.tsx` imports directly;
+// `header/nav-overflow-script.ts`, `i18n-version/version-switcher.tsx`, and
+// `i18n-version/language-switcher.tsx` are string-embedded client scripts and
+// splice in CURRENT_PATH_SCRIPT_PRELUDE instead. Nothing here may close over
+// module scope, because `readCurrentPath` is serialized with
+// `Function.prototype.toString()` into those script strings.
+
+/**
+ * The `dataset` property name of the current-route override — i.e. the
+ * `data-zd-current-path` attribute on `<html>`.
+ */
+export const CURRENT_PATH_DATASET_KEY = "zdCurrentPath";
+
+/**
+ * Resolve the current route. Read order is explicit input → dataset override →
+ * `window.location.pathname`; `||` (not `??`) so an empty string at any step
+ * falls through to the next source rather than winning.
+ *
+ * `datasetKey` is a parameter rather than a closed-over reference to
+ * {@link CURRENT_PATH_DATASET_KEY} so the function body stays self-contained
+ * when {@link CURRENT_PATH_SCRIPT_PRELUDE} serializes it into a client script.
+ *
+ * Returns `undefined` only when no source resolves (SSR); callers that treat a
+ * route as optional must handle that, and a resolved value may still match no
+ * route (e.g. the literal "srcdoc").
+ */
+export function readCurrentPath(datasetKey: string, explicit?: string): string | undefined {
+  const override =
+    typeof document === "undefined" ? undefined : document.documentElement.dataset[datasetKey];
+  return (
+    explicit || override || (typeof window === "undefined" ? undefined : window.location.pathname)
+  );
+}
+
+/**
+ * JS source declaring `readCurrentPath` and `CURRENT_PATH_DATASET_KEY` inside
+ * an inline client script, so a string-embedded reader calls
+ * `readCurrentPath(CURRENT_PATH_DATASET_KEY)` with the exact same key the
+ * TypeScript call sites use. Splice this into the script body before the first
+ * call.
+ */
+export const CURRENT_PATH_SCRIPT_PRELUDE =
+  `var CURRENT_PATH_DATASET_KEY=${JSON.stringify(CURRENT_PATH_DATASET_KEY)};` +
+  `var readCurrentPath=${readCurrentPath.toString()};`;

--- a/packages/zudo-doc/src/header/__tests__/nav-overflow-active-exec.test.ts
+++ b/packages/zudo-doc/src/header/__tests__/nav-overflow-active-exec.test.ts
@@ -12,6 +12,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { NAV_OVERFLOW_SCRIPT } from "../nav-overflow-script.js";
 import { NAV_TOP_ACTIVE } from "../nav-class-tokens.js";
+import { CURRENT_PATH_DATASET_KEY } from "../../current-path/index.js";
 
 function setLocation(pathname: string): void {
   (window as unknown as { happyDOM?: { setURL: (url: string) => void } }).happyDOM?.setURL(
@@ -40,7 +41,7 @@ function buildNav(): HTMLElement {
 describe("NAV_OVERFLOW_SCRIPT — executed in jsdom (applyActiveNav)", () => {
   afterEach(() => {
     document.body.innerHTML = "";
-    delete document.documentElement.dataset.zdCurrentPath;
+    delete document.documentElement.dataset[CURRENT_PATH_DATASET_KEY];
   });
 
   it("marks the matching top-level item active from location.pathname", () => {
@@ -72,7 +73,7 @@ describe("NAV_OVERFLOW_SCRIPT — executed in jsdom (applyActiveNav)", () => {
 
   it("prefers document.documentElement.dataset.zdCurrentPath over location.pathname", () => {
     setLocation("/blog/post-1");
-    document.documentElement.dataset.zdCurrentPath = "/docs/introduction";
+    document.documentElement.dataset[CURRENT_PATH_DATASET_KEY] = "/docs/introduction";
     const nav = buildNav();
 
     new Function(NAV_OVERFLOW_SCRIPT)();

--- a/packages/zudo-doc/src/header/nav-overflow-script.ts
+++ b/packages/zudo-doc/src/header/nav-overflow-script.ts
@@ -31,6 +31,7 @@
 // script can be reviewed in isolation.
 
 import { AFTER_NAVIGATE_EVENT } from "../transitions/page-events.js";
+import { CURRENT_PATH_SCRIPT_PRELUDE } from "../current-path/index.js";
 import { computeActiveNavPath, pathMatchesNavPath } from "./nav-active.js";
 import {
   NAV_CHEVRON_ACTIVE,
@@ -46,17 +47,6 @@ import {
   NAV_TOP_ACTIVE,
   NAV_TOP_INACTIVE,
 } from "./nav-class-tokens.js";
-
-// Explicit current-route override read order, shared by all four active-nav
-// read sites (sidebar-tree-island, this script, version-switcher,
-// language-switcher — zudolab/zudo-doc#3398): an embedding host may set
-// `document.documentElement.dataset.zdCurrentPath` before `location.pathname`
-// is trustworthy. Inside an iframe `srcdoc` document, `location.pathname` is
-// the literal string "srcdoc" (matches no route) and Chromium refuses
-// `history.replaceState` there, so the page can't self-correct via
-// navigation (spike ledger adl-0005). Written inline into the script string
-// below (rather than a `.toString()`-embedded helper) since the whole
-// NAV_OVERFLOW_SCRIPT body is already hand-authored plain JS.
 
 // The class lists spliced into the script below are the SSR ↔ runtime
 // lockstep: they must match the strings header.tsx renders. Both files import
@@ -90,12 +80,10 @@ export const NAV_OVERFLOW_SCRIPT = `(function () {
     catch (e) { return ""; }
   }
 
-  // Explicit current-route override — see the module-level comment in
-  // nav-overflow-script.ts for the full rationale (zudolab/zudo-doc#3398).
-  function getCurrentPath() {
-    var override = document.documentElement.dataset.zdCurrentPath;
-    return override || location.pathname;
-  }
+  // Explicit current-route override, embedded from current-path/index.ts so
+  // this script cannot drift from the three other read sites
+  // (zudolab/zudo-doc#3398, #3408).
+  ${CURRENT_PATH_SCRIPT_PRELUDE}
 
   // Shared matching core (zudolab/zudo-doc#3398): embedded verbatim from
   // nav-active.ts so this script's longest-match walk cannot drift from the
@@ -119,7 +107,7 @@ export const NAV_OVERFLOW_SCRIPT = `(function () {
     var topItems = Array.from(nav.querySelectorAll(":scope > [data-nav-item]"));
     if (topItems.length === 0) return;
 
-    var cur = trimSlashes(getCurrentPath());
+    var cur = trimSlashes(readCurrentPath(CURRENT_PATH_DATASET_KEY));
 
     // Build NavItemLike-shaped entries from the live DOM so the shared
     // computeActiveNavPath can do the deepest-match walk — the same call

--- a/packages/zudo-doc/src/i18n-version/__tests__/language-switcher.test.tsx
+++ b/packages/zudo-doc/src/i18n-version/__tests__/language-switcher.test.tsx
@@ -11,6 +11,7 @@ import {
 import type { LocaleLink } from "../types.js";
 import { makeUrlHelpers } from "../../url-helpers/index.js";
 import { AFTER_NAVIGATE_EVENT } from "../../transitions/index.js";
+import { CURRENT_PATH_SCRIPT_PRELUDE } from "../../current-path/index.js";
 
 // Minimal VNode → HTML serializer (mirrors the helper used in
 // breadcrumb.test.tsx — kept inline so the test runs without a render
@@ -194,8 +195,10 @@ describe("LANGUAGE_SWITCHER_INIT_SCRIPT", () => {
     expect(LANGUAGE_SWITCHER_INIT_SCRIPT).toContain("data-language-switcher");
     expect(LANGUAGE_SWITCHER_INIT_SCRIPT).toContain("switchLocaleHref");
     // Explicit current-route override read order (zudolab/zudo-doc#3398):
-    // dataset attribute first, location.pathname as the fallback default.
-    expect(LANGUAGE_SWITCHER_INIT_SCRIPT).toContain("dataset.zdCurrentPath");
+    // dataset attribute first, location.pathname as the fallback default. The
+    // reader is spliced in from current-path/index.ts (#3408); the executing
+    // proof lives in current-path/__tests__/current-path-surfaces.test.tsx.
+    expect(LANGUAGE_SWITCHER_INIT_SCRIPT).toContain(CURRENT_PATH_SCRIPT_PRELUDE);
     expect(LANGUAGE_SWITCHER_INIT_SCRIPT).toContain("location.pathname");
     // idempotency guard (single document-level listener per page lifetime)
     expect(LANGUAGE_SWITCHER_INIT_SCRIPT).toContain("__zdLanguageSwitcherInit");

--- a/packages/zudo-doc/src/i18n-version/__tests__/version-switcher.test.tsx
+++ b/packages/zudo-doc/src/i18n-version/__tests__/version-switcher.test.tsx
@@ -16,6 +16,7 @@ import type {
 } from "../types.js";
 import type { VersionSwitcherRewireConfig } from "../version-switcher.js";
 import { AFTER_NAVIGATE_EVENT } from "../../transitions/page-events.js";
+import { CURRENT_PATH_SCRIPT_PRELUDE } from "../../current-path/index.js";
 import { makeUrlHelpers } from "../../url-helpers/index.js";
 
 type AnyVNode = VNode<{ children?: ComponentChildren; [key: string]: unknown }>;
@@ -446,8 +447,10 @@ describe("VERSION_SWITCHER_REWIRE_SCRIPT", () => {
     expect(VERSION_SWITCHER_REWIRE_SCRIPT).toContain("data-version-rewire");
     expect(VERSION_SWITCHER_REWIRE_SCRIPT).toContain("computeVersionSwitcherState");
     // Explicit current-route override read order (zudolab/zudo-doc#3398):
-    // dataset attribute first, location.pathname as the fallback default.
-    expect(VERSION_SWITCHER_REWIRE_SCRIPT).toContain("dataset.zdCurrentPath");
+    // dataset attribute first, location.pathname as the fallback default. The
+    // reader is spliced in from current-path/index.ts (#3408); the executing
+    // proof lives in current-path/__tests__/current-path-surfaces.test.tsx.
+    expect(VERSION_SWITCHER_REWIRE_SCRIPT).toContain(CURRENT_PATH_SCRIPT_PRELUDE);
     expect(VERSION_SWITCHER_REWIRE_SCRIPT).toContain("location.pathname");
     // idempotency guard (single document-level listener per page lifetime)
     expect(VERSION_SWITCHER_REWIRE_SCRIPT).toContain("__zdVersionSwitcherRewire");

--- a/packages/zudo-doc/src/i18n-version/language-switcher.tsx
+++ b/packages/zudo-doc/src/i18n-version/language-switcher.tsx
@@ -29,6 +29,7 @@ import type { VNode } from "preact";
 import { Fragment } from "preact";
 import type { LocaleLink } from "./types.js";
 import { AFTER_NAVIGATE_EVENT } from "../transitions/index.js";
+import { CURRENT_PATH_SCRIPT_PRELUDE } from "../current-path/index.js";
 
 /**
  * The minimal project config the client re-wire needs to reproduce
@@ -124,15 +125,17 @@ export function switchLocaleHref(
  * or a cross-locale header repaint, but the listener is registered exactly
  * once per page lifetime.
  *
- * The pathname fed to `switchLocaleHref` prefers
- * `document.documentElement.dataset.zdCurrentPath` over `location.pathname` —
- * the same explicit current-route override `nav-overflow-script.ts` /
- * `sidebar-tree-island` / `version-switcher.tsx` read (zudolab/zudo-doc#3398).
+ * The pathname fed to `switchLocaleHref` comes from the embedded
+ * `readCurrentPath`, which prefers the `data-zd-current-path` override over
+ * `location.pathname` — the same explicit current-route reader
+ * `nav-overflow-script.ts` / `sidebar-tree-island` / `version-switcher.tsx`
+ * use (zudolab/zudo-doc#3398, consolidated by #3408).
  */
 export const LANGUAGE_SWITCHER_INIT_SCRIPT = `(function(){
 var FLAG="__zdLanguageSwitcherInit";
 if(window[FLAG])return;
 window[FLAG]=true;
+${CURRENT_PATH_SCRIPT_PRELUDE}
 var switchLocaleHref=${switchLocaleHref.toString()};
 function rewire(){
 var containers=document.querySelectorAll("[data-language-switcher]");
@@ -145,7 +148,7 @@ for(var j=0;j<anchors.length;j++){
 var a=anchors[j];
 var target=a.getAttribute("lang");
 if(!target)continue;
-a.setAttribute("href",switchLocaleHref(document.documentElement.dataset.zdCurrentPath||location.pathname,config,currentLang,target));
+a.setAttribute("href",switchLocaleHref(readCurrentPath(CURRENT_PATH_DATASET_KEY),config,currentLang,target));
 }
 }
 }

--- a/packages/zudo-doc/src/i18n-version/version-switcher.tsx
+++ b/packages/zudo-doc/src/i18n-version/version-switcher.tsx
@@ -66,6 +66,7 @@
 import type { VNode } from "preact";
 import type { VersionEntry, VersionSwitcherLabels } from "./types.js";
 import { AFTER_NAVIGATE_EVENT } from "../transitions/page-events.js";
+import { CURRENT_PATH_SCRIPT_PRELUDE } from "../current-path/index.js";
 import { UNAVAILABLE_VERSIONS_ATTR } from "../version-availability/index.js";
 
 export interface VersionSwitcherProps {
@@ -553,16 +554,18 @@ document.addEventListener(${JSON.stringify(AFTER_NAVIGATE_EVENT)},initVersionSwi
  * a cross-locale header repaint, but the listener registers exactly once per
  * page lifetime.
  *
- * The pathname fed to `computeVersionSwitcherState` prefers
- * `document.documentElement.dataset.zdCurrentPath` over `location.pathname` —
- * the same explicit current-route override `nav-overflow-script.ts` /
- * `sidebar-tree-island` / `language-switcher.tsx` read (zudolab/zudo-doc#3398).
+ * The pathname fed to `computeVersionSwitcherState` comes from the embedded
+ * `readCurrentPath`, which prefers the `data-zd-current-path` override over
+ * `location.pathname` — the same explicit current-route reader
+ * `nav-overflow-script.ts` / `sidebar-tree-island` / `language-switcher.tsx`
+ * use (zudolab/zudo-doc#3398, consolidated by #3408).
  */
 export const VERSION_SWITCHER_REWIRE_SCRIPT = `(function(){
 var FLAG="__zdVersionSwitcherRewire";
 if(window[FLAG])return;
 window[FLAG]=true;
 var ATTR=${JSON.stringify(UNAVAILABLE_VERSIONS_ATTR)};
+${CURRENT_PATH_SCRIPT_PRELUDE}
 var computeVersionSwitcherState=${computeVersionSwitcherState.toString()};
 function setActive(a,active){
 a.classList.toggle("font-bold",active);
@@ -604,7 +607,7 @@ for(var j=0;j<versionAnchors.length;j++){
 var s=versionAnchors[j].getAttribute("data-version-slug");
 if(s)slugs.push(s);
 }
-var state=computeVersionSwitcherState(document.documentElement.dataset.zdCurrentPath||location.pathname,config,slugs);
+var state=computeVersionSwitcherState(readCurrentPath(CURRENT_PATH_DATASET_KEY),config,slugs);
 var latest=c.querySelector("[data-version-latest]");
 if(latest){
 latest.setAttribute("href",state.latestHref);

--- a/packages/zudo-doc/src/sidebar-tree-island/__tests__/sidebar-tree-active-path.test.tsx
+++ b/packages/zudo-doc/src/sidebar-tree-island/__tests__/sidebar-tree-active-path.test.tsx
@@ -17,6 +17,7 @@ import { render } from "preact";
 import { act } from "preact/test-utils";
 import { SidebarTree, type SidebarTreeProps } from "../index.js";
 import type { SidebarNavNode } from "../../sidebar/types.js";
+import { CURRENT_PATH_DATASET_KEY } from "../../current-path/index.js";
 
 const NODES: SidebarNavNode[] = [
   {
@@ -65,12 +66,12 @@ afterEach(() => {
     mounted.remove();
     mounted = null;
   }
-  delete document.documentElement.dataset.zdCurrentPath;
+  delete document.documentElement.dataset[CURRENT_PATH_DATASET_KEY];
 });
 
 describe("SidebarTree — explicit current-route override", () => {
   it("prefers the explicit currentPath prop over the dataset override", () => {
-    document.documentElement.dataset.zdCurrentPath = "/docs/introduction";
+    document.documentElement.dataset[CURRENT_PATH_DATASET_KEY] = "/docs/introduction";
     const container = mount({ nodes: NODES, currentPath: "/docs/guides/getting-started" });
 
     const active = container.querySelector('a[aria-current="page"]');
@@ -78,7 +79,7 @@ describe("SidebarTree — explicit current-route override", () => {
   });
 
   it("falls back to document.documentElement.dataset.zdCurrentPath when no currentPath prop is given", () => {
-    document.documentElement.dataset.zdCurrentPath = "/docs/introduction";
+    document.documentElement.dataset[CURRENT_PATH_DATASET_KEY] = "/docs/introduction";
     const container = mount({ nodes: NODES });
 
     const active = container.querySelector('a[aria-current="page"]');

--- a/packages/zudo-doc/src/sidebar-tree-island/index.tsx
+++ b/packages/zudo-doc/src/sidebar-tree-island/index.tsx
@@ -18,6 +18,7 @@ import { smartBreakToHtml } from "../smart-break/index.js";
 import { AFTER_NAVIGATE_EVENT, BEFORE_NAVIGATE_EVENT } from "../transitions/index.js";
 import { filterTree } from "../sidebar-filter/index.js";
 import { findActiveSlug, normalizePath } from "../sidebar-active-slug/index.js";
+import { CURRENT_PATH_DATASET_KEY, readCurrentPath } from "../current-path/index.js";
 import { ensureSidebarScrollPreserve } from "./sidebar-scroll-preserve.js";
 
 // The persisted aside can transiently tear down and re-mount its SidebarTree
@@ -61,26 +62,12 @@ function saveOpenSet(set: Set<string>) {
 }
 
 /**
- * Explicit current-route override, checked before `window.location.pathname`.
- * An embedding host (e.g. an iframe `srcdoc` preview shell) sets
- * `document.documentElement.dataset.zdCurrentPath` because inside
- * `about:srcdoc`, `location.pathname` is the literal string "srcdoc" (matches
- * no route) and Chromium refuses `history.replaceState` there, so the page
- * cannot self-correct via navigation (zudolab/zudo-doc#3398, spike ledger
- * adl-0005). This is the same override source `nav-overflow-script.ts` /
- * `version-switcher.tsx` / `language-switcher.tsx` read.
- */
-function currentPathOverride(): string | undefined {
-  if (typeof document === "undefined") return undefined;
-  return document.documentElement.dataset.zdCurrentPath || undefined;
-}
-
-/**
  * Derive the active slug from an explicit current-route input. Resolution
- * order: the `pathname` argument, then `currentPathOverride()`, then
- * `window.location.pathname`. Used as a hydration-time fallback when the
- * parent island does not forward `currentSlug` through its prop boundary,
- * and at every View Transition to keep the highlight in sync.
+ * order is owned by {@link readCurrentPath}: the `pathname` argument, then the
+ * `data-zd-current-path` override, then `window.location.pathname`. Used as a
+ * hydration-time fallback when the parent island does not forward
+ * `currentSlug` through its prop boundary, and at every View Transition to
+ * keep the highlight in sync.
  *
  * Returns `undefined` both when no pathname is resolvable AND when the
  * resolved pathname matches no route (e.g. the literal "srcdoc") — callers
@@ -88,11 +75,10 @@ function currentPathOverride(): string | undefined {
  * already set rather than clearing it.
  */
 function deriveActiveSlug(nodes: SidebarNavNode[], pathname?: string): string | undefined {
-  // `||` (not `??`) so an empty-string `pathname` falls through to the live
-  // sources instead of silently disabling derivation — SidebarWithDefaults
-  // defaults its own currentPath to "", so "" is the natural absent shape.
-  const resolved =
-    pathname || currentPathOverride() || (typeof window !== "undefined" ? window.location.pathname : undefined);
+  // An empty-string `pathname` must fall through to the live sources instead
+  // of silently disabling derivation — SidebarWithDefaults defaults its own
+  // currentPath to "", so "" is the natural absent shape.
+  const resolved = readCurrentPath(CURRENT_PATH_DATASET_KEY, pathname);
   if (!resolved) return undefined;
   return findActiveSlug(nodes, normalizePath(resolved));
 }
@@ -175,10 +161,10 @@ export interface SidebarTreeProps {
   nodes: SidebarNavNode[];
   currentSlug?: string;
   /**
-   * Explicit current-route override, checked before
-   * `document.documentElement.dataset.zdCurrentPath` and
-   * `window.location.pathname` when deriving the active slug on hydration
-   * and at every View Transition. See `deriveActiveSlug` (zudolab/zudo-doc#3398).
+   * Explicit current-route override, checked before the
+   * `data-zd-current-path` dataset override and `window.location.pathname`
+   * when deriving the active slug on hydration and at every View Transition.
+   * See `deriveActiveSlug` (zudolab/zudo-doc#3398).
    */
   currentPath?: string;
   rootMenuItems?: SidebarRootMenuItem[];


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3408

---

## Summary
- Fixes #3408 (agent-found during epic zudolab/zudo-doc#3394): the `dataset.zdCurrentPath` current-route override was hand-copied in four shapes across four modules with the key as a bare literal everywhere.
- New `src/current-path/` module: `CURRENT_PATH_DATASET_KEY`, a serialization-safe `readCurrentPath(datasetKey, explicit?)` (key as parameter, not closure), and `CURRENT_PATH_SCRIPT_PRELUDE` spliced into the three string-embedded client scripts.
- New executing (not string-matching) surface test drives all four surfaces through the shared key; drift now fails at test time (verified by temporarily hardcoding a stale key — 1 test failed as intended).
- Public API widened deliberately: `./current-path` exports entry + public-api snapshot update, required because the ejectable sidebar-tree-island imports it (same rationale as `./sidebar-active-slug`).

## Test Plan
- Package: build clean, 189 files / 2174 tests green, tsc clean.
- Root: `pnpm check` clean, `pnpm test:unit` 942 green; shim/eject/template-drift/pin-parity guards green.
- `/code-review low --fix`: no findings.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/3409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789596372&installation_model_id=20910&pr_number=3409&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F3409&signature=796d6252257ab189e007c70987e4f7bf7a48e3f2106bda21fbda62b5c7ae25a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->