### PR TITLE
feat: scaffold per-package changelogs

### DIFF
--- a/.claude/skills/l-generator-cli-tester/SKILL.md
+++ b/.claude/skills/l-generator-cli-tester/SKILL.md
@@ -33,6 +33,7 @@ Where `<pattern>` is one of the test patterns listed below.
 | `design-token-panel` | Only design token panel enabled (uses --design-token-panel CLI flag) |
 | `light-dark` | Light-dark color mode |
 | `lang-ja` | Japanese as default language |
+| `multi-changelog` | Per-package changelog pages and nested Changelog dropdown |
 | `all-features` | Everything ON (except tauri/tauriDev — Rust toolchain, out of scope for this smoke pattern) |
 
 ## Architecture context (read before verifying files)
@@ -57,7 +58,7 @@ files:
 | `skillSymlinker` | Copies `scripts/setup-doc-skill.sh` |
 | `claudeSkills` | Copies `.claude/skills/{zudo-doc-design-system,zudo-doc-translate,zudo-doc-version-bump}/**` from the monorepo |
 | `claudeSkillsWriting` | Copies `.claude/skills/zudo-doc-writing/**` (scaffold.ts, from `templates/features/claudeSkillsWriting/`) |
-| `changelog` (scaffold.ts, not a feature module) | Adds `src/content/docs/changelog/index.mdx` (+ locale mirror if i18n is also on) |
+| `changelog` (scaffold.ts, not a feature module) | Adds `src/content/docs/changelog/index.mdx` (+ locale mirror if i18n is also on); `--changelog-packages` adds a landing page and one nested page per slug |
 
 Every other feature (`search`, `sidebarFilter`, `sidebarResizer`,
 `sidebarToggle`, `claudeResources`, `versioning`, `bodyFootUtil`, `llmsTxt`,
@@ -201,6 +202,24 @@ cd __inbox/generator-test-lang-ja && \
   --no-search --no-sidebar-filter --no-i18n --no-claude-resources \
   --lang ja --color-scheme-mode single --scheme "Default Dark" --no-install
 ```
+
+**multi-changelog:**
+
+```bash
+cd __inbox/generator-test-multi-changelog && \
+  node $REPO_ROOT/packages/create-zudo-doc/dist/index.js test-project --yes \
+  --changelog-packages core,cli --i18n --no-install
+```
+
+The value-taking option implies `changelog`. The generated project must contain
+`src/content/docs/changelog/index.mdx`,
+`src/content/docs/changelog/core/index.mdx`,
+`src/content/docs/changelog/cli/index.mdx`, and the matching
+`src/content/docs-ja/changelog/**` mirrors. The landing page uses
+`<CategoryNav category="changelog" />`; each package page starts at `##
+Unreleased` and has quoted frontmatter titles. `zfb.config.ts` must contain a
+Changelog header item with `core` and `cli` children that have paths but no
+`categoryMatch`.
 
 **all-features** (mirrors `scaffold.test.ts`'s `ALL_FEATURES` minus `tauri`/`tauriDev`):
 
@@ -464,6 +483,17 @@ There is no `src/config/settings.ts` to read in a fresh scaffold. Read `__inbox/
 - `tagGovernance: "warn"`, `tagVocabulary: true`, `tagVocabularyEntries: tagVocabulary` (raw import reference)
 - `versions: []`
 - `footer` is an object with `links`, `copyright`, and `taglist`
+
+**multi-changelog:**
+
+- `zfb.config.ts` has `headerNav`'s Changelog item with `categoryMatch:
+  "changelog"` and children for `core` and `cli`; children have no
+  `categoryMatch`
+- `src/content/docs/changelog/index.mdx` is the landing page and contains the
+  CategoryNav component
+- `src/content/docs/changelog/{core,cli}/index.mdx` each has a quoted `title`,
+  the corresponding `sidebar_position`, and `## Unreleased`
+- the i18n mirror has the same nested file set under `src/content/docs-ja/`
 
 ## Step 8: Compare Against Showcase
 

--- a/.claude/skills/l-run-generator-cli-whole-test/SKILL.md
+++ b/.claude/skills/l-run-generator-cli-whole-test/SKILL.md
@@ -45,9 +45,10 @@ Run in this order (CLI flags and details are defined in `/l-generator-cli-tester
 7. **`design-token-panel`** — Only design token panel enabled (uses `--design-token-panel` CLI flag)
 8. **`light-dark`** — Light-dark color scheme mode
 9. **`lang-ja`** — Japanese as default language
-10. **`all-features`** — Everything ON, maximum complexity (uses the enumerated CLI invocation)
+10. **`multi-changelog`** — Per-package changelog pages and nested Changelog dropdown
+11. **`all-features`** — Everything ON, maximum complexity (uses the enumerated CLI invocation)
 
-> **Note:** These 10 patterns are valid manual smoke tests. The authoritative bug-hunt pattern matrix (15 patterns across Waves 4, 5, and 5b) lives in the Wave 2 spec (`__inbox/gen-cli-audit-spec/spec.md`) and the associated bug-hunt issues. Do not delete or rename these 10 patterns — they remain useful standalone checks.
+> **Note:** These 11 patterns are valid manual smoke tests. The authoritative bug-hunt pattern matrix (15 patterns across Waves 4, 5, and 5b) lives in the Wave 2 spec (`__inbox/gen-cli-audit-spec/spec.md`) and the associated bug-hunt issues. Do not delete or rename these 11 patterns — they remain useful standalone checks.
 
 ### Running each pattern
 
@@ -157,6 +158,7 @@ Run every pattern again from scratch to ensure fixes didn't break other patterns
 /l-generator-cli-tester design-token-panel
 /l-generator-cli-tester light-dark
 /l-generator-cli-tester lang-ja
+/l-generator-cli-tester multi-changelog
 /l-generator-cli-tester all-features
 ```
 
@@ -197,7 +199,7 @@ Output a final report:
 
 ### Summary
 
-- Patterns tested: 9
+- Patterns tested: 11
 - Passed on first try: 6
 - Needed fixes: 3
 - Unit tests: PASS

--- a/.claude/skills/l-run-generator-cli-whole-test/SKILL.md
+++ b/.claude/skills/l-run-generator-cli-whole-test/SKILL.md
@@ -200,7 +200,7 @@ Output a final report:
 ### Summary
 
 - Patterns tested: 11
-- Passed on first try: 6
+- Passed on first try: 8
 - Needed fixes: 3
 - Unit tests: PASS
 

--- a/packages/create-zudo-doc/CLAUDE.md
+++ b/packages/create-zudo-doc/CLAUDE.md
@@ -39,6 +39,12 @@ migration, epics #2321/#2344/#2356). `src/features/<name>.ts`'s header
 comment says, per feature, exactly why there's nothing (or almost nothing)
 left to inject or copy.
 
+The `changelog` feature is handled directly in `scaffold.ts`. The optional
+`--changelog-packages <a,b>` value (also available as the `changelogPackages`
+preset/API array) implies `changelog`, seeds one nested page per validated slug,
+and emits the Changelog header dropdown. `CreateOptions` and `PresetJson` must
+remain in parity for this value as well as the other preset-only options.
+
 ## Key Files
 
 | File | Role |
@@ -52,7 +58,7 @@ left to inject or copy.
 | `src/constants.ts` | Feature definitions, supported langs, header-right labels, and the current Default light/dark scheme pairing |
 | `src/utils.ts` | Shared utilities (patchFile, patchDefaultLang, getSecondaryLang) |
 | `src/cli.ts` | CLI argument parsing (minimist) |
-| `src/api.ts` | Programmatic API (`createZudoDoc()`). `CreateOptions` must stay in sync with `PresetJson` (`preset.ts`) — a field added to one and not the other is a type-level parity gap (#2922). Shape validation for `headerRightItems`/`metaTags` is shared via `preset.ts`'s exported `validateHeaderRightItems()`/`validateMetaTags()` — extend those, don't re-implement the allowlists here. |
+| `src/api.ts` | Programmatic API (`createZudoDoc()`). `CreateOptions` must stay in sync with `PresetJson` (`preset.ts`) — a field added to one and not the other is a type-level parity gap (#2922). Shape validation for `headerRightItems`/`metaTags`/`changelogPackages` is shared via `preset.ts`'s exported validators — extend those, don't re-implement the allowlists here. |
 | `src/prompts.ts` | Interactive prompts (@clack/prompts) |
 | `src/index.ts` | Entry point |
 
@@ -92,7 +98,7 @@ Runs vitest tests in `src/__tests__/`.
 Two Claude Code skills test the full scaffold-build-run cycle:
 
 - `/l-generator-cli-tester <pattern>` — Test a single generation pattern
-- `/l-run-generator-cli-whole-test` — Run all 10 patterns, fix bugs, verify everything
+- `/l-run-generator-cli-whole-test` — Run all 11 patterns, fix bugs, verify everything
 
 #### Test patterns
 

--- a/packages/create-zudo-doc/README.md
+++ b/packages/create-zudo-doc/README.md
@@ -91,6 +91,7 @@ Each feature has a `--[no-]<flag>` form. Passing `--feature` enables it; `--no-f
 | `--[no-]footer-copyright` | Copyright notice in the footer | on |
 | `--[no-]footer-taglist` | Grouped tag index in the footer (requires tag-governance) | off |
 | `--[no-]changelog` | Changelog page | off |
+| `--changelog-packages <a,b>` | Per-package changelog pages and a Changelog dropdown (implies `--changelog`) | none |
 
 ### Advanced
 
@@ -121,6 +122,9 @@ pnpm create zudo-doc my-docs \
 
 # Fully featured site from a preset file
 pnpm create zudo-doc my-docs --preset ./my-preset.json --install
+
+# Per-package changelog pages
+pnpm create zudo-doc my-docs --changelog-packages core,cli --yes
 ```
 
 ## Programmatic API
@@ -134,6 +138,7 @@ await createZudoDoc({
   colorSchemeMode: "single",
   singleScheme: "Default Dark",
   features: ["search", "sidebarFilter", "tagGovernance"],
+  changelogPackages: ["core", "cli"],
   packageManager: "pnpm",
   install: true,
 });

--- a/packages/create-zudo-doc/src/__tests__/cli.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/cli.test.ts
@@ -53,6 +53,12 @@ describe("parseArgs", () => {
     it("--theme-pack undefined when not provided", () => {
       expect(parseArgs([]).themePack).toBeUndefined();
     });
+
+    it("--changelog-packages parses, trims, and drops empty entries", () => {
+      expect(
+        parseArgs(["--changelog-packages", " core, ,cli,, "]).changelogPackages,
+      ).toEqual(["core", "cli"]);
+    });
   });
 
   describe("boolean feature flags — enabled", () => {
@@ -150,6 +156,32 @@ describe("parseArgs", () => {
       expect(result.pm).toBe("pnpm");
       expect(result.yes).toBe(true);
     });
+  });
+});
+
+describe("validateArgs — changelog packages", () => {
+  it("accepts valid slugs, including a numeric slug", () => {
+    expect(
+      validateArgs({ changelogPackages: ["core", "cli-tool", "123"] }),
+    ).toBeNull();
+  });
+
+  it("rejects an invalid slug", () => {
+    expect(validateArgs({ changelogPackages: ["core_lib"] })).toMatch(
+      /Invalid changelog package slug "core_lib"/,
+    );
+  });
+
+  it("rejects duplicate slugs", () => {
+    expect(validateArgs({ changelogPackages: ["core", "core"] })).toMatch(
+      /Duplicate changelog package "core"/,
+    );
+  });
+
+  it("rejects an empty list", () => {
+    expect(validateArgs({ changelogPackages: [] })).toMatch(
+      /must contain at least one package/,
+    );
   });
 });
 

--- a/packages/create-zudo-doc/src/__tests__/preset.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/preset.test.ts
@@ -19,6 +19,33 @@ describe("presetToChoices — cjkFriendly", () => {
   });
 });
 
+describe("changelogPackages preset support", () => {
+  it("forwards normalized package slugs", () => {
+    expect(
+      presetToChoices({ changelogPackages: [" core ", "", "cli"] }),
+    ).toEqual(expect.objectContaining({ changelogPackages: ["core", "cli"] }));
+  });
+
+  it("accepts valid slugs, including a numeric slug", () => {
+    expect(validatePreset({ changelogPackages: ["core", "123"] })).toBeNull();
+  });
+
+  it("rejects an invalid slug", () => {
+    expect(validatePreset({ changelogPackages: ["core_lib"] })).toMatch(
+      /Invalid changelog package slug "core_lib"/,
+    );
+  });
+
+  it("rejects duplicate and empty lists", () => {
+    expect(validatePreset({ changelogPackages: ["core", "core"] })).toMatch(
+      /Duplicate changelog package "core"/,
+    );
+    expect(validatePreset({ changelogPackages: [] })).toMatch(
+      /must contain at least one package/,
+    );
+  });
+});
+
 describe("presetToChoices — minifyHtml", () => {
   it("forwards minifyHtml: true", () => {
     const choices = presetToChoices({ minifyHtml: true });

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -876,6 +876,95 @@ describe("scaffold — changelog feature", () => {
     ).toBe(true);
   });
 
+  it("seeds nested per-package pages, a landing page, and dropdown config", async () => {
+    await scaffold({
+      ...baseChoices,
+      projectName: "test-multi-changelog",
+      features: ["changelog"],
+      changelogPackages: ["core", "123"],
+    });
+    const project = projectPath("test-multi-changelog");
+    const landing = await fs.readFile(
+      path.join(project, "src/content/docs/changelog/index.mdx"),
+      "utf-8",
+    );
+    const numericPage = await fs.readFile(
+      path.join(project, "src/content/docs/changelog/123/index.mdx"),
+      "utf-8",
+    );
+    const config = await fs.readFile(path.join(project, "zfb.config.ts"), "utf-8");
+    const claude = await fs.readFile(path.join(project, "CLAUDE.md"), "utf-8");
+
+    expect(landing).toContain("description: Release notes for each package.");
+    expect(landing).toContain('<CategoryNav category="changelog" />');
+    expect(landing).not.toContain("# Changelog");
+    expect(numericPage).toContain('title: "123"');
+    expect(numericPage).toContain("sidebar_position: 2");
+    expect(numericPage).toContain("## Unreleased");
+    expect(numericPage).not.toMatch(/^# /m);
+    expect(config).toContain('categoryMatch: "changelog"');
+    expect(config).toContain('path: "/docs/changelog/core"');
+    expect(config).toContain('path: "/docs/changelog/123"');
+    expect(claude).toContain(
+      "Changelog pages at `/docs/changelog/<slug>` — one per package: core, 123",
+    );
+  });
+
+  it("mirrors nested per-package pages in the secondary locale", async () => {
+    await scaffold({
+      ...baseChoices,
+      projectName: "test-multi-changelog-i18n",
+      features: ["changelog", "i18n"],
+      changelogPackages: ["core", "cli"],
+    });
+    for (const slug of ["core", "cli"]) {
+      expect(
+        await fs.pathExists(
+          projectPath("test-multi-changelog-i18n", `src/content/docs-ja/changelog/${slug}/index.mdx`),
+        ),
+      ).toBe(true);
+    }
+    const landing = await fs.readFile(
+      projectPath("test-multi-changelog-i18n", "src/content/docs-ja/changelog/index.mdx"),
+      "utf-8",
+    );
+    expect(landing).toContain("パッケージごとのリリースノート。");
+  });
+
+  it("removes the body-level H1 from the single changelog starter", async () => {
+    await scaffold({
+      ...baseChoices,
+      projectName: "test-single-changelog-no-h1",
+      features: ["changelog"],
+    });
+    const content = await fs.readFile(
+      projectPath("test-single-changelog-no-h1", "src/content/docs/changelog/index.mdx"),
+      "utf-8",
+    );
+    expect(content).not.toMatch(/^# /m);
+    expect(content).toContain("## Unreleased");
+  });
+
+  it("auto-enables changelog and warns when packages override --no-changelog", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await scaffold({
+      ...baseChoices,
+      projectName: "test-multi-changelog-no-changelog",
+      features: [],
+      changelogPackages: ["core"],
+      explicitlyDisabledFeatures: ["changelog"],
+    });
+    expect(warning).toHaveBeenCalledWith(
+      "changelog-packages requires changelog; enabling it despite --no-changelog",
+    );
+    expect(
+      await fs.pathExists(
+        projectPath("test-multi-changelog-no-changelog", "src/content/docs/changelog/core/index.mdx"),
+      ),
+    ).toBe(true);
+    warning.mockRestore();
+  });
+
   it("does not write a changelog directory when disabled", async () => {
     await scaffold(baseChoices);
     expect(
@@ -957,6 +1046,11 @@ describe("scaffold — every-feature manifest is exactly base + the documented p
       "zfb.config.ts",
     ].sort();
     expect(files).toEqual(expected);
+    const config = await fs.readFile(
+      projectPath("test-all-on", "zfb.config.ts"),
+      "utf-8",
+    );
+    expect(config).not.toContain("children:");
   });
 });
 
@@ -2158,6 +2252,40 @@ describe("createZudoDoc() — CreateOptions preset parity (#2922)", () => {
     const config = await fs.readFile(path.join(targetDir, "zfb.config.ts"), "utf-8");
     expect(config).toContain('component: "github-link"');
     expect(config).toContain('trigger: "ai-chat"');
+  });
+
+  it("createZudoDoc() accepts changelogPackages and implies changelog", async () => {
+    const targetDir = await createZudoDoc({
+      projectName: "valid-multi-changelog-test",
+      colorSchemeMode: "single",
+      singleScheme: "Default Dark",
+      features: [],
+      changelogPackages: ["core", "cli"],
+      packageManager: "pnpm",
+    });
+    expect(
+      await fs.pathExists(
+        path.join(targetDir, "src/content/docs/changelog/core/index.mdx"),
+      ),
+    ).toBe(true);
+    const config = await fs.readFile(path.join(targetDir, "zfb.config.ts"), "utf-8");
+    expect(config).toContain('path: "/docs/changelog/cli"');
+  });
+
+  it("createZudoDoc() and validatePreset() reject the same invalid changelog slug", async () => {
+    const invalidPackages = ["core_lib"];
+    const expected = /Invalid changelog package slug "core_lib"/;
+    await expect(
+      createZudoDoc({
+        projectName: "invalid-multi-changelog-test",
+        colorSchemeMode: "single",
+        singleScheme: "Default Dark",
+        features: [],
+        changelogPackages: invalidPackages,
+        packageManager: "pnpm",
+      }),
+    ).rejects.toThrow(expected);
+    expect(validatePreset({ changelogPackages: invalidPackages })).toMatch(expected);
   });
 
   it("createZudoDoc() throws for a non-object metaTags value, same rule as validatePreset()", async () => {

--- a/packages/create-zudo-doc/src/__tests__/zfb-config-gen.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/zfb-config-gen.test.ts
@@ -482,6 +482,34 @@ describe("generateZfbConfig — changelog headerNav entry", () => {
     const result = generateZfbConfig(baseChoices);
     expect(result).not.toContain("Changelog");
   });
+
+  it("adds categoryMatch-less package children for the multi-changelog layout", () => {
+    const result = generateZfbConfig({
+      ...baseChoices,
+      features: ["changelog"],
+      changelogPackages: ["core", "cli"],
+    });
+    expect(result).toContain('categoryMatch: "changelog"');
+    expect(result).toContain('label: "core"');
+    expect(result).toContain('path: "/docs/changelog/core"');
+    expect(result).toContain('label: "cli"');
+    expect(result).toContain('path: "/docs/changelog/cli"');
+    const children = result.match(
+      /children: \[([\s\S]*?)\n\s{8}\],/,
+    );
+    expect(children?.[1]).toBeDefined();
+    expect(children?.[1]).not.toContain("categoryMatch");
+  });
+
+  it("keeps the flat Changelog item when no package slugs are supplied", () => {
+    const result = generateZfbConfig({
+      ...baseChoices,
+      features: ["changelog"],
+      changelogPackages: [],
+    });
+    expect(result).toContain('categoryMatch: "changelog"');
+    expect(result).not.toContain("children:");
+  });
 });
 
 describe("generateZfbConfig — headerRightItems override", () => {

--- a/packages/create-zudo-doc/src/api.ts
+++ b/packages/create-zudo-doc/src/api.ts
@@ -1,7 +1,12 @@
 import path from "path";
 import { SINGLE_SCHEMES, THEME_PACKS } from "./constants.js";
 import type { PresetHeaderRightItem, PresetMetaTagsConfig } from "./preset.js";
-import { validateHeaderRightItems, validateMetaTags } from "./preset.js";
+import {
+  parseChangelogPackages,
+  validateChangelogPackages,
+  validateHeaderRightItems,
+  validateMetaTags,
+} from "./preset.js";
 import { scaffold } from "./scaffold.js";
 import { initGitRepo, installDependencies, validateProjectName } from "./utils.js";
 
@@ -20,6 +25,8 @@ export interface CreateOptions {
   /** Theme pack slug (ADR #2818 Decision 7), validated against THEME_PACKS. Default: "default". */
   themePack?: string;
   features: string[];
+  /** Package slugs for the nested changelog layout; implies `changelog`. */
+  changelogPackages?: string[];
   /** GitHub repository URL — drives the header GitHub link and body-foot
    *  "View source on GitHub" link. Empty = disabled. */
   githubUrl?: string;
@@ -83,7 +90,17 @@ export async function createZudoDoc(options: CreateOptions): Promise<string> {
     const err = validateMetaTags(rest.metaTags);
     if (err) throw new Error(err);
   }
-  const choices = { ...rest, defaultLang: rest.defaultLang ?? "en" };
+  let changelogPackages = rest.changelogPackages;
+  if (changelogPackages !== undefined) {
+    const err = validateChangelogPackages(changelogPackages);
+    if (err) throw new Error(err);
+    changelogPackages = parseChangelogPackages(changelogPackages);
+  }
+  const choices = {
+    ...rest,
+    defaultLang: rest.defaultLang ?? "en",
+    changelogPackages,
+  };
   await scaffold(choices);
   const targetDir = path.resolve(process.cwd(), choices.projectName);
   if (install) {

--- a/packages/create-zudo-doc/src/claude-md-gen.ts
+++ b/packages/create-zudo-doc/src/claude-md-gen.ts
@@ -190,7 +190,10 @@ export function generateCLAUDEFile(choices: UserChoices): string {
     llmsTxt: "Generates llms.txt for LLM consumption",
     claudeResources: "Auto-generated docs for Claude Code resources",
     codexResources: "Auto-generated docs for Codex resources (.codex/, AGENTS.md)",
-    changelog: "Changelog page at `/docs/changelog`",
+    changelog:
+      choices.changelogPackages && choices.changelogPackages.length > 0
+        ? `Changelog pages at \`/docs/changelog/<slug>\` — one per package: ${choices.changelogPackages.join(", ")}`
+        : "Changelog page at `/docs/changelog`",
     tauri:
       "Desktop app wrapper (`cargo tauri dev` / `cargo tauri build`) — Cmd/Ctrl+F find bar via the package-owned `FindInPageInit` island (`findInPage: true` in `zfb.config.ts`)",
     tagGovernance:

--- a/packages/create-zudo-doc/src/cli.ts
+++ b/packages/create-zudo-doc/src/cli.ts
@@ -1,6 +1,10 @@
 import minimist from "minimist";
 import pc from "picocolors";
 import { FEATURES, SINGLE_SCHEMES, SUPPORTED_LANGS, THEME_PACKS } from "./constants.js";
+import {
+  parseChangelogPackages,
+  validateChangelogPackages,
+} from "./preset.js";
 import { validateProjectName } from "./utils.js";
 
 export interface CliArgs {
@@ -34,6 +38,7 @@ export interface CliArgs {
   dynamicPageTransition?: boolean;
   footerCopyright?: boolean;
   changelog?: boolean;
+  changelogPackages?: string[];
   tagGovernance?: boolean;
   footerTaglist?: boolean;
   bodyFootUtil?: boolean;
@@ -59,6 +64,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
       "dark-scheme",
       "default-mode",
       "theme-pack",
+      "changelog-packages",
       "github-url",
       "preset",
       "pm",
@@ -96,6 +102,13 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
   if (raw["dark-scheme"]) args.darkScheme = raw["dark-scheme"];
   if (raw["default-mode"]) args.defaultMode = raw["default-mode"];
   if (raw["theme-pack"]) args.themePack = raw["theme-pack"];
+  if (raw["changelog-packages"] !== undefined) {
+    args.changelogPackages = parseChangelogPackages(
+      typeof raw["changelog-packages"] === "string"
+        ? raw["changelog-packages"]
+        : String(raw["changelog-packages"] ?? ""),
+    );
+  }
   if (raw.preset) args.preset = raw.preset;
   if (raw.pm) args.pm = raw.pm;
   if (typeof raw["github-url"] === "string") args.githubUrl = raw["github-url"];
@@ -143,6 +156,7 @@ ${pc.bold("Options:")}
   --theme-pack <slug>          Theme pack (${themePackList})
                                Default: default
 ${featureHelp}
+  --changelog-packages <a,b>  Per-package changelog pages (implies changelog)
   --github-url <url>           GitHub repository URL (drives header link + source link)
   --preset <path>              Load settings from a JSON preset file (use "-" for stdin)
   --pm <manager>               pnpm | npm | yarn | bun
@@ -161,6 +175,9 @@ ${pc.bold("Examples:")}
 
   ${pc.dim("# Fully specified")}
   create-zudo-doc my-docs --lang ja --scheme "Default Dark" --no-i18n --pm pnpm --install
+
+  ${pc.dim("# Per-package changelog pages")}
+  create-zudo-doc my-docs --changelog-packages core,cli --yes
 `);
 }
 
@@ -199,6 +216,11 @@ export function validateArgs(args: CliArgs): string | null {
 
   if (args.pm && !["pnpm", "npm", "yarn", "bun"].includes(args.pm)) {
     return `Invalid package manager "${args.pm}". Must be pnpm, npm, yarn, or bun`;
+  }
+
+  if (args.changelogPackages !== undefined) {
+    const changelogError = validateChangelogPackages(args.changelogPackages);
+    if (changelogError) return changelogError;
   }
 
   // Validate scheme combinations

--- a/packages/create-zudo-doc/src/index.ts
+++ b/packages/create-zudo-doc/src/index.ts
@@ -60,6 +60,9 @@ async function main() {
   if (args.themePack) prefilled.themePack = args.themePack;
   if (args.pm) prefilled.packageManager = args.pm;
   if (args.githubUrl !== undefined) prefilled.githubUrl = args.githubUrl;
+  if (args.changelogPackages !== undefined) {
+    prefilled.changelogPackages = args.changelogPackages;
+  }
 
   // Build feature overrides from explicit flags — driven by FEATURES constant
   const featureFlags: Partial<Record<string, boolean>> = {};
@@ -95,6 +98,9 @@ async function main() {
     prefilled.themePack ??= "default";
     prefilled.packageManager ??= "pnpm";
     prefilled.githubUrl ??= "";
+    // A blank package list is the explicit non-interactive choice for the
+    // existing single-page changelog. A non-empty CLI/preset list above wins.
+    prefilled.changelogPackages ??= [];
     // For features: set defaults for any not explicitly specified
     const featureDefaults: Partial<Record<string, boolean>> = {};
     for (const f of FEATURES) {

--- a/packages/create-zudo-doc/src/preset.ts
+++ b/packages/create-zudo-doc/src/preset.ts
@@ -58,6 +58,51 @@ export interface PresetMetaTagsConfig {
   twitterCreator?: string;
 }
 
+const CHANGELOG_PACKAGE_SLUG_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+/**
+ * Parse the comma-separated CLI form (or normalize the array form used by
+ * presets and the programmatic API). Empty entries are ignored so a trailing
+ * comma is harmless; validation below still rejects an entirely empty list.
+ */
+export function parseChangelogPackages(
+  value: string | readonly string[],
+): string[] {
+  const values = typeof value === "string" ? value.split(",") : value;
+  return values.map((slug) => slug.trim()).filter(Boolean);
+}
+
+/**
+ * Shared changelog-package validation for CLI, JSON presets, and the
+ * programmatic API. Keeping this next to the parser prevents the three entry
+ * points from accepting different slug grammars or duplicate lists.
+ */
+export function validateChangelogPackages(list: unknown): string | null {
+  if (!Array.isArray(list)) {
+    return `"changelogPackages" must be an array`;
+  }
+  for (let i = 0; i < list.length; i++) {
+    if (typeof list[i] !== "string") {
+      return `changelogPackages[${i}] must be a string`;
+    }
+  }
+  const packages = parseChangelogPackages(list as string[]);
+  if (packages.length === 0) {
+    return `"changelogPackages" must contain at least one package`;
+  }
+  const seen = new Set<string>();
+  for (const slug of packages) {
+    if (!CHANGELOG_PACKAGE_SLUG_RE.test(slug)) {
+      return `Invalid changelog package slug "${slug}". Slugs must match /^[a-z0-9][a-z0-9-]*$/`;
+    }
+    if (seen.has(slug)) {
+      return `Duplicate changelog package "${slug}"`;
+    }
+    seen.add(slug);
+  }
+  return null;
+}
+
 /**
  * Validates a `headerRightItems` value against the v1 preset allowlist.
  * Shared by `validatePreset()` (JSON preset path) and `createZudoDoc()`
@@ -158,6 +203,8 @@ export interface PresetJson {
   /** Theme pack slug (ADR #2818 Decision 7), validated against THEME_PACKS. */
   themePack?: string;
   features?: string[];
+  /** Package slugs for the nested changelog layout. */
+  changelogPackages?: string[];
   githubUrl?: string;
   cjkFriendly?: boolean;
   minifyHtml?: boolean;
@@ -203,6 +250,18 @@ export function validatePreset(json: unknown): string | null {
   }
   if (p.features !== undefined && !Array.isArray(p.features)) {
     return `"features" must be an array in preset`;
+  }
+  if (p.changelogPackages !== undefined) {
+    if (!Array.isArray(p.changelogPackages)) {
+      return `"changelogPackages" must be an array in preset`;
+    }
+    const changelogPackages = p.changelogPackages.every(
+      (slug): slug is string => typeof slug === "string",
+    )
+      ? parseChangelogPackages(p.changelogPackages)
+      : p.changelogPackages;
+    const err = validateChangelogPackages(changelogPackages);
+    if (err) return err;
   }
   if (p.defaultLang && !VALID_LANGS.has(p.defaultLang)) {
     return `Invalid language "${p.defaultLang}" in preset`;
@@ -277,6 +336,9 @@ export function presetToChoices(json: PresetJson): PartialChoices {
   if (json.githubUrl !== undefined) choices.githubUrl = json.githubUrl;
   if (json.cjkFriendly !== undefined) choices.cjkFriendly = json.cjkFriendly;
   if (json.minifyHtml !== undefined) choices.minifyHtml = json.minifyHtml;
+  if (json.changelogPackages !== undefined) {
+    choices.changelogPackages = parseChangelogPackages(json.changelogPackages);
+  }
   if (json.headerRightItems !== undefined) {
     choices.headerRightItems = json.headerRightItems;
   }

--- a/packages/create-zudo-doc/src/prompts.ts
+++ b/packages/create-zudo-doc/src/prompts.ts
@@ -1,6 +1,11 @@
 import * as p from "@clack/prompts";
 import { SINGLE_SCHEMES, FEATURES, SUPPORTED_LANGS, THEME_PACKS } from "./constants.js";
-import type { PresetHeaderRightItem, PresetMetaTagsConfig } from "./preset.js";
+import {
+  parseChangelogPackages,
+  validateChangelogPackages,
+  type PresetHeaderRightItem,
+  type PresetMetaTagsConfig,
+} from "./preset.js";
 import { validateProjectName } from "./utils.js";
 
 export interface UserChoices {
@@ -18,6 +23,10 @@ export interface UserChoices {
   themePack?: string;
   // Features
   features: string[];
+  // Optional package slugs for the nested changelog layout. An empty array
+  // means the single starter page; undefined means the interactive prompt has
+  // not answered yet.
+  changelogPackages?: string[];
   // Feature values explicitly disabled via --no-<flag> on the CLI. Used to
   // emit a warning when an auto-enable (e.g. bodyFootUtil forces docHistory)
   // overrides an explicit user choice. Never populated by interactive prompts.
@@ -53,6 +62,7 @@ export interface PartialChoices {
   defaultMode?: "light" | "dark";
   themePack?: string;
   features?: Partial<Record<string, boolean>>;
+  changelogPackages?: string[];
   // Feature values explicitly disabled via --no-<flag> on the CLI. Threaded
   // through to UserChoices so scaffold.ts can warn on forced auto-enables.
   explicitlyDisabledFeatures?: string[];
@@ -229,6 +239,26 @@ export async function runPrompts(
     features = result;
   }
 
+  // 4.5 Changelog package layout. A blank answer deliberately preserves the
+  // existing single-page starter. CLI/preset/--yes callers prefill this value
+  // so they remain non-interactive.
+  let changelogPackages = prefilled.changelogPackages;
+  if (features.includes("changelog") && changelogPackages === undefined) {
+    const result = await p.text({
+      message:
+        "Package changelogs (comma-separated slugs; leave empty for a single changelog):",
+      placeholder: "core,cli",
+      defaultValue: "",
+      validate(value) {
+        if (!value.trim()) return;
+        const parsed = parseChangelogPackages(value);
+        return validateChangelogPackages(parsed) ?? undefined;
+      },
+    });
+    if (p.isCancel(result)) process.exit(0);
+    changelogPackages = parseChangelogPackages(result);
+  }
+
   // 5. GitHub URL (drives header GitHub icon + view-source link)
   let githubUrl: string | undefined = prefilled.githubUrl;
   if (githubUrl === undefined) {
@@ -275,6 +305,7 @@ export async function runPrompts(
     defaultMode,
     themePack,
     features,
+    changelogPackages,
     explicitlyDisabledFeatures: prefilled.explicitlyDisabledFeatures,
     githubUrl,
     cjkFriendly: prefilled.cjkFriendly,

--- a/packages/create-zudo-doc/src/scaffold.ts
+++ b/packages/create-zudo-doc/src/scaffold.ts
@@ -202,8 +202,6 @@ title: Changelog
 sidebar_position: 99
 ---
 
-# Changelog
-
 ## Unreleased
 
 - Initial release
@@ -214,7 +212,49 @@ title: 変更履歴
 sidebar_position: 99
 ---
 
-# 変更履歴
+## 未リリース
+
+- 初回リリース
+`;
+
+const CHANGELOG_LANDING_CONTENT_EN = () => `---
+title: Changelog
+description: Release notes for each package.
+sidebar_position: 99
+---
+
+Release notes for each package.
+
+<CategoryNav category="changelog" />
+`;
+
+const CHANGELOG_LANDING_CONTENT_JA = () => `---
+title: 変更履歴
+description: パッケージごとのリリースノート。
+sidebar_position: 99
+---
+
+パッケージごとのリリースノート。
+
+<CategoryNav category="changelog" />
+`;
+
+const CHANGELOG_PACKAGE_CONTENT_EN = (slug: string, position: number) => `---
+title: "${slug}"
+description: Release notes for ${slug}.
+sidebar_position: ${position}
+---
+
+## Unreleased
+
+- Initial release
+`;
+
+const CHANGELOG_PACKAGE_CONTENT_JA = (slug: string, position: number) => `---
+title: "${slug}"
+description: ${slug} のリリースノート。
+sidebar_position: ${position}
+---
 
 ## 未リリース
 
@@ -247,6 +287,21 @@ export async function scaffold(choices: UserChoices): Promise<void> {
       );
     }
     choices.features = [...choices.features, "docHistory"];
+  }
+
+  // A non-empty package list implies the changelog feature. Warn when the
+  // CLI explicitly disabled it, then honor the package-layout request.
+  if (
+    choices.changelogPackages !== undefined &&
+    choices.changelogPackages.length > 0 &&
+    !choices.features.includes("changelog")
+  ) {
+    if (choices.explicitlyDisabledFeatures?.includes("changelog")) {
+      console.warn(
+        "changelog-packages requires changelog; enabling it despite --no-changelog",
+      );
+    }
+    choices.features = [...choices.features, "changelog"];
   }
 
   // Resolve template directories
@@ -402,26 +457,70 @@ export async function scaffold(choices: UserChoices): Promise<void> {
 
   // When changelog is ON, create a starter changelog page
   if (choices.features.includes("changelog")) {
-    const changelogContent =
-      defaultLang === "ja" ? CHANGELOG_CONTENT_JA() : CHANGELOG_CONTENT_EN();
-    await fs.outputFile(
-      path.join(targetDir, "src/content/docs/changelog/index.mdx"),
-      changelogContent,
-    );
+    const packageSlugs = choices.changelogPackages ?? [];
+    if (packageSlugs.length === 0) {
+      const changelogContent =
+        defaultLang === "ja" ? CHANGELOG_CONTENT_JA() : CHANGELOG_CONTENT_EN();
+      await fs.outputFile(
+        path.join(targetDir, "src/content/docs/changelog/index.mdx"),
+        changelogContent,
+      );
+    } else {
+      const landingContent =
+        defaultLang === "ja"
+          ? CHANGELOG_LANDING_CONTENT_JA()
+          : CHANGELOG_LANDING_CONTENT_EN();
+      await fs.outputFile(
+        path.join(targetDir, "src/content/docs/changelog/index.mdx"),
+        landingContent,
+      );
+      for (const [index, slug] of packageSlugs.entries()) {
+        const packageContent =
+          defaultLang === "ja"
+            ? CHANGELOG_PACKAGE_CONTENT_JA(slug, index + 1)
+            : CHANGELOG_PACKAGE_CONTENT_EN(slug, index + 1);
+        await fs.outputFile(
+          path.join(targetDir, `src/content/docs/changelog/${slug}/index.mdx`),
+          packageContent,
+        );
+      }
+    }
 
     if (choices.features.includes("i18n")) {
       const secondaryLang = getSecondaryLang(defaultLang);
-      const secondaryChangelogContent =
-        secondaryLang === "ja"
-          ? CHANGELOG_CONTENT_JA()
-          : CHANGELOG_CONTENT_EN();
-      await fs.outputFile(
-        path.join(
-          targetDir,
-          `src/content/docs-${secondaryLang}/changelog/index.mdx`,
-        ),
-        secondaryChangelogContent,
-      );
+      if (packageSlugs.length === 0) {
+        const secondaryChangelogContent =
+          secondaryLang === "ja"
+            ? CHANGELOG_CONTENT_JA()
+            : CHANGELOG_CONTENT_EN();
+        await fs.outputFile(
+          path.join(
+            targetDir,
+            `src/content/docs-${secondaryLang}/changelog/index.mdx`,
+          ),
+          secondaryChangelogContent,
+        );
+      } else {
+        const secondaryLandingContent =
+          secondaryLang === "ja"
+            ? CHANGELOG_LANDING_CONTENT_JA()
+            : CHANGELOG_LANDING_CONTENT_EN();
+        const secondaryDir = `src/content/docs-${secondaryLang}/changelog`;
+        await fs.outputFile(
+          path.join(targetDir, `${secondaryDir}/index.mdx`),
+          secondaryLandingContent,
+        );
+        for (const [index, slug] of packageSlugs.entries()) {
+          const secondaryPackageContent =
+            secondaryLang === "ja"
+              ? CHANGELOG_PACKAGE_CONTENT_JA(slug, index + 1)
+              : CHANGELOG_PACKAGE_CONTENT_EN(slug, index + 1);
+          await fs.outputFile(
+            path.join(targetDir, `${secondaryDir}/${slug}/index.mdx`),
+            secondaryPackageContent,
+          );
+        }
+      }
     }
   }
 

--- a/packages/create-zudo-doc/src/zfb-config-gen.ts
+++ b/packages/create-zudo-doc/src/zfb-config-gen.ts
@@ -346,11 +346,25 @@ function buildDesiredConfig(choices: UserChoices): Record<string, unknown> {
     });
   }
   if (choices.features.includes("changelog")) {
-    headerNav.push({
-      label: "Changelog",
-      path: "/docs/changelog",
-      categoryMatch: "changelog",
-    });
+    if (choices.changelogPackages && choices.changelogPackages.length > 0) {
+      headerNav.push({
+        label: "Changelog",
+        path: "/docs/changelog",
+        categoryMatch: "changelog",
+        // nav-scope matches the first slug segment only; nested children
+        // highlight by path and must not carry a multi-segment categoryMatch.
+        children: choices.changelogPackages.map((slug) => ({
+          label: slug,
+          path: `/docs/changelog/${slug}`,
+        })),
+      });
+    } else {
+      headerNav.push({
+        label: "Changelog",
+        path: "/docs/changelog",
+        categoryMatch: "changelog",
+      });
+    }
   }
   desired.headerNav = headerNav;
 


### PR DESCRIPTION
Parent: #3598

Addresses #3601.

## Summary

- add `--changelog-packages` across CLI, preset, prompts, and programmatic API
- scaffold package landing/pages and locale mirrors
- emit a Changelog dropdown with path-active children

## Validation

- `pnpm --filter create-zudo-doc test`
- integrated 30-step `pnpm b4push` gate on the epic base

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/3610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789935502&installation_model_id=20910&pr_number=3610&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F3610&signature=c0f5d999a589021769c6e2e7dd0f809b22a354a54b3faf25a95ce9958e6d243c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->