### PR TITLE
Drawer Refresh: refresh nested-island props across soft navigation (#3529)

### DIFF
--- a/e2e/mobile-drawer-helpers.ts
+++ b/e2e/mobile-drawer-helpers.ts
@@ -1,0 +1,79 @@
+/**
+ * Shared helpers for the mobile drawer (`SidebarToggle` island).
+ *
+ * The drawer's selectors (`aria-label` strings, backdrop, panel hook) were
+ * previously duplicated across spec files — this module is the one place they
+ * live, mirroring the `sidebar-helpers.ts` convention for the desktop sidebar.
+ * `smoke-mobile-sidebar.spec.ts` / `smoke-smart-break.spec.ts` predate it and
+ * still carry local copies; new drawer specs should import from here.
+ */
+
+import { expect, type Page } from "@playwright/test";
+
+/** The drawer panel — `data-zd-mobile-sidebar` is the stable theme-pack hook. */
+export function mobileSidebar(page: Page) {
+  return page.locator("[data-zd-mobile-sidebar]");
+}
+
+/**
+ * Selector for a drawer-owned anchor, slash-tolerant like `spaClick`.
+ *
+ * Use with `spaClickSelector` when a spec must prove the click landed on a
+ * DRAWER link: the bare-href `spaClick` uses `document.querySelector`, which
+ * is visibility-agnostic and takes the first document-order match — today
+ * that happens to be the drawer link (the sidebarToggle slot renders before
+ * the hidden desktop nav), but any header re-composition would silently move
+ * the click onto a hidden desktop nav link with the same href.
+ */
+export function drawerLinkSelector(href: string): string {
+  return `[data-zd-mobile-sidebar] a[href="${href}"], [data-zd-mobile-sidebar] a[href="${href}/"]`;
+}
+
+/**
+ * Open the mobile drawer via the hamburger, retrying the click as a unit.
+ *
+ * `SidebarToggle` is `Island({ when: "visible" })` — its `onClick` only
+ * exists once the island has hydrated, and the zfb runtime dispatches no
+ * event and mutates no DOM attribute on mount completion, so there is no
+ * better signal to poll. A click issued before hydration is silently
+ * dropped. Retrying the click-and-check as a unit via `toPass` (mirrors
+ * `theme-pack-helpers.ts`'s `openFlyout`) makes a dropped first click
+ * self-heal instead of flaking — and succeeding at all proves hydration
+ * completed.
+ */
+export async function openMobileDrawer(page: Page): Promise<void> {
+  const hamburger = page.locator('button[aria-label="Open sidebar"]');
+  const closeButton = page.locator('button[aria-label="Close sidebar"]');
+  await expect(async () => {
+    // Idempotent retry body: a previous iteration may have already opened the
+    // drawer (the click landed but the 500ms visibility check missed a slow
+    // paint). The hamburger's aria-label flips to "Close sidebar" while open,
+    // so re-clicking would wait on a locator that no longer resolves for
+    // Playwright's full action timeout — which `toPass`'s budget cannot
+    // interrupt. Skip the click when the drawer is already open.
+    if (!(await closeButton.isVisible())) {
+      await hamburger.click({ timeout: 2000 });
+    }
+    await expect(closeButton).toBeVisible({ timeout: 500 });
+  }).toPass({ timeout: 10000 });
+}
+
+/**
+ * Close the drawer via the backdrop overlay, not the hamburger button.
+ *
+ * `z-modal-backdrop` (50) sits ABOVE the header's `z-toolbar` (20) by design
+ * (`sidebar-toggle-island/index.tsx`'s backdrop comment) — the open drawer
+ * is a modal surface that dims the whole viewport, hamburger included. A
+ * real pointer click therefore cannot land on the "Close sidebar" button
+ * while the drawer is open, so the close is dispatched directly on the
+ * backdrop.
+ */
+export async function closeMobileDrawer(page: Page): Promise<void> {
+  // Precondition, not a wait: the backdrop element is always in the DOM (only
+  // class-hidden when closed) and `dispatchEvent` fires its handler regardless
+  // of visibility, so without this check a close on a never-opened drawer
+  // would "succeed" and the hamburger assertion below would pass trivially.
+  await expect(page.locator('button[aria-label="Close sidebar"]')).toBeVisible();
+  await page.locator("header div.fixed.inset-0").dispatchEvent("click");
+  await expect(page.locator('button[aria-label="Open sidebar"]')).toBeVisible({ timeout: 5000 });
+}

--- a/e2e/smoke-mobile-drawer-section-swap.spec.ts
+++ b/e2e/smoke-mobile-drawer-section-swap.spec.ts
@@ -1,0 +1,232 @@
+/**
+ * Regression spec for the mobile drawer's cross-section soft-navigation bug
+ * (zudolab/zudo-doc#3525, root cause + fix in epic #3529).
+ *
+ * At mobile viewport the header persists across a same-locale SPA swap
+ * (persist key `header-${lang}`), and the mobile drawer (`SidebarToggle`)
+ * lives INSIDE that persisted header. `zfb`'s props-refresh path only fires
+ * for a persisted element that is itself an island root — `<header>` is not
+ * one — so before the #3530 fix, a same-locale CROSS-SECTION swap left the
+ * drawer re-mounting from the previous page's serialized `data-props`: a
+ * stale tree AND a stale active marker.
+ *
+ * No existing spec covers this: every persist spec is desktop-pinned
+ * (`smoke-vt-chrome-persist.spec.ts` and siblings), and the one drawer nav
+ * test (`smoke-mobile-sidebar.spec.ts:86`) is same-section and only asserts
+ * that the drawer closed after navigating — it never proves cross-section
+ * softness or checks tree/active-marker freshness.
+ *
+ * Journey — both hops are SPA soft navigations via real drawer links. The
+ * smoke fixture's getting-started page has no article-body link into the
+ * guides section, and the desktop header nav is `hidden ... lg:flex` at
+ * this viewport, so the drawer's root menu is the only cross-section path:
+ *
+ *   1. /docs/getting-started (origin, a single-page section) — open the
+ *      drawer (the retry-click doubles as the hydration wait) and record
+ *      the baseline tree + active marker + persisted-header snapshot.
+ *   2. Close, reopen, click "Back to main menu", soft-navigate via the
+ *      "Learn" root-menu link to /docs/guides — the CROSS-SECTION hop.
+ *   3. Reopen, soft-navigate via the now-visible "Writing Docs" child link
+ *      to /docs/guides/page-1 — a same-section hop that lands on an
+ *      unambiguous destination leaf carrying its own active marker.
+ *   4. Reopen and assert: the destination-only leaf is present and active,
+ *      the origin-only leaf is gone, the persisted header survived both
+ *      halves of the persist contract (DOM identity AND its computed
+ *      `viewTransitionName`), and exactly one Navigation Timing entry
+ *      exists for the whole journey (a hard load anywhere would add a
+ *      second — this is the automated proxy for the source issue's
+ *      five-point softness proof).
+ */
+import { test, expect, type Page } from "@playwright/test";
+import { spaClick } from "./nav-helpers";
+
+test.use({ viewport: { width: 390, height: 844 } });
+
+const GETTING_STARTED = "/docs/getting-started";
+const GUIDES_INDEX_HREF = "/docs/guides";
+const GUIDES_PAGE_1_HREF = "/docs/guides/page-1";
+
+function mobileSidebar(page: Page) {
+  return page.locator("[data-zd-mobile-sidebar]");
+}
+
+/**
+ * Open the mobile drawer via the hamburger, retrying the click as a unit.
+ *
+ * `SidebarToggle` is `Island({ when: "visible" })` — its `onClick` only
+ * exists once the island has hydrated, and the zfb runtime dispatches no
+ * event and mutates no DOM attribute on mount completion, so there is no
+ * better signal to poll. A click issued before hydration is silently
+ * dropped. Retrying the click-and-check as a unit via `toPass` (mirrors
+ * `theme-pack-helpers.ts`'s `openFlyout`) makes a dropped first click
+ * self-heal instead of flaking — and succeeding at all proves hydration
+ * completed. Module evaluation (which runs `ensureNestedIslandPropsRefresh`
+ * as a side effect, `sidebar-toggle-island/index.tsx:20`) strictly precedes
+ * the mount call in zfb's island-mount chain, so "the button is clickable"
+ * is a safe proxy for "the before-swap refresh listener is registered" —
+ * navigating before this wait is the documented uncovered race
+ * (`nested-island-props-refresh.ts`'s "Known gap" comment) and would make
+ * the whole regression proof meaningless.
+ */
+async function openMobileDrawer(page: Page): Promise<void> {
+  const hamburger = page.locator('button[aria-label="Open sidebar"]');
+  const closeButton = page.locator('button[aria-label="Close sidebar"]');
+  await expect(async () => {
+    await hamburger.click();
+    await expect(closeButton).toBeVisible({ timeout: 500 });
+  }).toPass({ timeout: 10000 });
+}
+
+/**
+ * Close the drawer via the backdrop overlay, not the hamburger button.
+ *
+ * `z-modal-backdrop` (50) sits ABOVE the header's `z-toolbar` (20) by design
+ * (`sidebar-toggle-island/index.tsx`'s backdrop comment) — the open drawer
+ * is a modal surface that dims the whole viewport, hamburger included. A
+ * real pointer click therefore cannot land on the "Close sidebar" button
+ * while the drawer is open (mirrors `smoke-mobile-sidebar.spec.ts`'s
+ * "clicking backdrop closes the sidebar" test, which dispatches directly on
+ * the backdrop for the same reason).
+ */
+async function closeMobileDrawer(page: Page): Promise<void> {
+  await page.locator("header div.fixed.inset-0").dispatchEvent("click");
+  await expect(page.locator('button[aria-label="Open sidebar"]')).toBeVisible({ timeout: 5000 });
+}
+
+interface HeaderPersistSnapshot {
+  marker: number;
+  viewTransitionName: string | null;
+}
+
+/**
+ * Tag the persisted `<header>` with a unique marker property and read its
+ * computed `viewTransitionName`, so a later read can prove BOTH halves of
+ * "the persist survived": DOM-node identity (the marker survives only if
+ * it is literally the same element) and the named view-transition CSS
+ * assignment (which a persist regression could disturb independently).
+ */
+async function tagHeaderForPersistCheck(page: Page): Promise<HeaderPersistSnapshot> {
+  return page.evaluate(() => {
+    const header = document.querySelector("header");
+    if (!header) throw new Error("Expected a <header> element");
+    const marker = Date.now() + Math.random();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (header as any).__drawerSwapMarker__ = marker;
+    return { marker, viewTransitionName: getComputedStyle(header).viewTransitionName };
+  });
+}
+
+async function readHeaderPersistSnapshot(page: Page): Promise<HeaderPersistSnapshot | null> {
+  return page.evaluate(() => {
+    const header = document.querySelector("header");
+    if (!header) return null;
+    return {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      marker: (header as any).__drawerSwapMarker__ as number,
+      viewTransitionName: getComputedStyle(header).viewTransitionName,
+    };
+  });
+}
+
+test.describe("Mobile drawer: cross-section soft-navigation regression (#3525/#3529)", () => {
+  test("drawer tree and active marker refresh after a cross-section SPA swap, header persist intact", async ({
+    page,
+  }) => {
+    await page.goto(GETTING_STARTED, { waitUntil: "domcontentloaded" });
+
+    // ---- Step 1: origin baseline --------------------------------------
+    await openMobileDrawer(page);
+    const sidebarPanel = mobileSidebar(page);
+    const gettingStartedLink = sidebarPanel.getByRole("link", {
+      name: "Getting Started",
+      exact: true,
+    });
+    const writingDocsLink = sidebarPanel.getByRole("link", { name: "Writing Docs", exact: true });
+
+    await expect(
+      gettingStartedLink,
+      "origin section's own leaf should be the active marker",
+    ).toHaveAttribute("aria-current", "page");
+    await expect(
+      writingDocsLink,
+      "destination-only guides leaf must not exist yet on the origin section's tree",
+    ).toHaveCount(0);
+
+    const baseline = await tagHeaderForPersistCheck(page);
+
+    // ---- Step 2: close, reopen, soft-navigate cross-section via the
+    // drawer's root menu (the only cross-section path at this viewport) --
+    await closeMobileDrawer(page);
+    await openMobileDrawer(page);
+    await sidebarPanel.getByRole("button", { name: "Back to main menu" }).click();
+
+    const learnLink = sidebarPanel.getByRole("link", { name: "Learn", exact: true });
+    await expect(learnLink, "root menu should list the guides section's entry point").toBeVisible();
+
+    const crossSectionSwapFired = await spaClick(page, GUIDES_INDEX_HREF);
+    expect(crossSectionSwapFired, "zfb:after-swap did not fire for the cross-section hop").toBe(
+      true,
+    );
+
+    const afterCrossSection = await readHeaderPersistSnapshot(page);
+    expect(afterCrossSection, "header should still exist after the cross-section swap").not.toBeNull();
+    expect(
+      afterCrossSection!.marker,
+      "header DOM node should be the same instance after the cross-section swap",
+    ).toBe(baseline.marker);
+    expect(
+      afterCrossSection!.viewTransitionName,
+      "header viewTransitionName should be unchanged after the cross-section swap",
+    ).toBe(baseline.viewTransitionName);
+
+    // ---- Step 3: reopen, soft-navigate to the unambiguous destination leaf
+    await openMobileDrawer(page);
+    await expect(
+      gettingStartedLink,
+      "origin-only leaf should already be gone once the drawer shows the guides tree",
+    ).toHaveCount(0);
+    await expect(
+      writingDocsLink,
+      "destination guides leaf should now be present in the reopened tree",
+    ).toBeVisible();
+
+    const sameSectionSwapFired = await spaClick(page, GUIDES_PAGE_1_HREF);
+    expect(sameSectionSwapFired, "zfb:after-swap did not fire for the same-section hop").toBe(
+      true,
+    );
+
+    // ---- Step 4: reopen and assert the full regression contract --------
+    await openMobileDrawer(page);
+
+    await expect(
+      writingDocsLink,
+      "destination-ONLY tree item should appear",
+    ).toBeVisible();
+    await expect(writingDocsLink, "destination link should carry the active marker").toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    await expect(writingDocsLink).toHaveAttribute("data-nav-active", "");
+
+    await expect(gettingStartedLink, "origin-only tree item should be gone").toHaveCount(0);
+
+    const final = await readHeaderPersistSnapshot(page);
+    expect(final, "header should still exist at the end of the journey").not.toBeNull();
+    expect(
+      final!.marker,
+      "header DOM node should still be the same instance at the end of the journey",
+    ).toBe(baseline.marker);
+    expect(
+      final!.viewTransitionName,
+      "header viewTransitionName should still be unchanged at the end of the journey",
+    ).toBe(baseline.viewTransitionName);
+
+    const navigationEntryCount = await page.evaluate(
+      () => performance.getEntriesByType("navigation").length,
+    );
+    expect(
+      navigationEntryCount,
+      "exactly one Navigation Timing entry should exist for the whole journey — a hard load at any hop would add a second",
+    ).toBe(1);
+  });
+});

--- a/e2e/smoke-mobile-drawer-section-swap.spec.ts
+++ b/e2e/smoke-mobile-drawer-section-swap.spec.ts
@@ -32,13 +32,19 @@
  *   4. Reopen and assert: the destination-only leaf is present and active,
  *      the origin-only leaf is gone, the persisted header survived both
  *      halves of the persist contract (DOM identity AND its computed
- *      `viewTransitionName`), and exactly one Navigation Timing entry
- *      exists for the whole journey (a hard load anywhere would add a
- *      second — this is the automated proxy for the source issue's
- *      five-point softness proof).
+ *      `viewTransitionName`), and the single Navigation Timing entry still
+ *      names the ORIGIN URL (a hard load anywhere would reset the
+ *      per-document timeline with that hop's URL instead — this is the
+ *      automated proxy for the source issue's five-point softness proof).
  */
 import { test, expect, type Page } from "@playwright/test";
-import { spaClick } from "./nav-helpers";
+import { spaClickSelector } from "./nav-helpers";
+import {
+  closeMobileDrawer,
+  drawerLinkSelector,
+  mobileSidebar,
+  openMobileDrawer,
+} from "./mobile-drawer-helpers";
 
 test.use({ viewport: { width: 390, height: 844 } });
 
@@ -46,52 +52,24 @@ const GETTING_STARTED = "/docs/getting-started";
 const GUIDES_INDEX_HREF = "/docs/guides";
 const GUIDES_PAGE_1_HREF = "/docs/guides/page-1";
 
-function mobileSidebar(page: Page) {
-  return page.locator("[data-zd-mobile-sidebar]");
-}
-
-/**
- * Open the mobile drawer via the hamburger, retrying the click as a unit.
- *
- * `SidebarToggle` is `Island({ when: "visible" })` — its `onClick` only
- * exists once the island has hydrated, and the zfb runtime dispatches no
- * event and mutates no DOM attribute on mount completion, so there is no
- * better signal to poll. A click issued before hydration is silently
- * dropped. Retrying the click-and-check as a unit via `toPass` (mirrors
- * `theme-pack-helpers.ts`'s `openFlyout`) makes a dropped first click
- * self-heal instead of flaking — and succeeding at all proves hydration
- * completed. Module evaluation (which runs `ensureNestedIslandPropsRefresh`
- * as a side effect, `sidebar-toggle-island/index.tsx:20`) strictly precedes
- * the mount call in zfb's island-mount chain, so "the button is clickable"
- * is a safe proxy for "the before-swap refresh listener is registered" —
- * navigating before this wait is the documented uncovered race
- * (`nested-island-props-refresh.ts`'s "Known gap" comment) and would make
- * the whole regression proof meaningless.
- */
-async function openMobileDrawer(page: Page): Promise<void> {
-  const hamburger = page.locator('button[aria-label="Open sidebar"]');
-  const closeButton = page.locator('button[aria-label="Close sidebar"]');
-  await expect(async () => {
-    await hamburger.click();
-    await expect(closeButton).toBeVisible({ timeout: 500 });
-  }).toPass({ timeout: 10000 });
-}
-
-/**
- * Close the drawer via the backdrop overlay, not the hamburger button.
- *
- * `z-modal-backdrop` (50) sits ABOVE the header's `z-toolbar` (20) by design
- * (`sidebar-toggle-island/index.tsx`'s backdrop comment) — the open drawer
- * is a modal surface that dims the whole viewport, hamburger included. A
- * real pointer click therefore cannot land on the "Close sidebar" button
- * while the drawer is open (mirrors `smoke-mobile-sidebar.spec.ts`'s
- * "clicking backdrop closes the sidebar" test, which dispatches directly on
- * the backdrop for the same reason).
- */
-async function closeMobileDrawer(page: Page): Promise<void> {
-  await page.locator("header div.fixed.inset-0").dispatchEvent("click");
-  await expect(page.locator('button[aria-label="Open sidebar"]')).toBeVisible({ timeout: 5000 });
-}
+// Drawer plumbing lives in the shared helper module (`mobile-drawer-helpers.ts`).
+// Two rationale notes specific to THIS spec:
+//
+//   - `openMobileDrawer` succeeding is also the hydration gate for the
+//     regression proof: module evaluation (which runs
+//     `ensureNestedIslandPropsRefresh` as a side effect,
+//     `sidebar-toggle-island/index.tsx`) strictly precedes the mount call in
+//     zfb's island-mount chain, so "the button is clickable" is a safe proxy
+//     for "the before-swap refresh listener is registered" — navigating
+//     before this wait is the documented uncovered race
+//     (`nested-island-props-refresh.ts`'s "Known gap" comment) and would make
+//     the whole regression proof meaningless.
+//
+//   - The SPA clicks MUST go through `drawerLinkSelector`: the bare-href
+//     `spaClick` takes the first document-order `a[href]` match, and any
+//     header re-composition could silently move that onto the hidden desktop
+//     `Learn` link — leaving this spec green without ever exercising the
+//     drawer path it exists to prove.
 
 interface HeaderPersistSnapshot {
   marker: number;
@@ -132,6 +110,11 @@ test.describe("Mobile drawer: cross-section soft-navigation regression (#3525/#3
   test("drawer tree and active marker refresh after a cross-section SPA swap, header persist intact", async ({
     page,
   }) => {
+    // The journey's own step budgets (4 drawer opens at 10s each, 2 swap waits
+    // at 10s each, a close at 5s) sum well past Playwright's 30s default; a
+    // single slow-CI hydration retry would otherwise kill the test mid-journey
+    // with a timeout that says nothing about the regression under test.
+    test.setTimeout(90_000);
     await page.goto(GETTING_STARTED, { waitUntil: "domcontentloaded" });
 
     // ---- Step 1: origin baseline --------------------------------------
@@ -153,6 +136,10 @@ test.describe("Mobile drawer: cross-section soft-navigation regression (#3525/#3
     ).toHaveCount(0);
 
     const baseline = await tagHeaderForPersistCheck(page);
+    expect(
+      baseline.viewTransitionName,
+      "persisted header should carry a real view-transition-name (features.css assigns zfb-header) — a 'none' baseline would make every later comparison vacuous",
+    ).not.toBe("none");
 
     // ---- Step 2: close, reopen, soft-navigate cross-section via the
     // drawer's root menu (the only cross-section path at this viewport) --
@@ -163,7 +150,10 @@ test.describe("Mobile drawer: cross-section soft-navigation regression (#3525/#3
     const learnLink = sidebarPanel.getByRole("link", { name: "Learn", exact: true });
     await expect(learnLink, "root menu should list the guides section's entry point").toBeVisible();
 
-    const crossSectionSwapFired = await spaClick(page, GUIDES_INDEX_HREF);
+    const crossSectionSwapFired = await spaClickSelector(
+      page,
+      drawerLinkSelector(GUIDES_INDEX_HREF),
+    );
     expect(crossSectionSwapFired, "zfb:after-swap did not fire for the cross-section hop").toBe(
       true,
     );
@@ -190,7 +180,10 @@ test.describe("Mobile drawer: cross-section soft-navigation regression (#3525/#3
       "destination guides leaf should now be present in the reopened tree",
     ).toBeVisible();
 
-    const sameSectionSwapFired = await spaClick(page, GUIDES_PAGE_1_HREF);
+    const sameSectionSwapFired = await spaClickSelector(
+      page,
+      drawerLinkSelector(GUIDES_PAGE_1_HREF),
+    );
     expect(sameSectionSwapFired, "zfb:after-swap did not fire for the same-section hop").toBe(
       true,
     );
@@ -221,12 +214,21 @@ test.describe("Mobile drawer: cross-section soft-navigation regression (#3525/#3
       "header viewTransitionName should still be unchanged at the end of the journey",
     ).toBe(baseline.viewTransitionName);
 
-    const navigationEntryCount = await page.evaluate(
-      () => performance.getEntriesByType("navigation").length,
+    // The Navigation Timing timeline is per-document, so a hard load does NOT
+    // "add a second entry" — it replaces the document and resets the timeline
+    // to exactly one entry again. The count alone can never catch one; the
+    // single entry's URL can: it must still be the journey's ORIGIN, whereas a
+    // hard load at any hop would leave that hop's URL here instead.
+    const navigationEntryUrls = await page.evaluate(() =>
+      performance.getEntriesByType("navigation").map((entry) => entry.name),
     );
     expect(
-      navigationEntryCount,
-      "exactly one Navigation Timing entry should exist for the whole journey — a hard load at any hop would add a second",
-    ).toBe(1);
+      navigationEntryUrls,
+      "exactly one Navigation Timing entry should exist for the whole journey",
+    ).toHaveLength(1);
+    expect(
+      navigationEntryUrls[0],
+      "the only hard load should be the journey's origin — this is the automated proxy for the source issue's softness proof",
+    ).toContain(GETTING_STARTED);
   });
 });

--- a/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
+++ b/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
@@ -707,19 +707,40 @@ describe("A2 no-stub: injected routes render correct HTML (packageOwnedRoutes:tr
   // All of it traces to this one intentional, self-contained toolchain
   // change; no unattributed bytes.
 
+  // 2026-08-19 re-baseline (Drawer Refresh epic, zudolab/zudo-doc#3525, wave-3
+  // confirm sub #3532): all three pages moved by a page-independent delta —
+  // the same shape as the #3401 entry above. Root cause: #3530 (nested-island
+  // props-refresh at the before-swap seam) adds a new module
+  // `transitions/nested-island-props-refresh.ts` and wires it in from
+  // `sidebar-toggle-island/index.tsx` (`ensureNestedIslandPropsRefresh()`,
+  // called at module scope). That island ships inside this fixture's bundled
+  // islands chunk (confirmed by grepping a fresh build's
+  // `assets/islands-<hash>.js` for `SidebarToggle`), so the source change
+  // shifts the chunk's content hash — and therefore the hashed filename string
+  // (`assets/islands-<hash>.js`) embedded verbatim in every SSG page,
+  // unconditional and page-independent, exactly like the #3401 script-text
+  // deltas above. `header.tsx`/`transitions/index.ts`/`eject/index.ts` deltas
+  // in this same epic (#3530's re-exported barrel entry + comment updates)
+  // are comment/type-only and contribute no bytes. The sibling sub #3531 (new
+  // e2e spec `smoke-mobile-drawer-section-swap.spec.ts`) touches only test
+  // code and is likewise inert here.
+  //
+  // All of it traces to this one intentional, already-merged epic change; no
+  // unattributed bytes.
+
   it("parity: /404.html normalized-HTML sha256 is stable (stub-defaults path)", () => {
     const html = readBuiltHtml(fixtureDir, "404.html");
-    expect(sha256Html(html)).toMatchInlineSnapshot(`"277bff98a8c915d0fb39ef864d8e1273ccd17a0defc944464a7ec6bc87765de3"`);
+    expect(sha256Html(html)).toMatchInlineSnapshot(`"22bb416fb0002eb35b555051c73f7b9be5930a83f6ef0e0cda5b6acfd07c1050"`);
   });
 
   it("parity: /docs/getting-started/index.html normalized-HTML sha256 is stable (stub-defaults path)", () => {
     const html = readBuiltHtml(fixtureDir, "docs/getting-started/index.html");
-    expect(sha256Html(html)).toMatchInlineSnapshot(`"6bf7926f9e25707b8de53c3d2be276253f138497e54eb44d7046c05db56c297d"`);
+    expect(sha256Html(html)).toMatchInlineSnapshot(`"b0e72a15f55df682905b7b7c8f544e428ac440f2e04cec7ee266769a2c276f9a"`);
   });
 
   it("parity: /docs/getting-started/coverage/index.html normalized-HTML sha256 is stable (new page, #3179)", () => {
     const html = readBuiltHtml(fixtureDir, "docs/getting-started/coverage/index.html");
-    expect(sha256Html(html)).toMatchInlineSnapshot(`"5d1f4635a82eff94ffac690a0e37801f3103466654c6f135340579ae22bce709"`);
+    expect(sha256Html(html)).toMatchInlineSnapshot(`"e1bb7893dd3264b1449b93d8940000cf19b5adcb777be419613b660c3e6d958b"`);
   });
 });
 

--- a/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
+++ b/packages/zudo-doc/src/__tests__/route-injection-build.slow.test.ts
@@ -728,6 +728,19 @@ describe("A2 no-stub: injected routes render correct HTML (packageOwnedRoutes:tr
   // All of it traces to this one intentional, already-merged epic change; no
   // unattributed bytes.
 
+  // 2026-08-20 (same epic, review fix — NO re-baseline needed): `applyProps`
+  // in `transitions/nested-island-props-refresh.ts` now also sets
+  // `data-zfb-island-remount` (the in-flight-import race fix), and
+  // `sidebar-toggle-island/index.tsx` imports the ensure helper through the
+  // transitions barrel instead of the deep path. A fresh run confirmed the
+  // three hashes below are unmoved: the changed bytes live INSIDE the islands
+  // chunk, and `parity-html-normalize.mjs` replaces hashed asset filenames
+  // with stable placeholders, so chunk-content changes are inert here. (That
+  // also means the entry above's "shifts the hashed filename embedded in
+  // every page" mechanism cannot be what moved these hashes on 2026-08-19 —
+  // the movement must have come from other non-normalized bytes of the same
+  // epic change.)
+
   it("parity: /404.html normalized-HTML sha256 is stable (stub-defaults path)", () => {
     const html = readBuiltHtml(fixtureDir, "404.html");
     expect(sha256Html(html)).toMatchInlineSnapshot(`"22bb416fb0002eb35b555051c73f7b9be5930a83f6ef0e0cda5b6acfd07c1050"`);

--- a/packages/zudo-doc/src/eject/index.ts
+++ b/packages/zudo-doc/src/eject/index.ts
@@ -271,6 +271,11 @@ export interface ZudoDocJson {
 //   re-export all page-events symbols (BEFORE_NAVIGATE_EVENT, AFTER_NAVIGATE_EVENT,
 //   onBeforeNavigate, onAfterNavigate), so the rewrite is safe — callers importing
 //   only those symbols from `@takazudo/zudo-doc/transitions` will find them.
+//   The same obligation now covers `ensureNestedIslandPropsRefresh`, which
+//   `sidebar-toggle-island` imports from `../transitions/nested-island-props-refresh.js`
+//   (zudolab/zudo-doc#3530): anything an ejectable component reaches for under
+//   `../transitions/` must be re-exported by that barrel, whatever file it
+//   actually lives in.
 
 /**
  * Rewrite parent-relative cross-component imports (`../<seg>/<rest>`) to

--- a/packages/zudo-doc/src/eject/index.ts
+++ b/packages/zudo-doc/src/eject/index.ts
@@ -272,10 +272,11 @@ export interface ZudoDocJson {
 //   onBeforeNavigate, onAfterNavigate), so the rewrite is safe — callers importing
 //   only those symbols from `@takazudo/zudo-doc/transitions` will find them.
 //   The same obligation now covers `ensureNestedIslandPropsRefresh`, which
-//   `sidebar-toggle-island` imports from `../transitions/nested-island-props-refresh.js`
+//   `sidebar-toggle-island` imports from `../transitions/index.js`
 //   (zudolab/zudo-doc#3530): anything an ejectable component reaches for under
 //   `../transitions/` must be re-exported by that barrel, whatever file it
-//   actually lives in.
+//   actually lives in — the rewrite collapses every `../transitions/<rest>`
+//   specifier to `@takazudo/zudo-doc/transitions`.
 
 /**
  * Rewrite parent-relative cross-component imports (`../<seg>/<rest>`) to

--- a/packages/zudo-doc/src/header/header.tsx
+++ b/packages/zudo-doc/src/header/header.tsx
@@ -310,10 +310,15 @@ export function Header(props: HeaderProps): JSX.Element {
       //   - Search: <site-search> custom element re-registers on
       //     AFTER_NAVIGATE_EVENT (_search-widget-script.ts:184, verified (a))
       //   - SidebarToggle (mobile): closes on AFTER_NAVIGATE_EVENT
-      //     (sidebar-toggle.tsx:72, verified (a); sidebar content is
-      //     re-serialised into Island data-props on every SSR render, so
-      //     same-locale swaps see stale SSR in the persist window but the
-      //     Island re-hydrates with correct nodes on mount)
+      //     (sidebar-toggle-island/index.tsx, verified (a)). Its section tree
+      //     rides the Island's serialised data-props, and re-hydration alone
+      //     does NOT correct it — the header is lifted verbatim, so the Island
+      //     re-mounts from the OLD props (zudolab/zudo-doc#3525). What corrects
+      //     it is `ensureNestedIslandPropsRefresh`
+      //     (transitions/nested-island-props-refresh.ts, registered from the
+      //     island module): on BEFORE_SWAP_EVENT it copies the incoming
+      //     document's data-props onto the live nested islands, and
+      //     mountNewIslands re-reads the attribute at mount time (#3530)
       //   - Header nav + aria-current: NAV_OVERFLOW_SCRIPT re-runs on
       //     AFTER_NAVIGATE_EVENT (nav-overflow-script.ts:198, verified (a))
       //   - LanguageSwitcher: its target hrefs ARE per-page (the equivalent

--- a/packages/zudo-doc/src/sidebar-toggle-island/index.tsx
+++ b/packages/zudo-doc/src/sidebar-toggle-island/index.tsx
@@ -8,8 +8,16 @@ import { useState, useEffect } from "preact/hooks";
 // After zudolab/zudo-doc#1335 the host components pull lifecycle event names
 // from the v2 transitions module rather than hard-coding `astro:*` literals.
 import { AFTER_NAVIGATE_EVENT } from "../transitions/index.js";
+import { ensureNestedIslandPropsRefresh } from "../transitions/nested-island-props-refresh.js";
 import { SidebarTree } from "../sidebar-tree-island/index.js";
 import type { SidebarNavNode, SidebarRootMenuItem, SidebarLocaleLink } from "../sidebar/types.js";
+
+// This island lives INSIDE the persisted `<header>`, so a same-locale swap
+// lifts it verbatim and would re-mount it from the previous page's serialized
+// props (zudolab/zudo-doc#3525). The refresh has to outlive the island's own
+// mount/unmount cycle across a swap, so it is installed at document lifetime
+// here rather than from an effect. SSR evaluation is a safe no-op.
+ensureNestedIslandPropsRefresh();
 
 const cx = (...classes: Array<string | false | null | undefined>) =>
   classes.filter(Boolean).join(" ");

--- a/packages/zudo-doc/src/sidebar-toggle-island/index.tsx
+++ b/packages/zudo-doc/src/sidebar-toggle-island/index.tsx
@@ -7,8 +7,12 @@
 import { useState, useEffect } from "preact/hooks";
 // After zudolab/zudo-doc#1335 the host components pull lifecycle event names
 // from the v2 transitions module rather than hard-coding `astro:*` literals.
-import { AFTER_NAVIGATE_EVENT } from "../transitions/index.js";
-import { ensureNestedIslandPropsRefresh } from "../transitions/nested-island-props-refresh.js";
+// `ensureNestedIslandPropsRefresh` is imported through the barrel (not the
+// deep `./nested-island-props-refresh.js` path) on purpose: eject rewrites
+// EVERY `../transitions/<anything>.js` import to the single specifier
+// `@takazudo/zudo-doc/transitions`, so two distinct relative imports would
+// collapse into duplicate import statements in an ejected copy.
+import { AFTER_NAVIGATE_EVENT, ensureNestedIslandPropsRefresh } from "../transitions/index.js";
 import { SidebarTree } from "../sidebar-tree-island/index.js";
 import type { SidebarNavNode, SidebarRootMenuItem, SidebarLocaleLink } from "../sidebar/types.js";
 

--- a/packages/zudo-doc/src/transitions/__tests__/nested-island-props-refresh.test.ts
+++ b/packages/zudo-doc/src/transitions/__tests__/nested-island-props-refresh.test.ts
@@ -1,0 +1,363 @@
+/** @vitest-environment happy-dom */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BEFORE_SWAP_EVENT } from "../page-events.js";
+import {
+  disposeNestedIslandPropsRefresh,
+  ensureNestedIslandPropsRefresh,
+  installNestedIslandPropsRefresh,
+} from "../nested-island-props-refresh.js";
+
+const PERSIST_ATTR = "data-zfb-transition-persist";
+const ISLAND_ATTR = "data-zfb-island";
+const PROPS_ATTR = "data-props";
+
+/** Props serialization is opaque to the helper, so any stable string will do. */
+const oldTree = '{"nodes":[{"slug":"guides/a"}]}';
+const newTree = '{"nodes":[{"slug":"reference/b"}]}';
+
+function setLiveBody(html: string): void {
+  document.body.innerHTML = html;
+}
+
+/** Mirror the router: the incoming side is a separately parsed Document. */
+function parseIncoming(bodyHtml: string): Document {
+  return new DOMParser().parseFromString(
+    `<!doctype html><html><head></head><body>${bodyHtml}</body></html>`,
+    "text/html",
+  );
+}
+
+/** Dispatch the REAL `zfb:before-swap` event the router fires. */
+function dispatchBeforeSwap(newDocument: unknown): void {
+  const event = new Event(BEFORE_SWAP_EVENT);
+  Object.assign(event, { newDocument });
+  document.dispatchEvent(event);
+}
+
+function island(name: string, props?: string): string {
+  const propsAttr = props === undefined ? "" : ` ${PROPS_ATTR}='${props}'`;
+  return `<div ${ISLAND_ATTR}="${name}"${propsAttr}></div>`;
+}
+
+function header(persistKey: string, inner: string): string {
+  return `<header ${PERSIST_ATTR}="${persistKey}">${inner}</header>`;
+}
+
+function liveIsland(name: string): Element {
+  const element = document.querySelector(`[${ISLAND_ATTR}="${name}"]`);
+  if (!element) throw new Error(`No live island named ${name}`);
+  return element;
+}
+
+// The module-level singleton registry and the happy-dom `document` both outlive
+// a single test, so every direct install has to be torn down or its listener
+// leaks into the next case and quietly refreshes what that case asserts stays
+// stale.
+const pendingDisposers: Array<() => void> = [];
+
+function install(): () => void {
+  const dispose = installNestedIslandPropsRefresh({ document });
+  pendingDisposers.push(dispose);
+  return dispose;
+}
+
+afterEach(() => {
+  while (pendingDisposers.length > 0) pendingDisposers.pop()?.();
+  disposeNestedIslandPropsRefresh(document);
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("nested-island props refresh on zfb:before-swap", () => {
+  it("refreshes a nested island inside a persisted root paired by exact key", () => {
+    install();
+    setLiveBody(header("header-en", island("SidebarToggle", oldTree)));
+
+    dispatchBeforeSwap(
+      parseIncoming(header("header-en", island("SidebarToggle", newTree))),
+    );
+
+    expect(liveIsland("SidebarToggle").getAttribute(PROPS_ATTR)).toBe(newTree);
+  });
+
+  it("pairs roots by key, not by document position", () => {
+    install();
+    setLiveBody(
+      header("header-en", island("SidebarToggle", oldTree)) +
+        header("footer-en", island("FooterNav", oldTree)),
+    );
+
+    // Incoming emits the same two keys in the OPPOSITE order. Positional
+    // matching would cross-assign the footer's props onto the header island.
+    dispatchBeforeSwap(
+      parseIncoming(
+        header("footer-en", island("FooterNav", '{"footer":true}')) +
+          header("header-en", island("SidebarToggle", newTree)),
+      ),
+    );
+
+    expect(liveIsland("SidebarToggle").getAttribute(PROPS_ATTR)).toBe(newTree);
+    expect(liveIsland("FooterNav").getAttribute(PROPS_ATTR)).toBe('{"footer":true}');
+  });
+
+  it("does not refresh across different locale keys", () => {
+    install();
+    setLiveBody(header("header-en", island("SidebarToggle", oldTree)));
+
+    // A cross-locale hop: zfb replaces the header outright because the keys
+    // differ, so there is nothing for this helper to pair.
+    dispatchBeforeSwap(
+      parseIncoming(header("header-ja", island("SidebarToggle", newTree))),
+    );
+
+    expect(liveIsland("SidebarToggle").getAttribute(PROPS_ATTR)).toBe(oldTree);
+  });
+
+  it("skips a live persisted key with no incoming counterpart", () => {
+    install();
+    setLiveBody(header("header-en", island("SidebarToggle", oldTree)));
+
+    dispatchBeforeSwap(parseIncoming(island("SidebarToggle", newTree)));
+
+    expect(liveIsland("SidebarToggle").getAttribute(PROPS_ATTR)).toBe(oldTree);
+  });
+
+  it("skips a persist key duplicated in the live document", () => {
+    install();
+    setLiveBody(
+      header("header-en", island("SidebarToggle", oldTree)) +
+        header("header-en", island("ThemeToggle", oldTree)),
+    );
+
+    dispatchBeforeSwap(
+      parseIncoming(header("header-en", island("SidebarToggle", newTree))),
+    );
+
+    expect(liveIsland("SidebarToggle").getAttribute(PROPS_ATTR)).toBe(oldTree);
+  });
+
+  it("skips a persist key duplicated in the incoming document", () => {
+    install();
+    setLiveBody(header("header-en", island("SidebarToggle", oldTree)));
+
+    dispatchBeforeSwap(
+      parseIncoming(
+        header("header-en", island("SidebarToggle", newTree)) +
+          header("header-en", island("SidebarToggle", '{"third":true}')),
+      ),
+    );
+
+    expect(liveIsland("SidebarToggle").getAttribute(PROPS_ATTR)).toBe(oldTree);
+  });
+
+  it("skips a name that appears twice inside one persisted root", () => {
+    install();
+    setLiveBody(
+      header(
+        "header-en",
+        island("SidebarToggle", oldTree) +
+          island("SidebarToggle", oldTree) +
+          island("ThemeToggle", '{"mode":"light"}'),
+      ),
+    );
+
+    // Incoming carries the same duplicate pair in the reverse order, plus a
+    // uniquely-named sibling that must still be refreshed.
+    dispatchBeforeSwap(
+      parseIncoming(
+        header(
+          "header-en",
+          island("SidebarToggle", '{"second":true}') +
+            island("SidebarToggle", newTree) +
+            island("ThemeToggle", '{"mode":"dark"}'),
+        ),
+      ),
+    );
+
+    const duplicates = document.querySelectorAll(
+      `[${ISLAND_ATTR}="SidebarToggle"]`,
+    );
+    for (const element of duplicates) {
+      expect(element.getAttribute(PROPS_ATTR)).toBe(oldTree);
+    }
+    expect(liveIsland("ThemeToggle").getAttribute(PROPS_ATTR)).toBe('{"mode":"dark"}');
+  });
+
+  it("excludes an island that carries its own persist attribute", () => {
+    install();
+    setLiveBody(
+      `<header ${PERSIST_ATTR}="header-en">` +
+        `<div ${ISLAND_ATTR}="SearchWidget" ${PERSIST_ATTR}="search" ${PROPS_ATTR}='${oldTree}'></div>` +
+        island("SidebarToggle", oldTree) +
+        `</header>`,
+    );
+
+    dispatchBeforeSwap(
+      parseIncoming(
+        `<header ${PERSIST_ATTR}="header-en">` +
+          `<div ${ISLAND_ATTR}="SearchWidget" ${PERSIST_ATTR}="search" ${PROPS_ATTR}='${newTree}'></div>` +
+          island("SidebarToggle", newTree) +
+          `</header>`,
+      ),
+    );
+
+    // zfb's own persisted-island props/remount path owns SearchWidget.
+    expect(liveIsland("SearchWidget").getAttribute(PROPS_ATTR)).toBe(oldTree);
+    expect(liveIsland("SidebarToggle").getAttribute(PROPS_ATTR)).toBe(newTree);
+  });
+
+  it("excludes an island owned by a nested persisted boundary", () => {
+    install();
+    setLiveBody(
+      `<header ${PERSIST_ATTR}="header-en">` +
+        island("SidebarToggle", oldTree) +
+        `<div ${PERSIST_ATTR}="inner-widget">${island("ThemeToggle", oldTree)}</div>` +
+        `</header>`,
+    );
+
+    dispatchBeforeSwap(
+      parseIncoming(
+        `<header ${PERSIST_ATTR}="header-en">` +
+          island("SidebarToggle", newTree) +
+          `<div ${PERSIST_ATTR}="inner-widget">${island("ThemeToggle", newTree)}</div>` +
+          `</header>`,
+      ),
+    );
+
+    expect(liveIsland("SidebarToggle").getAttribute(PROPS_ATTR)).toBe(newTree);
+    // ThemeToggle is unreachable from both directions: the outer root's group
+    // stops at the inner boundary, and the inner boundary is itself dropped as
+    // a refresh root because it sits inside another persisted element.
+    expect(liveIsland("ThemeToggle").getAttribute(PROPS_ATTR)).toBe(oldTree);
+  });
+
+  it("removes data-props when the incoming island has none", () => {
+    install();
+    setLiveBody(header("header-en", island("SidebarToggle", oldTree)));
+
+    dispatchBeforeSwap(
+      parseIncoming(header("header-en", island("SidebarToggle"))),
+    );
+
+    expect(liveIsland("SidebarToggle").hasAttribute(PROPS_ATTR)).toBe(false);
+  });
+
+  it("does not touch the attribute when the props are unchanged", () => {
+    install();
+    const themeProps = '{"defaultMode":"light"}';
+    setLiveBody(
+      header(
+        "header-en",
+        island("SidebarToggle", oldTree) + island("ThemeToggle", themeProps),
+      ),
+    );
+
+    // ThemeToggle's props are page-independent, so a swap re-serializes the
+    // identical string — that must not produce an attribute write.
+    const themeToggle = liveIsland("ThemeToggle");
+    const setAttribute = vi.spyOn(themeToggle, "setAttribute");
+    const removeAttribute = vi.spyOn(themeToggle, "removeAttribute");
+
+    dispatchBeforeSwap(
+      parseIncoming(
+        header(
+          "header-en",
+          island("SidebarToggle", newTree) + island("ThemeToggle", themeProps),
+        ),
+      ),
+    );
+
+    expect(setAttribute).not.toHaveBeenCalled();
+    expect(removeAttribute).not.toHaveBeenCalled();
+    expect(themeToggle.getAttribute(PROPS_ATTR)).toBe(themeProps);
+    expect(liveIsland("SidebarToggle").getAttribute(PROPS_ATTR)).toBe(newTree);
+  });
+
+  it("ignores an event whose newDocument is missing, foreign, or the live document", () => {
+    install();
+    setLiveBody(header("header-en", island("SidebarToggle", oldTree)));
+
+    dispatchBeforeSwap(undefined);
+    dispatchBeforeSwap(null);
+    dispatchBeforeSwap({ querySelectorAll: () => [] });
+    dispatchBeforeSwap(document);
+
+    expect(liveIsland("SidebarToggle").getAttribute(PROPS_ATTR)).toBe(oldTree);
+  });
+
+  it("stops refreshing after the installer's disposer runs", () => {
+    const dispose = install();
+    setLiveBody(header("header-en", island("SidebarToggle", oldTree)));
+
+    dispose();
+    dispatchBeforeSwap(
+      parseIncoming(header("header-en", island("SidebarToggle", newTree))),
+    );
+
+    expect(liveIsland("SidebarToggle").getAttribute(PROPS_ATTR)).toBe(oldTree);
+  });
+});
+
+describe("ensureNestedIslandPropsRefresh", () => {
+  it("installs exactly one listener however many times it is called", () => {
+    const addEventListener = vi.spyOn(document, "addEventListener");
+
+    ensureNestedIslandPropsRefresh({ document });
+    ensureNestedIslandPropsRefresh({ document });
+    ensureNestedIslandPropsRefresh({ document });
+
+    const registrations = addEventListener.mock.calls.filter(
+      ([type]) => type === BEFORE_SWAP_EVENT,
+    );
+    expect(registrations).toHaveLength(1);
+  });
+
+  it("still refreshes after repeated installation, and only once per island", () => {
+    ensureNestedIslandPropsRefresh({ document });
+    ensureNestedIslandPropsRefresh({ document });
+    setLiveBody(header("header-en", island("SidebarToggle", oldTree)));
+
+    const target = liveIsland("SidebarToggle");
+    const setAttribute = vi.spyOn(target, "setAttribute");
+
+    dispatchBeforeSwap(
+      parseIncoming(header("header-en", island("SidebarToggle", newTree))),
+    );
+
+    expect(setAttribute).toHaveBeenCalledTimes(1);
+    expect(target.getAttribute(PROPS_ATTR)).toBe(newTree);
+  });
+
+  it("can be disposed and re-installed", () => {
+    ensureNestedIslandPropsRefresh({ document });
+    setLiveBody(header("header-en", island("SidebarToggle", oldTree)));
+
+    disposeNestedIslandPropsRefresh(document);
+    dispatchBeforeSwap(
+      parseIncoming(header("header-en", island("SidebarToggle", newTree))),
+    );
+    expect(liveIsland("SidebarToggle").getAttribute(PROPS_ATTR)).toBe(oldTree);
+
+    ensureNestedIslandPropsRefresh({ document });
+    dispatchBeforeSwap(
+      parseIncoming(header("header-en", island("SidebarToggle", newTree))),
+    );
+    expect(liveIsland("SidebarToggle").getAttribute(PROPS_ATTR)).toBe(newTree);
+  });
+
+  it("disposing a document that was never installed is a no-op", () => {
+    expect(() => disposeNestedIslandPropsRefresh(document)).not.toThrow();
+  });
+
+  it("is reachable from the transitions barrel", async () => {
+    // `sidebar-toggle-island` is ejectable, and eject rewrites its
+    // `../transitions/nested-island-props-refresh.js` import to
+    // `@takazudo/zudo-doc/transitions`. If the barrel stops re-exporting this,
+    // every ejected project's drawer silently loses the refresh.
+    const barrel = await import("../index.js");
+    expect(barrel.ensureNestedIslandPropsRefresh).toBe(
+      ensureNestedIslandPropsRefresh,
+    );
+  });
+});

--- a/packages/zudo-doc/src/transitions/__tests__/nested-island-props-refresh.test.ts
+++ b/packages/zudo-doc/src/transitions/__tests__/nested-island-props-refresh.test.ts
@@ -11,6 +11,7 @@ import {
 const PERSIST_ATTR = "data-zfb-transition-persist";
 const ISLAND_ATTR = "data-zfb-island";
 const PROPS_ATTR = "data-props";
+const REMOUNT_ATTR = "data-zfb-island-remount";
 
 /** Props serialization is opaque to the helper, so any stable string will do. */
 const oldTree = '{"nodes":[{"slug":"guides/a"}]}';
@@ -79,6 +80,33 @@ describe("nested-island props refresh on zfb:before-swap", () => {
     );
 
     expect(liveIsland("SidebarToggle").getAttribute(PROPS_ATTR)).toBe(newTree);
+  });
+
+  it("flags a refreshed island for remount so an in-flight import re-reads props", () => {
+    // zfb's `fire()` snapshots `data-props` BEFORE its dynamic import starts;
+    // on resolve it uses that pre-navigation snapshot UNLESS
+    // `data-zfb-island-remount` is present. Without the flag, an import in
+    // flight across the swap mounts the OLD tree while the DOM attribute looks
+    // correct — #3525 reproduces invisibly.
+    install();
+    setLiveBody(header("header-en", island("SidebarToggle", oldTree)));
+
+    dispatchBeforeSwap(
+      parseIncoming(header("header-en", island("SidebarToggle", newTree))),
+    );
+
+    expect(liveIsland("SidebarToggle").getAttribute(REMOUNT_ATTR)).toBe("");
+  });
+
+  it("does not flag an island whose props are unchanged", () => {
+    install();
+    setLiveBody(header("header-en", island("SidebarToggle", oldTree)));
+
+    dispatchBeforeSwap(
+      parseIncoming(header("header-en", island("SidebarToggle", oldTree))),
+    );
+
+    expect(liveIsland("SidebarToggle").hasAttribute(REMOUNT_ATTR)).toBe(false);
   });
 
   it("pairs roots by key, not by document position", () => {
@@ -325,7 +353,8 @@ describe("ensureNestedIslandPropsRefresh", () => {
       parseIncoming(header("header-en", island("SidebarToggle", newTree))),
     );
 
-    expect(setAttribute).toHaveBeenCalledTimes(1);
+    const propsWrites = setAttribute.mock.calls.filter(([name]) => name === PROPS_ATTR);
+    expect(propsWrites).toHaveLength(1);
     expect(target.getAttribute(PROPS_ATTR)).toBe(newTree);
   });
 

--- a/packages/zudo-doc/src/transitions/index.ts
+++ b/packages/zudo-doc/src/transitions/index.ts
@@ -10,7 +10,6 @@
 //   - `page-events.ts` — navigation-lifecycle constants and subscribe
 //     helpers. With the SPA router, AFTER_NAVIGATE_EVENT fires after
 //     each same-document swap; BEFORE_NAVIGATE_EVENT fires before.
-
 //   - `nested-island-props-refresh.ts` — the document-lifetime helper that
 //     refreshes nested-island `data-props` at the `zfb:before-swap` seam
 //     (zudolab/zudo-doc#3530).

--- a/packages/zudo-doc/src/transitions/index.ts
+++ b/packages/zudo-doc/src/transitions/index.ts
@@ -11,9 +11,24 @@
 //     helpers. With the SPA router, AFTER_NAVIGATE_EVENT fires after
 //     each same-document swap; BEFORE_NAVIGATE_EVENT fires before.
 
+//   - `nested-island-props-refresh.ts` — the document-lifetime helper that
+//     refreshes nested-island `data-props` at the `zfb:before-swap` seam
+//     (zudolab/zudo-doc#3530).
+
 export {
   BEFORE_NAVIGATE_EVENT,
   AFTER_NAVIGATE_EVENT,
   onBeforeNavigate,
   onAfterNavigate,
 } from "./page-events.js";
+
+// `BEFORE_SWAP_EVENT` stays OUT of this barrel on purpose (see its JSDoc in
+// page-events.ts): its consumers need the raw event object's `newDocument`, not
+// a bare notification, so they import it from `./page-events.js` directly.
+//
+// The refresh helper's `ensure` entrypoint, by contrast, MUST be reachable
+// here. `sidebar-toggle-island` is ejectable, and eject rewrites every
+// parent-relative import `../<seg>/<rest>` to `@takazudo/zudo-doc/<seg>`
+// (`eject/index.ts`) — so the island's `../transitions/…` import lands on this
+// barrel in an ejected project and would otherwise resolve to nothing.
+export { ensureNestedIslandPropsRefresh } from "./nested-island-props-refresh.js";

--- a/packages/zudo-doc/src/transitions/nested-island-props-refresh.ts
+++ b/packages/zudo-doc/src/transitions/nested-island-props-refresh.ts
@@ -199,8 +199,10 @@ function collectUniqueOwnedIslands(root: Element): Map<string, Element> {
 
 /**
  * Index elements by an attribute value, keeping only values that occur exactly
- * once. Empty values are skipped: zfb emits a bare `data-zfb-island` before its
- * rewriter fills in the component name, and such a marker cannot be matched.
+ * once. An empty value is skipped rather than treated as a key of its own: zfb
+ * emits a bare `data-zfb-island` before its rewriter fills in the component
+ * name, and an empty persist key is likewise not an identity anything should be
+ * paired on.
  */
 function indexUniquely(
   elements: Iterable<Element>,

--- a/packages/zudo-doc/src/transitions/nested-island-props-refresh.ts
+++ b/packages/zudo-doc/src/transitions/nested-island-props-refresh.ts
@@ -1,0 +1,259 @@
+// Refresh nested-island `data-props` at the `zfb:before-swap` seam.
+//
+// The problem (zudolab/zudo-doc#3525, root cause in epic #3529)
+// ------------------------------------------------------------
+// The header carries `data-zfb-transition-persist="header-${lang}"`, so a
+// same-locale soft navigation LIFTS the live `<header>` element verbatim into
+// the incoming body instead of replacing it. zfb refreshes serialized props
+// only for a persisted element that is ITSELF an island root
+// (`swapBodyElement` → `data-zfb-island-remount`); `<header>` is not one, so
+// every island NESTED inside it keeps the `data-props` string that was
+// serialized for the page the user is leaving. The mobile drawer
+// (`SidebarToggle`) is such a nested island, so after a cross-section hop it
+// re-mounts from the previous section's tree — stale nodes, and a stale active
+// marker on top (`useActiveSlug` in `sidebar-tree-island/index.tsx` keeps the
+// existing slug when re-derivation against a stale tree yields `undefined`, so
+// correcting the nodes corrects the marker too).
+//
+// Why the fix belongs on `zfb:before-swap`
+// ----------------------------------------
+// The router's swap sequence (`@takazudo/zfb-runtime`
+// `client-router/router.js`) is:
+//
+//   cancelPendingIslands() → unmountIslands(document.body, incoming.body)
+//   → doSwap() [dispatches `zfb:before-swap`, then swapBodyElement()]
+//   → … → mountNewIslands()
+//
+// By the time `zfb:before-swap` dispatches, the nested islands have already
+// been torn down (they carry no persist attribute of their own, so
+// `unmountIslands` does NOT skip them), and `mountNewIslands` re-reads
+// `data-props` from the DOM at mount time. So writing the incoming value onto
+// the live element in this window is picked up on the next mount with no extra
+// remount flag and no second render.
+//
+// This helper imports `BEFORE_SWAP_EVENT` straight from `./page-events.js`
+// rather than through `./index.js`: the barrel deliberately does not re-export
+// it, because consumers of this event need the raw event object's
+// `newDocument` rather than a bare notification. `theme/theme-pack-provider.tsx`
+// — the #3136/#3137 precedent for mutating `event.newDocument` on this event —
+// imports it the same way.
+//
+// Known gap: the pre-hydration race
+// ---------------------------------
+// Registration happens as a side effect of importing the `SidebarToggle`
+// island module, and that island is `when: "visible"` — so on a page where the
+// hamburger has never become visible (desktop viewport, or a soft navigation
+// performed before the drawer bundle loaded) no listener is installed and that
+// swap goes unrefreshed. This is accepted rather than worked around: before
+// the drawer's first hydration there is no stale mounted state to correct, and
+// whatever `data-props` the header is carrying at that point is re-read from
+// scratch on the first mount that does happen.
+
+import { BEFORE_SWAP_EVENT } from "./page-events.js";
+
+/** zfb's persisted-element marker; the pairing key for live ↔ incoming roots. */
+const PERSIST_ATTR = "data-zfb-transition-persist";
+
+/** zfb's SSR island marker; its value is the component name. */
+const ISLAND_ATTR = "data-zfb-island";
+
+/** zfb's serialized-props attribute; opaque to this module. */
+const PROPS_ATTR = "data-props";
+
+/** `Node.DOCUMENT_NODE`, spelled out so no DOM global is needed under SSR. */
+const DOCUMENT_NODE = 9;
+
+interface NestedIslandPropsRefreshOptions {
+  document: Document;
+}
+
+const installedControllers = new WeakMap<Document, () => void>();
+
+/**
+ * Install the before-swap props-refresh listener on a document.
+ *
+ * This low-level entrypoint owns an explicit cleanup for focused tests and
+ * non-singleton hosts. Browser modules use the durable, duplicate-safe
+ * `ensureNestedIslandPropsRefresh` wrapper below instead.
+ */
+export function installNestedIslandPropsRefresh({
+  document,
+}: NestedIslandPropsRefreshOptions): () => void {
+  const onBeforeSwap = (event: Event) => {
+    const incoming = (event as Event & { newDocument?: unknown }).newDocument;
+    // A missing or non-Document `newDocument` (a synthetic dispatch, a future
+    // runtime that renames the field) means there is nothing to copy FROM, and
+    // `newDocument === document` would make every island its own source. Both
+    // are no-ops rather than throws — but note this is a targeted guard, not a
+    // try/catch around the refresh: a bug inside `refreshNestedIslandProps`
+    // must still surface.
+    if (!isDocument(incoming) || incoming === document) return;
+    refreshNestedIslandProps(document, incoming);
+  };
+
+  document.addEventListener(BEFORE_SWAP_EVENT, onBeforeSwap);
+  return () => document.removeEventListener(BEFORE_SWAP_EVENT, onBeforeSwap);
+}
+
+/**
+ * Install exactly one document-lifetime controller for a browser document.
+ * Repeated calls from component renders or duplicate boot paths are no-ops.
+ */
+export function ensureNestedIslandPropsRefresh(
+  options?: NestedIslandPropsRefreshOptions,
+): void {
+  const resolved = options ?? resolveBrowserOptions();
+  if (!resolved || installedControllers.has(resolved.document)) return;
+  installedControllers.set(
+    resolved.document,
+    installNestedIslandPropsRefresh(resolved),
+  );
+}
+
+/** Test/HMR teardown for a controller installed through the singleton wrapper. */
+export function disposeNestedIslandPropsRefresh(document: Document): void {
+  installedControllers.get(document)?.();
+  installedControllers.delete(document);
+}
+
+/**
+ * Copy `data-props` from the incoming document onto the live nested islands
+ * that are about to be lifted through the swap.
+ *
+ * Matching contract, in order:
+ *   1. Pair persisted ROOTS by exact `data-zfb-transition-persist` value. A key
+ *      that is missing on either side, or duplicated on either side, is
+ *      skipped — there is no defensible pairing for it.
+ *   2. Within a paired root, group the islands it OWNS by island name.
+ *   3. Refresh only names that resolve to exactly one island on both sides.
+ *
+ * Position is never used: the live and incoming DOM are different renders of
+ * different pages, so ordinal alignment would silently cross-assign props the
+ * moment a conditional island appears or disappears.
+ */
+function refreshNestedIslandProps(
+  liveDocument: Document,
+  incomingDocument: Document,
+): void {
+  const liveRoots = collectRefreshableRoots(liveDocument);
+  if (liveRoots.size === 0) return;
+  const incomingRoots = collectRefreshableRoots(incomingDocument);
+
+  for (const [persistKey, liveRoot] of liveRoots) {
+    const incomingRoot = incomingRoots.get(persistKey);
+    if (!incomingRoot) continue;
+
+    const incomingIslands = collectUniqueOwnedIslands(incomingRoot);
+    if (incomingIslands.size === 0) continue;
+
+    for (const [name, liveIsland] of collectUniqueOwnedIslands(liveRoot)) {
+      const incomingIsland = incomingIslands.get(name);
+      if (!incomingIsland) continue;
+      applyProps(liveIsland, incomingIsland);
+    }
+  }
+}
+
+/**
+ * Map each `data-zfb-transition-persist` value to the element this helper may
+ * refresh through, dropping two kinds of entry:
+ *
+ *   - a value that appears more than once in the document — a duplicated
+ *     persist key is ambiguous, and zfb's swap treats the key as an identity;
+ *   - a persisted element nested inside another persisted element. zfb lifts
+ *     persisted nodes individually (`swapBodyElement`), so a nested one is
+ *     either an island root whose props it refreshes itself, or a degenerate
+ *     case whose lift it cannot place coherently. Either way this helper stays
+ *     out — which is also what makes the islands under such a boundary
+ *     unreachable from every direction, not just from the outer root's group.
+ */
+function collectRefreshableRoots(doc: Document): Map<string, Element> {
+  const roots = indexUniquely(
+    doc.querySelectorAll(`[${PERSIST_ATTR}]`),
+    PERSIST_ATTR,
+  );
+  for (const [persistKey, element] of roots) {
+    if (element.parentElement?.closest(`[${PERSIST_ATTR}]`)) {
+      roots.delete(persistKey);
+    }
+  }
+  return roots;
+}
+
+/**
+ * Map island name → island element for the islands `root` OWNS, dropping names
+ * that appear more than once inside it.
+ *
+ * `closest` starts at the element itself, so the single ancestor-or-self check
+ * covers both exclusions the contract calls for: an island carrying its own
+ * persist attribute, and an island sitting inside a NESTED persisted boundary.
+ * In either case zfb's persisted-island props/remount path already owns that
+ * element's refresh, and this helper must not compete with it.
+ */
+function collectUniqueOwnedIslands(root: Element): Map<string, Element> {
+  const owned = Array.from(root.querySelectorAll(`[${ISLAND_ATTR}]`)).filter(
+    (island) => island.closest(`[${PERSIST_ATTR}]`) === root,
+  );
+  return indexUniquely(owned, ISLAND_ATTR);
+}
+
+/**
+ * Index elements by an attribute value, keeping only values that occur exactly
+ * once. Empty values are skipped: zfb emits a bare `data-zfb-island` before its
+ * rewriter fills in the component name, and such a marker cannot be matched.
+ */
+function indexUniquely(
+  elements: Iterable<Element>,
+  attribute: string,
+): Map<string, Element> {
+  const byValue = new Map<string, Element>();
+  const duplicated = new Set<string>();
+  for (const element of elements) {
+    const value = element.getAttribute(attribute);
+    if (!value) continue;
+    if (byValue.has(value)) {
+      duplicated.add(value);
+      continue;
+    }
+    byValue.set(value, element);
+  }
+  for (const value of duplicated) byValue.delete(value);
+  return byValue;
+}
+
+/**
+ * Mirror the incoming island's `data-props` onto the live one. The value is
+ * treated as opaque serialized data — never parsed, never merged — so this
+ * stays correct whatever zfb's serialization format is. An absent incoming
+ * attribute means the incoming render has no props, which must REMOVE the live
+ * attribute rather than leave the previous page's value in place.
+ */
+function applyProps(liveIsland: Element, incomingIsland: Element): void {
+  const incoming = incomingIsland.getAttribute(PROPS_ATTR);
+  const current = liveIsland.getAttribute(PROPS_ATTR);
+  if (incoming === current) return;
+  if (incoming === null) {
+    liveIsland.removeAttribute(PROPS_ATTR);
+    return;
+  }
+  liveIsland.setAttribute(PROPS_ATTR, incoming);
+}
+
+/**
+ * Structural Document check. `instanceof Document` is unreliable here: the
+ * incoming document is parsed by the router and, in tests, comes from a DOM
+ * implementation whose constructor is not the ambient global.
+ */
+function isDocument(value: unknown): value is Document {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Partial<Document>;
+  return (
+    candidate.nodeType === DOCUMENT_NODE &&
+    typeof candidate.querySelectorAll === "function"
+  );
+}
+
+function resolveBrowserOptions(): NestedIslandPropsRefreshOptions | undefined {
+  if (typeof document === "undefined") return undefined;
+  return { document };
+}

--- a/packages/zudo-doc/src/transitions/nested-island-props-refresh.ts
+++ b/packages/zudo-doc/src/transitions/nested-island-props-refresh.ts
@@ -44,10 +44,16 @@
 // island module, and that island is `when: "visible"` — so on a page where the
 // hamburger has never become visible (desktop viewport, or a soft navigation
 // performed before the drawer bundle loaded) no listener is installed and that
-// swap goes unrefreshed. This is accepted rather than worked around: before
-// the drawer's first hydration there is no stale mounted state to correct, and
-// whatever `data-props` the header is carrying at that point is re-read from
-// scratch on the first mount that does happen.
+// swap goes unrefreshed. Nothing else refreshes a persisted header's nested
+// `data-props`, so an unrefreshed swap leaves the value serialized for the page
+// where the header FIRST rendered — and a drawer that hydrates only later
+// (e.g. a desktop → mobile viewport change after several soft navigations)
+// mounts from that original page's tree. This is accepted rather than worked
+// around: in this package's bundled-islands build the chunk containing this
+// module loads with the first island that hydrates on page one, so in practice
+// the listener is installed before the first swap; closing the residual
+// per-island-bundle gap would require registration from an always-loaded
+// module instead of this lazy island's own bundle.
 
 import { BEFORE_SWAP_EVENT } from "./page-events.js";
 
@@ -60,6 +66,20 @@ const ISLAND_ATTR = "data-zfb-island";
 /** zfb's serialized-props attribute; opaque to this module. */
 const PROPS_ATTR = "data-props";
 
+/**
+ * zfb's cross-package "needs-remount" flag (`clearMountedForRemount` /
+ * `fire()` in `@takazudo/zfb`'s runtime). Load-bearing for one race: an island
+ * whose dynamic import is still in flight when the swap happens. `fire()`
+ * snapshots `readProps(element)` BEFORE the import starts, and on resolve uses
+ * that pre-navigation snapshot UNLESS this flag is present — with the flag it
+ * re-reads `data-props` at resolve time, which is exactly the runtime's
+ * documented channel for "a props refresh that happened during the import".
+ * For the common already-unmounted island, `mountNewIslands` consumes and
+ * clears the flag before a normal fresh-props mount, so setting it is a no-op
+ * there.
+ */
+const ISLAND_REMOUNT_ATTR = "data-zfb-island-remount";
+
 /** `Node.DOCUMENT_NODE`, spelled out so no DOM global is needed under SSR. */
 const DOCUMENT_NODE = 9;
 
@@ -67,6 +87,9 @@ interface NestedIslandPropsRefreshOptions {
   document: Document;
 }
 
+// The install/ensure/dispose document-singleton shape below mirrors
+// `sidebar-tree-island/sidebar-scroll-preserve.ts` — keep the two in step (or
+// extract a shared factory) when changing the ensure/dispose semantics.
 const installedControllers = new WeakMap<Document, () => void>();
 
 /**
@@ -236,9 +259,13 @@ function applyProps(liveIsland: Element, incomingIsland: Element): void {
   if (incoming === current) return;
   if (incoming === null) {
     liveIsland.removeAttribute(PROPS_ATTR);
-    return;
+  } else {
+    liveIsland.setAttribute(PROPS_ATTR, incoming);
   }
-  liveIsland.setAttribute(PROPS_ATTR, incoming);
+  // See ISLAND_REMOUNT_ATTR above: without the flag, an island whose dynamic
+  // import is in flight across the swap mounts from its pre-navigation props
+  // snapshot and #3525 reproduces with the DOM attribute looking correct.
+  liveIsland.setAttribute(ISLAND_REMOUNT_ATTR, "");
 }
 
 /**


### PR DESCRIPTION
- issues
    - https://github.com/zudolab/zudo-doc/issues/3529
- parent PR
    - https://github.com/zudolab/zudo-doc/pull/3528

---

## Summary

- Fixes zudolab/zudo-doc#3525 (via epic #3529): after a same-locale cross-section SOFT navigation, the mobile drawer kept the origin section's tree and active marker, because the drawer island — nested inside the persisted `header-${lang}` element — was re-mounted from the stale serialized `data-props` the header lift carried over.
- Adds a document-lifetime `zfb:before-swap` helper that refreshes nested-island `data-props` from the incoming document, generalizing what zfb already does for top-level persisted islands. The persist key and all persist behavior (#1546 locale toggle, #1547 no-flash) are untouched.
- Adds the missing mobile cross-section soft-nav e2e coverage (no prior spec exercised the drawer at a mobile viewport across sections).

## Changes

**Core fix (`packages/zudo-doc/src/transitions/nested-island-props-refresh.ts`, wired from `sidebar-toggle-island/index.tsx`)**
- Persisted roots paired by exact `data-zfb-transition-persist` value; islands grouped by name within the pair; only uniquely matched names refreshed (never positional); own-persist and nested-persist-boundary islands excluded; absent incoming `data-props` removes the attribute; unchanged props are a no-op; sets `data-zfb-island-remount` on change so an island whose dynamic import is in flight across the swap re-reads props on resolve.
- Idempotent per-document registration (WeakMap dispose), pre-hydration race documented; exported from the transitions barrel so ejected projects keep resolving it (eject `rewireImports` note extended + pinned by test).
- Corrected the stale header.tsx comment that claimed the drawer "re-hydrates with correct nodes on mount".

**e2e (`e2e/smoke-mobile-drawer-section-swap.spec.ts`, helpers in `e2e/mobile-drawer-helpers.ts`)**
- 390x844, smoke fixture: open drawer (waits for hydration), soft-navigate cross-section via drawer-scoped `spaClickSelector`, assert destination-only item appears / origin-only item gone / `aria-current="page"`, header persist survives (DOM identity + `viewTransitionName`), softness proven by single origin-named navigation entry. Proven to FAIL with the helper registration reverted.

**Tests / baselines**
- 20 unit tests for the helper (real `zfb:before-swap` dispatch, all matching/exclusion/removal/idempotency cases).
- `route-injection-build.slow.test.ts`: three A2 parity hashes re-baselined with documented attribution (103/103 green).

## Test Plan

- CI on this PR: all checks green (incl. E2E and Slow Unit Tests).
- Wave-3 confirm sub (#3532): persist e2e suite 18/18 (i18n/versioning persist specs prove #1546 preserved), slow suite 103/103, full 457-page `pnpm build` clean.
- Review: `/code-review medium --fix` ran on the merged base; 7 findings fixed; the one design-decision finding tracked as #3538.
