### PR TITLE
Scaffold Pin Staleness Gate: stop create-zudo-doc shipping a stale zfb pin

### DIFF
--- a/.github/workflows/publish-create-zudo-doc.yml
+++ b/.github/workflows/publish-create-zudo-doc.yml
@@ -17,6 +17,17 @@
 #   auth check and would abort first. Safeguard 1 remains as defense-in-depth for a
 #   matching-prefix-but-invalid-semver ref.
 #
+# Scaffold pin freshness (Safeguard 4/5):
+#   Runs scripts/check-scaffold-pin-freshness.mjs against the live npm registry —
+#   this is the actual enforcement point for the #3442 recurrence shape (a
+#   scaffold pin, e.g. @takazudo/zfb, that was current when
+#   scripts/release-create-zudo-doc.sh prepared the release but went stale before
+#   publication). It runs unconditionally, including on a dry run, so
+#   `dry_run: true` proves this safeguard passes too — consistent with this
+#   workflow's "prove the token and safeguards pass" contract above. See
+#   RELEASE.md ("Scaffold pin freshness gate") for what a failure means, the
+#   remedy, and how prerelease pins are compared against the registry.
+#
 # NPM_TOKEN must be an Automation token (type: "Automation" in npmjs.com).
 # Automation tokens bypass npm's 2FA for `npm publish`, which is required
 # for CI-driven publishing. Classic Publish tokens with 2FA enabled would
@@ -72,11 +83,11 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name || github.ref }}
 
-      # ── Safeguard 1/4: Tag must start with "v" ─────────────────────────────
+      # ── Safeguard 1/5: Tag must start with "v" ─────────────────────────────
       # Reject accidental triggers from non-version tags (e.g. "latest",
       # "stable", or typos). Pure shell — runs before any tooling setup so
       # bad tags fail fast with a clear message.
-      - name: '[Safeguard 1/4] Reject non-v* release tags'
+      - name: '[Safeguard 1/5] Reject non-v* release tags'
         shell: bash
         env:
           TAG: ${{ github.event.release.tag_name || github.ref_name }}
@@ -107,10 +118,10 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
-      # ── Safeguard 2/4: package.json version must match the tag ─────────────
+      # ── Safeguard 2/5: package.json version must match the tag ─────────────
       # Prevents a publish where the tag was pushed without a matching version
       # bump (or vice-versa). Uses the VERSION env set by Safeguard 1.
-      - name: '[Safeguard 2/4] Assert package.json version matches tag'
+      - name: '[Safeguard 2/5] Assert package.json version matches tag'
         shell: bash
         run: |
           PKG_VERSION=$(node -p "require('./packages/create-zudo-doc/package.json').version")
@@ -122,13 +133,13 @@ jobs:
             exit 1
           fi
 
-      # ── Safeguard 3/4: Version must not already be published ───────────────
+      # ── Safeguard 3/5: Version must not already be published ───────────────
       # npm publish is irreversible (unpublish is locked after 72 h for
       # packages with dependents). Guard against accidental double-publish.
       # We check stdout: `npm view` prints the version string if it exists
       # and exits 0; it prints nothing and exits non-zero if absent.
       # We treat non-empty stdout as "already published".
-      - name: '[Safeguard 3/4] Assert version not yet published to npm'
+      - name: '[Safeguard 3/5] Assert version not yet published to npm'
         shell: bash
         run: |
           EXISTING=$(npm view "create-zudo-doc@$VERSION" version 2>/dev/null || true)
@@ -167,14 +178,34 @@ jobs:
           echo "DIST_TAG=$DIST_TAG" >> "$GITHUB_ENV"
           echo "Dist tag: $DIST_TAG (version: $VERSION)"
 
-      # ── Safeguard 4/4: Dry-run path ────────────────────────────────────────
+      # ── Safeguard 4/5: Scaffold pin freshness ───────────────────────────────
+      # The actual enforcement point for the #3442 recurrence shape: a pin in
+      # packages/create-zudo-doc/src/scaffold.ts (e.g. @takazudo/zfb) that was
+      # current when scripts/release-create-zudo-doc.sh prepared this release
+      # can go stale in the gap before publication — that gap is exactly how
+      # create-zudo-doc@5.5.3 shipped a three-week-stale zfb pin. Runs
+      # unconditionally (including on dry_run) so a dry run proves this
+      # safeguard passes too, matching Safeguards 1-3 above. A registry lookup
+      # failure fails the gate the same as a confirmed-stale pin — see
+      # RELEASE.md ("Scaffold pin freshness gate") for the remedy and how
+      # prerelease pins are compared against the registry's "next" dist-tag.
+      - name: '[Safeguard 4/5] Assert scaffold pins are current'
+        shell: bash
+        run: |
+          if ! pnpm check:scaffold-pin-freshness; then
+            echo "::error::A scaffold pin in packages/create-zudo-doc/src/scaffold.ts is stale, or the npm registry lookup failed. See RELEASE.md 'Scaffold pin freshness gate'."
+            echo "::error::Remedy: bump the pin via /dev-bump-zudo-deps (this keeps scripts/check-pin-parity.mjs pin parity intact), then re-tag and re-publish."
+            exit 1
+          fi
+
+      # ── Safeguard 5/5: Dry-run path ────────────────────────────────────────
       # When dry_run is true (workflow_dispatch only), prove the secret
       # authenticates and print what would be published — then stop.
       # NOTE: `npm publish --dry-run` does NOT prove auth; it skips network
       # calls entirely and never contacts the registry. Running `npm whoami`
       # with NODE_AUTH_TOKEN is the only way to confirm the token is valid
       # before the real publish.
-      - name: '[Safeguard 4/4] Dry-run: verify auth then stop (skip real publish)'
+      - name: '[Safeguard 5/5] Dry-run: verify auth then stop (skip real publish)'
         if: ${{ inputs.dry_run == true }}
         shell: bash
         env:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -94,9 +94,12 @@ mode the workflow verifies that `NPM_TOKEN` authenticates against the registry v
 **Caveat:** the dry-run must target the *candidate* tag or ref — NOT `main` and NOT
 an already-published tag. The reason is ordering: the workflow runs a "version not
 already published" safeguard (Safeguard 3) *before* the dry-run/auth step
-(Safeguard 4). An already-published tag triggers a hard failure at Safeguard 3 and
+(Safeguard 5). An already-published tag triggers a hard failure at Safeguard 3 and
 the auth smoke is never reached. Similarly, dispatching from `main` fails at
 Safeguard 1 (tag-shape check) before auth is tested.
+
+Scaffold pin freshness (Safeguard 4) also runs before the auth step, unconditionally
+— see "Scaffold pin freshness gate" below.
 
 Correct dry-run target: a tag or branch pointing at the candidate commit whose
 version has been bumped in `package.json` but not yet published to npm.
@@ -195,6 +198,75 @@ produced here, not consumed — their versions belong to the release flow.
 
 A bump that changes `scaffold.ts` needs a `create-zudo-doc` release afterward so
 downstream scaffolds get the new pins.
+
+---
+
+## Scaffold pin freshness gate
+
+`scripts/check-scaffold-pin-freshness.mjs` (`pnpm check:scaffold-pin-freshness`)
+closes the **recurrence** half of #3442: `create-zudo-doc@5.5.3` shipped on
+2026-08-17 pinning `@takazudo/zfb` at `2.5.2` — three weeks after the fix it
+needed had already shipped upstream. Nothing checked that a scaffold pin was
+still current **at release time**, and the failure was invisible to every other
+gate (build, typecheck, and link check all pass; it only shows in a browser).
+
+This is a different question from `check:pin-parity` above. Pin parity asks "do
+`scaffold.ts` and the rest of the repo agree with each other?" (internal
+consistency). This gate asks "is what they agree on still current on npm?"
+(freshness against the registry) — and it deliberately does **not** relax any
+pin to a caret; #3455 explicitly rejected that option, since `scaffold.ts`'s
+exact-pin literals are a reproducibility guarantee (see `check:pin-parity`'s own
+documentation). The fix for a stale pin is always to bump the exact literal.
+
+**Where it runs:**
+
+- **`.github/workflows/publish-create-zudo-doc.yml`, Safeguard 4/5** — the real
+  enforcement point. `scripts/release-create-zudo-doc.sh` only *prepares* a
+  release (rewrites pins, bumps versions); publication happens later, when a
+  human publishes the GitHub Draft Release, and a pin can go stale in that gap.
+  This step runs unconditionally, immediately before `npm publish` (including on
+  a `dry_run`, so a dry run proves this safeguard too) and blocks the release if
+  it fails.
+- **`scripts/release-create-zudo-doc.sh`** — the same check runs as an early
+  preflight in the real (non-`DRY=1`) path, before any file is bumped. This is
+  early feedback only, not the enforcement point: a release author learns about
+  a stale pin while preparing instead of days later at publish time.
+- **By hand:** `pnpm check:scaffold-pin-freshness`.
+
+**Deliberately NOT a PR gate.** It does not run in `pr-checks.yml` and is not
+part of the `scripts/run-b4push.sh` guard region (so the
+`check:b4push-ci-parity` meta-check has nothing to reconcile it against). Two
+independent reasons: an upstream publish must never block an unrelated PR, and
+the check makes a live call to the npm registry — the opposite of the
+deterministic, offline-friendly checks that gate routine PRs and pushes.
+
+**What a failure means:** the scaffold would ship (or just shipped, in the
+release-script case) a pin behind what the registry actually has — a fresh
+`create-zudo-doc` scaffold would install an out-of-date `@takazudo/zfb` (or
+whichever pinned package went stale), reproducing the #3442 shape.
+
+**Remedy:** bump the stale pin — `/dev-bump-zudo-deps`, or by hand — then
+re-run `pnpm check:pin-parity` to confirm the bump kept every pin location in
+agreement (see "Bumping the toolchain" above), and re-run
+`pnpm check:scaffold-pin-freshness` to confirm the gate now passes.
+
+**Prerelease pins read the `next` dist-tag, not `latest`.** A pin carrying a
+`-prerelease` suffix (e.g. `0.2.0-next.9`) is compared against the registry's
+`next` dist-tag. As the "dist-tag table" section above documents, `next` and
+`latest` are two permanently-diverging channels once a package has any stable
+release — `next` is not "the version after latest," it is a separate, often
+much *older*, opt-in preview line. Comparing every pin against `latest`
+unconditionally would misfire on a correct prerelease pin, flagging it "stale"
+against a numerically higher stable `latest` it was never meant to track — the
+same `next`/`latest` divergence #3442 named as the likely cause of the original
+gap. If the registry has no `next` tag at all for a prerelease pin, the package
+is reported "skipped," not stale, not a failure.
+
+**Fails closed on a registry error.** A lookup failure (network error, timeout,
+unusable response) blocks the gate the same as a confirmed-stale pin, but is
+reported as a distinct finding kind ("lookup-error" vs. "stale") — a release
+blocked by a flaky registry is recoverable by retrying; a stale release already
+published to npm is not.
 
 ---
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -259,8 +259,11 @@ much *older*, opt-in preview line. Comparing every pin against `latest`
 unconditionally would misfire on a correct prerelease pin, flagging it "stale"
 against a numerically higher stable `latest` it was never meant to track — the
 same `next`/`latest` divergence #3442 named as the likely cause of the original
-gap. If the registry has no `next` tag at all for a prerelease pin, the package
-is reported "skipped," not stale, not a failure.
+gap. If the registry has no `next` tag at all for a prerelease pin, it depends
+on `latest`: when `latest` is itself a prerelease the package has no stable
+line and `latest` *is* the preview channel, so it becomes the comparison
+target; when `latest` is stable, the package is reported "skipped," not stale,
+not a failure.
 
 **Fails closed on a registry error.** A lookup failure (network error, timeout,
 unusable response) blocks the gate the same as a confirmed-stale pin, but is

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "check:template-drift": "bash scripts/check-template-drift.sh",
     "check:fixture-settings-drift": "node scripts/check-fixture-settings-drift.mjs",
     "check:pin-parity": "node scripts/check-pin-parity.mjs",
+    "check:scaffold-pin-freshness": "node scripts/check-scaffold-pin-freshness.mjs",
     "check:b4push-ci-parity": "node scripts/check-b4push-ci-parity.mjs",
     "check:e2e-spec-naming": "node scripts/check-e2e-spec-naming.mjs",
     "check:flaky-tracking-issue": "node scripts/check-flaky-tracking-issue.mjs",

--- a/scripts/__tests__/check-scaffold-pin-freshness.test.mjs
+++ b/scripts/__tests__/check-scaffold-pin-freshness.test.mjs
@@ -271,7 +271,32 @@ describe("checkScaffoldPinFreshness — (4) prerelease semantics", () => {
     expect(result.findings[0].kind).toBe("ok");
   });
 
-  it("skips (does not fail or report stale) a prerelease pin when the registry has no 'next' tag", async () => {
+  it("falls back to 'latest' when there is no 'next' tag AND 'latest' is itself a prerelease", async () => {
+    // A package with no stable release yet (e.g. published only as
+    // 0.x.y-next.N) has no separate "next" tag — its "latest" IS the preview
+    // line. Skipping there would make the gate permanently blind to exactly
+    // the #3442 staleness shape it exists to catch.
+    const fetchDistTags = stubRegistry({
+      "@takazudo/zfb": { latest: "0.3.0-next.1" }, // no "next" key
+    });
+
+    const result = await checkScaffoldPinFreshness({
+      scaffoldSrc: PRERELEASE_SCAFFOLD_SRC, // pins 0.2.0-next.9
+      packages: ["@takazudo/zfb"],
+      fetchDistTags,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.findings[0]).toEqual(
+      expect.objectContaining({
+        kind: "stale",
+        tag: "latest",
+        registryVersion: "0.3.0-next.1",
+      }),
+    );
+  });
+
+  it("skips (does not fail or report stale) a prerelease pin when the registry has no 'next' tag and 'latest' is stable", async () => {
     const fetchDistTags = stubRegistry({
       "@takazudo/zfb": { latest: "2.7.1" }, // no "next" key
     });

--- a/scripts/__tests__/check-scaffold-pin-freshness.test.mjs
+++ b/scripts/__tests__/check-scaffold-pin-freshness.test.mjs
@@ -1,0 +1,312 @@
+// scripts/__tests__/check-scaffold-pin-freshness.test.mjs
+//
+// Unit tests for scripts/check-scaffold-pin-freshness.mjs (#3456). The
+// registry lookup is always INJECTED via the `fetchDistTags` parameter —
+// these tests never touch the real npm registry. Covers the four
+// acceptance-criteria behaviors from #3456:
+//   1. A deliberately-stale pin fails, naming package/current pin/newer version.
+//   2. A current pin passes.
+//   3. A simulated registry/network failure fails the gate, reported
+//      distinctly from staleness ("lookup-error" vs "stale").
+//   4. A prerelease pin is compared against "next" (not "latest") and is not
+//      falsely reported stale merely because a stable "latest" is numerically
+//      higher.
+//
+// File extension note: this test intentionally lives at `.test.mjs` (not the
+// repo's usual `.test.ts` for scripts/__tests__) because the file name is
+// specified exactly by #3456. vitest.config.ts's "scripts" project include
+// glob was widened to also match `*.test.mjs` so this file actually runs
+// under `pnpm test:unit` / `vitest run` — see the comment there.
+
+import { describe, it, expect } from "vitest";
+
+import {
+  checkScaffoldPinFreshness,
+  isPrereleaseVersion,
+  DEFAULT_TIMEOUT_MS,
+} from "../check-scaffold-pin-freshness.mjs";
+
+// A minimal scaffold.ts stand-in exercising every literal pin form
+// readScaffoldPin() understands (see check-pin-parity.mjs's docs).
+const SCAFFOLD_SRC = `
+export const ZUDO_DOC_PIN = "^0.2.22";
+
+function generatePackageJson() {
+  return {
+    dependencies: {
+      "@takazudo/zfb": "2.7.1",
+      "@takazudo/zfb-runtime": "2.7.1",
+      "@takazudo/zfb-md-wasm": "2.7.1",
+      "@takazudo/zdtp": "0.4.1",
+      "@takazudo/zudo-doc": ZUDO_DOC_PIN,
+    },
+  };
+}
+`;
+
+const PRERELEASE_SCAFFOLD_SRC = `
+function generatePackageJson() {
+  return {
+    dependencies: {
+      "@takazudo/zfb": "0.2.0-next.9",
+    },
+  };
+}
+`;
+
+/** Builds an injected fetchDistTags stub from a plain { pkg: distTagsMap } table. */
+function stubRegistry(table) {
+  return async (pkgName) => {
+    const entry = table[pkgName];
+    if (entry === undefined) {
+      throw new Error(`stubRegistry: no entry configured for ${pkgName}`);
+    }
+    if (entry instanceof Error) {
+      throw entry;
+    }
+    return entry;
+  };
+}
+
+describe("isPrereleaseVersion", () => {
+  it("detects a -next.N suffix", () => {
+    expect(isPrereleaseVersion("0.2.0-next.9")).toBe(true);
+  });
+
+  it("treats a clean version as not prerelease", () => {
+    expect(isPrereleaseVersion("2.7.1")).toBe(false);
+  });
+
+  it("tolerates a leading caret", () => {
+    expect(isPrereleaseVersion("^0.2.0-next.9")).toBe(true);
+  });
+});
+
+describe("checkScaffoldPinFreshness — validation", () => {
+  it("throws when fetchDistTags is not a function", async () => {
+    await expect(
+      checkScaffoldPinFreshness({ scaffoldSrc: SCAFFOLD_SRC }),
+    ).rejects.toThrow(/fetchDistTags/);
+  });
+});
+
+describe("checkScaffoldPinFreshness — (1) stale pin", () => {
+  it("fails and names the package, current pin, and newer version", async () => {
+    const fetchDistTags = stubRegistry({
+      "@takazudo/zfb": { latest: "2.9.0" },
+    });
+
+    const result = await checkScaffoldPinFreshness({
+      scaffoldSrc: SCAFFOLD_SRC,
+      packages: ["@takazudo/zfb"],
+      fetchDistTags,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.findings).toHaveLength(1);
+    const [finding] = result.findings;
+    expect(finding.kind).toBe("stale");
+    // Actionable: names the package, the pin currently in scaffold.ts, and
+    // the newer version the registry has.
+    expect(finding.message).toContain("@takazudo/zfb");
+    expect(finding.message).toContain("2.7.1"); // current (stale) pin
+    expect(finding.message).toContain("2.9.0"); // newer version available
+    expect(finding.pin).toBe("2.7.1");
+    expect(finding.registryVersion).toBe("2.9.0");
+  });
+});
+
+describe("checkScaffoldPinFreshness — (2) current pin", () => {
+  it("passes when the pin exactly matches the registry latest", async () => {
+    const fetchDistTags = stubRegistry({
+      "@takazudo/zfb": { latest: "2.7.1" },
+    });
+
+    const result = await checkScaffoldPinFreshness({
+      scaffoldSrc: SCAFFOLD_SRC,
+      packages: ["@takazudo/zfb"],
+      fetchDistTags,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.findings).toEqual([
+      expect.objectContaining({ kind: "ok", pkg: "@takazudo/zfb" }),
+    ]);
+  });
+
+  it("passes when the pin is numerically AHEAD of latest (not just equal)", async () => {
+    // A pin ahead of the registry (e.g. an in-flight bump not yet propagated
+    // to `latest`) must not be reported stale — only "behind" is stale.
+    const fetchDistTags = stubRegistry({
+      "@takazudo/zfb": { latest: "2.5.0" },
+    });
+
+    const result = await checkScaffoldPinFreshness({
+      scaffoldSrc: SCAFFOLD_SRC,
+      packages: ["@takazudo/zfb"],
+      fetchDistTags,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.findings[0].kind).toBe("ok");
+  });
+});
+
+describe("checkScaffoldPinFreshness — (3) registry/network failure", () => {
+  it("fails the gate on a rejected lookup, reported distinctly from staleness", async () => {
+    const fetchDistTags = stubRegistry({
+      "@takazudo/zfb": new Error("network timeout"),
+    });
+
+    const result = await checkScaffoldPinFreshness({
+      scaffoldSrc: SCAFFOLD_SRC,
+      packages: ["@takazudo/zfb"],
+      fetchDistTags,
+    });
+
+    expect(result.ok).toBe(false);
+    const [finding] = result.findings;
+    expect(finding.kind).toBe("lookup-error");
+    expect(finding.kind).not.toBe("stale");
+    expect(finding.message).toContain("network timeout");
+  });
+
+  it("fails when the registry response has no usable latest tag (malformed shape)", async () => {
+    const fetchDistTags = stubRegistry({
+      "@takazudo/zfb": {}, // no "latest" key at all
+    });
+
+    const result = await checkScaffoldPinFreshness({
+      scaffoldSrc: SCAFFOLD_SRC,
+      packages: ["@takazudo/zfb"],
+      fetchDistTags,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.findings[0].kind).toBe("lookup-error");
+  });
+
+  it("does not swallow a lookup failure alongside other passing packages (fail-closed overall)", async () => {
+    const fetchDistTags = stubRegistry({
+      "@takazudo/zfb": { latest: "2.7.1" }, // current
+      "@takazudo/zdtp": new Error("ECONNRESET"), // fails
+    });
+
+    const result = await checkScaffoldPinFreshness({
+      scaffoldSrc: SCAFFOLD_SRC,
+      packages: ["@takazudo/zfb", "@takazudo/zdtp"],
+      fetchDistTags,
+    });
+
+    // One package is fine, but any lookup error fails the whole gate.
+    expect(result.ok).toBe(false);
+    const kinds = result.findings.map((f) => f.kind).sort();
+    expect(kinds).toEqual(["lookup-error", "ok"]);
+  });
+});
+
+describe("checkScaffoldPinFreshness — (4) prerelease semantics", () => {
+  it("compares a prerelease pin against the 'next' tag, not 'latest' — not falsely stale", async () => {
+    // The pin (0.2.0-next.9) is numerically LOWER than the stable `latest`
+    // (2.7.1) — a naive latest-only compare would wrongly flag this stale.
+    const fetchDistTags = stubRegistry({
+      "@takazudo/zfb": { latest: "2.7.1", next: "0.2.0-next.9" },
+    });
+
+    const result = await checkScaffoldPinFreshness({
+      scaffoldSrc: PRERELEASE_SCAFFOLD_SRC,
+      packages: ["@takazudo/zfb"],
+      fetchDistTags,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.findings[0]).toEqual(
+      expect.objectContaining({ kind: "ok", tag: "next", pin: "0.2.0-next.9" }),
+    );
+  });
+
+  it("still catches genuine cross-core staleness on the next line itself", async () => {
+    // Comparison is on the numeric MAJOR.MINOR.PATCH core only (mirrors
+    // check-pin-parity.mjs's parseSemverCore/satisfiesCaret rationale), so
+    // two prereleases sharing a core (e.g. 0.2.0-next.9 vs 0.2.0-next.20)
+    // compare equal — this test uses a core bump (0.2.0 -> 0.3.0) so the
+    // "next" line's own staleness is still caught.
+    const fetchDistTags = stubRegistry({
+      "@takazudo/zfb": { latest: "2.7.1", next: "0.3.0-next.1" },
+    });
+
+    const result = await checkScaffoldPinFreshness({
+      scaffoldSrc: PRERELEASE_SCAFFOLD_SRC,
+      packages: ["@takazudo/zfb"],
+      fetchDistTags,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.findings[0]).toEqual(
+      expect.objectContaining({
+        kind: "stale",
+        tag: "next",
+        registryVersion: "0.3.0-next.1",
+      }),
+    );
+  });
+
+  it("does not treat a same-core prerelease bump as stale (core-only comparison)", async () => {
+    // Documents the known limitation from the test above: 0.2.0-next.9 vs
+    // 0.2.0-next.20 share a core and are NOT distinguished — this is
+    // intentional (see checkScaffoldPinFreshness's parseCore/compareCore),
+    // not a bug, and is asserted here so a future change to that behavior
+    // is a deliberate, visible decision.
+    const fetchDistTags = stubRegistry({
+      "@takazudo/zfb": { latest: "2.7.1", next: "0.2.0-next.20" },
+    });
+
+    const result = await checkScaffoldPinFreshness({
+      scaffoldSrc: PRERELEASE_SCAFFOLD_SRC,
+      packages: ["@takazudo/zfb"],
+      fetchDistTags,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.findings[0].kind).toBe("ok");
+  });
+
+  it("skips (does not fail or report stale) a prerelease pin when the registry has no 'next' tag", async () => {
+    const fetchDistTags = stubRegistry({
+      "@takazudo/zfb": { latest: "2.7.1" }, // no "next" key
+    });
+
+    const result = await checkScaffoldPinFreshness({
+      scaffoldSrc: PRERELEASE_SCAFFOLD_SRC,
+      packages: ["@takazudo/zfb"],
+      fetchDistTags,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.findings[0].kind).toBe("skipped");
+  });
+});
+
+describe("checkScaffoldPinFreshness — unreadable pin", () => {
+  it("fails when scaffold.ts has no literal pin for the package", async () => {
+    const fetchDistTags = stubRegistry({
+      "@takazudo/does-not-exist": { latest: "1.0.0" },
+    });
+
+    const result = await checkScaffoldPinFreshness({
+      scaffoldSrc: SCAFFOLD_SRC,
+      packages: ["@takazudo/does-not-exist"],
+      fetchDistTags,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.findings[0].kind).toBe("unreadable-pin");
+  });
+});
+
+describe("module exports", () => {
+  it("exposes a bounded default timeout", () => {
+    expect(typeof DEFAULT_TIMEOUT_MS).toBe("number");
+    expect(DEFAULT_TIMEOUT_MS).toBeGreaterThan(0);
+  });
+});

--- a/scripts/check-pin-parity.mjs
+++ b/scripts/check-pin-parity.mjs
@@ -64,7 +64,9 @@ const FIXTURE_PACKAGE = "@takazudo/zudo-doc";
 // default scaffold is pure static and consumers choose their deploy adapter.
 // @takazudo/zdtp is included here so the scaffold's emitted zdtp pin is
 // parity-checked against root dependencies — same staleness class as #2381 / #2445.
-const PINNED_PACKAGES = [
+// Exported (#3456) so scripts/check-scaffold-pin-freshness.mjs can reuse the
+// same package list against the npm registry instead of duplicating it.
+export const PINNED_PACKAGES = [
   "@takazudo/zfb",
   "@takazudo/zfb-runtime",
   "@takazudo/zfb-md-wasm",
@@ -182,8 +184,11 @@ const FIRST_PARTY_PEER_CHECKS = [
  * `@takazudo/zudo-doc-history-server` (no closing quote follows `zudo-doc` in
  * the longer name). When the value is a bare identifier instead of a quoted
  * literal, we resolve that identifier's `const NAME = "..."` declaration.
+ *
+ * Exported (#3456) so scripts/check-scaffold-pin-freshness.mjs can read the
+ * same scaffold-emitted pin without re-implementing this parsing.
  */
-function readScaffoldPin(scaffoldSrc, pkgName) {
+export function readScaffoldPin(scaffoldSrc, pkgName) {
   const escaped = pkgName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const re = new RegExp(
     `["']${escaped}["']\\s*(?::|\\]\\s*=)\\s*["']([^"']+)["']`,

--- a/scripts/check-scaffold-pin-freshness.mjs
+++ b/scripts/check-scaffold-pin-freshness.mjs
@@ -42,15 +42,24 @@
 //      (e.g. `0.2.0-next.9`) as "stale" against a numerically higher stable
 //      `latest` it was never meant to track. So: a pin carrying a
 //      `-prerelease` suffix is compared against the registry's `next`
-//      dist-tag, never `latest`. If the registry has no `next` tag at all,
-//      the package is reported "skipped" — not stale, not a failure.
+//      dist-tag, never a STABLE `latest`. Two sub-cases when there is no
+//      `next` tag: if `latest` is itself a prerelease the package has no
+//      stable line at all and `latest` IS the preview channel, so it is used
+//      as the comparison target (skipping there would leave the gate
+//      permanently blind to the very staleness shape it exists to catch);
+//      if `latest` is stable, the package is reported "skipped" — not
+//      stale, not a failure.
 //
 // Design: the registry lookup is INJECTED (`fetchDistTags`) so
 // checkScaffoldPinFreshness() is pure and the test suite never touches the
 // real network. The CLI wrapper at the bottom of this file supplies the
 // real npm registry fetch (bounded by DEFAULT_TIMEOUT_MS).
 //
-// NOT wired into any workflow or release script yet — that is Wave 2 (#3457).
+// Wired in by #3457: Safeguard 4/5 of .github/workflows/publish-create-zudo-doc.yml
+// (immediately before `npm publish`, run even on a dry run), plus an early-feedback
+// preflight in scripts/release-create-zudo-doc.sh and the `check:scaffold-pin-freshness`
+// package script. Deliberately NOT a PR gate — it hits the live registry, so an
+// upstream publish must never be able to fail an unrelated PR.
 
 import { readFileSync } from "node:fs";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -171,8 +180,20 @@ export async function checkScaffoldPinFreshness({
     }
 
     const prerelease = isPrereleaseVersion(scaffoldPin);
-    const targetTag = prerelease ? "next" : "latest";
-    const registryVersion = distTags?.[targetTag];
+    let targetTag = prerelease ? "next" : "latest";
+    let registryVersion = distTags?.[targetTag];
+
+    // Semantics #3, refinement: a package with NO stable release yet has no
+    // separate "next" tag — its "latest" IS the preview line (e.g. a 0.x
+    // package published only as 0.5.0-next.N). Skipping there would make the
+    // gate permanently blind to exactly the #3442 staleness shape it exists
+    // to catch, so fall back to "latest" when "latest" is itself a
+    // prerelease. When "latest" is stable, the skip below still applies —
+    // that is the diverging-channels case the skip was written for.
+    if (prerelease && !registryVersion && isPrereleaseVersion(distTags?.latest)) {
+      targetTag = "latest";
+      registryVersion = distTags.latest;
+    }
 
     if (!registryVersion) {
       if (prerelease) {
@@ -183,8 +204,9 @@ export async function checkScaffoldPinFreshness({
           pkg: pkgName,
           pin: scaffoldPin,
           message:
-            `${pkgName} pin ${scaffoldPin} is a prerelease and the registry ` +
-            `has no "next" dist-tag to compare against — skipping (not reported stale).`,
+            `${pkgName} pin ${scaffoldPin} is a prerelease, the registry has no ` +
+            `"next" dist-tag, and "latest" is a stable line this pin was never ` +
+            `meant to track — skipping (not reported stale).`,
         });
         continue;
       }

--- a/scripts/check-scaffold-pin-freshness.mjs
+++ b/scripts/check-scaffold-pin-freshness.mjs
@@ -1,0 +1,325 @@
+#!/usr/bin/env node
+// scripts/check-scaffold-pin-freshness.mjs
+//
+// Scaffold pin STALENESS gate (#3456, epic #3455 — the recurrence-prevention
+// half of #3442). Failure mode this closes: `create-zudo-doc@5.5.3` shipped
+// on 2026-08-17 pinning `@takazudo/zfb` at `2.5.2` — three weeks after the
+// upstream mermaid fix landed on 2026-07-27. Every fresh scaffold with
+// mermaid diagrams was broken out of the box, and the failure was invisible
+// to every automated gate: build exits 0, typecheck passes, link check
+// passes. It only shows in a browser. Nothing checked that the pin was
+// current AT RELEASE TIME. That is what this script checks.
+//
+// This is deliberately NOT a "relax the pin to a caret" tool — #3455
+// explicitly REJECTED that option. scripts/check-pin-parity.mjs documents
+// the scaffold literal as a reproducibility guarantee ("a fresh scaffold
+// gets EXACTLY these versions") and enforces exact equality. This script
+// leaves that contract untouched; it only detects staleness so a human /
+// release process can decide to bump the exact pin.
+//
+// Semantics (also asserted in
+// scripts/__tests__/check-scaffold-pin-freshness.test.mjs):
+//
+//   1. FAIL CLOSED on registry/network error. A lookup failure is a GATE
+//      FAILURE, never a silent pass — a release blocked by a flaky registry
+//      is recoverable; a stale release published to npm is not. It is
+//      reported as a DISTINCT finding kind ("lookup-error") from a stale
+//      pin ("stale"), so an operator can tell "the registry was
+//      unreachable" apart from "a pin is actually behind" from the output
+//      alone.
+//   2. BOUNDED REQUEST TIMEOUT (see DEFAULT_TIMEOUT_MS) on the real registry
+//      fetch, so a hung/slow registry can never hang a release indefinitely.
+//      A request that times out surfaces as an aborted fetch, which is
+//      caught and reported the same way as any other lookup failure (#1).
+//   3. PRERELEASE SEMANTICS. RELEASE.md ("dist-tag table" / "How `latest`
+//      stays current") documents that `next` and `latest` are two
+//      permanently-diverging channels once a package has any stable
+//      release — `next` is NOT "the next version after latest", it is a
+//      separate, often much OLDER, opt-in preview line. #3442 names this
+//      divergence as the likely cause of the original 3-week gap: naively
+//      comparing every pin against `latest` would ALSO misfire in the
+//      opposite direction, permanently flagging a correct prerelease pin
+//      (e.g. `0.2.0-next.9`) as "stale" against a numerically higher stable
+//      `latest` it was never meant to track. So: a pin carrying a
+//      `-prerelease` suffix is compared against the registry's `next`
+//      dist-tag, never `latest`. If the registry has no `next` tag at all,
+//      the package is reported "skipped" — not stale, not a failure.
+//
+// Design: the registry lookup is INJECTED (`fetchDistTags`) so
+// checkScaffoldPinFreshness() is pure and the test suite never touches the
+// real network. The CLI wrapper at the bottom of this file supplies the
+// real npm registry fetch (bounded by DEFAULT_TIMEOUT_MS).
+//
+// NOT wired into any workflow or release script yet — that is Wave 2 (#3457).
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { dirname, resolve } from "node:path";
+
+import { PINNED_PACKAGES, readScaffoldPin } from "./check-pin-parity.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const ROOT_DIR = resolve(__dirname, "..");
+const SCAFFOLD_TS_PATH = resolve(
+  ROOT_DIR,
+  "packages/create-zudo-doc/src/scaffold.ts",
+);
+
+/** Per-request timeout (ms) for the real registry lookup — semantics #2. */
+export const DEFAULT_TIMEOUT_MS = 10_000;
+
+const REGISTRY_BASE = "https://registry.npmjs.org";
+
+/**
+ * True when `version` carries a `-prerelease` suffix (e.g. "0.2.0-next.9").
+ * A leading `^`/`~` is tolerated even though scaffold pins are expected to be
+ * exact literals — matches the tolerance in check-pin-parity.mjs's
+ * parseSemverCore().
+ */
+export function isPrereleaseVersion(version) {
+  return (
+    typeof version === "string" && /-/.test(version.replace(/^[\^~]/, ""))
+  );
+}
+
+/**
+ * Parse the numeric MAJOR.MINOR.PATCH core out of a version string, dropping
+ * any prerelease/build suffix. Mirrors check-pin-parity.mjs's
+ * parseSemverCore(): this gate cares about cross-version staleness (is the
+ * pin numerically behind?), not exact prerelease-identifier ordering.
+ * Returns null when the three numeric segments can't be read.
+ *
+ * KNOWN LIMITATION (intentional, mirrors satisfiesCaret()'s rationale): two
+ * prereleases sharing a core — e.g. "0.2.0-next.9" vs "0.2.0-next.20" —
+ * compare EQUAL and are never reported stale against each other. Catching
+ * that class would need real prerelease-identifier ordering (fragile across
+ * -next/-beta/-rc), which is out of scope for the false-positive this gate
+ * exists to prevent (see semantics #3). A core-level bump (e.g. 0.2.0-next.9
+ * vs 0.3.0-next.1) is still caught.
+ */
+function parseCore(version) {
+  if (typeof version !== "string") return null;
+  const core = version.trim().replace(/^[\^~]/, "").split(/[-+]/, 1)[0];
+  const m = core.match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!m) return null;
+  return { major: Number(m[1]), minor: Number(m[2]), patch: Number(m[3]) };
+}
+
+function compareCore(a, b) {
+  return a.major - b.major || a.minor - b.minor || a.patch - b.patch;
+}
+
+/**
+ * Evaluate every package in `packages` for pin staleness against the
+ * registry, using the injected `fetchDistTags(pkgName) => Promise<Record<string,string>>`
+ * (a dist-tag-name → version map, e.g. `{ latest: "2.7.1", next: "0.2.0-next.9" }`
+ * — the shape `GET /-/package/<pkg>/dist-tags` returns).
+ *
+ * Returns `{ ok, findings }`. `ok` is false when ANY package is "stale" OR
+ * ANY lookup failed ("lookup-error" / "unreadable-pin") — fail-closed, see
+ * semantics #1 above. Each finding has a `kind` of:
+ *   "stale"          — pin is behind the comparison dist-tag.
+ *   "ok"              — pin is current.
+ *   "skipped"         — prerelease pin with no "next" tag to compare against.
+ *   "lookup-error"    — registry fetch failed, or returned an unusable shape.
+ *   "unreadable-pin"  — scaffold.ts has no parseable literal for this
+ *                        package (should already be caught by
+ *                        check-pin-parity.mjs; reported here too so this
+ *                        gate never passes on a pin it could not actually
+ *                        read).
+ */
+export async function checkScaffoldPinFreshness({
+  scaffoldSrc,
+  packages = PINNED_PACKAGES,
+  fetchDistTags,
+}) {
+  if (typeof fetchDistTags !== "function") {
+    throw new TypeError(
+      "checkScaffoldPinFreshness requires a fetchDistTags(pkgName) function",
+    );
+  }
+
+  const findings = [];
+
+  for (const pkgName of packages) {
+    const scaffoldPin = readScaffoldPin(scaffoldSrc, pkgName);
+    if (scaffoldPin === null) {
+      findings.push({
+        kind: "unreadable-pin",
+        pkg: pkgName,
+        message: `Could not locate a literal pin for ${pkgName} in scaffold.ts.`,
+      });
+      continue;
+    }
+
+    let distTags;
+    try {
+      distTags = await fetchDistTags(pkgName);
+    } catch (error) {
+      findings.push({
+        kind: "lookup-error",
+        pkg: pkgName,
+        pin: scaffoldPin,
+        message:
+          `Registry lookup failed for ${pkgName} — treating as a gate ` +
+          `failure distinct from staleness (fail-closed): ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+      });
+      continue;
+    }
+
+    const prerelease = isPrereleaseVersion(scaffoldPin);
+    const targetTag = prerelease ? "next" : "latest";
+    const registryVersion = distTags?.[targetTag];
+
+    if (!registryVersion) {
+      if (prerelease) {
+        // Semantics #3: a prerelease pin with nothing to compare against is
+        // NOT a failure and NOT "stale" — it is simply not evaluated.
+        findings.push({
+          kind: "skipped",
+          pkg: pkgName,
+          pin: scaffoldPin,
+          message:
+            `${pkgName} pin ${scaffoldPin} is a prerelease and the registry ` +
+            `has no "next" dist-tag to compare against — skipping (not reported stale).`,
+        });
+        continue;
+      }
+      findings.push({
+        kind: "lookup-error",
+        pkg: pkgName,
+        pin: scaffoldPin,
+        message:
+          `Registry response for ${pkgName} had no "latest" dist-tag — ` +
+          `treating as a gate failure distinct from staleness (fail-closed).`,
+      });
+      continue;
+    }
+
+    const pinCore = parseCore(scaffoldPin);
+    const registryCore = parseCore(registryVersion);
+    if (!pinCore || !registryCore) {
+      findings.push({
+        kind: "lookup-error",
+        pkg: pkgName,
+        pin: scaffoldPin,
+        message:
+          `Could not parse a semver core from ${pkgName} pin (${scaffoldPin}) ` +
+          `or registry version (${registryVersion}) — treating as a gate ` +
+          `failure distinct from staleness (fail-closed).`,
+      });
+      continue;
+    }
+
+    if (compareCore(pinCore, registryCore) < 0) {
+      findings.push({
+        kind: "stale",
+        pkg: pkgName,
+        pin: scaffoldPin,
+        registryVersion,
+        tag: targetTag,
+        message:
+          `${pkgName} scaffold pin is STALE — scaffold.ts pins ${scaffoldPin}, ` +
+          `but registry "${targetTag}" is ${registryVersion}. Bump the pin in ` +
+          `packages/create-zudo-doc/src/scaffold.ts.`,
+      });
+      continue;
+    }
+
+    findings.push({
+      kind: "ok",
+      pkg: pkgName,
+      pin: scaffoldPin,
+      registryVersion,
+      tag: targetTag,
+      message: `${pkgName} pin ${scaffoldPin} is current (registry "${targetTag}" = ${registryVersion}).`,
+    });
+  }
+
+  const ok = findings.every((f) => f.kind === "ok" || f.kind === "skipped");
+  return { ok, findings };
+}
+
+/**
+ * Real registry lookup: GET the dist-tags map for `pkgName`, bounded by
+ * `timeoutMs` (semantics #2). Never called from tests — see the injected
+ * `fetchDistTags` seam on checkScaffoldPinFreshness().
+ */
+async function fetchDistTagsFromRegistry(pkgName, timeoutMs = DEFAULT_TIMEOUT_MS) {
+  const url = `${REGISTRY_BASE}/-/package/${encodeURIComponent(pkgName)}/dist-tags`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    if (!res.ok) {
+      throw new Error(
+        `npm registry returned ${res.status} ${res.statusText} for ${pkgName}`,
+      );
+    }
+    return await res.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function formatFinding(f) {
+  const label =
+    f.kind === "ok"
+      ? "OK     "
+      : f.kind === "skipped"
+        ? "SKIP   "
+        : f.kind === "stale"
+          ? "STALE  "
+          : "ERROR  ";
+  return `  ${label} ${f.message}`;
+}
+
+async function main() {
+  const scaffoldSrc = readFileSync(SCAFFOLD_TS_PATH, "utf-8");
+  const result = await checkScaffoldPinFreshness({
+    scaffoldSrc,
+    fetchDistTags: (pkgName) => fetchDistTagsFromRegistry(pkgName),
+  });
+
+  for (const f of result.findings) {
+    console.log(formatFinding(f));
+  }
+
+  if (!result.ok) {
+    const stale = result.findings.filter((f) => f.kind === "stale");
+    const errors = result.findings.filter(
+      (f) => f.kind === "lookup-error" || f.kind === "unreadable-pin",
+    );
+    console.error("");
+    console.error("Scaffold pin freshness check FAILED.");
+    if (stale.length > 0) {
+      console.error(
+        `  ${stale.length} stale pin(s) — bump packages/create-zudo-doc/src/scaffold.ts to the versions named above.`,
+      );
+    }
+    if (errors.length > 0) {
+      console.error(
+        `  ${errors.length} lookup error(s) — registry unreachable, timed out, or returned an unusable response. This is DISTINCT from staleness: it means the gate could not verify freshness at all, not that a pin was confirmed stale. Retry once the registry is reachable.`,
+      );
+    }
+    return 1;
+  }
+
+  console.log("");
+  console.log("OK — all scaffold pins are current (or intentionally skipped as prerelease-with-no-next-tag).");
+  return 0;
+}
+
+const invokedDirectly =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  main()
+    .then((code) => process.exit(code))
+    .catch((error) => {
+      console.error("Unexpected failure in check-scaffold-pin-freshness:", error);
+      process.exit(1);
+    });
+}

--- a/scripts/release-create-zudo-doc.sh
+++ b/scripts/release-create-zudo-doc.sh
@@ -196,6 +196,31 @@ if [ "${DRY:-0}" = "1" ]; then
   exit 0
 fi
 
+# ── Scaffold pin freshness (early feedback, #3457) ────────────────────────────
+#
+# This is EARLY FEEDBACK ONLY, not the enforcement point — publication happens
+# later, when a human publishes the GitHub Draft Release
+# (.github/workflows/publish-create-zudo-doc.yml), and a scaffold pin can go
+# stale in the gap between this script preparing the release and that publish.
+# The gate that actually BLOCKS a stale release runs there, immediately before
+# `npm publish`. Running it here too just means a release author learns about
+# a stale pin now, while preparing, instead of days later at publish time. See
+# RELEASE.md ("Scaffold pin freshness gate") for what a failure means, the
+# remedy, and how prerelease pins are compared against the registry.
+
+echo ""
+echo "▶ Checking scaffold pin freshness against the npm registry..."
+if (cd "$ROOT_DIR" && pnpm check:scaffold-pin-freshness); then
+  echo "  ✓ scaffold pins are current"
+else
+  echo ""
+  echo "Error: scaffold pin freshness check failed — a pin in packages/create-zudo-doc/src/scaffold.ts" >&2
+  echo "        is stale, or the npm registry lookup failed. See RELEASE.md 'Scaffold pin freshness gate'." >&2
+  echo "Remedy: bump the pin via /dev-bump-zudo-deps, then re-run 'pnpm check:pin-parity' to confirm every" >&2
+  echo "        pin location still agrees, and re-run this script." >&2
+  exit 1
+fi
+
 # ── Read current versions (real run) ─────────────────────────────────────────
 
 OLD_ROOT_VERSION=$(node -p "require('$PKG_JSON').version" 2>/dev/null)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -49,7 +49,14 @@ export default defineConfig({
         extends: true,
         test: {
           name: "scripts",
-          include: ["scripts/__tests__/**/*.test.ts"],
+          // `.test.mjs` alongside the usual `.test.ts`: #3456's spec named
+          // scripts/__tests__/check-scaffold-pin-freshness.test.mjs exactly
+          // (the script under test is plain .mjs with no TS syntax), so the
+          // glob was widened rather than renaming the file to the .ts norm.
+          include: [
+            "scripts/__tests__/**/*.test.ts",
+            "scripts/__tests__/**/*.test.mjs",
+          ],
           // Subprocess-heavy integration-flavored tests; 2x the largest 30s
           // child budget for load headroom under host CPU contention (#2563).
           testTimeout: 60_000,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -49,10 +49,17 @@ export default defineConfig({
         extends: true,
         test: {
           name: "scripts",
-          // `.test.mjs` alongside the usual `.test.ts`: #3456's spec named
-          // scripts/__tests__/check-scaffold-pin-freshness.test.mjs exactly
-          // (the script under test is plain .mjs with no TS syntax), so the
-          // glob was widened rather than renaming the file to the .ts norm.
+          // `.test.mjs` alongside the usual `.test.ts` (#3456). The norm here is
+          // `.test.ts` even for `.mjs` scripts — check-pin-parity.test.ts imports
+          // straight from check-pin-parity.mjs and typechecks fine, because it
+          // annotates its own locals. A test that is plain JS does not: this
+          // project adds `noUncheckedIndexedAccess` on top of strict, and
+          // `scripts/**` is inside tsconfig's `include`, so writing a plain-JS
+          // test as `.ts` demanded ~18 non-null assertions on ordinary
+          // `results[0]` reads — noise that asserts nothing about the code under
+          // test. Measured, not assumed: the rename was tried and produced
+          // exactly those errors. Prefer `.test.ts` for anything that carries
+          // real types; `.test.mjs` is for plain-JS tests of plain-JS scripts.
           include: [
             "scripts/__tests__/**/*.test.ts",
             "scripts/__tests__/**/*.test.mjs",


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3455

---

## Summary

Closes the gap that let #3442 happen silently. Child of super-epic #3443; merges into `base/sweep-260818`.

## The failure this prevents

`create-zudo-doc@5.5.3` shipped on 2026-08-17 pinning `@takazudo/zfb` `2.5.2` — three weeks after the upstream mermaid fix landed. Every fresh scaffold containing mermaid diagrams was broken out of the box, and **no automated gate could see it**: build exits 0, typecheck passes, link check passes. It only showed in a browser.

Nothing checked that the scaffold's pin was current at release time.

**The caret option was rejected.** `check-pin-parity.mjs` documents the scaffold literal as a reproducibility guarantee — "A fresh scaffold gets EXACTLY these versions" — enforced by `rootPin !== scaffoldPin`. Pins stay exact; the gate attacks the staleness instead.

## What landed

**`scripts/check-scaffold-pin-freshness.mjs`** — a pure `checkScaffoldPinFreshness({scaffoldSrc, packages, fetchDistTags})` with an **injectable** registry lookup (so the 17 tests never touch the network), plus a CLI wrapper with a bounded timeout. It reuses `PINNED_PACKAGES` and `readScaffoldPin` from `check-pin-parity.mjs` — now exported rather than re-implemented, so the three scaffold pin forms (literal, constant-reference, bracket-assignment) are parsed by the one existing implementation.

Semantics, all asserted by tests:
- **Fail closed** on registry/network error, reported *distinctly* from staleness — a release blocked by a flaky registry is recoverable; a stale release on npm is not.
- **Prerelease pins compare against the `next` dist-tag, never a stable `latest`** — `RELEASE.md` documents those as permanently-diverging channels, and #3442 names a naive latest-only comparison as the likely cause of the original gap.
- Review caught a hole in that rule: a prerelease pin whose package has **no `next` tag** was skipped unconditionally, so a 0.x package published only as `0.5.0-next.N` (where `latest` *is* the preview line) could never be detected as stale — #3442's exact shape. It now falls back to `latest` only when `latest` is itself a prerelease.

**Wiring (#3457)** — the gate runs as **Safeguard 4/5 in `publish-create-zudo-doc.yml`, immediately before `npm publish`**, and unconditionally so a dry run also proves it passes. This placement is the point: `release-create-zudo-doc.sh` only *prepares* a release, and a pin can go stale between preparing and publishing, so a prepare-only gate would not block anything. It also runs as an early-feedback preflight in the release script (after the `DRY=1` early return, keeping that path network-free) and as `pnpm check:scaffold-pin-freshness`.

**Deliberately not a PR gate** — it hits the live registry, so an upstream publish must never fail an unrelated PR. The B4push/CI parity check was consulted rather than assumed: it reconciles only `REQUIRED_CI_GUARDS` ↔ `pr-checks.yml` and the `run-b4push.sh` marker region, so a release-only gate needs no entry — verified by re-running it.

**`RELEASE.md`** documents where the gate runs, what a failure means, the remedy, and the prerelease rule.

## Verified

Live-registry run reports all four pins current; `check-pin-parity` and `check-b4push-ci-parity` unchanged; the `DRY=1` release path still exits 0 without network; workflow YAML parses; 17/17 gate tests plus 55/55 across the touched scripts suites.

## Raised

#3469 — the gate is a no-op for *same-core* prerelease staleness (`0.2.0-next.9` → `0.2.0-next.20`), since comparison is core-only. Inert today (all four pins are stable) but silent if a pin ever moves to a `next` line.