### PR TITLE
Wire published-pin guard into release checks

### DIFF
--- a/.claude/skills/l-make-release/SKILL.md
+++ b/.claude/skills/l-make-release/SKILL.md
@@ -209,7 +209,7 @@ Mirror the English content in Japanese. Sections: `### 破壊的変更`, `### �
 ## Step 4 — Validate
 
 ```bash
-pnpm b4push
+B4PUSH_SKIP_PIN_PUBLISHED=1 pnpm b4push
 ```
 
 Fix any failures and recommit before proceeding. Do not tag until b4push is fully green.

--- a/.github/workflows/exam.yml
+++ b/.github/workflows/exam.yml
@@ -5,12 +5,13 @@
 # they accumulate.
 #
 # Jobs:
-#   e2e-full        — full e2e suite (CI-safe lane) + quarantine @flaky lane
-#   slow-create     — create-zudo-doc slow integration tests (real npm install + zfb build)
-#   slow-zudo-doc   — @takazudo/zudo-doc slow route-injection-build test (real zfb builds +
-#                     npm pack; #2530 — moved out of pnpm test/pr-checks package-tests)
-#   theme-a11y      — rendered per-theme-pack WCAG contrast audit (scripts/theme-a11y-audit.ts);
-#                     too slow/still-maturing for pr-checks, so it's T3-only (#3036)
+#   scaffold-pin-published — cheap registry guard for unpublished scaffold pins (#3549)
+#   e2e-full              — full e2e suite (CI-safe lane) + quarantine @flaky lane
+#   slow-create           — create-zudo-doc slow integration tests (real npm install + zfb build)
+#   slow-zudo-doc         — @takazudo/zudo-doc slow route-injection-build test (real zfb builds +
+#                           npm pack; #2530 — moved out of pnpm test/pr-checks package-tests)
+#   theme-a11y            — rendered per-theme-pack WCAG contrast audit (scripts/theme-a11y-audit.ts);
+#                           too slow/still-maturing for pr-checks, so it's T3-only (#3036)
 #
 # Failure reporting:
 #   scripts/file-exam-issue.sh  — deduped failure issue, scoped per-workflow-job-identity
@@ -41,7 +42,74 @@ permissions:
 
 jobs:
   # ---------------------------------------------------------------------------
-  # Job 1: Full E2E — CI-safe suite + quarantine @flaky lane
+  # Job 1: Scaffold pin published guard — cheap, no install required
+  # ---------------------------------------------------------------------------
+  # This check intentionally runs directly with Node: it imports only built-in
+  # modules and sibling scripts, so package-manager setup/install would add
+  # needless cost.
+  scaffold-pin-published:
+    name: Scaffold Pin Published Guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version-file: .nvmrc
+
+      - name: Run scaffold pin published guard
+        run: node scripts/check-scaffold-pin-published.mjs
+
+  # ---------------------------------------------------------------------------
+  # Job 2: Notify scaffold pin guard status
+  # ---------------------------------------------------------------------------
+  scaffold-pin-published-notify:
+    name: Scaffold Pin Guard Notification
+    needs: [scaffold-pin-published]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Notify via IFTTT
+        if: env.IFTTT_PROD_NOTIFY != ''
+        env:
+          IFTTT_PROD_NOTIFY: ${{ secrets.IFTTT_PROD_NOTIFY }}
+          RAW_COMMIT_MSG: ${{ github.event.head_commit.message }}
+          PIN_PUBLISHED_RESULT: ${{ needs.scaffold-pin-published.result }}
+          GITHUB_SHA_VAL: ${{ github.sha }}
+          SERVER_URL: ${{ github.server_url }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          if [ "$PIN_PUBLISHED_RESULT" = "success" ]; then
+            STATUS="zudo-doc scaffold pin published guard succeeded!"
+          elif [ "$PIN_PUBLISHED_RESULT" = "failure" ]; then
+            STATUS="zudo-doc scaffold pin published guard failed"
+          else
+            STATUS="zudo-doc scaffold pin published guard cancelled"
+          fi
+
+          COMMIT_MSG=$(printf '%s\n' "$RAW_COMMIT_MSG" | head -1)
+          SHORT_SHA=$(echo "$GITHUB_SHA_VAL" | cut -c1-7)
+          RUN_URL="${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
+
+          PAYLOAD=$(jq -n \
+            --arg v1 "$STATUS" \
+            --arg v2 "$SHORT_SHA $COMMIT_MSG" \
+            --arg v3 "$RUN_URL" \
+            '{"value1":$v1,"value2":$v2,"value3":$v3}')
+
+          curl -sSf --max-time 10 -X POST "$IFTTT_PROD_NOTIFY" \
+            -H 'Content-Type: application/json' \
+            -d "$PAYLOAD" || echo "::warning::IFTTT notification failed"
+
+  # ---------------------------------------------------------------------------
+  # Job 3: Full E2E — CI-safe suite + quarantine @flaky lane
   # ---------------------------------------------------------------------------
   e2e-full:
     name: Full E2E Tests
@@ -170,7 +238,7 @@ jobs:
           retention-days: 14
 
   # ---------------------------------------------------------------------------
-  # Job 2: create-zudo-doc slow integration tests
+  # Job 4: create-zudo-doc slow integration tests
   # ---------------------------------------------------------------------------
   # Runs `test:slow` which exercises real `pnpm install` against the registry
   # + a full zfb build. Too expensive for every PR; runs nightly here.
@@ -221,7 +289,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
 
   # ---------------------------------------------------------------------------
-  # Job 3: @takazudo/zudo-doc slow route-injection-build test
+  # Job 5: @takazudo/zudo-doc slow route-injection-build test
   # ---------------------------------------------------------------------------
   # Runs `test:slow`, which exercises ~11 real `zfb build`s (the injected-route
   # byte-parity proof, PKGWIRE #2425 / A2 #2363) plus an `npm pack` round trip —
@@ -280,7 +348,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
 
   # ---------------------------------------------------------------------------
-  # Job 4: Theme A11y Audit — rendered per-theme-pack WCAG contrast audit
+  # Job 6: Theme A11y Audit — rendered per-theme-pack WCAG contrast audit
   # ---------------------------------------------------------------------------
   # scripts/theme-a11y-audit.ts renders the BUILT showcase once per (theme pack
   # × light/dark mode) via a real browser and reads computed styles — distinct

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -295,6 +295,47 @@ published to npm is not.
 
 ---
 
+## Scaffold pin published gate
+
+`scripts/check-scaffold-pin-published.mjs` (`pnpm check:scaffold-pin-published`)
+answers a different release-window question from the freshness gate above:
+does every internal package pin emitted by `scaffold.ts` have at least one
+published npm version satisfying its caret range? A release can legitimately
+create a new range before that version is published, so this check must tolerate
+the short window between bumping pins and publishing the packages.
+
+**Where it runs:**
+
+- **Nightly Exam** — `.github/workflows/exam.yml` runs the check directly with
+  Node, without installing dependencies. This is the routine enforcement point
+  once the previous release should be live on npm; a failure sends the usual
+  IFTTT notification.
+- **`scripts/run-b4push.sh`** — the check is step 18, after the
+  `b4push-ci-parity:guards:end` marker. The release sequence is
+  `bump pins → b4push → publish`, so the release instructions run
+  `B4PUSH_SKIP_PIN_PUBLISHED=1 pnpm b4push` during that intentional window.
+- **`scripts/release-create-zudo-doc.sh`** — the check also runs in the
+  preflight, before any version bump. It catches an unpublished pin left behind
+  by an aborted earlier release.
+- **By hand:** `pnpm check:scaffold-pin-published`.
+
+**Deliberately NOT a PR gate.** This check makes live npm registry calls, and a
+new scaffold pin is expected to be unpublished while its release is in flight.
+Making it a normal PR or unconditionally blocking b4push would create the same
+publish-lag deadlock described in the pin-parity section: the release could not
+pass its checks until after publication, but publication requires the checked
+commit first. The b4push escape is limited to the release workflow; nightly
+enforcement and the release preflight still catch a pin that remains unpublished
+outside that window.
+
+**What a failure means:** at least one scaffold pin has no satisfying version on
+the npm registry, or the registry lookup failed. For a release in progress, use
+the documented b4push escape and publish the packages in the required order. For
+an ordinary nightly or preflight failure, finish or roll back the pending release,
+then re-run `pnpm check:scaffold-pin-published`.
+
+---
+
 ## Tag namespaces and Draft Release model
 
 Each package has its own tag namespace and its own publish workflow. Publishing a

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "check:fixture-settings-drift": "node scripts/check-fixture-settings-drift.mjs",
     "check:pin-parity": "node scripts/check-pin-parity.mjs",
     "check:scaffold-pin-freshness": "node scripts/check-scaffold-pin-freshness.mjs",
+    "check:scaffold-pin-published": "node scripts/check-scaffold-pin-published.mjs",
     "check:b4push-ci-parity": "node scripts/check-b4push-ci-parity.mjs",
     "check:e2e-spec-naming": "node scripts/check-e2e-spec-naming.mjs",
     "check:flaky-tracking-issue": "node scripts/check-flaky-tracking-issue.mjs",

--- a/scripts/__tests__/check-scaffold-pin-published.test.mjs
+++ b/scripts/__tests__/check-scaffold-pin-published.test.mjs
@@ -1,0 +1,188 @@
+// Unit tests for check-scaffold-pin-published.mjs. Registry responses are
+// always injected, so this spec never touches the network.
+
+import { describe, it, expect } from "vitest";
+
+import {
+  checkScaffoldPinPublished,
+  satisfiesCaretPublished,
+  DEFAULT_TIMEOUT_MS,
+} from "../check-scaffold-pin-published.mjs";
+
+const SCAFFOLD_SRC = `
+export const ZUDO_DOC_PIN = "^5.7.0";
+function scaffold() {
+  const deps = {
+    "@takazudo/zudo-doc": ZUDO_DOC_PIN,
+  };
+  deps["@takazudo/zudo-doc-history-server"] = "^5.7.0";
+  return deps;
+}
+`;
+
+const PRERELEASE_SCAFFOLD_SRC = `
+const ZUDO_DOC_PIN = "^5.7.0-next.2";
+const deps = { "@takazudo/zudo-doc": ZUDO_DOC_PIN };
+`;
+
+function stubRegistry(table) {
+  return async (pkgName) => {
+    const entry = table[pkgName];
+    if (entry === undefined) {
+      throw new Error(`stubRegistry: no entry configured for ${pkgName}`);
+    }
+    if (entry instanceof Error) throw entry;
+    return entry;
+  };
+}
+
+function packument(...versions) {
+  return { versions: Object.fromEntries(versions.map((version) => [version, {}])) };
+}
+
+describe("satisfiesCaretPublished", () => {
+  it("handles caret lower and upper boundaries", () => {
+    expect(satisfiesCaretPublished("5.7.0", "^5.7.0")).toBe(true);
+    expect(satisfiesCaretPublished("5.6.9", "^5.7.0")).toBe(false);
+    expect(satisfiesCaretPublished("5.9.0", "^5.7.0")).toBe(true);
+    expect(satisfiesCaretPublished("6.0.0", "^5.7.0")).toBe(false);
+    expect(satisfiesCaretPublished("6.0.0-next.1", "^5.7.0")).toBe(false);
+    expect(satisfiesCaretPublished("0.5.0", "^0.4.0")).toBe(false);
+    expect(satisfiesCaretPublished("0.4.9", "^0.4.0")).toBe(true);
+    expect(satisfiesCaretPublished("0.0.5", "^0.0.4")).toBe(false);
+  });
+
+  it("orders prereleases instead of ignoring their identifiers", () => {
+    expect(satisfiesCaretPublished("5.7.0-next.1", "^5.7.0-next.2")).toBe(false);
+    expect(satisfiesCaretPublished("5.7.0-next.2", "^5.7.0-next.2")).toBe(true);
+    expect(satisfiesCaretPublished("5.7.0-next.10", "^5.7.0-next.2")).toBe(true);
+    expect(satisfiesCaretPublished("5.7.0", "^5.7.0-next.2")).toBe(true);
+    expect(satisfiesCaretPublished("5.7.1-next.1", "^5.7.0-next.2")).toBe(false);
+    expect(satisfiesCaretPublished("5.8.0", "^5.7.0-next.2")).toBe(true);
+  });
+
+  it("returns null for malformed ranges or versions", () => {
+    expect(satisfiesCaretPublished("5.7.0", "5.7.0")).toBe(null);
+    expect(satisfiesCaretPublished("not-semver", "^5.7.0")).toBe(null);
+    expect(satisfiesCaretPublished("5.7", "^5.7.0")).toBe(null);
+  });
+});
+
+describe("checkScaffoldPinPublished", () => {
+  it("passes when a published version satisfies the internal pin", async () => {
+    const result = await checkScaffoldPinPublished({
+      scaffoldSrc: SCAFFOLD_SRC,
+      fetchPackument: stubRegistry({
+        "@takazudo/zudo-doc": packument("5.6.1", "5.7.0"),
+        "@takazudo/zudo-doc-history-server": packument("5.7.1"),
+      }),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        kind: "ok",
+        pkg: "@takazudo/zudo-doc",
+        pin: "^5.7.0",
+        publishedVersion: "5.7.0",
+      }),
+      expect.objectContaining({
+        kind: "ok",
+        pkg: "@takazudo/zudo-doc-history-server",
+        publishedVersion: "5.7.1",
+      }),
+    ]);
+  });
+
+  it("fails unsatisfied when the pin is ahead of the registry", async () => {
+    const result = await checkScaffoldPinPublished({
+      scaffoldSrc: SCAFFOLD_SRC,
+      packages: ["@takazudo/zudo-doc"],
+      fetchPackument: stubRegistry({
+        "@takazudo/zudo-doc": packument("5.6.0"),
+      }),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.findings[0]).toEqual(
+      expect.objectContaining({ kind: "unsatisfied", pkg: "@takazudo/zudo-doc" }),
+    );
+  });
+
+  it("fails closed with a distinct lookup-error on registry failure", async () => {
+    const result = await checkScaffoldPinPublished({
+      scaffoldSrc: SCAFFOLD_SRC,
+      packages: ["@takazudo/zudo-doc"],
+      fetchPackument: stubRegistry({
+        "@takazudo/zudo-doc": new Error("network timeout"),
+      }),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.findings[0].kind).toBe("lookup-error");
+    expect(result.findings[0].message).toContain("network timeout");
+  });
+
+  it("reports malformed and empty versions payloads as lookup-error", async () => {
+    for (const payload of [{}, { versions: {} }, { versions: null }, { versions: [] }]) {
+      const result = await checkScaffoldPinPublished({
+        scaffoldSrc: SCAFFOLD_SRC,
+        packages: ["@takazudo/zudo-doc"],
+        fetchPackument: stubRegistry({ "@takazudo/zudo-doc": payload }),
+      });
+      expect(result.ok).toBe(false);
+      expect(result.findings[0].kind).toBe("lookup-error");
+    }
+  });
+
+  it("checks both internal pins and handles an unreadable pin", async () => {
+    const result = await checkScaffoldPinPublished({
+      scaffoldSrc: SCAFFOLD_SRC,
+      packages: ["@takazudo/zudo-doc", "@takazudo/missing"],
+      fetchPackument: stubRegistry({
+        "@takazudo/zudo-doc": packument("5.7.0"),
+      }),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.findings.map(({ kind }) => kind)).toEqual([
+      "ok",
+      "unreadable-pin",
+    ]);
+  });
+
+  it("reports an invalid pin range as unreadable-pin without looking it up", async () => {
+    const fetchPackument = async () => {
+      throw new Error("must not look up an invalid pin");
+    };
+    const result = await checkScaffoldPinPublished({
+      scaffoldSrc: `const deps = { "@takazudo/zudo-doc": "5.7.0" };`,
+      packages: ["@takazudo/zudo-doc"],
+      fetchPackument,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.findings[0]).toEqual(
+      expect.objectContaining({ kind: "unreadable-pin", pin: "5.7.0" }),
+    );
+  });
+
+  it("does not accept a prerelease below the pin floor", async () => {
+    const result = await checkScaffoldPinPublished({
+      scaffoldSrc: PRERELEASE_SCAFFOLD_SRC,
+      packages: ["@takazudo/zudo-doc"],
+      fetchPackument: stubRegistry({
+        "@takazudo/zudo-doc": packument("5.7.0-next.1"),
+      }),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.findings[0].kind).toBe("unsatisfied");
+  });
+});
+
+describe("module exports", () => {
+  it("exposes a bounded default timeout", () => {
+    expect(DEFAULT_TIMEOUT_MS).toBe(10_000);
+  });
+});

--- a/scripts/check-pin-parity.mjs
+++ b/scripts/check-pin-parity.mjs
@@ -84,7 +84,7 @@ export const PINNED_PACKAGES = [
 // are the source of truth that WRITES these pins on every release bump. Keep
 // this list in sync with those steps so any future 3rd internal pin gets
 // guarded here too.
-const INTERNAL_PINNED_PACKAGES = [
+export const INTERNAL_PINNED_PACKAGES = [
   "@takazudo/zudo-doc",
   "@takazudo/zudo-doc-history-server",
 ];

--- a/scripts/check-scaffold-pin-published.mjs
+++ b/scripts/check-scaffold-pin-published.mjs
@@ -1,0 +1,363 @@
+#!/usr/bin/env node
+// scripts/check-scaffold-pin-published.mjs
+//
+// Verify that every internal package pin emitted by the scaffold has at least
+// one published version in the npm registry that satisfies its caret range.
+// This catches a release-ordering failure that a parity check cannot see:
+// scaffold.ts can be updated to the next lockstep version before that version
+// has actually been published.
+//
+// The registry lookup is injected into checkScaffoldPinPublished() so the pure
+// check is network-free in tests. The command-line wrapper uses the abbreviated
+// npm packument, which includes the complete versions map.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { dirname, resolve } from "node:path";
+
+import {
+  INTERNAL_PINNED_PACKAGES,
+  readScaffoldPin,
+} from "./check-pin-parity.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const ROOT_DIR = resolve(__dirname, "..");
+const SCAFFOLD_TS_PATH = resolve(
+  ROOT_DIR,
+  "packages/create-zudo-doc/src/scaffold.ts",
+);
+
+/** Per-request timeout for the real registry lookup. */
+export const DEFAULT_TIMEOUT_MS = 10_000;
+
+const REGISTRY_BASE = "https://registry.npmjs.org";
+const REGISTRY_ACCEPT = "application/vnd.npm.install-v1+json";
+
+const SEMVER_RE =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
+
+function compareNumericIdentifier(a, b) {
+  if (a.length !== b.length) return a.length < b.length ? -1 : 1;
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function isNumericIdentifier(identifier) {
+  return /^(?:0|[1-9]\d*)$/.test(identifier);
+}
+
+/**
+ * Parse a complete semver version. Build metadata is accepted and ignored for
+ * precedence, as required by semver. Returning null keeps malformed registry
+ * entries and malformed scaffold ranges fail-closed rather than silently
+ * matching them.
+ */
+export function parsePublishedVersion(value) {
+  if (typeof value !== "string") return null;
+  const match = value.trim().match(SEMVER_RE);
+  if (!match) return null;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4] ? match[4].split(".") : [],
+  };
+}
+
+function compareParsedVersions(a, b) {
+  const core =
+    a.major - b.major || a.minor - b.minor || a.patch - b.patch;
+  if (core !== 0) return core < 0 ? -1 : 1;
+
+  if (a.prerelease.length === 0 && b.prerelease.length === 0) return 0;
+  if (a.prerelease.length === 0) return 1;
+  if (b.prerelease.length === 0) return -1;
+
+  const length = Math.max(a.prerelease.length, b.prerelease.length);
+  for (let index = 0; index < length; index += 1) {
+    const left = a.prerelease[index];
+    const right = b.prerelease[index];
+    if (left === undefined) return -1;
+    if (right === undefined) return 1;
+    if (left === right) continue;
+
+    const leftNumeric = isNumericIdentifier(left);
+    const rightNumeric = isNumericIdentifier(right);
+    if (leftNumeric && rightNumeric) {
+      return compareNumericIdentifier(left, right);
+    }
+    if (leftNumeric) return -1;
+    if (rightNumeric) return 1;
+    return left < right ? -1 : 1;
+  }
+  return 0;
+}
+
+function parseCaretRange(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("^") || trimmed.length === 1) return null;
+  const version = parsePublishedVersion(trimmed.slice(1));
+  return version ? { floor: version } : null;
+}
+
+/**
+ * Test one published version against an internal scaffold caret pin.
+ *
+ * This intentionally does not use check-pin-parity.mjs's satisfiesCaret():
+ * that helper compares only numeric cores. Here prerelease identifiers are
+ * significant. The behavior mirrors npm/pnpm semver resolution:
+ *
+ *   - A prerelease candidate is excluded unless the range itself has a
+ *     prerelease comparator with the same major/minor/patch tuple.
+ *   - Once opted into that prerelease tuple, identifiers are ordered locally
+ *     according to semver (numeric identifiers before string identifiers,
+ *     numeric comparison without Number overflow).
+ *   - Stable releases satisfy a prerelease floor when they are otherwise in
+ *     range (for example, 5.7.0 satisfies ^5.7.0-next.2).
+ *
+ * Returns null for a malformed/non-caret range so callers can report an
+ * "unreadable-pin" finding instead of passing an invalid pin.
+ */
+export function satisfiesCaretPublished(version, caretRange) {
+  const candidate = parsePublishedVersion(version);
+  const range = parseCaretRange(caretRange);
+  if (!candidate || !range) return null;
+
+  const floor = range.floor;
+  const candidateCore =
+    candidate.major - floor.major ||
+    candidate.minor - floor.minor ||
+    candidate.patch - floor.patch;
+
+  // npm's prerelease rule: a prerelease is eligible only when the range
+  // carries a prerelease comparator for exactly this core tuple.
+  if (
+    candidate.prerelease.length > 0 &&
+    (floor.prerelease.length === 0 || candidateCore !== 0)
+  ) {
+    return false;
+  }
+
+  if (compareParsedVersions(candidate, floor) < 0) return false;
+
+  // Caret upper bounds are exclusive, including prereleases at the upper
+  // boundary (e.g. 6.0.0-next.1 is outside ^5.7.0).
+  let upper;
+  if (floor.major > 0) {
+    upper = { major: floor.major + 1, minor: 0, patch: 0 };
+  } else if (floor.minor > 0) {
+    upper = { major: 0, minor: floor.minor + 1, patch: 0 };
+  } else {
+    upper = { major: 0, minor: 0, patch: floor.patch + 1 };
+  }
+  if (
+    candidate.major > upper.major ||
+    (candidate.major === upper.major && candidate.minor > upper.minor) ||
+    (candidate.major === upper.major &&
+      candidate.minor === upper.minor &&
+      candidate.patch >= upper.patch)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function publishedVersionsFromPackument(packument, pkgName) {
+  if (
+    !packument ||
+    typeof packument !== "object" ||
+    Array.isArray(packument) ||
+    !packument.versions ||
+    typeof packument.versions !== "object" ||
+    Array.isArray(packument.versions)
+  ) {
+    throw new Error(
+      `Registry response for ${pkgName} has no usable "versions" map`,
+    );
+  }
+
+  const versionNames = Object.keys(packument.versions);
+  if (versionNames.length === 0) {
+    throw new Error(`Registry response for ${pkgName} has an empty "versions" map`);
+  }
+
+  const versions = versionNames.map((version) => {
+    const parsed = parsePublishedVersion(version);
+    if (!parsed) {
+      throw new Error(
+        `Registry response for ${pkgName} contains invalid published version ${JSON.stringify(version)}`,
+      );
+    }
+    return { name: version, parsed };
+  });
+  return versions;
+}
+
+/**
+ * Evaluate all internal scaffold pins using an injected packument lookup.
+ * `fetchPackument(pkgName)` must resolve to an npm packument with a complete
+ * `versions` map. Every lookup and malformed response fails closed.
+ */
+export async function checkScaffoldPinPublished({
+  scaffoldSrc,
+  packages = INTERNAL_PINNED_PACKAGES,
+  fetchPackument,
+}) {
+  if (typeof fetchPackument !== "function") {
+    throw new TypeError(
+      "checkScaffoldPinPublished requires a fetchPackument(pkgName) function",
+    );
+  }
+
+  const findings = [];
+  for (const pkgName of packages) {
+    const scaffoldPin = readScaffoldPin(scaffoldSrc, pkgName);
+    const range = parseCaretRange(scaffoldPin);
+    if (scaffoldPin === null || !range) {
+      findings.push({
+        kind: "unreadable-pin",
+        pkg: pkgName,
+        pin: scaffoldPin,
+        message:
+          scaffoldPin === null
+            ? `Could not locate a literal pin for ${pkgName} in scaffold.ts.`
+            : `Scaffold pin for ${pkgName} is not a valid caret semver range: ${JSON.stringify(scaffoldPin)}.`,
+      });
+      continue;
+    }
+
+    let versions;
+    try {
+      const packument = await fetchPackument(pkgName);
+      versions = publishedVersionsFromPackument(packument, pkgName);
+    } catch (error) {
+      findings.push({
+        kind: "lookup-error",
+        pkg: pkgName,
+        pin: scaffoldPin,
+        message:
+          `Registry lookup failed for ${pkgName} — treating as a gate ` +
+          `failure (fail-closed): ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+      });
+      continue;
+    }
+
+    const matching = versions
+      .filter(({ parsed }) =>
+        satisfiesCaretPublished(parsedToVersion(parsed), scaffoldPin),
+      )
+      .sort((a, b) => compareParsedVersions(b.parsed, a.parsed));
+
+    if (matching.length === 0) {
+      findings.push({
+        kind: "unsatisfied",
+        pkg: pkgName,
+        pin: scaffoldPin,
+        publishedVersions: versions.map(({ name }) => name),
+        message:
+          `${pkgName} scaffold pin ${scaffoldPin} is UNSATISFIED — no ` +
+          `published registry version satisfies this range.`,
+      });
+      continue;
+    }
+
+    const publishedVersion = matching[0].name;
+    findings.push({
+      kind: "ok",
+      pkg: pkgName,
+      pin: scaffoldPin,
+      publishedVersion,
+      message:
+        `${pkgName} scaffold pin ${scaffoldPin} is satisfied by published ` +
+        `version ${publishedVersion}.`,
+    });
+  }
+
+  return {
+    ok: findings.every((finding) => finding.kind === "ok"),
+    findings,
+  };
+}
+
+// Reconstructing a parsed version for the public predicate keeps the registry
+// scan's parsed representation private while preserving build metadata-free
+// semver precedence. Packument keys are already complete validated versions,
+// so this conversion cannot fail.
+function parsedToVersion(parsed) {
+  const core = `${parsed.major}.${parsed.minor}.${parsed.patch}`;
+  return parsed.prerelease.length > 0
+    ? `${core}-${parsed.prerelease.join(".")}`
+    : core;
+}
+
+/** Real npm registry lookup, bounded so a release cannot hang indefinitely. */
+async function fetchPackumentFromRegistry(
+  pkgName,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+) {
+  const url = `${REGISTRY_BASE}/${encodeURIComponent(pkgName)}`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, {
+      headers: { Accept: REGISTRY_ACCEPT },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      throw new Error(
+        `npm registry returned ${response.status} ${response.statusText} for ${pkgName}`,
+      );
+    }
+    return await response.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function formatFinding(finding) {
+  const label =
+    finding.kind === "ok"
+      ? "OK     "
+      : finding.kind === "unsatisfied"
+        ? "UNSAT  "
+        : finding.kind === "unreadable-pin"
+          ? "ERROR  "
+          : "ERROR  ";
+  return `  ${label} ${finding.message}`;
+}
+
+async function main() {
+  const scaffoldSrc = readFileSync(SCAFFOLD_TS_PATH, "utf-8");
+  const result = await checkScaffoldPinPublished({
+    scaffoldSrc,
+    fetchPackument: (pkgName) => fetchPackumentFromRegistry(pkgName),
+  });
+
+  for (const finding of result.findings) console.log(formatFinding(finding));
+  if (!result.ok) {
+    console.error("");
+    console.error("Scaffold published-pin check FAILED.");
+    console.error(
+      "  Every internal scaffold pin must have at least one published registry version satisfying its range.",
+    );
+    return 1;
+  }
+
+  console.log("");
+  console.log("OK — all internal scaffold pins have a published satisfying version.");
+  return 0;
+}
+
+const invokedDirectly =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  main()
+    .then((code) => process.exit(code))
+    .catch((error) => {
+      console.error("Unexpected failure in check-scaffold-pin-published:", error);
+      process.exit(1);
+    });
+}

--- a/scripts/release-create-zudo-doc.sh
+++ b/scripts/release-create-zudo-doc.sh
@@ -221,6 +221,18 @@ else
   exit 1
 fi
 
+echo ""
+echo "▶ Checking scaffold pins for a published satisfying version..."
+if (cd "$ROOT_DIR" && pnpm check:scaffold-pin-published); then
+  echo "  ✓ scaffold pins have a published satisfying version"
+else
+  echo ""
+  echo "Error: scaffold pin published check failed — a pin has no satisfying version on the npm registry." >&2
+  echo "        This can indicate an unfinished release from an earlier run. See RELEASE.md 'Scaffold pin published gate'." >&2
+  echo "Remedy: finish or roll back the pending publication, then re-run this script." >&2
+  exit 1
+fi
+
 # ── Read current versions (real run) ─────────────────────────────────────────
 
 OLD_ROOT_VERSION=$(node -p "require('$PKG_JSON').version" 2>/dev/null)
@@ -416,7 +428,7 @@ echo ""
 echo "Next steps:"
 echo "  1. Fill in changelog: src/content/docs/changelog/$NEW_VERSION.mdx"
 echo "  2. Fill in Japanese:  src/content/docs-ja/changelog/$NEW_VERSION.mdx"
-echo "  3. Run pnpm b4push to validate"
+echo "  3. Run B4PUSH_SKIP_PIN_PUBLISHED=1 pnpm b4push to validate"
 echo "  4. Commit, push, wait for CI."
 echo ""
 echo "  Publish ORDER matters — zudo-doc and zudo-doc-history-server first,"

--- a/scripts/run-b4push.sh
+++ b/scripts/run-b4push.sh
@@ -23,20 +23,21 @@ set -euo pipefail
 #  15. @takazudo/zudo-doc publish contract (check:prepack-contract)
 #  16. Default-lane dist-mutating test guard (#3488)
 #  17. Required-checks manifest + B4push/CI parity meta-checks (#3494, #1967)
-#  18. Type checking (zfb check + workspace package typechecks)
-#  19. Worker contract proof (types + Workers runtime + Wrangler dry-run)
-#  20. Root unit tests (test:unit) — 903 tests (901 passed, 2 skipped); builds @takazudo/zudo-doc
-#  21. Slow unit tests (test:unit:slow + two create-zudo-doc specs) — 60 slow root tests +
+#  18. Scaffold pin published guard (release-window-aware; #3549)
+#  19. Type checking (zfb check + workspace package typechecks)
+#  20. Worker contract proof (types + Workers runtime + Wrangler dry-run)
+#  21. Root unit tests (test:unit) — 903 tests (901 passed, 2 skipped); builds @takazudo/zudo-doc
+#  22. Slow unit tests (test:unit:slow + two create-zudo-doc specs) — 60 slow root tests +
 #      5 retiered create-zudo-doc tests; blocking
-#  22. Package tests (test:packages) — 2,988 suite tests across 4 workspace packages
+#  23. Package tests (test:packages) — 2,988 suite tests across 4 workspace packages
 #      (44/73/596/2,275; 5 retiered create-zudo-doc tests run in Slow Unit Tests)
-#  23. Package safelist check (#1994) — requires dist/safelist.css from step 20
-#  24. Build (zfb build)
-#  25. Content-fallback check (#3134) — no page may ship a <pre data-zfb-content-fallback> body
-#  26. Link check
-#  27. HTML validation (html-validate dist/**/*.html)
-#  28. Automated preview smoke (blocking)
-#  29. Manual interactive smoke (operator-driven)
+#  24. Package safelist check (#1994) — requires dist/safelist.css from step 21
+#  25. Build (zfb build)
+#  26. Content-fallback check (#3134) — no page may ship a <pre data-zfb-content-fallback> body
+#  27. Link check
+#  28. HTML validation (html-validate dist/**/*.html)
+#  29. Automated preview smoke (blocking)
+#  30. Manual interactive smoke (operator-driven)
 #
 # The former "Z-index codegen drift check" step was retired in
 # zudolab/zudo-doc#2661: the project-side src/config/z-index-tokens.ts (and
@@ -49,13 +50,14 @@ set -euo pipefail
 # it for time-budget reasons — the bounded fast pass stays fast.
 #
 # Env overrides for non-interactive use:
-#   B4PUSH_SKIP_HTML_VALIDATE=1  — skip HTML validation (step 26)
-#   B4PUSH_SKIP_PREVIEW_SMOKE=1  — skip the automated preview smoke (step 27)
-#   B4PUSH_SKIP_MANUAL_SMOKE=1   — skip the manual interactive smoke
+#   B4PUSH_SKIP_PIN_PUBLISHED=1  — skip the release-window guard (step 18)
+#   B4PUSH_SKIP_HTML_VALIDATE=1  — skip HTML validation (step 28)
+#   B4PUSH_SKIP_PREVIEW_SMOKE=1  — skip the automated preview smoke (step 29)
+#   B4PUSH_SKIP_MANUAL_SMOKE=1   — skip the manual interactive smoke (step 30)
 
 START_TIME=$(date +%s)
 FAILURES=()
-TOTAL_STEPS=29
+TOTAL_STEPS=30
 CURRENT_STEP=0
 
 # Per-step elapsed timing (#2538) — makes budget creep in any one step
@@ -297,7 +299,23 @@ fi
 
 # <<< b4push-ci-parity:guards:end
 
-# ── Step 18: Type checking ─────────────────────────────
+# ── Step 18: Scaffold pin published guard (#3549) ─────
+# This live npm-registry check belongs outside the parity guard region: the
+# scaffold intentionally points at the in-flight release version before that
+# version is published. Release callers opt out during that window; nightly
+# exam and the release preflight enforce it when a published pin is expected.
+step "Scaffold pin published guard (check:scaffold-pin-published)"
+if [[ "${B4PUSH_SKIP_PIN_PUBLISHED:-}" == "1" ]]; then
+  skip "Scaffold pin published guard (B4PUSH_SKIP_PIN_PUBLISHED=1)"
+else
+  if (cd "$ROOT_DIR" && pnpm check:scaffold-pin-published); then
+    pass "Scaffold pin published guard passed"
+  else
+    fail "Scaffold pin published guard"
+  fi
+fi
+
+# ── Step 19: Type checking ─────────────────────────────
 # Prefer `zfb check` (the post-cutover entry point). If it fails to
 # start (e.g. binary not yet built), fall back to `tsc --noEmit` so the
 # typecheck still gates pushes.
@@ -330,7 +348,7 @@ else
   fail "Package typechecks"
 fi
 
-# ── Step 19: Worker contract proof ───────────────────
+# ── Step 20: Worker contract proof ───────────────────
 step "Worker contract proof (types + runtime + dry-run)"
 if (cd "$ROOT_DIR" && pnpm verify:worker-contract); then
   pass "Worker contract proof passed"
@@ -338,7 +356,7 @@ else
   fail "Worker contract proof"
 fi
 
-# ── Step 20: Root unit tests ──────────────────────────
+# ── Step 21: Root unit tests ──────────────────────────
 # Root `test:unit` (vitest) guards src/**/__tests__ and scripts/__tests__,
 # which previously ran in no local gate and no CI workflow (#1856). Runs
 # before the expensive site build for fast logic-level feedback.
@@ -362,7 +380,7 @@ else
   fail "Root unit tests"
 fi
 
-# ── Step 21: Slow unit tests ──────────────────────────
+# ── Step 22: Slow unit tests ──────────────────────────
 # The subprocess-heavy root specs and the two retiered create-zudo-doc specs
 # are excluded from their default lanes and remain blocking local gates.
 # Keep both invocations in this existing step so b4push retains its current
@@ -384,7 +402,7 @@ else
   fail "retiered create-zudo-doc slow tests"
 fi
 
-# ── Step 22: Package tests ────────────────────────────
+# ── Step 23: Package tests ────────────────────────────
 # Runs all workspace package test suites (2,988 tests across 4 packages: search-worker 44,
 # doc-history-server 73, create-zudo-doc 596, zudo-doc 2,275). The 5 retiered
 # create-zudo-doc tests run in the blocking Slow Unit Tests lane. Closes the local/CI
@@ -397,7 +415,7 @@ else
   fail "Package tests + subpath resolution"
 fi
 
-# ── Step 23: Package safelist check ──────────────────
+# ── Step 24: Package safelist check ──────────────────
 # Verifies that the generated dist/safelist.css in packages/zudo-doc/ covers
 # every responsive-variant + arbitrary-value utility class used in
 # packages/zudo-doc/src/**/*.tsx. Catches regressions where gen-safelist.mjs
@@ -410,7 +428,7 @@ else
   fail "Package safelist check"
 fi
 
-# ── Step 24: Build ────────────────────────────────────
+# ── Step 25: Build ────────────────────────────────────
 # --no-strict-content-bridge overrides the zfb.config.ts strictContentBridge
 # gate (#3234) so this build still produces a dist/ for step 25's
 # content-fallback check to scan — the two guards can't run on the same build.
@@ -421,7 +439,7 @@ else
   fail "Build"
 fi
 
-# ── Step 25: Content-fallback check ───────────────────
+# ── Step 26: Content-fallback check ───────────────────
 #
 # zfb only *warns* when it declines to wire a page's compiled MDX through
 # the content bridge, then ships that page's whole body as a single
@@ -439,7 +457,7 @@ else
   fail "Content-fallback check"
 fi
 
-# ── Step 26: Link check ───────────────────────────────
+# ── Step 27: Link check ───────────────────────────────
 #
 # Strict on broken links + absolute MDX-source warnings (real 404s
 # / sub-path bypass). Trailing-slash warnings stay warn-only — they
@@ -459,7 +477,7 @@ else
   fail "Link check"
 fi
 
-# ── Step 27: HTML validation ──────────────────────────
+# ── Step 28: HTML validation ──────────────────────────
 step "HTML validation (html-validate)"
 if [[ "${B4PUSH_SKIP_HTML_VALIDATE:-}" == "1" ]]; then
   skip "HTML validation (B4PUSH_SKIP_HTML_VALIDATE=1)"
@@ -471,7 +489,7 @@ else
   fi
 fi
 
-# ── Step 28: Automated preview smoke (blocking) ──────
+# ── Step 29: Automated preview smoke (blocking) ──────
 step "Preview smoke (automated)"
 if [[ "${B4PUSH_SKIP_PREVIEW_SMOKE:-}" == "1" ]]; then
   skip "Preview smoke (B4PUSH_SKIP_PREVIEW_SMOKE=1)"
@@ -483,7 +501,7 @@ else
   fi
 fi
 
-# ── Step 29: Manual interactive smoke ────────────────
+# ── Step 30: Manual interactive smoke ────────────────
 step "Manual interactive smoke"
 if [[ "${B4PUSH_SKIP_MANUAL_SMOKE:-}" == "1" ]]; then
   skip "Manual smoke (B4PUSH_SKIP_MANUAL_SMOKE=1)"


### PR DESCRIPTION
Parent: #3547

## Summary

- add release-window-aware b4push enforcement and escape
- add a dependency-free nightly exam job with notification
- enforce release preflight and document the workflow

## Test plan

- focused guard execution and skip checks
- `pnpm check:b4push-ci-parity`
- `pnpm check:compatibility-contract`
- shell and workflow syntax validation

Closes #3549.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/3560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789763042&installation_model_id=20910&pr_number=3560&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F3560&signature=a6a193d39a0fad5a7e4e296d790f01e783f59e888922547d8d95ae9792ece042"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->