### PR TITLE
Ship ejected nav regeneration and preserve docTags coverage

### DIFF
--- a/packages/create-zudo-doc/src/__tests__/zfb-config-gen.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/zfb-config-gen.test.ts
@@ -256,7 +256,7 @@ describe("generateZfbConfig — simple boolean feature fields", () => {
     (feature) => {
       const fieldName = expected_field_name(feature);
       const result = generateZfbConfig(baseChoices);
-      expect(result).not.toMatch(new RegExp(`\\b${fieldName}:\\s*true`));
+      expect(result).not.toMatch(new RegExp(`\\b${fieldName}\\s*:`));
     },
   );
 

--- a/packages/zudo-doc/API.md
+++ b/packages/zudo-doc/API.md
@@ -530,6 +530,26 @@ The eject surface exposed by `zudo-doc eject <component>`. Defined in `packages/
 | `doc-history` | `@takazudo/zudo-doc/doc-history` | `src/components/zudo-doc/doc-history` |
 | `site-tree-nav-island` | `@takazudo/zudo-doc/site-tree-nav-island` | `src/components/zudo-doc/site-tree-nav-island` |
 
+### Ejected header frozen-script regeneration
+
+The `header` payload includes `gen-nav-overflow-script.mjs` beside the editable
+TypeScript sources. Editing `nav-active.ts` or `nav-class-tokens.ts` requires a
+regeneration so the server-rendered classes and the client-router repaint stay
+in lockstep:
+
+```sh
+node ./src/components/zudo-doc/header/gen-nav-overflow-script.mjs
+```
+
+Commit the rewritten `nav-overflow-generated-script.ts` with the customization.
+The generator deliberately gets the current-path prelude and after-navigation
+event from the installed `@takazudo/zudo-doc` package, while the active-match
+functions and class tokens come from the local ejected files. It resolves its
+`esbuild` transformer through the package's own dependency graph; the project
+does not need to install a separate generator tool. The output remains a frozen
+plain string, so its inline-script bytes and CSP hash do not depend on the
+consumer bundler.
+
 ---
 
 ## Migration Notes

--- a/packages/zudo-doc/README.md
+++ b/packages/zudo-doc/README.md
@@ -67,6 +67,23 @@ pnpm add @takazudo/zfb-md-wasm
 
 Projects scaffolded by `create-zudo-doc` already include it. If you never render `<HtmlPreview>` / `<HighlightedCode>`, you can omit it.
 
+## Ejected header customization
+
+`zudo-doc eject header` copies a complete frozen-script regeneration path into
+`src/components/zudo-doc/header`. After changing the ejected `nav-active.ts` or
+`nav-class-tokens.ts`, regenerate the local client controller and commit the
+result:
+
+```sh
+node ./src/components/zudo-doc/header/gen-nav-overflow-script.mjs
+```
+
+The command uses the two local customization inputs plus the installed
+package's current-path and page-event inputs. Its `esbuild` transformer is
+provided by `@takazudo/zudo-doc`; no additional project dependency is needed.
+The resulting `nav-overflow-generated-script.ts` stays frozen for stable CSP
+hashes across consumer bundlers.
+
 ## ⚠️ HTML preview iframe sandbox — trust assumption
 
 `<HtmlPreview>` / `<HtmlPreviewWrapper>` render their preview inside an `<iframe srcdoc>` whose `sandbox` attribute **defaults** to:

--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -664,6 +664,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^8.4.2",
+    "esbuild": ">=0.28.1",
     "fs-extra": "^11.3.0",
     "gray-matter": "^4.0.3",
     "minimist": "^1.2.8",
@@ -682,7 +683,6 @@
     "@types/node": "^25.3.5",
     "@types/pluralize": "^0.0.33",
     "@types/string-similarity": "^4.0.2",
-    "esbuild": ">=0.28.1",
     "happy-dom": "^20.10.6",
     "npm-run-all2": "^7.0.2",
     "preact": "^10.29.1",

--- a/packages/zudo-doc/scripts/check-eject-sources.mjs
+++ b/packages/zudo-doc/scripts/check-eject-sources.mjs
@@ -9,7 +9,7 @@
 //           non-empty (contains at least one file).
 // Exit 1 → a directory is missing or empty (with a clear diagnostic message).
 
-import { statSync, readdirSync } from "node:fs";
+import { statSync, readdirSync, existsSync, readFileSync } from "node:fs";
 import { resolve, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -64,6 +64,22 @@ for (const name of EJECTABLE) {
   }
 
   process.stdout.write(`[check-eject-sources] eject/${name}/ OK (${size} files)\n`);
+}
+
+const headerGenerator = resolve(EJECT_ROOT, "header/gen-nav-overflow-script.mjs");
+const sourceGenerator = resolve(PKG_ROOT, "scripts/gen-nav-overflow-script.mjs");
+if (!existsSync(headerGenerator)) {
+  process.stderr.write(
+    "\n[check-eject-sources] ERROR: eject/header/gen-nav-overflow-script.mjs is missing.\n" +
+      "  The ejected header must ship its frozen-script regeneration path.\n",
+  );
+  ok = false;
+} else if (readFileSync(headerGenerator, "utf8") !== readFileSync(sourceGenerator, "utf8")) {
+  process.stderr.write(
+    "\n[check-eject-sources] ERROR: the ejected header generator is stale.\n" +
+      "  Re-run `pnpm --filter @takazudo/zudo-doc build` and retry.\n",
+  );
+  ok = false;
 }
 
 if (!ok) process.exit(1);

--- a/packages/zudo-doc/scripts/copy-eject-sources.mjs
+++ b/packages/zudo-doc/scripts/copy-eject-sources.mjs
@@ -16,7 +16,7 @@
 // watch or otherwise. We wipe and recreate `eject/` here to keep the
 // output deterministic (no stale files from renamed or removed components).
 
-import { cpSync, rmSync, mkdirSync, statSync, readdirSync } from "node:fs";
+import { cpSync, copyFileSync, rmSync, mkdirSync, statSync, readdirSync } from "node:fs";
 import { resolve, dirname, relative, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -79,6 +79,17 @@ for (const name of EJECTABLE) {
     recursive: true,
     filter: (src) => !shouldExclude(src, srcDir),
   });
+
+  // The frozen header literal has two project-owned inputs after eject
+  // (nav-active.ts and nav-class-tokens.ts). Ship the real generator beside
+  // them so local edits have a deterministic regeneration path; its other two
+  // inputs remain package-owned and are resolved from the installed dist/.
+  if (name === "header") {
+    copyFileSync(
+      resolve(PKG_ROOT, "scripts/gen-nav-overflow-script.mjs"),
+      resolve(destDir, "gen-nav-overflow-script.mjs"),
+    );
+  }
 
   const n = countFiles(destDir);
   totalFiles += n;

--- a/packages/zudo-doc/scripts/gen-nav-overflow-script.mjs
+++ b/packages/zudo-doc/scripts/gen-nav-overflow-script.mjs
@@ -22,13 +22,14 @@
 // reflects on a live function again, and the emitted bytes become
 // consumer-bundler-independent.
 //
-// HOW: reads `src/current-path/index.ts`, `src/header/nav-active.ts`,
-// `src/header/nav-class-tokens.ts`, and `src/transitions/page-events.ts`
+// HOW (package build): reads `src/current-path/index.ts`,
+// `src/header/nav-active.ts`, `src/header/nav-class-tokens.ts`, and
+// `src/transitions/page-events.ts`
 // SOURCE, strips TypeScript types deterministically via esbuild's
 // `transformSync()` (same rationale as gen-search-widget-script.mjs — see
 // that file's header comment for the full `ts.transpileModule()` vs esbuild
 // history, zudolab/zudo-doc#3422 / #3430 — identical here: esbuild is only a
-// transitive dep via tsup, declared as an explicit `esbuild` devDependency,
+// package dependency (it is also used by the shipped ejected-header generator),
 // and the effective floor tracks the root `pnpm.overrides` range), executes
 // each transpiled CommonJS module in an isolated sandbox (empty
 // `module`/`exports`; all four source files are import-free), then reads
@@ -68,6 +69,14 @@
 // from its four source files. It stays internal like the source files it
 // reads — NOT added to the package `exports` map or `files[]`.
 //
+// EJECTED HEADER MODE (zudolab/zudo-doc#3541): copy-eject-sources.mjs ships
+// this same generator beside the ejected header files. In that location it
+// reads project-owned nav-active.ts / nav-class-tokens.ts locally, while the
+// current-path and page-event inputs come from the installed package's dist/
+// modules. It resolves esbuild from that package's dependency graph, so a
+// consumer runs the understandable, self-contained command printed by eject:
+// `node ./src/components/zudo-doc/header/gen-nav-overflow-script.mjs`.
+//
 // `buildNavOverflowScript()` is exported so both this script's CLI entry
 // point AND the vitest drift-guard test
 // (`src/header/__tests__/nav-overflow-script.test.ts`) can call it: the test
@@ -89,17 +98,87 @@
 // zudolab/zudo-doc#3535 — see scripts/check-nav-overflow-script-drift.sh.
 
 import { readFileSync, writeFileSync, existsSync, realpathSync } from "node:fs";
+import { createRequire } from "node:module";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { transformSync } from "esbuild";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const PKG_ROOT = resolve(__dirname, "..");
-const CURRENT_PATH_SRC_PATH = resolve(PKG_ROOT, "src/current-path/index.ts");
-const NAV_ACTIVE_SRC_PATH = resolve(PKG_ROOT, "src/header/nav-active.ts");
-const NAV_CLASS_TOKENS_SRC_PATH = resolve(PKG_ROOT, "src/header/nav-class-tokens.ts");
-const PAGE_EVENTS_SRC_PATH = resolve(PKG_ROOT, "src/transitions/page-events.ts");
-const OUTPUT_PATH = resolve(PKG_ROOT, "src/header/nav-overflow-generated-script.ts");
+
+/** Find the installed package from an ejected header without assuming npm's
+ * node_modules layout. The symlinked package root is enough: createRequire()
+ * below resolves esbuild from the package's own dependency graph under npm,
+ * pnpm, and yarn installs. */
+function findInstalledPackageRoot(startDirs) {
+  for (const startDir of startDirs) {
+    let dir = resolve(startDir);
+    while (true) {
+      const candidate = resolve(dir, "node_modules/@takazudo/zudo-doc");
+      if (existsSync(resolve(candidate, "package.json"))) return realpathSync(candidate);
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  }
+  throw new Error(
+    "[gen-nav-overflow-script] could not find node_modules/@takazudo/zudo-doc. " +
+      "Run this command from an installed zudo-doc project after `pnpm install`.",
+  );
+}
+
+/** Resolve the generator's four inputs and output in package-build or ejected mode. */
+export function resolveGenerationContext() {
+  const packageRootCandidate = resolve(__dirname, "..");
+  const packageHeaderDir = resolve(packageRootCandidate, "src/header");
+  const isPackageGenerator = existsSync(resolve(packageHeaderDir, "nav-active.ts"));
+
+  if (isPackageGenerator) {
+    return {
+      kind: "package",
+      packageRoot: packageRootCandidate,
+      currentPathSource: resolve(packageRootCandidate, "src/current-path/index.ts"),
+      navActiveSource: resolve(packageHeaderDir, "nav-active.ts"),
+      navClassTokensSource: resolve(packageHeaderDir, "nav-class-tokens.ts"),
+      pageEventsSource: resolve(packageRootCandidate, "src/transitions/page-events.ts"),
+      outputPath: resolve(packageHeaderDir, "nav-overflow-generated-script.ts"),
+    };
+  }
+
+  // In an ejected payload this script sits beside the two project-owned
+  // customization inputs. The current-path prelude and page-event vocabulary
+  // intentionally stay package-owned and come from the installed compiled
+  // modules, so an ejected project does not fork framework lifecycle inputs.
+  if (
+    !existsSync(resolve(__dirname, "nav-active.ts")) ||
+    !existsSync(resolve(__dirname, "nav-class-tokens.ts"))
+  ) {
+    throw new Error(
+      "[gen-nav-overflow-script] expected nav-active.ts and nav-class-tokens.ts " +
+        `beside the ejected generator at ${__dirname}`,
+    );
+  }
+  const packageRoot = findInstalledPackageRoot([process.cwd(), __dirname]);
+  return {
+    kind: "ejected",
+    packageRoot,
+    currentPathSource: resolve(packageRoot, "dist/current-path/index.js"),
+    navActiveSource: resolve(__dirname, "nav-active.ts"),
+    navClassTokensSource: resolve(__dirname, "nav-class-tokens.ts"),
+    pageEventsSource: resolve(packageRoot, "dist/transitions/page-events.js"),
+    outputPath: resolve(__dirname, "nav-overflow-generated-script.ts"),
+  };
+}
+
+function loadTransformSync(packageRoot) {
+  try {
+    const requireFromPackage = createRequire(resolve(packageRoot, "package.json"));
+    return requireFromPackage("esbuild").transformSync;
+  } catch (err) {
+    throw new Error(
+      "[gen-nav-overflow-script] could not load the esbuild dependency shipped by " +
+        `@takazudo/zudo-doc: ${err.message}`,
+    );
+  }
+}
 
 // Explicit, stable esbuild options — identical rationale to
 // gen-search-widget-script.mjs's TRANSFORM_OPTIONS (see that file): `format:
@@ -137,11 +216,14 @@ function assertNoModuleScaffolding(label, text) {
 }
 
 /** Transpile a TS source file to CommonJS JS, type-stripped, via esbuild's `transformSync`. */
-function transpile(sourcePath) {
+function transpile(sourcePath, transformSync) {
   const source = readFileSync(sourcePath, "utf8");
   let result;
   try {
-    result = transformSync(source, TRANSFORM_OPTIONS);
+    result = transformSync(source, {
+      ...TRANSFORM_OPTIONS,
+      loader: sourcePath.endsWith(".ts") ? "ts" : "js",
+    });
   } catch (err) {
     const messages = (err.errors ?? []).map((e) => e.text).join("; ") || err.message;
     throw new Error(
@@ -175,8 +257,8 @@ function executeCommonJs(code, label) {
 }
 
 /** Extract the real CURRENT_PATH_SCRIPT_PRELUDE value from current-path/index.ts. */
-function extractCurrentPathPrelude() {
-  const outputText = transpile(CURRENT_PATH_SRC_PATH);
+function extractCurrentPathPrelude(context, transformSync) {
+  const outputText = transpile(context.currentPathSource, transformSync);
   const exportsObj = executeCommonJs(outputText, "current-path/index.ts");
   const value = exportsObj.CURRENT_PATH_SCRIPT_PRELUDE;
   if (typeof value !== "string" || !value) {
@@ -189,8 +271,8 @@ function extractCurrentPathPrelude() {
 }
 
 /** Extract the real, unit-tested pathMatchesNavPath/computeActiveNavPath source text from nav-active.ts. */
-function extractNavActiveFunctions() {
-  const outputText = transpile(NAV_ACTIVE_SRC_PATH);
+function extractNavActiveFunctions(context, transformSync) {
+  const outputText = transpile(context.navActiveSource, transformSync);
   const exportsObj = executeCommonJs(outputText, "nav-active.ts");
   const { pathMatchesNavPath, computeActiveNavPath } = exportsObj;
   if (typeof pathMatchesNavPath !== "function" || typeof computeActiveNavPath !== "function") {
@@ -224,8 +306,8 @@ const NAV_CLASS_TOKEN_NAMES = [
 ];
 
 /** Extract the twelve real class-token arrays from nav-class-tokens.ts. */
-function extractNavClassTokens() {
-  const outputText = transpile(NAV_CLASS_TOKENS_SRC_PATH);
+function extractNavClassTokens(context, transformSync) {
+  const outputText = transpile(context.navClassTokensSource, transformSync);
   const exportsObj = executeCommonJs(outputText, "nav-class-tokens.ts");
   const tokens = {};
   for (const name of NAV_CLASS_TOKEN_NAMES) {
@@ -255,8 +337,8 @@ function extractNavClassTokens() {
 }
 
 /** Extract the real AFTER_NAVIGATE_EVENT value from transitions/page-events.ts — never hardcoded. */
-function extractAfterNavigateEvent() {
-  const outputText = transpile(PAGE_EVENTS_SRC_PATH);
+function extractAfterNavigateEvent(context, transformSync) {
+  const outputText = transpile(context.pageEventsSource, transformSync);
   const exportsObj = executeCommonJs(outputText, "page-events.ts");
   const value = exportsObj.AFTER_NAVIGATE_EVENT;
   if (typeof value !== "string" || !value) {
@@ -288,9 +370,13 @@ const clsAppend = (tokens) => JSON.stringify(" " + tokens.join(" "));
  * in nav-overflow-script.ts, but with the four previously-live interpolations
  * replaced by frozen values extracted above.
  */
-export function buildNavOverflowScript() {
-  const currentPathPrelude = extractCurrentPathPrelude();
-  const { pathMatchesNavPathSrc, computeActiveNavPathSrc } = extractNavActiveFunctions();
+export function buildNavOverflowScript(context = resolveGenerationContext()) {
+  const transformSync = loadTransformSync(context.packageRoot);
+  const currentPathPrelude = extractCurrentPathPrelude(context, transformSync);
+  const { pathMatchesNavPathSrc, computeActiveNavPathSrc } = extractNavActiveFunctions(
+    context,
+    transformSync,
+  );
   const {
     NAV_TOP_ACTIVE,
     NAV_TOP_INACTIVE,
@@ -304,8 +390,10 @@ export function buildNavOverflowScript() {
     NAV_MENU_PLAIN_ACTIVE_SUFFIX,
     NAV_MENU_CHILD_ACTIVE,
     NAV_MENU_CHILD_INACTIVE,
-  } = extractNavClassTokens();
-  const afterNavigateEventLiteral = JSON.stringify(extractAfterNavigateEvent());
+  } = extractNavClassTokens(context, transformSync);
+  const afterNavigateEventLiteral = JSON.stringify(
+    extractAfterNavigateEvent(context, transformSync),
+  );
 
   return /* javascript */ `(function () {
   var cleanupNavOverflow = null;
@@ -610,10 +698,9 @@ const isMainModule = (() => {
   }
 })();
 
-if (isMainModule) {
-  const script = buildNavOverflowScript();
-
-  const banner = `// GENERATED FILE — do not edit by hand.
+function buildGeneratedModule(script, context) {
+  const banner = context.kind === "package"
+    ? `// GENERATED FILE — do not edit by hand.
 // Produced by scripts/gen-nav-overflow-script.mjs (zudolab/zudo-doc#3534,
 // epic #3533) from src/current-path/index.ts (CURRENT_PATH_SCRIPT_PRELUDE),
 // src/header/nav-active.ts (pathMatchesNavPath/computeActiveNavPath,
@@ -627,9 +714,18 @@ if (isMainModule) {
 // zudolab/zudo-doc#3421 / #3431) — a deliberate departure from this repo's
 // usual gitignored-generated-file convention (routes-src/, virtual-modules.d.ts).
 // Regenerate AND commit the result after editing any of the four source files.
+`
+    : `// GENERATED FILE — do not edit by hand.
+// Produced by the ejected header's gen-nav-overflow-script.mjs from the local
+// nav-active.ts and nav-class-tokens.ts customization inputs plus the installed
+// @takazudo/zudo-doc current-path and page-event inputs.
+// Re-run \`node ./src/components/zudo-doc/header/gen-nav-overflow-script.mjs\`
+// after editing either local input, then commit this file with your customization.
+// The script value remains frozen so its CSP bytes do not depend on the
+// consumer bundler.
 `;
 
-  const output = `${banner}
+  return `${banner}
 /** Returns the frozen desktop-nav overflow controller IIFE script. NOTE: the
  * vitest drift guard imports buildNavOverflowScript from
  * scripts/gen-nav-overflow-script.mjs (a fresh re-generation) — NEVER from
@@ -645,17 +741,31 @@ export function buildNavOverflowScript(): string {
  * transitions/page-events.ts for the frozen sources. */
 export const NAV_OVERFLOW_SCRIPT: string = buildNavOverflowScript();
 `;
+}
 
-  const existing = existsSync(OUTPUT_PATH) ? readFileSync(OUTPUT_PATH, "utf8") : null;
+/** Regenerate the committed package literal or the local ejected literal. */
+export function generateNavOverflowScript(context = resolveGenerationContext()) {
+  const script = buildNavOverflowScript(context);
+  const output = buildGeneratedModule(script, context);
+
+  const existing = existsSync(context.outputPath)
+    ? readFileSync(context.outputPath, "utf8")
+    : null;
 
   if (existing === output) {
     process.stdout.write(
-      "[gen-nav-overflow-script] nav-overflow-generated-script.ts unchanged, skip write\n",
+      `[gen-nav-overflow-script] ${context.outputPath} unchanged, skip write\n`,
     );
   } else {
-    writeFileSync(OUTPUT_PATH, output, "utf8");
+    writeFileSync(context.outputPath, output, "utf8");
     process.stdout.write(
-      "[gen-nav-overflow-script] nav-overflow-generated-script.ts written\n",
+      `[gen-nav-overflow-script] ${context.outputPath} written\n`,
     );
   }
+
+  return { output, outputPath: context.outputPath, changed: existing !== output };
+}
+
+if (isMainModule) {
+  generateNavOverflowScript();
 }

--- a/packages/zudo-doc/src/__tests__/eject.test.ts
+++ b/packages/zudo-doc/src/__tests__/eject.test.ts
@@ -2,10 +2,18 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "fs-extra";
 import os from "os";
 import path from "path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
 import { eject, EJECTABLE } from "@takazudo/zudo-doc/eject";
 import type { ZudoDocJson } from "@takazudo/zudo-doc/eject";
 
 const TEMP_PREFIX = "create-zudo-doc-eject-test-";
+const execFileAsync = promisify(execFile);
+const REAL_PACKAGE_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
 
 // ── Fixture helpers ───────────────────────────────────────────────────────────
 
@@ -56,6 +64,12 @@ const ANSI_ESCAPE = new RegExp(
 
 function capturedOutput(spy: ReturnType<typeof vi.spyOn>): string {
   return spy.mock.calls.flat().join("\n").replace(ANSI_ESCAPE, "");
+}
+
+function extractFrozenScript(generatedModule: string): string {
+  const match = generatedModule.match(/  return (".*");$/m);
+  if (!match?.[1]) throw new Error("generated module did not contain a string return");
+  return JSON.parse(match[1]) as string;
 }
 
 // ── Test state ────────────────────────────────────────────────────────────────
@@ -321,6 +335,75 @@ describe("eject() — copy + provenance", () => {
     expect(await fs.pathExists(destDir)).toBe(true);
     expect(await fs.pathExists(path.join(destDir, "index.ts"))).toBe(true);
     expect(await fs.pathExists(path.join(destDir, "comp.tsx"))).toBe(true);
+  });
+
+  it("ships a runnable header generator that embeds local tokens and package inputs", async () => {
+    const projectDir = path.join(tempDir, "project-header-generator");
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    await fs.ensureDir(path.join(projectDir, "node_modules/@takazudo"));
+    await fs.ensureSymlink(
+      REAL_PACKAGE_ROOT,
+      path.join(projectDir, "node_modules/@takazudo/zudo-doc"),
+      "dir",
+    );
+
+    await eject("header", {
+      cwd: projectDir,
+      resolvePackageRoot: makeResolver(REAL_PACKAGE_ROOT),
+    });
+
+    expect(capturedOutput(log)).toContain(
+      "node ./src/components/zudo-doc/header/gen-nav-overflow-script.mjs",
+    );
+
+    const headerDir = path.join(
+      projectDir,
+      "src/components/zudo-doc/header",
+    );
+    const generatorPath = path.join(headerDir, "gen-nav-overflow-script.mjs");
+    const tokensPath = path.join(headerDir, "nav-class-tokens.ts");
+    const outputPath = path.join(headerDir, "nav-overflow-generated-script.ts");
+    expect(await fs.pathExists(generatorPath)).toBe(true);
+
+    const packageGenerated = await fs.readFile(outputPath, "utf8");
+
+    // With untouched local sources, ejected regeneration must preserve the
+    // exact inline-script bytes (and therefore the consumer's CSP hash), even
+    // though the generated module's provenance banner is local-project-aware.
+    await execFileAsync(process.execPath, [generatorPath], { cwd: projectDir });
+    const ejectedGenerated = await fs.readFile(outputPath, "utf8");
+    expect(extractFrozenScript(ejectedGenerated)).toBe(
+      extractFrozenScript(packageGenerated),
+    );
+
+    const tokens = await fs.readFile(tokensPath, "utf8");
+    await fs.writeFile(
+      tokensPath,
+      tokens.replace('"bg-fg"', '"ejected-regenerated-active"'),
+      "utf8",
+    );
+    const navActivePath = path.join(headerDir, "nav-active.ts");
+    const navActive = await fs.readFile(navActivePath, "utf8");
+    await fs.writeFile(
+      navActivePath,
+      navActive.replace(
+        "if (currentPath === navPath) return true;",
+        'if (currentPath === navPath) return navPath !== "ejected-never-match";',
+      ),
+      "utf8",
+    );
+
+    await execFileAsync(process.execPath, [generatorPath], { cwd: projectDir });
+
+    const after = await fs.readFile(outputPath, "utf8");
+    expect(after).not.toBe(ejectedGenerated);
+    expect(after).toContain("ejected-regenerated-active");
+    expect(after).toContain("ejected-never-match");
+    // These values come from the installed package's current-path and
+    // transitions modules, proving all four generator inputs are available.
+    expect(after).toContain("zdCurrentPath");
+    expect(after).toContain("zfb:after-swap");
+    log.mockRestore();
   });
 
   it("writes .zudo-doc.json with the component recorded", async () => {

--- a/packages/zudo-doc/src/__tests__/eject.test.ts
+++ b/packages/zudo-doc/src/__tests__/eject.test.ts
@@ -3,8 +3,10 @@ import fs from "fs-extra";
 import os from "os";
 import path from "path";
 import { execFile } from "node:child_process";
+import { createRequire } from "node:module";
 import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
+import { transformSync } from "esbuild";
 import { eject, EJECTABLE } from "@takazudo/zudo-doc/eject";
 import type { ZudoDocJson } from "@takazudo/zudo-doc/eject";
 
@@ -13,6 +15,11 @@ const execFileAsync = promisify(execFile);
 const REAL_PACKAGE_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "../..",
+);
+const requireFromTest = createRequire(import.meta.url);
+const ESBUILD_ROOT = path.resolve(
+  path.dirname(requireFromTest.resolve("esbuild")),
+  "..",
 );
 
 // ── Fixture helpers ───────────────────────────────────────────────────────────
@@ -70,6 +77,18 @@ function extractFrozenScript(generatedModule: string): string {
   const match = generatedModule.match(/  return (".*");$/m);
   if (!match?.[1]) throw new Error("generated module did not contain a string return");
   return JSON.parse(match[1]) as string;
+}
+
+function evaluateTypeScriptModule(source: string): Record<string, unknown> {
+  const code = transformSync(source, {
+    loader: "ts",
+    format: "cjs",
+    target: "es2020",
+    platform: "neutral",
+  }).code;
+  const moduleObj: { exports: Record<string, unknown> } = { exports: {} };
+  new Function("module", "exports", code)(moduleObj, moduleObj.exports);
+  return moduleObj.exports;
 }
 
 // ── Test state ────────────────────────────────────────────────────────────────
@@ -340,16 +359,63 @@ describe("eject() — copy + provenance", () => {
   it("ships a runnable header generator that embeds local tokens and package inputs", async () => {
     const projectDir = path.join(tempDir, "project-header-generator");
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const headerSourceDir = path.join(REAL_PACKAGE_ROOT, "src/header");
+    const pkgRoot = await buildFixturePackage(tempDir, "header", {
+      "gen-nav-overflow-script.mjs": await fs.readFile(
+        path.join(REAL_PACKAGE_ROOT, "scripts/gen-nav-overflow-script.mjs"),
+        "utf8",
+      ),
+      "nav-active.ts": await fs.readFile(
+        path.join(headerSourceDir, "nav-active.ts"),
+        "utf8",
+      ),
+      "nav-class-tokens.ts": await fs.readFile(
+        path.join(headerSourceDir, "nav-class-tokens.ts"),
+        "utf8",
+      ),
+      "nav-overflow-generated-script.ts": await fs.readFile(
+        path.join(headerSourceDir, "nav-overflow-generated-script.ts"),
+        "utf8",
+      ),
+    });
+
+    const currentPathExports = evaluateTypeScriptModule(
+      await fs.readFile(
+        path.join(REAL_PACKAGE_ROOT, "src/current-path/index.ts"),
+        "utf8",
+      ),
+    );
+    const pageEventExports = evaluateTypeScriptModule(
+      await fs.readFile(
+        path.join(REAL_PACKAGE_ROOT, "src/transitions/page-events.ts"),
+        "utf8",
+      ),
+    );
+    await fs.outputFile(
+      path.join(pkgRoot, "dist/current-path/index.js"),
+      `export const CURRENT_PATH_SCRIPT_PRELUDE = ${JSON.stringify(currentPathExports.CURRENT_PATH_SCRIPT_PRELUDE)};\n`,
+    );
+    await fs.outputFile(
+      path.join(pkgRoot, "dist/transitions/page-events.js"),
+      `export const AFTER_NAVIGATE_EVENT = ${JSON.stringify(pageEventExports.AFTER_NAVIGATE_EVENT)};\n`,
+    );
+    await fs.ensureDir(path.join(pkgRoot, "node_modules"));
+    await fs.ensureSymlink(
+      ESBUILD_ROOT,
+      path.join(pkgRoot, "node_modules/esbuild"),
+      "dir",
+    );
+
     await fs.ensureDir(path.join(projectDir, "node_modules/@takazudo"));
     await fs.ensureSymlink(
-      REAL_PACKAGE_ROOT,
+      pkgRoot,
       path.join(projectDir, "node_modules/@takazudo/zudo-doc"),
       "dir",
     );
 
     await eject("header", {
       cwd: projectDir,
-      resolvePackageRoot: makeResolver(REAL_PACKAGE_ROOT),
+      resolvePackageRoot: makeResolver(pkgRoot),
     });
 
     expect(capturedOutput(log)).toContain(

--- a/packages/zudo-doc/src/eject/index.ts
+++ b/packages/zudo-doc/src/eject/index.ts
@@ -552,4 +552,13 @@ export async function eject(
         `  Provenance:  .zudo-doc.json\n`,
     ),
   );
+
+  if (component === "header") {
+    console.log(
+      pc.bold("Header frozen-script regeneration:") +
+        `\n  After editing ${localDir}/nav-active.ts or nav-class-tokens.ts, run:` +
+        `\n  node ./${localDir}/gen-nav-overflow-script.mjs` +
+        `\n  Commit ${localDir}/nav-overflow-generated-script.ts with your edits.\n`,
+    );
+  }
 }

--- a/packages/zudo-doc/src/header/nav-overflow-script.ts
+++ b/packages/zudo-doc/src/header/nav-overflow-script.ts
@@ -46,12 +46,15 @@
 // `src/header/__tests__/nav-overflow-script.test.ts` proves the committed
 // literal still matches a fresh regeneration.
 //
-// EJECTED COPIES (`zudo-doc eject header`): the generator is NOT shipped, so
-// in an ejected tree the re-exported literal is permanently frozen — editing
-// the ejected `./nav-class-tokens.ts` or `./nav-active.ts` changes the SSR
-// markup (header.tsx imports them live) but NOT this client script, breaking
-// the SSR ↔ runtime class lockstep those files exist to guarantee. To change
-// the client script in an ejected copy, edit the literal in
-// `./nav-overflow-generated-script.ts` directly (it is plain JS in a string)
-// and keep it in step with your token edits by hand.
+// EJECTED COPIES (`zudo-doc eject header`): the payload ships
+// `./gen-nav-overflow-script.mjs`. After editing the local `./nav-active.ts`
+// or `./nav-class-tokens.ts`, run:
+//
+//   node ./src/components/zudo-doc/header/gen-nav-overflow-script.mjs
+//
+// The generator reads those two local customization inputs and the installed
+// package's current-path/page-event inputs, then rewrites the local
+// `./nav-overflow-generated-script.ts`. Commit that generated file with the
+// edits. Do not edit its string literal by hand: regeneration preserves the
+// frozen, consumer-bundler-independent bytes required for stable CSP hashes.
 export { NAV_OVERFLOW_SCRIPT } from "./nav-overflow-generated-script.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
       diff:
         specifier: ^8.0.0
         version: 8.0.3
+      esbuild:
+        specifier: '>=0.28.1'
+        version: 0.28.1
       fs-extra:
         specifier: ^11.3.0
         version: 11.3.4
@@ -253,9 +256,6 @@ importers:
       '@types/string-similarity':
         specifier: ^4.0.2
         version: 4.0.2
-      esbuild:
-        specifier: '>=0.28.1'
-        version: 0.28.1
       happy-dom:
         specifier: ^20.10.6
         version: 20.10.6


### PR DESCRIPTION
Tracking: #3568

Closes #3541.
Closes #3504.
Closes #3568.

## Summary

- ship a complete nav-overflow regeneration path with `zudo-doc eject header`
- combine locally customized nav behavior/tokens with installed package lifecycle inputs while preserving frozen, consumer-bundler-independent script bytes
- resolve the generator's transformer through `@takazudo/zudo-doc` and document the exact invocation/output contract
- strengthen shared boolean-feature tests so unselected `docTags` cannot emit either `true` or `false`

## Validation

- ordered workspace build: passed
- zudo-doc package suite: 2,282 tests passed
- create-zudo-doc focused generator suite: 79 tests passed
- package typechecks: passed
- zudo-doc prepack contract: passed
- nav-overflow drift check: passed
- packed tarball includes the ejected generator and runtime `esbuild` dependency
- ejected fixture proves unchanged CSP bytes and all four generator inputs
- worker foreground reviews and final manager review: no remaining actionable findings

## Visual verification

Not applicable: no rendered markup or styling changed; the affected behavior is build/eject tooling covered by byte-level and subprocess fixture tests.
