### PR TITLE
Fix grouped note tray indentation

### DIFF
--- a/packages/zudo-doc/src/sidebar-tree-island/__tests__/sidebar-tree-note-tray-ssg.test.tsx
+++ b/packages/zudo-doc/src/sidebar-tree-island/__tests__/sidebar-tree-note-tray-ssg.test.tsx
@@ -98,6 +98,9 @@ describe("SidebarTree — note tray SSG", () => {
     expect(html).not.toContain("12-09");
     expect(html.indexOf("Newest")).toBeLessThan(html.indexOf("Active article"));
     expect(html).not.toContain("text-bg/70");
+
+    const activeLink = html.match(/<a href="\/docs\/notes\/active"[^>]*>/)?.[0];
+    expect(activeLink).toContain("padding-left:calc(3 * clamp(0.8rem, 1.2vw, 1.625rem) + 1.25rem + 5px)");
   });
 
   it("localizes month labels for English and Japanese and keeps active groups open", () => {

--- a/packages/zudo-doc/src/sidebar-tree-island/index.tsx
+++ b/packages/zudo-doc/src/sidebar-tree-island/index.tsx
@@ -44,6 +44,7 @@ function ToggleChevron({ isExpanded, className }: { isExpanded: boolean; classNa
 }
 
 const STORAGE_KEY = "zd-sidebar-open";
+const GROUPED_TRAY_ITEM_DEPTH = 3;
 
 function padLeft(depth: number, forCategory: boolean): string {
   if (depth === 0) return `calc(${BASE_PAD} + ${forCategory ? "0.15rem" : "0rem"})`;
@@ -528,7 +529,9 @@ function TrayGroupNode({
               currentSlug={currentSlug}
               isLast={index === group.items.length - 1}
               showDate
-              depth={2}
+              // Leave one visual indentation step between the group branch
+              // and its dated child branch so the hierarchy reads clearly.
+              depth={GROUPED_TRAY_ITEM_DEPTH}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary

- shift grouped note-tray child connectors and labels right by one shared responsive indentation step
- keep group headings, row rhythm, active styles, and right-aligned dates unchanged
- add an SSG regression assertion for grouped-row indentation

## Visual contract

- Expected: dated child-row connectors and titles align with the deeper hierarchy shown in the supplied right-hand reference.
- Forbidden: the child connector/title remains pulled left as in the supplied left-hand current state.
- Preserved: root tray row, group toggle and label, typography, vertical rhythm, active state, and right-aligned MM-DD dates.
- Viewport: desktop sidebar layout matching the supplied side-by-side screenshot.

## Verification

- `pnpm --filter @takazudo/zudo-doc test -- sidebar-tree-note-tray-ssg.test.tsx` (207 files, 2,383 tests passed)
- `pnpm --filter @takazudo/zudo-doc typecheck`
- guarded Playwright desktop capture against the sidebar fixture
- `B4PUSH_SKIP_PIN_PUBLISHED=1 B4PUSH_SKIP_MANUAL_SMOKE=1 pnpm b4push` (30 checks passed or documented skips)
- Codex review: no actionable findings
