### PR TITLE
DTP Shadow Diagnostic: make it fire for the host shape that motivated it

### DIFF
--- a/packages/zudo-doc/src/plugins/__tests__/routes.test.ts
+++ b/packages/zudo-doc/src/plugins/__tests__/routes.test.ts
@@ -394,6 +394,104 @@ describe("routes plugin — DTP shadow diagnostic (#3420, #3428)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// DTP shadow diagnostic — re-export false-positive guard (#3451).
+//
+// Narrowing the denominator to reader-facing routes (#3434) made a false
+// positive reachable: a `pages/docs/[[...slug]].tsx` that merely default
+// re-exports the package route it shadows —
+//
+//   export { default, paths, frontmatter } from "@takazudo/zudo-doc/routes/docs-slug";
+//
+// — still reaches the configured bootstrap through `routes/_chrome.tsx`, so
+// it should not warn. Every fixture below shadows ONLY `/docs/[[...slug]]`,
+// which is the sole reader-facing route under default settings (no locales,
+// versions, docTags, or aiAssistant) — so that one file alone determines
+// warn vs. silent.
+// ---------------------------------------------------------------------------
+
+/** The `/docs/[[...slug]]` route's own package entrypoint — mirrors the
+ *  "Static / always-on" entry in `deriveRoutes()`. */
+const DOCS_SLUG_ENTRYPOINT = "@takazudo/zudo-doc/routes/docs-slug";
+
+/** Write `pages/docs/[[...slug]].tsx` with arbitrary `content` — the sole
+ *  reader-facing route under default settings, so it alone drives warn vs.
+ *  silent for the fixtures below. */
+function writeDocsSlugPage(projectRoot: string, content: string) {
+  const absPath = join(projectRoot, "pages", "docs", "[[...slug]].tsx");
+  mkdirSync(dirname(absPath), { recursive: true });
+  writeFileSync(absPath, content);
+}
+
+/** Run `setup()` against a `pages/docs/[[...slug]].tsx` fixture with the
+ *  given `content` and return the collected warnings. */
+function warningsForDocsSlugFixture(content: string): string[] {
+  const projectRoot = makeProjectRoot();
+  writeDocsSlugPage(projectRoot, content);
+  const designTokenPanelConfigModule = writeConfigModule(projectRoot);
+
+  const { ctx, warnings } = makeCtx(projectRoot, {
+    packageOwnedRoutes: true,
+    designTokenPanel: true,
+    designTokenPanelConfigModule,
+  });
+  routesPlugin.setup!(ctx as never);
+  return warnings;
+}
+
+describe("routes plugin — DTP shadow diagnostic re-export guard (#3451)", () => {
+  it("case 1: exact default re-export from the shadowed route's own entrypoint → silent", () => {
+    const warnings = warningsForDocsSlugFixture(
+      `export { default, paths, frontmatter } from "${DOCS_SLUG_ENTRYPOINT}";\n`,
+    );
+    expect(warnings).toHaveLength(0);
+  });
+
+  it("case 2: specifier appears only in a comment → warns", () => {
+    const warnings = warningsForDocsSlugFixture(
+      `// export { default, paths, frontmatter } from "${DOCS_SLUG_ENTRYPOINT}";\n` +
+        "export default function Page() { return null; }\n",
+    );
+    expect(warnings).toHaveLength(1);
+  });
+
+  it("case 3: unused import of the specifier → warns", () => {
+    const warnings = warningsForDocsSlugFixture(
+      `import "${DOCS_SLUG_ENTRYPOINT}";\n` +
+        "export default function Page() { return null; }\n",
+    );
+    expect(warnings).toHaveLength(1);
+  });
+
+  it("case 4: imports a different package route than the one shadowed → warns", () => {
+    const warnings = warningsForDocsSlugFixture(
+      'export { default, paths } from "@takazudo/zudo-doc/routes/locale-index";\n',
+    );
+    expect(warnings).toHaveLength(1);
+  });
+
+  it("case 5: imports the package route but exports its own default → warns", () => {
+    const warnings = warningsForDocsSlugFixture(
+      `import DocsSlug, { paths, frontmatter } from "${DOCS_SLUG_ENTRYPOINT}";\n` +
+        "export default function CustomPage(props) { return DocsSlug(props); }\n" +
+        "export { paths, frontmatter };\n",
+    );
+    expect(warnings).toHaveLength(1);
+  });
+
+  it("case 6: genuine stub with no package-route reference at all → warns", () => {
+    const warnings = warningsForDocsSlugFixture("export default function Page() { return null; }\n");
+    expect(warnings).toHaveLength(1);
+  });
+
+  it("the warning text states the re-export heuristic's limits", () => {
+    const warnings = warningsForDocsSlugFixture("export default function Page() { return null; }\n");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("re-exports a shadowed route's own entrypoint");
+    expect(warnings[0]).toContain("best-effort text scan");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // The extracted warn/silent predicate (#3434). `deriveRoutes` always emits a
 // counted `/docs/[[...slug]]`, so the empty-denominator case is unreachable
 // through `setup()` — calling the helper directly is the only way to prove the

--- a/packages/zudo-doc/src/plugins/__tests__/routes.test.ts
+++ b/packages/zudo-doc/src/plugins/__tests__/routes.test.ts
@@ -30,7 +30,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readdirSync, readFileSyn
 import { join, relative, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { tmpdir } from "node:os";
-import routesPlugin from "../routes.js";
+import routesPlugin, { shouldWarnDtpFullyShadowed } from "../routes.js";
 
 /** Minimal mock of the fields `routes.ts`'s `setup()` actually reads
  *  (`options`, `projectRoot`) plus no-op stubs for the rest of
@@ -201,9 +201,10 @@ function collectSourceFiles(dir: string, out: string[] = []): string[] {
 }
 
 // ---------------------------------------------------------------------------
-// DTP shadow diagnostic (zudolab/zudo-doc#3420, spec #3428) — warns at plugin
-// setup when `designTokenPanelConfigModule` is set but every derived route's
-// URL is shadowed by a kept user `pages/` file, unless the resolved
+// DTP shadow diagnostic (zudolab/zudo-doc#3420, spec #3428; scoped by
+// #3434/#3435) — warns at plugin setup when `designTokenPanel` is on,
+// `designTokenPanelConfigModule` is set, and every READER-FACING derived
+// route's URL is shadowed by a kept user `pages/` file, unless the resolved
 // `chromeBindingsModule` already names the documented workaround.
 // ---------------------------------------------------------------------------
 
@@ -212,6 +213,11 @@ function collectSourceFiles(dir: string, out: string[] = []): string[] {
  *  section "Static / always-on". Used below to build full vs. partial
  *  shadowing fixtures without reaching into the plugin's private catalog. */
 const ALWAYS_ON_ROUTE_PATTERNS = ["/404", "/sitemap.xml", "/robots.txt", "/docs/[[...slug]]"];
+
+/** The subset of `ALWAYS_ON_ROUTE_PATTERNS` tagged
+ *  `includedInDtpShadowDiagnostic: true` — i.e. the diagnostic's whole
+ *  denominator for a project with no locales, versions or tags. */
+const ALWAYS_ON_READER_FACING_PATTERNS = ["/docs/[[...slug]]"];
 
 /** Write a `pages/` stub file that shadows `pattern` (the plain FILE form —
  *  one of the two shapes `derivePagesCandidates` recognises). */
@@ -241,6 +247,7 @@ describe("routes plugin — DTP shadow diagnostic (#3420, #3428)", () => {
 
     const { ctx, warnings } = makeCtx(projectRoot, {
       packageOwnedRoutes: true,
+      designTokenPanel: true,
       designTokenPanelConfigModule,
     });
     routesPlugin.setup!(ctx as never);
@@ -251,17 +258,48 @@ describe("routes plugin — DTP shadow diagnostic (#3420, #3428)", () => {
     expect(warnings[0]).toContain("DesignTokenPanelBootstrap");
   });
 
-  it("stays silent when shadowing is only partial", () => {
+  // The #3420 motivating shape, and the regression #3434 exists to fix: the
+  // locked minimal scaffold keeps exactly two `pages/` stubs — `index.tsx`
+  // (which shadows nothing in the catalog, since `/` is never injected) and
+  // `docs/[[...slug]].tsx`. `/404`, `/sitemap.xml` and `/robots.txt` therefore
+  // survive, which held the old all-routes `every()` at `false` forever — even
+  // though every doc page a reader visits is stub-rendered with no panel.
+  it("warns for the locked minimal scaffold, where /404, /sitemap.xml and /robots.txt survive unshadowed (#3434)", () => {
     const projectRoot = makeProjectRoot();
-    // Shadow every route except /sitemap.xml.
-    for (const pattern of ALWAYS_ON_ROUTE_PATTERNS) {
-      if (pattern === "/sitemap.xml") continue;
-      shadowRouteWithStub(projectRoot, pattern);
-    }
+    // `pages/index.tsx` verbatim — NOT via `shadowRouteWithStub`, because it
+    // shadows no injected route at all (that is the point of this fixture).
+    mkdirSync(join(projectRoot, "pages"), { recursive: true });
+    writeFileSync(
+      join(projectRoot, "pages", "index.tsx"),
+      "export default function Page() { return null; }\n",
+    );
+    shadowRouteWithStub(projectRoot, "/docs/[[...slug]]");
     const designTokenPanelConfigModule = writeConfigModule(projectRoot);
 
     const { ctx, warnings } = makeCtx(projectRoot, {
       packageOwnedRoutes: true,
+      designTokenPanel: true,
+      designTokenPanelConfigModule,
+    });
+    routesPlugin.setup!(ctx as never);
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("zudolab/zudo-doc#3420");
+  });
+
+  it("stays silent when shadowing is only partial", () => {
+    const projectRoot = makeProjectRoot();
+    // `docTags` widens the reader-facing set to three patterns; shadow all but
+    // one of them (plus every always-on route, to prove the surviving
+    // reader-facing route is what keeps this silent).
+    for (const pattern of ALWAYS_ON_ROUTE_PATTERNS) shadowRouteWithStub(projectRoot, pattern);
+    shadowRouteWithStub(projectRoot, "/docs/tags");
+    const designTokenPanelConfigModule = writeConfigModule(projectRoot);
+
+    const { ctx, warnings } = makeCtx(projectRoot, {
+      packageOwnedRoutes: true,
+      docTags: true,
+      designTokenPanel: true,
       designTokenPanelConfigModule,
     });
     routesPlugin.setup!(ctx as never);
@@ -275,6 +313,25 @@ describe("routes plugin — DTP shadow diagnostic (#3420, #3428)", () => {
 
     const { ctx, warnings } = makeCtx(projectRoot, {
       packageOwnedRoutes: true,
+      designTokenPanel: true,
+      designTokenPanelConfigModule,
+    });
+    routesPlugin.setup!(ctx as never);
+
+    expect(warnings).toHaveLength(0);
+  });
+
+  it("stays silent when only the non-reader-facing routes are shadowed", () => {
+    const projectRoot = makeProjectRoot();
+    for (const pattern of ALWAYS_ON_ROUTE_PATTERNS) {
+      if (ALWAYS_ON_READER_FACING_PATTERNS.includes(pattern)) continue;
+      shadowRouteWithStub(projectRoot, pattern);
+    }
+    const designTokenPanelConfigModule = writeConfigModule(projectRoot);
+
+    const { ctx, warnings } = makeCtx(projectRoot, {
+      packageOwnedRoutes: true,
+      designTokenPanel: true,
       designTokenPanelConfigModule,
     });
     routesPlugin.setup!(ctx as never);
@@ -286,7 +343,29 @@ describe("routes plugin — DTP shadow diagnostic (#3420, #3428)", () => {
     const projectRoot = makeProjectRoot();
     for (const pattern of ALWAYS_ON_ROUTE_PATTERNS) shadowRouteWithStub(projectRoot, pattern);
 
-    const { ctx, warnings } = makeCtx(projectRoot, { packageOwnedRoutes: true });
+    const { ctx, warnings } = makeCtx(projectRoot, {
+      packageOwnedRoutes: true,
+      designTokenPanel: true,
+    });
+    routesPlugin.setup!(ctx as never);
+
+    expect(warnings).toHaveLength(0);
+  });
+
+  // #3435 — `designTokenPanelConfigModule` resolves unconditionally and
+  // `designTokenPanel` defaults to false, so a host with the feature off and a
+  // leftover config-module value must not be told to wire up a panel that
+  // never renders either way (settings.ts documents the setting as irrelevant
+  // in that state).
+  it("stays silent when designTokenPanel is off, even with a config module and full shadowing (#3435)", () => {
+    const projectRoot = makeProjectRoot();
+    for (const pattern of ALWAYS_ON_ROUTE_PATTERNS) shadowRouteWithStub(projectRoot, pattern);
+    const designTokenPanelConfigModule = writeConfigModule(projectRoot);
+
+    const { ctx, warnings } = makeCtx(projectRoot, {
+      packageOwnedRoutes: true,
+      designTokenPanelConfigModule,
+    });
     routesPlugin.setup!(ctx as never);
 
     expect(warnings).toHaveLength(0);
@@ -304,12 +383,67 @@ describe("routes plugin — DTP shadow diagnostic (#3420, #3428)", () => {
 
     const { ctx, warnings } = makeCtx(projectRoot, {
       packageOwnedRoutes: true,
+      designTokenPanel: true,
       designTokenPanelConfigModule,
       chromeBindingsModule: "./src/chrome-bindings.tsx",
     });
     routesPlugin.setup!(ctx as never);
 
     expect(warnings).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The extracted warn/silent predicate (#3434). `deriveRoutes` always emits a
+// counted `/docs/[[...slug]]`, so the empty-denominator case is unreachable
+// through `setup()` — calling the helper directly is the only way to prove the
+// vacuity guard is live rather than dead code.
+// ---------------------------------------------------------------------------
+
+describe("shouldWarnDtpFullyShadowed — vacuity guard (#3434)", () => {
+  const alwaysShadowed = () => true;
+
+  it("returns false for an empty route list (never vacuously true)", () => {
+    expect(shouldWarnDtpFullyShadowed([], alwaysShadowed)).toBe(false);
+  });
+
+  it("returns false when no route is tagged reader-facing, however shadowed", () => {
+    expect(
+      shouldWarnDtpFullyShadowed(
+        [
+          { pattern: "/sitemap.xml", includedInDtpShadowDiagnostic: false },
+          { pattern: "/robots.txt", includedInDtpShadowDiagnostic: false },
+        ],
+        alwaysShadowed,
+      ),
+    ).toBe(false);
+  });
+
+  it("ignores unshadowed non-reader-facing routes when deciding", () => {
+    const shadowed = new Set(["/docs/[[...slug]]"]);
+    expect(
+      shouldWarnDtpFullyShadowed(
+        [
+          { pattern: "/404", includedInDtpShadowDiagnostic: false },
+          { pattern: "/sitemap.xml", includedInDtpShadowDiagnostic: false },
+          { pattern: "/docs/[[...slug]]", includedInDtpShadowDiagnostic: true },
+        ],
+        (pattern) => shadowed.has(pattern),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false while any reader-facing route survives", () => {
+    const shadowed = new Set(["/docs/[[...slug]]"]);
+    expect(
+      shouldWarnDtpFullyShadowed(
+        [
+          { pattern: "/docs/[[...slug]]", includedInDtpShadowDiagnostic: true },
+          { pattern: "/docs/tags", includedInDtpShadowDiagnostic: true },
+        ],
+        (pattern) => shadowed.has(pattern),
+      ),
+    ).toBe(false);
   });
 });
 

--- a/packages/zudo-doc/src/plugins/routes.ts
+++ b/packages/zudo-doc/src/plugins/routes.ts
@@ -503,8 +503,17 @@ const plugin = definePlugin({
           // A kept `pages/` file that exactly default-re-exports the
           // shadowed route's own entrypoint still reaches the configured
           // bootstrap through routes/_chrome.tsx — don't count it as a real
-          // shadow (#3451).
-          if (route && isExactDefaultReExport(readFileSync(abs, "utf8"), route.entrypoint)) {
+          // shadow (#3451). Read failures (unreadable file, a path that is
+          // actually a directory) fall back to "counts as a shadow": this is a
+          // build-time DIAGNOSTIC and must never be the thing that fails a
+          // build.
+          let source: string | undefined;
+          try {
+            source = readFileSync(abs, "utf8");
+          } catch {
+            return true;
+          }
+          if (route && isExactDefaultReExport(source, route.entrypoint)) {
             return false;
           }
           return true;
@@ -519,9 +528,23 @@ const plugin = definePlugin({
         // literal token ever appearing in the resolved file keeps warning —
         // the message below tells such hosts the warning is safe to ignore
         // once the workaround is genuinely wired up.
+        // Read guarded for the same reason as the candidate scan above: this
+        // whole block only ever prints a warning, so an unreadable file (EACCES,
+        // EIO) must degrade to "assume not applied" rather than throw out of
+        // setup() and fail the build. `resolveHostModuleOverride` already proved
+        // this path exists and is a file, so EISDIR is not reachable here — but
+        // leaving the two reads asymmetrically guarded would read as deliberate.
+        let chromeBindingsSource: string | undefined;
+        if (chromeBindingsAbsPath !== undefined) {
+          try {
+            chromeBindingsSource = readFileSync(chromeBindingsAbsPath, "utf8");
+          } catch {
+            chromeBindingsSource = undefined;
+          }
+        }
         const workaroundLikelyApplied =
-          chromeBindingsAbsPath !== undefined &&
-          readFileSync(chromeBindingsAbsPath, "utf8").includes("DesignTokenPanelBootstrap");
+          chromeBindingsSource !== undefined &&
+          chromeBindingsSource.includes("DesignTokenPanelBootstrap");
         if (!workaroundLikelyApplied) {
           ctx.logger.warn(
             "zudo-doc: settings.designTokenPanelConfigModule is set, but every " +

--- a/packages/zudo-doc/src/plugins/routes.ts
+++ b/packages/zudo-doc/src/plugins/routes.ts
@@ -51,12 +51,13 @@
 //      resolved absolute path (never a silent fallback to the package default).
 //
 //      Between #3 and #4, a build-time-only DIAGNOSTIC (no behavior change,
-//      zudolab/zudo-doc#3420, spec #3428) warns when `designTokenPanelConfigModule`
-//      is set but every derived route below is shadowed by a kept user
-//      `pages/` file — meaning the configured builder can never reach an
-//      injected route. Suppressed when the resolved `chromeBindingsModule`
-//      file already names `DesignTokenPanelBootstrap` (the documented
-//      workaround). See the guard case inline, next to #3 above.
+//      zudolab/zudo-doc#3420, spec #3428; scoped by #3434/#3435) warns when
+//      `settings.designTokenPanel` is on, `designTokenPanelConfigModule` is
+//      set, and every READER-FACING derived route below is shadowed by a kept
+//      user `pages/` file — meaning the configured builder can never reach an
+//      injected route a reader browses. Suppressed when the resolved
+//      `chromeBindingsModule` file already names `DesignTokenPanelBootstrap`
+//      (the documented workaround). See the guard case inline, next to #3 above.
 //
 //   4. injectRoute(pattern, entrypoint[, opts]) — the 16-route catalog
 //      (Decision 3), patterns derived from `options.settings.locales` /
@@ -112,6 +113,12 @@ interface RoutesSettings {
   versions?: RoutesVersionConfig[] | false;
   docTags?: boolean;
   aiAssistant?: boolean;
+  /** See `settings.ts` — whether the interactive Design Token Panel is enabled
+   *  at all. Read ONLY by the shadow diagnostic below (#3435): with the feature
+   *  off, `designTokenPanelConfigModule` is documented as irrelevant, so the
+   *  diagnostic must not tell such a host to wire up a panel that never
+   *  renders either way. Nothing else in this plugin gates on it. */
+  designTokenPanel?: boolean;
   /** See `settings.ts` — project-root-relative path to a host bindings module. */
   chromeBindingsModule?: string;
   /** See `settings.ts` — project-root-relative path to a host design-token
@@ -142,6 +149,51 @@ interface RouteSpec {
   pattern: string;
   entrypoint: string;
   opts?: { prerender?: boolean };
+  /**
+   * Whether this route counts toward the DTP shadow diagnostic's denominator
+   * (#3434). REQUIRED, deliberately — a newly added route must state its
+   * membership, so forgetting one is a type error instead of the silent
+   * miss #3434 *is*.
+   *
+   * The name is scoped to the DIAGNOSTIC, not to the route's own nature,
+   * because that is all the flag actually asserts. In particular it is NOT
+   * `rendersPanel`: `/404` genuinely DOES render the configured DTP bootstrap
+   * (`routes/404.tsx` passes `bodyEndComponents={<BodyEndIslands …/>}`, and
+   * `routes/_chrome.tsx` feeds that chrome the configured wrapper), so a
+   * `rendersPanel: false` tag on it would be a false claim in the source. It
+   * is likewise not `kind: "doc-content"` — the counted set includes the
+   * locale home, the tag pages and the version pages.
+   *
+   * `false` for the four routes a reader never browses as documentation:
+   * `/sitemap.xml` and `/robots.txt` cannot render an HTML panel at all (they
+   * would hold the check at "not fully shadowed" forever), `/api/ai-chat` is a
+   * JSON endpoint, and `/404` is an error page — losing the panel there says
+   * nothing about whether the site's docs still have one. The never-injected
+   * `/` (see the note in `deriveRoutes`) is absent from the catalog entirely
+   * and so cannot be counted either.
+   */
+  includedInDtpShadowDiagnostic: boolean;
+}
+
+/**
+ * The DTP shadow diagnostic's warn/silent decision, extracted from `setup()`
+ * so the vacuity guard below is directly unit-testable (#3434).
+ *
+ * Returns `true` only when there is at least one reader-facing route AND every
+ * one of them is shadowed. The emptiness check is the whole reason this is a
+ * named function: `[].every(…)` is vacuously `true`, so an empty denominator
+ * would otherwise fire the warning for every host. That state is unreachable
+ * through `deriveRoutes` today (`/docs/[[...slug]]` is always emitted and
+ * always counted), which is exactly why it needs a test that calls this
+ * directly — a build-driven test cannot construct it.
+ */
+export function shouldWarnDtpFullyShadowed(
+  routes: ReadonlyArray<Pick<RouteSpec, "pattern" | "includedInDtpShadowDiagnostic">>,
+  isShadowed: (pattern: string) => boolean,
+): boolean {
+  const counted = routes.filter((route) => route.includedInDtpShadowDiagnostic);
+  if (counted.length === 0) return false;
+  return counted.every((route) => isShadowed(route.pattern));
 }
 
 /**
@@ -164,15 +216,15 @@ function deriveRoutes(settings: RoutesSettings): RouteSpec[] {
   // ctx.command). The routes/index.tsx entrypoint exists and is exported from
   // the package for when the user drops their pages/index.tsx stub and a future
   // zfb version lifts the restriction. Tracked: Takazudo/zudo-front-builder#1227.
-  routes.push({ pattern: "/404", entrypoint: "@takazudo/zudo-doc/routes/404" });
-  routes.push({ pattern: "/sitemap.xml", entrypoint: "@takazudo/zudo-doc/routes/sitemap.xml" });
-  routes.push({ pattern: "/robots.txt", entrypoint: "@takazudo/zudo-doc/routes/robots.txt" });
-  routes.push({ pattern: "/docs/[[...slug]]", entrypoint: "@takazudo/zudo-doc/routes/docs-slug" });
+  routes.push({ pattern: "/404", entrypoint: "@takazudo/zudo-doc/routes/404", includedInDtpShadowDiagnostic: false });
+  routes.push({ pattern: "/sitemap.xml", entrypoint: "@takazudo/zudo-doc/routes/sitemap.xml", includedInDtpShadowDiagnostic: false });
+  routes.push({ pattern: "/robots.txt", entrypoint: "@takazudo/zudo-doc/routes/robots.txt", includedInDtpShadowDiagnostic: false });
+  routes.push({ pattern: "/docs/[[...slug]]", entrypoint: "@takazudo/zudo-doc/routes/docs-slug", includedInDtpShadowDiagnostic: true });
 
   // ── Tags (gated on settings.docTags) ──────────────────────────────────
   if (docTags) {
-    routes.push({ pattern: "/docs/tags", entrypoint: "@takazudo/zudo-doc/routes/docs-tags-index" });
-    routes.push({ pattern: "/docs/tags/[tag]", entrypoint: "@takazudo/zudo-doc/routes/docs-tags-tag" });
+    routes.push({ pattern: "/docs/tags", entrypoint: "@takazudo/zudo-doc/routes/docs-tags-index", includedInDtpShadowDiagnostic: true });
+    routes.push({ pattern: "/docs/tags/[tag]", entrypoint: "@takazudo/zudo-doc/routes/docs-tags-tag", includedInDtpShadowDiagnostic: true });
   }
 
   // ── AI chat (SSR — prerender:false; gated on settings.aiAssistant) ─────
@@ -181,28 +233,29 @@ function deriveRoutes(settings: RoutesSettings): RouteSpec[] {
       pattern: "/api/ai-chat",
       entrypoint: "@takazudo/zudo-doc/routes/api-ai-chat",
       opts: { prerender: false },
+      includedInDtpShadowDiagnostic: false,
     });
   }
 
   // ── Versions (default-locale) ─────────────────────────────────────────
   if (hasVersions) {
-    routes.push({ pattern: "/docs/versions", entrypoint: "@takazudo/zudo-doc/routes/docs-versions" });
-    routes.push({ pattern: "/v/[version]/docs/[[...slug]]", entrypoint: "@takazudo/zudo-doc/routes/v-docs-slug" });
-    routes.push({ pattern: "/v/[version]/[locale]/docs/[[...slug]]", entrypoint: "@takazudo/zudo-doc/routes/v-locale-docs-slug" });
+    routes.push({ pattern: "/docs/versions", entrypoint: "@takazudo/zudo-doc/routes/docs-versions", includedInDtpShadowDiagnostic: true });
+    routes.push({ pattern: "/v/[version]/docs/[[...slug]]", entrypoint: "@takazudo/zudo-doc/routes/v-docs-slug", includedInDtpShadowDiagnostic: true });
+    routes.push({ pattern: "/v/[version]/[locale]/docs/[[...slug]]", entrypoint: "@takazudo/zudo-doc/routes/v-locale-docs-slug", includedInDtpShadowDiagnostic: true });
   }
 
   // ── Per non-default locale (dynamic [locale] pattern, injected once) ───
   // Only emit the locale-prefixed patterns when at least one non-default
   // locale is configured — otherwise `[locale]` paths() would enumerate empty.
   if (localeCodes.length > 0) {
-    routes.push({ pattern: "/[locale]", entrypoint: "@takazudo/zudo-doc/routes/locale-index" });
-    routes.push({ pattern: "/[locale]/docs/[[...slug]]", entrypoint: "@takazudo/zudo-doc/routes/locale-docs-slug" });
+    routes.push({ pattern: "/[locale]", entrypoint: "@takazudo/zudo-doc/routes/locale-index", includedInDtpShadowDiagnostic: true });
+    routes.push({ pattern: "/[locale]/docs/[[...slug]]", entrypoint: "@takazudo/zudo-doc/routes/locale-docs-slug", includedInDtpShadowDiagnostic: true });
     if (docTags) {
-      routes.push({ pattern: "/[locale]/docs/tags", entrypoint: "@takazudo/zudo-doc/routes/locale-docs-tags-index" });
-      routes.push({ pattern: "/[locale]/docs/tags/[tag]", entrypoint: "@takazudo/zudo-doc/routes/locale-docs-tags-tag" });
+      routes.push({ pattern: "/[locale]/docs/tags", entrypoint: "@takazudo/zudo-doc/routes/locale-docs-tags-index", includedInDtpShadowDiagnostic: true });
+      routes.push({ pattern: "/[locale]/docs/tags/[tag]", entrypoint: "@takazudo/zudo-doc/routes/locale-docs-tags-tag", includedInDtpShadowDiagnostic: true });
     }
     if (hasVersions) {
-      routes.push({ pattern: "/[locale]/docs/versions", entrypoint: "@takazudo/zudo-doc/routes/locale-docs-versions" });
+      routes.push({ pattern: "/[locale]/docs/versions", entrypoint: "@takazudo/zudo-doc/routes/locale-docs-versions", includedInDtpShadowDiagnostic: true });
     }
   }
 
@@ -361,25 +414,37 @@ const plugin = definePlugin({
         : `export { buildDesignTokenPanelConfig } from "@takazudo/zudo-doc/design-token-panel-config";\n`,
     );
 
-    // (3.5) DTP shadow diagnostic (zudolab/zudo-doc#3420, spec #3428).
+    // (3.5) DTP shadow diagnostic (zudolab/zudo-doc#3420, spec #3428; scoped
+    // by #3434/#3435).
     // Decision 6 above drops an injected route SILENTLY when a kept user
     // `pages/` file claims the same URL — so a locked-manifest host that
     // sets `designTokenPanelConfigModule` while its `pages/` stubs shadow
-    // EVERY injected route gets no configured DTP island anywhere: the panel
-    // vanishes site-wide with no build error. Warn loudly at setup instead.
-    // "ALL derived routes shadowed" is the sufficient condition — partial
-    // shadowing stays silent (the config still applies on the surviving
-    // routes). Gated on the RESOLVED path (not the raw setting) since
-    // `resolveHostModuleOverride` above already turned an invalid setting
-    // into a thrown Error — reaching here means the module genuinely
-    // resolved. Diagnostic only: does not change which routes get injected
-    // below.
-    if (designTokenPanelConfigAbsPath) {
+    // every injected route a READER BROWSES gets no configured DTP island on
+    // any page of its documentation: the panel vanishes with no build error.
+    // Warn loudly at setup instead. "All reader-facing derived routes
+    // shadowed" is the sufficient condition (`includedInDtpShadowDiagnostic`
+    // on `RouteSpec` — the original `every(derivedRoutes)` never fired for
+    // the very host shape that motivated the diagnostic, because
+    // `/sitemap.xml` and `/robots.txt` are always injected and are never
+    // shadowed by the two-stub minimal scaffold, #3434). Partial shadowing
+    // stays silent (the config still applies on the surviving reader routes).
+    //
+    // Two gates, both needed:
+    //  - `settings.designTokenPanel` — with the feature off, `settings.ts`
+    //    documents `designTokenPanelConfigModule` as irrelevant, so warning
+    //    about a panel that never renders either way contradicts the
+    //    documented contract (#3435).
+    //  - the RESOLVED path, not the raw setting — `resolveHostModuleOverride`
+    //    above already turned an invalid setting into a thrown Error, so
+    //    reaching here means the module genuinely resolved.
+    //
+    // Diagnostic only: does not change which routes get injected below.
+    if (settings.designTokenPanel === true && designTokenPanelConfigAbsPath) {
       const pagesDir = join(ctx.projectRoot, "pages");
-      const allRoutesShadowed = derivedRoutes.every((route) =>
-        derivePagesCandidates(route.pattern).some((rel) => existsSync(join(pagesDir, rel))),
+      const readerRoutesAllShadowed = shouldWarnDtpFullyShadowed(derivedRoutes, (pattern) =>
+        derivePagesCandidates(pattern).some((rel) => existsSync(join(pagesDir, rel))),
       );
-      if (allRoutesShadowed) {
+      if (readerRoutesAllShadowed) {
         // Best-effort heuristic: a cheap text scan for the literal export
         // name, not an evaluation of the resolved module — the module
         // cannot be executed here, at plugin setup. A host that composes
@@ -394,9 +459,10 @@ const plugin = definePlugin({
         if (!workaroundLikelyApplied) {
           ctx.logger.warn(
             "zudo-doc: settings.designTokenPanelConfigModule is set, but every " +
-              "injected route's URL is shadowed by a kept user pages/ file — the " +
-              "configured Design Token Panel builder can never apply anywhere on " +
-              "this site (zudolab/zudo-doc#3420). Thread your builder through " +
+              "reader-facing injected route's URL is shadowed by a kept user " +
+              "pages/ file — the configured Design Token Panel builder can never " +
+              "apply on any documentation page a reader browses on this site " +
+              "(zudolab/zudo-doc#3420). Thread your builder through " +
               "chromeBindings.DesignTokenPanelBootstrap instead — that binding wins " +
               "everywhere, including stub-rendered pages (see the " +
               "designTokenPanelConfigModule docblock in settings.ts). If you already " +

--- a/packages/zudo-doc/src/plugins/routes.ts
+++ b/packages/zudo-doc/src/plugins/routes.ts
@@ -57,7 +57,10 @@
 //      user `pages/` file — meaning the configured builder can never reach an
 //      injected route a reader browses. Suppressed when the resolved
 //      `chromeBindingsModule` file already names `DesignTokenPanelBootstrap`
-//      (the documented workaround). See the guard case inline, next to #3 above.
+//      (the documented workaround), or when a shadowing `pages/` file is an
+//      exact default re-export of the shadowed route's own entrypoint (#3451
+//      — such a file still reaches the bootstrap through `routes/_chrome.tsx`).
+//      See the guard case inline, next to #3 above.
 //
 //   4. injectRoute(pattern, entrypoint[, opts]) — the 16-route catalog
 //      (Decision 3), patterns derived from `options.settings.locales` /
@@ -194,6 +197,52 @@ export function shouldWarnDtpFullyShadowed(
   const counted = routes.filter((route) => route.includedInDtpShadowDiagnostic);
   if (counted.length === 0) return false;
   return counted.every((route) => isShadowed(route.pattern));
+}
+
+/**
+ * Best-effort check for the one shape that makes a `pages/` file shadowing a
+ * package route harmless to the DTP shadow diagnostic (#3451): an exact
+ * default RE-EXPORT of that route's OWN package entrypoint —
+ *
+ *   export { default, paths, frontmatter } from "@takazudo/zudo-doc/routes/docs-slug";
+ *
+ * Such a file still reaches the configured chrome bootstrap through
+ * `routes/_chrome.tsx` (it forwards to the very entrypoint the package would
+ * have injected), so `existsSync` finding it should not count as a real
+ * shadow — narrowing the diagnostic's denominator to reader-facing routes
+ * (#3434) made this false positive reachable, where before it was hidden by
+ * the always-surviving `/404` / `/sitemap.xml` entries.
+ *
+ * Deliberately NARROW, and best-effort in the same sense as the
+ * `workaroundLikelyApplied` check in `setup()` below: a cheap text scan over
+ * the file's source, not module evaluation or an AST parse. It intentionally
+ * does NOT suppress on any of these shapes, because none of them prove the
+ * route still reaches the bootstrap:
+ *
+ *  - the specifier appearing only inside a comment (stripped before matching)
+ *  - an unused import of the specifier (no `export { default … } from` at all)
+ *  - a re-export of a DIFFERENT package route (the specifier must match
+ *    `entrypoint` exactly)
+ *  - a file that imports the package route but exports its own default
+ *
+ * Conversely, a host that reaches the same entrypoint some OTHER way this
+ * scan cannot see (e.g. a local wrapper module) still counts as shadowed and
+ * may trigger the diagnostic even though it is actually safe — that false
+ * positive is the accepted cost of a text-only heuristic (the warning
+ * message states this limit too).
+ */
+function isExactDefaultReExport(source: string, entrypoint: string): boolean {
+  // Strip comments first so a commented-out re-export line is never mistaken
+  // for a live one. This itself is best-effort: it does not understand
+  // string literals, so a `//`/`/* */` sequence inside a string would also
+  // get stripped — an acceptable limit for the simple import/export-only
+  // `pages/` stub files this heuristic targets.
+  const withoutComments = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+  const specifier = entrypoint.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const reExportPattern = new RegExp(
+    `export\\s*\\{[^}]*\\bdefault\\b(?!\\s+as\\s)[^}]*\\}\\s*from\\s*(["'])${specifier}\\1`,
+  );
+  return reExportPattern.test(withoutComments);
 }
 
 /**
@@ -415,7 +464,7 @@ const plugin = definePlugin({
     );
 
     // (3.5) DTP shadow diagnostic (zudolab/zudo-doc#3420, spec #3428; scoped
-    // by #3434/#3435).
+    // by #3434/#3435; re-export false-positive guarded by #3451).
     // Decision 6 above drops an injected route SILENTLY when a kept user
     // `pages/` file claims the same URL — so a locked-manifest host that
     // sets `designTokenPanelConfigModule` while its `pages/` stubs shadow
@@ -441,9 +490,26 @@ const plugin = definePlugin({
     // Diagnostic only: does not change which routes get injected below.
     if (settings.designTokenPanel === true && designTokenPanelConfigAbsPath) {
       const pagesDir = join(ctx.projectRoot, "pages");
-      const readerRoutesAllShadowed = shouldWarnDtpFullyShadowed(derivedRoutes, (pattern) =>
-        derivePagesCandidates(pattern).some((rel) => existsSync(join(pagesDir, rel))),
-      );
+      // Looked up per-pattern below so the re-export guard (#3451) can
+      // compare a shadowing file's specifier against THIS route's own
+      // `entrypoint` — a re-export of a different package route must still
+      // count as a real shadow.
+      const routesByPattern = new Map(derivedRoutes.map((route) => [route.pattern, route]));
+      const readerRoutesAllShadowed = shouldWarnDtpFullyShadowed(derivedRoutes, (pattern) => {
+        const route = routesByPattern.get(pattern);
+        return derivePagesCandidates(pattern).some((rel) => {
+          const abs = join(pagesDir, rel);
+          if (!existsSync(abs)) return false;
+          // A kept `pages/` file that exactly default-re-exports the
+          // shadowed route's own entrypoint still reaches the configured
+          // bootstrap through routes/_chrome.tsx — don't count it as a real
+          // shadow (#3451).
+          if (route && isExactDefaultReExport(readFileSync(abs, "utf8"), route.entrypoint)) {
+            return false;
+          }
+          return true;
+        });
+      });
       if (readerRoutesAllShadowed) {
         // Best-effort heuristic: a cheap text scan for the literal export
         // name, not an evaluation of the resolved module — the module
@@ -468,7 +534,13 @@ const plugin = definePlugin({
               "designTokenPanelConfigModule docblock in settings.ts). If you already " +
               "did this via a chromeBindingsModule that composes the bootstrap " +
               'indirectly (never spelling "DesignTokenPanelBootstrap" literally in ' +
-              "the resolved file), this warning is safe to ignore.",
+              "the resolved file), this warning is safe to ignore. A pages/ file " +
+              "that cleanly re-exports a shadowed route's own entrypoint " +
+              '(`export { default, paths, frontmatter } from "@takazudo/zudo-doc/' +
+              'routes/…"`) does not count as a real shadow either — but that check ' +
+              "is also a best-effort text scan, not module evaluation, so a file " +
+              "that reaches the same entrypoint some other way may still trigger " +
+              "this warning even though it is safe.",
           );
         }
       }

--- a/packages/zudo-doc/src/settings.ts
+++ b/packages/zudo-doc/src/settings.ts
@@ -482,14 +482,20 @@ export interface Settings {
    * minimal scaffold, which is what kept the original all-routes form of this
    * check from ever firing (#3434).
    *
-   * Two further suppressions: the diagnostic is silent unless
+   * Three further suppressions: the diagnostic is silent unless
    * `designTokenPanel` is `true` (with the feature off this setting is
-   * irrelevant, per the paragraph above — #3435), and silent when the resolved
+   * irrelevant, per the paragraph above — #3435); silent when the resolved
    * `chromeBindingsModule` file already contains the literal token
    * `DesignTokenPanelBootstrap` (a best-effort static text scan — an
    * indirectly-composed override that never spells the name out keeps
-   * warning). Partial shadowing stays silent: the config still applies on
-   * whichever reader-facing routes survive.
+   * warning); and a `pages/` file that is an exact default re-export of the
+   * shadowed route's OWN package entrypoint
+   * (`export { default, paths, frontmatter } from "@takazudo/zudo-doc/routes/…"`)
+   * does not count as a shadow at all, because it still reaches the configured
+   * bootstrap through `routes/_chrome.tsx` (#3451 — also a best-effort text
+   * scan, so a file that reaches the same entrypoint some other way still
+   * counts as shadowed). Partial shadowing stays silent: the config still
+   * applies on whichever reader-facing routes survive.
    */
   designTokenPanelConfigModule?: string;
   /**

--- a/packages/zudo-doc/src/settings.ts
+++ b/packages/zudo-doc/src/settings.ts
@@ -466,20 +466,30 @@ export interface Settings {
    * binding wins everywhere and is unaffected by this rule. See
    * `docs/adr/route-injection-seam.md`.
    *
-   * EDGE CASE (zudolab/zudo-doc#3420, diagnostic added #3428): a
-   * locked-manifest host whose kept `pages/` stubs happen to shadow EVERY
-   * injected route (Decision 6 in `plugins/routes.ts` drops a collided
-   * injected route silently — user `pages/` always wins) gets no configured
-   * DTP island anywhere on the site when this setting is set, with no build
-   * error. `plugins/routes.ts` now probes for exactly this at plugin setup —
-   * if every derived route's URL resolves to an existing user `pages/` file,
-   * it emits a loud `ctx.logger.warn` naming this gap and the
-   * `chromeBindings.DesignTokenPanelBootstrap` workaround above, UNLESS the
-   * resolved `chromeBindingsModule` file already contains the literal token
+   * EDGE CASE (zudolab/zudo-doc#3420, diagnostic added #3428, scoped by
+   * #3434/#3435): a locked-manifest host whose kept `pages/` stubs happen to
+   * shadow every injected route a READER BROWSES (Decision 6 in
+   * `plugins/routes.ts` drops a collided injected route silently — user
+   * `pages/` always wins) gets no configured DTP island on any page of its
+   * documentation when this setting is set, with no build error.
+   * `plugins/routes.ts` now probes for exactly this at plugin setup — if every
+   * derived route tagged `includedInDtpShadowDiagnostic` resolves to an
+   * existing user `pages/` file, it emits a loud `ctx.logger.warn` naming this
+   * gap and the `chromeBindings.DesignTokenPanelBootstrap` workaround above.
+   * The denominator deliberately excludes `/404`, `/sitemap.xml`,
+   * `/robots.txt` and `/api/ai-chat` — none of them is a documentation page a
+   * reader browses, and the two non-HTML ones could never be shadowed by a
+   * minimal scaffold, which is what kept the original all-routes form of this
+   * check from ever firing (#3434).
+   *
+   * Two further suppressions: the diagnostic is silent unless
+   * `designTokenPanel` is `true` (with the feature off this setting is
+   * irrelevant, per the paragraph above — #3435), and silent when the resolved
+   * `chromeBindingsModule` file already contains the literal token
    * `DesignTokenPanelBootstrap` (a best-effort static text scan — an
    * indirectly-composed override that never spells the name out keeps
    * warning). Partial shadowing stays silent: the config still applies on
-   * whichever routes survive.
+   * whichever reader-facing routes survive.
    */
   designTokenPanelConfigModule?: string;
   /**


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3449

---

## Summary

Fixes two defects in the DTP shadow diagnostic added by #3428, both found by `/code-review` on that PR. Child of super-epic #3443; merges into `base/sweep-260818`.

## The diagnostic never fired for the shape it was built for (#3434)

`deriveRoutes` unconditionally pushes `/404`, `/sitemap.xml` and `/robots.txt` before any feature gating, and never injects `/`. So for the locked-manifest host that motivated #3420 — `pages/index.tsx` + `pages/docs/[[...slug]].tsx` stubs — those three survived, `every()` stayed `false`, and **no warning was emitted**, even though every doc page a reader visits was stub-rendered with no panel. Two of the survivors can't render an HTML panel at all, so they held it at `false` permanently.

The denominator is now scoped to reader-facing routes via a **required** `includedInDtpShadowDiagnostic` flag on `RouteSpec`, declared per route in `deriveRoutes`. Required, so a newly added route must state its membership — drift becomes a type error rather than the silent miss this issue was.

The flag is deliberately **not** named `rendersPanel`: `/404` genuinely does render the configured bootstrap (`routes/404.tsx` → `BodyEndIslands` → `_chrome.tsx`'s `ConfiguredDesignTokenPanelBootstrap`), so that name would have put a false claim in the source.

## It warned when the feature was off (#3435)

`designTokenPanelConfigModule` resolves unconditionally and `designTokenPanel` defaults to `false`, so a host with the panel switched off plus a leftover config value was told to wire a panel that never renders — contradicting `settings.ts`, which documents the setting as irrelevant when the feature is off. The guard now requires `designTokenPanel === true`; `RoutesSettings` gained the missing member.

## Narrowing made a false positive reachable

A `pages/` stub that merely re-exports the package route counts as shadowing for the `existsSync` probe but *does* reach the bootstrap. Suppressed by an exact match on `export { …default… } from "<that route's own entrypoint>"` — quote-backreferenced so a prefix can't match, `default as X` excluded, comments stripped first. Six named cases pin the boundary: only exact forwarding is silent; comment-only, unused import, different route, own-default and plain stub all still warn.

## Robustness

Both `readFileSync` calls in this warn-only block are guarded. `existsSync` passing doesn't imply readable, and a diagnostic whose entire job is to print a warning must never throw out of `setup()` and fail a build.

## Tests

27 → 28 tests on `routes.test.ts`. Both regression tests were confirmed to **fail against the pre-fix guard** before being kept, and the vacuity guard is exercised by direct call to the extracted `shouldWarnDtpFullyShadowed` helper.