### PR TITLE
Document nested-island props preservation

### DIFF
--- a/packages/zudo-doc/API.md
+++ b/packages/zudo-doc/API.md
@@ -70,6 +70,8 @@ behaviour byte-for-byte.
 | `docContentHeaderExtras` | Renders nothing. A renderer (not a component) called as `({ entry, slug, locale, isFallback?, version? }) => unknown` for `kind === "entry"` doc pages on all 4 doc routes (including versioned pages — it receives `version` and decides for itself). Renders between the `<h1>` and the metainfo/tags block in `DocContentHeader`. |
 | `homeExtras` | Renders nothing. A renderer called as `({ locale }) => unknown` for the home hero. The `/` home route is never injected by the routes plugin (zfb rejects `/`), so this fires on injected `/[locale]` homes and on any host that threads it through `createChrome`; a `HomePageView` `extras` prop takes precedence when both are present. Rendered INLINE at the end of the links row, `/`-separated (#3012). |
 
+Host islands rendered through `headerRightComponents` can preserve session-scoped props across navigation that retains the same persisted root by placing `data-zd-props-preserve` on the live island or an ancestor inside that root. The live side governs this opt-out. Putting the attribute on the persisted root preserves every nested island; preserved islands receive neither a `data-props` write nor a remount flag.
+
 ### `createHomePageView(ctx)` (`./home-page`)
 
 Factory for the shared home-page (site index) body: hero (logo mask block,

--- a/packages/zudo-doc/CLAUDE.md
+++ b/packages/zudo-doc/CLAUDE.md
@@ -467,7 +467,13 @@ specifier end-to-end.
    base/i18n stubs consume the virtual object; the generator's doc-history
    patch must spread it before replacing only `DocHistory`. Components declared
    only inside the virtual module are SSR-presentational unless a separate
-   static island registration path exists.
+   static island registration path exists. A host island with session-scoped
+   props (for example, a badge nested under the persisted header) can opt out
+   of the nested-island props refresh with `data-zd-props-preserve` on the
+   island or an ancestor inside the persisted root. The live side governs; the
+   attribute on the persisted root is a blanket opt-out for every nested
+   island, and an opted-out island receives neither a props write nor a remount
+   flag.
 
 ### GOTCHA — preact/compat `paths` stay in the PROJECT tsconfig, not the base
 

--- a/packages/zudo-doc/src/header/header.tsx
+++ b/packages/zudo-doc/src/header/header.tsx
@@ -319,6 +319,8 @@ export function Header(props: HeaderProps): JSX.Element {
       //     island module): on BEFORE_SWAP_EVENT it copies the incoming
       //     document's data-props onto the live nested islands, and
       //     mountNewIslands re-reads the attribute at mount time (#3530)
+      //     Host islands can opt out with data-zd-props-preserve on the live
+      //     island or an ancestor inside this persisted root (#3555).
       //   - Header nav + aria-current: NAV_OVERFLOW_SCRIPT re-runs on
       //     AFTER_NAVIGATE_EVENT (frozen by zudolab/zudo-doc#3534 — the
       //     `addEventListener(${afterNavigateEventLiteral}, initNavOverflow)`

--- a/packages/zudo-doc/src/transitions/__tests__/nested-island-props-refresh.test.ts
+++ b/packages/zudo-doc/src/transitions/__tests__/nested-island-props-refresh.test.ts
@@ -11,6 +11,7 @@ import {
 const PERSIST_ATTR = "data-zfb-transition-persist";
 const ISLAND_ATTR = "data-zfb-island";
 const PROPS_ATTR = "data-props";
+const PROPS_PRESERVE_ATTR = "data-zd-props-preserve";
 const REMOUNT_ATTR = "data-zfb-island-remount";
 
 /** Props serialization is opaque to the helper, so any stable string will do. */
@@ -258,6 +259,136 @@ describe("nested-island props refresh on zfb:before-swap", () => {
     // stops at the inner boundary, and the inner boundary is itself dropped as
     // a refresh root because it sits inside another persisted element.
     expect(liveIsland("ThemeToggle").getAttribute(PROPS_ATTR)).toBe(oldTree);
+  });
+
+  it("preserves an island carrying data-zd-props-preserve", () => {
+    install();
+    setLiveBody(
+      header(
+        "header-en",
+        `<div ${ISLAND_ATTR}="SearchWidget" ${PROPS_PRESERVE_ATTR} ${PROPS_ATTR}='${oldTree}'></div>`,
+      ),
+    );
+
+    dispatchBeforeSwap(
+      parseIncoming(
+        header(
+          "header-en",
+          `<div ${ISLAND_ATTR}="SearchWidget" ${PROPS_ATTR}='${newTree}'></div>`,
+        ),
+      ),
+    );
+
+    const preserved = liveIsland("SearchWidget");
+    expect(preserved.getAttribute(PROPS_ATTR)).toBe(oldTree);
+    expect(preserved.hasAttribute(REMOUNT_ATTR)).toBe(false);
+  });
+
+  it("preserves an island under a data-zd-props-preserve ancestor within the root", () => {
+    install();
+    setLiveBody(
+      header(
+        "header-en",
+        `<div ${PROPS_PRESERVE_ATTR}><div ${ISLAND_ATTR}="SearchWidget" ${PROPS_ATTR}='${oldTree}'></div></div>`,
+      ),
+    );
+
+    dispatchBeforeSwap(
+      parseIncoming(
+        header(
+          "header-en",
+          `<div ${PROPS_PRESERVE_ATTR}><div ${ISLAND_ATTR}="SearchWidget" ${PROPS_ATTR}='${newTree}'></div></div>`,
+        ),
+      ),
+    );
+
+    const preserved = liveIsland("SearchWidget");
+    expect(preserved.getAttribute(PROPS_ATTR)).toBe(oldTree);
+    expect(preserved.hasAttribute(REMOUNT_ATTR)).toBe(false);
+  });
+
+  it("preserves every island when the persisted root carries data-zd-props-preserve", () => {
+    install();
+    setLiveBody(
+      `<header ${PERSIST_ATTR}="header-en" ${PROPS_PRESERVE_ATTR}>` +
+        island("SearchWidget", oldTree) +
+        island("SidebarToggle", oldTree) +
+        `</header>`,
+    );
+
+    dispatchBeforeSwap(
+      parseIncoming(
+        `<header ${PERSIST_ATTR}="header-en" ${PROPS_PRESERVE_ATTR}>` +
+          island("SearchWidget", newTree) +
+          island("SidebarToggle", newTree) +
+          `</header>`,
+      ),
+    );
+
+    for (const name of ["SearchWidget", "SidebarToggle"]) {
+      const preserved = liveIsland(name);
+      expect(preserved.getAttribute(PROPS_ATTR)).toBe(oldTree);
+      expect(preserved.hasAttribute(REMOUNT_ATTR)).toBe(false);
+    }
+  });
+
+  it("refreshes an island when only an ancestor outside the persisted root is preserved", () => {
+    install();
+    setLiveBody(
+      `<div ${PROPS_PRESERVE_ATTR}>${header("header-en", island("SearchWidget", oldTree))}</div>`,
+    );
+
+    dispatchBeforeSwap(
+      parseIncoming(
+        `<div ${PROPS_PRESERVE_ATTR}>${header("header-en", island("SearchWidget", newTree))}</div>`,
+      ),
+    );
+
+    expect(liveIsland("SearchWidget").getAttribute(PROPS_ATTR)).toBe(newTree);
+    expect(liveIsland("SearchWidget").getAttribute(REMOUNT_ATTR)).toBe("");
+  });
+
+  it("refreshes sibling islands without data-zd-props-preserve", () => {
+    install();
+    setLiveBody(
+      header(
+        "header-en",
+        `<div ${ISLAND_ATTR}="SearchWidget" ${PROPS_PRESERVE_ATTR} ${PROPS_ATTR}='${oldTree}'></div>` +
+          island("SidebarToggle", oldTree),
+      ),
+    );
+
+    dispatchBeforeSwap(
+      parseIncoming(
+        header(
+          "header-en",
+          `<div ${ISLAND_ATTR}="SearchWidget" ${PROPS_PRESERVE_ATTR} ${PROPS_ATTR}='${newTree}'></div>` +
+            island("SidebarToggle", newTree),
+        ),
+      ),
+    );
+
+    expect(liveIsland("SearchWidget").getAttribute(PROPS_ATTR)).toBe(oldTree);
+    expect(liveIsland("SearchWidget").hasAttribute(REMOUNT_ATTR)).toBe(false);
+    expect(liveIsland("SidebarToggle").getAttribute(PROPS_ATTR)).toBe(newTree);
+    expect(liveIsland("SidebarToggle").getAttribute(REMOUNT_ATTR)).toBe("");
+  });
+
+  it("refreshes normally when data-zd-props-preserve exists only on the incoming side", () => {
+    install();
+    setLiveBody(header("header-en", island("SearchWidget", oldTree)));
+
+    dispatchBeforeSwap(
+      parseIncoming(
+        header(
+          "header-en",
+          `<div ${ISLAND_ATTR}="SearchWidget" ${PROPS_PRESERVE_ATTR} ${PROPS_ATTR}='${newTree}'></div>`,
+        ),
+      ),
+    );
+
+    expect(liveIsland("SearchWidget").getAttribute(PROPS_ATTR)).toBe(newTree);
+    expect(liveIsland("SearchWidget").getAttribute(REMOUNT_ATTR)).toBe("");
   });
 
   it("removes data-props when the incoming island has none", () => {

--- a/packages/zudo-doc/src/transitions/nested-island-props-refresh.ts
+++ b/packages/zudo-doc/src/transitions/nested-island-props-refresh.ts
@@ -66,6 +66,9 @@ const ISLAND_ATTR = "data-zfb-island";
 /** zfb's serialized-props attribute; opaque to this module. */
 const PROPS_ATTR = "data-props";
 
+/** Opts a live nested island out of this helper's props refresh. */
+const PROPS_PRESERVE_ATTR = "data-zd-props-preserve";
+
 /**
  * zfb's cross-package "needs-remount" flag (`clearMountedForRemount` /
  * `fire()` in `@takazudo/zfb`'s runtime). Load-bearing for one race: an island
@@ -148,6 +151,11 @@ export function disposeNestedIslandPropsRefresh(document: Document): void {
  *      that is missing on either side, or duplicated on either side, is
  *      skipped — there is no defensible pairing for it.
  *   2. Within a paired root, group the islands it OWNS by island name.
+ *      On the live side only, exclude an island carrying
+ *      `data-zd-props-preserve`, or one with an ancestor carrying that
+ *      attribute when the closest such ancestor is inside the persisted root
+ *      (including the root itself). The incoming side is never filtered:
+ *      preservation is a live-side opt-out, not an incoming-side pairing rule.
  *   3. Refresh only names that resolve to exactly one island on both sides.
  *
  * Position is never used: the live and incoming DOM are different renders of
@@ -169,7 +177,7 @@ function refreshNestedIslandProps(
     const incomingIslands = collectUniqueOwnedIslands(incomingRoot);
     if (incomingIslands.size === 0) continue;
 
-    for (const [name, liveIsland] of collectUniqueOwnedIslands(liveRoot)) {
+    for (const [name, liveIsland] of collectUniqueOwnedIslands(liveRoot, true)) {
       const incomingIsland = incomingIslands.get(name);
       if (!incomingIsland) continue;
       applyProps(liveIsland, incomingIsland);
@@ -213,9 +221,17 @@ function collectRefreshableRoots(doc: Document): Map<string, Element> {
  * In either case zfb's persisted-island props/remount path already owns that
  * element's refresh, and this helper must not compete with it.
  */
-function collectUniqueOwnedIslands(root: Element): Map<string, Element> {
+function collectUniqueOwnedIslands(
+  root: Element,
+  excludePreserved = false,
+): Map<string, Element> {
   const owned = Array.from(root.querySelectorAll(`[${ISLAND_ATTR}]`)).filter(
-    (island) => island.closest(`[${PERSIST_ATTR}]`) === root,
+    (island) => {
+      if (island.closest(`[${PERSIST_ATTR}]`) !== root) return false;
+      if (!excludePreserved) return true;
+      const preserveBoundary = island.closest(`[${PROPS_PRESERVE_ATTR}]`);
+      return preserveBoundary === null || !root.contains(preserveBoundary);
+    },
   );
   return indexUniquely(owned, ISLAND_ATTR);
 }

--- a/src/content/docs-ja/guides/header-right-items.mdx
+++ b/src/content/docs-ja/guides/header-right-items.mdx
@@ -143,7 +143,7 @@ headerRightItems: [
 
 プロジェクト固有のコンポーネント名は `chromeBindings.headerRightComponents` で解決します。型付きの設定手順全体は [Host Chrome Bindings](../reference/host-chrome-bindings.mdx) を参照してください。クライアント island に対応する静的な登録経路も用意していない限り、レンダラーは SSR 表示用として扱います。
 
-登録済み island の props が現在のページではなくブラウザーセッションに属する場合は、live island 自体か persist されたヘッダー内の祖先要素に `data-zd-props-preserve` を付けます。オプトアウトは live DOM を基準に判定され、対象 island のシリアライズ済み props は置き換えられず、remount 対象にもなりません。persist されたヘッダー自体に属性を付けると配下の全 island がオプトアウトされるため、遷移先ページの props を受け取るべき island には付けないでください。
+登録済み island の props が現在のページではなくブラウザーセッションに属する場合は、遷移前から存在する island 自体か、persist されたヘッダー内の祖先要素に `data-zd-props-preserve` を付けます。オプトアウトは遷移前から存在する DOM を基準に判定され、対象 island のシリアライズ済み props は置き換えられず、remount 対象にもなりません。persist されたヘッダー自体に属性を付けると配下の全 island がオプトアウトされるため、遷移先ページの props を受け取るべき island には付けないでください。
 
 ## テーマ切替のカスタマイズ
 

--- a/src/content/docs-ja/guides/header-right-items.mdx
+++ b/src/content/docs-ja/guides/header-right-items.mdx
@@ -139,6 +139,12 @@ headerRightItems: [
 ],
 ```
 
+### カスタムレンダラーを追加する
+
+プロジェクト固有のコンポーネント名は `chromeBindings.headerRightComponents` で解決します。型付きの設定手順全体は [Host Chrome Bindings](../reference/host-chrome-bindings.mdx) を参照してください。クライアント island に対応する静的な登録経路も用意していない限り、レンダラーは SSR 表示用として扱います。
+
+登録済み island の props が現在のページではなくブラウザーセッションに属する場合は、live island 自体か persist されたヘッダー内の祖先要素に `data-zd-props-preserve` を付けます。オプトアウトは live DOM を基準に判定され、対象 island のシリアライズ済み props は置き換えられず、remount 対象にもなりません。persist されたヘッダー自体に属性を付けると配下の全 island がオプトアウトされるため、遷移先ページの props を受け取るべき island には付けないでください。
+
 ## テーマ切替のカスタマイズ
 
 組み込みの `theme-toggle` コンポーネントでたいていのサイトは事足ります。それでも、トグルを独自の場所に配置したい、自前の island ラッパーに組み込みたい、あるいは `@takazudo/zudo-doc/theme` バレル(React 解決の落とし穴があります — 後述)を避けたいといった理由で、プロジェクト内に **自前の** `ThemeToggle` を持ち続ける場合があります。いずれの場合も、ローカルにコンポーネントを手でコピーするのではなく、**専用の `@takazudo/zudo-doc/theme-toggle` サブパスから `ThemeToggle` をインポート**してください。

--- a/src/content/docs-ja/reference/host-chrome-bindings.mdx
+++ b/src/content/docs-ja/reference/host-chrome-bindings.mdx
@@ -97,6 +97,18 @@ export const chromeBindings = defineChromeBindings({
 
 ルートコンテキストを通るのは項目名だけで、`headerRightComponents` 自体はホストのコーラブルモジュールに残ります。ほかの bindings モジュール内コンポーネントと同様、静的なアイランド登録経路も持たない限り SSR 表示用として扱ってください。
 
+### セッション固有の island props を保持する
+
+同一ロケール内でページを移動すると、persist されたヘッダー内の island が持つシリアライズ済み props は、デフォルトでは遷移先ページの値に更新されます。ページから導出する props にはこの動作を使ってください。一方、静的に登録したホスト island がセッション固有の props を持つ場合 — たとえば、初期カウントを次ページの SSR スナップショットで置き換えたくないバッジ — は、island のルート要素か persist されたヘッダー内の祖先要素に `data-zd-props-preserve` を付けます。
+
+```tsx
+<div data-zd-props-preserve>
+  <SessionBadge initialCount={unreadCount} />
+</div>
+```
+
+オプトアウトの判定に使われるのは遷移前から存在する live DOM です。遷移先ページだけに属性を付けても、現在の island は保持されません。保持対象の island では `data-props` の更新も remount フラグの付与も行われません。persist されたヘッダー自体に `data-zd-props-preserve` を付けると、配下の全 island が一括でオプトアウトされます。そのため、セッション固有の props を所有する範囲だけを囲むようにしてください。
+
 ### 既存スロットの「取り残し」も解消する
 
 `docContentHeaderExtras` と `homeExtras` は新しい継ぎ目ですが、`ChromeHostBindings` にはこのチャネルが存在する以前から、注入ルートへ**届く手段がなかった**スロットがいくつかありました — それらはスタブのデフォルトのまま黙って据え置かれていました。`chromeBindingsModule` はそれらをまとめて解消します。

--- a/src/content/docs/guides/header-right-items.mdx
+++ b/src/content/docs/guides/header-right-items.mdx
@@ -139,6 +139,12 @@ headerRightItems: [
 ],
 ```
 
+### Add a custom renderer
+
+Project-owned component names are resolved through `chromeBindings.headerRightComponents`; see [Host Chrome Bindings](../reference/host-chrome-bindings.mdx) for the complete typed setup. Treat a renderer as SSR-presentational unless its client island also has a supported static registration path.
+
+For a registered island whose props belong to the browser session rather than the current page, add `data-zd-props-preserve` to the live island or an ancestor inside the persisted header. The live DOM governs this opt-out: navigation neither replaces that island's serialized props nor marks it for remount. Putting the attribute on the persisted header opts out every nested island, so leave it off page-derived islands that should receive the incoming page's props.
+
 ## Customizing the theme toggle
 
 The built-in `theme-toggle` component is enough for most sites. Some consumers still keep their **own** `ThemeToggle` in their project — to place it in a custom spot, compose it into their own island wrapper, or because they were avoiding the `@takazudo/zudo-doc/theme` barrel (which has a React-resolution hazard — see below). In all of these cases, **import `ThemeToggle` from the dedicated `@takazudo/zudo-doc/theme-toggle` subpath** instead of hand-copying a local component.

--- a/src/content/docs/reference/host-chrome-bindings.mdx
+++ b/src/content/docs/reference/host-chrome-bindings.mdx
@@ -103,6 +103,18 @@ The renderer receives the exact header-right render context: the serialized `ite
 
 Only the item name travels in the route-context data. `headerRightComponents` remains in the host-callables module and is never serialized. As with other bindings-module components, treat these renderers as SSR-presentational unless they also have a supported static island-registration path.
 
+### Preserving session-scoped island props
+
+By default, same-locale navigation refreshes the serialized props of islands nested under the persisted header from the incoming page. Keep that behavior for page-derived props. If a statically registered host island instead owns session-scoped props — for example, a badge whose initial count must not be replaced by the next page's SSR snapshot — place `data-zd-props-preserve` on the island's root element or an ancestor inside the persisted header:
+
+```tsx
+<div data-zd-props-preserve>
+  <SessionBadge initialCount={unreadCount} />
+</div>
+```
+
+The live DOM governs the opt-out; adding the attribute only to the incoming page does not preserve the current island. A preserved island receives neither an updated `data-props` value nor a remount flag. Placing `data-zd-props-preserve` on the persisted header itself is a blanket opt-out for every nested island, so prefer the narrowest boundary that owns the session-scoped props.
+
 ### It un-strands the pre-existing slots too
 
 `docContentHeaderExtras` and `homeExtras` are new, but `ChromeHostBindings` already had several slots that had **no way to reach injected routes** before this channel existed — they silently stayed at their stub defaults. `chromeBindingsModule` un-strands all of them at once:


### PR DESCRIPTION
Parent: #3554

## Summary

- document the public preserve contract in package references
- add content-equivalent EN/JA guidance and examples
- clarify the persisted-header integration comment

## Test plan

- bilingual semantic/example parity
- MDX formatting and diff checks

Closes #3556.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/3567"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789770000&installation_model_id=20910&pr_number=3567&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F3567&signature=a4787a54b861982c9b30a29740265b14d7b9cf7e827e709f731a28a99bd0ecdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->