### PR TITLE
Ship anchor-aware link checks in scaffolds

### DIFF
--- a/.check-links-allowlist
+++ b/.check-links-allowlist
@@ -1,10 +1,10 @@
 # Known exceptions for `pnpm run check:links` (consumed by
 # `scripts/check-links.js --allowlist=...`).
 #
-# Format: `<file>:<line>:<href>` per line. `#` comments and blank
-# lines are ignored. Each entry MUST match the printed report
-# verbatim (file path relative to repo root, 1-based line number,
-# href as it appeared in the source/dist).
+# Format: `<file>:<line>:<href>` per line. Comment-only (`# ...`) and
+# blank lines are ignored; `#` inside an href is preserved. Each entry
+# MUST match the printed report verbatim (file path relative to repo
+# root, 1-based line number, href as it appeared in the source/dist).
 #
 # Add entries here when an issue cannot be fixed at the source —
 # typically: doc pages that reference EN-only siblings from JA, or

--- a/.template-drift-allowlist
+++ b/.template-drift-allowlist
@@ -38,6 +38,10 @@
 # import.
 src/styles/global.css
 
+# scripts/check-links.js
+# reason: generated projects resolve base/trailingSlash/docsDir/locales from zfb.config.ts; the host checker reads src/config/settings.ts.
+scripts/check-links.js
+
 # ── tsconfig.json ───────────────────────────────────────────────────────────
 # The template ships the minimal 5-field extends form documented in
 # packages/zudo-doc/CLAUDE.md's "Shipped ambient type shims + tsconfig base"

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -98,9 +98,10 @@ const baseChoices: UserChoices = {
 // The locked manifest (#2653 Decision 4 / #2660 completion comment).
 // ---------------------------------------------------------------------------
 
-/** The locked ~17-file barebone (EN-only) manifest. Grew from 12 to 13 with
+/** The locked ~18-file barebone (EN-only) manifest. Grew from 12 to 13 with
  *  pnpm-workspace.yaml (#2923 — disables pnpm 11's minimumReleaseAge gate),
- *  then from 13 to 17 with the default public/ favicon set (#3186). */
+ *  then from 13 to 17 with the default public/ favicon set (#3186), and to
+ *  18 with the generated-project link checker (#3552). */
 const BAREBONE_MANIFEST = [
   ".gitignore",
   ".npmrc",
@@ -113,6 +114,7 @@ const BAREBONE_MANIFEST = [
   "public/favicon-32x32.png",
   "public/favicon.ico",
   "public/favicon.svg",
+  "scripts/check-links.js",
   "src/content/docs/getting-started/index.mdx",
   "src/content/docs/getting-started/installation.mdx",
   "src/content/docs/getting-started/introduction.mdx",
@@ -165,7 +167,7 @@ describe("scaffold — barebone manifest (locked 17-file shape, #2653 Decision 4
     await fs.remove(dir);
   });
 
-  it("emits EXACTLY the 17 locked-manifest files — no more, no less", () => {
+  it("emits EXACTLY the 18 locked-manifest files — no more, no less", () => {
     expect(files).toEqual(BAREBONE_MANIFEST);
   });
 });
@@ -898,7 +900,7 @@ describe("scaffold — changelog feature", () => {
 });
 
 describe("scaffold — every-feature manifest is exactly base + the documented per-feature deltas", () => {
-  it("all-on scaffold emits exactly the expected 45-file set", async () => {
+  it("all-on scaffold emits exactly the expected 46-file set", async () => {
     await scaffold({
       ...baseChoices,
       projectName: "test-all-on",
@@ -922,6 +924,7 @@ describe("scaffold — every-feature manifest is exactly base + the documented p
       "public/favicon-32x32.png",
       "public/favicon.ico",
       "public/favicon.svg",
+      "scripts/check-links.js",
       "scripts/setup-doc-skill.sh",
       "src-tauri-dev/.gitignore",
       "src-tauri-dev/Cargo.toml",
@@ -1479,7 +1482,7 @@ describe("scaffold — CLAUDE.md generation", () => {
 });
 
 describe("scaffold — generated package.json", () => {
-  it("scripts: only dev/build/preview/check by default — no check:html, gen:z-index, or check:z-index", async () => {
+  it("scripts: emits dev/build/preview/check/check:links by default — no check:html, gen:z-index, or check:z-index", async () => {
     await scaffold(baseChoices);
     const pkg = await fs.readJson(projectPath("test-doc", "package.json"));
     expect(pkg.scripts).toEqual({
@@ -1487,6 +1490,7 @@ describe("scaffold — generated package.json", () => {
       build: "zfb build",
       preview: "zfb preview",
       check: "zfb check",
+      "check:links": "node scripts/check-links.js",
     });
   });
 

--- a/packages/create-zudo-doc/src/__tests__/template-check-links.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/template-check-links.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import fs from "fs-extra";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const TEMP_PREFIX = "create-zudo-doc-check-links-test-";
+const TEMPLATE_SCRIPT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../templates/base/scripts/check-links.js",
+);
+
+type Fixture = {
+  config?: string;
+  files: Record<string, string>;
+  args?: string[];
+};
+
+async function runFixture(fixture: Fixture) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), TEMP_PREFIX));
+  await fs.outputFile(
+    path.join(root, "zfb.config.ts"),
+    fixture.config ?? 'export default defineConfig(zudoDoc({ siteName: "Fixture" }));\n',
+  );
+  for (const [relativePath, content] of Object.entries(fixture.files)) {
+    await fs.outputFile(path.join(root, relativePath), content);
+  }
+  expect(await fs.pathExists(path.join(root, "dist"))).toBe(false);
+  const result = spawnSync(process.execPath, [TEMPLATE_SCRIPT, ...(fixture.args ?? [])], {
+    cwd: root,
+    encoding: "utf-8",
+  });
+  await fs.remove(root);
+  return result;
+}
+
+describe("generated check-links.js — source anchors without dist (#3552)", () => {
+  it("rejects a broken anchor", async () => {
+    const result = await runFixture({
+      args: ["--strict-anchors"],
+      files: {
+        "src/content/docs/source.mdx": "[broken](/docs/target#does-not-exist)\n",
+        "src/content/docs/target.mdx": "## Real heading\n",
+      },
+    });
+    expect(result.status).toBe(1);
+    expect(`${result.stdout}${result.stderr}`).toContain("missing target id");
+  });
+
+  it("accepts a valid hierarchical heading anchor", async () => {
+    const result = await runFixture({
+      args: ["--strict-anchors"],
+      files: {
+        "src/content/docs/source.mdx": "[child](/docs/target#parent-child)\n",
+        "src/content/docs/target.mdx": "## Parent\n### Child\n",
+      },
+    });
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+  });
+
+  it("accepts a static id target", async () => {
+    const result = await runFixture({
+      args: ["--strict-anchors"],
+      files: {
+        "src/content/docs/source.mdx": "[static](/docs/target#custom-target)\n",
+        "src/content/docs/target.mdx": '<div id="custom-target">Target</div>\n',
+      },
+    });
+    expect(result.status).toBe(0);
+  });
+
+  it("uses defaults for omitted fields and reads docsDir/locales overrides literally", async () => {
+    const defaultResult = await runFixture({
+      args: ["--strict-anchors"],
+      files: {
+        "src/content/docs/source.mdx": "[default](/docs/target#default-target)\n",
+        "src/content/docs/target.mdx": "## Default Target\n",
+      },
+    });
+    expect(defaultResult.status).toBe(0);
+    expect(defaultResult.stdout).toContain("base: /, trailingSlash: false");
+
+    const overrideResult = await runFixture({
+      config: `export default defineConfig(zudoDoc({
+  base: "/site/",
+  trailingSlash: true,
+  docsDir: "docs",
+  locales: { ja: { label: "日本語", dir: "docs-ja" } },
+}));\n`,
+      args: ["--strict-anchors"],
+      files: {
+        "docs/source.mdx": "[default](/site/docs/target#default-target)\n",
+        "docs/target.mdx": "## Default Target\n",
+        "docs-ja/source.mdx": "[日本語](/site/ja/docs/target#ja-target)\n",
+        "docs-ja/target.mdx": "## Ja Target\n",
+      },
+    });
+    expect(overrideResult.status).toBe(0);
+    expect(overrideResult.stdout).toContain("base: /site/, trailingSlash: true");
+  });
+
+  it("fails loudly when a relevant config field is dynamic", async () => {
+    const result = await runFixture({
+      config: `const docsDir = "docs";
+export default defineConfig(zudoDoc({ docsDir }));\n`,
+      files: {},
+    });
+    expect(result.status).toBe(1);
+    expect(`${result.stdout}${result.stderr}`).toContain("field docsDir");
+    expect(`${result.stdout}${result.stderr}`).toContain("literal string");
+  });
+});

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -907,6 +907,7 @@ function generatePackageJson(choices: UserChoices) {
     build: "zfb build",
     preview: "zfb preview",
     check: "zfb check",
+    "check:links": "node scripts/check-links.js",
   };
 
   if (choices.features.includes("docHistory")) {

--- a/packages/create-zudo-doc/templates/base/scripts/check-links.js
+++ b/packages/create-zudo-doc/templates/base/scripts/check-links.js
@@ -1,0 +1,833 @@
+#!/usr/bin/env node
+
+/**
+ * Check links in a generated zudo-doc project.
+ *
+ * The source scan is intentionally useful before a build: generated projects
+ * do not need a dist/ directory for anchor validation. When dist/ exists, its
+ * HTML is checked as an additional pass.
+ */
+
+import { access, readFile, readdir, stat } from "node:fs/promises";
+import { dirname, extname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { extractHeadings, slugify } from "@takazudo/zudo-doc/extract-headings";
+
+const CLI_USAGE = `Usage: pnpm check:links -- [options]
+
+Options:
+  -h, --help           Show this help
+  --strict-broken      Fail when broken links remain after the allowlist
+  --strict-absolute    Fail when absolute MDX links remain after the allowlist
+  --strict-anchors     Fail when invalid anchors remain after the allowlist
+  --strict-trailing    Fail when trailing-slash warnings remain after the allowlist
+  --allowlist=PATH     Exclude exact <file>:<line>:<href> entries from failure counts`;
+
+class CliArgumentError extends Error {}
+
+function parseCliArgs(argv) {
+  const result = {
+    help: false,
+    strictBroken: false,
+    strictAbsolute: false,
+    strictAnchors: false,
+    strictTrailing: false,
+    allowlistPath: null,
+  };
+
+  for (const arg of argv) {
+    if (arg === "--") continue;
+    if (arg === "-h" || arg === "--help") result.help = true;
+    else if (arg === "--strict-broken") result.strictBroken = true;
+    else if (arg === "--strict-absolute") result.strictAbsolute = true;
+    else if (arg === "--strict-anchors") result.strictAnchors = true;
+    else if (arg === "--strict-trailing") result.strictTrailing = true;
+    else if (arg.startsWith("--allowlist=")) {
+      result.allowlistPath = arg.slice("--allowlist=".length);
+      if (!result.allowlistPath) {
+        throw new CliArgumentError("--allowlist requires a non-empty path");
+      }
+    } else {
+      throw new CliArgumentError(`Unknown option: ${arg}\n\n${CLI_USAGE}`);
+    }
+  }
+  return result;
+}
+
+async function fileExists(filePath) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function isDirectory(dirPath) {
+  try {
+    return (await stat(dirPath)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+export async function collectFiles(dir, extensions) {
+  const files = [];
+  async function walk(current) {
+    let entries;
+    try {
+      entries = await readdir(current, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = join(current, entry.name);
+      if (entry.isDirectory()) await walk(full);
+      else if (extensions.some((extension) => entry.name.endsWith(extension))) {
+        files.push(full);
+      }
+    }
+  }
+  await walk(dir);
+  return files.sort();
+}
+
+// ---------------------------------------------------------------------------
+// zfb.config.ts literal extraction
+// ---------------------------------------------------------------------------
+
+function skipTrivia(source, index, end = source.length) {
+  let cursor = index;
+  while (cursor < end) {
+    if (/\s/.test(source[cursor])) {
+      cursor += 1;
+      continue;
+    }
+    if (source.startsWith("//", cursor)) {
+      const newline = source.indexOf("\n", cursor + 2);
+      cursor = newline === -1 || newline >= end ? end : newline + 1;
+      continue;
+    }
+    if (source.startsWith("/*", cursor)) {
+      const close = source.indexOf("*/", cursor + 2);
+      if (close === -1 || close + 2 > end) {
+        throw new Error("unterminated block comment");
+      }
+      cursor = close + 2;
+      continue;
+    }
+    break;
+  }
+  return cursor;
+}
+
+function readStringEnd(source, start, end = source.length) {
+  const quote = source[start];
+  if (quote !== "\"" && quote !== "'") return null;
+  let cursor = start + 1;
+  while (cursor < end) {
+    if (source[cursor] === "\\") {
+      cursor += 2;
+      continue;
+    }
+    if (source[cursor] === quote) return cursor + 1;
+    cursor += 1;
+  }
+  throw new Error("unterminated string literal");
+}
+
+function readStringValue(source, start, end, fieldName) {
+  const valueStart = skipTrivia(source, start, end);
+  const valueEnd = readStringEnd(source, valueStart, end);
+  if (valueEnd === null || skipTrivia(source, valueEnd, end) !== end) {
+    throw new Error(
+      `zfb.config.ts field ${fieldName} must be a literal string (dynamic expressions are not supported)`,
+    );
+  }
+  const raw = source.slice(valueStart, valueEnd);
+  try {
+    if (raw[0] === '"') return JSON.parse(raw);
+    // Generated configs use JSON strings, but accepting ordinary single-
+    // quoted TypeScript literals makes the extractor useful for hand edits.
+    let result = "";
+    for (let i = 1; i < raw.length - 1; i += 1) {
+      if (raw[i] !== "\\") {
+        result += raw[i];
+        continue;
+      }
+      const escaped = raw[++i];
+      const escapes = {
+        n: "\n",
+        r: "\r",
+        t: "\t",
+        b: "\b",
+        f: "\f",
+        v: "\v",
+        "0": "\0",
+        "\\": "\\",
+        "'": "'",
+        '"': '"',
+      };
+      if (escaped === "u") {
+        const hex = raw.slice(i + 1, i + 5);
+        if (!/^[0-9a-fA-F]{4}$/.test(hex)) throw new Error("invalid unicode escape");
+        result += String.fromCharCode(Number.parseInt(hex, 16));
+        i += 4;
+      } else if (escaped === "x") {
+        const hex = raw.slice(i + 1, i + 3);
+        if (!/^[0-9a-fA-F]{2}$/.test(hex)) throw new Error("invalid hex escape");
+        result += String.fromCharCode(Number.parseInt(hex, 16));
+        i += 2;
+      } else if (escaped in escapes) result += escapes[escaped];
+      else throw new Error(`unsupported escape \\${escaped}`);
+    }
+    return result;
+  } catch (error) {
+    throw new Error(`zfb.config.ts field ${fieldName} has an invalid string literal: ${error.message}`);
+  }
+}
+
+function matchingDelimiter(source, start, end = source.length) {
+  const opening = source[start];
+  const pairs = { "{": "}", "[": "]", "(": ")" };
+  if (!(opening in pairs)) throw new Error(`expected an object/array/call at offset ${start}`);
+  const stack = [pairs[opening]];
+  let cursor = start + 1;
+  while (cursor < end) {
+    if (source[cursor] === "\"" || source[cursor] === "'") {
+      cursor = readStringEnd(source, cursor, end);
+      continue;
+    }
+    if (source.startsWith("//", cursor)) {
+      const newline = source.indexOf("\n", cursor + 2);
+      cursor = newline === -1 || newline >= end ? end : newline + 1;
+      continue;
+    }
+    if (source.startsWith("/*", cursor)) {
+      const close = source.indexOf("*/", cursor + 2);
+      if (close === -1 || close + 2 > end) throw new Error("unterminated block comment");
+      cursor = close + 2;
+      continue;
+    }
+    if (source[cursor] in pairs) stack.push(pairs[source[cursor]]);
+    else if (source[cursor] === stack.at(-1)) stack.pop();
+    else if (source[cursor] === "}" || source[cursor] === "]" || source[cursor] === ")") {
+      throw new Error(`unexpected delimiter ${source[cursor]} in zfb.config.ts`);
+    }
+    if (stack.length === 0) return cursor;
+    cursor += 1;
+  }
+  throw new Error("unterminated literal in zfb.config.ts");
+}
+
+function valueEndAtComma(source, start, end) {
+  const stack = [];
+  let cursor = start;
+  while (cursor < end) {
+    if (source[cursor] === "\"" || source[cursor] === "'") {
+      cursor = readStringEnd(source, cursor, end);
+      continue;
+    }
+    if (source.startsWith("//", cursor)) {
+      const newline = source.indexOf("\n", cursor + 2);
+      cursor = newline === -1 || newline >= end ? end : newline + 1;
+      continue;
+    }
+    if (source.startsWith("/*", cursor)) {
+      const close = source.indexOf("*/", cursor + 2);
+      if (close === -1 || close + 2 > end) throw new Error("unterminated block comment");
+      cursor = close + 2;
+      continue;
+    }
+    if (source[cursor] === "{" || source[cursor] === "[" || source[cursor] === "(") {
+      stack.push(source[cursor]);
+      cursor += 1;
+      continue;
+    }
+    if (source[cursor] === "}" || source[cursor] === "]" || source[cursor] === ")") {
+      if (stack.length === 0) return cursor;
+      stack.pop();
+      cursor += 1;
+      continue;
+    }
+    if (source[cursor] === "," && stack.length === 0) return cursor;
+    cursor += 1;
+  }
+  return end;
+}
+
+function parseObjectEntries(source, open, close, context) {
+  const entries = new Map();
+  let cursor = open + 1;
+  while (true) {
+    cursor = skipTrivia(source, cursor, close);
+    if (cursor >= close) break;
+    if (source.startsWith("...", cursor)) {
+      throw new Error(
+        `zfb.config.ts ${context} contains a spread; config fields must be literal values`,
+      );
+    }
+    let key;
+    if (source[cursor] === "\"" || source[cursor] === "'") {
+      const keyEnd = readStringEnd(source, cursor, close);
+      key = readStringValue(source, cursor, keyEnd, `${context} key`);
+      cursor = keyEnd;
+    } else {
+      const match = /^[A-Za-z_$][A-Za-z0-9_$]*/.exec(source.slice(cursor, close));
+      if (!match) throw new Error(`zfb.config.ts ${context} has an invalid property name`);
+      key = match[0];
+      cursor += key.length;
+    }
+    cursor = skipTrivia(source, cursor, close);
+    if (source[cursor] !== ":") {
+      const literalKind = key === "base" || key === "docsDir" ? "literal string" : "literal value";
+      throw new Error(`zfb.config.ts field ${key} must be a ${literalKind} (dynamic expressions are not supported)`);
+    }
+    const valueStart = cursor + 1;
+    const comma = valueEndAtComma(source, valueStart, close);
+    const previous = entries.get(key);
+    if (previous !== undefined) throw new Error(`zfb.config.ts declares ${context}.${key} more than once`);
+    entries.set(key, { start: valueStart, end: comma });
+    cursor = comma;
+    if (cursor < close && source[cursor] === ",") cursor += 1;
+    else if (cursor < close) throw new Error(`zfb.config.ts ${context} has an invalid separator`);
+  }
+  return entries;
+}
+
+function readLiteralBoolean(source, start, end, fieldName) {
+  const valueStart = skipTrivia(source, start, end);
+  for (const [literal, value] of [["true", true], ["false", false]]) {
+    const literalEnd = valueStart + literal.length;
+    if (source.slice(valueStart, literalEnd) === literal && skipTrivia(source, literalEnd, end) === end) {
+      return value;
+    }
+  }
+  throw new Error(
+    `zfb.config.ts field ${fieldName} must be the literal true or false (dynamic expressions are not supported)`,
+  );
+}
+
+function readObjectValue(source, start, end, fieldName) {
+  const valueStart = skipTrivia(source, start, end);
+  if (source[valueStart] !== "{") {
+    throw new Error(`zfb.config.ts field ${fieldName} must be a literal object`);
+  }
+  const valueClose = matchingDelimiter(source, valueStart, end);
+  if (skipTrivia(source, valueClose + 1, end) !== end) {
+    throw new Error(`zfb.config.ts field ${fieldName} must be a literal object (dynamic expressions are not supported)`);
+  }
+  return { open: valueStart, close: valueClose };
+}
+
+function findZudoDocCall(source) {
+  let cursor = 0;
+  let found = null;
+  while (cursor < source.length) {
+    if (source[cursor] === "\"" || source[cursor] === "'") {
+      cursor = readStringEnd(source, cursor);
+      continue;
+    }
+    if (source.startsWith("//", cursor)) {
+      const newline = source.indexOf("\n", cursor + 2);
+      cursor = newline === -1 ? source.length : newline + 1;
+      continue;
+    }
+    if (source.startsWith("/*", cursor)) {
+      const close = source.indexOf("*/", cursor + 2);
+      if (close === -1) throw new Error("unterminated block comment in zfb.config.ts");
+      cursor = close + 2;
+      continue;
+    }
+    if (source.startsWith("zudoDoc", cursor) && !/[A-Za-z0-9_$]/.test(source[cursor - 1] ?? "")) {
+      const afterName = cursor + "zudoDoc".length;
+      if (!/[A-Za-z0-9_$]/.test(source[afterName] ?? "")) {
+        const openParen = skipTrivia(source, afterName);
+        if (source[openParen] === "(") {
+          if (found !== null) throw new Error("zfb.config.ts must contain exactly one zudoDoc({...}) call");
+          found = openParen;
+          cursor = openParen + 1;
+          continue;
+        }
+      }
+    }
+    cursor += 1;
+  }
+  return found;
+}
+
+export async function parseZfbConfig(configPath) {
+  const source = await readFile(configPath, "utf-8");
+  const openParen = findZudoDocCall(source);
+  if (openParen === null) throw new Error("zfb.config.ts does not contain a zudoDoc({...}) call");
+  const closeParen = matchingDelimiter(source, openParen);
+  const objectOpen = skipTrivia(source, openParen + 1, closeParen);
+  if (source[objectOpen] !== "{") {
+    throw new Error("zfb.config.ts zudoDoc() argument must be a literal object (imports and spreads are not supported)");
+  }
+  const objectClose = matchingDelimiter(source, objectOpen, closeParen);
+  if (skipTrivia(source, objectClose + 1, closeParen) !== closeParen) {
+    throw new Error("zfb.config.ts zudoDoc() accepts one literal object argument");
+  }
+
+  const entries = parseObjectEntries(source, objectOpen, objectClose, "zudoDoc({...})");
+  const result = {
+    basePath: "/",
+    trailingSlash: false,
+    docsDir: "src/content/docs",
+    localeDirs: [],
+    localeKeys: [],
+  };
+
+  const base = entries.get("base");
+  if (base) result.basePath = readStringValue(source, base.start, base.end, "base");
+  const trailing = entries.get("trailingSlash");
+  if (trailing) result.trailingSlash = readLiteralBoolean(source, trailing.start, trailing.end, "trailingSlash");
+  const docsDir = entries.get("docsDir");
+  if (docsDir) result.docsDir = readStringValue(source, docsDir.start, docsDir.end, "docsDir");
+
+  const locales = entries.get("locales");
+  if (locales) {
+    const localeObject = readObjectValue(source, locales.start, locales.end, "locales");
+    const localeEntries = parseObjectEntries(source, localeObject.open, localeObject.close, "locales");
+    for (const [key, value] of localeEntries) {
+      const localeConfig = readObjectValue(source, value.start, value.end, `locales.${key}`);
+      const localeFields = parseObjectEntries(source, localeConfig.open, localeConfig.close, `locales.${key}`);
+      const dir = localeFields.get("dir");
+      if (!dir) {
+        throw new Error(`zfb.config.ts field locales.${key}.dir is required for link checking`);
+      }
+      result.localeKeys.push(key);
+      result.localeDirs.push(readStringValue(source, dir.start, dir.end, `locales.${key}.dir`));
+    }
+  }
+  return result;
+}
+
+export async function parseBasePath(configPath) {
+  return (await parseZfbConfig(configPath)).basePath;
+}
+
+export async function parseTrailingSlash(configPath) {
+  return (await parseZfbConfig(configPath)).trailingSlash;
+}
+
+export async function parseContentDirs(configPath) {
+  const config = await parseZfbConfig(configPath);
+  return {
+    docsDir: config.docsDir,
+    localeDirs: config.localeDirs,
+    localeKeys: config.localeKeys,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Shared link and anchor logic
+// ---------------------------------------------------------------------------
+
+export function extractHtmlLinks(html) {
+  const links = [];
+  const regex = /<a\s[^>]*?href=(?:"([^"]*)"|'([^']*)')[^>]*>/gi;
+  let match;
+  let lastIndex = 0;
+  let line = 1;
+  while ((match = regex.exec(html)) !== null) {
+    const href = match[1] ?? match[2];
+    if (/^(?:https?:|mailto:|javascript:|data:|tel:)/i.test(href)) continue;
+    for (let i = lastIndex; i < match.index; i += 1) if (html[i] === "\n") line += 1;
+    lastIndex = match.index;
+    links.push({ href, line });
+  }
+  return links;
+}
+
+function safeDecodePath(path) {
+  try {
+    return decodeURIComponent(path);
+  } catch {
+    return path;
+  }
+}
+
+function parseHref(href) {
+  const hashAt = href.indexOf("#");
+  const beforeFragment = hashAt === -1 ? href : href.slice(0, hashAt);
+  const queryAt = beforeFragment.indexOf("?");
+  const rawPath = queryAt === -1 ? beforeFragment : beforeFragment.slice(0, queryAt);
+  const rawFragment = hashAt === -1 ? null : href.slice(hashAt + 1);
+  if (rawFragment === null) return { path: safeDecodePath(rawPath), fragment: null, fragmentError: null };
+  if (rawFragment === "") return { path: safeDecodePath(rawPath), fragment: "", fragmentError: "empty fragment" };
+  try {
+    return { path: safeDecodePath(rawPath), fragment: decodeURIComponent(rawFragment), fragmentError: null };
+  } catch {
+    return { path: safeDecodePath(rawPath), fragment: rawFragment, fragmentError: "malformed percent-encoding" };
+  }
+}
+
+function stripInlineCode(line) {
+  let result = line.replace(/(?<!\\)``[^`]*(?:``|$)/g, (match) => " ".repeat(match.length));
+  return result.replace(/(?<!\\)`[^`]*(?:`|$)/g, (match) => " ".repeat(match.length));
+}
+
+function assertLocaleList(locales) {
+  if (!Array.isArray(locales) || !locales.every((locale) => typeof locale === "string")) {
+    throw new TypeError("locales must be passed explicitly as an array of locale keys");
+  }
+}
+
+export function extractMdxAbsoluteLinks(content, locales) {
+  assertLocaleList(locales);
+  const localeAlternation = locales.length > 0
+    ? `(?:${locales.map((key) => `${key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/`).join("|")})?`
+    : "";
+  const issues = [];
+  const lines = content.split("\n");
+  let inCodeBlock = false;
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (/^```/.test(line.trimStart())) {
+      inCodeBlock = !inCodeBlock;
+      continue;
+    }
+    if (inCodeBlock) continue;
+    const searchLine = stripInlineCode(line);
+    const mdRegex = new RegExp(`\\]\\((\\/${localeAlternation}docs\\/[^)]*)\\)`, "g");
+    let match;
+    while ((match = mdRegex.exec(searchLine)) !== null) issues.push({ href: match[1], line: i + 1 });
+    const jsxRegex = new RegExp(`href="(\\/${localeAlternation}docs\\/[^"]*)"`, "g");
+    while ((match = jsxRegex.exec(searchLine)) !== null) issues.push({ href: match[1], line: i + 1 });
+  }
+  return issues;
+}
+
+export function extractMdxFragmentLinks(content) {
+  const links = [];
+  const lines = content.split("\n");
+  let codeFenceOpener = null;
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const fence = /^([`~]{3,})/.exec(line.trimStart())?.[1];
+    if (fence !== undefined) {
+      if (codeFenceOpener === null) codeFenceOpener = fence;
+      else if (fence[0] === codeFenceOpener[0] && fence.length >= codeFenceOpener.length) codeFenceOpener = null;
+      continue;
+    }
+    if (codeFenceOpener !== null) continue;
+    const searchLine = stripInlineCode(line);
+    let match;
+    const markdownLink = /\]\(\s*([^\s)#]*#[^\s)]*)(?:\s+[^)]*)?\)/g;
+    while ((match = markdownLink.exec(searchLine)) !== null) {
+      if (!/^(?:https?:|mailto:|javascript:|data:|tel:)/i.test(match[1])) links.push({ href: match[1], line: i + 1 });
+    }
+    const jsxHref = /\bhref\s*=\s*(?:"([^"]*#[^"]*)"|'([^']*#[^']*)')/g;
+    while ((match = jsxHref.exec(searchLine)) !== null) {
+      const href = match[1] ?? match[2];
+      if (!/^(?:https?:|mailto:|javascript:|data:|tel:)/i.test(href)) links.push({ href, line: i + 1 });
+    }
+  }
+  return links;
+}
+
+function headingText(raw) {
+  return raw
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/(?<![\w])__([^_]+)__(?![\w])/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1")
+    .replace(/(?<![\w])_([^_]+)_(?![\w])/g, "$1")
+    .trim();
+}
+
+function allHierarchicalHeadingIds(body) {
+  const ids = new Set(extractHeadings(body).map((heading) => heading.slug));
+  const seen = new Map();
+  const stack = [];
+  let codeFenceOpener = null;
+  for (const line of body.split("\n")) {
+    const fence = /^([`~]{3,})/.exec(line.trimStart())?.[1];
+    if (fence !== undefined) {
+      if (codeFenceOpener === null) codeFenceOpener = fence;
+      else if (fence[0] === codeFenceOpener[0] && fence.length >= codeFenceOpener.length) codeFenceOpener = null;
+      continue;
+    }
+    if (codeFenceOpener !== null) continue;
+    const match = /^(#{2,6})[ \t]+(.+)$/.exec(line.trim());
+    if (match === null) continue;
+    const depth = match[1].length;
+    const base = slugify(headingText(match[2]));
+    if (base === "") continue;
+    while ((stack.at(-1)?.depth ?? -1) >= depth) stack.pop();
+    const parent = stack.at(-1);
+    const candidate = parent === undefined ? base : `${parent.id}-${base}`;
+    const count = seen.get(candidate) ?? 0;
+    seen.set(candidate, count + 1);
+    const id = count === 0 ? candidate : `${candidate}-${count}`;
+    stack.push({ depth, id });
+    ids.add(id);
+  }
+  return ids;
+}
+
+function extractStaticMdxIds(body) {
+  const ids = new Set();
+  let codeFenceOpener = null;
+  const visibleLines = [];
+  for (const line of body.split("\n")) {
+    const fence = /^([`~]{3,})/.exec(line.trimStart())?.[1];
+    if (fence !== undefined) {
+      if (codeFenceOpener === null) codeFenceOpener = fence;
+      else if (fence[0] === codeFenceOpener[0] && fence.length >= codeFenceOpener.length) codeFenceOpener = null;
+      visibleLines.push("");
+      continue;
+    }
+    visibleLines.push(codeFenceOpener === null ? stripInlineCode(line) : "");
+  }
+  const elements = visibleLines.join("\n");
+  const regex = /<[A-Za-z][^>]*\bid\s*=\s*(?:"([^"]+)"|'([^']+)')[^>]*>/gs;
+  let match;
+  while ((match = regex.exec(elements)) !== null) ids.add(match[1] ?? match[2]);
+  return ids;
+}
+
+async function resolveMdxTarget(sourceFile, href, contentDirs, locales, basePath) {
+  const { path: decodedPath } = parseHref(href);
+  let rawPath = decodedPath;
+  if (basePath !== "/" && rawPath.startsWith(basePath)) rawPath = "/" + rawPath.slice(basePath.length);
+  let target;
+  if (rawPath === "") target = sourceFile;
+  else if (rawPath.startsWith("/docs/")) target = resolve(contentDirs[0], rawPath.slice("/docs/".length));
+  else {
+    const locale = locales.find((key) => rawPath.startsWith(`/${key}/docs/`));
+    if (locale !== undefined) {
+      const localeDir = contentDirs[locales.indexOf(locale) + 1];
+      if (localeDir === undefined) return null;
+      target = resolve(localeDir, rawPath.slice(`/${locale}/docs/`.length));
+    } else if (rawPath.startsWith("/")) return null;
+    else target = resolve(dirname(sourceFile), rawPath);
+  }
+  const candidates = extname(target)
+    ? [target]
+    : [target, `${target}.mdx`, `${target}.md`, resolve(target, "index.mdx"), resolve(target, "index.md")];
+  for (const candidate of candidates) {
+    if (await fileExists(candidate) && (await stat(candidate)).isFile()) return candidate;
+  }
+  return null;
+}
+
+export async function checkMdxAnchors(contentDirs, rootDir, basePath = "/", locales, excludePatterns = []) {
+  assertLocaleList(locales);
+  const anchors = [];
+  const idCache = new Map();
+  for (const dir of contentDirs) {
+    if (!(await fileExists(dir))) continue;
+    for (const file of await collectFiles(dir, [".mdx", ".md"])) {
+      const content = await readFile(file, "utf-8");
+      for (const { href, line } of extractMdxFragmentLinks(content)) {
+        if (excludePatterns.some((pattern) => pattern.test(href))) continue;
+        const parsed = parseHref(href);
+        if (parsed.fragmentError !== null) {
+          anchors.push({ file: relative(rootDir, file), line, href, fragment: parsed.fragment, reason: parsed.fragmentError });
+          continue;
+        }
+        const target = await resolveMdxTarget(file, href, contentDirs, locales, basePath);
+        if (target === null) continue;
+        let ids = idCache.get(target);
+        if (ids === undefined) {
+          const targetBody = await readFile(target, "utf-8");
+          ids = allHierarchicalHeadingIds(targetBody);
+          for (const id of extractStaticMdxIds(targetBody)) ids.add(id);
+          idCache.set(target, ids);
+        }
+        if (!ids.has(parsed.fragment)) anchors.push({ file: relative(rootDir, file), line, href, fragment: parsed.fragment, reason: "missing target id" });
+      }
+    }
+  }
+  return anchors;
+}
+
+async function resolveDistTarget(href, distDir, basePath = "/", fileDir = "", sourceFile = null) {
+  const { path: clean, fragment, fragmentError } = parseHref(href);
+  if (!clean) return { type: "root", targetFile: sourceFile ?? join(distDir, "index.html"), fragment, fragmentError };
+  let absolute = clean;
+  if (!clean.startsWith("/")) absolute = "/" + join(fileDir ? relative(distDir, fileDir) : "", clean);
+  let stripped = absolute;
+  if (basePath !== "/" && stripped.startsWith(basePath)) stripped = "/" + stripped.slice(basePath.length);
+  const relPath = stripped.startsWith("/") ? stripped.slice(1) : stripped;
+  if (!relPath) return { type: "root", targetFile: join(distDir, "index.html"), fragment, fragmentError };
+  if (extname(relPath)) {
+    const targetFile = join(distDir, relPath);
+    return { type: (await fileExists(targetFile)) ? "file" : "missing", targetFile, fragment, fragmentError };
+  }
+  const indexFile = join(distDir, relPath, "index.html");
+  if (await fileExists(indexFile)) return { type: "directoryIndex", targetFile: indexFile, fragment, fragmentError };
+  const htmlFile = join(distDir, relPath + ".html");
+  if (await fileExists(htmlFile)) return { type: "file", targetFile: htmlFile, fragment, fragmentError };
+  return { type: "missing", targetFile: null, fragment, fragmentError };
+}
+
+export async function resolveLinkDetail(href, distDir, basePath = "/", fileDir = "") {
+  return (await resolveDistTarget(href, distDir, basePath, fileDir)).type;
+}
+
+export async function resolveLink(href, distDir, basePath = "/", fileDir = "") {
+  return (await resolveDistTarget(href, distDir, basePath, fileDir)).type !== "missing";
+}
+
+export async function checkHtmlLinksAndTrailing(
+  distDir,
+  rootDir,
+  basePath = "/",
+  excludePatterns = [],
+  checkTrailing = false,
+) {
+  const broken = [];
+  const anchors = [];
+  const trailingSlash = [];
+  const idCache = new Map();
+  const cache = new Map();
+  for (const file of await collectFiles(distDir, [".html"])) {
+    const content = await readFile(file, "utf-8");
+    for (const { href, line } of extractHtmlLinks(content)) {
+      if (excludePatterns.some((pattern) => pattern.test(href))) continue;
+      const cacheKey = href.startsWith("/") ? href : `${file}:${href}`;
+      let detail = cache.get(cacheKey);
+      if (detail === undefined) {
+        detail = await resolveDistTarget(href, distDir, basePath, dirname(file), file);
+        cache.set(cacheKey, detail);
+      }
+      if (detail.type === "missing") broken.push({ file: relative(rootDir, file), line, href });
+      if (detail.fragment !== null) {
+        let reason = detail.fragmentError;
+        if (reason === null && detail.type !== "missing" && detail.targetFile !== null && extname(detail.targetFile) === ".html") {
+          let ids = idCache.get(detail.targetFile);
+          if (ids === undefined) {
+            const targetHtml = await readFile(detail.targetFile, "utf-8");
+            ids = new Set();
+            const idRegex = /\bid\s*=\s*(?:"([^"]*)"|'([^']*)')/gi;
+            let idMatch;
+            while ((idMatch = idRegex.exec(targetHtml)) !== null) ids.add(idMatch[1] ?? idMatch[2]);
+            idCache.set(detail.targetFile, ids);
+          }
+          if (!ids.has(detail.fragment)) reason = "missing target id";
+        }
+        if (reason !== null) anchors.push({ file: relative(rootDir, file), line, href, fragment: detail.fragment, reason });
+      }
+      if (checkTrailing) {
+        const pathPart = href.split("#")[0].split("?")[0];
+        if (pathPart && pathPart !== "/" && pathPart !== "." && pathPart !== "./" && !pathPart.endsWith("/") && !extname(pathPart) && detail.type === "directoryIndex") {
+          trailingSlash.push({ file: relative(rootDir, file), line, href });
+        }
+      }
+    }
+  }
+  return { broken, anchors, trailingSlash };
+}
+
+export async function checkMdxLinks(
+  contentDirs,
+  rootDir,
+  distDir = null,
+  basePath = "/",
+  locales = [],
+) {
+  assertLocaleList(locales);
+  const warnings = [];
+  for (const dir of contentDirs) {
+    if (!(await fileExists(dir))) continue;
+    for (const file of await collectFiles(dir, [".mdx", ".md"])) {
+      const content = await readFile(file, "utf-8");
+      for (const { href, line } of extractMdxAbsoluteLinks(content, locales)) {
+        if (distDir && await resolveLink(href, distDir, basePath)) continue;
+        warnings.push({ file: relative(rootDir, file), line, href });
+      }
+    }
+  }
+  return warnings;
+}
+
+export function formatReport(brokenLinks, mdxWarnings, trailingSlashWarnings = [], anchorWarnings = []) {
+  const lines = [];
+  const section = (title, entries, format) => {
+    if (entries.length === 0) return;
+    lines.push(title);
+    for (const entry of entries) lines.push(`  ${format(entry)}`);
+    lines.push("");
+  };
+  section("=== Broken Links in Built HTML ===", brokenLinks, (e) => `${e.file}:${e.line}  ${e.href}`);
+  section("=== Absolute Links Bypassing Base Path (MDX Source) ===", mdxWarnings, (e) => `${e.file}:${e.line}  ${e.href}`);
+  section("=== Links Missing Trailing Slash ===", trailingSlashWarnings, (e) => `${e.file}:${e.line}  ${e.href}`);
+  section("=== Invalid Anchors ===", anchorWarnings, (e) => `${e.file}:${e.line}  ${e.href}  (fragment: #${e.fragment}; ${e.reason})`);
+  const total = brokenLinks.length + mdxWarnings.length + trailingSlashWarnings.length + anchorWarnings.length;
+  if (total === 0) lines.push("✓ No broken links, invalid anchors, or absolute path issues found");
+  else {
+    const parts = [];
+    if (brokenLinks.length) parts.push(`${brokenLinks.length} broken link${brokenLinks.length === 1 ? "" : "s"}`);
+    if (mdxWarnings.length) parts.push(`${mdxWarnings.length} absolute path warning${mdxWarnings.length === 1 ? "" : "s"}`);
+    if (trailingSlashWarnings.length) parts.push(`${trailingSlashWarnings.length} trailing slash warning${trailingSlashWarnings.length === 1 ? "" : "s"}`);
+    if (anchorWarnings.length) parts.push(`${anchorWarnings.length} invalid anchor${anchorWarnings.length === 1 ? "" : "s"}`);
+    lines.push(`✗ Found ${parts.join(" and ")}`);
+  }
+  return lines.join("\n");
+}
+
+export async function readAllowlist(allowlistPath) {
+  if (!allowlistPath || !(await fileExists(allowlistPath))) return new Set();
+  return new Set((await readFile(allowlistPath, "utf-8")).split("\n").map((line) => line.trim()).filter((line) => line && !line.startsWith("#")));
+}
+
+function entryKey(entry) {
+  return `${entry.file}:${entry.line}:${entry.href}`;
+}
+
+async function main() {
+  const options = parseCliArgs(process.argv.slice(2));
+  if (options.help) {
+    console.log(CLI_USAGE);
+    return;
+  }
+  const rootDir = resolve(process.cwd());
+  const configPath = join(rootDir, "zfb.config.ts");
+  const config = await parseZfbConfig(configPath);
+  const contentDirs = [resolve(rootDir, config.docsDir), ...config.localeDirs.map((dir) => resolve(rootDir, dir))];
+  const distDir = join(rootDir, "dist");
+  const hasDist = await isDirectory(distDir);
+  const excludePatterns = [/\/v\/[^/]+\//];
+  console.log(`Checking links (base: ${config.basePath}, trailingSlash: ${config.trailingSlash})...`);
+  console.log(`Source scan: ${contentDirs.map((dir) => relative(rootDir, dir) || ".").join(", ")}${hasDist ? "; dist/ pass enabled" : "; dist/ absent (source-only)"}\n`);
+
+  const [{ broken, anchors: htmlAnchors, trailingSlash }, mdxWarnings, mdxAnchors] = await Promise.all([
+    hasDist ? checkHtmlLinksAndTrailing(distDir, rootDir, config.basePath, excludePatterns, config.trailingSlash) : Promise.resolve({ broken: [], anchors: [], trailingSlash: [] }),
+    checkMdxLinks(contentDirs, rootDir, hasDist ? distDir : null, config.basePath, config.localeKeys),
+    checkMdxAnchors(contentDirs, rootDir, config.basePath, config.localeKeys, excludePatterns),
+  ]);
+  const anchorWarnings = [...htmlAnchors, ...mdxAnchors];
+  const allowlistPath = options.allowlistPath ? (options.allowlistPath.startsWith("/") ? options.allowlistPath : join(rootDir, options.allowlistPath)) : null;
+  const allowlist = await readAllowlist(allowlistPath);
+  const filter = (entries) => entries.filter((entry) => !allowlist.has(entryKey(entry)));
+  const realBroken = filter(broken);
+  const realAbsolute = filter(mdxWarnings);
+  const realAnchors = filter(anchorWarnings);
+  const realTrailing = filter(trailingSlash);
+  console.log(formatReport(broken, mdxWarnings, trailingSlash, anchorWarnings));
+  const skipped = broken.length - realBroken.length + mdxWarnings.length - realAbsolute.length + anchorWarnings.length - realAnchors.length + trailingSlash.length - realTrailing.length;
+  if (skipped > 0) console.log(`\nAllowlist: ${skipped} known exception${skipped === 1 ? "" : "s"} excluded from strict-mode counts (${allowlistPath}).`);
+  let failed = false;
+  if (options.strictBroken && realBroken.length) { console.log(`\n❌ STRICT FAIL: ${realBroken.length} broken link${realBroken.length === 1 ? "" : "s"} (after allowlist).`); failed = true; }
+  if (options.strictAbsolute && realAbsolute.length) { console.log(`\n❌ STRICT FAIL: ${realAbsolute.length} absolute MDX-source link${realAbsolute.length === 1 ? "" : "s"} (after allowlist).`); failed = true; }
+  if (options.strictAnchors && realAnchors.length) { console.log(`\n❌ STRICT FAIL: ${realAnchors.length} invalid anchor${realAnchors.length === 1 ? "" : "s"} (after allowlist).`); failed = true; }
+  if (options.strictTrailing && realTrailing.length) { console.log(`\n❌ STRICT FAIL: ${realTrailing.length} trailing-slash warning${realTrailing.length === 1 ? "" : "s"} (after allowlist).`); failed = true; }
+  if (failed) process.exitCode = 1;
+  else if ((broken.length || mdxWarnings.length || anchorWarnings.length || trailingSlash.length) && !options.strictBroken && !options.strictAbsolute && !options.strictAnchors && !options.strictTrailing) {
+    console.log("\nNote: Issues found but running in non-strict mode (exit 0).");
+    console.log("Use --strict-broken / --strict-absolute / --strict-anchors / --strict-trailing to fail on selected issue categories.");
+  }
+}
+
+const isMain = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+if (isMain) {
+  main().catch((error) => {
+    console.error(error instanceof CliArgumentError ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/__tests__/check-links.test.ts
+++ b/scripts/__tests__/check-links.test.ts
@@ -12,10 +12,13 @@ import {
   resolveLinkDetail,
   resolveLink,
   extractMdxAbsoluteLinks,
+  extractMdxFragmentLinks,
   checkHtmlLinksAndTrailing,
   checkMdxLinks,
+  checkMdxAnchors,
   formatReport,
   collectFiles,
+  readAllowlist,
 } from "../check-links.js";
 
 const CHECK_LINKS_SCRIPT = fileURLToPath(new URL("../check-links.js", import.meta.url));
@@ -38,6 +41,7 @@ describe("check-links", () => {
         "--",
         "--strict-broken",
         "--strict-absolute",
+        "--strict-anchors",
         "--strict-trailing",
         "--allowlist=.check-links-allowlist",
         "-h",
@@ -48,6 +52,7 @@ describe("check-links", () => {
       expect(result.status).toBe(0);
       expect(result.stdout).toContain("--strict-broken");
       expect(result.stdout).toContain("--strict-absolute");
+      expect(result.stdout).toContain("--strict-anchors");
       expect(result.stdout).toContain("--strict-trailing");
       expect(result.stdout).not.toMatch(/^\s*--strict\s/m);
     });
@@ -218,8 +223,10 @@ describe("check-links", () => {
       );
     });
 
-    it("skips anchor-only links", () => {
-      expect(extractHtmlLinks(`<a href="#section">A</a>`)).toEqual([]);
+    it("extracts anchor-only links for local-fragment validation", () => {
+      expect(extractHtmlLinks(`<a href="#section">A</a>`)).toEqual([
+        { href: "#section", line: 1 },
+      ]);
     });
 
     it("skips mailto links", () => {
@@ -608,6 +615,36 @@ describe("check-links", () => {
     });
   });
 
+  describe("extractMdxFragmentLinks", () => {
+    it("finds relative, local, query-plus-fragment, and empty fragments", () => {
+      const content = [
+        "[relative](./other.mdx#target)",
+        "[local](#local)",
+        "[query](./other.mdx?view=all#target)",
+        "[empty](#)",
+      ].join("\n");
+      expect(extractMdxFragmentLinks(content)).toEqual([
+        { href: "./other.mdx#target", line: 1 },
+        { href: "#local", line: 2 },
+        { href: "./other.mdx?view=all#target", line: 3 },
+        { href: "#", line: 4 },
+      ]);
+    });
+
+    it("preserves fenced-code and inline-code exclusions", () => {
+      const content = [
+        "`[inline](./other.mdx#hidden)`",
+        "~~~md",
+        "[fenced](./other.mdx#hidden)",
+        "~~~",
+        "[visible](./other.mdx#shown)",
+      ].join("\n");
+      expect(extractMdxFragmentLinks(content)).toEqual([
+        { href: "./other.mdx#shown", line: 5 },
+      ]);
+    });
+  });
+
   // --- checkHtmlLinksAndTrailing (integration) ---
 
   describe("checkHtmlLinksAndTrailing", () => {
@@ -648,6 +685,97 @@ describe("check-links", () => {
 
       const { broken } = await checkHtmlLinksAndTrailing(distDir, tmpDir, BASE);
       expect(broken).toEqual([]);
+    });
+
+    it("validates hierarchical, h5/h6, and non-heading target ids", async () => {
+      const distDir = join(tmpDir, "dist");
+      mkdirSync(join(distDir, "docs", "source"), { recursive: true });
+      mkdirSync(join(distDir, "docs", "target"), { recursive: true });
+      writeFileSync(
+        join(distDir, "docs", "source", "index.html"),
+        [
+          '<a href="../target/#parent-child">hierarchical</a>',
+          '<a href="../target/#parent-child-deep">h5</a>',
+          '<a href="../target/#static-target">static</a>',
+        ].join("\n"),
+      );
+      writeFileSync(
+        join(distDir, "docs", "target", "index.html"),
+        '<h3 id="parent-child"></h3><h5 id="parent-child-deep"></h5><div id="static-target"></div>',
+      );
+
+      const { anchors } = await checkHtmlLinksAndTrailing(distDir, tmpDir);
+      expect(anchors).toEqual([]);
+    });
+
+    it("reports leaf-only and missing anchors with source details", async () => {
+      const distDir = join(tmpDir, "dist");
+      mkdirSync(join(distDir, "docs", "source"), { recursive: true });
+      mkdirSync(join(distDir, "docs", "target"), { recursive: true });
+      writeFileSync(
+        join(distDir, "docs", "source", "index.html"),
+        '<a href="../target/#child">leaf only</a>\n<a href="../target/#absent">missing</a>',
+      );
+      writeFileSync(
+        join(distDir, "docs", "target", "index.html"),
+        '<h3 id="parent-child"></h3>',
+      );
+
+      const { anchors } = await checkHtmlLinksAndTrailing(distDir, tmpDir);
+      expect(anchors).toEqual([
+        {
+          file: "dist/docs/source/index.html", line: 1,
+          href: "../target/#child", fragment: "child", reason: "missing target id",
+        },
+        {
+          file: "dist/docs/source/index.html", line: 2,
+          href: "../target/#absent", fragment: "absent", reason: "missing target id",
+        },
+      ]);
+    });
+
+    it("handles local, query, encoded, empty, and malformed fragments", async () => {
+      const distDir = join(tmpDir, "dist");
+      mkdirSync(join(distDir, "docs", "source"), { recursive: true });
+      writeFileSync(
+        join(distDir, "docs", "source", "index.html"),
+        [
+          '<div id="local"></div><div id="foo bar"></div>',
+          '<a href="#local">local</a>',
+          '<a href="?view=all#local">query</a>',
+          '<a href="#foo%20bar">encoded</a>',
+          '<a href="#">empty</a>',
+          '<a href="#bad%ZZ">malformed</a>',
+        ].join("\n"),
+      );
+
+      const { anchors } = await checkHtmlLinksAndTrailing(distDir, tmpDir);
+      expect(anchors).toEqual([
+        {
+          file: "dist/docs/source/index.html", line: 5,
+          href: "#", fragment: "", reason: "empty fragment",
+        },
+        {
+          file: "dist/docs/source/index.html", line: 6,
+          href: "#bad%ZZ", fragment: "bad%ZZ", reason: "malformed percent-encoding",
+        },
+      ]);
+    });
+
+    it("keeps anchor checks behind version exclude patterns", async () => {
+      const distDir = join(tmpDir, "dist");
+      mkdirSync(join(distDir, "docs", "source"), { recursive: true });
+      mkdirSync(join(distDir, "v", "1.0", "target"), { recursive: true });
+      writeFileSync(
+        join(distDir, "docs", "source", "index.html"),
+        '<a href="/v/1.0/target/#missing">versioned</a>',
+      );
+      writeFileSync(join(distDir, "v", "1.0", "target", "index.html"), "<p>target</p>");
+
+      const { anchors } = await checkHtmlLinksAndTrailing(
+        distDir, tmpDir, "/", [/\/v\/[^/]+\//],
+      );
+      expect(anchors).toEqual([]);
     });
   });
 
@@ -721,6 +849,129 @@ describe("check-links", () => {
         [],
       );
       expect(warnings).toEqual([]);
+    });
+  });
+
+  describe("checkMdxAnchors", () => {
+    it("validates hierarchical h5/h6 and explicit static ids in relative targets", async () => {
+      const docsDir = join(tmpDir, "src", "content", "docs");
+      mkdirSync(docsDir, { recursive: true });
+      writeFileSync(
+        join(docsDir, "source.mdx"),
+        [
+          "[child](./target.mdx#parent-child)",
+          "[deep](./target.mdx#parent-child-deep)",
+          "[static](./target.mdx#static-target)",
+        ].join("\n"),
+      );
+      writeFileSync(
+        join(docsDir, "target.mdx"),
+        "## Parent\n### Child\n##### Deep\n<div id=\"static-target\" />",
+      );
+
+      expect(await checkMdxAnchors([docsDir], tmpDir, "/", [])).toEqual([]);
+    });
+
+    it("does not mistake prose containing id syntax for a static element id", async () => {
+      const docsDir = join(tmpDir, "src", "content", "docs");
+      mkdirSync(docsDir, { recursive: true });
+      writeFileSync(join(docsDir, "source.mdx"), "[x](./target.mdx#not-an-id)");
+      writeFileSync(join(docsDir, "target.mdx"), 'The syntax is `id="not-an-id"`.');
+
+      const anchors = await checkMdxAnchors([docsDir], tmpDir, "/", []);
+      expect(anchors).toHaveLength(1);
+      expect(anchors[0]?.reason).toBe("missing target id");
+    });
+
+    it("reports the leaf-only mistake and a nonexistent anchor", async () => {
+      const docsDir = join(tmpDir, "src", "content", "docs");
+      mkdirSync(docsDir, { recursive: true });
+      writeFileSync(
+        join(docsDir, "source.mdx"),
+        "[leaf](./target.mdx#child)\n[missing](./target.mdx#nonexistent-anchor)",
+      );
+      writeFileSync(join(docsDir, "target.mdx"), "## Parent\n### Child");
+
+      const anchors = await checkMdxAnchors([docsDir], tmpDir, "/", []);
+      expect(anchors).toEqual([
+        {
+          file: "src/content/docs/source.mdx", line: 1,
+          href: "./target.mdx#child", fragment: "child", reason: "missing target id",
+        },
+        {
+          file: "src/content/docs/source.mdx", line: 2,
+          href: "./target.mdx#nonexistent-anchor", fragment: "nonexistent-anchor", reason: "missing target id",
+        },
+      ]);
+    });
+
+    it("handles local, query, percent-encoded, empty, and malformed fragments", async () => {
+      const docsDir = join(tmpDir, "src", "content", "docs");
+      mkdirSync(docsDir, { recursive: true });
+      writeFileSync(
+        join(docsDir, "source.mdx"),
+        [
+          "## Local",
+          '<div id="foo bar" />',
+          "[local](#local)",
+          "[query](./target.mdx?view=all#target)",
+          "[encoded](#foo%20bar)",
+          "[empty](#)",
+          "[malformed](#bad%ZZ)",
+        ].join("\n"),
+      );
+      writeFileSync(join(docsDir, "target.mdx"), "## Target");
+
+      const anchors = await checkMdxAnchors([docsDir], tmpDir, "/", []);
+      expect(anchors).toEqual([
+        {
+          file: "src/content/docs/source.mdx", line: 6,
+          href: "#", fragment: "", reason: "empty fragment",
+        },
+        {
+          file: "src/content/docs/source.mdx", line: 7,
+          href: "#bad%ZZ", fragment: "bad%ZZ", reason: "malformed percent-encoding",
+        },
+      ]);
+    });
+
+    it("resolves a JA-to-EN anchor in the actual EN target", async () => {
+      const docsDir = join(tmpDir, "src", "content", "docs");
+      const jaDir = join(tmpDir, "src", "content", "docs-ja");
+      mkdirSync(docsDir, { recursive: true });
+      mkdirSync(jaDir, { recursive: true });
+      writeFileSync(join(docsDir, "target.mdx"), "## English Target");
+      writeFileSync(join(jaDir, "target.mdx"), "## Japanese Target");
+      writeFileSync(jaDir + "/source.mdx", "[EN](/docs/target#english-target)");
+
+      expect(
+        await checkMdxAnchors([docsDir, jaDir], tmpDir, "/", ["ja"]),
+      ).toEqual([]);
+    });
+
+    it("keeps source anchor checks behind version exclude patterns", async () => {
+      const docsDir = join(tmpDir, "src", "content", "docs");
+      mkdirSync(docsDir, { recursive: true });
+      writeFileSync(
+        join(docsDir, "source.mdx"),
+        "[versioned](/v/1.0/docs/target#missing)",
+      );
+      expect(
+        await checkMdxAnchors([docsDir], tmpDir, "/", [], [/\/v\/[^/]+\//]),
+      ).toEqual([]);
+    });
+  });
+
+  describe("readAllowlist", () => {
+    it("preserves href fragments while ignoring comment-only lines", async () => {
+      const file = join(tmpDir, ".check-links-allowlist");
+      writeFileSync(
+        file,
+        "# comment\nsrc/content/docs/a.mdx:3:./b.mdx#target\n",
+      );
+      expect(await readAllowlist(file)).toEqual(
+        new Set(["src/content/docs/a.mdx:3:./b.mdx#target"]),
+      );
     });
   });
 
@@ -891,7 +1142,7 @@ describe("check-links", () => {
     it("shows success message when no issues", () => {
       const report = formatReport([], []);
       expect(report).toContain(
-        "✓ No broken links or absolute path issues found",
+        "✓ No broken links, invalid anchors, or absolute path issues found",
       );
     });
 
@@ -924,6 +1175,23 @@ describe("check-links", () => {
       expect(report).toContain("=== Broken Links");
       expect(report).not.toContain("=== Absolute Links");
       expect(report).toContain("✗ Found 1 broken link");
+    });
+
+    it("formats invalid anchors as their own category with the fragment", () => {
+      const report = formatReport([], [], [], [
+        {
+          file: "src/content/docs/a.mdx",
+          line: 3,
+          href: "./b.mdx#missing",
+          fragment: "missing",
+          reason: "missing target id",
+        },
+      ]);
+      expect(report).toContain("=== Invalid Anchors ===");
+      expect(report).toContain(
+        "./b.mdx#missing  (fragment: #missing; missing target id)",
+      );
+      expect(report).toContain("✗ Found 1 invalid anchor");
     });
   });
 });

--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -3,13 +3,17 @@
 /**
  * check-links.js — Post-build broken link checker
  *
- * Mode 1: Scan built HTML in dist/ for broken internal links
- * Mode 2: Scan MDX source for absolute links bypassing base path
+ * Mode 1: Scan built HTML in dist/ for broken internal links and anchors
+ * Mode 2: Scan MDX source for absolute links and invalid fragment targets
  */
 
-import { readFile, readdir, access } from "node:fs/promises";
+import { readFile, readdir, access, stat } from "node:fs/promises";
 import { join, extname, resolve, relative, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  extractHeadings,
+  slugify,
+} from "@takazudo/zudo-doc/extract-headings";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
@@ -22,6 +26,7 @@ Options:
   -h, --help           Show this help
   --strict-broken      Fail when broken links remain after the allowlist
   --strict-absolute    Fail when absolute MDX links remain after the allowlist
+  --strict-anchors     Fail when invalid anchors remain after the allowlist
   --strict-trailing    Fail when trailing-slash warnings remain after the allowlist
   --allowlist=PATH     Exclude exact <file>:<line>:<href> entries from failure counts`;
 
@@ -32,6 +37,7 @@ function parseCliArgs(argv) {
     help: false,
     strictBroken: false,
     strictAbsolute: false,
+    strictAnchors: false,
     strictTrailing: false,
     allowlistPath: null,
   };
@@ -46,6 +52,8 @@ function parseCliArgs(argv) {
       result.strictBroken = true;
     } else if (arg === "--strict-absolute") {
       result.strictAbsolute = true;
+    } else if (arg === "--strict-anchors") {
+      result.strictAnchors = true;
     } else if (arg === "--strict-trailing") {
       result.strictTrailing = true;
     } else if (arg.startsWith("--allowlist=")) {
@@ -152,9 +160,8 @@ export function extractHtmlLinks(html) {
   let lastIndex = 0;
   let currentLine = 1;
   while ((match = regex.exec(html)) !== null) {
-    const href = match[1] || match[2];
+    const href = match[1] ?? match[2];
     if (/^https?:\/\//i.test(href)) continue;
-    if (/^#/.test(href)) continue;
     if (/^mailto:/i.test(href)) continue;
     if (/^javascript:/i.test(href)) continue;
     if (/^data:/i.test(href)) continue;
@@ -186,6 +193,108 @@ function safeDecodePath(path) {
   }
 }
 
+function parseHref(href) {
+  const hashAt = href.indexOf("#");
+  const beforeFragment = hashAt === -1 ? href : href.slice(0, hashAt);
+  const queryAt = beforeFragment.indexOf("?");
+  const rawPath = queryAt === -1
+    ? beforeFragment
+    : beforeFragment.slice(0, queryAt);
+  const rawFragment = hashAt === -1 ? null : href.slice(hashAt + 1);
+
+  if (rawFragment === null) {
+    return {
+      path: safeDecodePath(rawPath),
+      fragment: null,
+      fragmentError: null,
+    };
+  }
+  if (rawFragment === "") {
+    return {
+      path: safeDecodePath(rawPath),
+      fragment: "",
+      fragmentError: "empty fragment",
+    };
+  }
+  try {
+    return {
+      path: safeDecodePath(rawPath),
+      fragment: decodeURIComponent(rawFragment),
+      fragmentError: null,
+    };
+  } catch {
+    return {
+      path: safeDecodePath(rawPath),
+      fragment: rawFragment,
+      fragmentError: "malformed percent-encoding",
+    };
+  }
+}
+
+async function resolveLinkTargetDetail(
+  href,
+  distDir,
+  basePath = "/",
+  fileDir = "",
+  sourceFile = null,
+) {
+  const { path: clean, fragment, fragmentError } = parseHref(href);
+  if (!clean) {
+    return {
+      type: "root",
+      targetFile: sourceFile ?? join(distDir, "index.html"),
+      fragment,
+      fragmentError,
+    };
+  }
+
+  let absolute = clean;
+  if (!clean.startsWith("/")) {
+    const dirInDist = fileDir ? relative(distDir, fileDir) : "";
+    absolute = "/" + join(dirInDist, clean);
+  }
+
+  let stripped = absolute;
+  if (basePath !== "/" && stripped.startsWith(basePath)) {
+    stripped = "/" + stripped.slice(basePath.length);
+  }
+
+  const relPath = stripped.startsWith("/") ? stripped.slice(1) : stripped;
+  if (!relPath) {
+    return {
+      type: "root",
+      targetFile: join(distDir, "index.html"),
+      fragment,
+      fragmentError,
+    };
+  }
+
+  if (extname(relPath)) {
+    const targetFile = join(distDir, relPath);
+    return {
+      type: (await fileExists(targetFile)) ? "file" : "missing",
+      targetFile,
+      fragment,
+      fragmentError,
+    };
+  }
+
+  const indexFile = join(distDir, relPath, "index.html");
+  if (await fileExists(indexFile)) {
+    return {
+      type: "directoryIndex",
+      targetFile: indexFile,
+      fragment,
+      fragmentError,
+    };
+  }
+  const htmlFile = join(distDir, relPath + ".html");
+  if (await fileExists(htmlFile)) {
+    return { type: "file", targetFile: htmlFile, fragment, fragmentError };
+  }
+  return { type: "missing", targetFile: null, fragment, fragmentError };
+}
+
 /**
  * Resolve a link and return its resolution type:
  *   'root'           — empty path or resolves to the site root (always valid)
@@ -194,43 +303,7 @@ function safeDecodePath(path) {
  *   'missing'        — target does not exist
  */
 export async function resolveLinkDetail(href, distDir, basePath = "/", fileDir = "") {
-  const clean = safeDecodePath(href.split("#")[0].split("?")[0]);
-  if (!clean) return "root";
-
-  let absolute = clean;
-
-  // Resolve relative links against the file's directory within dist
-  if (!clean.startsWith("/")) {
-    // Relative link — resolve against the file's containing directory
-    const dirInDist = fileDir ? relative(distDir, fileDir) : "";
-    absolute = "/" + join(dirInDist, clean);
-  }
-
-  // Strip base path prefix from the href to get the path relative to dist/
-  let stripped = absolute;
-  if (basePath !== "/" && stripped.startsWith(basePath)) {
-    stripped = "/" + stripped.slice(basePath.length);
-  }
-
-  const relPath = stripped.startsWith("/") ? stripped.slice(1) : stripped;
-  if (!relPath) return "root";
-
-  // Has file extension → check exact path
-  if (extname(relPath)) {
-    const exists = await fileExists(join(distDir, relPath));
-    return exists ? "file" : "missing";
-  }
-
-  // Ends with / → check index.html inside
-  if (relPath.endsWith("/")) {
-    const exists = await fileExists(join(distDir, relPath, "index.html"));
-    return exists ? "directoryIndex" : "missing";
-  }
-
-  // No extension, no trailing slash → try dir/index.html then .html
-  if (await fileExists(join(distDir, relPath, "index.html"))) return "directoryIndex";
-  if (await fileExists(join(distDir, relPath + ".html"))) return "file";
-  return "missing";
+  return (await resolveLinkTargetDetail(href, distDir, basePath, fileDir)).type;
 }
 
 export async function resolveLink(href, distDir, basePath = "/", fileDir = "") {
@@ -302,6 +375,225 @@ export function extractMdxAbsoluteLinks(content, locales) {
   return issues;
 }
 
+/** Extract internal MDX/Markdown links that carry a fragment. */
+export function extractMdxFragmentLinks(content) {
+  const links = [];
+  const lines = content.split("\n");
+  let codeFenceOpener = null;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const fence = /^([`~]{3,})/.exec(line.trimStart())?.[1];
+    if (fence !== undefined) {
+      if (codeFenceOpener === null) codeFenceOpener = fence;
+      else if (
+        fence[0] === codeFenceOpener[0] &&
+        fence.length >= codeFenceOpener.length
+      ) {
+        codeFenceOpener = null;
+      }
+      continue;
+    }
+    if (codeFenceOpener !== null) continue;
+
+    const searchLine = stripInlineCode(line);
+    let match;
+    const markdownLink = /\]\(\s*([^\s)#]*#[^\s)]*)(?:\s+[^)]*)?\)/g;
+    while ((match = markdownLink.exec(searchLine)) !== null) {
+      const href = match[1];
+      if (!/^(?:https?:|mailto:|javascript:|data:|tel:)/i.test(href)) {
+        links.push({ href, line: i + 1 });
+      }
+    }
+
+    const jsxHref = /\bhref\s*=\s*(?:"([^"]*#[^"]*)"|'([^']*#[^']*)')/g;
+    while ((match = jsxHref.exec(searchLine)) !== null) {
+      const href = match[1] ?? match[2];
+      if (!/^(?:https?:|mailto:|javascript:|data:|tel:)/i.test(href)) {
+        links.push({ href, line: i + 1 });
+      }
+    }
+  }
+
+  return links;
+}
+
+function headingText(raw) {
+  return raw
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/(?<![\w])__([^_]+)__(?![\w])/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1")
+    .replace(/(?<![\w])_([^_]+)_(?![\w])/g, "$1")
+    .trim();
+}
+
+/** All-depth mirror of the renderer's hierarchical SlugAllocator. */
+function allHierarchicalHeadingIds(body) {
+  const ids = new Set(extractHeadings(body).map((heading) => heading.slug));
+  const seen = new Map();
+  const stack = [];
+  let codeFenceOpener = null;
+
+  for (const line of body.split("\n")) {
+    const fence = /^([`~]{3,})/.exec(line.trimStart())?.[1];
+    if (fence !== undefined) {
+      if (codeFenceOpener === null) codeFenceOpener = fence;
+      else if (
+        fence[0] === codeFenceOpener[0] &&
+        fence.length >= codeFenceOpener.length
+      ) {
+        codeFenceOpener = null;
+      }
+      continue;
+    }
+    if (codeFenceOpener !== null) continue;
+
+    const match = /^(#{2,6})[ \t]+(.+)$/.exec(line.trim());
+    if (match === null) continue;
+    const depth = match[1].length;
+    const base = slugify(headingText(match[2]));
+    if (base === "") continue;
+
+    while ((stack.at(-1)?.depth ?? -1) >= depth) stack.pop();
+    const parent = stack.at(-1);
+    const candidate = parent === undefined ? base : `${parent.id}-${base}`;
+    const count = seen.get(candidate) ?? 0;
+    seen.set(candidate, count + 1);
+    const id = count === 0 ? candidate : `${candidate}-${count}`;
+    stack.push({ depth, id });
+    ids.add(id);
+  }
+  return ids;
+}
+
+function extractStaticMdxIds(body) {
+  const ids = new Set();
+  let codeFenceOpener = null;
+  const visibleLines = [];
+  for (const line of body.split("\n")) {
+    const fence = /^([`~]{3,})/.exec(line.trimStart())?.[1];
+    if (fence !== undefined) {
+      if (codeFenceOpener === null) codeFenceOpener = fence;
+      else if (
+        fence[0] === codeFenceOpener[0] &&
+        fence.length >= codeFenceOpener.length
+      ) {
+        codeFenceOpener = null;
+      }
+      visibleLines.push("");
+      continue;
+    }
+    visibleLines.push(codeFenceOpener === null ? stripInlineCode(line) : "");
+  }
+
+  const elements = visibleLines.join("\n");
+  const regex = /<[A-Za-z][^>]*\bid\s*=\s*(?:"([^"]+)"|'([^']+)')[^>]*>/gs;
+  let match;
+  while ((match = regex.exec(elements)) !== null) {
+    ids.add(match[1] ?? match[2]);
+  }
+  return ids;
+}
+
+async function resolveMdxTarget(sourceFile, href, contentDirs, locales, basePath) {
+  const { path: decodedPath } = parseHref(href);
+  let rawPath = decodedPath;
+  if (basePath !== "/" && rawPath.startsWith(basePath)) {
+    rawPath = "/" + rawPath.slice(basePath.length);
+  }
+
+  let target;
+  if (rawPath === "") {
+    target = sourceFile;
+  } else if (rawPath.startsWith("/docs/")) {
+    target = resolve(contentDirs[0], rawPath.slice("/docs/".length));
+  } else {
+    const locale = locales.find((key) => rawPath.startsWith(`/${key}/docs/`));
+    if (locale !== undefined) {
+      const localeIndex = locales.indexOf(locale);
+      const localeDir = contentDirs[localeIndex + 1];
+      if (localeDir === undefined) return null;
+      target = resolve(localeDir, rawPath.slice(`/${locale}/docs/`.length));
+    } else if (rawPath.startsWith("/")) {
+      return null;
+    } else {
+      target = resolve(dirname(sourceFile), rawPath);
+    }
+  }
+
+  const candidates = extname(target)
+    ? [target]
+    : [
+        target,
+        `${target}.mdx`,
+        `${target}.md`,
+        resolve(target, "index.mdx"),
+        resolve(target, "index.md"),
+      ];
+  for (const candidate of candidates) {
+    if (await fileExists(candidate) && (await stat(candidate)).isFile()) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+export async function checkMdxAnchors(
+  contentDirs,
+  rootDir,
+  basePath = "/",
+  locales,
+  excludePatterns = [],
+) {
+  assertLocaleList(locales);
+  const anchors = [];
+  const idCache = new Map();
+
+  for (const dir of contentDirs) {
+    if (!(await fileExists(dir))) continue;
+    const files = await collectFiles(dir, [".mdx", ".md"]);
+    for (const file of files) {
+      const content = await readFile(file, "utf-8");
+      for (const { href, line } of extractMdxFragmentLinks(content)) {
+        if (excludePatterns.some((pattern) => pattern.test(href))) continue;
+        const parsed = parseHref(href);
+        if (parsed.fragmentError !== null) {
+          anchors.push({
+            file: relative(rootDir, file),
+            line,
+            href,
+            fragment: parsed.fragment,
+            reason: parsed.fragmentError,
+          });
+          continue;
+        }
+
+        const target = await resolveMdxTarget(file, href, contentDirs, locales, basePath);
+        if (target === null) continue;
+        let ids = idCache.get(target);
+        if (ids === undefined) {
+          const targetBody = await readFile(target, "utf-8");
+          ids = allHierarchicalHeadingIds(targetBody);
+          for (const id of extractStaticMdxIds(targetBody)) ids.add(id);
+          idCache.set(target, ids);
+        }
+        if (!ids.has(parsed.fragment)) {
+          anchors.push({
+            file: relative(rootDir, file),
+            line,
+            href,
+            fragment: parsed.fragment,
+            reason: "missing target id",
+          });
+        }
+      }
+    }
+  }
+  return anchors;
+}
+
 // --- Main Check Functions ---
 
 /**
@@ -319,11 +611,13 @@ export async function checkHtmlLinksAndTrailing(
   checkTrailing = false,
 ) {
   const broken = [];
+  const anchors = [];
   const trailingSlash = [];
   const htmlFiles = await collectFiles(distDir, [".html"]);
   // One shared cache keyed by resolution type ("root"|"file"|"directoryIndex"|"missing").
   // Both checks read from the same resolved detail so each href is stat'd once.
   const cache = new Map();
+  const idCache = new Map();
 
   for (const file of htmlFiles) {
     const content = await readFile(file, "utf-8");
@@ -334,19 +628,59 @@ export async function checkHtmlLinksAndTrailing(
     for (const { href, line } of links) {
       if (excludePatterns.some((p) => p.test(href))) continue;
 
-      // Cache key: absolute links use href only; relative links include fileDir
-      const cacheKey = href.startsWith("/") ? href : `${fileDir}:${href}`;
-      let type;
+      // Cache key: absolute links use href only; relative and local-fragment
+      // links include their exact source file.
+      const cacheKey = href.startsWith("/") ? href : `${file}:${href}`;
+      let detail;
       if (cache.has(cacheKey)) {
-        type = cache.get(cacheKey);
+        detail = cache.get(cacheKey);
       } else {
-        type = await resolveLinkDetail(href, distDir, basePath, fileDir);
-        cache.set(cacheKey, type);
+        detail = await resolveLinkTargetDetail(
+          href,
+          distDir,
+          basePath,
+          fileDir,
+          file,
+        );
+        cache.set(cacheKey, detail);
       }
+      const { type } = detail;
 
       // Broken-link check
       if (type === "missing") {
         broken.push({ file: relFile, line, href });
+      }
+
+      if (detail.fragment !== null) {
+        let reason = detail.fragmentError;
+        if (
+          reason === null &&
+          type !== "missing" &&
+          detail.targetFile !== null &&
+          extname(detail.targetFile) === ".html"
+        ) {
+          let ids = idCache.get(detail.targetFile);
+          if (ids === undefined) {
+            const targetHtml = await readFile(detail.targetFile, "utf-8");
+            ids = new Set();
+            const idRegex = /\bid\s*=\s*(?:"([^"]*)"|'([^']*)')/gi;
+            let idMatch;
+            while ((idMatch = idRegex.exec(targetHtml)) !== null) {
+              ids.add(idMatch[1] ?? idMatch[2]);
+            }
+            idCache.set(detail.targetFile, ids);
+          }
+          if (!ids.has(detail.fragment)) reason = "missing target id";
+        }
+        if (reason !== null) {
+          anchors.push({
+            file: relFile,
+            line,
+            href,
+            fragment: detail.fragment,
+            reason,
+          });
+        }
       }
 
       // Trailing-slash check (opt-in)
@@ -368,7 +702,7 @@ export async function checkHtmlLinksAndTrailing(
     }
   }
 
-  return { broken, trailingSlash };
+  return { broken, anchors, trailingSlash };
 }
 
 export async function checkMdxLinks(contentDirs, rootDir, distDir = null, basePath = "/", locales) {
@@ -396,7 +730,12 @@ export async function checkMdxLinks(contentDirs, rootDir, distDir = null, basePa
 
 // --- Report ---
 
-export function formatReport(brokenLinks, mdxWarnings, trailingSlashWarnings = []) {
+export function formatReport(
+  brokenLinks,
+  mdxWarnings,
+  trailingSlashWarnings = [],
+  anchorWarnings = [],
+) {
   const lines = [];
 
   if (brokenLinks.length > 0) {
@@ -423,7 +762,21 @@ export function formatReport(brokenLinks, mdxWarnings, trailingSlashWarnings = [
     lines.push("");
   }
 
-  const total = brokenLinks.length + mdxWarnings.length + trailingSlashWarnings.length;
+  if (anchorWarnings.length > 0) {
+    lines.push("=== Invalid Anchors ===");
+    for (const { file, line, href, fragment, reason } of anchorWarnings) {
+      lines.push(
+        `  ${file}:${line}  ${href}  (fragment: #${fragment}; ${reason})`,
+      );
+    }
+    lines.push("");
+  }
+
+  const total =
+    brokenLinks.length +
+    mdxWarnings.length +
+    trailingSlashWarnings.length +
+    anchorWarnings.length;
   if (total > 0) {
     const parts = [];
     if (brokenLinks.length > 0) {
@@ -441,9 +794,14 @@ export function formatReport(brokenLinks, mdxWarnings, trailingSlashWarnings = [
         `${trailingSlashWarnings.length} trailing slash warning${trailingSlashWarnings.length === 1 ? "" : "s"}`,
       );
     }
+    if (anchorWarnings.length > 0) {
+      parts.push(
+        `${anchorWarnings.length} invalid anchor${anchorWarnings.length === 1 ? "" : "s"}`,
+      );
+    }
     lines.push(`✗ Found ${parts.join(" and ")}`);
   } else {
-    lines.push("✓ No broken links or absolute path issues found");
+    lines.push("✓ No broken links, invalid anchors, or absolute path issues found");
   }
 
   return lines.join("\n");
@@ -452,7 +810,7 @@ export function formatReport(brokenLinks, mdxWarnings, trailingSlashWarnings = [
 // --- Allowlist ---
 
 /**
- * Read the allowlist file (one entry per line; `#` comments stripped).
+ * Read the allowlist file (one entry per line; comment-only lines skipped).
  * Each non-blank line is a literal `<file>:<line>:<href>` exact match.
  * Returns a Set for O(1) lookup against `entryKey()` output below.
  */
@@ -462,7 +820,8 @@ export async function readAllowlist(allowlistPath) {
   const text = await readFile(allowlistPath, "utf-8");
   const lines = text
     .split("\n")
-    .map((l) => l.replace(/#.*$/, "").trim())
+    .map((l) => l.trim())
+    .filter((l) => !l.startsWith("#"))
     .filter((l) => l.length > 0);
   return new Set(lines);
 }
@@ -478,6 +837,7 @@ async function main() {
     help,
     strictBroken,
     strictAbsolute,
+    strictAnchors,
     strictTrailing,
     allowlistPath,
   } = parseCliArgs(process.argv.slice(2));
@@ -506,22 +866,33 @@ async function main() {
   const contentDirs = [join(rootDir, docsDir), ...localeDirs.map((d) => join(rootDir, d))];
 
   // Single-pass dist walk: broken links + trailing-slash warnings in one read.
-  const [{ broken: brokenLinks, trailingSlash: trailingSlashWarnings }, mdxWarnings] =
+  const [
+    {
+      broken: brokenLinks,
+      anchors: htmlAnchorWarnings,
+      trailingSlash: trailingSlashWarnings,
+    },
+    mdxWarnings,
+    mdxAnchorWarnings,
+  ] =
     await Promise.all([
       checkHtmlLinksAndTrailing(distDir, rootDir, basePath, excludePatterns, trailingSlash),
       checkMdxLinks(contentDirs, rootDir, distDir, basePath, localeKeys),
+      checkMdxAnchors(contentDirs, rootDir, basePath, localeKeys, excludePatterns),
     ]);
+  const anchorWarnings = [...htmlAnchorWarnings, ...mdxAnchorWarnings];
 
   // --- Flag parsing ---
   //
-  // Three strict knobs (separable so a deploy can fail on real 404s
+  // Four strict knobs (separable so a deploy can fail on real 404s
   // without blocking on warn-only categories) plus an allowlist:
   //
   //   --strict-broken    fail when broken links > 0 (after allowlist)
   //   --strict-absolute  fail when absolute warnings > 0 (after allowlist)
+  //   --strict-anchors   fail when invalid anchors > 0 (after allowlist)
   //   --strict-trailing  fail when trailing-slash warnings > 0 (after allowlist)
   //   --allowlist=PATH   skip entries listed in PATH (one
-  //                      `<file>:<line>:<href>` per line, `#` comments)
+  //                      `<file>:<line>:<href>` per line, comment-only lines)
   const resolvedAllowlist = allowlistPath
     ? (allowlistPath.startsWith("/") ? allowlistPath : join(rootDir, allowlistPath))
     : null;
@@ -533,14 +904,21 @@ async function main() {
   const filterOut = (entries) => entries.filter((e) => !allowlist.has(entryKey(e)));
   const realBroken = filterOut(brokenLinks);
   const realAbsolute = filterOut(mdxWarnings);
+  const realAnchors = filterOut(anchorWarnings);
   const realTrailing = filterOut(trailingSlashWarnings);
 
-  console.log(formatReport(brokenLinks, mdxWarnings, trailingSlashWarnings));
+  console.log(formatReport(
+    brokenLinks,
+    mdxWarnings,
+    trailingSlashWarnings,
+    anchorWarnings,
+  ));
 
   if (allowlist.size > 0) {
     const skipped =
       (brokenLinks.length - realBroken.length) +
       (mdxWarnings.length - realAbsolute.length) +
+      (anchorWarnings.length - realAnchors.length) +
       (trailingSlashWarnings.length - realTrailing.length);
     if (skipped > 0) {
       console.log(
@@ -550,7 +928,10 @@ async function main() {
   }
 
   const hasIssues =
-    brokenLinks.length > 0 || mdxWarnings.length > 0 || trailingSlashWarnings.length > 0;
+    brokenLinks.length > 0 ||
+    mdxWarnings.length > 0 ||
+    anchorWarnings.length > 0 ||
+    trailingSlashWarnings.length > 0;
 
   // Per-category strict failure (real counts). Combined into one exit
   // code so b4push only needs one invocation. Print which category
@@ -564,6 +945,10 @@ async function main() {
     console.log(`\n❌ STRICT FAIL: ${realAbsolute.length} absolute MDX-source link${realAbsolute.length === 1 ? "" : "s"} (after allowlist).`);
     failed = true;
   }
+  if (strictAnchors && realAnchors.length > 0) {
+    console.log(`\n❌ STRICT FAIL: ${realAnchors.length} invalid anchor${realAnchors.length === 1 ? "" : "s"} (after allowlist).`);
+    failed = true;
+  }
   if (strictTrailing && realTrailing.length > 0) {
     console.log(`\n❌ STRICT FAIL: ${realTrailing.length} trailing-slash warning${realTrailing.length === 1 ? "" : "s"} (after allowlist).`);
     failed = true;
@@ -572,10 +957,10 @@ async function main() {
     process.exit(1);
   }
 
-  if (hasIssues && !strictBroken && !strictAbsolute && !strictTrailing) {
+  if (hasIssues && !strictBroken && !strictAbsolute && !strictAnchors && !strictTrailing) {
     console.log("\nNote: Issues found but running in non-strict mode (exit 0).");
     console.log(
-      "Use --strict-broken / --strict-absolute / --strict-trailing to fail on selected issue categories.",
+      "Use --strict-broken / --strict-absolute / --strict-anchors / --strict-trailing to fail on selected issue categories.",
     );
   }
 }

--- a/scripts/run-b4push.sh
+++ b/scripts/run-b4push.sh
@@ -471,7 +471,7 @@ fi
 # entry whenever the underlying issue gets fixed so the strict
 # gate then catches future regressions of the same shape.
 step "Link check (check-links --strict-broken --strict-absolute)"
-if (cd "$ROOT_DIR" && pnpm run check:links -- --strict-broken --strict-absolute --allowlist=.check-links-allowlist); then
+if (cd "$ROOT_DIR" && pnpm run check:links -- --strict-broken --strict-absolute --strict-anchors --allowlist=.check-links-allowlist); then
   pass "Link check passed"
 else
   fail "Link check"


### PR DESCRIPTION
Parent: #3550

## Summary

- ship the anchor-aware checker in generated projects
- extract literal scaffold settings from `zfb.config.ts`
- wire `check:links` into generated manifests and add direct no-dist tests

## Test plan

- create-zudo-doc fast tests
- template drift and package typecheck

Closes #3552.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/3563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789768708&installation_model_id=20910&pr_number=3563&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F3563&signature=2a2fa9a669dfc99be6a708cb565907fd2d1a189390fbb8c1d1856f88d893804c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->