### PR TITLE
test: cover nested changelog navigation

### DIFF
--- a/e2e/fixtures/smoke/src/config/settings.ts
+++ b/e2e/fixtures/smoke/src/config/settings.ts
@@ -80,6 +80,15 @@ export const settings = {
         { label: "Guides", path: "/docs/guides", categoryMatch: "guides" },
       ],
     },
+    {
+      label: "Changelog",
+      path: "/docs/changelog",
+      categoryMatch: "changelog",
+      children: [
+        { label: "pkg-a", path: "/docs/changelog/pkg-a" },
+        { label: "pkg-b", path: "/docs/changelog/pkg-b" },
+      ],
+    },
   ] satisfies HeaderNavItem[] as HeaderNavItem[],
   headerRightItems: [
     { type: "trigger", trigger: "design-token-panel" },

--- a/e2e/fixtures/smoke/src/content/docs/changelog/index.mdx
+++ b/e2e/fixtures/smoke/src/content/docs/changelog/index.mdx
@@ -1,0 +1,8 @@
+---
+title: Changelog
+sidebar_position: 90
+---
+
+Release notes for the packages in this fixture.
+
+<CategoryNav category="changelog" />

--- a/e2e/fixtures/smoke/src/content/docs/changelog/pkg-a/1.0.0.mdx
+++ b/e2e/fixtures/smoke/src/content/docs/changelog/pkg-a/1.0.0.mdx
@@ -1,0 +1,6 @@
+---
+title: 1.0.0
+sidebar_position: 1001
+---
+
+Released: 2026-01-01

--- a/e2e/fixtures/smoke/src/content/docs/changelog/pkg-a/1.1.0.mdx
+++ b/e2e/fixtures/smoke/src/content/docs/changelog/pkg-a/1.1.0.mdx
@@ -1,0 +1,6 @@
+---
+title: 1.1.0
+sidebar_position: 1002
+---
+
+Released: 2026-02-01

--- a/e2e/fixtures/smoke/src/content/docs/changelog/pkg-a/index.mdx
+++ b/e2e/fixtures/smoke/src/content/docs/changelog/pkg-a/index.mdx
@@ -1,0 +1,10 @@
+---
+title: pkg-a
+description: Release notes for package A.
+sidebar_position: 1
+category_sort_order: desc
+---
+
+Version history for package A.
+
+<CategoryNav category="changelog/pkg-a" />

--- a/e2e/fixtures/smoke/src/content/docs/changelog/pkg-b/1.0.0.mdx
+++ b/e2e/fixtures/smoke/src/content/docs/changelog/pkg-b/1.0.0.mdx
@@ -1,0 +1,6 @@
+---
+title: 1.0.0
+sidebar_position: 1001
+---
+
+Released: 2026-01-01

--- a/e2e/fixtures/smoke/src/content/docs/changelog/pkg-b/index.mdx
+++ b/e2e/fixtures/smoke/src/content/docs/changelog/pkg-b/index.mdx
@@ -1,0 +1,7 @@
+---
+title: pkg-b
+sidebar_position: 2
+category_sort_order: desc
+---
+
+Version history for package B.

--- a/e2e/smoke-changelog-dropdown.spec.ts
+++ b/e2e/smoke-changelog-dropdown.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect } from "./fixtures";
+import { expectHtmlAttr, getAttrValue } from "./html-assertions";
+import { readDistFile } from "./smoke-dist-helper";
+
+function extractHeaderNav(html: string): string {
+  const match = html.match(
+    /<nav\b(?=[^>]*\bdata-header-nav\b)[^>]*>[\s\S]*?<\/nav>/,
+  );
+  expect(match).toBeTruthy();
+  return match![0];
+}
+
+function extractChangelogDropdown(html: string): {
+  dropdown: string;
+  trigger: string;
+} {
+  const nav = extractHeaderNav(html);
+  const trigger = [...nav.matchAll(
+    /<a\b(?=[^>]*\baria-haspopup\b)[^>]*>[\s\S]*?<\/a>/g,
+  )].find((candidate) =>
+    getAttrValue(candidate[0], "href")?.includes("/docs/changelog"),
+  );
+
+  expect(trigger).toBeTruthy();
+  const triggerStart = trigger!.index!;
+  const triggerEnd = triggerStart + trigger![0].length;
+  const dropdownStart = nav.lastIndexOf("<div", triggerStart);
+  const nextItemOffset = nav
+    .slice(triggerEnd)
+    .search(/<(?:div|a)\b(?=[^>]*\bdata-nav-item(?:\s|>))/);
+  const dropdownEnd =
+    nextItemOffset === -1 ? nav.length : triggerEnd + nextItemOffset;
+
+  return {
+    dropdown: nav.slice(dropdownStart, dropdownEnd),
+    trigger: trigger![0],
+  };
+}
+
+function extractCategoryNav(html: string): string {
+  const match = html.match(
+    /<nav\b(?=[^>]*aria-label=["']Child pages["'])[^>]*>[\s\S]*?<\/nav>/,
+  );
+  expect(match).toBeTruthy();
+  return match![0];
+}
+
+function extractSidebar(html: string): string {
+  const match = html.match(
+    /<aside\b(?=[^>]*\bid=["']desktop-sidebar["'])[^>]*>[\s\S]*?<\/aside>/,
+  );
+  expect(match).toBeTruthy();
+  return match![0];
+}
+
+function expectActiveChangelogChild(
+  dropdown: string,
+  packagePath: string,
+): void {
+  const children = [...dropdown.matchAll(/<a\b[^>]*>[\s\S]*?<\/a>/g)].filter(
+    (anchor) =>
+      getAttrValue(anchor[0], "href")?.includes("/docs/changelog/pkg-"),
+  );
+  const active = children.filter((anchor) =>
+    /\bdata-active(?:\s*=|\s|>)/.test(anchor[0]),
+  );
+
+  expect(active).toHaveLength(1);
+  expect(getAttrValue(active[0][0], "href")).toContain(packagePath);
+}
+
+test.describe("Nested Changelog navigation (static)", () => {
+  test("Changelog dropdown links to both package pages", () => {
+    const html = readDistFile("docs/getting-started/index.html");
+    const { dropdown, trigger } = extractChangelogDropdown(html);
+
+    expect(getAttrValue(trigger, "href")).toContain("/docs/changelog");
+    expect(trigger).toContain("Changelog");
+    expectHtmlAttr(dropdown, "href", "/docs/changelog/pkg-a");
+    expectHtmlAttr(dropdown, "href", "/docs/changelog/pkg-b");
+    expect(dropdown).toContain("pkg-a");
+    expect(dropdown).toContain("pkg-b");
+  });
+
+  test("Changelog dropdown marks the active package child", () => {
+    const pkgAHtml = readDistFile("docs/changelog/pkg-a/1.1.0/index.html");
+    const pkgBHtml = readDistFile("docs/changelog/pkg-b/1.0.0/index.html");
+
+    const pkgADropdown = extractChangelogDropdown(pkgAHtml);
+    expectHtmlAttr(pkgADropdown.dropdown, "aria-current", "page");
+    expectActiveChangelogChild(
+      pkgADropdown.dropdown,
+      "/docs/changelog/pkg-a",
+    );
+
+    const pkgBDropdown = extractChangelogDropdown(pkgBHtml);
+    expectHtmlAttr(pkgBDropdown.dropdown, "aria-current", "page");
+    expectActiveChangelogChild(
+      pkgBDropdown.dropdown,
+      "/docs/changelog/pkg-b",
+    );
+  });
+
+  test("Changelog landing cards link to both packages", () => {
+    const html = readDistFile("docs/changelog/index.html");
+    const categoryNav = extractCategoryNav(html);
+
+    expectHtmlAttr(categoryNav, "href", "/docs/changelog/pkg-a/");
+    expectHtmlAttr(categoryNav, "href", "/docs/changelog/pkg-b/");
+    expect(categoryNav).toContain("pkg-a");
+    expect(categoryNav).toContain("pkg-b");
+  });
+
+  test("pkg-a versions are listed newest first", () => {
+    const html = readDistFile("docs/changelog/pkg-a/index.html");
+    const categoryNav = extractCategoryNav(html);
+    const newest = categoryNav.indexOf("1.1.0");
+    const oldest = categoryNav.indexOf("1.0.0");
+
+    expect(newest).toBeGreaterThanOrEqual(0);
+    expect(oldest).toBeGreaterThanOrEqual(0);
+    expect(newest).toBeLessThan(oldest);
+  });
+
+  test("pkg-a sidebar is scoped to the Changelog section", () => {
+    const html = readDistFile("docs/changelog/pkg-a/1.1.0/index.html");
+    const sidebar = extractSidebar(html);
+
+    expectHtmlAttr(sidebar, "href", "/docs/changelog/pkg-a/");
+    expectHtmlAttr(sidebar, "href", "/docs/changelog/pkg-b/");
+  });
+});


### PR DESCRIPTION
Parent: #3598

Addresses #3603.

## Summary

- add nested package changelog content to the smoke fixture
- add static coverage for dropdown links, active children, landing cards, ordering, and sidebar scope

## Validation

- smoke fixture build and Playwright static checks
- integrated 30-step `pnpm b4push` gate on the epic base

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/3612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789935509&installation_model_id=20910&pr_number=3612&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F3612&signature=326c8a251637dc6e8507473600ab6dedee6e9c95b7241be21fb110703f00f305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->