### PR TITLE
fix: show created dates only in sitemap trays

### DIFF
--- a/packages/zudo-doc/src/home-page/__tests__/home-page.test.tsx
+++ b/packages/zudo-doc/src/home-page/__tests__/home-page.test.tsx
@@ -255,7 +255,7 @@ describe("createHomePageView — SiteTreeNav island", () => {
     expect(html).not.toContain('href="/docs/develop"');
   });
 
-  it("localizes note-tray dates and the existing updated label", () => {
+  it("localizes note-tray dates without rendering the updated label", () => {
     const ctx = makeFakeChromeContext({
       overrides: {
         t: (key: string, locale: string) =>
@@ -297,7 +297,11 @@ describe("createHomePageView — SiteTreeNav island", () => {
     );
 
     expect(html).toContain("2026年8月19日");
-    expect(html).toContain("更新 2026年8月20日");
+    const noteTrayRow = html.match(
+      /<a[^>]*data-note-tray-row[^>]*>[\s\S]*?<\/a>/,
+    )?.[0];
+    expect(noteTrayRow).toBeDefined();
+    expect(noteTrayRow).not.toContain("更新");
   });
 });
 

--- a/packages/zudo-doc/src/site-tree-nav-island/__tests__/site-tree-nav-ssg.test.tsx
+++ b/packages/zudo-doc/src/site-tree-nav-island/__tests__/site-tree-nav-ssg.test.tsx
@@ -183,7 +183,7 @@ describe("SiteTreeNav — note-tray blocks", () => {
 
     expect(html).toContain('<time datetime="2026-08-19"');
     expect(html).toContain("Aug 19, 2026");
-    expect(html).toContain("Updated Aug 20, 2026");
+    expect(html).not.toContain("Updated");
     expect(html).not.toContain("data-note-tray-group");
   });
 
@@ -242,7 +242,7 @@ describe("SiteTreeNav — note-tray blocks", () => {
     expect(html).toContain('data-note-tray-group="2026-08"');
     expect(html).toContain("2026年8月");
     expect(html).toContain(">08-19</time>");
-    expect(html).toContain("更新 2026年8月15日");
+    expect(html).not.toContain("更新");
     expect(html.indexOf("Newest")).toBeLessThan(html.indexOf("Newer"));
     expect(html.indexOf("2026年8月")).toBeLessThan(html.indexOf("2026年7月"));
   });

--- a/packages/zudo-doc/src/site-tree-nav-island/index.tsx
+++ b/packages/zudo-doc/src/site-tree-nav-island/index.tsx
@@ -57,7 +57,7 @@ export interface SiteTreeNavProps {
   initiallyCollapsedCategorySlugs?: string[];
   /** Locale used by dated note-tray rows. */
   locale?: string;
-  /** Localized label shown before an item's updated date. */
+  /** @deprecated — no longer rendered (created date only). */
   updatedLabel?: string;
 }
 
@@ -332,11 +332,6 @@ function NoteTrayRow({
       )}
       <span className="min-w-0">
         <span>{item.label}</span>
-        {item.updated && (
-          <span className="block text-micro text-muted">
-            {updatedLabel} {formatDate(item.updated, locale)}
-          </span>
-        )}
       </span>
     </a>
   );


### PR DESCRIPTION
Parent: #3653
Implements: #3655

## Summary

- remove rendered updated dates from SiteTreeNav note-tray rows
- preserve the public updatedLabel prop as deprecated compatibility surface
- update SSG and home-page assertions

## Verification

- package build and 2,383 package tests passed
- type/content checks passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/3664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790035959&installation_model_id=20910&pr_number=3664&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F3664&signature=054f66803bf90696b9087966ee6e4507198b40d542a5e0f811ea756c4bc8d8cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->