### PR TITLE
Add configurable SiteTreeNav category ignores

### DIFF
--- a/.fixture-settings-drift-allowlist
+++ b/.fixture-settings-drift-allowlist
@@ -218,3 +218,12 @@ i18n:favicon
 theme:favicon
 smoke:favicon
 versioning:favicon
+
+# ── siteTreeNavIgnore ─────────────────────────────────────────────────────────
+# reason: no e2e fixture has an inbox/ or develop/ category, so the setting is
+#         not exercised; fixtures keep the package default []
+sidebar:siteTreeNavIgnore
+i18n:siteTreeNavIgnore
+theme:siteTreeNavIgnore
+smoke:siteTreeNavIgnore
+versioning:siteTreeNavIgnore

--- a/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
+++ b/packages/create-zudo-doc/src/__tests__/scaffold.test.ts
@@ -1950,6 +1950,7 @@ describe("scaffold — settings-drift guard: generator-known fields must cover e
       base: "no CLI/prompt surface yet — hand-edit post-scaffold (sub-path deploys)",
       trailingSlash: "no CLI/prompt surface yet — hand-edit post-scaffold",
       home: "no CLI/prompt surface yet — hand-edit post-scaffold to opt into the wide package-owned home layout",
+      siteTreeNavIgnore: "no CLI/prompt surface yet — hand-edit post-scaffold to hide top-level categories from the home grid / <SiteTreeNav />",
       docsDir: "no CLI/prompt surface yet — generator always uses the default",
       entryDocSlug: "no CLI/prompt surface yet — hand-edit post-scaffold",
       mermaid: "no CLI/prompt surface yet — package default (on) is correct for all scaffolds",

--- a/packages/zudo-doc/API.md
+++ b/packages/zudo-doc/API.md
@@ -80,6 +80,10 @@ Factory for the shared home-page (site index) body: hero (logo mask block,
 `HomePageView` component with props
 `{ locale, extras?, heroLink?, tree, categoryOrder, tagCount, tags?, tagLimit? }`.
 
+The `SiteTreeNav` island's `categoryIgnore` comes from
+`settings.siteTreeNavIgnore` (default `[]`; the package hard-coded
+`["inbox", "develop"]` before #3641).
+
 `tagCount` (together with `settings.docTags`) gates the tags section. When
 `tags` (the pre-resolved `TagItem[]` list `prepareHomeData` now also returns) is
 provided and non-empty, the section renders the tag chips — capped at `tagLimit`
@@ -163,7 +167,7 @@ behavior change from the previous standalone-line-below-the-row placement,
 | `./home-page` | `createHomePageView(ctx)` — home-page (site index) view factory; see below |
 | `./category-nav` | Category navigation component |
 | `./category-tree-nav` | Category tree navigation component |
-| `./site-tree-nav` | Site tree navigation component |
+| `./site-tree-nav` | Site tree navigation component; its `SiteTreeNavDeps.categoryIgnore` field is optional (omitted means nothing is hidden) |
 | `./html-preview-wrapper` | HTML preview wrapper component |
 | `./design-token-panel-bootstrap` | Design token panel bootstrap wiring |
 

--- a/packages/zudo-doc/src/__tests__/config.test.ts
+++ b/packages/zudo-doc/src/__tests__/config.test.ts
@@ -222,6 +222,17 @@ describe("zudoDoc() default-merge semantics", () => {
     expect(opts?.settings.home).toEqual({ wide: true });
     expect(JSON.parse(JSON.stringify(opts?.settings)).home).toEqual({ wide: true });
   });
+
+  it("defaults siteTreeNavIgnore to an empty list", () => {
+    const opts = routesOptions(zudoDoc({}));
+    expect(DEFAULT_SETTINGS.siteTreeNavIgnore).toEqual([]);
+    expect(opts?.settings.siteTreeNavIgnore).toEqual([]);
+  });
+
+  it("serializes siteTreeNavIgnore into the route settings", () => {
+    const opts = routesOptions(zudoDoc({ siteTreeNavIgnore: ["inbox"] }));
+    expect(opts?.settings.siteTreeNavIgnore).toEqual(["inbox"]);
+  });
 });
 
 // ── Serializability split (virtual-module payload carries no functions) ───────

--- a/packages/zudo-doc/src/__tests__/public-api-snapshot.test.ts
+++ b/packages/zudo-doc/src/__tests__/public-api-snapshot.test.ts
@@ -250,6 +250,7 @@ describe("Settings public field set snapshot", () => {
         "base",
         "trailingSlash",
         "home",
+        "siteTreeNavIgnore",
         "minifyHtml",
         "docsDir",
         "entryDocSlug",

--- a/packages/zudo-doc/src/chrome/derive.tsx
+++ b/packages/zudo-doc/src/chrome/derive.tsx
@@ -592,6 +592,7 @@ export function deriveMdxComponents(ctx: ChromeContext) {
       groupSatelliteNodes: ctx.groupSatelliteNodes as never,
       getCategoryOrder: ctx.getCategoryOrder,
       versionedDocsUrl: ctx.versionedDocsUrl,
+      categoryIgnore: ctx.settings.siteTreeNavIgnore,
     }) as unknown as FactoryComponent);
 
   const NoteTrayIndexWrapper = createNoteTrayIndexWrapper({

--- a/packages/zudo-doc/src/config.ts
+++ b/packages/zudo-doc/src/config.ts
@@ -131,6 +131,7 @@ export const DEFAULT_SETTINGS: Settings = {
   base: "/",
   trailingSlash: false,
   home: { wide: false },
+  siteTreeNavIgnore: [],
   minifyHtml: true,
   docsDir: "src/content/docs",
   entryDocSlug: "getting-started",
@@ -266,6 +267,15 @@ export interface ZudoDocConfig {
    * @default { wide: false }
    */
   home?: HomeConfig;
+  /**
+   * Top-level category slugs hidden from the package-owned home-page category
+   * grid on `/` and locale homes AND from the `<SiteTreeNav />` /
+   * `<SiteTreeNavDemo />` MDX tag. They still appear in header nav, sidebar,
+   * search and sitemap. Before this field the package hard-coded
+   * `["inbox", "develop"]` (#3641).
+   * @default []
+   */
+  siteTreeNavIgnore?: string[];
   /**
    * Minify production HTML output from `zfb build`.
    * @default true

--- a/packages/zudo-doc/src/home-page/__tests__/home-page.test.tsx
+++ b/packages/zudo-doc/src/home-page/__tests__/home-page.test.tsx
@@ -50,6 +50,25 @@ const CHANGELOG_TREE: DocNavNode[] = [
     ],
   },
 ];
+const DEVELOP_TREE: DocNavNode[] = [
+  {
+    slug: "develop",
+    label: "develop",
+    position: 0,
+    href: "/docs/develop",
+    hasPage: true,
+    children: [
+      {
+        slug: "develop/example",
+        label: "Example",
+        position: 0,
+        href: "/docs/develop/example",
+        hasPage: true,
+        children: [],
+      },
+    ],
+  },
+];
 
 function makeProps(overrides: Partial<HomePageViewProps> = {}): HomePageViewProps {
   return {
@@ -219,6 +238,21 @@ describe("createHomePageView — SiteTreeNav island", () => {
 
     expect(html).toContain('aria-expanded="true" aria-label="Collapse Release notes"');
     expect(html).toContain('href="/docs/changelog/1.0.0"');
+  });
+
+  it("shows a develop category by default when no siteTreeNavIgnore setting is provided", () => {
+    const HomePageView = createHomePageView(makeFakeChromeContext());
+    const html = render(<HomePageView {...makeProps({ tree: DEVELOP_TREE })} />);
+
+    expect(html).toContain('href="/docs/develop"');
+  });
+
+  it("hides a develop category when siteTreeNavIgnore includes it", () => {
+    const ctx = makeFakeChromeContext({ settings: { siteTreeNavIgnore: ["develop"] } });
+    const HomePageView = createHomePageView(ctx);
+    const html = render(<HomePageView {...makeProps({ tree: DEVELOP_TREE })} />);
+
+    expect(html).not.toContain('href="/docs/develop"');
   });
 
   it("localizes note-tray dates and the existing updated label", () => {

--- a/packages/zudo-doc/src/home-page/index.tsx
+++ b/packages/zudo-doc/src/home-page/index.tsx
@@ -146,6 +146,7 @@ export function createHomePageView<S extends Settings = Settings>(
 ): (props: HomePageViewProps) => JSX.Element {
   assertChromeContext(ctx, "createHomePageView");
   const settings = ctx.settings;
+  const categoryIgnore = settings.siteTreeNavIgnore ?? [];
   const t = ctx.t;
   const withBase = ctx.withBase;
   const defaultLocale = ctx.defaultLocale;
@@ -280,7 +281,7 @@ export function createHomePageView<S extends Settings = Settings>(
             <SiteTreeNav
               tree={tree as unknown as SidebarNavNode[]}
               categoryOrder={categoryOrder}
-              categoryIgnore={["inbox", "develop"]}
+              categoryIgnore={categoryIgnore}
               initiallyCollapsedCategorySlugs={initiallyCollapsedCategorySlugs}
               locale={locale}
               updatedLabel={t("doc.updated", locale)}

--- a/packages/zudo-doc/src/settings.ts
+++ b/packages/zudo-doc/src/settings.ts
@@ -335,6 +335,8 @@ export interface Settings {
   trailingSlash: boolean;
   /** Package-owned home-page layout. Narrow when omitted. */
   home?: HomeConfig;
+  /** Top-level category slugs hidden from the package home-page grid and the `<SiteTreeNav />` MDX tag. Nothing hidden when omitted. */
+  siteTreeNavIgnore?: string[];
   /** Minify production HTML output from `zfb build`. Defaults to `true` when omitted. */
   minifyHtml?: boolean;
   docsDir: string;

--- a/packages/zudo-doc/src/site-tree-nav/__tests__/site-tree-nav-factory.test.tsx
+++ b/packages/zudo-doc/src/site-tree-nav/__tests__/site-tree-nav-factory.test.tsx
@@ -14,6 +14,7 @@
 
 import { describe, expect, it, vi } from "vitest";
 import { SiteTreeNav } from "../../site-tree-nav-island/index.js";
+import type { SiteTreeNavProps } from "../../site-tree-nav-island/index.js";
 import { createSiteTreeNavWrapper } from "../index.js";
 import type { SiteTreeNavDeps } from "../index.js";
 import type { SidebarNavNode } from "../../sidebar/types.js";
@@ -118,6 +119,29 @@ describe("createSiteTreeNavWrapper — Island(when:idle) preserved (epic #2344 S
     expect(() => SiteTreeNavWrapper({ lang: "en", ariaLabel: "Site navigation" })).not.toThrow();
   });
 
+  it("passes categoryIgnore to the SiteTreeNav island", () => {
+    const deps = makeDeps({
+      categoryIgnore: ["develop"],
+      buildNavTree: () => [makeNode("develop", [makeNode("develop/example")])],
+      getCategoryOrder: () => [],
+    });
+    const SiteTreeNavWrapper = createSiteTreeNavWrapper(deps);
+    const result = SiteTreeNavWrapper({ lang: "en" });
+
+    expect(siteTreeNavProps(result).categoryIgnore).toEqual(["develop"]);
+  });
+
+  it("leaves categoryIgnore undefined when omitted so a develop root is shown", () => {
+    const deps = makeDeps({
+      buildNavTree: () => [makeNode("develop", [makeNode("develop/example")])],
+      getCategoryOrder: () => [],
+    });
+    const SiteTreeNavWrapper = createSiteTreeNavWrapper(deps);
+    const result = SiteTreeNavWrapper({ lang: "en" });
+
+    expect(siteTreeNavProps(result).categoryIgnore).toBeUndefined();
+  });
+
   it("SiteTreeNav island marker name is 'SiteTreeNav' — proxy for data-zfb-island (epic #2344 S8)", () => {
     // The Island({when:"idle", children:<SiteTreeNav ...>}) call in the factory
     // relies on SiteTreeNav.displayName === "SiteTreeNav" to emit
@@ -141,6 +165,11 @@ describe("createSiteTreeNavWrapper — Island(when:idle) preserved (epic #2344 S
 function treeOf(result: unknown): SidebarNavNode[] {
   const el = result as { props: { children: { props: { tree: SidebarNavNode[] } } } };
   return el.props.children.props.tree;
+}
+
+function siteTreeNavProps(result: unknown): SiteTreeNavProps {
+  const el = result as { props: { children: { props: SiteTreeNavProps } } };
+  return el.props.children.props;
 }
 
 describe("createSiteTreeNavWrapper — version threading (#3218)", () => {

--- a/packages/zudo-doc/src/site-tree-nav/index.tsx
+++ b/packages/zudo-doc/src/site-tree-nav/index.tsx
@@ -114,6 +114,13 @@ export interface SiteTreeNavDeps {
    * loud dev warning is emitted) rather than throwing.
    */
   versionedDocsUrl?: (slug: string, versionSlug: string, lang: string) => string;
+  /**
+   * Top-level category slugs hidden from the SiteTreeNav island. This optional
+   * field keeps hand-constructed `SiteTreeNavDeps` compatible with the frozen
+   * `./site-tree-nav` public subpath; omitted means nothing is hidden. The
+   * package chrome passes `settings.siteTreeNavIgnore`.
+   */
+  categoryIgnore?: string[];
 }
 
 /**
@@ -139,6 +146,7 @@ export function createSiteTreeNavWrapper(
     groupSatelliteNodes,
     getCategoryOrder,
     versionedDocsUrl,
+    categoryIgnore,
   } = deps;
 
   function SiteTreeNavWrapper({
@@ -186,7 +194,7 @@ export function createSiteTreeNavWrapper(
         <SiteTreeNav
           tree={tree}
           categoryOrder={categoryOrder}
-          categoryIgnore={["inbox", "develop"]}
+          categoryIgnore={categoryIgnore}
           ariaLabel={ariaLabel}
         />
       ),

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -77,6 +77,7 @@ export const settings = {
   sitemap: true,
   docMetainfo: true,
   docTags: true,
+  siteTreeNavIgnore: ["inbox", "develop"] as string[], // hides the showcase's develop/ category from the home grid + <SiteTreeNav /> (#1463/#1480 → setting per #3641)
   // Not yet wired: settings uses "before-pager" but DocTags (v2 package) expects "before-footer" — types must align first (#2140).
   tagPlacement: "after-title" as TagPlacement,
   /**


### PR DESCRIPTION
Parent: #3643

Implements #3644.

## Summary

- add `siteTreeNavIgnore` to package configuration with a default of `[]`
- thread the setting through package home pages and the MDX SiteTreeNav wrapper
- preserve the showcase exclusion and cover configuration, rendering, API, and drift contracts

## Migration

The package default changes from the previously hard-coded `["inbox", "develop"]` exclusion to `[]`. Consumer sites that relied on those categories being hidden should add `siteTreeNavIgnore: ["inbox", "develop"]` to `zudoDoc({...})`.

## Test plan

- complete `@takazudo/zudo-doc` package suite
- `create-zudo-doc` suite
- type check and fixture drift check
- centralized DOM-aware built-output verification

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/3648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789993442&installation_model_id=20910&pr_number=3648&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F3648&signature=0689dc527b6d4e2668f0a35b3c58f5f9dba771ac90b0efa9ae1def58f4970683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->