### PR TITLE
Fix stripMarkdown entity and underscore corruption

### DIFF
--- a/packages/zudo-doc/src/md-utils/__tests__/md-utils.test.ts
+++ b/packages/zudo-doc/src/md-utils/__tests__/md-utils.test.ts
@@ -61,6 +61,7 @@ describe("md-utils stripMarkdown plain-text preservation (zudo-doc#3478)", () =>
     expect(
       stripMarkdown("&#x41;&#X42; &lt;b&gt; &quot;x&quot; &apos;y&apos;"),
     ).toBe('AB <b> "x" \'y\'');
+    expect(stripMarkdown("left&nbsp;right")).toBe("left\u00a0right");
   });
 
   it("decodes references only once and leaves invalid numeric references intact", () => {
@@ -68,6 +69,7 @@ describe("md-utils stripMarkdown plain-text preservation (zudo-doc#3478)", () =>
     expect(stripMarkdown("&#999999999999999999999;")).toBe(
       "&#999999999999999999999;",
     );
+    expect(stripMarkdown("&#xD800;")).toBe("&#xD800;");
   });
 
   it("preserves intraword underscores in identifiers", () => {

--- a/packages/zudo-doc/src/md-utils/__tests__/md-utils.test.ts
+++ b/packages/zudo-doc/src/md-utils/__tests__/md-utils.test.ts
@@ -53,6 +53,39 @@ describe("md-utils stripMarkdown JSX comment removal (zudo-doc#2175)", () => {
   });
 });
 
+describe("md-utils stripMarkdown plain-text preservation (zudo-doc#3478)", () => {
+  it("decodes decimal, hexadecimal, and common named character references", () => {
+    expect(stripMarkdown("DELETE /items/&#123;item_id&#125;")).toBe(
+      "DELETE /items/{item_id}",
+    );
+    expect(
+      stripMarkdown("&#x41;&#X42; &lt;b&gt; &quot;x&quot; &apos;y&apos;"),
+    ).toBe('AB <b> "x" \'y\'');
+  });
+
+  it("decodes references only once and leaves invalid numeric references intact", () => {
+    expect(stripMarkdown("&amp;#123; &amp;lt;")).toBe("&#123; &lt;");
+    expect(stripMarkdown("&#999999999999999999999;")).toBe(
+      "&#999999999999999999999;",
+    );
+  });
+
+  it("preserves intraword underscores in identifiers", () => {
+    expect(stripMarkdown("GET /account_settings/export_targets")).toBe(
+      "GET /account_settings/export_targets",
+    );
+    expect(stripMarkdown("error_code_400 item_part_id is_active")).toBe(
+      "error_code_400 item_part_id is_active",
+    );
+  });
+
+  it("continues to remove valid underscore emphasis delimiters", () => {
+    expect(stripMarkdown("_italic_ and __bold__ and ___both___")).toBe(
+      "italic and bold and both",
+    );
+  });
+});
+
 describe("md-utils slugToUrl", () => {
   it("builds a path-only default-locale URL", () => {
     expect(slugToUrl("guides/intro", null, "")).toBe("/docs/guides/intro");

--- a/packages/zudo-doc/src/md-utils/index.ts
+++ b/packages/zudo-doc/src/md-utils/index.ts
@@ -9,6 +9,42 @@ import { join, relative } from "node:path";
 import matter from "gray-matter";
 import { toRouteSlug } from "../slug/index.js";
 
+const NAMED_CHARACTER_REFERENCES: Readonly<Record<string, string>> = {
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+  nbsp: "\u00a0",
+};
+
+function decodeCharacterReferences(value: string): string {
+  return value
+    .replace(
+      /&#(?:([0-9]+)|[xX]([0-9a-fA-F]+));/g,
+      (
+        reference,
+        decimal: string | undefined,
+        hexadecimal: string | undefined,
+      ) => {
+        const digits = decimal ?? hexadecimal;
+        if (!digits) return reference;
+        const codePoint = Number.parseInt(digits, decimal ? 10 : 16);
+        try {
+          return String.fromCodePoint(codePoint);
+        } catch {
+          return reference;
+        }
+      },
+    )
+    .replace(
+      /&(lt|gt|quot|apos|nbsp);/g,
+      (reference, name: string) =>
+        NAMED_CHARACTER_REFERENCES[name] ?? reference,
+    )
+    // Decode ampersands last so encoded references are decoded only once.
+    .replace(/&amp;/g, "&");
+}
+
 /**
  * Frontmatter fields the integrations read off each MDX/MD file. Extra
  * keys pass through via the index signature. Mirrors the host project's
@@ -50,23 +86,28 @@ export interface MdDocFrontmatter {
  * rules without also updating the byte-equality fixtures (topic-plugin-audit).
  */
 export function stripMarkdown(md: string): string {
+  const withoutCodeCommentsAndTags = md
+    // Remove code blocks
+    .replace(/```[\s\S]*?```/g, "")
+    .replace(/`[^`]+`/g, "")
+    // Remove JSX/MDX block comments ({/* ... */}) — they never render to
+    // users in MDX, so a leading comment must not become a page's fallback
+    // description (zudo-doc#2175). Must precede the emphasis rule below,
+    // which would otherwise mangle the `/* … */` asterisks into `{/ … /}`.
+    .replace(/\{\/\*[\s\S]*?\*\/\}/g, "")
+    // Remove HTML tags
+    .replace(/<[^>]+>/g, "");
+
   return (
-    md
-      // Remove code blocks
-      .replace(/```[\s\S]*?```/g, "")
-      .replace(/`[^`]+`/g, "")
-      // Remove JSX/MDX block comments ({/* ... */}) — they never render to
-      // users in MDX, so a leading comment must not become a page's fallback
-      // description (zudo-doc#2175). Must precede the emphasis rule below,
-      // which would otherwise mangle the `/* … */` asterisks into `{/ … /}`.
-      .replace(/\{\/\*[\s\S]*?\*\/\}/g, "")
-      // Remove HTML tags
-      .replace(/<[^>]+>/g, "")
+    decodeCharacterReferences(withoutCodeCommentsAndTags)
       // Remove headings markers
       .replace(/^#{1,6}\s+/gm, "")
       // Remove emphasis/bold markers
       .replace(/\*{1,3}([^*]+)\*{1,3}/g, "$1")
-      .replace(/_{1,3}([^_]+)_{1,3}/g, "$1")
+      .replace(
+        /(^|[^\p{L}\p{N}])(_{1,3})(?=\S)([^_\n]*?\S)\2(?=$|[^\p{L}\p{N}])/gmu,
+        "$1$3",
+      )
       // Remove images (must run before link removal)
       .replace(/!\[[^\]]*\]\([^)]+\)/g, "")
       // Remove links but keep text

--- a/packages/zudo-doc/src/md-utils/index.ts
+++ b/packages/zudo-doc/src/md-utils/index.ts
@@ -29,6 +29,12 @@ function decodeCharacterReferences(value: string): string {
         const digits = decimal ?? hexadecimal;
         if (!digits) return reference;
         const codePoint = Number.parseInt(digits, decimal ? 10 : 16);
+        if (
+          codePoint > 0x10ffff ||
+          (codePoint >= 0xd800 && codePoint <= 0xdfff)
+        ) {
+          return reference;
+        }
         try {
           return String.fromCodePoint(codePoint);
         } catch {


### PR DESCRIPTION
Closes #3478.

## Summary

- decode decimal, hexadecimal, and common named HTML character references after stripping HTML tags
- decode ampersands last to prevent encoded references from being decoded twice
- preserve intraword underscores in identifiers while still removing valid `_`, `__`, and `___` emphasis delimiters
- leave out-of-range and surrogate numeric references unchanged instead of risking malformed output

## Tests

- `pnpm --dir packages/zudo-doc exec vitest run --config vitest.config.ts src/md-utils/__tests__/md-utils.test.ts`
- `pnpm --filter @takazudo/zudo-doc typecheck`
- `pnpm --filter @takazudo/zudo-doc test` (192 files, 2,251 tests)
- `git diff --check`

## Review

- completed a focused correctness review of character-reference decoding and underscore delimiter behavior
- added review-driven coverage for non-breaking spaces and surrogate numeric references
- UI verification is not applicable because this changes build-time plain-text extraction only

## Risk

- scoped to plain-text output produced by `stripMarkdown`; rendered MDX/HTML is unchanged
