### PR TITLE
fix(theme-packs): normalize sidebar current rows

### DIFF
--- a/e2e/theme-pack-sidebar-active.spec.ts
+++ b/e2e/theme-pack-sidebar-active.spec.ts
@@ -1,0 +1,140 @@
+import type { Locator, Page } from "@playwright/test";
+import { test, expect } from "./fixtures";
+import { desktopSidebar } from "./sidebar-helpers";
+import {
+  THEME_PACK_STORAGE_KEY,
+  waitForActivePack,
+} from "./theme-pack-helpers";
+
+const PAGE = "/docs/getting-started/";
+const CURRENT_ROW_SELECTOR = 'a[aria-current="page"]:not([data-nav-active])';
+const MOBILE_CURRENT_ROW_SELECTOR =
+  'aside[data-zd-mobile-sidebar] a[aria-current="page"]:not([data-nav-active])';
+
+const CORRECTED_PACKS = {
+  drift: { nestedRadius: "999px", nestedShadow: true },
+  hearth: { nestedRadius: "8px", nestedShadow: true },
+  sakura: { nestedRadius: "9999px", nestedShadow: true },
+  scandi: { nestedRadius: "999px", nestedShadow: false },
+  timberline: { nestedRadius: "4px", nestedShadow: true },
+} as const;
+
+test.use({ viewport: { width: 1280, height: 800 } });
+
+type ActiveRowStyle = {
+  backgroundColor: string;
+  borderRadius: string;
+  boxShadow: string;
+};
+
+function activeRowStyle(locator: Locator): Promise<ActiveRowStyle> {
+  return locator.evaluate((element) => {
+    const style = getComputedStyle(element);
+    return {
+      backgroundColor: style.backgroundColor,
+      borderRadius: style.borderRadius,
+      boxShadow: style.boxShadow,
+    };
+  });
+}
+
+function hasVisibleBackground(color: string): boolean {
+  return color !== "transparent" && color !== "rgba(0, 0, 0, 0)";
+}
+
+async function enabledPackSlugs(page: Page): Promise<string[]> {
+  return page.evaluate(() =>
+    Object.keys(
+      (
+        window as unknown as {
+          __zudoDocThemePacks: { packs: Record<string, string> };
+        }
+      ).__zudoDocThemePacks.packs,
+    ),
+  );
+}
+
+async function activatePack(page: Page, packSlug: string): Promise<void> {
+  await page.evaluate(
+    ({ key, value }) => localStorage.setItem(key, value),
+    { key: THEME_PACK_STORAGE_KEY, value: packSlug },
+  );
+  await page.reload({ waitUntil: "load" });
+  await waitForActivePack(page, packSlug);
+}
+
+test.describe("Theme-pack sidebar active-row shape", () => {
+  test("keeps every non-pill current row square while preserving corrected packs' nested states", async ({
+    page,
+  }) => {
+    test.slow();
+    await page.goto(PAGE, { waitUntil: "load" });
+    const packSlugs = await enabledPackSlugs(page);
+    expect(packSlugs[0]).toBe("default");
+
+    for (const packSlug of packSlugs) {
+      await activatePack(page, packSlug);
+
+      const currentRow = desktopSidebar(page).locator(CURRENT_ROW_SELECTOR);
+      await expect(currentRow).toBeVisible();
+
+      const square = await activeRowStyle(currentRow);
+      expect(
+        square.borderRadius,
+        `${packSlug} rounded a non-pill desktop current row`,
+      ).toBe("0px");
+
+      const corrected = CORRECTED_PACKS[
+        packSlug as keyof typeof CORRECTED_PACKS
+      ];
+      if (corrected) {
+        expect(
+          hasVisibleBackground(square.backgroundColor),
+          `${packSlug} lost its current-row fill`,
+        ).toBe(true);
+
+        // Flip only the stable marker to prove the two CSS states without
+        // reshaping the fixture's real navigation tree.
+        await currentRow.evaluate((element) => {
+          element.setAttribute("data-nav-active", "");
+        });
+        const markedRow = desktopSidebar(page).locator(
+          'a[aria-current="page"][data-nav-active]',
+        );
+        const nested = await activeRowStyle(markedRow);
+        expect(
+          nested.borderRadius,
+          `${packSlug} lost its nested active radius`,
+        ).toBe(corrected.nestedRadius);
+        if (corrected.nestedShadow) {
+          expect(
+            nested.boxShadow,
+            `${packSlug} lost its nested active shadow`,
+          ).not.toBe("none");
+        }
+
+        await markedRow.evaluate((element) => {
+          element.removeAttribute("data-nav-active");
+        });
+        expect((await activeRowStyle(currentRow)).borderRadius).toBe("0px");
+      }
+    }
+  });
+
+  test("keeps Sakura and Scandi non-pill current rows square in the mobile drawer", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto(PAGE, { waitUntil: "load" });
+
+    for (const packSlug of ["sakura", "scandi"]) {
+      await activatePack(page, packSlug);
+      const currentRow = page.locator(MOBILE_CURRENT_ROW_SELECTOR);
+      await expect(currentRow).toHaveCount(1);
+      expect(
+        (await activeRowStyle(currentRow)).borderRadius,
+        `${packSlug} rounded a non-pill mobile current row`,
+      ).toBe("0px");
+    }
+  });
+});

--- a/packages/zudo-doc/src/theme-packs/drift/pack.css
+++ b/packages/zudo-doc/src/theme-packs/drift/pack.css
@@ -9,7 +9,7 @@
    same desaturated blue accent family, never harsh white. Chrome is
    ringed by glow rather than drawn by border: hairline rings +
    layered soft shadows on code, cards, and admonitions; fixed
-   radial light pools drift at opposite page corners; nav/TOC
+   radial light pools drift at opposite page corners; nested nav/TOC
    actives are pill-shaped and glowing. Syntax is a hushed pastel
    palette around the blue axis.
 
@@ -282,6 +282,11 @@ html[data-theme-pack="drift"] #desktop-sidebar a {
     color 0.2s,
     background-color 0.2s,
     box-shadow 0.25s;
+}
+/* Non-pill current rows keep the stock full-width band. The explicit
+   data-nav-active marker below is reserved for Drift's nested glow pill. */
+html[data-theme-pack="drift"] #desktop-sidebar a[aria-current="page"]:not([data-nav-active]) {
+  border-radius: 0;
 }
 html[data-theme-pack="drift"] #desktop-sidebar a:hover {
   text-decoration: none;

--- a/packages/zudo-doc/src/theme-packs/hearth/pack.css
+++ b/packages/zudo-doc/src/theme-packs/hearth/pack.css
@@ -214,6 +214,11 @@ html[data-theme-pack="hearth"] #desktop-sidebar a {
     background-color 0.15s ease,
     color 0.15s ease;
 }
+/* Keep the structural current-row band square; data-nav-active is the
+   explicit hook for Hearth's nested brick cushion. */
+html[data-theme-pack="hearth"] #desktop-sidebar a[aria-current="page"]:not([data-nav-active]) {
+  border-radius: 0;
+}
 html[data-theme-pack="hearth"] #desktop-sidebar a:hover {
   color: var(--zd-accent);
   text-decoration: none;

--- a/packages/zudo-doc/src/theme-packs/sakura/pack.css
+++ b/packages/zudo-doc/src/theme-packs/sakura/pack.css
@@ -250,6 +250,12 @@ html[data-theme-pack="sakura"] #desktop-sidebar a,
 html[data-theme-pack="sakura"] aside[data-zd-mobile-sidebar] a {
   border-radius: 9999px;
 }
+/* Non-pill current rows stay square in both sidebar surfaces; the
+   data-nav-active rule below owns Sakura's nested petal shape. */
+html[data-theme-pack="sakura"] #desktop-sidebar a[aria-current="page"]:not([data-nav-active]),
+html[data-theme-pack="sakura"] aside[data-zd-mobile-sidebar] a[aria-current="page"]:not([data-nav-active]) {
+  border-radius: 0;
+}
 html[data-theme-pack="sakura"] #desktop-sidebar a:not([data-nav-active]):hover,
 html[data-theme-pack="sakura"] aside[data-zd-mobile-sidebar] a:not([data-nav-active]):hover {
   text-decoration: none;

--- a/packages/zudo-doc/src/theme-packs/scandi/pack.css
+++ b/packages/zudo-doc/src/theme-packs/scandi/pack.css
@@ -2,7 +2,7 @@
    Scandi — zudo-doc theme pack (ADR docs/adr/theme-packs.md)
 
    Hygge minimalism: an oat/ecru room with sage and clay accents,
-   pill-shaped nav actives, an even 8px radius discipline, and a
+   pill-shaped nested nav actives, an even 8px radius discipline, and a
    linen-subtle weave on the page body (two cheap repeating
    gradients at ~2% ink — text backdrops stay effectively solid).
    Light = a Scandinavian interior at midday; dark = hygge night —
@@ -180,12 +180,12 @@ html[data-theme-pack="scandi"] aside[data-zd-mobile-sidebar] a:hover:not([data-n
   background: color-mix(in srgb, var(--zd-accent) 10%, transparent);
   color: var(--zd-accent-hover);
 }
-/* root-level actives carry aria-current="page" but not
-   data-nav-active — round their default ink fill to the 8px
-   discipline so no squared default remnant survives. */
-html[data-theme-pack="scandi"] #desktop-sidebar a[aria-current="page"],
-html[data-theme-pack="scandi"] aside[data-zd-mobile-sidebar] a[aria-current="page"] {
-  border-radius: 8px;
+/* Non-pill current rows keep the structural full-width band square in
+   both sidebar surfaces. The data-nav-active rule below owns the flat
+   nested pill. */
+html[data-theme-pack="scandi"] #desktop-sidebar a[aria-current="page"]:not([data-nav-active]),
+html[data-theme-pack="scandi"] aside[data-zd-mobile-sidebar] a[aria-current="page"]:not([data-nav-active]) {
+  border-radius: 0;
 }
 /* active leaf item: THE signature — a full pill in deep sage
    (candle amber at night), oat text, flat as painted wood. Fill

--- a/packages/zudo-doc/src/theme-packs/timberline/pack.css
+++ b/packages/zudo-doc/src/theme-packs/timberline/pack.css
@@ -243,6 +243,11 @@ html[data-theme-pack="timberline"] #desktop-sidebar a {
     background-color 0.15s ease,
     color 0.15s ease;
 }
+/* Keep the structural current-row plank square; data-nav-active is the
+   explicit hook for Timberline's nested chamfer. */
+html[data-theme-pack="timberline"] #desktop-sidebar a[aria-current="page"]:not([data-nav-active]) {
+  border-radius: 0;
+}
 html[data-theme-pack="timberline"] #desktop-sidebar a:hover:not([data-nav-active]):not([aria-current="page"]) {
   color: var(--zd-accent);
   text-decoration: none;


### PR DESCRIPTION
Closes #3618.

Parent epic: #3617
Superseded source report: #3615

**Difficulty:** standard - the root-versus-nested marker contract is explicit, with deterministic computed-style coverage

## Summary

- keep non-pill current rows square in the five rounded-link packs identified by
  a full-catalog deployed-site audit
- add a full-catalog computed-style regression for the square and pack-specific
  nested-active states, including the affected mobile selectors
- verify Claude, Codex, and a real nested Reference link across the affected
  packs against the source screenshots at the reported desktop viewport

## Screenshot requirement contract

**Expected:** At desktop widths, `/docs/claude/` and `/docs/codex/` current rows
use the same edge-to-edge rectangular shape as the current Reference root row in
every enabled pack, with each pack's existing indicator intact and the five
corrected packs' fill visible. Real nested
`data-nav-active` links retain each affected pack's prior radius/shadow
treatment; active TOC styling remains unchanged.

**Forbidden:** Non-pill current rows remain rounded capsules in Drift, Hearth,
Sakura, Scandi, or Timberline solely because a blanket sidebar-anchor radius
wins. The fix removes nested active treatments or changes an unrelated pack.

**Unknown:** The report demonstrates Drift dark mode only. The radius rule is
mode-independent; dark mode is verified directly across the five affected packs
and any light-mode divergence is treated as a defect.

**Viewport:** desktop layout (`>=1024px`), verified at 1710×1072. Sakura and
Scandi are also verified in the mobile drawer at 390px.

Expected root-row baseline:

![Reference root active row](https://github.com/user-attachments/assets/b5b08773-0d80-4797-8986-dcaab03d7d26)

Forbidden rounded overview state:

![Claude rounded root active row](https://github.com/user-attachments/assets/c6cb0f26-b24b-4350-bbe8-43a78fe062d0)

## Implementation plan

- [x] add non-pill current-row overrides to Drift, Hearth, Sakura, Scandi, and
  Timberline (including Sakura/Scandi mobile selectors)
- [x] add full-catalog theme-fixture computed-style coverage for both marker
  states
- [x] rebuild workspace artifacts and run the focused theme fixture
- [x] run code review and L5 verification
- [x] run pre-push validation
- [x] run CI

## Verification

- `pnpm check`
- `pnpm check:e2e-spec-naming`
- `pnpm build:workspace`
- focused Playwright theme project: 2 passed
- `pnpm b4push`: all 30 checks passed, including 2,321 package tests, 475-page
  production builds, strict links/HTML, automated preview smoke, and manual UI
  smoke
- L5 route verification at 1710×1072 for Claude, Codex, and nested Reference
  states across all five affected packs, plus Sakura/Scandi at 390×844

## Risk controls

- shared SidebarTree markup remains unchanged
- the other 26 packs remain unchanged
- the permanent test asserts every enabled pack's non-pill row plus each
  corrected pack's preserved nested-active state
