### PR TITLE
Validate anchors in showcase link checks

### DIFF
--- a/.check-links-allowlist
+++ b/.check-links-allowlist
@@ -1,10 +1,10 @@
 # Known exceptions for `pnpm run check:links` (consumed by
 # `scripts/check-links.js --allowlist=...`).
 #
-# Format: `<file>:<line>:<href>` per line. `#` comments and blank
-# lines are ignored. Each entry MUST match the printed report
-# verbatim (file path relative to repo root, 1-based line number,
-# href as it appeared in the source/dist).
+# Format: `<file>:<line>:<href>` per line. Comment-only (`# ...`) and
+# blank lines are ignored; `#` inside an href is preserved. Each entry
+# MUST match the printed report verbatim (file path relative to repo
+# root, 1-based line number, href as it appeared in the source/dist).
 #
 # Add entries here when an issue cannot be fixed at the source —
 # typically: doc pages that reference EN-only siblings from JA, or

--- a/scripts/__tests__/check-links.test.ts
+++ b/scripts/__tests__/check-links.test.ts
@@ -12,10 +12,13 @@ import {
   resolveLinkDetail,
   resolveLink,
   extractMdxAbsoluteLinks,
+  extractMdxFragmentLinks,
   checkHtmlLinksAndTrailing,
   checkMdxLinks,
+  checkMdxAnchors,
   formatReport,
   collectFiles,
+  readAllowlist,
 } from "../check-links.js";
 
 const CHECK_LINKS_SCRIPT = fileURLToPath(new URL("../check-links.js", import.meta.url));
@@ -38,6 +41,7 @@ describe("check-links", () => {
         "--",
         "--strict-broken",
         "--strict-absolute",
+        "--strict-anchors",
         "--strict-trailing",
         "--allowlist=.check-links-allowlist",
         "-h",
@@ -48,6 +52,7 @@ describe("check-links", () => {
       expect(result.status).toBe(0);
       expect(result.stdout).toContain("--strict-broken");
       expect(result.stdout).toContain("--strict-absolute");
+      expect(result.stdout).toContain("--strict-anchors");
       expect(result.stdout).toContain("--strict-trailing");
       expect(result.stdout).not.toMatch(/^\s*--strict\s/m);
     });
@@ -218,8 +223,10 @@ describe("check-links", () => {
       );
     });
 
-    it("skips anchor-only links", () => {
-      expect(extractHtmlLinks(`<a href="#section">A</a>`)).toEqual([]);
+    it("extracts anchor-only links for local-fragment validation", () => {
+      expect(extractHtmlLinks(`<a href="#section">A</a>`)).toEqual([
+        { href: "#section", line: 1 },
+      ]);
     });
 
     it("skips mailto links", () => {
@@ -608,6 +615,36 @@ describe("check-links", () => {
     });
   });
 
+  describe("extractMdxFragmentLinks", () => {
+    it("finds relative, local, query-plus-fragment, and empty fragments", () => {
+      const content = [
+        "[relative](./other.mdx#target)",
+        "[local](#local)",
+        "[query](./other.mdx?view=all#target)",
+        "[empty](#)",
+      ].join("\n");
+      expect(extractMdxFragmentLinks(content)).toEqual([
+        { href: "./other.mdx#target", line: 1 },
+        { href: "#local", line: 2 },
+        { href: "./other.mdx?view=all#target", line: 3 },
+        { href: "#", line: 4 },
+      ]);
+    });
+
+    it("preserves fenced-code and inline-code exclusions", () => {
+      const content = [
+        "`[inline](./other.mdx#hidden)`",
+        "~~~md",
+        "[fenced](./other.mdx#hidden)",
+        "~~~",
+        "[visible](./other.mdx#shown)",
+      ].join("\n");
+      expect(extractMdxFragmentLinks(content)).toEqual([
+        { href: "./other.mdx#shown", line: 5 },
+      ]);
+    });
+  });
+
   // --- checkHtmlLinksAndTrailing (integration) ---
 
   describe("checkHtmlLinksAndTrailing", () => {
@@ -648,6 +685,97 @@ describe("check-links", () => {
 
       const { broken } = await checkHtmlLinksAndTrailing(distDir, tmpDir, BASE);
       expect(broken).toEqual([]);
+    });
+
+    it("validates hierarchical, h5/h6, and non-heading target ids", async () => {
+      const distDir = join(tmpDir, "dist");
+      mkdirSync(join(distDir, "docs", "source"), { recursive: true });
+      mkdirSync(join(distDir, "docs", "target"), { recursive: true });
+      writeFileSync(
+        join(distDir, "docs", "source", "index.html"),
+        [
+          '<a href="../target/#parent-child">hierarchical</a>',
+          '<a href="../target/#parent-child-deep">h5</a>',
+          '<a href="../target/#static-target">static</a>',
+        ].join("\n"),
+      );
+      writeFileSync(
+        join(distDir, "docs", "target", "index.html"),
+        '<h3 id="parent-child"></h3><h5 id="parent-child-deep"></h5><div id="static-target"></div>',
+      );
+
+      const { anchors } = await checkHtmlLinksAndTrailing(distDir, tmpDir);
+      expect(anchors).toEqual([]);
+    });
+
+    it("reports leaf-only and missing anchors with source details", async () => {
+      const distDir = join(tmpDir, "dist");
+      mkdirSync(join(distDir, "docs", "source"), { recursive: true });
+      mkdirSync(join(distDir, "docs", "target"), { recursive: true });
+      writeFileSync(
+        join(distDir, "docs", "source", "index.html"),
+        '<a href="../target/#child">leaf only</a>\n<a href="../target/#absent">missing</a>',
+      );
+      writeFileSync(
+        join(distDir, "docs", "target", "index.html"),
+        '<h3 id="parent-child"></h3>',
+      );
+
+      const { anchors } = await checkHtmlLinksAndTrailing(distDir, tmpDir);
+      expect(anchors).toEqual([
+        {
+          file: "dist/docs/source/index.html", line: 1,
+          href: "../target/#child", fragment: "child", reason: "missing target id",
+        },
+        {
+          file: "dist/docs/source/index.html", line: 2,
+          href: "../target/#absent", fragment: "absent", reason: "missing target id",
+        },
+      ]);
+    });
+
+    it("handles local, query, encoded, empty, and malformed fragments", async () => {
+      const distDir = join(tmpDir, "dist");
+      mkdirSync(join(distDir, "docs", "source"), { recursive: true });
+      writeFileSync(
+        join(distDir, "docs", "source", "index.html"),
+        [
+          '<div id="local"></div><div id="foo bar"></div>',
+          '<a href="#local">local</a>',
+          '<a href="?view=all#local">query</a>',
+          '<a href="#foo%20bar">encoded</a>',
+          '<a href="#">empty</a>',
+          '<a href="#bad%ZZ">malformed</a>',
+        ].join("\n"),
+      );
+
+      const { anchors } = await checkHtmlLinksAndTrailing(distDir, tmpDir);
+      expect(anchors).toEqual([
+        {
+          file: "dist/docs/source/index.html", line: 5,
+          href: "#", fragment: "", reason: "empty fragment",
+        },
+        {
+          file: "dist/docs/source/index.html", line: 6,
+          href: "#bad%ZZ", fragment: "bad%ZZ", reason: "malformed percent-encoding",
+        },
+      ]);
+    });
+
+    it("keeps anchor checks behind version exclude patterns", async () => {
+      const distDir = join(tmpDir, "dist");
+      mkdirSync(join(distDir, "docs", "source"), { recursive: true });
+      mkdirSync(join(distDir, "v", "1.0", "target"), { recursive: true });
+      writeFileSync(
+        join(distDir, "docs", "source", "index.html"),
+        '<a href="/v/1.0/target/#missing">versioned</a>',
+      );
+      writeFileSync(join(distDir, "v", "1.0", "target", "index.html"), "<p>target</p>");
+
+      const { anchors } = await checkHtmlLinksAndTrailing(
+        distDir, tmpDir, "/", [/\/v\/[^/]+\//],
+      );
+      expect(anchors).toEqual([]);
     });
   });
 
@@ -721,6 +849,129 @@ describe("check-links", () => {
         [],
       );
       expect(warnings).toEqual([]);
+    });
+  });
+
+  describe("checkMdxAnchors", () => {
+    it("validates hierarchical h5/h6 and explicit static ids in relative targets", async () => {
+      const docsDir = join(tmpDir, "src", "content", "docs");
+      mkdirSync(docsDir, { recursive: true });
+      writeFileSync(
+        join(docsDir, "source.mdx"),
+        [
+          "[child](./target.mdx#parent-child)",
+          "[deep](./target.mdx#parent-child-deep)",
+          "[static](./target.mdx#static-target)",
+        ].join("\n"),
+      );
+      writeFileSync(
+        join(docsDir, "target.mdx"),
+        "## Parent\n### Child\n##### Deep\n<div id=\"static-target\" />",
+      );
+
+      expect(await checkMdxAnchors([docsDir], tmpDir, "/", [])).toEqual([]);
+    });
+
+    it("does not mistake prose containing id syntax for a static element id", async () => {
+      const docsDir = join(tmpDir, "src", "content", "docs");
+      mkdirSync(docsDir, { recursive: true });
+      writeFileSync(join(docsDir, "source.mdx"), "[x](./target.mdx#not-an-id)");
+      writeFileSync(join(docsDir, "target.mdx"), 'The syntax is `id="not-an-id"`.');
+
+      const anchors = await checkMdxAnchors([docsDir], tmpDir, "/", []);
+      expect(anchors).toHaveLength(1);
+      expect(anchors[0]?.reason).toBe("missing target id");
+    });
+
+    it("reports the leaf-only mistake and a nonexistent anchor", async () => {
+      const docsDir = join(tmpDir, "src", "content", "docs");
+      mkdirSync(docsDir, { recursive: true });
+      writeFileSync(
+        join(docsDir, "source.mdx"),
+        "[leaf](./target.mdx#child)\n[missing](./target.mdx#nonexistent-anchor)",
+      );
+      writeFileSync(join(docsDir, "target.mdx"), "## Parent\n### Child");
+
+      const anchors = await checkMdxAnchors([docsDir], tmpDir, "/", []);
+      expect(anchors).toEqual([
+        {
+          file: "src/content/docs/source.mdx", line: 1,
+          href: "./target.mdx#child", fragment: "child", reason: "missing target id",
+        },
+        {
+          file: "src/content/docs/source.mdx", line: 2,
+          href: "./target.mdx#nonexistent-anchor", fragment: "nonexistent-anchor", reason: "missing target id",
+        },
+      ]);
+    });
+
+    it("handles local, query, percent-encoded, empty, and malformed fragments", async () => {
+      const docsDir = join(tmpDir, "src", "content", "docs");
+      mkdirSync(docsDir, { recursive: true });
+      writeFileSync(
+        join(docsDir, "source.mdx"),
+        [
+          "## Local",
+          '<div id="foo bar" />',
+          "[local](#local)",
+          "[query](./target.mdx?view=all#target)",
+          "[encoded](#foo%20bar)",
+          "[empty](#)",
+          "[malformed](#bad%ZZ)",
+        ].join("\n"),
+      );
+      writeFileSync(join(docsDir, "target.mdx"), "## Target");
+
+      const anchors = await checkMdxAnchors([docsDir], tmpDir, "/", []);
+      expect(anchors).toEqual([
+        {
+          file: "src/content/docs/source.mdx", line: 6,
+          href: "#", fragment: "", reason: "empty fragment",
+        },
+        {
+          file: "src/content/docs/source.mdx", line: 7,
+          href: "#bad%ZZ", fragment: "bad%ZZ", reason: "malformed percent-encoding",
+        },
+      ]);
+    });
+
+    it("resolves a JA-to-EN anchor in the actual EN target", async () => {
+      const docsDir = join(tmpDir, "src", "content", "docs");
+      const jaDir = join(tmpDir, "src", "content", "docs-ja");
+      mkdirSync(docsDir, { recursive: true });
+      mkdirSync(jaDir, { recursive: true });
+      writeFileSync(join(docsDir, "target.mdx"), "## English Target");
+      writeFileSync(join(jaDir, "target.mdx"), "## Japanese Target");
+      writeFileSync(jaDir + "/source.mdx", "[EN](/docs/target#english-target)");
+
+      expect(
+        await checkMdxAnchors([docsDir, jaDir], tmpDir, "/", ["ja"]),
+      ).toEqual([]);
+    });
+
+    it("keeps source anchor checks behind version exclude patterns", async () => {
+      const docsDir = join(tmpDir, "src", "content", "docs");
+      mkdirSync(docsDir, { recursive: true });
+      writeFileSync(
+        join(docsDir, "source.mdx"),
+        "[versioned](/v/1.0/docs/target#missing)",
+      );
+      expect(
+        await checkMdxAnchors([docsDir], tmpDir, "/", [], [/\/v\/[^/]+\//]),
+      ).toEqual([]);
+    });
+  });
+
+  describe("readAllowlist", () => {
+    it("preserves href fragments while ignoring comment-only lines", async () => {
+      const file = join(tmpDir, ".check-links-allowlist");
+      writeFileSync(
+        file,
+        "# comment\nsrc/content/docs/a.mdx:3:./b.mdx#target\n",
+      );
+      expect(await readAllowlist(file)).toEqual(
+        new Set(["src/content/docs/a.mdx:3:./b.mdx#target"]),
+      );
     });
   });
 
@@ -891,7 +1142,7 @@ describe("check-links", () => {
     it("shows success message when no issues", () => {
       const report = formatReport([], []);
       expect(report).toContain(
-        "✓ No broken links or absolute path issues found",
+        "✓ No broken links, invalid anchors, or absolute path issues found",
       );
     });
 
@@ -924,6 +1175,23 @@ describe("check-links", () => {
       expect(report).toContain("=== Broken Links");
       expect(report).not.toContain("=== Absolute Links");
       expect(report).toContain("✗ Found 1 broken link");
+    });
+
+    it("formats invalid anchors as their own category with the fragment", () => {
+      const report = formatReport([], [], [], [
+        {
+          file: "src/content/docs/a.mdx",
+          line: 3,
+          href: "./b.mdx#missing",
+          fragment: "missing",
+          reason: "missing target id",
+        },
+      ]);
+      expect(report).toContain("=== Invalid Anchors ===");
+      expect(report).toContain(
+        "./b.mdx#missing  (fragment: #missing; missing target id)",
+      );
+      expect(report).toContain("✗ Found 1 invalid anchor");
     });
   });
 });

--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -3,13 +3,17 @@
 /**
  * check-links.js — Post-build broken link checker
  *
- * Mode 1: Scan built HTML in dist/ for broken internal links
- * Mode 2: Scan MDX source for absolute links bypassing base path
+ * Mode 1: Scan built HTML in dist/ for broken internal links and anchors
+ * Mode 2: Scan MDX source for absolute links and invalid fragment targets
  */
 
-import { readFile, readdir, access } from "node:fs/promises";
+import { readFile, readdir, access, stat } from "node:fs/promises";
 import { join, extname, resolve, relative, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  extractHeadings,
+  slugify,
+} from "@takazudo/zudo-doc/extract-headings";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
@@ -22,6 +26,7 @@ Options:
   -h, --help           Show this help
   --strict-broken      Fail when broken links remain after the allowlist
   --strict-absolute    Fail when absolute MDX links remain after the allowlist
+  --strict-anchors     Fail when invalid anchors remain after the allowlist
   --strict-trailing    Fail when trailing-slash warnings remain after the allowlist
   --allowlist=PATH     Exclude exact <file>:<line>:<href> entries from failure counts`;
 
@@ -32,6 +37,7 @@ function parseCliArgs(argv) {
     help: false,
     strictBroken: false,
     strictAbsolute: false,
+    strictAnchors: false,
     strictTrailing: false,
     allowlistPath: null,
   };
@@ -46,6 +52,8 @@ function parseCliArgs(argv) {
       result.strictBroken = true;
     } else if (arg === "--strict-absolute") {
       result.strictAbsolute = true;
+    } else if (arg === "--strict-anchors") {
+      result.strictAnchors = true;
     } else if (arg === "--strict-trailing") {
       result.strictTrailing = true;
     } else if (arg.startsWith("--allowlist=")) {
@@ -152,9 +160,8 @@ export function extractHtmlLinks(html) {
   let lastIndex = 0;
   let currentLine = 1;
   while ((match = regex.exec(html)) !== null) {
-    const href = match[1] || match[2];
+    const href = match[1] ?? match[2];
     if (/^https?:\/\//i.test(href)) continue;
-    if (/^#/.test(href)) continue;
     if (/^mailto:/i.test(href)) continue;
     if (/^javascript:/i.test(href)) continue;
     if (/^data:/i.test(href)) continue;
@@ -186,6 +193,108 @@ function safeDecodePath(path) {
   }
 }
 
+function parseHref(href) {
+  const hashAt = href.indexOf("#");
+  const beforeFragment = hashAt === -1 ? href : href.slice(0, hashAt);
+  const queryAt = beforeFragment.indexOf("?");
+  const rawPath = queryAt === -1
+    ? beforeFragment
+    : beforeFragment.slice(0, queryAt);
+  const rawFragment = hashAt === -1 ? null : href.slice(hashAt + 1);
+
+  if (rawFragment === null) {
+    return {
+      path: safeDecodePath(rawPath),
+      fragment: null,
+      fragmentError: null,
+    };
+  }
+  if (rawFragment === "") {
+    return {
+      path: safeDecodePath(rawPath),
+      fragment: "",
+      fragmentError: "empty fragment",
+    };
+  }
+  try {
+    return {
+      path: safeDecodePath(rawPath),
+      fragment: decodeURIComponent(rawFragment),
+      fragmentError: null,
+    };
+  } catch {
+    return {
+      path: safeDecodePath(rawPath),
+      fragment: rawFragment,
+      fragmentError: "malformed percent-encoding",
+    };
+  }
+}
+
+async function resolveLinkTargetDetail(
+  href,
+  distDir,
+  basePath = "/",
+  fileDir = "",
+  sourceFile = null,
+) {
+  const { path: clean, fragment, fragmentError } = parseHref(href);
+  if (!clean) {
+    return {
+      type: "root",
+      targetFile: sourceFile ?? join(distDir, "index.html"),
+      fragment,
+      fragmentError,
+    };
+  }
+
+  let absolute = clean;
+  if (!clean.startsWith("/")) {
+    const dirInDist = fileDir ? relative(distDir, fileDir) : "";
+    absolute = "/" + join(dirInDist, clean);
+  }
+
+  let stripped = absolute;
+  if (basePath !== "/" && stripped.startsWith(basePath)) {
+    stripped = "/" + stripped.slice(basePath.length);
+  }
+
+  const relPath = stripped.startsWith("/") ? stripped.slice(1) : stripped;
+  if (!relPath) {
+    return {
+      type: "root",
+      targetFile: join(distDir, "index.html"),
+      fragment,
+      fragmentError,
+    };
+  }
+
+  if (extname(relPath)) {
+    const targetFile = join(distDir, relPath);
+    return {
+      type: (await fileExists(targetFile)) ? "file" : "missing",
+      targetFile,
+      fragment,
+      fragmentError,
+    };
+  }
+
+  const indexFile = join(distDir, relPath, "index.html");
+  if (await fileExists(indexFile)) {
+    return {
+      type: "directoryIndex",
+      targetFile: indexFile,
+      fragment,
+      fragmentError,
+    };
+  }
+  const htmlFile = join(distDir, relPath + ".html");
+  if (await fileExists(htmlFile)) {
+    return { type: "file", targetFile: htmlFile, fragment, fragmentError };
+  }
+  return { type: "missing", targetFile: null, fragment, fragmentError };
+}
+
 /**
  * Resolve a link and return its resolution type:
  *   'root'           — empty path or resolves to the site root (always valid)
@@ -194,43 +303,7 @@ function safeDecodePath(path) {
  *   'missing'        — target does not exist
  */
 export async function resolveLinkDetail(href, distDir, basePath = "/", fileDir = "") {
-  const clean = safeDecodePath(href.split("#")[0].split("?")[0]);
-  if (!clean) return "root";
-
-  let absolute = clean;
-
-  // Resolve relative links against the file's directory within dist
-  if (!clean.startsWith("/")) {
-    // Relative link — resolve against the file's containing directory
-    const dirInDist = fileDir ? relative(distDir, fileDir) : "";
-    absolute = "/" + join(dirInDist, clean);
-  }
-
-  // Strip base path prefix from the href to get the path relative to dist/
-  let stripped = absolute;
-  if (basePath !== "/" && stripped.startsWith(basePath)) {
-    stripped = "/" + stripped.slice(basePath.length);
-  }
-
-  const relPath = stripped.startsWith("/") ? stripped.slice(1) : stripped;
-  if (!relPath) return "root";
-
-  // Has file extension → check exact path
-  if (extname(relPath)) {
-    const exists = await fileExists(join(distDir, relPath));
-    return exists ? "file" : "missing";
-  }
-
-  // Ends with / → check index.html inside
-  if (relPath.endsWith("/")) {
-    const exists = await fileExists(join(distDir, relPath, "index.html"));
-    return exists ? "directoryIndex" : "missing";
-  }
-
-  // No extension, no trailing slash → try dir/index.html then .html
-  if (await fileExists(join(distDir, relPath, "index.html"))) return "directoryIndex";
-  if (await fileExists(join(distDir, relPath + ".html"))) return "file";
-  return "missing";
+  return (await resolveLinkTargetDetail(href, distDir, basePath, fileDir)).type;
 }
 
 export async function resolveLink(href, distDir, basePath = "/", fileDir = "") {
@@ -302,6 +375,225 @@ export function extractMdxAbsoluteLinks(content, locales) {
   return issues;
 }
 
+/** Extract internal MDX/Markdown links that carry a fragment. */
+export function extractMdxFragmentLinks(content) {
+  const links = [];
+  const lines = content.split("\n");
+  let codeFenceOpener = null;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const fence = /^([`~]{3,})/.exec(line.trimStart())?.[1];
+    if (fence !== undefined) {
+      if (codeFenceOpener === null) codeFenceOpener = fence;
+      else if (
+        fence[0] === codeFenceOpener[0] &&
+        fence.length >= codeFenceOpener.length
+      ) {
+        codeFenceOpener = null;
+      }
+      continue;
+    }
+    if (codeFenceOpener !== null) continue;
+
+    const searchLine = stripInlineCode(line);
+    let match;
+    const markdownLink = /\]\(\s*([^\s)#]*#[^\s)]*)(?:\s+[^)]*)?\)/g;
+    while ((match = markdownLink.exec(searchLine)) !== null) {
+      const href = match[1];
+      if (!/^(?:https?:|mailto:|javascript:|data:|tel:)/i.test(href)) {
+        links.push({ href, line: i + 1 });
+      }
+    }
+
+    const jsxHref = /\bhref\s*=\s*(?:"([^"]*#[^"]*)"|'([^']*#[^']*)')/g;
+    while ((match = jsxHref.exec(searchLine)) !== null) {
+      const href = match[1] ?? match[2];
+      if (!/^(?:https?:|mailto:|javascript:|data:|tel:)/i.test(href)) {
+        links.push({ href, line: i + 1 });
+      }
+    }
+  }
+
+  return links;
+}
+
+function headingText(raw) {
+  return raw
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/(?<![\w])__([^_]+)__(?![\w])/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1")
+    .replace(/(?<![\w])_([^_]+)_(?![\w])/g, "$1")
+    .trim();
+}
+
+/** All-depth mirror of the renderer's hierarchical SlugAllocator. */
+function allHierarchicalHeadingIds(body) {
+  const ids = new Set(extractHeadings(body).map((heading) => heading.slug));
+  const seen = new Map();
+  const stack = [];
+  let codeFenceOpener = null;
+
+  for (const line of body.split("\n")) {
+    const fence = /^([`~]{3,})/.exec(line.trimStart())?.[1];
+    if (fence !== undefined) {
+      if (codeFenceOpener === null) codeFenceOpener = fence;
+      else if (
+        fence[0] === codeFenceOpener[0] &&
+        fence.length >= codeFenceOpener.length
+      ) {
+        codeFenceOpener = null;
+      }
+      continue;
+    }
+    if (codeFenceOpener !== null) continue;
+
+    const match = /^(#{2,6})[ \t]+(.+)$/.exec(line.trim());
+    if (match === null) continue;
+    const depth = match[1].length;
+    const base = slugify(headingText(match[2]));
+    if (base === "") continue;
+
+    while ((stack.at(-1)?.depth ?? -1) >= depth) stack.pop();
+    const parent = stack.at(-1);
+    const candidate = parent === undefined ? base : `${parent.id}-${base}`;
+    const count = seen.get(candidate) ?? 0;
+    seen.set(candidate, count + 1);
+    const id = count === 0 ? candidate : `${candidate}-${count}`;
+    stack.push({ depth, id });
+    ids.add(id);
+  }
+  return ids;
+}
+
+function extractStaticMdxIds(body) {
+  const ids = new Set();
+  let codeFenceOpener = null;
+  const visibleLines = [];
+  for (const line of body.split("\n")) {
+    const fence = /^([`~]{3,})/.exec(line.trimStart())?.[1];
+    if (fence !== undefined) {
+      if (codeFenceOpener === null) codeFenceOpener = fence;
+      else if (
+        fence[0] === codeFenceOpener[0] &&
+        fence.length >= codeFenceOpener.length
+      ) {
+        codeFenceOpener = null;
+      }
+      visibleLines.push("");
+      continue;
+    }
+    visibleLines.push(codeFenceOpener === null ? stripInlineCode(line) : "");
+  }
+
+  const elements = visibleLines.join("\n");
+  const regex = /<[A-Za-z][^>]*\bid\s*=\s*(?:"([^"]+)"|'([^']+)')[^>]*>/gs;
+  let match;
+  while ((match = regex.exec(elements)) !== null) {
+    ids.add(match[1] ?? match[2]);
+  }
+  return ids;
+}
+
+async function resolveMdxTarget(sourceFile, href, contentDirs, locales, basePath) {
+  const { path: decodedPath } = parseHref(href);
+  let rawPath = decodedPath;
+  if (basePath !== "/" && rawPath.startsWith(basePath)) {
+    rawPath = "/" + rawPath.slice(basePath.length);
+  }
+
+  let target;
+  if (rawPath === "") {
+    target = sourceFile;
+  } else if (rawPath.startsWith("/docs/")) {
+    target = resolve(contentDirs[0], rawPath.slice("/docs/".length));
+  } else {
+    const locale = locales.find((key) => rawPath.startsWith(`/${key}/docs/`));
+    if (locale !== undefined) {
+      const localeIndex = locales.indexOf(locale);
+      const localeDir = contentDirs[localeIndex + 1];
+      if (localeDir === undefined) return null;
+      target = resolve(localeDir, rawPath.slice(`/${locale}/docs/`.length));
+    } else if (rawPath.startsWith("/")) {
+      return null;
+    } else {
+      target = resolve(dirname(sourceFile), rawPath);
+    }
+  }
+
+  const candidates = extname(target)
+    ? [target]
+    : [
+        target,
+        `${target}.mdx`,
+        `${target}.md`,
+        resolve(target, "index.mdx"),
+        resolve(target, "index.md"),
+      ];
+  for (const candidate of candidates) {
+    if (await fileExists(candidate) && (await stat(candidate)).isFile()) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+export async function checkMdxAnchors(
+  contentDirs,
+  rootDir,
+  basePath = "/",
+  locales,
+  excludePatterns = [],
+) {
+  assertLocaleList(locales);
+  const anchors = [];
+  const idCache = new Map();
+
+  for (const dir of contentDirs) {
+    if (!(await fileExists(dir))) continue;
+    const files = await collectFiles(dir, [".mdx", ".md"]);
+    for (const file of files) {
+      const content = await readFile(file, "utf-8");
+      for (const { href, line } of extractMdxFragmentLinks(content)) {
+        if (excludePatterns.some((pattern) => pattern.test(href))) continue;
+        const parsed = parseHref(href);
+        if (parsed.fragmentError !== null) {
+          anchors.push({
+            file: relative(rootDir, file),
+            line,
+            href,
+            fragment: parsed.fragment,
+            reason: parsed.fragmentError,
+          });
+          continue;
+        }
+
+        const target = await resolveMdxTarget(file, href, contentDirs, locales, basePath);
+        if (target === null) continue;
+        let ids = idCache.get(target);
+        if (ids === undefined) {
+          const targetBody = await readFile(target, "utf-8");
+          ids = allHierarchicalHeadingIds(targetBody);
+          for (const id of extractStaticMdxIds(targetBody)) ids.add(id);
+          idCache.set(target, ids);
+        }
+        if (!ids.has(parsed.fragment)) {
+          anchors.push({
+            file: relative(rootDir, file),
+            line,
+            href,
+            fragment: parsed.fragment,
+            reason: "missing target id",
+          });
+        }
+      }
+    }
+  }
+  return anchors;
+}
+
 // --- Main Check Functions ---
 
 /**
@@ -319,11 +611,13 @@ export async function checkHtmlLinksAndTrailing(
   checkTrailing = false,
 ) {
   const broken = [];
+  const anchors = [];
   const trailingSlash = [];
   const htmlFiles = await collectFiles(distDir, [".html"]);
   // One shared cache keyed by resolution type ("root"|"file"|"directoryIndex"|"missing").
   // Both checks read from the same resolved detail so each href is stat'd once.
   const cache = new Map();
+  const idCache = new Map();
 
   for (const file of htmlFiles) {
     const content = await readFile(file, "utf-8");
@@ -334,19 +628,59 @@ export async function checkHtmlLinksAndTrailing(
     for (const { href, line } of links) {
       if (excludePatterns.some((p) => p.test(href))) continue;
 
-      // Cache key: absolute links use href only; relative links include fileDir
-      const cacheKey = href.startsWith("/") ? href : `${fileDir}:${href}`;
-      let type;
+      // Cache key: absolute links use href only; relative and local-fragment
+      // links include their exact source file.
+      const cacheKey = href.startsWith("/") ? href : `${file}:${href}`;
+      let detail;
       if (cache.has(cacheKey)) {
-        type = cache.get(cacheKey);
+        detail = cache.get(cacheKey);
       } else {
-        type = await resolveLinkDetail(href, distDir, basePath, fileDir);
-        cache.set(cacheKey, type);
+        detail = await resolveLinkTargetDetail(
+          href,
+          distDir,
+          basePath,
+          fileDir,
+          file,
+        );
+        cache.set(cacheKey, detail);
       }
+      const { type } = detail;
 
       // Broken-link check
       if (type === "missing") {
         broken.push({ file: relFile, line, href });
+      }
+
+      if (detail.fragment !== null) {
+        let reason = detail.fragmentError;
+        if (
+          reason === null &&
+          type !== "missing" &&
+          detail.targetFile !== null &&
+          extname(detail.targetFile) === ".html"
+        ) {
+          let ids = idCache.get(detail.targetFile);
+          if (ids === undefined) {
+            const targetHtml = await readFile(detail.targetFile, "utf-8");
+            ids = new Set();
+            const idRegex = /\bid\s*=\s*(?:"([^"]*)"|'([^']*)')/gi;
+            let idMatch;
+            while ((idMatch = idRegex.exec(targetHtml)) !== null) {
+              ids.add(idMatch[1] ?? idMatch[2]);
+            }
+            idCache.set(detail.targetFile, ids);
+          }
+          if (!ids.has(detail.fragment)) reason = "missing target id";
+        }
+        if (reason !== null) {
+          anchors.push({
+            file: relFile,
+            line,
+            href,
+            fragment: detail.fragment,
+            reason,
+          });
+        }
       }
 
       // Trailing-slash check (opt-in)
@@ -368,7 +702,7 @@ export async function checkHtmlLinksAndTrailing(
     }
   }
 
-  return { broken, trailingSlash };
+  return { broken, anchors, trailingSlash };
 }
 
 export async function checkMdxLinks(contentDirs, rootDir, distDir = null, basePath = "/", locales) {
@@ -396,7 +730,12 @@ export async function checkMdxLinks(contentDirs, rootDir, distDir = null, basePa
 
 // --- Report ---
 
-export function formatReport(brokenLinks, mdxWarnings, trailingSlashWarnings = []) {
+export function formatReport(
+  brokenLinks,
+  mdxWarnings,
+  trailingSlashWarnings = [],
+  anchorWarnings = [],
+) {
   const lines = [];
 
   if (brokenLinks.length > 0) {
@@ -423,7 +762,21 @@ export function formatReport(brokenLinks, mdxWarnings, trailingSlashWarnings = [
     lines.push("");
   }
 
-  const total = brokenLinks.length + mdxWarnings.length + trailingSlashWarnings.length;
+  if (anchorWarnings.length > 0) {
+    lines.push("=== Invalid Anchors ===");
+    for (const { file, line, href, fragment, reason } of anchorWarnings) {
+      lines.push(
+        `  ${file}:${line}  ${href}  (fragment: #${fragment}; ${reason})`,
+      );
+    }
+    lines.push("");
+  }
+
+  const total =
+    brokenLinks.length +
+    mdxWarnings.length +
+    trailingSlashWarnings.length +
+    anchorWarnings.length;
   if (total > 0) {
     const parts = [];
     if (brokenLinks.length > 0) {
@@ -441,9 +794,14 @@ export function formatReport(brokenLinks, mdxWarnings, trailingSlashWarnings = [
         `${trailingSlashWarnings.length} trailing slash warning${trailingSlashWarnings.length === 1 ? "" : "s"}`,
       );
     }
+    if (anchorWarnings.length > 0) {
+      parts.push(
+        `${anchorWarnings.length} invalid anchor${anchorWarnings.length === 1 ? "" : "s"}`,
+      );
+    }
     lines.push(`✗ Found ${parts.join(" and ")}`);
   } else {
-    lines.push("✓ No broken links or absolute path issues found");
+    lines.push("✓ No broken links, invalid anchors, or absolute path issues found");
   }
 
   return lines.join("\n");
@@ -452,7 +810,7 @@ export function formatReport(brokenLinks, mdxWarnings, trailingSlashWarnings = [
 // --- Allowlist ---
 
 /**
- * Read the allowlist file (one entry per line; `#` comments stripped).
+ * Read the allowlist file (one entry per line; comment-only lines skipped).
  * Each non-blank line is a literal `<file>:<line>:<href>` exact match.
  * Returns a Set for O(1) lookup against `entryKey()` output below.
  */
@@ -462,7 +820,8 @@ export async function readAllowlist(allowlistPath) {
   const text = await readFile(allowlistPath, "utf-8");
   const lines = text
     .split("\n")
-    .map((l) => l.replace(/#.*$/, "").trim())
+    .map((l) => l.trim())
+    .filter((l) => !l.startsWith("#"))
     .filter((l) => l.length > 0);
   return new Set(lines);
 }
@@ -478,6 +837,7 @@ async function main() {
     help,
     strictBroken,
     strictAbsolute,
+    strictAnchors,
     strictTrailing,
     allowlistPath,
   } = parseCliArgs(process.argv.slice(2));
@@ -506,22 +866,33 @@ async function main() {
   const contentDirs = [join(rootDir, docsDir), ...localeDirs.map((d) => join(rootDir, d))];
 
   // Single-pass dist walk: broken links + trailing-slash warnings in one read.
-  const [{ broken: brokenLinks, trailingSlash: trailingSlashWarnings }, mdxWarnings] =
+  const [
+    {
+      broken: brokenLinks,
+      anchors: htmlAnchorWarnings,
+      trailingSlash: trailingSlashWarnings,
+    },
+    mdxWarnings,
+    mdxAnchorWarnings,
+  ] =
     await Promise.all([
       checkHtmlLinksAndTrailing(distDir, rootDir, basePath, excludePatterns, trailingSlash),
       checkMdxLinks(contentDirs, rootDir, distDir, basePath, localeKeys),
+      checkMdxAnchors(contentDirs, rootDir, basePath, localeKeys, excludePatterns),
     ]);
+  const anchorWarnings = [...htmlAnchorWarnings, ...mdxAnchorWarnings];
 
   // --- Flag parsing ---
   //
-  // Three strict knobs (separable so a deploy can fail on real 404s
+  // Four strict knobs (separable so a deploy can fail on real 404s
   // without blocking on warn-only categories) plus an allowlist:
   //
   //   --strict-broken    fail when broken links > 0 (after allowlist)
   //   --strict-absolute  fail when absolute warnings > 0 (after allowlist)
+  //   --strict-anchors   fail when invalid anchors > 0 (after allowlist)
   //   --strict-trailing  fail when trailing-slash warnings > 0 (after allowlist)
   //   --allowlist=PATH   skip entries listed in PATH (one
-  //                      `<file>:<line>:<href>` per line, `#` comments)
+  //                      `<file>:<line>:<href>` per line, comment-only lines)
   const resolvedAllowlist = allowlistPath
     ? (allowlistPath.startsWith("/") ? allowlistPath : join(rootDir, allowlistPath))
     : null;
@@ -533,14 +904,21 @@ async function main() {
   const filterOut = (entries) => entries.filter((e) => !allowlist.has(entryKey(e)));
   const realBroken = filterOut(brokenLinks);
   const realAbsolute = filterOut(mdxWarnings);
+  const realAnchors = filterOut(anchorWarnings);
   const realTrailing = filterOut(trailingSlashWarnings);
 
-  console.log(formatReport(brokenLinks, mdxWarnings, trailingSlashWarnings));
+  console.log(formatReport(
+    brokenLinks,
+    mdxWarnings,
+    trailingSlashWarnings,
+    anchorWarnings,
+  ));
 
   if (allowlist.size > 0) {
     const skipped =
       (brokenLinks.length - realBroken.length) +
       (mdxWarnings.length - realAbsolute.length) +
+      (anchorWarnings.length - realAnchors.length) +
       (trailingSlashWarnings.length - realTrailing.length);
     if (skipped > 0) {
       console.log(
@@ -550,7 +928,10 @@ async function main() {
   }
 
   const hasIssues =
-    brokenLinks.length > 0 || mdxWarnings.length > 0 || trailingSlashWarnings.length > 0;
+    brokenLinks.length > 0 ||
+    mdxWarnings.length > 0 ||
+    anchorWarnings.length > 0 ||
+    trailingSlashWarnings.length > 0;
 
   // Per-category strict failure (real counts). Combined into one exit
   // code so b4push only needs one invocation. Print which category
@@ -564,6 +945,10 @@ async function main() {
     console.log(`\n❌ STRICT FAIL: ${realAbsolute.length} absolute MDX-source link${realAbsolute.length === 1 ? "" : "s"} (after allowlist).`);
     failed = true;
   }
+  if (strictAnchors && realAnchors.length > 0) {
+    console.log(`\n❌ STRICT FAIL: ${realAnchors.length} invalid anchor${realAnchors.length === 1 ? "" : "s"} (after allowlist).`);
+    failed = true;
+  }
   if (strictTrailing && realTrailing.length > 0) {
     console.log(`\n❌ STRICT FAIL: ${realTrailing.length} trailing-slash warning${realTrailing.length === 1 ? "" : "s"} (after allowlist).`);
     failed = true;
@@ -572,10 +957,10 @@ async function main() {
     process.exit(1);
   }
 
-  if (hasIssues && !strictBroken && !strictAbsolute && !strictTrailing) {
+  if (hasIssues && !strictBroken && !strictAbsolute && !strictAnchors && !strictTrailing) {
     console.log("\nNote: Issues found but running in non-strict mode (exit 0).");
     console.log(
-      "Use --strict-broken / --strict-absolute / --strict-trailing to fail on selected issue categories.",
+      "Use --strict-broken / --strict-absolute / --strict-anchors / --strict-trailing to fail on selected issue categories.",
     );
   }
 }

--- a/scripts/run-b4push.sh
+++ b/scripts/run-b4push.sh
@@ -471,7 +471,7 @@ fi
 # entry whenever the underlying issue gets fixed so the strict
 # gate then catches future regressions of the same shape.
 step "Link check (check-links --strict-broken --strict-absolute)"
-if (cd "$ROOT_DIR" && pnpm run check:links -- --strict-broken --strict-absolute --allowlist=.check-links-allowlist); then
+if (cd "$ROOT_DIR" && pnpm run check:links -- --strict-broken --strict-absolute --strict-anchors --allowlist=.check-links-allowlist); then
   pass "Link check passed"
 else
   fail "Link check"


### PR DESCRIPTION
Parent: #3550

## Summary

- validate fragments in built HTML and MDX source
- add strict-anchor reporting, allowlisting, and b4push enforcement
- cover hierarchical, static-id, locale, encoding, and exclusion cases

## Test plan

- 103 focused link-checker tests
- showcase build and strict link check

Closes #3551.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/3562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789768707&installation_model_id=20910&pr_number=3562&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F3562&signature=44a4d1a784b803ec81542dc79274d2547d7a9dce33b894db3ac1227b9204166d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->