### PR TITLE
[Browser Embed][Sub] Catalog v2: add hasStylesheet, fail closed on v1

### DIFF
--- a/packages/zudo-doc/scripts/check-catalog.mjs
+++ b/packages/zudo-doc/scripts/check-catalog.mjs
@@ -7,10 +7,12 @@
 // stale manifest for consumers (mirrors check-theme-packs.mjs).
 //
 // Asserts: dist/catalog.js and dist/catalog.d.ts exist, the manifest has
-// schemaVersion 1, exactly 31 packs (the current bundled pack count —
-// zudolab/zudo-doc#3349 acceptance criterion), and every pack carries the
-// full preview.{light,dark} swatch fields the catalog exists to serve
-// (bg/fg/accent/syntax).
+// schemaVersion 2, exactly 31 packs (the current bundled pack count —
+// zudolab/zudo-doc#3349 acceptance criterion), every entry carries the
+// registry-derived `hasStylesheet` boolean, and every pack carries the full
+// preview.{light,dark} swatch fields the catalog exists to serve
+// (bg/fg/accent/syntax). Catalog schemaVersion 2 is independent from each
+// pack's own meta.json schemaVersion 1.
 //
 // Exit 0 → dist/catalog.js is valid and complete.
 // Exit 1 → missing artifact or a shape violation (with a clear diagnostic).
@@ -37,7 +39,7 @@ if (!existsSync(DIST_JS) || !existsSync(DIST_DTS)) {
   process.exit(1);
 }
 
-const { default: catalog } = await import(DIST_JS);
+const { default: catalog, validateThemePackCatalog } = await import(DIST_JS);
 
 let allOk = true;
 function fail(message) {
@@ -45,8 +47,18 @@ function fail(message) {
   allOk = false;
 }
 
-if (catalog.schemaVersion !== 1) {
-  fail(`schemaVersion must be 1, got ${JSON.stringify(catalog.schemaVersion)}.`);
+if (typeof validateThemePackCatalog !== "function") {
+  fail("catalog must export validateThemePackCatalog(value).");
+} else {
+  try {
+    validateThemePackCatalog(catalog);
+  } catch (err) {
+    fail(`catalog validator rejected the generated manifest: ${err.message}`);
+  }
+}
+
+if (catalog.schemaVersion !== 2) {
+  fail(`schemaVersion must be 2, got ${JSON.stringify(catalog.schemaVersion)}.`);
 }
 if (!Array.isArray(catalog.packs)) {
   fail(`catalog.packs must be an array, got ${typeof catalog.packs}.`);
@@ -57,7 +69,14 @@ if (!Array.isArray(catalog.packs)) {
     );
   }
   for (const pack of catalog.packs) {
-    const preview = pack?.preview;
+    if (pack === null || typeof pack !== "object" || Array.isArray(pack)) {
+      fail("catalog entry must be an object.");
+      continue;
+    }
+    if (typeof pack.hasStylesheet !== "boolean") {
+      fail(`pack "${pack.slug}" is missing boolean hasStylesheet.`);
+    }
+    const preview = pack.meta?.preview;
     for (const mode of ["light", "dark"]) {
       const swatches = preview?.[mode];
       if (!swatches) {

--- a/packages/zudo-doc/scripts/gen-catalog.mjs
+++ b/packages/zudo-doc/scripts/gen-catalog.mjs
@@ -5,10 +5,12 @@
 // for the `@takazudo/zudo-doc/catalog` browser-safe data export (zudolab/
 // zudo-doc#3349, epic #3345 "theme catalog single-sourcing"). Aggregates
 // EVERY bundled theme pack's validated `meta.json` into one
-// `{ schemaVersion: 1, packs: ThemePackMeta[] }` manifest, `"default"` first
-// then alphabetical (the `resolveEnabledPacks` convention — this script calls
-// that same pure resolver with no settings so it resolves every pack, in that
-// canonical order).
+// `{ schemaVersion: 2, packs: ThemePackCatalogEntry[] }` manifest, `"default"`
+// first then alphabetical (the `resolveEnabledPacks` convention — this script
+// calls that same pure resolver with no settings so it resolves every pack, in
+// that canonical order). Catalog schema v2 is independent from the schema
+// version inside each pack's `meta.json` (currently v1); those two version
+// numbers must not be conflated.
 //
 // GENERATION SEQUENCING (binding, per the issue spec): this emits the
 // COMPLETE dist/ artifact pair directly, rather than generating a
@@ -57,15 +59,19 @@ try {
   process.exit(1);
 }
 const manifest = {
-  schemaVersion: 1,
-  packs: enabled.map((entry) => entry.meta),
+  schemaVersion: 2,
+  packs: enabled.map(({ slug, meta, hasStylesheet }) => ({
+    slug,
+    meta,
+    hasStylesheet,
+  })),
 };
 
-const banner = "// GENERATED FILE — do not edit by hand.\n// Produced by scripts/gen-catalog.mjs (zudolab/zudo-doc#3349) from the\n// validated src/theme-packs/<slug>/meta.json registry. Re-run `pnpm build`\n// to regenerate after adding, removing, or editing a theme pack.\n";
+const banner = "// GENERATED FILE — do not edit by hand.\n// Produced by scripts/gen-catalog.mjs (zudolab/zudo-doc#3349, #3675) from the\n// validated src/theme-packs/<slug>/meta.json registry. Re-run `pnpm build`\n// to regenerate after adding, removing, or editing a theme pack.\n// Catalog schemaVersion 2 is distinct from each pack's meta.json schemaVersion 1.\n";
 
 writeFileSync(
   DIST_JS,
-  `${banner}const catalog = ${JSON.stringify(manifest)};\n\nexport default catalog;\n`,
+  `${banner}const catalog = ${JSON.stringify(manifest)};\n\n/**\n * Validate the browser-facing catalog contract before consuming its entries.\n *\n * Catalog schemaVersion 2 is deliberately independent from the schemaVersion\n * in each pack's meta.json (currently 1). This validator checks the catalog\n * contract only; those per-pack metadata versions must not be conflated.\n */\nexport function validateThemePackCatalog(value) {\n  if (value === null || typeof value !== \"object\" || Array.isArray(value)) {\n    throw new TypeError(\n      \`@takazudo/zudo-doc/catalog: expected a catalog manifest object with schemaVersion 2; got \${describeCatalogValue(value)}.\`,\n    );\n  }\n\n  if (value.schemaVersion !== 2) {\n    throw new Error(\n      \`@takazudo/zudo-doc/catalog: unsupported catalog schemaVersion \${describeCatalogValue(value.schemaVersion)}; expected 2.\`,\n    );\n  }\n\n  if (!Array.isArray(value.packs)) {\n    throw new TypeError(\n      \`@takazudo/zudo-doc/catalog: catalog.packs must be an array; got \${describeCatalogValue(value.packs)}.\`,\n    );\n  }\n\n  for (const [index, entry] of value.packs.entries()) {\n    if (entry === null || typeof entry !== \"object\" || Array.isArray(entry)) {\n      throw new TypeError(\n        \`@takazudo/zudo-doc/catalog: catalog.packs[\${index}] must be an object; got \${describeCatalogValue(entry)}.\`,\n      );\n    }\n    if (typeof entry.slug !== \"string\") {\n      throw new TypeError(\n        \`@takazudo/zudo-doc/catalog: catalog.packs[\${index}].slug must be a string; got \${describeCatalogValue(entry.slug)}.\`,\n      );\n    }\n    if (entry.meta === null || typeof entry.meta !== \"object\" || Array.isArray(entry.meta)) {\n      throw new TypeError(\n        \`@takazudo/zudo-doc/catalog: catalog.packs[\${index}].meta must be an object; got \${describeCatalogValue(entry.meta)}.\`,\n      );\n    }\n    if (typeof entry.hasStylesheet !== \"boolean\") {\n      throw new TypeError(\n        \`@takazudo/zudo-doc/catalog: catalog.packs[\${index}].hasStylesheet must be a boolean; got \${describeCatalogValue(entry.hasStylesheet)}.\`,\n      );\n    }\n  }\n\n  return value;\n}\n\n/** @param {unknown} value */\nfunction describeCatalogValue(value) {\n  if (value === undefined) return \"undefined\";\n  try {\n    const json = JSON.stringify(value);\n    return json === undefined ? String(value) : json;\n  } catch {\n    return String(value);\n  }\n}\n\nexport default catalog;\n`,
 );
 
 writeFileSync(
@@ -74,17 +80,48 @@ writeFileSync(
 
 export type { ThemePackMeta };
 
-/** The aggregated theme-pack catalog manifest shape — mirrors the
- *  postBuild-time \`theme-packs/index.json\` registry manifest
- *  (\`ThemePacksIndexManifest\` in plugins/internal/theme-packs/types.ts),
- *  duplicated here rather than imported so this module stays free of any
- *  node-touching import chain. */
-export interface ThemePacksIndexManifest {
-  schemaVersion: 1;
-  packs: ThemePackMeta[];
+/** One entry in the browser-facing catalog (catalog schemaVersion 2). */
+export interface ThemePackCatalogEntry {
+  /** The pack directory slug. */
+  slug: string;
+  /** The pack's metadata; its own meta.json schemaVersion is currently 1. */
+  meta: ThemePackMeta;
+  /** Whether the pack ships a pack.css stylesheet, from the real registry. */
+  hasStylesheet: boolean;
 }
 
-declare const catalog: ThemePacksIndexManifest;
+/** The v2 catalog entry is structurally the same as a resolved registry entry. */
+export type ThemePackRegistryEntry = ThemePackCatalogEntry;
+
+/**
+ * The browser-facing theme-pack catalog manifest.
+ *
+ * This catalog schemaVersion 2 is distinct from each pack's meta.json
+ * schemaVersion 1. The two version numbers are unrelated and must not be
+ * conflated. The manifest is declared here instead of importing the
+ * postBuild-time theme-packs/index.json type so the browser export keeps its
+ * own contract and remains free of node-touching imports.
+ */
+export interface ThemePacksCatalogManifest {
+  schemaVersion: 2;
+  packs: ThemePackCatalogEntry[];
+}
+
+/**
+ * @deprecated Use ThemePacksCatalogManifest. This catalog-only legacy name is
+ * not the postBuild plugin's separate \`ThemePacksIndexManifest\` type.
+ */
+export type ThemePacksIndexManifest = ThemePacksCatalogManifest;
+
+/**
+ * Validate and return a browser-facing catalog manifest. Throws when the
+ * catalog is not schemaVersion 2 or has malformed v2 entries.
+ */
+export declare function validateThemePackCatalog(
+  value: unknown,
+): ThemePacksCatalogManifest;
+
+declare const catalog: ThemePacksCatalogManifest;
 export default catalog;
 `,
 );

--- a/packages/zudo-doc/src/__tests__/catalog.test.ts
+++ b/packages/zudo-doc/src/__tests__/catalog.test.ts
@@ -13,12 +13,13 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PKG_ROOT = resolve(__dirname, "../..");
+const DIST_DTS = resolve(PKG_ROOT, "dist/catalog.d.ts");
 
 describe("@takazudo/zudo-doc/catalog", () => {
   it("aggregates every bundled theme pack, default first then alphabetical", async () => {
     const { default: catalog } = await import(resolve(PKG_ROOT, "dist/catalog.js"));
 
-    expect(catalog.schemaVersion).toBe(1);
+    expect(catalog.schemaVersion).toBe(2);
     expect(catalog.packs.length).toBe(31);
     expect(catalog.packs[0].slug).toBe("default");
 
@@ -30,8 +31,9 @@ describe("@takazudo/zudo-doc/catalog", () => {
     const { default: catalog } = await import(resolve(PKG_ROOT, "dist/catalog.js"));
 
     for (const pack of catalog.packs) {
+      expect(typeof pack.hasStylesheet, `${pack.slug}.hasStylesheet`).toBe("boolean");
       for (const mode of ["light", "dark"] as const) {
-        const swatches = pack.preview[mode];
+        const swatches = pack.meta.preview[mode];
         expect(swatches.bg, `${pack.slug}.preview.${mode}.bg`).toBeTruthy();
         expect(swatches.fg, `${pack.slug}.preview.${mode}.fg`).toBeTruthy();
         expect(swatches.accent, `${pack.slug}.preview.${mode}.accent`).toBeTruthy();
@@ -41,6 +43,52 @@ describe("@takazudo/zudo-doc/catalog", () => {
         expect(swatches.syntax.callable, `${pack.slug}.preview.${mode}.syntax.callable`).toBeTruthy();
       }
     }
+  });
+
+  it("carries hasStylesheet from the filesystem registry, not a slug heuristic", async () => {
+    const { default: catalog } = await import(resolve(PKG_ROOT, "dist/catalog.js"));
+    const { loadThemePackRegistry, resolveEnabledPacks } = await import(
+      resolve(PKG_ROOT, "dist/theme-packs-registry/index.js"),
+    );
+    const registry = loadThemePackRegistry(resolve(PKG_ROOT, "src/theme-packs"));
+    const enabled = resolveEnabledPacks(registry, {});
+
+    expect(
+      catalog.packs.map((pack: { slug: string; hasStylesheet: boolean }) => [
+        pack.slug,
+        pack.hasStylesheet,
+      ]),
+    ).toEqual(
+      enabled.map((entry: { slug: string; hasStylesheet: boolean }) => [
+        entry.slug,
+        entry.hasStylesheet,
+      ]),
+    );
+  });
+
+  it("exports a v2 validator that rejects a v1-shaped manifest", async () => {
+    const { default: catalog, validateThemePackCatalog } = await import(
+      resolve(PKG_ROOT, "dist/catalog.js"),
+    );
+
+    expect(validateThemePackCatalog(catalog)).toBe(catalog);
+    const v1Manifest = {
+      schemaVersion: 1,
+      packs: catalog.packs.map((pack: { meta: unknown }) => pack.meta),
+    };
+    expect(() => validateThemePackCatalog(v1Manifest)).toThrow(
+      /schemaVersion 1.*expected 2/,
+    );
+  });
+
+  it("declares the v2 manifest and entry types in the generated declaration", async () => {
+    const fs = await import("node:fs/promises");
+    const dts = await fs.readFile(DIST_DTS, "utf8");
+
+    expect(dts).toContain("interface ThemePackCatalogEntry");
+    expect(dts).toContain("interface ThemePacksCatalogManifest");
+    expect(dts).toContain("hasStylesheet: boolean");
+    expect(dts).toContain("validateThemePackCatalog");
   });
 
   it("exposes the ./catalog subpath export", async () => {


### PR DESCRIPTION
Parent: #3672

Closes #3675

## Summary

- advances the theme-pack catalog to schema v2 with an explicit `hasStylesheet` capability
- makes older v1 data fail closed so consumers never infer a stylesheet that is not declared

## Test plan

- package unit tests
- catalog build and prepack-contract checks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/3688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790309412&installation_model_id=20910&pr_number=3688&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F3688&signature=3d200e8f187564f46e192674bf9fc39e0706ff3d9e440c8f5680039ffdfaf0d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->