### PR TITLE
fix: warn on multi-changelog landing sources

### DIFF
--- a/packages/zudo-doc/src/integrations/changelog/__tests__/changelog.test.ts
+++ b/packages/zudo-doc/src/integrations/changelog/__tests__/changelog.test.ts
@@ -134,6 +134,37 @@ describe("changelog integration", () => {
     expect(second).toContain("First release.");
   });
 
+  it("warns when a landing directory contains per-package changelogs", () => {
+    const root = tempProject();
+    writeEntry(root, "changelog/index.mdx", "---\ntitle: Changelog\n---\n");
+    writeEntry(root, "changelog/pkg-a/1.0.0.mdx", "---\ntitle: 1.0.0\n---\n");
+    writeEntry(root, "changelog/img/x.png", "not a changelog");
+
+    const warnings: string[] = [];
+    const logger = {
+      info: () => undefined,
+      warn: (message: string) => warnings.push(message),
+    };
+    const landingResult = emitChangelogs({
+      projectRoot: root,
+      changelogs: [{ sourceDir: "changelog", outputFile: "CHANGELOG.md" }],
+      logger,
+    });
+
+    expect(readFileSync(landingResult.written[0]!, "utf-8")).toContain("# Changelog");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("changelog");
+    expect(warnings[0]).toContain("pkg-a");
+    expect(warnings[0]).not.toContain("img");
+
+    emitChangelogs({
+      projectRoot: root,
+      changelogs: [{ sourceDir: "changelog/pkg-a", outputFile: "packages/pkg-a/CHANGELOG.md" }],
+      logger,
+    });
+    expect(warnings).toHaveLength(1);
+  });
+
   it("fails clearly when a configured source directory is missing", () => {
     const root = tempProject();
 

--- a/packages/zudo-doc/src/integrations/changelog/emit.ts
+++ b/packages/zudo-doc/src/integrations/changelog/emit.ts
@@ -1,5 +1,5 @@
-import { mkdirSync, writeFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { mkdirSync, readdirSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
 import { generateChangelogMarkdown } from "./generate.js";
 import { loadChangelogEntries } from "./load.js";
 import type { ChangelogEmitOptions, ChangelogEmitResult } from "./types.js";
@@ -11,6 +11,16 @@ export function emitChangelogs(options: ChangelogEmitOptions): ChangelogEmitResu
     const sourceDir = resolve(options.projectRoot, config.sourceDir);
     const outputFile = resolve(options.projectRoot, config.outputFile);
     const entries = loadChangelogEntries({ sourceDir });
+    if (entries.length === 0) {
+      const nestedMdxDirs = findNestedMdxDirs(sourceDir);
+      if (nestedMdxDirs.length > 0) {
+        options.logger?.warn?.(
+          `Changelog sourceDir "${config.sourceDir}" (${sourceDir}) yielded 0 releases but contains .mdx files in sub-directories: ${nestedMdxDirs.join(
+            ", ",
+          )}. In a multi-changelog layout, each changelogs[] entry must point at a per-package directory (for example "${config.sourceDir}/<name>") whose per-release files are non-index .mdx files; the loader intentionally skips index.mdx.`,
+        );
+      }
+    }
     const markdown = generateChangelogMarkdown(entries, {
       title: config.title,
       packageName: config.packageName,
@@ -23,4 +33,16 @@ export function emitChangelogs(options: ChangelogEmitOptions): ChangelogEmitResu
   }
 
   return { written };
+}
+
+function findNestedMdxDirs(sourceDir: string): string[] {
+  return readdirSync(sourceDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .filter((entry) =>
+      readdirSync(join(sourceDir, entry.name), { withFileTypes: true }).some(
+        (nestedEntry) => nestedEntry.isFile() && nestedEntry.name.endsWith(".mdx"),
+      ),
+    )
+    .map((entry) => entry.name)
+    .sort();
 }


### PR DESCRIPTION
Parent: #3598

Addresses #3600.

## Summary

- warn when a changelog source points at a multi-package landing directory
- preserve the existing header-only output behavior and release count logging
- cover package and asset-only nested directories

## Validation

- `pnpm --filter @takazudo/zudo-doc test`
- integrated 30-step `pnpm b4push` gate on the epic base

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/3609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789935501&installation_model_id=20910&pr_number=3609&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F3609&signature=4a48366fb1844f2cc72d2816d408bc25d3b48767754cd2728eb3ea16f240e972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->