### PR TITLE
fix: harden nested changelog navigation

### DIFF
--- a/packages/zudo-doc/src/category-nav/__tests__/category-nav-factory.test.tsx
+++ b/packages/zudo-doc/src/category-nav/__tests__/category-nav-factory.test.tsx
@@ -121,6 +121,55 @@ describe("createCategoryNavWrapper — version threading (#3218), category mode"
   });
 });
 
+describe("createCategoryNavWrapper — nested changelog categories", () => {
+  function makeChangelogDeps(): CategoryNavDeps {
+    const tree: CategoryNavNode[] = [
+      makeNode("changelog", {
+        label: "Changelog",
+        children: [
+          makeNode("changelog/pkg-a", { label: "Package A", description: "Package A releases" }),
+          makeNode("changelog/pkg-b", { label: "Package B", description: "Package B releases" }),
+        ],
+      }),
+    ];
+    return makeDeps({ buildNavTree: () => tree });
+  }
+
+  it("renders the two package cards under category=changelog", () => {
+    const result = createCategoryNavWrapper(makeChangelogDeps())({ category: "changelog" });
+    expect(cardsOf(result).map(({ label, href, description }) => ({ label, href, description }))).toEqual([
+      { label: "Package A", href: "/docs/changelog/pkg-a", description: "Package A releases" },
+      { label: "Package B", href: "/docs/changelog/pkg-b", description: "Package B releases" },
+    ]);
+  });
+
+  it("renders a package's version pages under category=changelog/pkg-a", () => {
+    const deps = makeChangelogDeps();
+    const originalBuildNavTree = deps.buildNavTree;
+    deps.buildNavTree = (...args) =>
+      originalBuildNavTree(...args).map((node) => ({
+        ...node,
+        children: node.children.map((child) =>
+          child.slug === "changelog/pkg-a"
+            ? {
+                ...child,
+                children: [
+                  makeNode("changelog/pkg-a/1.0", { label: "1.0", href: "/docs/changelog/pkg-a/1.0" }),
+                  makeNode("changelog/pkg-a/2.0", { label: "2.0", href: "/docs/changelog/pkg-a/2.0" }),
+                ],
+              }
+            : child,
+        ),
+      }));
+
+    const result = createCategoryNavWrapper(deps)({ category: "changelog/pkg-a" });
+    expect(cardsOf(result).map((card) => card.href)).toEqual([
+      "/docs/changelog/pkg-a/1.0",
+      "/docs/changelog/pkg-a/2.0",
+    ]);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // `categories` mode (explicit top-level slug list)
 // ---------------------------------------------------------------------------

--- a/packages/zudo-doc/src/config-assertions/__tests__/index.test.ts
+++ b/packages/zudo-doc/src/config-assertions/__tests__/index.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { warnAmbiguousDropdownCategoryMatch } from "../index.js";
+
+function warningCollector(): { warnings: string[]; logger: { warn(message: string): void } } {
+  const warnings: string[] = [];
+  return { warnings, logger: { warn: (message: string) => warnings.push(message) } };
+}
+
+describe("warnAmbiguousDropdownCategoryMatch", () => {
+  it("warns once for duplicate child categoryMatch values", () => {
+    const { warnings, logger } = warningCollector();
+
+    warnAmbiguousDropdownCategoryMatch(
+      [
+        {
+          label: "Changelog",
+          categoryMatch: "changelog",
+          children: [
+            { label: "Package A", categoryMatch: "changelog" },
+            { label: "Package B", categoryMatch: "changelog" },
+          ],
+        },
+      ],
+      logger,
+    );
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('"Changelog"');
+    expect(warnings[0]).toContain('"changelog"');
+    expect(warnings[0]).toContain("omit categoryMatch");
+  });
+
+  it("warns once for a slash-containing value even when parent and child repeat it", () => {
+    const { warnings, logger } = warningCollector();
+
+    warnAmbiguousDropdownCategoryMatch(
+      [
+        {
+          label: "Learn",
+          categoryMatch: "guides/components",
+          children: [{ label: "Components", categoryMatch: "guides/components" }],
+        },
+      ],
+      logger,
+    );
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('"Learn"');
+    expect(warnings[0]).toContain('"guides/components"');
+    expect(warnings[0]).toContain("contains `/`");
+  });
+
+  it("does not warn for the showcase Learn shape or omitted nested matchers", () => {
+    const { warnings, logger } = warningCollector();
+
+    warnAmbiguousDropdownCategoryMatch(
+      [
+        {
+          label: "Learn",
+          categoryMatch: "guides",
+          children: [
+            { label: "Guides", categoryMatch: "guides" },
+            { label: "Components", categoryMatch: "components" },
+            { label: "Markdown Features", categoryMatch: "markdown-features" },
+          ],
+        },
+        {
+          label: "Changelog",
+          categoryMatch: "changelog",
+          children: [{ label: "Package A" }, { label: "Package B" }],
+        },
+        {
+          label: "Default",
+          categoryMatch: "!",
+          children: [{ label: "A", categoryMatch: "!" }, { label: "B", categoryMatch: "!" }],
+        },
+      ],
+      logger,
+    );
+
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/zudo-doc/src/config-assertions/index.ts
+++ b/packages/zudo-doc/src/config-assertions/index.ts
@@ -9,6 +9,21 @@
 
 import type { FaviconConfig } from "../settings.js";
 
+/** Structural subset of a header dropdown read by the category-match guard. */
+export interface AmbiguousDropdownCategoryMatchItem {
+  label?: string;
+  categoryMatch?: string;
+  children?: Array<{
+    label?: string;
+    categoryMatch?: string;
+  }>;
+}
+
+/** Logger surface accepted by the non-throwing header-nav diagnostic. */
+export interface ConfigAssertionLogger {
+  warn(message: string): void;
+}
+
 /** Structural subset of `Settings` {@link assertNoEmptyStringFaviconOrLogo} reads. */
 export interface EmptyStringFaviconOrLogoSubject {
   logo?: string | false;
@@ -63,6 +78,73 @@ export function assertNoEmptyStringFaviconOrLogo(settings: EmptyStringFaviconOrL
           `Invalid favicon.${slot} "": omit the slot to fall back to the default, or supply a non-empty path.`,
         );
       }
+    }
+  }
+}
+
+/**
+ * Warn about `categoryMatch` values that cannot express the intended
+ * dropdown grouping.
+ *
+ * A category matcher is compared with the first slug segment by the nav-scope
+ * resolver, so a value containing `/` never matches. Likewise, duplicate
+ * child values make every matching child category-active. Children grouped
+ * under one top-level directory should omit `categoryMatch` and rely on the
+ * deepest matching child path; Learn-style children should use distinct
+ * top-level values.
+ *
+ * This is intentionally a diagnostic rather than a config assertion: malformed
+ * navigation should remain buildable, and each offending value is reported at
+ * most once per parent dropdown. The `"!"` matcher is the intentional default
+ * bucket and is excluded from both checks.
+ */
+export function warnAmbiguousDropdownCategoryMatch(
+  headerNav: readonly AmbiguousDropdownCategoryMatchItem[] | undefined,
+  logger: ConfigAssertionLogger = console,
+): void {
+  if (!headerNav) return;
+
+  for (const item of headerNav) {
+    const children = item.children;
+    if (!children || children.length === 0) continue;
+
+    const childCounts = new Map<string, number>();
+    for (const child of children) {
+      const value = child.categoryMatch;
+      if (value == null || value === "!") continue;
+      childCounts.set(value, (childCounts.get(value) ?? 0) + 1);
+    }
+
+    const offendingValues: string[] = [];
+    const addOffendingValue = (value: string | undefined): void => {
+      if (value == null || value === "!" || offendingValues.includes(value)) return;
+      offendingValues.push(value);
+    };
+
+    if (item.categoryMatch?.includes("/")) {
+      addOffendingValue(item.categoryMatch);
+    }
+    for (const child of children) {
+      if (child.categoryMatch?.includes("/")) {
+        addOffendingValue(child.categoryMatch);
+      }
+    }
+    for (const [value, count] of childCounts) {
+      if (count >= 2) addOffendingValue(value);
+    }
+
+    for (const value of offendingValues) {
+      const reasons = [
+        ...(value.includes("/") ? ["contains `/` and never matches a top-level slug"] : []),
+        ...((childCounts.get(value) ?? 0) >= 2 ? ["is shared by multiple children"] : []),
+      ].join("; ");
+      const parentLabel = item.label ?? "(unnamed)";
+      logger.warn(
+        `zudo-doc: header dropdown "${parentLabel}" has categoryMatch "${value}" that ${reasons}. ` +
+          "Children grouped under one top-level directory should omit categoryMatch " +
+          "(active state follows the deepest matching child path); Learn-style children " +
+          "should use distinct top-level values.",
+      );
     }
   }
 }

--- a/packages/zudo-doc/src/header-with-defaults/__tests__/header-nav-nested-children.test.tsx
+++ b/packages/zudo-doc/src/header-with-defaults/__tests__/header-nav-nested-children.test.tsx
@@ -1,0 +1,65 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { describe, expect, it } from "vitest";
+import { render } from "preact-render-to-string";
+import { Window } from "happy-dom";
+import { createHeaderWithDefaults } from "../index.js";
+import { makeFakeChromeContext } from "../../__tests__/fixtures/fake-chrome-context.js";
+import type { ChromeContext } from "../../factory-context/index.js";
+
+function realNavHref(
+  path: string,
+  lang: string | undefined,
+  currentVersion: string | undefined,
+  versioned = true,
+): string {
+  const isNonDefaultLocale = lang != null && lang !== "en";
+  const versionPrefix = versioned && currentVersion ? `/v/${currentVersion}` : "";
+  return isNonDefaultLocale ? `${versionPrefix}/${lang}${path}` : `${versionPrefix}${path}`;
+}
+
+describe("HeaderWithDefaults — nested dropdown children", () => {
+  function render_(lang: string, currentPath: string, currentVersion?: string): string {
+    const ctx = makeFakeChromeContext({
+      settings: {
+        headerNav: [
+          {
+            label: "Changelog",
+            path: "/docs/changelog",
+            categoryMatch: "changelog",
+            children: [
+              { label: "Package A", path: "/docs/changelog/pkg-a" },
+              { label: "Package B", path: "/docs/changelog/pkg-b" },
+            ],
+          },
+        ],
+        locales: { ja: {} },
+        versions: [{ slug: "1.0" }],
+      },
+      overrides: {
+        locales: ["en", "ja"],
+        navHref: realNavHref,
+      } as Partial<ChromeContext>,
+    });
+    const HeaderWithDefaults = createHeaderWithDefaults(ctx);
+    return render(<HeaderWithDefaults lang={lang} currentPath={currentPath} currentVersion={currentVersion} />);
+  }
+
+  it.each([
+    ["latest default-locale", "en", "/docs/changelog/pkg-a/1.0.0", undefined],
+    ["versioned default-locale", "en", "/v/1.0/docs/changelog/pkg-a/1.0.0", "1.0"],
+    ["versioned secondary-locale", "ja", "/v/1.0/ja/docs/changelog/pkg-a/1.0.0", "1.0"],
+  ])("marks one child and the parent active for %s", (_name, lang, currentPath, currentVersion) => {
+    const html = render_(lang, currentPath, currentVersion);
+    const window = new Window();
+    const root = window.document.createElement("div");
+    root.innerHTML = html;
+
+    const parent = root.querySelector("[data-nav-item-dropdown] > a");
+    expect(parent?.getAttribute("aria-current")).toBe("page");
+    expect(root.querySelectorAll('a[data-active=""]').length).toBe(1);
+    expect(root.querySelector('a[href*="pkg-a"]')?.getAttribute("data-active")).toBe("");
+    expect(root.querySelector('a[href*="pkg-b"]')?.hasAttribute("data-active")).toBe(false);
+  });
+});

--- a/packages/zudo-doc/src/header/__tests__/nav-active.test.ts
+++ b/packages/zudo-doc/src/header/__tests__/nav-active.test.ts
@@ -176,3 +176,35 @@ describe("isNavItemActiveByCategory", () => {
     expect(isNavItemActiveByCategory(child, "guides")).toBe(false);
   });
 });
+
+describe("nested dropdown children under one category", () => {
+  const changelog = {
+    path: "/docs/changelog",
+    categoryMatch: "changelog",
+    children: [
+      { path: "/docs/changelog/pkg-a" },
+      { path: "/docs/changelog/pkg-b" },
+    ],
+  } satisfies NavItemLike;
+
+  it("prefers the deepest child path for a nested package page", () => {
+    expect(computeActiveNavPath([changelog], "/docs/changelog/pkg-a/1.0.0")).toBe(
+      "/docs/changelog/pkg-a",
+    );
+  });
+
+  it("does not category-match children that omit categoryMatch", () => {
+    expect(isNavItemActiveByCategory(changelog.children![0]!, "changelog")).toBe(false);
+    expect(isNavItemActiveByCategory(changelog, "changelog")).toBe(true);
+  });
+
+  it("documents the duplicate-category footgun", () => {
+    const ambiguous = {
+      ...changelog,
+      children: changelog.children!.map((child) => ({ ...child, categoryMatch: "changelog" })),
+    } satisfies NavItemLike;
+
+    expect(isNavItemActiveByCategory(ambiguous.children![0]!, "changelog")).toBe(true);
+    expect(isNavItemActiveByCategory(ambiguous.children![1]!, "changelog")).toBe(true);
+  });
+});

--- a/packages/zudo-doc/src/header/__tests__/nav-overflow-active-exec.test.ts
+++ b/packages/zudo-doc/src/header/__tests__/nav-overflow-active-exec.test.ts
@@ -38,6 +38,22 @@ function buildNav(): HTMLElement {
   return nav;
 }
 
+function buildNestedChangelogNav(): HTMLElement {
+  const nav = document.createElement("nav");
+  nav.setAttribute("data-header-nav", "");
+  nav.innerHTML = `
+    <div data-nav-item data-nav-item-dropdown>
+      <a href="/docs/changelog">Changelog</a>
+      <div>
+        <a href="/docs/changelog/pkg-a">Package A</a>
+        <a href="/docs/changelog/pkg-b">Package B</a>
+      </div>
+    </div>
+  `;
+  document.body.appendChild(nav);
+  return nav;
+}
+
 describe("NAV_OVERFLOW_SCRIPT — executed in jsdom (applyActiveNav)", () => {
   afterEach(() => {
     document.body.innerHTML = "";
@@ -69,6 +85,24 @@ describe("NAV_OVERFLOW_SCRIPT — executed in jsdom (applyActiveNav)", () => {
     expect(learnLink?.getAttribute("aria-current")).toBe("page");
     expect(activeChild?.getAttribute("data-active")).toBe("");
     expect(inactiveChild?.hasAttribute("data-active")).toBe(false);
+  });
+
+  it("marks exactly one sibling-prefix changelog child active", () => {
+    setLocation("/docs/changelog/pkg-a/1.0.0");
+    const nav = buildNestedChangelogNav();
+
+    new Function(NAV_OVERFLOW_SCRIPT)();
+
+    expect(nav.querySelector('a[href="/docs/changelog"]')?.getAttribute("aria-current")).toBe(
+      "page",
+    );
+    expect(nav.querySelectorAll('a[data-active=""]').length).toBe(1);
+    expect(nav.querySelector('a[href="/docs/changelog/pkg-a"]')?.getAttribute("data-active")).toBe(
+      "",
+    );
+    expect(nav.querySelector('a[href="/docs/changelog/pkg-b"]')?.hasAttribute("data-active")).toBe(
+      false,
+    );
   });
 
   it("prefers document.documentElement.dataset.zdCurrentPath over location.pathname", () => {

--- a/packages/zudo-doc/src/header/header.tsx
+++ b/packages/zudo-doc/src/header/header.tsx
@@ -282,7 +282,14 @@ export function Header(props: HeaderProps): JSX.Element {
 
   const isNonDefaultLocale = lang != null && lang !== i18n.defaultLocale;
   const pathWithoutBase = urlHelpers.stripBase(currentPath);
-  const matchPath = pathForMatch(pathWithoutBase, lang, i18n.defaultLocale);
+  // `navHref` adds the active version prefix to rendered links, but the
+  // configured header paths are intentionally unversioned. Remove the
+  // version segment before locale normalization so SSR active state agrees
+  // with those configured paths on archived pages too. Keep this local to
+  // the renderer: `nav-active.ts` is embedded verbatim in the frozen
+  // overflow script and must remain unchanged.
+  const pathWithoutVersion = stripCurrentVersionPrefix(pathWithoutBase, currentVersion);
+  const matchPath = pathForMatch(pathWithoutVersion, lang, i18n.defaultLocale);
 
   const activeNavPath = computeActiveNavPath(headerNav, matchPath);
   const rightItemDispatch = createRightItemDispatch(headerRightComponents);
@@ -540,6 +547,24 @@ function renderNavItem(
       {label}
     </a>
   );
+}
+
+/**
+ * Remove the active `/v/{version}` route prefix from a pathname.
+ *
+ * Version slugs are a path segment, so `/v/1.0` must not strip a path such as
+ * `/v/1.01/...`. The equality branch also keeps the route root normalized to
+ * `/` instead of returning an empty string. This helper deliberately lives in
+ * `header.tsx`; `nav-active.ts` is copied into the CSP-hash-pinned overflow
+ * script and is not part of the SSR-only version normalization seam.
+ */
+function stripCurrentVersionPrefix(path: string, currentVersion?: string): string {
+  if (currentVersion == null || currentVersion === "") return path;
+
+  const prefix = `/v/${currentVersion}`;
+  if (path === prefix) return "/";
+  if (path.startsWith(`${prefix}/`)) return path.slice(prefix.length);
+  return path;
 }
 
 type RightItemContext = Omit<HeaderRightComponentProps, "item" | "index">;

--- a/packages/zudo-doc/src/preset.ts
+++ b/packages/zudo-doc/src/preset.ts
@@ -37,7 +37,10 @@ import { z } from "zod";
 import type { ColorScheme } from "./color-scheme-utils.js";
 import type { TagVocabularyEntry, FaviconConfig } from "./settings.js";
 import { assertNoCommaInVersionSlugs } from "./version-availability/index.js";
-import { assertNoEmptyStringFaviconOrLogo } from "./config-assertions/index.js";
+import {
+  assertNoEmptyStringFaviconOrLogo,
+  warnAmbiguousDropdownCategoryMatch,
+} from "./config-assertions/index.js";
 // Type-only — erased by esbuild before the node-builtin-free eval-graph
 // bundle runs (mirrors config.ts's `@takazudo/zfb/config` type-only import).
 import type { DirectiveSpec } from "@takazudo/zfb/config";
@@ -84,6 +87,16 @@ export interface PresetChangelogConfig {
   outputFile: string;
   packageName?: string;
   title?: string;
+}
+
+/** Minimal structural header-nav shape needed by preset diagnostics. */
+export interface PresetHeaderNavItem {
+  label?: string;
+  categoryMatch?: string;
+  children?: Array<{
+    label?: string;
+    categoryMatch?: string;
+  }>;
 }
 
 /**
@@ -169,6 +182,8 @@ export interface PresetSettings {
    * descriptor's options alongside `themePack`.
    */
   themePacks?: string[];
+  /** Header navigation, used for non-throwing dropdown category diagnostics. */
+  headerNav?: PresetHeaderNavItem[];
 }
 
 /**
@@ -333,6 +348,10 @@ export function zudoDocPreset({
   // `favicon` before it silently resolves to "the current document" per the
   // HTML spec (#3471, #3474).
   assertNoEmptyStringFaviconOrLogo(settings);
+
+  // This diagnostic belongs only to the directly-callable preset. `zudoDoc()`
+  // delegates here, so a second call site would emit duplicate warnings.
+  warnAmbiguousDropdownCategoryMatch(settings.headerNav);
 
   // `z.toJSONSchema` is a runtime call but the result is a stable JSON
   // document. Compute it once and reuse the same object across every


### PR DESCRIPTION
Parent: #3598

Addresses #3599.

## Summary

- normalize versioned header paths for SSR active-state matching
- warn about ambiguous dropdown `categoryMatch` values
- pin nested dropdown and `CategoryNav` behavior with focused tests

## Validation

- `pnpm --filter @takazudo/zudo-doc test`
- integrated 30-step `pnpm b4push` gate on the epic base

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/3608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789935498&installation_model_id=20910&pr_number=3608&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F3608&signature=ebda402d4d57c089f62a5845b84593ed2a57cc1a912b074baec83d06acc7404a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->