### PR TITLE
refactor: split NoteTrayIndex renderers and tests

### DIFF
--- a/packages/zudo-doc/src/nav-indexing/__tests__/note-tray-card-list.test.tsx
+++ b/packages/zudo-doc/src/nav-indexing/__tests__/note-tray-card-list.test.tsx
@@ -1,0 +1,23 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { describe, expect, it } from "vitest";
+import { NoteTrayIndex } from "../note-tray-index.js";
+import { serialize } from "./helpers.js";
+import { base, item } from "./note-tray-test-helpers.js";
+
+describe("NoteTrayIndex card style", () => {
+  it("renders cards with h2 links, excerpts, tags, and showDate-gated dates", () => {
+    const tagged = item("card", {
+      date: "2026-08-22",
+      tagLinks: [{ tag: "preact", href: "/docs/tags/preact" }],
+    });
+    const shown = serialize(NoteTrayIndex({ ...base, style: "cards", showDate: true, items: [tagged] }));
+    const hidden = serialize(NoteTrayIndex({ ...base, style: "cards", items: [tagged] }));
+    expect(shown).toContain("<h2");
+    expect(shown).toContain("About card");
+    expect(shown).toContain("#preact");
+    expect(shown).toContain("Aug 22, 2026");
+    expect(hidden).not.toContain("Aug 22, 2026");
+  });
+});

--- a/packages/zudo-doc/src/nav-indexing/__tests__/note-tray-index-list.test.tsx
+++ b/packages/zudo-doc/src/nav-indexing/__tests__/note-tray-index-list.test.tsx
@@ -1,0 +1,39 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { describe, expect, it } from "vitest";
+import { NoteTrayIndex } from "../note-tray-index.js";
+import { serialize } from "./helpers.js";
+import { base, item } from "./note-tray-test-helpers.js";
+
+describe("NoteTrayIndex index style", () => {
+  it("renders zero-padded index rows, descriptions, and optional date/updated", () => {
+    const html = serialize(
+      NoteTrayIndex({
+        ...base,
+        showDate: true,
+        items: [item("one", { rank: 1, date: "2026-08-22", updated: "2026-08-23" })],
+      }),
+    );
+    expect(html).toContain(">01</span>");
+    expect(html).toContain('href="/docs/one"');
+    expect(html).toContain("About one");
+    expect(html).toContain("Aug 22, 2026");
+    expect(html).toContain("Updated <time");
+  });
+
+  it("keeps the visible stable rank accessible and never invents rank 00", () => {
+    const ranked = serialize(
+      NoteTrayIndex({ ...base, items: [item("sixth", { rank: 6 })] }),
+    );
+    const missing = serialize(
+      NoteTrayIndex({ ...base, items: [item("missing", { rank: undefined })] }),
+    );
+
+    const rankSpan = ranked.match(/<span[^>]*>06<\/span>/)?.[0];
+    expect(rankSpan).toBeDefined();
+    expect(rankSpan).not.toContain("aria-hidden");
+    expect(missing).not.toContain(">00</span>");
+    expect(missing).toMatch(/<span[^>]*text-heading[^>]*><\/span>/);
+  });
+});

--- a/packages/zudo-doc/src/nav-indexing/__tests__/note-tray-index.test.tsx
+++ b/packages/zudo-doc/src/nav-indexing/__tests__/note-tray-index.test.tsx
@@ -2,113 +2,11 @@
 /** @jsxImportSource preact */
 
 import { describe, expect, it } from "vitest";
-import { NoteTrayIndex, type NoteTrayIndexItem } from "../note-tray-index.js";
-import { serialize } from "./helpers.js";
-
-const item = (slug: string, overrides: Partial<NoteTrayIndexItem> = {}): NoteTrayIndexItem => ({
-  slug,
-  label: slug,
-  description: `About ${slug}`,
-  href: `/docs/${slug}`,
-  hasPage: true,
-  children: [],
-  rank: 1,
-  ...overrides,
-});
-
-const base = {
-  locale: "en",
-  updatedLabel: "Updated",
-  dated: true,
-  tagLabels: { tags: "Tags", taggedWith: "Pages tagged with" },
-};
+import { NoteTrayIndex } from "../note-tray-index.js";
+import { base } from "./note-tray-test-helpers.js";
 
 describe("NoteTrayIndex", () => {
   it("renders nothing for an empty tray", () => {
     expect(NoteTrayIndex({ ...base, items: [] })).toBeNull();
-  });
-
-  it("renders zero-padded index rows, descriptions, and optional date/updated", () => {
-    const html = serialize(
-      NoteTrayIndex({
-        ...base,
-        showDate: true,
-        items: [item("one", { rank: 1, date: "2026-08-22", updated: "2026-08-23" })],
-      }),
-    );
-    expect(html).toContain(">01</span>");
-    expect(html).toContain('href="/docs/one"');
-    expect(html).toContain("About one");
-    expect(html).toContain("Aug 22, 2026");
-    expect(html).toContain("Updated <time");
-  });
-
-  it("keeps the visible stable rank accessible and never invents rank 00", () => {
-    const ranked = serialize(
-      NoteTrayIndex({ ...base, items: [item("sixth", { rank: 6 })] }),
-    );
-    const missing = serialize(
-      NoteTrayIndex({ ...base, items: [item("missing", { rank: undefined })] }),
-    );
-
-    const rankSpan = ranked.match(/<span[^>]*>06<\/span>/)?.[0];
-    expect(rankSpan).toBeDefined();
-    expect(rankSpan).not.toContain("aria-hidden");
-    expect(missing).not.toContain(">00</span>");
-    expect(missing).toMatch(/<span[^>]*text-heading[^>]*><\/span>/);
-  });
-
-  it("renders cards with h2 links, excerpts, tags, and showDate-gated dates", () => {
-    const tagged = item("card", {
-      date: "2026-08-22",
-      tagLinks: [{ tag: "preact", href: "/docs/tags/preact" }],
-    });
-    const shown = serialize(NoteTrayIndex({ ...base, style: "cards", showDate: true, items: [tagged] }));
-    const hidden = serialize(NoteTrayIndex({ ...base, style: "cards", items: [tagged] }));
-    expect(shown).toContain("<h2");
-    expect(shown).toContain("About card");
-    expect(shown).toContain("#preact");
-    expect(shown).toContain("Aug 22, 2026");
-    expect(hidden).not.toContain("Aug 22, 2026");
-  });
-
-  it.each([
-    ["en", "2026 August"],
-    ["ja", "2026年8月"],
-  ])("renders localized timeline month headers in %s", (locale, label) => {
-    const html = serialize(
-      NoteTrayIndex({
-        ...base,
-        locale,
-        style: "timeline",
-        items: [item("dated", { date: "2026-08-22" })],
-      }),
-    );
-    expect(html).toContain(label);
-    expect(html).toContain(locale === "ja" ? "2026年8月22日" : "Aug 22, 2026");
-    expect(html.indexOf("dated")).toBeLessThan(html.indexOf("About dated"));
-  });
-
-  it("honors descending group and rank order", () => {
-    const html = serialize(
-      NoteTrayIndex({
-        ...base,
-        style: "timeline",
-        order: "desc",
-        items: [
-          item("older-low", { date: "2026-07-01", rank: 1 }),
-          item("new-low", { date: "2026-08-01", rank: 2 }),
-          item("new-high", { date: "2026-08-02", rank: 3 }),
-        ],
-      }),
-    );
-    expect(html.indexOf("2026 August")).toBeLessThan(html.indexOf("2026 July"));
-    expect(html.indexOf("new-high")).toBeLessThan(html.indexOf("new-low"));
-  });
-
-  it("throws clearly when timeline is used on a non-dated tray", () => {
-    expect(() =>
-      NoteTrayIndex({ ...base, dated: false, style: "timeline", items: [item("one")] }),
-    ).toThrow(/requires a dated note tray/);
   });
 });

--- a/packages/zudo-doc/src/nav-indexing/__tests__/note-tray-test-helpers.ts
+++ b/packages/zudo-doc/src/nav-indexing/__tests__/note-tray-test-helpers.ts
@@ -1,0 +1,25 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import type { NoteTrayIndexItem } from "../note-tray-index.js";
+
+export const item = (
+  slug: string,
+  overrides: Partial<NoteTrayIndexItem> = {},
+): NoteTrayIndexItem => ({
+  slug,
+  label: slug,
+  description: `About ${slug}`,
+  href: `/docs/${slug}`,
+  hasPage: true,
+  children: [],
+  rank: 1,
+  ...overrides,
+});
+
+export const base = {
+  locale: "en",
+  updatedLabel: "Updated",
+  dated: true,
+  tagLabels: { tags: "Tags", taggedWith: "Pages tagged with" },
+};

--- a/packages/zudo-doc/src/nav-indexing/__tests__/note-tray-timeline.test.tsx
+++ b/packages/zudo-doc/src/nav-indexing/__tests__/note-tray-timeline.test.tsx
@@ -1,0 +1,49 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { describe, expect, it } from "vitest";
+import { NoteTrayIndex } from "../note-tray-index.js";
+import { serialize } from "./helpers.js";
+import { base, item } from "./note-tray-test-helpers.js";
+
+describe("NoteTrayIndex timeline style", () => {
+  it.each([
+    ["en", "2026 August"],
+    ["ja", "2026年8月"],
+  ])("renders localized timeline month headers in %s", (locale, label) => {
+    const html = serialize(
+      NoteTrayIndex({
+        ...base,
+        locale,
+        style: "timeline",
+        items: [item("dated", { date: "2026-08-22" })],
+      }),
+    );
+    expect(html).toContain(label);
+    expect(html).toContain(locale === "ja" ? "2026年8月22日" : "Aug 22, 2026");
+    expect(html.indexOf("dated")).toBeLessThan(html.indexOf("About dated"));
+  });
+
+  it("honors descending group and rank order", () => {
+    const html = serialize(
+      NoteTrayIndex({
+        ...base,
+        style: "timeline",
+        order: "desc",
+        items: [
+          item("older-low", { date: "2026-07-01", rank: 1 }),
+          item("new-low", { date: "2026-08-01", rank: 2 }),
+          item("new-high", { date: "2026-08-02", rank: 3 }),
+        ],
+      }),
+    );
+    expect(html.indexOf("2026 August")).toBeLessThan(html.indexOf("2026 July"));
+    expect(html.indexOf("new-high")).toBeLessThan(html.indexOf("new-low"));
+  });
+
+  it("throws clearly when timeline is used on a non-dated tray", () => {
+    expect(() =>
+      NoteTrayIndex({ ...base, dated: false, style: "timeline", items: [item("one")] }),
+    ).toThrow(/requires a dated note tray/);
+  });
+});

--- a/packages/zudo-doc/src/nav-indexing/note-tray-index-parts/card-list.tsx
+++ b/packages/zudo-doc/src/nav-indexing/note-tray-index-parts/card-list.tsx
@@ -1,0 +1,40 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import type { JSX } from "preact";
+import type { NoteTrayIndexProps } from "../note-tray-index.js";
+import { DateLine, ItemTags } from "./date-line.js";
+
+export function CardList(props: NoteTrayIndexProps): JSX.Element {
+  return (
+    <div class="grid grid-cols-1 gap-vsp-md">
+      {props.items.map((item) => (
+        <article key={item.slug} class="rounded border border-muted bg-surface px-hsp-xl py-vsp-lg">
+          {props.showDate && (
+            <div class="mb-vsp-xs">
+              <DateLine item={item} locale={props.locale} updatedLabel={props.updatedLabel} />
+            </div>
+          )}
+          <h2 class="text-title font-medium">
+            {item.href ? (
+              <a
+                class="text-fg hover:text-accent hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                href={item.href}
+              >
+                {item.label}
+              </a>
+            ) : (
+              item.label
+            )}
+          </h2>
+          {item.description && <p class="mt-vsp-xs text-muted">{item.description}</p>}
+          {item.tagLinks?.length ? (
+            <div class="mt-vsp-md">
+              <ItemTags item={item} labels={props.tagLabels} />
+            </div>
+          ) : null}
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/packages/zudo-doc/src/nav-indexing/note-tray-index-parts/date-line.tsx
+++ b/packages/zudo-doc/src/nav-indexing/note-tray-index-parts/date-line.tsx
@@ -1,0 +1,36 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import type { JSX } from "preact";
+import { formatDate } from "../../note-tray-model/index.js";
+import type { NoteTrayIndexItem } from "../note-tray-index.js";
+import { TagNav } from "../tag-nav.js";
+import type { TagNavLabels } from "../types.js";
+
+export function DateLine({
+  item,
+  locale,
+  updatedLabel,
+}: {
+  item: NoteTrayIndexItem;
+  locale: string;
+  updatedLabel: string;
+}): JSX.Element | null {
+  if (!item.date && !item.updated) return null;
+  return (
+    <span class="tabular-nums text-caption text-muted">
+      {item.date && <time datetime={item.date}>{formatDate(item.date, locale)}</time>}
+      {item.date && item.updated && <span aria-hidden="true"> · </span>}
+      {item.updated && (
+        <span>
+          {updatedLabel} <time datetime={item.updated}>{formatDate(item.updated, locale)}</time>
+        </span>
+      )}
+    </span>
+  );
+}
+
+export function ItemTags({ item, labels }: { item: NoteTrayIndexItem; labels?: TagNavLabels }) {
+  if (!labels || !item.tagLinks?.length) return null;
+  return <TagNav variant="page" tagLinks={item.tagLinks} labels={labels} />;
+}

--- a/packages/zudo-doc/src/nav-indexing/note-tray-index-parts/index-list.tsx
+++ b/packages/zudo-doc/src/nav-indexing/note-tray-index-parts/index-list.tsx
@@ -1,0 +1,46 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import type { JSX } from "preact";
+import { rankWidth } from "../../note-tray-model/index.js";
+import type { NoteTrayIndexProps } from "../note-tray-index.js";
+import { DateLine } from "./date-line.js";
+
+export function IndexList(props: NoteTrayIndexProps): JSX.Element {
+  const width = rankWidth(props.items);
+  return (
+    <ol class="border-t border-muted">
+      {props.items.map((item) => (
+        <li
+          key={item.slug}
+          class="grid grid-cols-[auto_1fr] gap-x-hsp-lg border-b border-muted py-vsp-md"
+        >
+          <span
+            class="tabular-nums text-heading leading-none text-muted"
+            style={{ width: `${width}ch` }}
+          >
+            {item.rank === undefined ? "" : String(item.rank).padStart(width, "0")}
+          </span>
+          <div class="min-w-0">
+            {item.href ? (
+              <a
+                class="font-medium text-fg hover:text-accent hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                href={item.href}
+              >
+                {item.label}
+              </a>
+            ) : (
+              <span class="font-medium text-fg">{item.label}</span>
+            )}
+            {item.description && <p class="mt-vsp-2xs text-small text-muted">{item.description}</p>}
+            {props.showDate && (
+              <span class="mt-vsp-2xs block">
+                <DateLine item={item} locale={props.locale} updatedLabel={props.updatedLabel} />
+              </span>
+            )}
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/packages/zudo-doc/src/nav-indexing/note-tray-index-parts/timeline.tsx
+++ b/packages/zudo-doc/src/nav-indexing/note-tray-index-parts/timeline.tsx
@@ -1,0 +1,47 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import type { JSX } from "preact";
+import { formatYearMonthLabel, groupItems } from "../../note-tray-model/index.js";
+import type { NoteTrayIndexProps } from "../note-tray-index.js";
+import { DateLine, ItemTags } from "./date-line.js";
+
+export function Timeline(props: NoteTrayIndexProps): JSX.Element {
+  const groups = groupItems(props.items, "month", props.order ?? "asc");
+  return (
+    <div class="space-y-vsp-lg">
+      {groups.map((group) => (
+        <section key={group.key}>
+          <h2 class="mb-vsp-sm text-small font-medium text-fg">
+            {formatYearMonthLabel(group.key, props.locale)}
+          </h2>
+          <ol class="ml-hsp-xs border-l border-muted">
+            {group.items.map((item) => (
+              <li key={item.slug} class="relative grid gap-vsp-2xs pb-vsp-lg pl-hsp-lg last:pb-0">
+                <span
+                  class="absolute -left-hsp-xs top-vsp-2xs size-icon-xs rounded-full border border-bg bg-muted"
+                  aria-hidden="true"
+                />
+                <div class="flex flex-wrap items-baseline gap-x-hsp-sm gap-y-vsp-2xs">
+                  <DateLine item={item} locale={props.locale} updatedLabel={props.updatedLabel} />
+                  {item.href ? (
+                    <a
+                      class="font-medium text-fg hover:text-accent hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                      href={item.href}
+                    >
+                      {item.label}
+                    </a>
+                  ) : (
+                    <span class="font-medium text-fg">{item.label}</span>
+                  )}
+                </div>
+                {item.description && <p class="text-small text-muted">{item.description}</p>}
+                <ItemTags item={item} labels={props.tagLabels} />
+              </li>
+            ))}
+          </ol>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/packages/zudo-doc/src/nav-indexing/note-tray-index.tsx
+++ b/packages/zudo-doc/src/nav-indexing/note-tray-index.tsx
@@ -2,15 +2,11 @@
 /** @jsxImportSource preact */
 
 import type { JSX } from "preact";
-import {
-  formatDate,
-  formatYearMonthLabel,
-  groupItems,
-  rankWidth,
-  type NoteTrayOrder,
-} from "../note-tray-model/index.js";
-import { TagNav } from "./tag-nav.js";
+import { CardList } from "./note-tray-index-parts/card-list.js";
+import { IndexList } from "./note-tray-index-parts/index-list.js";
+import { Timeline } from "./note-tray-index-parts/timeline.js";
 import type { TagLink, TagNavLabels } from "./types.js";
+import type { NoteTrayOrder } from "../note-tray-model/index.js";
 
 export type NoteTrayIndexStyle = "index" | "cards" | "timeline";
 
@@ -36,147 +32,6 @@ export interface NoteTrayIndexProps {
   dated: boolean;
   order?: NoteTrayOrder;
   tagLabels?: TagNavLabels;
-}
-
-function DateLine({
-  item,
-  locale,
-  updatedLabel,
-}: {
-  item: NoteTrayIndexItem;
-  locale: string;
-  updatedLabel: string;
-}): JSX.Element | null {
-  if (!item.date && !item.updated) return null;
-  return (
-    <span class="tabular-nums text-caption text-muted">
-      {item.date && <time datetime={item.date}>{formatDate(item.date, locale)}</time>}
-      {item.date && item.updated && <span aria-hidden="true"> · </span>}
-      {item.updated && (
-        <span>
-          {updatedLabel} <time datetime={item.updated}>{formatDate(item.updated, locale)}</time>
-        </span>
-      )}
-    </span>
-  );
-}
-
-function ItemTags({ item, labels }: { item: NoteTrayIndexItem; labels?: TagNavLabels }) {
-  if (!labels || !item.tagLinks?.length) return null;
-  return <TagNav variant="page" tagLinks={item.tagLinks} labels={labels} />;
-}
-
-function IndexList(props: NoteTrayIndexProps): JSX.Element {
-  const width = rankWidth(props.items);
-  return (
-    <ol class="border-t border-muted">
-      {props.items.map((item) => (
-        <li
-          key={item.slug}
-          class="grid grid-cols-[auto_1fr] gap-x-hsp-lg border-b border-muted py-vsp-md"
-        >
-          <span
-            class="tabular-nums text-heading leading-none text-muted"
-            style={{ width: `${width}ch` }}
-          >
-            {item.rank === undefined ? "" : String(item.rank).padStart(width, "0")}
-          </span>
-          <div class="min-w-0">
-            {item.href ? (
-              <a
-                class="font-medium text-fg hover:text-accent hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
-                href={item.href}
-              >
-                {item.label}
-              </a>
-            ) : (
-              <span class="font-medium text-fg">{item.label}</span>
-            )}
-            {item.description && <p class="mt-vsp-2xs text-small text-muted">{item.description}</p>}
-            {props.showDate && (
-              <span class="mt-vsp-2xs block">
-                <DateLine item={item} locale={props.locale} updatedLabel={props.updatedLabel} />
-              </span>
-            )}
-          </div>
-        </li>
-      ))}
-    </ol>
-  );
-}
-
-function CardList(props: NoteTrayIndexProps): JSX.Element {
-  return (
-    <div class="grid grid-cols-1 gap-vsp-md">
-      {props.items.map((item) => (
-        <article key={item.slug} class="rounded border border-muted bg-surface px-hsp-xl py-vsp-lg">
-          {props.showDate && (
-            <div class="mb-vsp-xs">
-              <DateLine item={item} locale={props.locale} updatedLabel={props.updatedLabel} />
-            </div>
-          )}
-          <h2 class="text-title font-medium">
-            {item.href ? (
-              <a
-                class="text-fg hover:text-accent hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
-                href={item.href}
-              >
-                {item.label}
-              </a>
-            ) : (
-              item.label
-            )}
-          </h2>
-          {item.description && <p class="mt-vsp-xs text-muted">{item.description}</p>}
-          {item.tagLinks?.length ? (
-            <div class="mt-vsp-md">
-              <ItemTags item={item} labels={props.tagLabels} />
-            </div>
-          ) : null}
-        </article>
-      ))}
-    </div>
-  );
-}
-
-function Timeline(props: NoteTrayIndexProps): JSX.Element {
-  const groups = groupItems(props.items, "month", props.order ?? "asc");
-  return (
-    <div class="space-y-vsp-lg">
-      {groups.map((group) => (
-        <section key={group.key}>
-          <h2 class="mb-vsp-sm text-small font-medium text-fg">
-            {formatYearMonthLabel(group.key, props.locale)}
-          </h2>
-          <ol class="ml-hsp-xs border-l border-muted">
-            {group.items.map((item) => (
-              <li key={item.slug} class="relative grid gap-vsp-2xs pb-vsp-lg pl-hsp-lg last:pb-0">
-                <span
-                  class="absolute -left-hsp-xs top-vsp-2xs size-icon-xs rounded-full border border-bg bg-muted"
-                  aria-hidden="true"
-                />
-                <div class="flex flex-wrap items-baseline gap-x-hsp-sm gap-y-vsp-2xs">
-                  <DateLine item={item} locale={props.locale} updatedLabel={props.updatedLabel} />
-                  {item.href ? (
-                    <a
-                      class="font-medium text-fg hover:text-accent hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
-                      href={item.href}
-                    >
-                      {item.label}
-                    </a>
-                  ) : (
-                    <span class="font-medium text-fg">{item.label}</span>
-                  )}
-                </div>
-                {item.description && <p class="text-small text-muted">{item.description}</p>}
-                <ItemTags item={item} labels={props.tagLabels} />
-              </li>
-            ))}
-          </ol>
-        </section>
-      ))}
-    </div>
-  );
 }
 
 export function NoteTrayIndex(props: NoteTrayIndexProps): JSX.Element | null {


### PR DESCRIPTION
Parent: #3653
Implements: #3654

## Summary

- split the public NoteTrayIndex dispatcher from the three internal style renderers
- split shared helpers and per-style test coverage without changing behavior

## Verification

- package build and 2,383 package tests passed
- type/content checks passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/3661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790035959&installation_model_id=20910&pr_number=3661&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F3661&signature=994c2e4f3d348b46729ede826e2ed5c94f6adc09b105d695e95975293d354edd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->