### PR TITLE
Add nested-island props preserve opt-out

### DIFF
--- a/packages/zudo-doc/src/transitions/__tests__/nested-island-props-refresh.test.ts
+++ b/packages/zudo-doc/src/transitions/__tests__/nested-island-props-refresh.test.ts
@@ -11,6 +11,7 @@ import {
 const PERSIST_ATTR = "data-zfb-transition-persist";
 const ISLAND_ATTR = "data-zfb-island";
 const PROPS_ATTR = "data-props";
+const PROPS_PRESERVE_ATTR = "data-zd-props-preserve";
 const REMOUNT_ATTR = "data-zfb-island-remount";
 
 /** Props serialization is opaque to the helper, so any stable string will do. */
@@ -258,6 +259,136 @@ describe("nested-island props refresh on zfb:before-swap", () => {
     // stops at the inner boundary, and the inner boundary is itself dropped as
     // a refresh root because it sits inside another persisted element.
     expect(liveIsland("ThemeToggle").getAttribute(PROPS_ATTR)).toBe(oldTree);
+  });
+
+  it("preserves an island carrying data-zd-props-preserve", () => {
+    install();
+    setLiveBody(
+      header(
+        "header-en",
+        `<div ${ISLAND_ATTR}="SearchWidget" ${PROPS_PRESERVE_ATTR} ${PROPS_ATTR}='${oldTree}'></div>`,
+      ),
+    );
+
+    dispatchBeforeSwap(
+      parseIncoming(
+        header(
+          "header-en",
+          `<div ${ISLAND_ATTR}="SearchWidget" ${PROPS_ATTR}='${newTree}'></div>`,
+        ),
+      ),
+    );
+
+    const preserved = liveIsland("SearchWidget");
+    expect(preserved.getAttribute(PROPS_ATTR)).toBe(oldTree);
+    expect(preserved.hasAttribute(REMOUNT_ATTR)).toBe(false);
+  });
+
+  it("preserves an island under a data-zd-props-preserve ancestor within the root", () => {
+    install();
+    setLiveBody(
+      header(
+        "header-en",
+        `<div ${PROPS_PRESERVE_ATTR}><div ${ISLAND_ATTR}="SearchWidget" ${PROPS_ATTR}='${oldTree}'></div></div>`,
+      ),
+    );
+
+    dispatchBeforeSwap(
+      parseIncoming(
+        header(
+          "header-en",
+          `<div ${PROPS_PRESERVE_ATTR}><div ${ISLAND_ATTR}="SearchWidget" ${PROPS_ATTR}='${newTree}'></div></div>`,
+        ),
+      ),
+    );
+
+    const preserved = liveIsland("SearchWidget");
+    expect(preserved.getAttribute(PROPS_ATTR)).toBe(oldTree);
+    expect(preserved.hasAttribute(REMOUNT_ATTR)).toBe(false);
+  });
+
+  it("preserves every island when the persisted root carries data-zd-props-preserve", () => {
+    install();
+    setLiveBody(
+      `<header ${PERSIST_ATTR}="header-en" ${PROPS_PRESERVE_ATTR}>` +
+        island("SearchWidget", oldTree) +
+        island("SidebarToggle", oldTree) +
+        `</header>`,
+    );
+
+    dispatchBeforeSwap(
+      parseIncoming(
+        `<header ${PERSIST_ATTR}="header-en" ${PROPS_PRESERVE_ATTR}>` +
+          island("SearchWidget", newTree) +
+          island("SidebarToggle", newTree) +
+          `</header>`,
+      ),
+    );
+
+    for (const name of ["SearchWidget", "SidebarToggle"]) {
+      const preserved = liveIsland(name);
+      expect(preserved.getAttribute(PROPS_ATTR)).toBe(oldTree);
+      expect(preserved.hasAttribute(REMOUNT_ATTR)).toBe(false);
+    }
+  });
+
+  it("refreshes an island when only an ancestor outside the persisted root is preserved", () => {
+    install();
+    setLiveBody(
+      `<div ${PROPS_PRESERVE_ATTR}>${header("header-en", island("SearchWidget", oldTree))}</div>`,
+    );
+
+    dispatchBeforeSwap(
+      parseIncoming(
+        `<div ${PROPS_PRESERVE_ATTR}>${header("header-en", island("SearchWidget", newTree))}</div>`,
+      ),
+    );
+
+    expect(liveIsland("SearchWidget").getAttribute(PROPS_ATTR)).toBe(newTree);
+    expect(liveIsland("SearchWidget").getAttribute(REMOUNT_ATTR)).toBe("");
+  });
+
+  it("refreshes sibling islands without data-zd-props-preserve", () => {
+    install();
+    setLiveBody(
+      header(
+        "header-en",
+        `<div ${ISLAND_ATTR}="SearchWidget" ${PROPS_PRESERVE_ATTR} ${PROPS_ATTR}='${oldTree}'></div>` +
+          island("SidebarToggle", oldTree),
+      ),
+    );
+
+    dispatchBeforeSwap(
+      parseIncoming(
+        header(
+          "header-en",
+          `<div ${ISLAND_ATTR}="SearchWidget" ${PROPS_PRESERVE_ATTR} ${PROPS_ATTR}='${newTree}'></div>` +
+            island("SidebarToggle", newTree),
+        ),
+      ),
+    );
+
+    expect(liveIsland("SearchWidget").getAttribute(PROPS_ATTR)).toBe(oldTree);
+    expect(liveIsland("SearchWidget").hasAttribute(REMOUNT_ATTR)).toBe(false);
+    expect(liveIsland("SidebarToggle").getAttribute(PROPS_ATTR)).toBe(newTree);
+    expect(liveIsland("SidebarToggle").getAttribute(REMOUNT_ATTR)).toBe("");
+  });
+
+  it("refreshes normally when data-zd-props-preserve exists only on the incoming side", () => {
+    install();
+    setLiveBody(header("header-en", island("SearchWidget", oldTree)));
+
+    dispatchBeforeSwap(
+      parseIncoming(
+        header(
+          "header-en",
+          `<div ${ISLAND_ATTR}="SearchWidget" ${PROPS_PRESERVE_ATTR} ${PROPS_ATTR}='${newTree}'></div>`,
+        ),
+      ),
+    );
+
+    expect(liveIsland("SearchWidget").getAttribute(PROPS_ATTR)).toBe(newTree);
+    expect(liveIsland("SearchWidget").getAttribute(REMOUNT_ATTR)).toBe("");
   });
 
   it("removes data-props when the incoming island has none", () => {

--- a/packages/zudo-doc/src/transitions/nested-island-props-refresh.ts
+++ b/packages/zudo-doc/src/transitions/nested-island-props-refresh.ts
@@ -66,6 +66,9 @@ const ISLAND_ATTR = "data-zfb-island";
 /** zfb's serialized-props attribute; opaque to this module. */
 const PROPS_ATTR = "data-props";
 
+/** Opts a live nested island out of this helper's props refresh. */
+const PROPS_PRESERVE_ATTR = "data-zd-props-preserve";
+
 /**
  * zfb's cross-package "needs-remount" flag (`clearMountedForRemount` /
  * `fire()` in `@takazudo/zfb`'s runtime). Load-bearing for one race: an island
@@ -148,6 +151,11 @@ export function disposeNestedIslandPropsRefresh(document: Document): void {
  *      that is missing on either side, or duplicated on either side, is
  *      skipped — there is no defensible pairing for it.
  *   2. Within a paired root, group the islands it OWNS by island name.
+ *      On the live side only, exclude an island carrying
+ *      `data-zd-props-preserve`, or one with an ancestor carrying that
+ *      attribute when the closest such ancestor is inside the persisted root
+ *      (including the root itself). The incoming side is never filtered:
+ *      preservation is a live-side opt-out, not an incoming-side pairing rule.
  *   3. Refresh only names that resolve to exactly one island on both sides.
  *
  * Position is never used: the live and incoming DOM are different renders of
@@ -169,7 +177,7 @@ function refreshNestedIslandProps(
     const incomingIslands = collectUniqueOwnedIslands(incomingRoot);
     if (incomingIslands.size === 0) continue;
 
-    for (const [name, liveIsland] of collectUniqueOwnedIslands(liveRoot)) {
+    for (const [name, liveIsland] of collectUniqueOwnedIslands(liveRoot, true)) {
       const incomingIsland = incomingIslands.get(name);
       if (!incomingIsland) continue;
       applyProps(liveIsland, incomingIsland);
@@ -213,9 +221,17 @@ function collectRefreshableRoots(doc: Document): Map<string, Element> {
  * In either case zfb's persisted-island props/remount path already owns that
  * element's refresh, and this helper must not compete with it.
  */
-function collectUniqueOwnedIslands(root: Element): Map<string, Element> {
+function collectUniqueOwnedIslands(
+  root: Element,
+  excludePreserved = false,
+): Map<string, Element> {
   const owned = Array.from(root.querySelectorAll(`[${ISLAND_ATTR}]`)).filter(
-    (island) => island.closest(`[${PERSIST_ATTR}]`) === root,
+    (island) => {
+      if (island.closest(`[${PERSIST_ATTR}]`) !== root) return false;
+      if (!excludePreserved) return true;
+      const preserveBoundary = island.closest(`[${PROPS_PRESERVE_ATTR}]`);
+      return preserveBoundary === null || !root.contains(preserveBoundary);
+    },
   );
   return indexUniquely(owned, ISLAND_ATTR);
 }


### PR DESCRIPTION
Parent: #3554

## Summary

- add the live-side `data-zd-props-preserve` exclusion
- preserve both serialized props and remount state
- cover island, ancestor, root, boundary, sibling, and incoming-only cases

## Test plan

- 26 focused transition tests
- package typecheck

Closes #3555.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/3566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789769997&installation_model_id=20910&pr_number=3566&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F3566&signature=a27f94bf52eba511e5e9f6057ecdf8d9a027498fe2e4fa25cc33a78728d02cc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->