### PR TITLE
[Browser Embed][Sub] Extract a browser-safe payload-types leaf

### DIFF
--- a/packages/zudo-doc/scripts/site-schema-graph.mjs
+++ b/packages/zudo-doc/scripts/site-schema-graph.mjs
@@ -15,6 +15,8 @@
 // fails to resolve, or gets inlined away.
 
 import { createRequire } from "node:module";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 
 /** Specifier classes that must never be reachable from `./site-schema`. */
 export const FORBIDDEN_SPECIFIERS = [
@@ -28,6 +30,56 @@ export const FORBIDDEN_SPECIFIERS = [
 /** The forbidden class a specifier belongs to, or `undefined` when it is fine. */
 export function forbiddenLabel(specifier) {
   return FORBIDDEN_SPECIFIERS.find((rule) => rule.pattern.test(specifier))?.label;
+}
+
+/** Every `from "..."` specifier in a declaration file. */
+export function declarationSpecifiers(source) {
+  return [...source.matchAll(/\bfrom\s*["']([^"']+)["']/g)].map((match) => match[1]);
+}
+
+/** Resolve a relative `.js`/extensionless specifier to its emitted `.d.ts`. */
+export function resolveDeclaration(fromFile, specifier) {
+  const base = resolve(dirname(fromFile), specifier);
+  for (const candidate of [
+    base.replace(/\.js$/, ".d.ts"),
+    `${base}.d.ts`,
+    resolve(base, "index.d.ts"),
+  ]) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+/**
+ * Walk the transitive emitted declaration graph rooted at `entry` and report
+ * forbidden package/specifier classes using the same rules as the JS guard.
+ *
+ * @param {string} entry - absolute path to an emitted `.d.ts` file.
+ * @returns {{ violations: Array<{ specifier: string, label: string, importer: string }>, files: string[] }}
+ */
+export function analyzeDeclarationGraph(entry) {
+  const seen = new Set();
+  const violations = [];
+  const queue = [entry];
+
+  while (queue.length > 0) {
+    const file = queue.pop();
+    if (seen.has(file)) continue;
+    seen.add(file);
+
+    for (const specifier of declarationSpecifiers(readFileSync(file, "utf8"))) {
+      const label = forbiddenLabel(specifier);
+      if (label) {
+        violations.push({ specifier, label, importer: file });
+        continue;
+      }
+      if (!specifier.startsWith(".")) continue;
+      const next = resolveDeclaration(file, specifier);
+      if (next) queue.push(next);
+    }
+  }
+
+  return { violations, files: [...seen].sort() };
 }
 
 /**

--- a/packages/zudo-doc/src/__tests__/route-context-payload-types.test.ts
+++ b/packages/zudo-doc/src/__tests__/route-context-payload-types.test.ts
@@ -1,0 +1,53 @@
+// Declaration-graph contract for the browser-safe route-context payload leaf.
+
+import { describe, expect, it } from "vitest";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = resolve(__dirname, "../..");
+const DIST_DTS = resolve(PKG_ROOT, "dist/route-context-payload/types.d.ts");
+const FACTORY_CONTEXT_DTS = resolve(PKG_ROOT, "dist/factory-context/index.d.ts");
+
+interface DeclarationGraph {
+  analyzeDeclarationGraph(entry: string): {
+    violations: Array<{ specifier: string; label: string; importer: string }>;
+    files: string[];
+  };
+}
+
+async function loadGraphHelper(): Promise<DeclarationGraph> {
+  const url = pathToFileURL(resolve(PKG_ROOT, "scripts/site-schema-graph.mjs")).href;
+  return (await import(/* @vite-ignore */ url)) as DeclarationGraph;
+}
+
+describe("route-context payload type leaf", () => {
+  it("has a transitively browser-clean emitted declaration graph", async () => {
+    expect(
+      existsSync(DIST_DTS),
+      `${DIST_DTS} missing — run \`pnpm --filter @takazudo/zudo-doc build\``,
+    ).toBe(true);
+
+    const { analyzeDeclarationGraph } = await loadGraphHelper();
+    const { violations, files } = analyzeDeclarationGraph(DIST_DTS);
+
+    expect(
+      violations,
+      violations.map((v) => `${v.specifier} (${v.label}) declared in ${v.importer}`).join("\n"),
+    ).toEqual([]);
+    // RouteContextPayload's default Settings generic makes this a real
+    // transitive walk rather than a single-file inspection.
+    expect(files.length).toBeGreaterThan(1);
+  });
+
+  it("keeps RouteContextPayload available from factory-context", () => {
+    expect(
+      existsSync(FACTORY_CONTEXT_DTS),
+      `${FACTORY_CONTEXT_DTS} missing — run \`pnpm --filter @takazudo/zudo-doc build\``,
+    ).toBe(true);
+    expect(readFileSync(FACTORY_CONTEXT_DTS, "utf8")).toContain(
+      'export type { RouteContextPayload } from "../route-context-payload/types.js";',
+    );
+  });
+});

--- a/packages/zudo-doc/src/__tests__/site-schema.test.ts
+++ b/packages/zudo-doc/src/__tests__/site-schema.test.ts
@@ -57,6 +57,10 @@ const DIST_DTS = resolve(PKG_ROOT, "dist/site-schema/index.d.ts");
 // vitest both resolve it, and TypeScript never has to.
 interface SiteSchemaGraph {
   forbiddenLabel(specifier: string): string | undefined;
+  analyzeDeclarationGraph(entry: string): {
+    violations: Array<{ specifier: string; label: string; importer: string }>;
+    files: string[];
+  };
   analyzeSiteSchemaGraph(args: { entry: string; resolveFrom: string[] }): Promise<{
     violations: Array<{ specifier: string; label: string; importer: string }>;
     specifiers: string[];
@@ -478,55 +482,20 @@ describe("site-schema stays browser-safe", () => {
 // (4b) Browser safety — TRANSITIVE declaration graph
 // ---------------------------------------------------------------------------
 
-/** Every `from "…"` specifier in a declaration file. */
-function declarationSpecifiers(source: string): string[] {
-  return [...source.matchAll(/\bfrom\s*["']([^"']+)["']/g)].map((m) => m[1] as string);
-}
-
-/** Resolve a relative `.js`/extensionless specifier to its emitted `.d.ts`. */
-function resolveDeclaration(fromFile: string, specifier: string): string | undefined {
-  const base = resolve(dirname(fromFile), specifier);
-  for (const candidate of [
-    base.replace(/\.js$/, ".d.ts"),
-    `${base}.d.ts`,
-    resolve(base, "index.d.ts"),
-  ]) {
-    if (existsSync(candidate)) return candidate;
-  }
-  return undefined;
-}
-
 describe("site-schema declaration graph", () => {
   it("never reaches @takazudo/zfb (or any other forbidden package) transitively", async () => {
-    const { forbiddenLabel } = await loadGraphHelper();
+    const { analyzeDeclarationGraph } = await loadGraphHelper();
     expect(
       existsSync(DIST_DTS),
       `${DIST_DTS} missing — run \`pnpm --filter @takazudo/zudo-doc build\``,
     ).toBe(true);
 
-    const seen = new Set<string>();
-    const violations: string[] = [];
-    const queue = [DIST_DTS];
-
-    while (queue.length > 0) {
-      const file = queue.pop() as string;
-      if (seen.has(file)) continue;
-      seen.add(file);
-
-      for (const specifier of declarationSpecifiers(readFileSync(file, "utf8"))) {
-        const label = forbiddenLabel(specifier);
-        if (label) {
-          violations.push(`${specifier} (${label}) declared in ${file}`);
-          continue;
-        }
-        if (!specifier.startsWith(".")) continue;
-        const next = resolveDeclaration(file, specifier);
-        if (next) queue.push(next);
-      }
-    }
-
-    expect(violations, violations.join("\n")).toEqual([]);
+    const { violations, files } = analyzeDeclarationGraph(DIST_DTS);
+    expect(
+      violations,
+      violations.map((v) => `${v.specifier} (${v.label}) declared in ${v.importer}`).join("\n"),
+    ).toEqual([]);
     // The walk must have covered more than the barrel itself.
-    expect(seen.size).toBeGreaterThan(1);
+    expect(files.length).toBeGreaterThan(1);
   });
 });

--- a/packages/zudo-doc/src/color-scheme-utils.ts
+++ b/packages/zudo-doc/src/color-scheme-utils.ts
@@ -22,60 +22,30 @@
  * scheme names, `colorMode` settings) stays project-side.
  */
 
-/** A color literal — an `oklch(…)` (or any valid CSS color) string. */
-export type OKLCH = string;
+import type {
+  ColorScheme,
+  ModeMap,
+  OKLCH,
+  RampRef,
+  Ramps,
+  SemanticKey,
+  StateRole,
+  SyntaxSemanticKey,
+} from "./route-context-payload/types.js";
 
-/** The four semantic state colors that live on their own ramp. */
-export type StateRole = "danger" | "success" | "warning" | "info";
+export type {
+  ColorScheme,
+  ModeMap,
+  OKLCH,
+  RampRef,
+  Ramps,
+  SemanticKey,
+  StateRole,
+  SyntaxSemanticKey,
+} from "./route-context-payload/types.js";
 
 /** Canonical order of the state ramp — used for `--palette-state-*` emit. */
 export const STATE_ROLES: readonly StateRole[] = ["danger", "success", "warning", "info"];
-
-/**
- * A reference into the shared ramps, resolved by `resolveRampRef`:
- *   - `{ base: n }`   → `ramps.base[n]`
- *   - `{ accent: n }` → `ramps.accent[n]`
- *   - `{ state: r }`  → `ramps.state[r]`
- *   - a bare string   → a literal OKLCH value, returned as-is
- */
-export type RampRef = { base: number } | { accent: number } | { state: StateRole } | OKLCH;
-
-/** The shared Tier-1 ramps. Values are identical across light/dark modes; the
- *  per-mode differences live in `ModeMap`, not here. */
-export interface Ramps {
-  /** Warm-neutral base ramp — 5 entries, index 0 = lightest. */
-  base: OKLCH[];
-  /** Accent ramp — 3 entries. */
-  accent: OKLCH[];
-  /** The four state colors. */
-  state: Record<StateRole, OKLCH>;
-}
-
-/** The 23 semantic roles that map onto `--zd-*` custom properties. */
-export type SemanticKey =
-  | "surface"
-  | "muted"
-  | "accent"
-  | "accentHover"
-  | "codeBg"
-  | "codeFg"
-  | "success"
-  | "danger"
-  | "warning"
-  | "info"
-  | "mermaidNodeBg"
-  | "mermaidText"
-  | "mermaidLine"
-  | "mermaidLabelBg"
-  | "mermaidNoteBg"
-  | "chatUserBg"
-  | "chatUserText"
-  | "chatAssistantBg"
-  | "chatAssistantText"
-  | "imageOverlayBg"
-  | "imageOverlayFg"
-  | "matchedKeywordBg"
-  | "matchedKeywordFg";
 
 /** Canonical order of the 23 semantic roles — used for `--zd-*` emit. */
 export const SEMANTIC_KEYS: readonly SemanticKey[] = [
@@ -121,8 +91,6 @@ export const SYNTAX_SEMANTIC_KEYS = [
   "syntaxDeleted",
 ] as const;
 
-export type SyntaxSemanticKey = (typeof SYNTAX_SEMANTIC_KEYS)[number];
-
 /** Existing semantic role inherited when a syntax role has no explicit map. */
 export const SYNTAX_SEMANTIC_ALIASES: Readonly<Record<SyntaxSemanticKey, SemanticKey>> = {
   syntaxComment: "muted",
@@ -147,27 +115,6 @@ export const SYNTAX_CSS_NAMES: Readonly<Record<SyntaxSemanticKey, string>> = {
   syntaxInserted: "--zd-syntax-inserted",
   syntaxDeleted: "--zd-syntax-deleted",
 };
-
-/** The per-mode wiring: each UI role points at a ramp stop (or literal OKLCH)
- *  via a `RampRef`. Two `ColorScheme`s (light + dark) share `ramps` but carry
- *  their own `ModeMap`. */
-export interface ModeMap {
-  bg: RampRef;
-  fg: RampRef;
-  selectionBg: RampRef;
-  selectionFg: RampRef;
-  semantic: Record<SemanticKey, RampRef>;
-  /** Optional syntax-specific overrides. An absent map and omitted roles
-   *  inherit the aliases in `SYNTAX_SEMANTIC_ALIASES`, preserving schemes
-   *  authored before syntax tokens existed. */
-  syntax?: Partial<Record<SyntaxSemanticKey, RampRef>>;
-}
-
-/** A complete color scheme — shared Tier-1 ramps + per-mode Tier-2 wiring. */
-export interface ColorScheme {
-  ramps: Ramps;
-  map: ModeMap;
-}
 
 /** Default per-mode semantic wiring (Default Dark reference — see epic #2584).
  *  Scheme authors spread this into `map.semantic` and override individual roles

--- a/packages/zudo-doc/src/factory-context/index.ts
+++ b/packages/zudo-doc/src/factory-context/index.ts
@@ -15,11 +15,14 @@
 // This module is **types only** — no runtime values, no node builtins — so it
 // stays importable from the config eval graph and from client islands alike.
 
-import type { Settings, TagVocabularyEntry } from "../settings.js";
+import type { Settings } from "../settings.js";
 // Type-only imports (erased at build — they never enter the runtime/eval graph,
 // so this module stays node-free; the foundation-eval-graph guard covers it).
-import type { ColorScheme } from "../color-scheme-utils.js";
-import type { ThemePackRegistry } from "../theme-packs-registry/index.js";
+import type {
+  ColorScheme,
+  RouteContextPayload,
+  ThemePackRegistry,
+} from "../route-context-payload/types.js";
 import type { UrlHelpers } from "../url-helpers/index.js";
 import type { NavSourceDocsAPI } from "../nav-source-docs/index.js";
 import type { DocRouteEntriesAPI } from "../doc-route-entries/index.js";
@@ -29,6 +32,8 @@ import type { DocNavNode, DocPageEntry } from "../doc-page-props/index.js";
 import type { HeadingItem } from "../extract-headings/index.js";
 import type { CategoryMeta } from "../sidebar-tree/index.js";
 import type { HeaderRightComponentRegistry } from "../header/types.js";
+
+export type { RouteContextPayload } from "../route-context-payload/types.js";
 
 /**
  * The i18n surface a factory may read. Parameterizes what `base.ts` used to read
@@ -130,39 +135,6 @@ export interface FactoryContext<S = Settings> {
 // (all imports above are `import type`, erased at build), so this module stays
 // importable from the config eval graph and client islands unchanged.
 // ===========================================================================
-
-/**
- * The serializable route-context payload carried by the
- * `virtual:zudo-doc-route-context` module (ADR `route-injection-seam.md`,
- * Decision 1) — DATA ONLY, no callables. `createRouteContext` rebuilds the full
- * runtime context from it by calling the importable package factories.
- */
-export interface RouteContextPayload<S = Settings> {
-  /** The host's resolved settings object. */
-  settings: S;
-  /** Per-locale UI-string tables (`translations[locale][key]`). */
-  translations: Record<string, Record<string, string>>;
-  /** The tag vocabulary (used only when `settings.tagVocabulary` is on). */
-  tagVocabulary: readonly TagVocabularyEntry[];
-  /** Host color-scheme palette map; `null` when the host passed none (chrome
-   *  then falls back to a neutral default scheme). */
-  colorSchemes: Record<string, ColorScheme> | null;
-  /**
-   * Resolved, enabled, ordered theme-pack registry (ADR
-   * `docs/adr/theme-packs.md`, Decision 2 "Registry threading to
-   * SSR/islands") — settings ∩ the bundled `theme-packs/` directories, in
-   * switcher order. `null` (or omitted) renders the whole feature inert (same
-   * accepted coupling class as {@link colorSchemes} for a
-   * `packageOwnedRoutes: false` host that builds its own payload without
-   * threading one).
-   *
-   * OPTIONAL on purpose: this field was added after the payload shape
-   * shipped, so an existing `packageOwnedRoutes: false` host that constructs
-   * its own payload predates it. `createRouteContext` normalizes an omitted
-   * value to `null` (→ inert) so upgrading such a host does not throw at SSR.
-   */
-  themePackRegistry?: ThemePackRegistry | null;
-}
 
 /** Aggregated `tag → docs` index entry built by `collectTags`. */
 export interface TagInfo {

--- a/packages/zudo-doc/src/route-context-payload/types.ts
+++ b/packages/zudo-doc/src/route-context-payload/types.ts
@@ -1,0 +1,161 @@
+// Browser-safe data contract for the serializable route-context payload.
+//
+// Keep this module types-only and deliberately narrow. Browser consumers use
+// its emitted declaration without traversing the broader factory-context or
+// the node-backed theme-pack registry barrel.
+
+import type { Settings } from "../settings.js";
+
+/** A color literal — an `oklch(...)` (or any valid CSS color) string. */
+export type OKLCH = string;
+
+/** The four semantic state colors that live on their own ramp. */
+export type StateRole = "danger" | "success" | "warning" | "info";
+
+/**
+ * A reference into the shared ramps:
+ * `{ base: n }`, `{ accent: n }`, `{ state: role }`, or a literal color.
+ */
+export type RampRef = { base: number } | { accent: number } | { state: StateRole } | OKLCH;
+
+/** The shared Tier-1 color ramps. */
+export interface Ramps {
+  base: OKLCH[];
+  accent: OKLCH[];
+  state: Record<StateRole, OKLCH>;
+}
+
+/** The semantic UI roles mapped by a color scheme. */
+export type SemanticKey =
+  | "surface"
+  | "muted"
+  | "accent"
+  | "accentHover"
+  | "codeBg"
+  | "codeFg"
+  | "success"
+  | "danger"
+  | "warning"
+  | "info"
+  | "mermaidNodeBg"
+  | "mermaidText"
+  | "mermaidLine"
+  | "mermaidLabelBg"
+  | "mermaidNoteBg"
+  | "chatUserBg"
+  | "chatUserText"
+  | "chatAssistantBg"
+  | "chatAssistantText"
+  | "imageOverlayBg"
+  | "imageOverlayFg"
+  | "matchedKeywordBg"
+  | "matchedKeywordFg";
+
+/** The syntax-specific semantic roles mapped by a color scheme. */
+export type SyntaxSemanticKey =
+  | "syntaxComment"
+  | "syntaxString"
+  | "syntaxNumber"
+  | "syntaxKeyword"
+  | "syntaxCallable"
+  | "syntaxType"
+  | "syntaxName"
+  | "syntaxInserted"
+  | "syntaxDeleted";
+
+/** The per-mode wiring from UI roles to ramp stops or literal colors. */
+export interface ModeMap {
+  bg: RampRef;
+  fg: RampRef;
+  selectionBg: RampRef;
+  selectionFg: RampRef;
+  semantic: Record<SemanticKey, RampRef>;
+  syntax?: Partial<Record<SyntaxSemanticKey, RampRef>>;
+}
+
+/** A complete color scheme — shared Tier-1 ramps + per-mode Tier-2 wiring. */
+export interface ColorScheme {
+  ramps: Ramps;
+  map: ModeMap;
+}
+
+/**
+ * A single tag-vocabulary entry. Content uses `id` exactly; the optional
+ * display metadata does not introduce alias or deprecation semantics.
+ */
+export interface TagVocabularyEntry {
+  id: string;
+  label?: string;
+  description?: string;
+  group?: string;
+}
+
+/** Resolved preview swatches for one theme-pack mode. */
+export interface ThemePackSwatches {
+  bg: string;
+  fg: string;
+  accent: string;
+  syntax: {
+    keyword: string;
+    string: string;
+    comment: string;
+    callable: string;
+  };
+}
+
+/**
+ * A theme pack's schema-validated metadata. `mode` is its designed-primary
+ * badge; each pack still supplies both light and dark preview swatches.
+ */
+export interface ThemePackMeta {
+  schemaVersion: 1;
+  slug: string;
+  name: string;
+  description: string;
+  mode: "light" | "dark";
+  version: string;
+  fonts: {
+    sans: string;
+    mono: string;
+    display?: string;
+    loaded: string[];
+  };
+  preview: {
+    light: ThemePackSwatches;
+    dark: ThemePackSwatches;
+  };
+}
+
+/** One entry in the aggregated, canonically ordered bundled registry. */
+export interface ThemePackRegistryEntry {
+  /** The pack directory name, equal to `meta.slug`. */
+  slug: string;
+  /** The pack's schema-validated metadata. */
+  meta: ThemePackMeta;
+  /** Whether the pack ships `pack.css` (`false` for the stock default pack). */
+  hasStylesheet: boolean;
+}
+
+/** The full bundled registry, or an enabled ordered subset of it. */
+export type ThemePackRegistry = ThemePackRegistryEntry[];
+
+/**
+ * Serializable data carried by `virtual:zudo-doc-route-context`.
+ * `createRouteContext` reconstructs all runtime callables from this payload.
+ */
+export interface RouteContextPayload<S = Settings> {
+  /** The host's resolved settings object. */
+  settings: S;
+  /** Per-locale UI-string tables (`translations[locale][key]`). */
+  translations: Record<string, Record<string, string>>;
+  /** The tag vocabulary (used only when `settings.tagVocabulary` is on). */
+  tagVocabulary: readonly TagVocabularyEntry[];
+  /** Host color-scheme palette map, or `null` when the host passed none. */
+  colorSchemes: Record<string, ColorScheme> | null;
+  /**
+   * Resolved, enabled, ordered theme-pack registry. Optional for compatibility
+   * with hosts that constructed the payload before registry threading shipped;
+   * `createRouteContext` normalizes omission to `null` (feature inert).
+   */
+  themePackRegistry?: ThemePackRegistry | null;
+}

--- a/packages/zudo-doc/src/settings.ts
+++ b/packages/zudo-doc/src/settings.ts
@@ -22,23 +22,7 @@
  */
 export type TagGovernanceMode = "off" | "warn" | "strict";
 
-/**
- * A single entry in the tag vocabulary.
- *
- * - `id`         — canonical tag id. What content files should ideally use.
- * - `label`      — optional human-readable label (falls back to `id`).
- * - `description`— optional short description for tooling / tag index pages.
- * - `group`      — optional grouping key used by the grouped tag footer
- *                  (e.g. `"type"`, `"level"`, `"topic"`).
- * Content must use `id` exactly. Retired or misspelled ids are unknown tags;
- * the vocabulary intentionally has no alias or deprecation migration fields.
- */
-export interface TagVocabularyEntry {
-  id: string;
-  label?: string;
-  description?: string;
-  group?: string;
-}
+export type { TagVocabularyEntry } from "./route-context-payload/types.js";
 
 export interface HeaderNavChildItem {
   label: string;

--- a/packages/zudo-doc/src/theme-packs-registry/load-registry.ts
+++ b/packages/zudo-doc/src/theme-packs-registry/load-registry.ts
@@ -13,22 +13,17 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 
-import type { ThemePackMeta } from "./meta-schema.js";
+import type {
+  ThemePackMeta,
+  ThemePackRegistry,
+  ThemePackRegistryEntry,
+} from "../route-context-payload/types.js";
 import { validateThemePack } from "./validator.js";
 
-/** One entry in the aggregated, canonically-ordered bundled registry. */
-export interface ThemePackRegistryEntry {
-  /** The pack's directory name (equals `meta.slug`). */
-  slug: string;
-  /** The pack's schema-validated `meta.json`. */
-  meta: ThemePackMeta;
-  /** Whether this pack ships a `pack.css` (always `false` for `"default"`). */
-  hasStylesheet: boolean;
-}
-
-/** The full bundled registry, or a subset of it (after `resolveEnabledPacks`)
- *  — an ordered array; order carries meaning (canonical / switcher order). */
-export type ThemePackRegistry = ThemePackRegistryEntry[];
+export type {
+  ThemePackRegistry,
+  ThemePackRegistryEntry,
+} from "../route-context-payload/types.js";
 
 function readFontFiles(fontsDir: string): string[] {
   if (!existsSync(fontsDir)) return [];

--- a/packages/zudo-doc/src/theme-packs-registry/meta-schema.ts
+++ b/packages/zudo-doc/src/theme-packs-registry/meta-schema.ts
@@ -10,6 +10,9 @@
 // dragging in filesystem access itself.
 
 import { z } from "zod";
+import type { ThemePackMeta, ThemePackSwatches } from "../route-context-payload/types.js";
+
+export type { ThemePackMeta, ThemePackSwatches } from "../route-context-payload/types.js";
 
 /** `[a-z0-9][a-z0-9-]*` — a pack's slug MUST equal its directory name
  *  (Decision 6.7 "slug regex + dir-name parity"). */
@@ -35,11 +38,7 @@ const themePackSwatchesSchema = z.object({
     comment: z.string().min(1),
     callable: z.string().min(1),
   }),
-});
-
-/** Preview swatches for the dialog grid — RESOLVED plain CSS colors, one set
- *  per mode. See {@link themePackMetaSchema}'s `preview` field. */
-export type ThemePackSwatches = z.infer<typeof themePackSwatchesSchema>;
+}) satisfies z.ZodType<ThemePackSwatches>;
 
 export const themePackMetaSchema = z.object({
   schemaVersion: z.literal(1),
@@ -58,11 +57,4 @@ export const themePackMetaSchema = z.object({
     light: themePackSwatchesSchema,
     dark: themePackSwatchesSchema,
   }),
-});
-
-/**
- * A pack's `meta.json`, schema-validated (ADR Decision 1). `mode` is a
- * designed-primary badge only — every pack still defines BOTH modes via
- * `light-dark()` in `pack.css`.
- */
-export type ThemePackMeta = z.infer<typeof themePackMetaSchema>;
+}) satisfies z.ZodType<ThemePackMeta>;


### PR DESCRIPTION
Parent: #3672

Closes #3676

## Summary

- extracts browser-safe route-context payload types into a leaf module
- keeps browser consumers away from server-only imports while preserving the public type contract

## Test plan

- type checking
- browser dependency-graph and package unit tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/3689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790309414&installation_model_id=20910&pr_number=3689&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F3689&signature=fa6fcf646f33572f22833089d9839defbbf02a8f2d836041c2489a35d61469ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->