### PR TITLE
[Test Hardening][Sub] Give the CLI smoke test an immutable bin+dist snapshot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ packages/zudo-doc/routes-src/
 # src/routes/_virtual.d.ts; it ships in the npm tarball via files[] but is
 # not tracked in git (same policy as routes-src/).
 packages/zudo-doc/virtual-modules.d.ts
+# Package-local CLI test snapshots (bin + dist), removed by the test suite.
+packages/zudo-doc/.cli-snapshot-*/
 .zfb/
 # W6A — un-ignore the create-zudo-doc seed file so it ships in the
 # generated tarball. .zfb/ stays gitignored everywhere else; the seed

--- a/packages/zudo-doc/src/eject-logo/__tests__/cli-smoke.test.ts
+++ b/packages/zudo-doc/src/eject-logo/__tests__/cli-smoke.test.ts
@@ -5,15 +5,30 @@
 // which exercise the pure logic and the programmatic `ejectLogo()` API
 // directly.
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+} from "vitest";
 import { spawnSync } from "node:child_process";
 import fs from "fs-extra";
 import os from "os";
 import path from "path";
+import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const BIN_PATH = path.resolve(__dirname, "../../../bin/zudo-doc.mjs");
+const PACKAGE_ROOT = path.resolve(__dirname, "../../..");
+const SNAPSHOT_PREFIX = path.join(PACKAGE_ROOT, ".cli-snapshot-");
+const REQUIRED_DIST_ENTRYPOINTS = [
+  "eject/index.js",
+  "eject-logo/index.js",
+  "theme-cli/index.js",
+];
 
 const TEMP_PREFIX = "eject-logo-cli-smoke-";
 
@@ -28,7 +43,7 @@ export default defineConfig(
 `;
 
 function runCli(args: string[], cwd: string) {
-  return spawnSync(process.execPath, [BIN_PATH, ...args], {
+  return spawnSync(process.execPath, [binPath, ...args], {
     cwd,
     encoding: "utf8",
     // Explicit subprocess deadline (#3465): a hung CLI fails as "the
@@ -42,10 +57,50 @@ function runCli(args: string[], cwd: string) {
   });
 }
 
+let snapshotDir: string | undefined;
+let binPath: string;
 let tempDir: string;
 let projectDir: string;
 let configPath: string;
 let svgPath: string;
+
+beforeAll(async () => {
+  // Keep the snapshot inside the package so the copied bin's bare imports
+  // (minimist and picocolors) still resolve through package/workspace
+  // node_modules. A system-temp snapshot cannot resolve those dependencies.
+  let lastCopyError: unknown;
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const candidate = await fs.mkdtemp(SNAPSHOT_PREFIX);
+    try {
+      await fs.copy(path.join(PACKAGE_ROOT, "bin"), path.join(candidate, "bin"));
+      await fs.copy(
+        path.join(PACKAGE_ROOT, "dist"),
+        path.join(candidate, "dist"),
+      );
+      for (const entrypoint of REQUIRED_DIST_ENTRYPOINTS) {
+        if (!(await fs.pathExists(path.join(candidate, "dist", entrypoint)))) {
+          throw new Error(`CLI snapshot is missing dist/${entrypoint}`);
+        }
+      }
+      snapshotDir = candidate;
+      binPath = path.join(candidate, "bin", "zudo-doc.mjs");
+      return;
+    } catch (error) {
+      // A concurrent `tsup` clean may remove live dist files mid-copy. Drop
+      // the partial candidate and retry until one immutable copy completes.
+      lastCopyError = error;
+      await fs.remove(candidate);
+      await delay(50);
+    }
+  }
+  throw lastCopyError ?? new Error("Could not create CLI snapshot");
+});
+
+afterAll(async () => {
+  if (snapshotDir) {
+    await fs.remove(snapshotDir);
+  }
+});
 
 beforeEach(async () => {
   tempDir = await fs.mkdtemp(path.join(os.tmpdir(), TEMP_PREFIX));


### PR DESCRIPTION
Closes #3481

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/3505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789728460&installation_model_id=20910&pr_number=3505&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F3505&signature=774397ae5435fe9d24ae8de553a69c1dce2462899fc44038f4821bf17be2e6c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->