### PR TITLE
[Test Hardening][Sub] Make the npm-pack tarball tests incapable of running lifecycle scripts

### DIFF
--- a/packages/create-zudo-doc/src/__tests__/claude-skills-tarball.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/claude-skills-tarball.test.ts
@@ -13,7 +13,15 @@
 // tarball's computed file list, it never triggers a build itself.
 
 import { describe, it, expect, beforeAll } from "vitest";
-import { execFileSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
+import {
+  cpSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -27,9 +35,12 @@ interface NpmPackDryRunEntry {
   files: NpmPackDryRunFile[];
 }
 
+const LIFECYCLE_OUTPUT_RE =
+  /(?:^> .*\b(?:prepare|prepack)\b|\[(?:copy-theme-css|copy-content-css|copy-page-loading-css|copy-features-css|copy-eject-sources|copy-routes-src|copy-virtual-modules|copy-theme-packs|gen-catalog|gen-search-widget-script)\]|^gen-safelist:)/m;
+
 // See theme-packs-tarball.test.ts for why this scans every `[` instead of
-// naively parsing from the first bracket — some npm/CI combinations leak a
-// lifecycle log line ahead of the JSON array.
+// naively parsing from the first bracket. Lifecycle output is rejected below;
+// this remains as defence-in-depth for unrelated npm output.
 function parsePackJson(stdout: string): NpmPackDryRunEntry[] {
   for (let i = stdout.indexOf("["); i !== -1; i = stdout.indexOf("[", i + 1)) {
     try {
@@ -45,15 +56,55 @@ function parsePackJson(stdout: string): NpmPackDryRunEntry[] {
 }
 
 function packFileList(): string[] {
-  const stdout = execFileSync(
-    "npm",
-    ["pack", "--dry-run", "--json", "--ignore-scripts"],
-    { cwd: PKG_ROOT, encoding: "utf8" },
-  );
-  const parsed = parsePackJson(stdout);
-  const entry = parsed[0];
-  if (!entry) throw new Error("npm pack --dry-run --json produced no entries");
-  return entry.files.map((f) => f.path);
+  // npm 10 can run `prepare` despite both ignore-scripts forms. Removing npm
+  // pack's lifecycle hooks from a throwaway snapshot makes the live package
+  // structurally unreachable by any script while preserving its file list.
+  const snapshotRoot = mkdtempSync(resolve(tmpdir(), "create-zudo-doc-pack-"));
+  try {
+    cpSync(PKG_ROOT, snapshotRoot, {
+      recursive: true,
+      filter: (source) => source !== resolve(PKG_ROOT, "node_modules"),
+    });
+    const packageJsonPath = resolve(snapshotRoot, "package.json");
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+      scripts?: Record<string, string>;
+    };
+    if (packageJson.scripts) {
+      delete packageJson.scripts.prepare;
+      delete packageJson.scripts.prepack;
+      delete packageJson.scripts.postpack;
+    }
+    writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+
+    const result = spawnSync(
+      "npm",
+      ["pack", "--dry-run", "--json", "--ignore-scripts"],
+      {
+        cwd: snapshotRoot,
+        encoding: "utf8",
+        env: { ...process.env, npm_config_ignore_scripts: "true" },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    if (result.error) throw result.error;
+    const stdout = result.stdout ?? "";
+    const stderr = result.stderr ?? "";
+    expect(
+      `${stdout}\n${stderr}`,
+      "npm pack must not run prepare, prepack, or the tsup onSuccess chain",
+    ).not.toMatch(LIFECYCLE_OUTPUT_RE);
+    if (result.status !== 0) {
+      throw new Error(
+        `npm pack --dry-run --json exited with status ${result.status}. stderr:\n${stderr}`,
+      );
+    }
+    const parsed = parsePackJson(stdout);
+    const entry = parsed[0];
+    if (!entry) throw new Error("npm pack --dry-run --json produced no entries");
+    return entry.files.map((f) => f.path);
+  } finally {
+    rmSync(snapshotRoot, { recursive: true, force: true });
+  }
 }
 
 describe("npm tarball ships claudeSkills template files (#2921)", () => {

--- a/packages/create-zudo-doc/src/__tests__/favicon-tarball.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/favicon-tarball.test.ts
@@ -10,7 +10,15 @@
 // itself.
 
 import { describe, it, expect, beforeAll } from "vitest";
-import { execFileSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
+import {
+  cpSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -24,9 +32,12 @@ interface NpmPackDryRunEntry {
   files: NpmPackDryRunFile[];
 }
 
+const LIFECYCLE_OUTPUT_RE =
+  /(?:^> .*\b(?:prepare|prepack)\b|\[(?:copy-theme-css|copy-content-css|copy-page-loading-css|copy-features-css|copy-eject-sources|copy-routes-src|copy-virtual-modules|copy-theme-packs|gen-catalog|gen-search-widget-script)\]|^gen-safelist:)/m;
+
 // See theme-packs-tarball.test.ts for why this scans every `[` instead of
-// naively parsing from the first bracket — some npm/CI combinations leak a
-// lifecycle log line ahead of the JSON array.
+// naively parsing from the first bracket. Lifecycle output is rejected below;
+// this remains as defence-in-depth for unrelated npm output.
 function parsePackJson(stdout: string): NpmPackDryRunEntry[] {
   for (let i = stdout.indexOf("["); i !== -1; i = stdout.indexOf("[", i + 1)) {
     try {
@@ -42,15 +53,55 @@ function parsePackJson(stdout: string): NpmPackDryRunEntry[] {
 }
 
 function packFileList(): string[] {
-  const stdout = execFileSync(
-    "npm",
-    ["pack", "--dry-run", "--json", "--ignore-scripts"],
-    { cwd: PKG_ROOT, encoding: "utf8" },
-  );
-  const parsed = parsePackJson(stdout);
-  const entry = parsed[0];
-  if (!entry) throw new Error("npm pack --dry-run --json produced no entries");
-  return entry.files.map((f) => f.path);
+  // npm 10 can run `prepare` despite both ignore-scripts forms. Removing npm
+  // pack's lifecycle hooks from a throwaway snapshot makes the live package
+  // structurally unreachable by any script while preserving its file list.
+  const snapshotRoot = mkdtempSync(resolve(tmpdir(), "create-zudo-doc-pack-"));
+  try {
+    cpSync(PKG_ROOT, snapshotRoot, {
+      recursive: true,
+      filter: (source) => source !== resolve(PKG_ROOT, "node_modules"),
+    });
+    const packageJsonPath = resolve(snapshotRoot, "package.json");
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+      scripts?: Record<string, string>;
+    };
+    if (packageJson.scripts) {
+      delete packageJson.scripts.prepare;
+      delete packageJson.scripts.prepack;
+      delete packageJson.scripts.postpack;
+    }
+    writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+
+    const result = spawnSync(
+      "npm",
+      ["pack", "--dry-run", "--json", "--ignore-scripts"],
+      {
+        cwd: snapshotRoot,
+        encoding: "utf8",
+        env: { ...process.env, npm_config_ignore_scripts: "true" },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    if (result.error) throw result.error;
+    const stdout = result.stdout ?? "";
+    const stderr = result.stderr ?? "";
+    expect(
+      `${stdout}\n${stderr}`,
+      "npm pack must not run prepare, prepack, or the tsup onSuccess chain",
+    ).not.toMatch(LIFECYCLE_OUTPUT_RE);
+    if (result.status !== 0) {
+      throw new Error(
+        `npm pack --dry-run --json exited with status ${result.status}. stderr:\n${stderr}`,
+      );
+    }
+    const parsed = parsePackJson(stdout);
+    const entry = parsed[0];
+    if (!entry) throw new Error("npm pack --dry-run --json produced no entries");
+    return entry.files.map((f) => f.path);
+  } finally {
+    rmSync(snapshotRoot, { recursive: true, force: true });
+  }
 }
 
 describe("npm tarball ships the default public/ favicon set (#3186)", () => {

--- a/packages/zudo-doc/src/__tests__/theme-packs-tarball.test.ts
+++ b/packages/zudo-doc/src/__tests__/theme-packs-tarball.test.ts
@@ -15,8 +15,15 @@
 // `route-injection-build.slow.test.ts`.
 
 import { describe, it, expect, beforeAll } from "vitest";
-import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import {
+  cpSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -30,14 +37,15 @@ interface NpmPackDryRunEntry {
   files: NpmPackDryRunFile[];
 }
 
+const LIFECYCLE_OUTPUT_RE =
+  /(?:^> .*\b(?:prepare|prepack)\b|\[(?:copy-theme-css|copy-content-css|copy-page-loading-css|copy-features-css|copy-eject-sources|copy-routes-src|copy-virtual-modules|copy-theme-packs|gen-catalog|gen-search-widget-script)\]|^gen-safelist:)/m;
+
 /**
- * Extract the JSON array from `npm pack --json` stdout. `--ignore-scripts`
- * SHOULD keep lifecycle output off stdout, but some npm/CI combinations still
- * leak a copy-script line ahead of the JSON — CI observed
- * `[copy-theme-packs] dist/theme-packs/ OK` prepended, which broke a naive
- * `JSON.parse(stdout)` with "Unexpected token 'c'". That leaked line itself
- * starts with `[`, so we can't just slice from the first bracket; scan every
- * `[` and return the first slice that parses to an array.
+ * Extract the JSON array from `npm pack --json` stdout. npm 10 can run
+ * `prepare` for `npm pack` despite the `--ignore-scripts` CLI flag; the
+ * previously observed `[copy-theme-packs]` prefix was evidence of that build,
+ * not a logging quirk. The subprocess guard below now rejects lifecycle output,
+ * while this scanner remains as defence-in-depth for unrelated npm noise.
  */
 function parsePackJson(stdout: string): NpmPackDryRunEntry[] {
   for (let i = stdout.indexOf("["); i !== -1; i = stdout.indexOf("[", i + 1)) {
@@ -54,20 +62,55 @@ function parsePackJson(stdout: string): NpmPackDryRunEntry[] {
 }
 
 function packFileList(): string[] {
-  // --ignore-scripts: this is a file-listing check against the CURRENT
-  // dist/ (the test harness already ran the real prepack/check-*.mjs guards
-  // via `pnpm --filter @takazudo/zudo-doc build`+`test` — see this repo's
-  // CLAUDE.md). It suppresses the lifecycle banners on most npm versions;
-  // parsePackJson() makes the parse robust to any that still leak.
-  const stdout = execFileSync(
-    "npm",
-    ["pack", "--dry-run", "--json", "--ignore-scripts"],
-    { cwd: PKG_ROOT, encoding: "utf8" },
-  );
-  const parsed = parsePackJson(stdout);
-  const entry = parsed[0];
-  if (!entry) throw new Error("npm pack --dry-run --json produced no entries");
-  return entry.files.map((f) => f.path);
+  // npm 10's directory packer unconditionally runs `prepare`, ignoring both
+  // ignore-scripts forms. Pack a sanitized snapshot so even that implementation
+  // cannot execute a lifecycle or mutate the live dist/ this test is inspecting.
+  const snapshotRoot = mkdtempSync(resolve(tmpdir(), "zudo-doc-pack-"));
+  try {
+    cpSync(PKG_ROOT, snapshotRoot, {
+      recursive: true,
+      filter: (source) => source !== resolve(PKG_ROOT, "node_modules"),
+    });
+    const packageJsonPath = resolve(snapshotRoot, "package.json");
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+      scripts?: Record<string, string>;
+    };
+    if (packageJson.scripts) {
+      delete packageJson.scripts.prepare;
+      delete packageJson.scripts.prepack;
+      delete packageJson.scripts.postpack;
+    }
+    writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+
+    const result = spawnSync(
+      "npm",
+      ["pack", "--dry-run", "--json", "--ignore-scripts"],
+      {
+        cwd: snapshotRoot,
+        encoding: "utf8",
+        env: { ...process.env, npm_config_ignore_scripts: "true" },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    if (result.error) throw result.error;
+    const stdout = result.stdout ?? "";
+    const stderr = result.stderr ?? "";
+    expect(
+      `${stdout}\n${stderr}`,
+      "npm pack must not run prepare, prepack, or the tsup onSuccess chain",
+    ).not.toMatch(LIFECYCLE_OUTPUT_RE);
+    if (result.status !== 0) {
+      throw new Error(
+        `npm pack --dry-run --json exited with status ${result.status}. stderr:\n${stderr}`,
+      );
+    }
+    const parsed = parsePackJson(stdout);
+    const entry = parsed[0];
+    if (!entry) throw new Error("npm pack --dry-run --json produced no entries");
+    return entry.files.map((f) => f.path);
+  } finally {
+    rmSync(snapshotRoot, { recursive: true, force: true });
+  }
 }
 
 describe("npm tarball ships theme-pack assets (ADR docs/adr/theme-packs.md, #2820)", () => {


### PR DESCRIPTION
Closes #3486

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/3510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789728468&installation_model_id=20910&pr_number=3510&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F3510&signature=1f97878723d8234b195823724cba7d76cdaac7a188ae6ac7bba30b3265a84487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->