### PR TITLE
deps(zfb): bump zfb family 2.6.0 → 2.7.1 and assert a collision-free target-manifest build

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,10 +106,10 @@
   },
   "dependencies": {
     "@takazudo/zdtp": "0.4.10",
-    "@takazudo/zfb": "2.6.0",
+    "@takazudo/zfb": "2.7.1",
     "@takazudo/zfb-adapter-cloudflare": "2.6.0",
-    "@takazudo/zfb-md-wasm": "2.6.0",
-    "@takazudo/zfb-runtime": "2.6.0",
+    "@takazudo/zfb-md-wasm": "2.7.1",
+    "@takazudo/zfb-runtime": "2.7.1",
     "@takazudo/zudo-doc": "workspace:*",
     "diff": "^8.0.3",
     "katex": "^0.16.38",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   "dependencies": {
     "@takazudo/zdtp": "0.4.10",
     "@takazudo/zfb": "2.7.1",
-    "@takazudo/zfb-adapter-cloudflare": "2.6.0",
+    "@takazudo/zfb-adapter-cloudflare": "2.7.1",
     "@takazudo/zfb-md-wasm": "2.7.1",
     "@takazudo/zfb-runtime": "2.7.1",
     "@takazudo/zudo-doc": "workspace:*",

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -751,9 +751,9 @@ function generatePackageJson(choices: UserChoices) {
     // default, so a fresh scaffold needs no config change to pick it up.
     // Also fixes the client router to tolerate about:srcdoc history
     // restrictions. No generator-side migration.
-    "@takazudo/zfb": "2.6.0",
-    "@takazudo/zfb-runtime": "2.6.0",
-    "@takazudo/zfb-md-wasm": "2.6.0",
+    "@takazudo/zfb": "2.7.1",
+    "@takazudo/zfb-runtime": "2.7.1",
+    "@takazudo/zfb-md-wasm": "2.7.1",
     // @takazudo/zudo-doc — published from this monorepo via
     // .github/workflows/publish-zudo-doc.yml. The pin here is bumped in
     // lockstep by scripts/release-create-zudo-doc.sh whenever zudo-doc's

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -633,9 +633,9 @@
   ],
   "peerDependencies": {
     "@takazudo/zdtp": "^0.4.10",
-    "@takazudo/zfb": "^2.6.0",
-    "@takazudo/zfb-md-wasm": "^2.6.0",
-    "@takazudo/zfb-runtime": "^2.6.0",
+    "@takazudo/zfb": "^2.7.1",
+    "@takazudo/zfb-md-wasm": "^2.7.1",
+    "@takazudo/zfb-runtime": "^2.7.1",
     "@takazudo/zudo-doc-history-server": "^5.5.3",
     "diff": "^8.0.0",
     "katex": "^0.16.0",
@@ -670,9 +670,9 @@
     "tsx": "^4.21.0"
   },
   "devDependencies": {
-    "@takazudo/zfb": "2.6.0",
-    "@takazudo/zfb-md-wasm": "2.6.0",
-    "@takazudo/zfb-runtime": "2.6.0",
+    "@takazudo/zfb": "2.7.1",
+    "@takazudo/zfb-md-wasm": "2.7.1",
+    "@takazudo/zfb-runtime": "2.7.1",
     "@takazudo/zudo-doc-history-server": "workspace:*",
     "@types/fs-extra": "^11.0.4",
     "@types/minimist": "^1.2.5",

--- a/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
+++ b/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
@@ -1841,31 +1841,32 @@ describe("S1 no-src: published package (routes-src/, no src/) renders injected r
 //   5. Computed-token smoke on built CSS (theme.css contract).
 //   6. Fixture file count == 17 (guards floor creep).
 //
-// *** KNOWN BENIGN WARNING — every Case TM build ***
-// Every build of this fixture logs `island marker name collision:
-// "ConfiguredDesignTokenPanelBootstrap"`. Cause: this fixture's `pages/index.tsx`
-// re-exports `@takazudo/zudo-doc/routes/index`, so the compiled
-// `dist/routes/_chrome.js` → `dist/routes/_design-token-panel-bootstrap.js`
-// graph is scanned alongside the staged `routes-src/` copy — the same
-// component reaches zfb's island scanner from two files, and the scanner keys
-// islands by marker name rather than resolved component identity. Benign: zfb
-// keeps the `routes-src/` copy and the surviving registry entry matches every
-// emitted marker, so behavior is correct — the cost is unconditional noise,
-// and it is why this fixture cannot assert a collision-free build (see "TM
-// group 2b" below for the full explanation and the local assertion it drives).
-// Decision (tolerate + file upstream) recorded on zudolab/zudo-doc#3418.
-// Upstream tracking issue (zfb island-scanner identity dedupe):
-// https://github.com/Takazudo/zudo-front-builder/issues/2441
+// *** RESOLVED as of zfb 2.7.1 — the collision warning is now ASSERTED ABSENT ***
+// Until zfb 2.7.1, every build of this fixture logged `island marker name
+// collision: "ConfiguredDesignTokenPanelBootstrap"`. Cause: this fixture's
+// `pages/index.tsx` re-exports `@takazudo/zudo-doc/routes/index`, so the
+// compiled `dist/routes/_chrome.js` → `dist/routes/_design-token-panel-bootstrap.js`
+// graph is scanned alongside the staged `routes-src/` copy — the same component
+// reached zfb's island scanner from two files, and the scanner keyed islands by
+// marker name rather than resolved component identity. It was benign (zfb kept
+// the `routes-src/` copy and the surviving registry entry matched every emitted
+// marker) but unconditional, which is why this fixture could not assert a
+// collision-free build. See "TM group 2b" below for the fuller explanation.
+// Decision (tolerate + file upstream) recorded on zudolab/zudo-doc#3418;
+// upstream issue Takazudo/zudo-front-builder#2441, fixed by PR #2442,
+// released in zfb 2.7.1 and adopted here (zudolab/zudo-doc#3433).
+// The setup test of "TM build+check+css" now asserts the warning is absent.
 //
-// The upstream fix (PR Takazudo/zudo-front-builder#2442) dedupes by resolved
-// component identity, and reaches THIS case via a byte-identity branch: the
-// staged copy is compared against the PUBLISHED file the package ships at the
-// same stem under `node_modules/@takazudo/zudo-doc/routes-src/`. So the
-// invariant we owe upstream is narrow — `ensureStaged` (src/plugins/routes.ts)
-// must stay byte-preserving RELATIVE TO WHAT THE PACKAGE SHIPS. A future
-// rewrite inside build-time `scripts/copy-routes-src.mjs` is harmless (it runs
-// pre-publish, so both compared participants are post-rewrite); a rewrite
-// inside `ensureStaged` would break the match and resurrect this warning.
+// The fix dedupes by resolved component identity, and reaches THIS case via a
+// byte-identity branch: the staged copy is compared against the PUBLISHED file
+// the package ships at the same stem under
+// `node_modules/@takazudo/zudo-doc/routes-src/`. So the invariant we owe
+// upstream is narrow — `ensureStaged` (src/plugins/routes.ts) must stay
+// byte-preserving RELATIVE TO WHAT THE PACKAGE SHIPS. A future rewrite inside
+// build-time `scripts/copy-routes-src.mjs` is harmless (it runs pre-publish, so
+// both compared participants are post-rewrite); a rewrite inside `ensureStaged`
+// would break the match and fail the collision-free assertion above. That
+// failure mode is the reason the assertion is worth keeping.
 //
 // Accepted upstream trade-off: two GENUINELY DIFFERENT components shipped by
 // the SAME package under one marker name are now silently deduped too. Only a
@@ -2120,7 +2121,22 @@ describe("TM build+check+css: the locked manifest builds, typechecks, and ships 
   it("setup: pack the package and build the target-manifest fixture (with the doc stub)", { timeout: 180_000 }, () => {
     const tarballPath = packPackage();
     fixtureDir = setupTargetManifestFixture(tarballPath);
-    runZfbBuild(fixtureDir);
+    const buildOutput = runZfbBuild(fixtureDir);
+    // Non-vacuity guard, and it must come FIRST: every assertion below is a
+    // NEGATIVE one, so an empty capture would pass them all while proving
+    // nothing. runZfbBuild merges stdout+stderr, so a successful build is
+    // never silent.
+    expect(buildOutput.length).toBeGreaterThan(0);
+    // This fixture double-scans the same components (dist graph + staged
+    // routes-src/ copy), which zfb ≤2.7.0 reported as a marker-name collision
+    // on every build. zfb 2.7.1 dedupes by resolved component identity, so a
+    // collision-free build is now assertable — and this assertion is the only
+    // end-to-end proof of that fix anywhere: zfb's own coverage stops at the
+    // classifier and never runs a real build. If it fails, report upstream
+    // (zudolab/zudo-doc#3433, Takazudo/zudo-front-builder#2441) rather than
+    // relaxing it — a genuine collision between two DIFFERENT components must
+    // still warn.
+    expect(buildOutput).not.toMatch(/island marker name collision/i);
   });
 
   // ---- Group 1 ----

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,17 +28,17 @@ importers:
         specifier: 0.4.10
         version: 0.4.10(preact@10.29.2)
       '@takazudo/zfb':
-        specifier: 2.6.0
-        version: 2.6.0(react@19.2.8)
+        specifier: 2.7.1
+        version: 2.7.1(react@19.2.8)
       '@takazudo/zfb-adapter-cloudflare':
         specifier: 2.6.0
         version: 2.6.0
       '@takazudo/zfb-md-wasm':
-        specifier: 2.6.0
-        version: 2.6.0
+        specifier: 2.7.1
+        version: 2.7.1
       '@takazudo/zfb-runtime':
-        specifier: 2.6.0
-        version: 2.6.0(@takazudo/zfb@2.6.0(react@19.2.8))(react@19.2.8)
+        specifier: 2.7.1
+        version: 2.7.1(@takazudo/zfb@2.7.1(react@19.2.8))(react@19.2.8)
       '@takazudo/zudo-doc':
         specifier: workspace:*
         version: link:packages/zudo-doc
@@ -227,14 +227,14 @@ importers:
         version: 4.21.0
     devDependencies:
       '@takazudo/zfb':
-        specifier: 2.6.0
-        version: 2.6.0(react@19.2.8)
+        specifier: 2.7.1
+        version: 2.7.1(react@19.2.8)
       '@takazudo/zfb-md-wasm':
-        specifier: 2.6.0
-        version: 2.6.0
+        specifier: 2.7.1
+        version: 2.7.1
       '@takazudo/zfb-runtime':
-        specifier: 2.6.0
-        version: 2.6.0(@takazudo/zfb@2.6.0(react@19.2.8))(react@19.2.8)
+        specifier: 2.7.1
+        version: 2.7.1(@takazudo/zfb@2.7.1(react@19.2.8))(react@19.2.8)
       '@takazudo/zudo-doc-history-server':
         specifier: workspace:*
         version: link:../doc-history-server
@@ -1138,47 +1138,47 @@ packages:
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@2.6.0':
-    resolution: {integrity: sha512-eMxaRTy8j4owXsJwpDFD9Yc93YLoLftSUl1jwfX7acBr94ayo+E5BD7d6pruVy8gaVGokzywyEUddSWF1rVttw==}
+  '@takazudo/zfb-darwin-arm64@2.7.1':
+    resolution: {integrity: sha512-fQUZIsEXxl35N12lKUBAd7QNZT5o7dKuZDHNkNe8IblP7zvw1uGqxJO7M4cQ2m+AITMCSmHK5lG2uI/vKgMPRA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@2.6.0':
-    resolution: {integrity: sha512-/6m81p+ZPe9Ha+3j7Fu9dpJxT4478svmzIobC74/xKflWU1x8CoZmvaaJAdmdSFokwDJiKMq4rjTBACzREUjuQ==}
+  '@takazudo/zfb-darwin-x64@2.7.1':
+    resolution: {integrity: sha512-pJVAnm+ep3eg3S5mR2JZP2m5jvUdWZrPFWKf4Twro6DsdCUID8/R1Xrfz/LC65z37vFVLUV3w7pYXFTlVEhO7A==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@2.6.0':
-    resolution: {integrity: sha512-sQqoK1K5FvjigKMhYdxKvoNGHL/+RDbaSNR1Tl0jvHbiUV+wWf374qadWD110tg2BgkVcGm8adSTvUh94DdzUA==}
+  '@takazudo/zfb-linux-arm64-gnu@2.7.1':
+    resolution: {integrity: sha512-wuK7eg64j0uzWuxrmv6BSBGBN7bBfFIJOAOsDc69CFyYj9LPMmNN5yrc1qBsAk3db19dEt3ZEq6XFRXH5fJM1Q==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@2.6.0':
-    resolution: {integrity: sha512-AmmegOReKDYcMPcdUgARf/fENQviwnN6MDT2yB4bVFI2eqw3LyY7b4Fxm60Clwn8pxptmmsLNAuXV3sRLiqiRg==}
+  '@takazudo/zfb-linux-x64-gnu@2.7.1':
+    resolution: {integrity: sha512-wTUTof1nG99IMdbIPGy4Zv8c08CdlXWx3/rI0YD50/P7bQ2X11AUN7brCoDiav4v0QQ9rPFEcSUkhADgxpX/SA==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-md-wasm@2.6.0':
-    resolution: {integrity: sha512-a6yisdeOzze8tnp1m2YdloTwwizJr6PiCQgfh6Y+roKrDY7VxFfRZ81R7vDaw3M8CxZ9i+GSLLyV5qBvOeERhg==}
+  '@takazudo/zfb-md-wasm@2.7.1':
+    resolution: {integrity: sha512-pEoaltJ0vSY+u6wCWmQAf3OnyWuA9EdbVF9pSrGlg+6JbHMlGqUdUNwEuRmMHXPPi5v9gnLdjCFNVIxXURnKdw==}
     engines: {node: '>=20.0.0', pnpm: '>=10.0.0'}
 
-  '@takazudo/zfb-runtime@2.6.0':
-    resolution: {integrity: sha512-4TQvzZqG9NAdvjC4b6T3Mj4DYqLfBLkahoHrFXHAVBFJa5WDfMJIm5hbHCFR6z6Qjtz9fpaWMwCu7u6XKGLHiQ==}
+  '@takazudo/zfb-runtime@2.7.1':
+    resolution: {integrity: sha512-vEE+kNsSrBFbDIFk5/LH3aJQ0baiKE7z815ShQhLUM2wy31JI3iZP6DD+pEzntDSs/5B+4qKMEoPHtQjIJdmMQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 2.6.0
+      '@takazudo/zfb': 2.7.1
       react: ^19.2.3
     peerDependenciesMeta:
       react:
         optional: true
 
-  '@takazudo/zfb-win32-x64-msvc@2.6.0':
-    resolution: {integrity: sha512-VoA7VWVZF9JQ6rduGjyKmCHlypkgu2B0DGQ8zn1AiKBSauPfUkYqvi24+LMt0WvFInviz6DZnLdcER2PjAlEcw==}
+  '@takazudo/zfb-win32-x64-msvc@2.7.1':
+    resolution: {integrity: sha512-31IAEC0C/dmKRrb7093DZjg+8p4o1oM3PtfUgkrqNmMZLxlbwxNOpXvaQGMGThrNzmVFYmNR7VLfhZ4hMvi52g==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@2.6.0':
-    resolution: {integrity: sha512-R7YIBbz89G+kghnVbccHNhv+AnlqAnmU9PdTUMGlR4Qp/EmborJuGtVMHB+3xH6Vubp0jmUnGhrI0jGUeIbv4g==}
+  '@takazudo/zfb@2.7.1':
+    resolution: {integrity: sha512-c6kuoMSmb6lbu7KNwsGTsHbQ1pUFkxnwdaxWnGfOCnXrx1OwQac/xywUmpGoUu5hr+3661hNadWmSdz3220R3A==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
     peerDependencies:
@@ -3231,19 +3231,19 @@ snapshots:
 
   '@takazudo/zfb-adapter-cloudflare@2.6.0': {}
 
-  '@takazudo/zfb-darwin-arm64@2.6.0':
+  '@takazudo/zfb-darwin-arm64@2.7.1':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@2.6.0':
+  '@takazudo/zfb-darwin-x64@2.7.1':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@2.6.0':
+  '@takazudo/zfb-linux-arm64-gnu@2.7.1':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@2.6.0':
+  '@takazudo/zfb-linux-x64-gnu@2.7.1':
     optional: true
 
-  '@takazudo/zfb-md-wasm@2.6.0':
+  '@takazudo/zfb-md-wasm@2.7.1':
     dependencies:
       '@types/mdast': 4.0.4
       mdast-util-directive: 3.1.0
@@ -3251,23 +3251,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@takazudo/zfb-runtime@2.6.0(@takazudo/zfb@2.6.0(react@19.2.8))(react@19.2.8)':
+  '@takazudo/zfb-runtime@2.7.1(@takazudo/zfb@2.7.1(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@takazudo/zfb': 2.6.0(react@19.2.8)
+      '@takazudo/zfb': 2.7.1(react@19.2.8)
       hono: 4.13.1
     optionalDependencies:
       react: 19.2.8
 
-  '@takazudo/zfb-win32-x64-msvc@2.6.0':
+  '@takazudo/zfb-win32-x64-msvc@2.7.1':
     optional: true
 
-  '@takazudo/zfb@2.6.0(react@19.2.8)':
+  '@takazudo/zfb@2.7.1(react@19.2.8)':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 2.6.0
-      '@takazudo/zfb-darwin-x64': 2.6.0
-      '@takazudo/zfb-linux-arm64-gnu': 2.6.0
-      '@takazudo/zfb-linux-x64-gnu': 2.6.0
-      '@takazudo/zfb-win32-x64-msvc': 2.6.0
+      '@takazudo/zfb-darwin-arm64': 2.7.1
+      '@takazudo/zfb-darwin-x64': 2.7.1
+      '@takazudo/zfb-linux-arm64-gnu': 2.7.1
+      '@takazudo/zfb-linux-x64-gnu': 2.7.1
+      '@takazudo/zfb-win32-x64-msvc': 2.7.1
       react: 19.2.8
 
   '@takazudo/zudo-design-token-lint@2.0.0':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ importers:
         specifier: 2.7.1
         version: 2.7.1(react@19.2.8)
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 2.6.0
-        version: 2.6.0
+        specifier: 2.7.1
+        version: 2.7.1
       '@takazudo/zfb-md-wasm':
         specifier: 2.7.1
         version: 2.7.1
@@ -1133,8 +1133,8 @@ packages:
     peerDependencies:
       preact: 10.29.2
 
-  '@takazudo/zfb-adapter-cloudflare@2.6.0':
-    resolution: {integrity: sha512-b0m+qluHHKJ09Hg0Sfo4COTyeMhpHROSV+DfRU3SqeXQiI8J2uzRRTuLD6dyvsyth4kqRyLTsKJ8AK4VLfanxA==}
+  '@takazudo/zfb-adapter-cloudflare@2.7.1':
+    resolution: {integrity: sha512-J0/sT9SY4Te4Yq6KM2cVlTRoGIprDRoqh33DNfDuYSM73kTFzf8N4e6SiRe4rx5p4f45eaw2Oz5CFUp5H4/qlg==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
@@ -3229,7 +3229,7 @@ snapshots:
       preact: 10.29.2
       tailwind-merge: 3.6.0
 
-  '@takazudo/zfb-adapter-cloudflare@2.6.0': {}
+  '@takazudo/zfb-adapter-cloudflare@2.7.1': {}
 
   '@takazudo/zfb-darwin-arm64@2.7.1':
     optional: true


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3433

---

## Summary

Bumps the `@takazudo/zfb` family to **2.7.1** and turns the long-standing "known benign warning" at the target-manifest fixture into an actual assertion.

zfb 2.7.1 carries `Takazudo/zudo-front-builder#2442` (issue `#2441`), which dedupes island registrations by **resolved component identity** rather than by marker name.

## Why the assertion matters more than the bump

The target-manifest fixture double-scans the same components — its `pages/index.tsx` re-exports `@takazudo/zudo-doc/routes/index`, so the compiled `dist/routes/` graph is scanned alongside the staged `routes-src/` copy. Until 2.7.1 that produced an unconditional `island marker name collision: "ConfiguredDesignTokenPanelBootstrap"` on every build. It was benign, but it meant this fixture could never use "zero warnings" as a health signal.

It can now, so it does — `expect(buildOutput).not.toMatch(/island marker name collision/i)` in the TM setup test.

**This assertion is the only end-to-end proof of the upstream fix that exists anywhere.** zfb's own coverage stops at its `is_same_package_duplicate` classifier and never runs a real build; upstream explicitly asked that the in-situ proof live here rather than being duplicated there. The code comment says so, and says that a failure should be reported upstream rather than relaxed — a collision between two genuinely *different* components must still warn.

**Guarded against going vacuous.** The assertion checks the captured output is non-empty *first*. Every assertion on `buildOutput` is a negative one, so an empty capture would satisfy them all while proving nothing — the same failure mode review caught in the search-widget drift gate (`git diff --exit-code` on an untracked path exits 0).

## Scope

All three lockstep packages move together across the four surfaces `check-pin-parity.mjs` governs — 12 literals:

| Surface | Form |
|---|---|
| Root `package.json` | exact ×3 |
| `packages/zudo-doc` devDependencies | exact ×3 |
| `packages/zudo-doc` peerDependencies | caret ×3 |
| `create-zudo-doc/src/scaffold.ts` | exact ×3 |

Deliberately scoped to the zfb family — other `@takazudo/*` deps (zdtp, history-server) are untouched.

## Verification

- **The collision assertion passes** on a real 10.7s build, with a non-empty capture.
- **A2 parity hashes unchanged** — 2.7.1 does not alter emitted HTML.
- `check:pin-parity` PASS · `check:search-widget-drift` PASS · `pnpm check` clean
- `pnpm test:packages`: 2208 + 603 + 73 + 44 all passing

Closes #3433.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/3441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789643466&installation_model_id=20910&pr_number=3441&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F3441&signature=5240bcd9d54efc2ff42301d48f0209eeac75138e5e27f793ae5271cca06e102a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->