### PR TITLE
Sweep Batch Guards: scanner-noise upstream, A2 parity CI gate, DTP shadowing diagnostic (#3425)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -515,21 +515,34 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Every-page script emitter files (zudolab/zudo-doc#3419) — a change
-          # to any of these can shift the byte-identical HTML the A2 no-stub
-          # parity hashes assert on. One path per line. The search-widget-script
-          # entry is a directory (trailing slash = prefix match below) — it
-          # covers scoring.ts and any committed generated file under it.
+          # Files whose change can shift the byte-identical HTML the A2 no-stub
+          # parity hashes assert on (zudolab/zudo-doc#3419). One path per line;
+          # a trailing slash means prefix (directory) match below.
+          #
+          # BEST-EFFORT, NOT EXHAUSTIVE. The hashes cover the WHOLE normalized
+          # page HTML, not just the inlined scripts, so any package source that
+          # contributes SSR markup to the fixture's pages can move them — the
+          # test file's own re-baseline log records exactly that happening for
+          # `src/header/header.tsx` and `src/doc-content-header/index.tsx`
+          # (#3039). Those two are listed for that reason; when a re-baseline
+          # traces to some other markup source, add it here in the same PR.
+          #
+          # The parity test file itself is listed so a PR that EDITS the
+          # expected hashes re-runs the suite and proves the new baseline,
+          # instead of skipping the gate on the one PR where it matters most.
           EMITTERS=(
             "packages/zudo-doc/src/theme/theme-pack-provider.tsx"
             "packages/zudo-doc/src/current-path/index.ts"
             "packages/zudo-doc/src/header/nav-overflow-script.ts"
             "packages/zudo-doc/src/header/nav-active.ts"
+            "packages/zudo-doc/src/header/header.tsx"
+            "packages/zudo-doc/src/doc-content-header/index.tsx"
             "packages/zudo-doc/src/i18n-version/version-switcher.tsx"
             "packages/zudo-doc/src/i18n-version/language-switcher.tsx"
             "packages/zudo-doc/src/search-widget-script/"
             "packages/zudo-doc/scripts/gen-search-widget-script.mjs"
             "packages/zudo-doc/src/transitions/page-events.ts"
+            "packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts"
           )
 
           CHANGED_FILES="$(git diff --name-only "$BASE_SHA"...HEAD)"
@@ -597,6 +610,7 @@ jobs:
         run: pnpm build:workspace
 
       - name: Run A2 no-stub parity slow-suite subset
+        id: parity
         if: steps.detect-emitters.outputs.run_parity == 'true'
         working-directory: packages/zudo-doc
         # Block scalar (not inline `run: <value>`) — the --testNamePattern
@@ -607,10 +621,11 @@ jobs:
           pnpm exec vitest run --config vitest.slow.config.ts --testNamePattern "A2 no-stub: injected routes render correct HTML.*(setup: fixture builds|parity:)"
 
       - name: Re-baseline guidance
-        # Scoped to the run path (not bare `if: failure()`) so an unrelated
-        # failure upstream — e.g. checkout itself — doesn't print a hash
-        # re-baseline message that has nothing to do with what broke.
-        if: failure() && steps.detect-emitters.outputs.run_parity == 'true'
+        # Scoped to the parity step's own outcome (not bare `if: failure()`,
+        # and not merely the run path) so an unrelated failure — checkout,
+        # pnpm install, build:workspace — doesn't print a hash re-baseline
+        # message that has nothing to do with what broke.
+        if: failure() && steps.parity.outcome == 'failure'
         run: |
           echo "::error::A2 no-stub parity suite failed."
           echo "If this is an intentional HTML/asset change (not a regression), re-baseline"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -19,6 +19,9 @@
 #   Worker Contract Proof    — Worker typecheck + runtime DO tests + Wrangler dry-run
 #   Package Unit Tests       — pnpm install; pnpm test:packages (all 5 package suites)
 #   Root Unit Tests          — pnpm install; pnpm test:unit (src/**/__tests__, scripts/__tests__)
+#   A2 Parity Gate           — path-filtered (#3419): skips unless an every-page script
+#                              emitter file changed; else pnpm install + build:workspace +
+#                              the A2 no-stub parity slow-suite subset
 #   Build Site               — full clone, pnpm install; pnpm build + check:links
 #   HTML validate            — needs build-site; pnpm check:html
 #   Build Doc History        — full clone, pnpm install; doc-history-server generate
@@ -474,6 +477,150 @@ jobs:
 
       - name: Run root unit tests
         run: pnpm test:unit
+
+  # ---------------------------------------------------------------------------
+  # Job 1.7: A2 no-stub parity gate (path-filtered) (#3419)
+  # ---------------------------------------------------------------------------
+  # The A2 no-stub parity describe in route-injection-build.slow.test.ts
+  # (packages/zudo-doc) asserts sha256-stable normalized HTML for pages built
+  # with package-owned routes and no host stubs. Those hashes only move when
+  # one of a small set of "every-page script emitter" files changes (scripts
+  # embedded via toString()/generated into every page's HTML — theme pack,
+  # current-path, nav overflow/active, i18n switchers, the search widget
+  # script generator, page-transition events). Running the full slow suite on
+  # every PR is wasteful, so this job diffs the PR against its base and only
+  # runs the parity subset when an emitter file is touched — otherwise it
+  # exits green on the skip path. The sibling generator-hardening epic
+  # (zudolab/zudo-doc#3425) is expected to exercise the RUN path.
+  #
+  # fetch-depth: 0 so the diff below has the full history needed to resolve
+  # the merge-base against the PR's base SHA (mirrors build-site/build-history).
+  a2-parity-gate:
+    name: A2 No-Stub Parity Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+
+      - name: Detect every-page script emitter changes
+        id: detect-emitters
+        env:
+          # Passed via env (not inlined into the script) so the SHA never
+          # flows through shell interpolation of a ${{ }} expression.
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+
+          # Every-page script emitter files (zudolab/zudo-doc#3419) — a change
+          # to any of these can shift the byte-identical HTML the A2 no-stub
+          # parity hashes assert on. One path per line. The search-widget-script
+          # entry is a directory (trailing slash = prefix match below) — it
+          # covers scoring.ts and any committed generated file under it.
+          EMITTERS=(
+            "packages/zudo-doc/src/theme/theme-pack-provider.tsx"
+            "packages/zudo-doc/src/current-path/index.ts"
+            "packages/zudo-doc/src/header/nav-overflow-script.ts"
+            "packages/zudo-doc/src/header/nav-active.ts"
+            "packages/zudo-doc/src/i18n-version/version-switcher.tsx"
+            "packages/zudo-doc/src/i18n-version/language-switcher.tsx"
+            "packages/zudo-doc/src/search-widget-script/"
+            "packages/zudo-doc/scripts/gen-search-widget-script.mjs"
+            "packages/zudo-doc/src/transitions/page-events.ts"
+          )
+
+          CHANGED_FILES="$(git diff --name-only "$BASE_SHA"...HEAD)"
+          echo "Changed files vs base ($BASE_SHA):"
+          echo "$CHANGED_FILES"
+          echo ""
+
+          MATCHED=0
+          while IFS= read -r file; do
+            if [ -z "$file" ]; then
+              continue
+            fi
+            for emitter in "${EMITTERS[@]}"; do
+              case "$emitter" in
+                */)
+                  case "$file" in
+                    "$emitter"*)
+                      echo "Emitter changed (dir match): $file"
+                      MATCHED=1
+                      ;;
+                  esac
+                  ;;
+                *)
+                  if [ "$file" = "$emitter" ]; then
+                    echo "Emitter changed: $file"
+                    MATCHED=1
+                  fi
+                  ;;
+              esac
+            done
+          done <<<"$CHANGED_FILES"
+
+          if [ "$MATCHED" -eq 0 ]; then
+            echo ""
+            echo "No every-page script emitter files changed — skipping the A2 no-stub parity suite."
+            echo "run_parity=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "run_parity=true" >> "$GITHUB_OUTPUT"
+
+      - name: Setup pnpm
+        if: steps.detect-emitters.outputs.run_parity == 'true'
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
+        with:
+          dest: ~/setup-pnpm-${{ github.job }}
+
+      - name: Setup Node.js
+        if: steps.detect-emitters.outputs.run_parity == 'true'
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        if: steps.detect-emitters.outputs.run_parity == 'true'
+        run: pnpm install --frozen-lockfile
+
+      # Mandatory, not just a freshness nicety: the slow suite builds its
+      # fixtures against workspace dist/, and ensure:workspace-build (which
+      # pnpm install alone triggers via prepare) only checks existence, not
+      # freshness (#3053) — a stale dist/ would silently pass a build that
+      # should have failed or produce parity hashes for the wrong source.
+      - name: Build workspace packages
+        if: steps.detect-emitters.outputs.run_parity == 'true'
+        run: pnpm build:workspace
+
+      - name: Run A2 no-stub parity slow-suite subset
+        if: steps.detect-emitters.outputs.run_parity == 'true'
+        working-directory: packages/zudo-doc
+        # Block scalar (not inline `run: <value>`) — the --testNamePattern
+        # value contains unquoted-looking `: ` sequences ("A2 no-stub: ...",
+        # "setup: ...") that a YAML plain scalar parses as a nested mapping
+        # key. Indentation-scoped block scalars have no such ambiguity.
+        run: |
+          pnpm exec vitest run --config vitest.slow.config.ts --testNamePattern "A2 no-stub: injected routes render correct HTML.*(setup: fixture builds|parity:)"
+
+      - name: Re-baseline guidance
+        # Scoped to the run path (not bare `if: failure()`) so an unrelated
+        # failure upstream — e.g. checkout itself — doesn't print a hash
+        # re-baseline message that has nothing to do with what broke.
+        if: failure() && steps.detect-emitters.outputs.run_parity == 'true'
+        run: |
+          echo "::error::A2 no-stub parity suite failed."
+          echo "If this is an intentional HTML/asset change (not a regression), re-baseline"
+          echo "the expected sha256 hashes in"
+          echo "packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts,"
+          echo "following that file's dated re-baseline comment-block convention (search for"
+          echo "'re-baseline' in the file for prior examples, e.g. a block like:"
+          echo "  // 2026-08-18 re-baseline (zudolab/zudo-doc#NNNN, <why>): ..."
+          echo "Add a NEW dated block with issue attribution in THIS PR when you update a hash —"
+          echo "do not silently overwrite an old hash without one."
 
   # ---------------------------------------------------------------------------
   # Job 2: Build the zfb docs site (full clone — needed for SSG meta dates)

--- a/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
+++ b/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
@@ -1811,6 +1811,22 @@ describe("S1 no-src: published package (routes-src/, no src/) renders injected r
 //   4. `zfb dev` renders / and /docs/getting-started/ (200 + content marker).
 //   5. Computed-token smoke on built CSS (theme.css contract).
 //   6. Fixture file count == 17 (guards floor creep).
+//
+// *** KNOWN BENIGN WARNING — every Case TM build ***
+// Every build of this fixture logs `island marker name collision:
+// "ConfiguredDesignTokenPanelBootstrap"`. Cause: this fixture's `pages/index.tsx`
+// re-exports `@takazudo/zudo-doc/routes/index`, so the compiled
+// `dist/routes/_chrome.js` → `dist/routes/_design-token-panel-bootstrap.js`
+// graph is scanned alongside the staged `routes-src/` copy — the same
+// component reaches zfb's island scanner from two files, and the scanner keys
+// islands by marker name rather than resolved component identity. Benign: zfb
+// keeps the `routes-src/` copy and the surviving registry entry matches every
+// emitted marker, so behavior is correct — the cost is unconditional noise,
+// and it is why this fixture cannot assert a collision-free build (see "TM
+// group 2b" below for the full explanation and the local assertion it drives).
+// Decision (tolerate + file upstream) recorded on zudolab/zudo-doc#3418.
+// Upstream tracking issue (zfb island-scanner identity dedupe):
+// UPSTREAM_ISSUE_URL_PLACEHOLDER
 // ---------------------------------------------------------------------------
 
 /** Set up a target-manifest fixture instance: copy the locked-manifest fixture

--- a/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
+++ b/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
@@ -1828,14 +1828,23 @@ describe("S1 no-src: published package (routes-src/, no src/) renders injected r
 // Upstream tracking issue (zfb island-scanner identity dedupe):
 // https://github.com/Takazudo/zudo-front-builder/issues/2441
 //
-// The upstream fix dedupes by resolved component identity, and reaches THIS
-// case via a byte-identity branch: the staged copy is compared against the file
-// the package ships at the same stem under `node_modules/@takazudo/zudo-doc/
-// routes-src/`. That branch only fires while `ensureStaged`
-// (src/plugins/routes.ts) stays a verbatim `cpSync`. If staging ever starts
-// rewriting what it copies — the way build-time `copy-routes-src.mjs` rewrites
-// specifiers — the two participants stop being byte-identical and this warning
-// returns. A genuinely different component colliding by name still warns.
+// The upstream fix (PR Takazudo/zudo-front-builder#2442) dedupes by resolved
+// component identity, and reaches THIS case via a byte-identity branch: the
+// staged copy is compared against the PUBLISHED file the package ships at the
+// same stem under `node_modules/@takazudo/zudo-doc/routes-src/`. So the
+// invariant we owe upstream is narrow — `ensureStaged` (src/plugins/routes.ts)
+// must stay byte-preserving RELATIVE TO WHAT THE PACKAGE SHIPS. A future
+// rewrite inside build-time `scripts/copy-routes-src.mjs` is harmless (it runs
+// pre-publish, so both compared participants are post-rewrite); a rewrite
+// inside `ensureStaged` would break the match and resurrect this warning.
+//
+// Accepted upstream trade-off: two GENUINELY DIFFERENT components shipped by
+// the SAME package under one marker name are now silently deduped too. Only a
+// cross-package name collision still warns. So zfb can no longer tell us if
+// this package ever collides two real components — our own tests are the only
+// guard for that.
+// Flipping this fixture to assert a collision-free build, once the upstream
+// fix ships and zfb is bumped here: zudolab/zudo-doc#3433.
 // ---------------------------------------------------------------------------
 
 /** Set up a target-manifest fixture instance: copy the locked-manifest fixture

--- a/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
+++ b/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
@@ -1826,7 +1826,16 @@ describe("S1 no-src: published package (routes-src/, no src/) renders injected r
 // group 2b" below for the full explanation and the local assertion it drives).
 // Decision (tolerate + file upstream) recorded on zudolab/zudo-doc#3418.
 // Upstream tracking issue (zfb island-scanner identity dedupe):
-// UPSTREAM_ISSUE_URL_PLACEHOLDER
+// https://github.com/Takazudo/zudo-front-builder/issues/2441
+//
+// The upstream fix dedupes by resolved component identity, and reaches THIS
+// case via a byte-identity branch: the staged copy is compared against the file
+// the package ships at the same stem under `node_modules/@takazudo/zudo-doc/
+// routes-src/`. That branch only fires while `ensureStaged`
+// (src/plugins/routes.ts) stays a verbatim `cpSync`. If staging ever starts
+// rewriting what it copies — the way build-time `copy-routes-src.mjs` rewrites
+// specifiers — the two participants stop being byte-identical and this warning
+// returns. A genuinely different component colliding by name still warns.
 // ---------------------------------------------------------------------------
 
 /** Set up a target-manifest fixture instance: copy the locked-manifest fixture

--- a/packages/zudo-doc/src/plugins/__tests__/route-pages-candidates.test.ts
+++ b/packages/zudo-doc/src/plugins/__tests__/route-pages-candidates.test.ts
@@ -1,0 +1,55 @@
+// Fast, isolated unit coverage for the pure route-pattern → `pages/`
+// candidate-file mapper (#3428, spec for zudolab/zudo-doc#3420's DTP shadow
+// diagnostic). No filesystem I/O here — the fs-probing side of the
+// diagnostic is covered by `routes.test.ts`.
+
+import { describe, expect, it } from "vitest";
+import { derivePagesCandidates, ROUTABLE_PAGE_EXTENSIONS } from "../route-pages-candidates.js";
+
+describe("derivePagesCandidates", () => {
+  it("covers every accepted extension, in both file and directory-index form", () => {
+    const candidates = derivePagesCandidates("/404");
+    for (const ext of ROUTABLE_PAGE_EXTENSIONS) {
+      expect(candidates).toContain(`404.${ext}`);
+      expect(candidates).toContain(`404/index.${ext}`);
+    }
+    expect(candidates).toHaveLength(ROUTABLE_PAGE_EXTENSIONS.length * 2);
+  });
+
+  it("maps a single dynamic segment to both the file and index forms (locale mapping)", () => {
+    const candidates = derivePagesCandidates("/[locale]");
+    expect(candidates).toContain("[locale].tsx");
+    expect(candidates).toContain("[locale]/index.tsx");
+  });
+
+  it("keeps earlier static segments as a literal directory prefix", () => {
+    const candidates = derivePagesCandidates("/docs/tags/[tag]");
+    expect(candidates).toContain("docs/tags/[tag].tsx");
+    expect(candidates).toContain("docs/tags/[tag]/index.tsx");
+    // Earlier segments never carry an extension or an index form of their own.
+    expect(candidates.some((c) => c.startsWith("docs.") || c.startsWith("docs/index."))).toBe(false);
+  });
+
+  it("combines a locale prefix with nested dynamic segments", () => {
+    const candidates = derivePagesCandidates("/[locale]/docs/tags/[tag]");
+    expect(candidates).toContain("[locale]/docs/tags/[tag].tsx");
+    expect(candidates).toContain("[locale]/docs/tags/[tag]/index.tsx");
+  });
+
+  it("preserves catchall and optional-catchall bracket syntax unchanged", () => {
+    expect(derivePagesCandidates("/docs/[...slug]")).toContain("docs/[...slug].tsx");
+    const optional = derivePagesCandidates("/docs/[[...slug]]");
+    expect(optional).toContain("docs/[[...slug]].tsx");
+    expect(optional).toContain("docs/[[...slug]]/index.tsx");
+  });
+
+  it("treats a dotted last segment as a literal URL segment, not a nested extension", () => {
+    const candidates = derivePagesCandidates("/sitemap.xml");
+    expect(candidates).toContain("sitemap.xml.tsx");
+    expect(candidates).toContain("sitemap.xml/index.tsx");
+  });
+
+  it("returns an empty list for the root pattern", () => {
+    expect(derivePagesCandidates("/")).toEqual([]);
+  });
+});

--- a/packages/zudo-doc/src/plugins/__tests__/routes.test.ts
+++ b/packages/zudo-doc/src/plugins/__tests__/routes.test.ts
@@ -35,15 +35,24 @@ import routesPlugin from "../routes.js";
 /** Minimal mock of the fields `routes.ts`'s `setup()` actually reads
  *  (`options`, `projectRoot`) plus no-op stubs for the rest of
  *  `ZfbSetupContext` (`command`, `config`, `logger`, `addAlias`,
- *  `addClientEntry`) — this plugin's `setup()` never touches those. */
+ *  `addClientEntry`) — this plugin's `setup()` never touches those.
+ *  `warnings` collects every `ctx.logger.warn(...)` call verbatim, for the
+ *  DTP shadow-diagnostic coverage below (#3428). */
 function makeCtx(projectRoot: string, settings: Record<string, unknown>) {
   const virtualModules = new Map<string, () => string | Promise<string>>();
+  const warnings: string[] = [];
   const ctx = {
     command: "build" as const,
     projectRoot,
     config: {} as never,
     options: { settings, translations: {}, tagVocabulary: [], colorSchemes: null },
-    logger: { info() {}, warn() {}, error() {} },
+    logger: {
+      info() {},
+      warn(msg: string) {
+        warnings.push(msg);
+      },
+      error() {},
+    },
     addAlias() {},
     addVirtualModule(specifier: string, loader: () => string | Promise<string>) {
       virtualModules.set(specifier, loader);
@@ -51,7 +60,7 @@ function makeCtx(projectRoot: string, settings: Record<string, unknown>) {
     injectRoute() {},
     addClientEntry() {},
   };
-  return { ctx, virtualModules };
+  return { ctx, virtualModules, warnings };
 }
 
 const tempDirs: string[] = [];
@@ -190,6 +199,119 @@ function collectSourceFiles(dir: string, out: string[] = []): string[] {
   }
   return out;
 }
+
+// ---------------------------------------------------------------------------
+// DTP shadow diagnostic (zudolab/zudo-doc#3420, spec #3428) — warns at plugin
+// setup when `designTokenPanelConfigModule` is set but every derived route's
+// URL is shadowed by a kept user `pages/` file, unless the resolved
+// `chromeBindingsModule` already names the documented workaround.
+// ---------------------------------------------------------------------------
+
+/** The static/always-on route patterns `deriveRoutes()` emits when locales,
+ *  versions, `docTags`, and `aiAssistant` are all absent — see `routes.ts`
+ *  section "Static / always-on". Used below to build full vs. partial
+ *  shadowing fixtures without reaching into the plugin's private catalog. */
+const ALWAYS_ON_ROUTE_PATTERNS = ["/404", "/sitemap.xml", "/robots.txt", "/docs/[[...slug]]"];
+
+/** Write a `pages/` stub file that shadows `pattern` (the plain FILE form —
+ *  one of the two shapes `derivePagesCandidates` recognises). */
+function shadowRouteWithStub(projectRoot: string, pattern: string) {
+  const relPath = `${pattern.replace(/^\//, "")}.tsx`;
+  const absPath = join(projectRoot, "pages", relPath);
+  mkdirSync(dirname(absPath), { recursive: true });
+  writeFileSync(absPath, "export default function Page() { return null; }\n");
+}
+
+/** Write a valid, existing `designTokenPanelConfigModule` file and return its
+ *  project-root-relative path for the settings object. */
+function writeConfigModule(projectRoot: string): string {
+  mkdirSync(join(projectRoot, "src"), { recursive: true });
+  writeFileSync(
+    join(projectRoot, "src", "dtp-config.ts"),
+    "export function buildDesignTokenPanelConfig() { return {}; }\n",
+  );
+  return "./src/dtp-config.ts";
+}
+
+describe("routes plugin — DTP shadow diagnostic (#3420, #3428)", () => {
+  it("warns exactly once when every derived route is shadowed and no chromeBindings workaround is present", () => {
+    const projectRoot = makeProjectRoot();
+    for (const pattern of ALWAYS_ON_ROUTE_PATTERNS) shadowRouteWithStub(projectRoot, pattern);
+    const designTokenPanelConfigModule = writeConfigModule(projectRoot);
+
+    const { ctx, warnings } = makeCtx(projectRoot, {
+      packageOwnedRoutes: true,
+      designTokenPanelConfigModule,
+    });
+    routesPlugin.setup!(ctx as never);
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("designTokenPanelConfigModule");
+    expect(warnings[0]).toContain("zudolab/zudo-doc#3420");
+    expect(warnings[0]).toContain("DesignTokenPanelBootstrap");
+  });
+
+  it("stays silent when shadowing is only partial", () => {
+    const projectRoot = makeProjectRoot();
+    // Shadow every route except /sitemap.xml.
+    for (const pattern of ALWAYS_ON_ROUTE_PATTERNS) {
+      if (pattern === "/sitemap.xml") continue;
+      shadowRouteWithStub(projectRoot, pattern);
+    }
+    const designTokenPanelConfigModule = writeConfigModule(projectRoot);
+
+    const { ctx, warnings } = makeCtx(projectRoot, {
+      packageOwnedRoutes: true,
+      designTokenPanelConfigModule,
+    });
+    routesPlugin.setup!(ctx as never);
+
+    expect(warnings).toHaveLength(0);
+  });
+
+  it("stays silent when no route is shadowed", () => {
+    const projectRoot = makeProjectRoot();
+    const designTokenPanelConfigModule = writeConfigModule(projectRoot);
+
+    const { ctx, warnings } = makeCtx(projectRoot, {
+      packageOwnedRoutes: true,
+      designTokenPanelConfigModule,
+    });
+    routesPlugin.setup!(ctx as never);
+
+    expect(warnings).toHaveLength(0);
+  });
+
+  it("stays silent when designTokenPanelConfigModule is unset, even with full shadowing", () => {
+    const projectRoot = makeProjectRoot();
+    for (const pattern of ALWAYS_ON_ROUTE_PATTERNS) shadowRouteWithStub(projectRoot, pattern);
+
+    const { ctx, warnings } = makeCtx(projectRoot, { packageOwnedRoutes: true });
+    routesPlugin.setup!(ctx as never);
+
+    expect(warnings).toHaveLength(0);
+  });
+
+  it("stays silent when the resolved chromeBindingsModule file names DesignTokenPanelBootstrap", () => {
+    const projectRoot = makeProjectRoot();
+    for (const pattern of ALWAYS_ON_ROUTE_PATTERNS) shadowRouteWithStub(projectRoot, pattern);
+    const designTokenPanelConfigModule = writeConfigModule(projectRoot);
+    writeFileSync(
+      join(projectRoot, "src", "chrome-bindings.tsx"),
+      'import { DesignTokenPanelBootstrap } from "@takazudo/zudo-doc/design-token-panel-bootstrap";\n' +
+        "export const chromeBindings = { DesignTokenPanelBootstrap };\n",
+    );
+
+    const { ctx, warnings } = makeCtx(projectRoot, {
+      packageOwnedRoutes: true,
+      designTokenPanelConfigModule,
+      chromeBindingsModule: "./src/chrome-bindings.tsx",
+    });
+    routesPlugin.setup!(ctx as never);
+
+    expect(warnings).toHaveLength(0);
+  });
+});
 
 describe("routes plugin — design-token-panel-config specifier is routes-only (#3396)", () => {
   const importers = collectSourceFiles(SRC_ROOT)

--- a/packages/zudo-doc/src/plugins/route-pages-candidates.ts
+++ b/packages/zudo-doc/src/plugins/route-pages-candidates.ts
@@ -1,0 +1,46 @@
+// Pure route-pattern → `pages/` candidate-file mapping, extracted so it can
+// be unit-tested in isolation from any filesystem probing (#3428, spec for
+// zudolab/zudo-doc#3420's DTP shadow diagnostic).
+//
+// Mirrors zfb's file→route derivation (`zfb-router`'s `scan_pages` /
+// `parse_route`, Next.js/Astro-style conventions): the URL's LAST path
+// segment may be authored either as a sibling FILE (`segment.<ext>`) or as a
+// directory INDEX (`segment/index.<ext>`), for any accepted page extension.
+// Earlier segments are always plain directories. Dynamic segments carry
+// their bracket syntax unchanged (`[locale]`, `[tag]`, `[...slug]`,
+// `[[...slug]]`) because zfb's `injectRoute` pattern syntax matches the
+// file-routing bracket syntax 1:1 — no separate translation needed.
+
+/**
+ * File extensions zfb's router accepts as `pages/` route sources. Mirrors
+ * the Rust-side single source of truth `zfb_types::ROUTABLE_PAGE_EXTENSIONS`
+ * (zfb crate `crates/zfb-types/src/page_extensions.rs`) — that constant is
+ * not importable from JS, so it is copied here deliberately; keep in sync if
+ * zfb ever changes its accepted extension list.
+ */
+export const ROUTABLE_PAGE_EXTENSIONS = ["tsx", "ts", "jsx", "js", "mdx", "md", "html"] as const;
+
+/**
+ * Derive every `pages/`-relative path that would shadow the given injected
+ * route pattern (a zfb `injectRoute` pattern string, e.g.
+ * `"/docs/tags/[tag]"` or `"/[locale]"`). Pure — no filesystem I/O; the
+ * caller probes each candidate against the host's real `pages/` dir.
+ *
+ * Returns `[]` for the empty/root pattern (`"/"`) — never produced by this
+ * plugin's route catalog (zfb rejects `injectRoute("/")` outright), so there
+ * is nothing meaningful to derive.
+ */
+export function derivePagesCandidates(pattern: string): string[] {
+  const segments = pattern.split("/").filter(Boolean);
+  if (segments.length === 0) return [];
+
+  const lastSegment = segments[segments.length - 1]!;
+  const dirPrefix = segments.length > 1 ? `${segments.slice(0, -1).join("/")}/` : "";
+
+  const candidates: string[] = [];
+  for (const ext of ROUTABLE_PAGE_EXTENSIONS) {
+    candidates.push(`${dirPrefix}${lastSegment}.${ext}`);
+    candidates.push(`${dirPrefix}${lastSegment}/index.${ext}`);
+  }
+  return candidates;
+}

--- a/packages/zudo-doc/src/plugins/routes.ts
+++ b/packages/zudo-doc/src/plugins/routes.ts
@@ -50,6 +50,14 @@
 //      present-but-missing file → a loud Error at plugin setup naming the
 //      resolved absolute path (never a silent fallback to the package default).
 //
+//      Between #3 and #4, a build-time-only DIAGNOSTIC (no behavior change,
+//      zudolab/zudo-doc#3420, spec #3428) warns when `designTokenPanelConfigModule`
+//      is set but every derived route below is shadowed by a kept user
+//      `pages/` file — meaning the configured builder can never reach an
+//      injected route. Suppressed when the resolved `chromeBindingsModule`
+//      file already names `DesignTokenPanelBootstrap` (the documented
+//      workaround). See the guard case inline, next to #3 above.
+//
 //   4. injectRoute(pattern, entrypoint[, opts]) — the 16-route catalog
 //      (Decision 3), patterns derived from `options.settings.locales` /
 //      `options.settings.versions`. Dynamic `[locale]` / `[version]` patterns
@@ -67,7 +75,7 @@
 // sibling `doc-history.ts` for the standalone-module rationale.
 
 import { createRequire } from "node:module";
-import { existsSync, statSync, cpSync, rmSync, mkdirSync } from "node:fs";
+import { existsSync, statSync, readFileSync, cpSync, rmSync, mkdirSync } from "node:fs";
 import { dirname, basename, join } from "node:path";
 import { definePlugin, type ZfbSetupContext } from "@takazudo/zfb/plugins";
 import {
@@ -75,6 +83,7 @@ import {
   resolveEnabledPacks,
   type ThemePackRegistry,
 } from "../theme-packs-registry/index.js";
+import { derivePagesCandidates } from "./route-pages-candidates.js";
 
 // ---------------------------------------------------------------------------
 // Options shape (filled by the preset from settings — fully serializable).
@@ -265,6 +274,9 @@ const plugin = definePlugin({
     const translations = options.translations ?? {};
     const tagVocabulary = options.tagVocabulary ?? [];
     const colorSchemes = options.colorSchemes ?? null;
+    // Computed once, shared by the shadow diagnostic below (3.5) and the
+    // injection loop (4) — both need the same derived catalog.
+    const derivedRoutes = deriveRoutes(settings);
 
     // (0) Theme-pack registry (ADR docs/adr/theme-packs.md, Decision 2
     // "Registry threading to SSR/islands", #2819). Resolves the shipped
@@ -349,6 +361,50 @@ const plugin = definePlugin({
         : `export { buildDesignTokenPanelConfig } from "@takazudo/zudo-doc/design-token-panel-config";\n`,
     );
 
+    // (3.5) DTP shadow-shadowing diagnostic (zudolab/zudo-doc#3420, spec
+    // #3428). Decision 6 above drops an injected route SILENTLY when a kept
+    // user `pages/` file claims the same URL — so a locked-manifest host
+    // that sets `designTokenPanelConfigModule` while its `pages/` stubs
+    // shadow EVERY injected route gets no configured DTP island anywhere:
+    // the panel vanishes site-wide with no build error. Warn loudly at setup
+    // instead. "ALL derived routes shadowed" is the sufficient condition —
+    // partial shadowing stays silent (the config still applies on the
+    // surviving routes). Diagnostic only: does not change which routes get
+    // injected below.
+    if (settings.designTokenPanelConfigModule) {
+      const pagesDir = join(ctx.projectRoot, "pages");
+      const allRoutesShadowed = derivedRoutes.every((route) =>
+        derivePagesCandidates(route.pattern).some((rel) => existsSync(join(pagesDir, rel))),
+      );
+      if (allRoutesShadowed) {
+        // Best-effort heuristic: a cheap text scan for the literal export
+        // name, not an evaluation of the resolved module — the module
+        // cannot be executed here, at plugin setup. A host that composes
+        // `chromeBindings.DesignTokenPanelBootstrap` indirectly (re-exported
+        // through another module, built from a variable, etc.) without the
+        // literal token ever appearing in the resolved file keeps warning —
+        // the message below tells such hosts the warning is safe to ignore
+        // once the workaround is genuinely wired up.
+        const workaroundLikelyApplied =
+          chromeBindingsAbsPath !== undefined &&
+          readFileSync(chromeBindingsAbsPath, "utf8").includes("DesignTokenPanelBootstrap");
+        if (!workaroundLikelyApplied) {
+          ctx.logger.warn(
+            "zudo-doc: settings.designTokenPanelConfigModule is set, but every " +
+              "injected route's URL is shadowed by a kept user pages/ file — the " +
+              "configured Design Token Panel builder can never apply anywhere on " +
+              "this site (zudolab/zudo-doc#3420). Thread your builder through " +
+              "chromeBindings.DesignTokenPanelBootstrap instead — that binding wins " +
+              "everywhere, including stub-rendered pages (see the " +
+              "designTokenPanelConfigModule docblock in settings.ts). If you already " +
+              "did this via a chromeBindingsModule that composes the bootstrap " +
+              'indirectly (never spelling "DesignTokenPanelBootstrap" literally in ' +
+              "the resolved file), this warning is safe to ignore.",
+          );
+        }
+      }
+    }
+
     // (4) Inject the derived route catalog (Decision 3). Build-only render
     // today (dev falls through — upstream #1227); precedence drops collisions
     // with kept user `pages/` routes (Decision 6).
@@ -410,7 +466,7 @@ const plugin = definePlugin({
       return dest;
     };
 
-    for (const route of deriveRoutes(settings)) {
+    for (const route of derivedRoutes) {
       let resolvedEntrypoint: string;
       try {
         const compiledPath = require.resolve(route.entrypoint);

--- a/packages/zudo-doc/src/plugins/routes.ts
+++ b/packages/zudo-doc/src/plugins/routes.ts
@@ -361,17 +361,20 @@ const plugin = definePlugin({
         : `export { buildDesignTokenPanelConfig } from "@takazudo/zudo-doc/design-token-panel-config";\n`,
     );
 
-    // (3.5) DTP shadow-shadowing diagnostic (zudolab/zudo-doc#3420, spec
-    // #3428). Decision 6 above drops an injected route SILENTLY when a kept
-    // user `pages/` file claims the same URL — so a locked-manifest host
-    // that sets `designTokenPanelConfigModule` while its `pages/` stubs
-    // shadow EVERY injected route gets no configured DTP island anywhere:
-    // the panel vanishes site-wide with no build error. Warn loudly at setup
-    // instead. "ALL derived routes shadowed" is the sufficient condition —
-    // partial shadowing stays silent (the config still applies on the
-    // surviving routes). Diagnostic only: does not change which routes get
-    // injected below.
-    if (settings.designTokenPanelConfigModule) {
+    // (3.5) DTP shadow diagnostic (zudolab/zudo-doc#3420, spec #3428).
+    // Decision 6 above drops an injected route SILENTLY when a kept user
+    // `pages/` file claims the same URL — so a locked-manifest host that
+    // sets `designTokenPanelConfigModule` while its `pages/` stubs shadow
+    // EVERY injected route gets no configured DTP island anywhere: the panel
+    // vanishes site-wide with no build error. Warn loudly at setup instead.
+    // "ALL derived routes shadowed" is the sufficient condition — partial
+    // shadowing stays silent (the config still applies on the surviving
+    // routes). Gated on the RESOLVED path (not the raw setting) since
+    // `resolveHostModuleOverride` above already turned an invalid setting
+    // into a thrown Error — reaching here means the module genuinely
+    // resolved. Diagnostic only: does not change which routes get injected
+    // below.
+    if (designTokenPanelConfigAbsPath) {
       const pagesDir = join(ctx.projectRoot, "pages");
       const allRoutesShadowed = derivedRoutes.every((route) =>
         derivePagesCandidates(route.pattern).some((rel) => existsSync(join(pagesDir, rel))),

--- a/packages/zudo-doc/src/settings.ts
+++ b/packages/zudo-doc/src/settings.ts
@@ -465,6 +465,21 @@ export interface Settings {
    * your builder through `chromeBindings.DesignTokenPanelBootstrap` — that
    * binding wins everywhere and is unaffected by this rule. See
    * `docs/adr/route-injection-seam.md`.
+   *
+   * EDGE CASE (zudolab/zudo-doc#3420, diagnostic added #3428): a
+   * locked-manifest host whose kept `pages/` stubs happen to shadow EVERY
+   * injected route (Decision 6 in `plugins/routes.ts` drops a collided
+   * injected route silently — user `pages/` always wins) gets no configured
+   * DTP island anywhere on the site when this setting is set, with no build
+   * error. `plugins/routes.ts` now probes for exactly this at plugin setup —
+   * if every derived route's URL resolves to an existing user `pages/` file,
+   * it emits a loud `ctx.logger.warn` naming this gap and the
+   * `chromeBindings.DesignTokenPanelBootstrap` workaround above, UNLESS the
+   * resolved `chromeBindingsModule` file already contains the literal token
+   * `DesignTokenPanelBootstrap` (a best-effort static text scan — an
+   * indirectly-composed override that never spells the name out keeps
+   * warning). Partial shadowing stays silent: the config still applies on
+   * whichever routes survive.
    */
   designTokenPanelConfigModule?: string;
   /**


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3425
- parent PR
    - https://github.com/zudolab/zudo-doc/pull/3424

---

## Summary

Epic-PR for **[Sweep Batch Guards]** (#3425), a child epic of super-epic #3423. Three independent guards from the 260818 agent-found sweep, batched per the tiny-batch rule. Targets `base/sweep-agent-found-260818`.

## Topics

**1. Upstream scanner-noise filing + local tolerance note (#3426, supersedes #3418)**

Comment-only in this repo. The Case TM fixture header now records the benign `island marker name collision: "ConfiguredDesignTokenPanelBootstrap"` warning, its dual-scan cause, and why the fixture cannot assert a collision-free build.

The upstream half was **redirected by user direction**: rather than only filing an issue, the zfb-side fix was handed to a live Claude session on the zfb repo, which implemented it directly — Takazudo/zudo-front-builder#2441 (issue) / Takazudo/zudo-front-builder#2442 (PR, open, gated on that repo's `main` ruleset). Approach: dedupe by resolved component identity, not a warning demotion.

Two upstream facts are recorded in the code comment because they are invisible from this codebase:
- The dedupe compares the staged copy against the **published** file, so the invariant we owe upstream is only that `ensureStaged` stays byte-preserving relative to what the package ships. A rewrite in build-time `copy-routes-src.mjs` is harmless (pre-publish).
- Accepted upstream trade-off: two *different* components shipped by the *same* package under one marker name are now silently deduped too. zfb can no longer report that case for us.

Follow-up #3433 tracks flipping the fixture to assert a collision-free build once #2442 merges and zfb is bumped.

**2. A2 parity CI gate (#3427, supersedes #3419)**

New `a2-parity-gate` job in `pr-checks.yml`, closing the latent-red window that bit PR #3409. Diffs the PR against `github.event.pull_request.base.sha` in-job (no third-party action, no mutable `origin/<base>` ref), exits green early unless an every-page script emitter changed, else runs `pnpm install` → `build:workspace` → the A2 no-stub parity subset.

Per the one-directional `check-b4push-ci-parity.mjs` contract this is CI-only by decision — no b4push step, no parity bookkeeping. Verified green.

**3. Routes-plugin full-shadowing diagnostic (#3428, supersedes #3420)**

Build-time diagnostic only, no route-injection behavior change. New pure helper `route-pages-candidates.ts` maps an `injectRoute` pattern to every `pages/`-relative path that would shadow it, mirroring zfb's real accepted extension set (`tsx, ts, jsx, js, mdx, md, html`, read from `zfb_types::ROUTABLE_PAGE_EXTENSIONS` rather than assumed). Warns once when `designTokenPanelConfigModule` is set and every derived route is shadowed, suppressed when the resolved `chromeBindingsModule` names `DesignTokenPanelBootstrap` (documented in-code as a best-effort text scan).

## Review outcome

`/code-review medium --fix` found 4 issues; 2 were fixed here, 2 raised for decision.

Fixed in the A2 gate: the emitter list was too narrow — the parity hashes cover the whole normalized page HTML, not just inlined scripts, and `header.tsx` / `doc-content-header/index.tsx` have moved them before (#3039). Both are now listed, the list is marked best-effort with a duty to extend, and the parity test file itself is listed so a re-baselining PR reruns the suite instead of skipping the gate on the one PR where it matters most. The guidance step is now scoped to the parity step's own outcome, so an install failure no longer prints a hash-mismatch message.

Raised, not fixed (both change semantics #3428 locked):
- #3434 — the shadow diagnostic never fires for the locked-manifest host shape that motivated #3420, because `/404`, `/sitemap.xml`, and `/robots.txt` are always in the denominator and are never shadowed.
- #3435 — the diagnostic can warn when `designTokenPanel` is `false`.

## Note on the gate's own coverage

#3427's acceptance criteria expected this PR to exercise the gate's **skip** path. Because the review added the parity test file to `EMITTERS`, and this PR edits that file, the gate takes its **run** path here instead — a strictly better self-test. The sibling generator-hardening epic will exercise it via a real emitter change.

## Verification (local, on the merged base)

`build:workspace` 16.6s · package typecheck clean · 41/41 plugin unit tests · A2 parity subset 4 passed with a real 4.4s fixture build · `check-b4push-ci-parity.mjs` green · YAML parses.