### PR TITLE
DTP Bootstrap Flake: diagnose first, then add deadline headroom + diagnostics capture

### DIFF
--- a/packages/zudo-doc/src/__tests__/design-token-panel-bootstrap.test.ts
+++ b/packages/zudo-doc/src/__tests__/design-token-panel-bootstrap.test.ts
@@ -49,6 +49,13 @@ import {
   type PanelConfigBuilder,
 } from "../design-token-panel-bootstrap.js";
 
+// Named-deadline headroom for the 39 `vi.waitFor()` calls below (#3465,
+// #3452 Wave 1 diagnosis): kept strictly inside the package testTimeout
+// (30_000, vitest.config.ts) so on expiry `vi.waitFor` rethrows the last
+// failing `expect(...)` — naming the exact awaited condition instead of a
+// blunt anonymous test timeout.
+const WAIT_FOR_OPTS = { timeout: 10_000, interval: 50 } as const;
+
 beforeEach(() => {
   vi.doMock("@takazudo/zdtp", zdtpFactory);
   zdtp.evaluations = 0;
@@ -150,7 +157,7 @@ async function activateViaToggle(
 ): Promise<void> {
   bootstrapDesignTokenPanel(builder);
   dispatchToggle(browser.windowTarget);
-  await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalled());
+  await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalled(), WAIT_FOR_OPTS);
 }
 
 describe("bootstrapDesignTokenPanel — lazy zdtp load", () => {
@@ -202,8 +209,9 @@ describe("bootstrapDesignTokenPanel — lazy zdtp load", () => {
 
     bootstrapDesignTokenPanel(builder);
     dispatchToggle(browser.windowTarget);
-    await vi.waitFor(() =>
-      expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce(),
+    await vi.waitFor(
+      () => expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce(),
+      WAIT_FOR_OPTS,
     );
 
     expect(zdtp.evaluations).toBe(1);
@@ -237,7 +245,7 @@ describe("bootstrapDesignTokenPanel — lazy zdtp load", () => {
     bootstrapDesignTokenPanel(builder);
     browser.setMode("dark");
     dispatchToggle(browser.windowTarget);
-    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalled());
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalled(), WAIT_FOR_OPTS);
 
     expect(builder).toHaveBeenLastCalledWith("dark");
     expect(zdtp.configurePanel).toHaveBeenCalledWith(
@@ -261,8 +269,9 @@ describe("bootstrapDesignTokenPanel — lazy zdtp load", () => {
       dispatchToggle(browser.windowTarget);
 
     bootstrapDesignTokenPanel(builder);
-    await vi.waitFor(() =>
-      expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce(),
+    await vi.waitFor(
+      () => expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce(),
+      WAIT_FOR_OPTS,
     );
 
     expect(zdtp.configurePanel).toHaveBeenCalledOnce();
@@ -284,8 +293,9 @@ describe("bootstrapDesignTokenPanel — lazy zdtp load", () => {
     dispatchToggle(browser.windowTarget);
     dispatchToggle(browser.windowTarget);
     dispatchToggle(browser.windowTarget);
-    await vi.waitFor(() =>
-      expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce(),
+    await vi.waitFor(
+      () => expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce(),
+      WAIT_FOR_OPTS,
     );
 
     expect(zdtp.evaluations).toBe(1);
@@ -306,7 +316,7 @@ describe("bootstrapDesignTokenPanel — lazy zdtp load", () => {
     bootstrapDesignTokenPanel(builder);
     dispatchToggle(browser.windowTarget);
     dispatchToggle(browser.windowTarget);
-    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce(), WAIT_FOR_OPTS);
     await settle();
 
     expect(zdtp.showDesignTokenPanel).not.toHaveBeenCalled();
@@ -323,8 +333,9 @@ describe("bootstrapDesignTokenPanel — lazy zdtp load", () => {
     });
 
     await activateViaToggle(browser, builder);
-    await vi.waitFor(() =>
-      expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce(),
+    await vi.waitFor(
+      () => expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce(),
+      WAIT_FOR_OPTS,
     );
 
     // Post-configure dispatches belong to zdtp's own module-scope listener
@@ -360,8 +371,9 @@ describe("bootstrapDesignTokenPanel — lazy zdtp load", () => {
     // model the browser behavior for the retry.
     vi.doMock("@takazudo/zdtp", zdtpFactory);
     dispatchToggle(browser.windowTarget);
-    await vi.waitFor(() =>
-      expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce(),
+    await vi.waitFor(
+      () => expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce(),
+      WAIT_FOR_OPTS,
     );
 
     // The retry toggle carries fresh intent (count restarted at 1 → shown).
@@ -381,7 +393,7 @@ describe("bootstrapDesignTokenPanel — lazy zdtp load", () => {
 
     bootstrapDesignTokenPanel(builder);
     dispatchToggle(browser.windowTarget);
-    await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledOnce(), WAIT_FOR_OPTS);
 
     expect(zdtp.configurePanel).toHaveBeenCalledOnce();
     expect(zdtp.showDesignTokenPanel).not.toHaveBeenCalled();
@@ -434,7 +446,7 @@ describe("bootstrapDesignTokenPanel — persisted-state probe", () => {
     browser.values.set("test-panel-state-v4", NON_EMPTY_ENVELOPE);
 
     bootstrapDesignTokenPanel(makeBuilder());
-    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce(), WAIT_FOR_OPTS);
     await settle();
 
     expect(zdtp.evaluations).toBe(1);
@@ -450,7 +462,7 @@ describe("bootstrapDesignTokenPanel — persisted-state probe", () => {
     browser.values.set("test-panel-state", NON_EMPTY_ENVELOPE);
 
     bootstrapDesignTokenPanel(makeBuilder());
-    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce(), WAIT_FOR_OPTS);
   });
 
   it("-open == \"1\" triggers the eager configure", async () => {
@@ -458,7 +470,7 @@ describe("bootstrapDesignTokenPanel — persisted-state probe", () => {
     browser.values.set("test-panel-open", "1");
 
     bootstrapDesignTokenPanel(makeBuilder());
-    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce(), WAIT_FOR_OPTS);
     await settle();
     expect(zdtp.showDesignTokenPanel).not.toHaveBeenCalled();
   });
@@ -468,7 +480,7 @@ describe("bootstrapDesignTokenPanel — persisted-state probe", () => {
     browser.values.set("test-panel--foundry-state-v4", NON_EMPTY_ENVELOPE);
 
     bootstrapDesignTokenPanel(makeBuilder());
-    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce(), WAIT_FOR_OPTS);
 
     expect(zdtp.configurePanel).toHaveBeenCalledWith(
       expect.objectContaining({ storagePrefix: "test-panel--foundry" }),
@@ -485,7 +497,7 @@ describe("bootstrapDesignTokenPanel — persisted-state probe", () => {
       browser.values.set(`test-panel${suffix}`, "1");
 
       bootstrapDesignTokenPanel(makeBuilder());
-      await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+      await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce(), WAIT_FOR_OPTS);
     },
   );
 
@@ -509,7 +521,7 @@ describe("bootstrapDesignTokenPanel — persisted-state probe", () => {
     browser.values.set("test-panel:visible", "1");
 
     bootstrapDesignTokenPanel(makeBuilder());
-    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce(), WAIT_FOR_OPTS);
     await settle();
 
     expect(zdtp.showDesignTokenPanel).not.toHaveBeenCalled();
@@ -526,7 +538,7 @@ describe("bootstrapDesignTokenPanel — persisted-state probe", () => {
     expect(zdtp.configurePanel).not.toHaveBeenCalled();
 
     dispatchToggle(browser.windowTarget);
-    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce(), WAIT_FOR_OPTS);
   });
 
   it(":autoload == \"1\" with :visible == \"0\" still triggers — the documented owner-mode-armed steady state", async () => {
@@ -540,7 +552,7 @@ describe("bootstrapDesignTokenPanel — persisted-state probe", () => {
     browser.values.set("test-panel:visible", "0");
 
     bootstrapDesignTokenPanel(makeBuilder());
-    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce(), WAIT_FOR_OPTS);
     await settle();
 
     // Armed, not opened: the probe never issues an explicit show().
@@ -559,7 +571,7 @@ describe("bootstrapDesignTokenPanel — persisted-state probe", () => {
 
     browser.setPack("foundry");
     browser.windowTarget.dispatchEvent(new Event("theme-pack-changed"));
-    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce(), WAIT_FOR_OPTS);
 
     // Configure read the pack live: the new namespace is bound directly, and
     // the configure body's own pack listener did not double-run for the
@@ -614,8 +626,9 @@ describe("bootstrapDesignTokenPanel — persisted-state probe", () => {
 
     bootstrapDesignTokenPanel(makeBuilder());
     dispatchToggle(browser.windowTarget);
-    await vi.waitFor(() =>
-      expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce(),
+    await vi.waitFor(
+      () => expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce(),
+      WAIT_FOR_OPTS,
     );
 
     expect(zdtp.configurePanel).toHaveBeenCalledOnce();
@@ -643,7 +656,7 @@ describe("bootstrapDesignTokenPanel — persisted-state probe", () => {
 
     // The lazy toggle path must still work with storage disabled.
     dispatchToggle(browser.windowTarget);
-    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce(), WAIT_FOR_OPTS);
   });
 });
 
@@ -698,7 +711,7 @@ describe("bootstrapDesignTokenPanel — persisted-state probe envelope policy", 
       browser.values.set("test-panel-state-v4", raw);
 
       bootstrapDesignTokenPanel(makeBuilder());
-      await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+      await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce(), WAIT_FOR_OPTS);
     },
   );
 
@@ -716,7 +729,7 @@ describe("bootstrapDesignTokenPanel — persisted-state probe envelope policy", 
 
       // Narrowed, not disabled: the toggle path still activates.
       dispatchToggle(browser.windowTarget);
-      await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+      await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce(), WAIT_FOR_OPTS);
     },
   );
 
@@ -742,7 +755,7 @@ describe("bootstrapDesignTokenPanel — persisted-state probe envelope policy", 
     browser.values.set("test-panel-state-v3", NON_EMPTY_ENVELOPE);
 
     bootstrapDesignTokenPanel(makeBuilder());
-    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce(), WAIT_FOR_OPTS);
   });
 
   it("several empty envelopes across versions still stay lazy", async () => {
@@ -825,7 +838,7 @@ describe("bootstrapDesignTokenPanel — resolved toggle channel", () => {
       makeBuilder({ storagePrefix: "test-panel", toggleEvent: "acme-open-tokens" }),
     );
     dispatchOn(browser.windowTarget, "acme-open-tokens");
-    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce(), WAIT_FOR_OPTS);
 
     expect(zdtp.evaluations).toBe(1);
     expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce();
@@ -836,7 +849,7 @@ describe("bootstrapDesignTokenPanel — resolved toggle channel", () => {
 
     bootstrapDesignTokenPanel(makeBuilder({ storagePrefix: "test-panel" }));
     dispatchOn(browser.windowTarget, "toggle-test-panel");
-    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce(), WAIT_FOR_OPTS);
 
     expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce();
   });
@@ -851,7 +864,7 @@ describe("bootstrapDesignTokenPanel — resolved toggle channel", () => {
     expect(zdtp.evaluations).toBe(0);
 
     dispatchOn(browser.windowTarget, "toggle-test-panel--foundry");
-    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce(), WAIT_FOR_OPTS);
   });
 
   it("a configured toggleEvent REPLACES the derived name: the derived channel is not registered", async () => {
@@ -877,7 +890,7 @@ describe("bootstrapDesignTokenPanel — resolved toggle channel", () => {
       makeBuilder({ storagePrefix: "test-panel", toggleEvent: "acme-open-tokens" }),
     );
     dispatchToggle(browser.windowTarget);
-    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce(), WAIT_FOR_OPTS);
 
     expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce();
   });
@@ -899,7 +912,7 @@ describe("bootstrapDesignTokenPanel — resolved toggle channel", () => {
     expect(zdtp.evaluations).toBe(0);
 
     dispatchToggle(browser.windowTarget);
-    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce(), WAIT_FOR_OPTS);
     expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce();
   });
 
@@ -916,7 +929,7 @@ describe("bootstrapDesignTokenPanel — resolved toggle channel", () => {
       }),
     );
     dispatchToggle(browser.windowTarget);
-    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce(), WAIT_FOR_OPTS);
     await settle();
 
     expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce();
@@ -930,7 +943,7 @@ describe("bootstrapDesignTokenPanel — resolved toggle channel", () => {
     // dispatch counting, so these must NOT collapse into one.
     dispatchToggle(browser.windowTarget);
     dispatchOn(browser.windowTarget, "toggle-test-panel");
-    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce(), WAIT_FOR_OPTS);
     await settle();
 
     expect(zdtp.showDesignTokenPanel).not.toHaveBeenCalled();
@@ -956,7 +969,7 @@ describe("bootstrapDesignTokenPanel — resolved toggle channel", () => {
     expect(zdtp.configurePanel).not.toHaveBeenCalled();
 
     dispatchOn(browser.windowTarget, "toggle-test-panel--foundry");
-    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce(), WAIT_FOR_OPTS);
     expect(zdtp.configurePanel).toHaveBeenCalledWith(
       expect.objectContaining({ storagePrefix: "test-panel--foundry" }),
     );
@@ -978,7 +991,7 @@ describe("bootstrapDesignTokenPanel — resolved toggle channel", () => {
     expect(zdtp.configurePanel).not.toHaveBeenCalled();
 
     dispatchOn(browser.windowTarget, "toggle-test-panel-dark");
-    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce(), WAIT_FOR_OPTS);
     expect(zdtp.configurePanel).toHaveBeenCalledWith(
       expect.objectContaining({ storagePrefix: "test-panel-dark" }),
     );
@@ -999,7 +1012,7 @@ describe("bootstrapDesignTokenPanel — resolved toggle channel", () => {
     expect(zdtp.evaluations).toBe(0);
 
     dispatchOn(browser.windowTarget, "toggle-test-panel");
-    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce(), WAIT_FOR_OPTS);
     // One dispatch reached exactly one live binding → odd net intent.
     expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce();
   });
@@ -1025,7 +1038,7 @@ describe("bootstrapDesignTokenPanel — resolved toggle channel", () => {
     await settle();
 
     dispatchToggle(browser.windowTarget);
-    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce(), WAIT_FOR_OPTS);
     expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce();
   });
 
@@ -1038,8 +1051,9 @@ describe("bootstrapDesignTokenPanel — resolved toggle channel", () => {
       dispatchToggle(browser.windowTarget);
 
     bootstrapDesignTokenPanel(makeBuilder({ storagePrefix: "test-panel" }));
-    await vi.waitFor(() =>
-      expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce(),
+    await vi.waitFor(
+      () => expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce(),
+      WAIT_FOR_OPTS,
     );
 
     expect(zdtp.configurePanel).toHaveBeenCalledOnce();
@@ -1052,8 +1066,9 @@ describe("bootstrapDesignTokenPanel — resolved toggle channel", () => {
       makeBuilder({ storagePrefix: "test-panel", toggleEvent: "acme-open-tokens" }),
     );
     dispatchToggle(browser.windowTarget);
-    await vi.waitFor(() =>
-      expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce(),
+    await vi.waitFor(
+      () => expect(zdtp.showDesignTokenPanel).toHaveBeenCalledOnce(),
+      WAIT_FOR_OPTS,
     );
 
     // Post-configure dispatches belong to the listeners zdtp binds itself;
@@ -1090,7 +1105,7 @@ describe("bootstrapDesignTokenPanel — color-scheme rebuild", () => {
     browser.values.set("test-panel-light-open", "1");
 
     bootstrapDesignTokenPanel(builder);
-    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce(), WAIT_FOR_OPTS);
 
     vi.useFakeTimers();
     browser.setMode("dark");
@@ -1205,7 +1220,7 @@ describe("bootstrapDesignTokenPanel — theme-pack interplay", () => {
   ): Promise<void> {
     browser.values.set(`${activePrefix}-state-v4`, NON_EMPTY_ENVELOPE);
     bootstrapDesignTokenPanel(builder);
-    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce(), WAIT_FOR_OPTS);
   }
 
   it("configures with the pack-scoped prefix when a non-default pack is already active at boot", async () => {
@@ -1237,7 +1252,7 @@ describe("bootstrapDesignTokenPanel — theme-pack interplay", () => {
     browser.values.set("zudo-doc-tweak-open", "1");
 
     bootstrapDesignTokenPanel(builder);
-    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(zdtp.configurePanel).toHaveBeenCalledOnce(), WAIT_FOR_OPTS);
 
     vi.useFakeTimers();
     browser.setPack("foundry");

--- a/packages/zudo-doc/src/eject-logo/__tests__/cli-smoke.test.ts
+++ b/packages/zudo-doc/src/eject-logo/__tests__/cli-smoke.test.ts
@@ -28,7 +28,15 @@ export default defineConfig(
 `;
 
 function runCli(args: string[], cwd: string) {
-  return spawnSync(process.execPath, [BIN_PATH, ...args], { cwd, encoding: "utf8" });
+  return spawnSync(process.execPath, [BIN_PATH, ...args], {
+    cwd,
+    encoding: "utf8",
+    // Explicit subprocess deadline (#3465): stays inside the package's
+    // testTimeout (30_000, vitest.config.ts) so a hung CLI fails as "the
+    // subprocess exceeded its own deadline" (SIGTERM here) rather than the
+    // ambiguous "Test timed out in 5000ms." vitest previously produced.
+    timeout: 25_000,
+  });
 }
 
 let tempDir: string;

--- a/packages/zudo-doc/src/eject-logo/__tests__/cli-smoke.test.ts
+++ b/packages/zudo-doc/src/eject-logo/__tests__/cli-smoke.test.ts
@@ -31,11 +31,14 @@ function runCli(args: string[], cwd: string) {
   return spawnSync(process.execPath, [BIN_PATH, ...args], {
     cwd,
     encoding: "utf8",
-    // Explicit subprocess deadline (#3465): stays inside the package's
-    // testTimeout (30_000, vitest.config.ts) so a hung CLI fails as "the
+    // Explicit subprocess deadline (#3465): a hung CLI fails as "the
     // subprocess exceeded its own deadline" (SIGTERM here) rather than the
     // ambiguous "Test timed out in 5000ms." vitest previously produced.
-    timeout: 25_000,
+    // Sized so that the WORST CASE — two sequential runCli() calls in one
+    // test (the "second run" cases below) — still totals under the package
+    // testTimeout (30_000, vitest.config.ts); a per-call 25s would have let
+    // two hung runs blow the blunt test timeout first, defeating the point.
+    timeout: 10_000,
   });
 }
 

--- a/packages/zudo-doc/vitest.config.ts
+++ b/packages/zudo-doc/vitest.config.ts
@@ -83,6 +83,16 @@ export default defineConfig({
     // separate config (vitest.slow.config.ts). Mirrors
     // packages/create-zudo-doc/vitest.config.ts (zudolab/zudo-doc#2530).
     exclude: ["**/node_modules/**", "**/*.slow.test.ts"],
+    // Deadline headroom under CPU contention (#3465, #3452 Wave 1 diagnosis):
+    // this suite runs real tsc (resolution-chain.test.ts, 11.3-18.4s
+    // observed), a subprocess CLI (eject-logo/cli-smoke.test.ts), and WASM
+    // loads (highlight-runtime.integration.test.ts) that legitimately exceed
+    // vitest's 5000ms default once the machine is contended. Ordering
+    // invariant: every per-operation deadline in this package (e.g. the
+    // cli-smoke spawnSync timeout, design-token-panel-bootstrap.test.ts's
+    // WAIT_FOR_OPTS) stays strictly BELOW this value, so the specific,
+    // diagnosable deadline always fires before this blunt one.
+    testTimeout: 30_000,
     server: {
       deps: {
         // Inline the zfb island runtime so vite transforms it through the

--- a/packages/zudo-doc/vitest.config.ts
+++ b/packages/zudo-doc/vitest.config.ts
@@ -88,10 +88,14 @@ export default defineConfig({
     // observed), a subprocess CLI (eject-logo/cli-smoke.test.ts), and WASM
     // loads (highlight-runtime.integration.test.ts) that legitimately exceed
     // vitest's 5000ms default once the machine is contended. Ordering
-    // invariant: every per-operation deadline in this package (e.g. the
-    // cli-smoke spawnSync timeout, design-token-panel-bootstrap.test.ts's
-    // WAIT_FOR_OPTS) stays strictly BELOW this value, so the specific,
-    // diagnosable deadline always fires before this blunt one.
+    // invariant: every per-operation deadline reached from a TEST BODY (e.g.
+    // the cli-smoke spawnSync timeout, design-token-panel-bootstrap.test.ts's
+    // WAIT_FOR_OPTS) stays strictly below this value — counting the worst-case
+    // number of sequential such operations in a single test, not just one —
+    // so the specific, diagnosable deadline always fires before this blunt
+    // one. Hook deadlines are exempt: they race vitest's separate hookTimeout,
+    // never this one (theme-packs-tarball.test.ts's 60s `beforeAll` is the
+    // one such case).
     testTimeout: 30_000,
     server: {
       deps: {


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3452

---

## Summary

Diagnosis-first. Child of super-epic #3443; merges into `base/sweep-260818`.

## The source issue's premise did not survive measurement

#3439 reported that `design-token-panel-bootstrap.test.ts` flaked under parallel load and suspected #3344's `@takazudo/zdtp` teardown race had survived the 0.4.10 fix. Its own stated gap was that **the failure signature was never captured**.

Wave 1 captured it. 16 full suite runs (2 idle + 14 under 24–240 busy-loop hogs on 12 CPUs), plus 3 scoped runs of the DTP file alone under maximum starvation:

- **The DTP file never failed** — 0/16, and 0/3 scoped; its slowest individual test took 235 ms against the 1000 ms bare-`vi.waitFor` deadline.
- **13/14 contended runs failed elsewhere**, every one a vitest deadline expiry: `resolution-chain.test.ts` (real tsc at 11.3–18.4 s), `eject-logo/cli-smoke.test.ts`, `highlight-runtime.integration.test.ts`, plus one `Hook timed out in 60000ms.` in `theme-packs-tarball.test.ts`.
- **Zero `document.getElementById`, zero unhandled rejections across all 19 logs** — the zdtp-race hypothesis has no supporting evidence. #3344 stays closed, and no upstream report was filed.

So the real problem was a **package-level deadline budget**, not a component race: the suite runs real `tsc`, subprocess and WASM work that legitimately exceeds vitest's 5000 ms default under contention.

**The #3429 DTP incident's cause remains open and uncaptured.** This PR does not claim to fix it.

## What landed

1. **`vitest.config.ts`** — `testTimeout: 30_000` at config level (not sprinkled per-test).
2. **`design-token-panel-bootstrap.test.ts`** — a shared `WAIT_FOR_OPTS` on all 39 `vi.waitFor()` calls. This is the diagnostics half: on expiry `vi.waitFor` rethrows the last failing `expect(...)`, so a future occurrence names the awaited condition instead of dying as an anonymous timeout — exactly the signature #3439 could not capture.
3. **`cli-smoke.test.ts`** — an explicit `spawnSync` deadline, so a hung CLI reports as a subprocess timeout rather than an ambiguous test timeout.

**Ordering invariant**, recorded in the config: per-operation deadlines stay below `testTimeout` — *counting the worst-case number of sequential operations in one test* — so the specific, diagnosable deadline always fires first. Review caught that a per-call 25 s across two sequential `runCli()` calls summed to 50 s and would have inverted exactly that; it is now 10 s. Hook deadlines are exempt and named, since they race the separate `hookTimeout`.

## Verification

5/5 full runs green under 36 hogs, 2/2 under 120 hogs, plain suite (2224 tests) and `pnpm check` green. All busy-loop hogs confirmed killed.

## Closes

#3465 — its mechanism (`cli-smoke` on the 5000 ms default via an untimed `spawnSync`) was reproduced live by Wave 1; items 1 and 3 are its fix.