### PR TITLE
[Browser Embed][Sub] Implement the pre-hydration pending state

### DIFF
--- a/packages/zudo-doc/scripts/check-catalog.mjs
+++ b/packages/zudo-doc/scripts/check-catalog.mjs
@@ -7,10 +7,12 @@
 // stale manifest for consumers (mirrors check-theme-packs.mjs).
 //
 // Asserts: dist/catalog.js and dist/catalog.d.ts exist, the manifest has
-// schemaVersion 1, exactly 31 packs (the current bundled pack count —
-// zudolab/zudo-doc#3349 acceptance criterion), and every pack carries the
-// full preview.{light,dark} swatch fields the catalog exists to serve
-// (bg/fg/accent/syntax).
+// schemaVersion 2, exactly 31 packs (the current bundled pack count —
+// zudolab/zudo-doc#3349 acceptance criterion), every entry carries the
+// registry-derived `hasStylesheet` boolean, and every pack carries the full
+// preview.{light,dark} swatch fields the catalog exists to serve
+// (bg/fg/accent/syntax). Catalog schemaVersion 2 is independent from each
+// pack's own meta.json schemaVersion 1.
 //
 // Exit 0 → dist/catalog.js is valid and complete.
 // Exit 1 → missing artifact or a shape violation (with a clear diagnostic).
@@ -37,7 +39,7 @@ if (!existsSync(DIST_JS) || !existsSync(DIST_DTS)) {
   process.exit(1);
 }
 
-const { default: catalog } = await import(DIST_JS);
+const { default: catalog, validateThemePackCatalog } = await import(DIST_JS);
 
 let allOk = true;
 function fail(message) {
@@ -45,8 +47,18 @@ function fail(message) {
   allOk = false;
 }
 
-if (catalog.schemaVersion !== 1) {
-  fail(`schemaVersion must be 1, got ${JSON.stringify(catalog.schemaVersion)}.`);
+if (typeof validateThemePackCatalog !== "function") {
+  fail("catalog must export validateThemePackCatalog(value).");
+} else {
+  try {
+    validateThemePackCatalog(catalog);
+  } catch (err) {
+    fail(`catalog validator rejected the generated manifest: ${err.message}`);
+  }
+}
+
+if (catalog.schemaVersion !== 2) {
+  fail(`schemaVersion must be 2, got ${JSON.stringify(catalog.schemaVersion)}.`);
 }
 if (!Array.isArray(catalog.packs)) {
   fail(`catalog.packs must be an array, got ${typeof catalog.packs}.`);
@@ -57,7 +69,14 @@ if (!Array.isArray(catalog.packs)) {
     );
   }
   for (const pack of catalog.packs) {
-    const preview = pack?.preview;
+    if (pack === null || typeof pack !== "object" || Array.isArray(pack)) {
+      fail("catalog entry must be an object.");
+      continue;
+    }
+    if (typeof pack.hasStylesheet !== "boolean") {
+      fail(`pack "${pack.slug}" is missing boolean hasStylesheet.`);
+    }
+    const preview = pack.meta?.preview;
     for (const mode of ["light", "dark"]) {
       const swatches = preview?.[mode];
       if (!swatches) {

--- a/packages/zudo-doc/scripts/copy-eject-sources.mjs
+++ b/packages/zudo-doc/scripts/copy-eject-sources.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // scripts/copy-eject-sources.mjs
 //
-// Copy each ejectable component's source directory verbatim from
+// Copy each ejectable component's source directory from
 // `src/<component>/` into `eject/<component>/` so the package can ship TS
 // source for the `zudo-doc eject <component>` CLI (Decision 1 — C0 #2359).
 //
@@ -16,7 +16,16 @@
 // watch or otherwise. We wipe and recreate `eject/` here to keep the
 // output deterministic (no stale files from renamed or removed components).
 
-import { cpSync, copyFileSync, rmSync, mkdirSync, statSync, readdirSync } from "node:fs";
+import {
+  cpSync,
+  copyFileSync,
+  readFileSync,
+  rmSync,
+  mkdirSync,
+  statSync,
+  readdirSync,
+  writeFileSync,
+} from "node:fs";
 import { resolve, dirname, relative, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -88,6 +97,28 @@ for (const name of EJECTABLE) {
     copyFileSync(
       resolve(PKG_ROOT, "scripts/gen-nav-overflow-script.mjs"),
       resolve(destDir, "gen-nav-overflow-script.mjs"),
+    );
+  }
+
+  // ThemeToggle shares the package-internal hydration hook with another
+  // component. Keep the ejected copy self-contained by placing that hook
+  // beside its index and retargeting only the generated eject artifact.
+  if (name === "theme-toggle") {
+    const indexPath = resolve(destDir, "index.tsx");
+    const sourceImport = 'from "../hydration-pending.js"';
+    const indexSource = readFileSync(indexPath, "utf8");
+    if (!indexSource.includes(sourceImport)) {
+      throw new Error(
+        "[copy-eject-sources] theme-toggle hydration-pending import changed; update the eject rewrite.",
+      );
+    }
+    copyFileSync(
+      resolve(SRC_ROOT, "hydration-pending.ts"),
+      resolve(destDir, "hydration-pending.ts"),
+    );
+    writeFileSync(
+      indexPath,
+      indexSource.replace(sourceImport, 'from "./hydration-pending.js"'),
     );
   }
 

--- a/packages/zudo-doc/scripts/gen-catalog.mjs
+++ b/packages/zudo-doc/scripts/gen-catalog.mjs
@@ -5,10 +5,12 @@
 // for the `@takazudo/zudo-doc/catalog` browser-safe data export (zudolab/
 // zudo-doc#3349, epic #3345 "theme catalog single-sourcing"). Aggregates
 // EVERY bundled theme pack's validated `meta.json` into one
-// `{ schemaVersion: 1, packs: ThemePackMeta[] }` manifest, `"default"` first
-// then alphabetical (the `resolveEnabledPacks` convention — this script calls
-// that same pure resolver with no settings so it resolves every pack, in that
-// canonical order).
+// `{ schemaVersion: 2, packs: ThemePackCatalogEntry[] }` manifest, `"default"`
+// first then alphabetical (the `resolveEnabledPacks` convention — this script
+// calls that same pure resolver with no settings so it resolves every pack, in
+// that canonical order). Catalog schema v2 is independent from the schema
+// version inside each pack's `meta.json` (currently v1); those two version
+// numbers must not be conflated.
 //
 // GENERATION SEQUENCING (binding, per the issue spec): this emits the
 // COMPLETE dist/ artifact pair directly, rather than generating a
@@ -57,15 +59,19 @@ try {
   process.exit(1);
 }
 const manifest = {
-  schemaVersion: 1,
-  packs: enabled.map((entry) => entry.meta),
+  schemaVersion: 2,
+  packs: enabled.map(({ slug, meta, hasStylesheet }) => ({
+    slug,
+    meta,
+    hasStylesheet,
+  })),
 };
 
-const banner = "// GENERATED FILE — do not edit by hand.\n// Produced by scripts/gen-catalog.mjs (zudolab/zudo-doc#3349) from the\n// validated src/theme-packs/<slug>/meta.json registry. Re-run `pnpm build`\n// to regenerate after adding, removing, or editing a theme pack.\n";
+const banner = "// GENERATED FILE — do not edit by hand.\n// Produced by scripts/gen-catalog.mjs (zudolab/zudo-doc#3349, #3675) from the\n// validated src/theme-packs/<slug>/meta.json registry. Re-run `pnpm build`\n// to regenerate after adding, removing, or editing a theme pack.\n// Catalog schemaVersion 2 is distinct from each pack's meta.json schemaVersion 1.\n";
 
 writeFileSync(
   DIST_JS,
-  `${banner}const catalog = ${JSON.stringify(manifest)};\n\nexport default catalog;\n`,
+  `${banner}const catalog = ${JSON.stringify(manifest)};\n\n/**\n * Validate the browser-facing catalog contract before consuming its entries.\n *\n * Catalog schemaVersion 2 is deliberately independent from the schemaVersion\n * in each pack's meta.json (currently 1). This validator checks the catalog\n * contract only; those per-pack metadata versions must not be conflated.\n */\nexport function validateThemePackCatalog(value) {\n  if (value === null || typeof value !== \"object\" || Array.isArray(value)) {\n    throw new TypeError(\n      \`@takazudo/zudo-doc/catalog: expected a catalog manifest object with schemaVersion 2; got \${describeCatalogValue(value)}.\`,\n    );\n  }\n\n  if (value.schemaVersion !== 2) {\n    throw new Error(\n      \`@takazudo/zudo-doc/catalog: unsupported catalog schemaVersion \${describeCatalogValue(value.schemaVersion)}; expected 2.\`,\n    );\n  }\n\n  if (!Array.isArray(value.packs)) {\n    throw new TypeError(\n      \`@takazudo/zudo-doc/catalog: catalog.packs must be an array; got \${describeCatalogValue(value.packs)}.\`,\n    );\n  }\n\n  for (const [index, entry] of value.packs.entries()) {\n    if (entry === null || typeof entry !== \"object\" || Array.isArray(entry)) {\n      throw new TypeError(\n        \`@takazudo/zudo-doc/catalog: catalog.packs[\${index}] must be an object; got \${describeCatalogValue(entry)}.\`,\n      );\n    }\n    if (typeof entry.slug !== \"string\") {\n      throw new TypeError(\n        \`@takazudo/zudo-doc/catalog: catalog.packs[\${index}].slug must be a string; got \${describeCatalogValue(entry.slug)}.\`,\n      );\n    }\n    if (entry.meta === null || typeof entry.meta !== \"object\" || Array.isArray(entry.meta)) {\n      throw new TypeError(\n        \`@takazudo/zudo-doc/catalog: catalog.packs[\${index}].meta must be an object; got \${describeCatalogValue(entry.meta)}.\`,\n      );\n    }\n    if (typeof entry.hasStylesheet !== \"boolean\") {\n      throw new TypeError(\n        \`@takazudo/zudo-doc/catalog: catalog.packs[\${index}].hasStylesheet must be a boolean; got \${describeCatalogValue(entry.hasStylesheet)}.\`,\n      );\n    }\n  }\n\n  return value;\n}\n\n/** @param {unknown} value */\nfunction describeCatalogValue(value) {\n  if (value === undefined) return \"undefined\";\n  try {\n    const json = JSON.stringify(value);\n    return json === undefined ? String(value) : json;\n  } catch {\n    return String(value);\n  }\n}\n\nexport default catalog;\n`,
 );
 
 writeFileSync(
@@ -74,17 +80,48 @@ writeFileSync(
 
 export type { ThemePackMeta };
 
-/** The aggregated theme-pack catalog manifest shape — mirrors the
- *  postBuild-time \`theme-packs/index.json\` registry manifest
- *  (\`ThemePacksIndexManifest\` in plugins/internal/theme-packs/types.ts),
- *  duplicated here rather than imported so this module stays free of any
- *  node-touching import chain. */
-export interface ThemePacksIndexManifest {
-  schemaVersion: 1;
-  packs: ThemePackMeta[];
+/** One entry in the browser-facing catalog (catalog schemaVersion 2). */
+export interface ThemePackCatalogEntry {
+  /** The pack directory slug. */
+  slug: string;
+  /** The pack's metadata; its own meta.json schemaVersion is currently 1. */
+  meta: ThemePackMeta;
+  /** Whether the pack ships a pack.css stylesheet, from the real registry. */
+  hasStylesheet: boolean;
 }
 
-declare const catalog: ThemePacksIndexManifest;
+/** The v2 catalog entry is structurally the same as a resolved registry entry. */
+export type ThemePackRegistryEntry = ThemePackCatalogEntry;
+
+/**
+ * The browser-facing theme-pack catalog manifest.
+ *
+ * This catalog schemaVersion 2 is distinct from each pack's meta.json
+ * schemaVersion 1. The two version numbers are unrelated and must not be
+ * conflated. The manifest is declared here instead of importing the
+ * postBuild-time theme-packs/index.json type so the browser export keeps its
+ * own contract and remains free of node-touching imports.
+ */
+export interface ThemePacksCatalogManifest {
+  schemaVersion: 2;
+  packs: ThemePackCatalogEntry[];
+}
+
+/**
+ * @deprecated Use ThemePacksCatalogManifest. This catalog-only legacy name is
+ * not the postBuild plugin's separate \`ThemePacksIndexManifest\` type.
+ */
+export type ThemePacksIndexManifest = ThemePacksCatalogManifest;
+
+/**
+ * Validate and return a browser-facing catalog manifest. Throws when the
+ * catalog is not schemaVersion 2 or has malformed v2 entries.
+ */
+export declare function validateThemePackCatalog(
+  value: unknown,
+): ThemePacksCatalogManifest;
+
+declare const catalog: ThemePacksCatalogManifest;
 export default catalog;
 `,
 );

--- a/packages/zudo-doc/scripts/site-schema-graph.mjs
+++ b/packages/zudo-doc/scripts/site-schema-graph.mjs
@@ -15,6 +15,8 @@
 // fails to resolve, or gets inlined away.
 
 import { createRequire } from "node:module";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 
 /** Specifier classes that must never be reachable from `./site-schema`. */
 export const FORBIDDEN_SPECIFIERS = [
@@ -28,6 +30,56 @@ export const FORBIDDEN_SPECIFIERS = [
 /** The forbidden class a specifier belongs to, or `undefined` when it is fine. */
 export function forbiddenLabel(specifier) {
   return FORBIDDEN_SPECIFIERS.find((rule) => rule.pattern.test(specifier))?.label;
+}
+
+/** Every `from "..."` specifier in a declaration file. */
+export function declarationSpecifiers(source) {
+  return [...source.matchAll(/\bfrom\s*["']([^"']+)["']/g)].map((match) => match[1]);
+}
+
+/** Resolve a relative `.js`/extensionless specifier to its emitted `.d.ts`. */
+export function resolveDeclaration(fromFile, specifier) {
+  const base = resolve(dirname(fromFile), specifier);
+  for (const candidate of [
+    base.replace(/\.js$/, ".d.ts"),
+    `${base}.d.ts`,
+    resolve(base, "index.d.ts"),
+  ]) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+/**
+ * Walk the transitive emitted declaration graph rooted at `entry` and report
+ * forbidden package/specifier classes using the same rules as the JS guard.
+ *
+ * @param {string} entry - absolute path to an emitted `.d.ts` file.
+ * @returns {{ violations: Array<{ specifier: string, label: string, importer: string }>, files: string[] }}
+ */
+export function analyzeDeclarationGraph(entry) {
+  const seen = new Set();
+  const violations = [];
+  const queue = [entry];
+
+  while (queue.length > 0) {
+    const file = queue.pop();
+    if (seen.has(file)) continue;
+    seen.add(file);
+
+    for (const specifier of declarationSpecifiers(readFileSync(file, "utf8"))) {
+      const label = forbiddenLabel(specifier);
+      if (label) {
+        violations.push({ specifier, label, importer: file });
+        continue;
+      }
+      if (!specifier.startsWith(".")) continue;
+      const next = resolveDeclaration(file, specifier);
+      if (next) queue.push(next);
+    }
+  }
+
+  return { violations, files: [...seen].sort() };
 }
 
 /**

--- a/packages/zudo-doc/src/__tests__/catalog.test.ts
+++ b/packages/zudo-doc/src/__tests__/catalog.test.ts
@@ -13,12 +13,13 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PKG_ROOT = resolve(__dirname, "../..");
+const DIST_DTS = resolve(PKG_ROOT, "dist/catalog.d.ts");
 
 describe("@takazudo/zudo-doc/catalog", () => {
   it("aggregates every bundled theme pack, default first then alphabetical", async () => {
     const { default: catalog } = await import(resolve(PKG_ROOT, "dist/catalog.js"));
 
-    expect(catalog.schemaVersion).toBe(1);
+    expect(catalog.schemaVersion).toBe(2);
     expect(catalog.packs.length).toBe(31);
     expect(catalog.packs[0].slug).toBe("default");
 
@@ -30,8 +31,9 @@ describe("@takazudo/zudo-doc/catalog", () => {
     const { default: catalog } = await import(resolve(PKG_ROOT, "dist/catalog.js"));
 
     for (const pack of catalog.packs) {
+      expect(typeof pack.hasStylesheet, `${pack.slug}.hasStylesheet`).toBe("boolean");
       for (const mode of ["light", "dark"] as const) {
-        const swatches = pack.preview[mode];
+        const swatches = pack.meta.preview[mode];
         expect(swatches.bg, `${pack.slug}.preview.${mode}.bg`).toBeTruthy();
         expect(swatches.fg, `${pack.slug}.preview.${mode}.fg`).toBeTruthy();
         expect(swatches.accent, `${pack.slug}.preview.${mode}.accent`).toBeTruthy();
@@ -41,6 +43,52 @@ describe("@takazudo/zudo-doc/catalog", () => {
         expect(swatches.syntax.callable, `${pack.slug}.preview.${mode}.syntax.callable`).toBeTruthy();
       }
     }
+  });
+
+  it("carries hasStylesheet from the filesystem registry, not a slug heuristic", async () => {
+    const { default: catalog } = await import(resolve(PKG_ROOT, "dist/catalog.js"));
+    const { loadThemePackRegistry, resolveEnabledPacks } = await import(
+      resolve(PKG_ROOT, "dist/theme-packs-registry/index.js"),
+    );
+    const registry = loadThemePackRegistry(resolve(PKG_ROOT, "src/theme-packs"));
+    const enabled = resolveEnabledPacks(registry, {});
+
+    expect(
+      catalog.packs.map((pack: { slug: string; hasStylesheet: boolean }) => [
+        pack.slug,
+        pack.hasStylesheet,
+      ]),
+    ).toEqual(
+      enabled.map((entry: { slug: string; hasStylesheet: boolean }) => [
+        entry.slug,
+        entry.hasStylesheet,
+      ]),
+    );
+  });
+
+  it("exports a v2 validator that rejects a v1-shaped manifest", async () => {
+    const { default: catalog, validateThemePackCatalog } = await import(
+      resolve(PKG_ROOT, "dist/catalog.js"),
+    );
+
+    expect(validateThemePackCatalog(catalog)).toBe(catalog);
+    const v1Manifest = {
+      schemaVersion: 1,
+      packs: catalog.packs.map((pack: { meta: unknown }) => pack.meta),
+    };
+    expect(() => validateThemePackCatalog(v1Manifest)).toThrow(
+      /schemaVersion 1.*expected 2/,
+    );
+  });
+
+  it("declares the v2 manifest and entry types in the generated declaration", async () => {
+    const fs = await import("node:fs/promises");
+    const dts = await fs.readFile(DIST_DTS, "utf8");
+
+    expect(dts).toContain("interface ThemePackCatalogEntry");
+    expect(dts).toContain("interface ThemePacksCatalogManifest");
+    expect(dts).toContain("hasStylesheet: boolean");
+    expect(dts).toContain("validateThemePackCatalog");
   });
 
   it("exposes the ./catalog subpath export", async () => {

--- a/packages/zudo-doc/src/__tests__/eject.test.ts
+++ b/packages/zudo-doc/src/__tests__/eject.test.ts
@@ -612,6 +612,21 @@ describe("eject() — import rewiring", () => {
 // ── eject() — host call site rewiring ────────────────────────────────────────
 
 describe("eject() — host call site rewiring", () => {
+  it("ships ThemeToggle with its hydration-pending hook as a same-directory dependency", async () => {
+    const ejectDir = path.join(REAL_PACKAGE_ROOT, "eject/theme-toggle");
+    const indexSource = await fs.readFile(path.join(ejectDir, "index.tsx"), "utf8");
+    const hookSource = await fs.readFile(
+      path.join(ejectDir, "hydration-pending.ts"),
+      "utf8",
+    );
+
+    expect(indexSource).toContain('from "./hydration-pending.js"');
+    expect(indexSource).not.toContain('from "../hydration-pending.js"');
+    expect(hookSource).toBe(
+      await fs.readFile(path.join(REAL_PACKAGE_ROOT, "src/hydration-pending.ts"), "utf8"),
+    );
+  });
+
   it("does not mistake an import example inside the copied tree for a host call site", async () => {
     const projectDir = path.join(tempDir, "project-self-import-comment");
     await fs.ensureDir(projectDir);

--- a/packages/zudo-doc/src/__tests__/features-css.test.ts
+++ b/packages/zudo-doc/src/__tests__/features-css.test.ts
@@ -22,6 +22,13 @@ function bridgeValue(name: string): string | undefined {
 }
 
 describe("src/features.css source contract", () => {
+  it("dims pending buttons and removes pointer hit-testing", () => {
+    expect(css).toContain(`button[data-zd-pending] {
+  opacity: 0.7;
+  pointer-events: none;
+}`);
+  });
+
   it("keeps the default header on an opaque surface layer", () => {
     expect(css).toContain("header[data-header]");
     expect(css).toContain("background-color: var(--color-surface, var(--color-bg));");

--- a/packages/zudo-doc/src/__tests__/route-context-payload-types.test.ts
+++ b/packages/zudo-doc/src/__tests__/route-context-payload-types.test.ts
@@ -1,0 +1,53 @@
+// Declaration-graph contract for the browser-safe route-context payload leaf.
+
+import { describe, expect, it } from "vitest";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = resolve(__dirname, "../..");
+const DIST_DTS = resolve(PKG_ROOT, "dist/route-context-payload/types.d.ts");
+const FACTORY_CONTEXT_DTS = resolve(PKG_ROOT, "dist/factory-context/index.d.ts");
+
+interface DeclarationGraph {
+  analyzeDeclarationGraph(entry: string): {
+    violations: Array<{ specifier: string; label: string; importer: string }>;
+    files: string[];
+  };
+}
+
+async function loadGraphHelper(): Promise<DeclarationGraph> {
+  const url = pathToFileURL(resolve(PKG_ROOT, "scripts/site-schema-graph.mjs")).href;
+  return (await import(/* @vite-ignore */ url)) as DeclarationGraph;
+}
+
+describe("route-context payload type leaf", () => {
+  it("has a transitively browser-clean emitted declaration graph", async () => {
+    expect(
+      existsSync(DIST_DTS),
+      `${DIST_DTS} missing — run \`pnpm --filter @takazudo/zudo-doc build\``,
+    ).toBe(true);
+
+    const { analyzeDeclarationGraph } = await loadGraphHelper();
+    const { violations, files } = analyzeDeclarationGraph(DIST_DTS);
+
+    expect(
+      violations,
+      violations.map((v) => `${v.specifier} (${v.label}) declared in ${v.importer}`).join("\n"),
+    ).toEqual([]);
+    // RouteContextPayload's default Settings generic makes this a real
+    // transitive walk rather than a single-file inspection.
+    expect(files.length).toBeGreaterThan(1);
+  });
+
+  it("keeps RouteContextPayload available from factory-context", () => {
+    expect(
+      existsSync(FACTORY_CONTEXT_DTS),
+      `${FACTORY_CONTEXT_DTS} missing — run \`pnpm --filter @takazudo/zudo-doc build\``,
+    ).toBe(true);
+    expect(readFileSync(FACTORY_CONTEXT_DTS, "utf8")).toContain(
+      'export type { RouteContextPayload } from "../route-context-payload/types.js";',
+    );
+  });
+});

--- a/packages/zudo-doc/src/__tests__/site-schema.test.ts
+++ b/packages/zudo-doc/src/__tests__/site-schema.test.ts
@@ -57,6 +57,10 @@ const DIST_DTS = resolve(PKG_ROOT, "dist/site-schema/index.d.ts");
 // vitest both resolve it, and TypeScript never has to.
 interface SiteSchemaGraph {
   forbiddenLabel(specifier: string): string | undefined;
+  analyzeDeclarationGraph(entry: string): {
+    violations: Array<{ specifier: string; label: string; importer: string }>;
+    files: string[];
+  };
   analyzeSiteSchemaGraph(args: { entry: string; resolveFrom: string[] }): Promise<{
     violations: Array<{ specifier: string; label: string; importer: string }>;
     specifiers: string[];
@@ -478,55 +482,20 @@ describe("site-schema stays browser-safe", () => {
 // (4b) Browser safety — TRANSITIVE declaration graph
 // ---------------------------------------------------------------------------
 
-/** Every `from "…"` specifier in a declaration file. */
-function declarationSpecifiers(source: string): string[] {
-  return [...source.matchAll(/\bfrom\s*["']([^"']+)["']/g)].map((m) => m[1] as string);
-}
-
-/** Resolve a relative `.js`/extensionless specifier to its emitted `.d.ts`. */
-function resolveDeclaration(fromFile: string, specifier: string): string | undefined {
-  const base = resolve(dirname(fromFile), specifier);
-  for (const candidate of [
-    base.replace(/\.js$/, ".d.ts"),
-    `${base}.d.ts`,
-    resolve(base, "index.d.ts"),
-  ]) {
-    if (existsSync(candidate)) return candidate;
-  }
-  return undefined;
-}
-
 describe("site-schema declaration graph", () => {
   it("never reaches @takazudo/zfb (or any other forbidden package) transitively", async () => {
-    const { forbiddenLabel } = await loadGraphHelper();
+    const { analyzeDeclarationGraph } = await loadGraphHelper();
     expect(
       existsSync(DIST_DTS),
       `${DIST_DTS} missing — run \`pnpm --filter @takazudo/zudo-doc build\``,
     ).toBe(true);
 
-    const seen = new Set<string>();
-    const violations: string[] = [];
-    const queue = [DIST_DTS];
-
-    while (queue.length > 0) {
-      const file = queue.pop() as string;
-      if (seen.has(file)) continue;
-      seen.add(file);
-
-      for (const specifier of declarationSpecifiers(readFileSync(file, "utf8"))) {
-        const label = forbiddenLabel(specifier);
-        if (label) {
-          violations.push(`${specifier} (${label}) declared in ${file}`);
-          continue;
-        }
-        if (!specifier.startsWith(".")) continue;
-        const next = resolveDeclaration(file, specifier);
-        if (next) queue.push(next);
-      }
-    }
-
-    expect(violations, violations.join("\n")).toEqual([]);
+    const { violations, files } = analyzeDeclarationGraph(DIST_DTS);
+    expect(
+      violations,
+      violations.map((v) => `${v.specifier} (${v.label}) declared in ${v.importer}`).join("\n"),
+    ).toEqual([]);
     // The walk must have covered more than the barrel itself.
-    expect(seen.size).toBeGreaterThan(1);
+    expect(files.length).toBeGreaterThan(1);
   });
 });

--- a/packages/zudo-doc/src/color-scheme-utils.ts
+++ b/packages/zudo-doc/src/color-scheme-utils.ts
@@ -22,60 +22,30 @@
  * scheme names, `colorMode` settings) stays project-side.
  */
 
-/** A color literal — an `oklch(…)` (or any valid CSS color) string. */
-export type OKLCH = string;
+import type {
+  ColorScheme,
+  ModeMap,
+  OKLCH,
+  RampRef,
+  Ramps,
+  SemanticKey,
+  StateRole,
+  SyntaxSemanticKey,
+} from "./route-context-payload/types.js";
 
-/** The four semantic state colors that live on their own ramp. */
-export type StateRole = "danger" | "success" | "warning" | "info";
+export type {
+  ColorScheme,
+  ModeMap,
+  OKLCH,
+  RampRef,
+  Ramps,
+  SemanticKey,
+  StateRole,
+  SyntaxSemanticKey,
+} from "./route-context-payload/types.js";
 
 /** Canonical order of the state ramp — used for `--palette-state-*` emit. */
 export const STATE_ROLES: readonly StateRole[] = ["danger", "success", "warning", "info"];
-
-/**
- * A reference into the shared ramps, resolved by `resolveRampRef`:
- *   - `{ base: n }`   → `ramps.base[n]`
- *   - `{ accent: n }` → `ramps.accent[n]`
- *   - `{ state: r }`  → `ramps.state[r]`
- *   - a bare string   → a literal OKLCH value, returned as-is
- */
-export type RampRef = { base: number } | { accent: number } | { state: StateRole } | OKLCH;
-
-/** The shared Tier-1 ramps. Values are identical across light/dark modes; the
- *  per-mode differences live in `ModeMap`, not here. */
-export interface Ramps {
-  /** Warm-neutral base ramp — 5 entries, index 0 = lightest. */
-  base: OKLCH[];
-  /** Accent ramp — 3 entries. */
-  accent: OKLCH[];
-  /** The four state colors. */
-  state: Record<StateRole, OKLCH>;
-}
-
-/** The 23 semantic roles that map onto `--zd-*` custom properties. */
-export type SemanticKey =
-  | "surface"
-  | "muted"
-  | "accent"
-  | "accentHover"
-  | "codeBg"
-  | "codeFg"
-  | "success"
-  | "danger"
-  | "warning"
-  | "info"
-  | "mermaidNodeBg"
-  | "mermaidText"
-  | "mermaidLine"
-  | "mermaidLabelBg"
-  | "mermaidNoteBg"
-  | "chatUserBg"
-  | "chatUserText"
-  | "chatAssistantBg"
-  | "chatAssistantText"
-  | "imageOverlayBg"
-  | "imageOverlayFg"
-  | "matchedKeywordBg"
-  | "matchedKeywordFg";
 
 /** Canonical order of the 23 semantic roles — used for `--zd-*` emit. */
 export const SEMANTIC_KEYS: readonly SemanticKey[] = [
@@ -121,8 +91,6 @@ export const SYNTAX_SEMANTIC_KEYS = [
   "syntaxDeleted",
 ] as const;
 
-export type SyntaxSemanticKey = (typeof SYNTAX_SEMANTIC_KEYS)[number];
-
 /** Existing semantic role inherited when a syntax role has no explicit map. */
 export const SYNTAX_SEMANTIC_ALIASES: Readonly<Record<SyntaxSemanticKey, SemanticKey>> = {
   syntaxComment: "muted",
@@ -147,27 +115,6 @@ export const SYNTAX_CSS_NAMES: Readonly<Record<SyntaxSemanticKey, string>> = {
   syntaxInserted: "--zd-syntax-inserted",
   syntaxDeleted: "--zd-syntax-deleted",
 };
-
-/** The per-mode wiring: each UI role points at a ramp stop (or literal OKLCH)
- *  via a `RampRef`. Two `ColorScheme`s (light + dark) share `ramps` but carry
- *  their own `ModeMap`. */
-export interface ModeMap {
-  bg: RampRef;
-  fg: RampRef;
-  selectionBg: RampRef;
-  selectionFg: RampRef;
-  semantic: Record<SemanticKey, RampRef>;
-  /** Optional syntax-specific overrides. An absent map and omitted roles
-   *  inherit the aliases in `SYNTAX_SEMANTIC_ALIASES`, preserving schemes
-   *  authored before syntax tokens existed. */
-  syntax?: Partial<Record<SyntaxSemanticKey, RampRef>>;
-}
-
-/** A complete color scheme — shared Tier-1 ramps + per-mode Tier-2 wiring. */
-export interface ColorScheme {
-  ramps: Ramps;
-  map: ModeMap;
-}
 
 /** Default per-mode semantic wiring (Default Dark reference — see epic #2584).
  *  Scheme authors spread this into `map.semantic` and override individual roles

--- a/packages/zudo-doc/src/factory-context/index.ts
+++ b/packages/zudo-doc/src/factory-context/index.ts
@@ -15,11 +15,14 @@
 // This module is **types only** — no runtime values, no node builtins — so it
 // stays importable from the config eval graph and from client islands alike.
 
-import type { Settings, TagVocabularyEntry } from "../settings.js";
+import type { Settings } from "../settings.js";
 // Type-only imports (erased at build — they never enter the runtime/eval graph,
 // so this module stays node-free; the foundation-eval-graph guard covers it).
-import type { ColorScheme } from "../color-scheme-utils.js";
-import type { ThemePackRegistry } from "../theme-packs-registry/index.js";
+import type {
+  ColorScheme,
+  RouteContextPayload,
+  ThemePackRegistry,
+} from "../route-context-payload/types.js";
 import type { UrlHelpers } from "../url-helpers/index.js";
 import type { NavSourceDocsAPI } from "../nav-source-docs/index.js";
 import type { DocRouteEntriesAPI } from "../doc-route-entries/index.js";
@@ -29,6 +32,8 @@ import type { DocNavNode, DocPageEntry } from "../doc-page-props/index.js";
 import type { HeadingItem } from "../extract-headings/index.js";
 import type { CategoryMeta } from "../sidebar-tree/index.js";
 import type { HeaderRightComponentRegistry } from "../header/types.js";
+
+export type { RouteContextPayload } from "../route-context-payload/types.js";
 
 /**
  * The i18n surface a factory may read. Parameterizes what `base.ts` used to read
@@ -130,39 +135,6 @@ export interface FactoryContext<S = Settings> {
 // (all imports above are `import type`, erased at build), so this module stays
 // importable from the config eval graph and client islands unchanged.
 // ===========================================================================
-
-/**
- * The serializable route-context payload carried by the
- * `virtual:zudo-doc-route-context` module (ADR `route-injection-seam.md`,
- * Decision 1) — DATA ONLY, no callables. `createRouteContext` rebuilds the full
- * runtime context from it by calling the importable package factories.
- */
-export interface RouteContextPayload<S = Settings> {
-  /** The host's resolved settings object. */
-  settings: S;
-  /** Per-locale UI-string tables (`translations[locale][key]`). */
-  translations: Record<string, Record<string, string>>;
-  /** The tag vocabulary (used only when `settings.tagVocabulary` is on). */
-  tagVocabulary: readonly TagVocabularyEntry[];
-  /** Host color-scheme palette map; `null` when the host passed none (chrome
-   *  then falls back to a neutral default scheme). */
-  colorSchemes: Record<string, ColorScheme> | null;
-  /**
-   * Resolved, enabled, ordered theme-pack registry (ADR
-   * `docs/adr/theme-packs.md`, Decision 2 "Registry threading to
-   * SSR/islands") — settings ∩ the bundled `theme-packs/` directories, in
-   * switcher order. `null` (or omitted) renders the whole feature inert (same
-   * accepted coupling class as {@link colorSchemes} for a
-   * `packageOwnedRoutes: false` host that builds its own payload without
-   * threading one).
-   *
-   * OPTIONAL on purpose: this field was added after the payload shape
-   * shipped, so an existing `packageOwnedRoutes: false` host that constructs
-   * its own payload predates it. `createRouteContext` normalizes an omitted
-   * value to `null` (→ inert) so upgrading such a host does not throw at SSR.
-   */
-  themePackRegistry?: ThemePackRegistry | null;
-}
 
 /** Aggregated `tag → docs` index entry built by `collectTags`. */
 export interface TagInfo {

--- a/packages/zudo-doc/src/features.css
+++ b/packages/zudo-doc/src/features.css
@@ -1044,3 +1044,8 @@ nav[data-zd-toc], div[data-zd-mobile-toc] {
 }
 
 /* END --zdc-* chrome component tokens */
+
+button[data-zd-pending] {
+  opacity: 0.7;
+  pointer-events: none;
+}

--- a/packages/zudo-doc/src/hydration-pending.ts
+++ b/packages/zudo-doc/src/hydration-pending.ts
@@ -1,0 +1,13 @@
+import { useEffect, useState } from "preact/hooks";
+
+/**
+ * Keep an interactive control pending until its first successful client mount.
+ * Initializing from `enabled` preserves server/client-first-render parity.
+ */
+export function useHydrationPending(enabled: boolean): boolean {
+  const [pending, setPending] = useState(enabled);
+
+  useEffect(() => setPending(false), []);
+
+  return pending;
+}

--- a/packages/zudo-doc/src/route-context-payload/types.ts
+++ b/packages/zudo-doc/src/route-context-payload/types.ts
@@ -1,0 +1,161 @@
+// Browser-safe data contract for the serializable route-context payload.
+//
+// Keep this module types-only and deliberately narrow. Browser consumers use
+// its emitted declaration without traversing the broader factory-context or
+// the node-backed theme-pack registry barrel.
+
+import type { Settings } from "../settings.js";
+
+/** A color literal — an `oklch(...)` (or any valid CSS color) string. */
+export type OKLCH = string;
+
+/** The four semantic state colors that live on their own ramp. */
+export type StateRole = "danger" | "success" | "warning" | "info";
+
+/**
+ * A reference into the shared ramps:
+ * `{ base: n }`, `{ accent: n }`, `{ state: role }`, or a literal color.
+ */
+export type RampRef = { base: number } | { accent: number } | { state: StateRole } | OKLCH;
+
+/** The shared Tier-1 color ramps. */
+export interface Ramps {
+  base: OKLCH[];
+  accent: OKLCH[];
+  state: Record<StateRole, OKLCH>;
+}
+
+/** The semantic UI roles mapped by a color scheme. */
+export type SemanticKey =
+  | "surface"
+  | "muted"
+  | "accent"
+  | "accentHover"
+  | "codeBg"
+  | "codeFg"
+  | "success"
+  | "danger"
+  | "warning"
+  | "info"
+  | "mermaidNodeBg"
+  | "mermaidText"
+  | "mermaidLine"
+  | "mermaidLabelBg"
+  | "mermaidNoteBg"
+  | "chatUserBg"
+  | "chatUserText"
+  | "chatAssistantBg"
+  | "chatAssistantText"
+  | "imageOverlayBg"
+  | "imageOverlayFg"
+  | "matchedKeywordBg"
+  | "matchedKeywordFg";
+
+/** The syntax-specific semantic roles mapped by a color scheme. */
+export type SyntaxSemanticKey =
+  | "syntaxComment"
+  | "syntaxString"
+  | "syntaxNumber"
+  | "syntaxKeyword"
+  | "syntaxCallable"
+  | "syntaxType"
+  | "syntaxName"
+  | "syntaxInserted"
+  | "syntaxDeleted";
+
+/** The per-mode wiring from UI roles to ramp stops or literal colors. */
+export interface ModeMap {
+  bg: RampRef;
+  fg: RampRef;
+  selectionBg: RampRef;
+  selectionFg: RampRef;
+  semantic: Record<SemanticKey, RampRef>;
+  syntax?: Partial<Record<SyntaxSemanticKey, RampRef>>;
+}
+
+/** A complete color scheme — shared Tier-1 ramps + per-mode Tier-2 wiring. */
+export interface ColorScheme {
+  ramps: Ramps;
+  map: ModeMap;
+}
+
+/**
+ * A single tag-vocabulary entry. Content uses `id` exactly; the optional
+ * display metadata does not introduce alias or deprecation semantics.
+ */
+export interface TagVocabularyEntry {
+  id: string;
+  label?: string;
+  description?: string;
+  group?: string;
+}
+
+/** Resolved preview swatches for one theme-pack mode. */
+export interface ThemePackSwatches {
+  bg: string;
+  fg: string;
+  accent: string;
+  syntax: {
+    keyword: string;
+    string: string;
+    comment: string;
+    callable: string;
+  };
+}
+
+/**
+ * A theme pack's schema-validated metadata. `mode` is its designed-primary
+ * badge; each pack still supplies both light and dark preview swatches.
+ */
+export interface ThemePackMeta {
+  schemaVersion: 1;
+  slug: string;
+  name: string;
+  description: string;
+  mode: "light" | "dark";
+  version: string;
+  fonts: {
+    sans: string;
+    mono: string;
+    display?: string;
+    loaded: string[];
+  };
+  preview: {
+    light: ThemePackSwatches;
+    dark: ThemePackSwatches;
+  };
+}
+
+/** One entry in the aggregated, canonically ordered bundled registry. */
+export interface ThemePackRegistryEntry {
+  /** The pack directory name, equal to `meta.slug`. */
+  slug: string;
+  /** The pack's schema-validated metadata. */
+  meta: ThemePackMeta;
+  /** Whether the pack ships `pack.css` (`false` for the stock default pack). */
+  hasStylesheet: boolean;
+}
+
+/** The full bundled registry, or an enabled ordered subset of it. */
+export type ThemePackRegistry = ThemePackRegistryEntry[];
+
+/**
+ * Serializable data carried by `virtual:zudo-doc-route-context`.
+ * `createRouteContext` reconstructs all runtime callables from this payload.
+ */
+export interface RouteContextPayload<S = Settings> {
+  /** The host's resolved settings object. */
+  settings: S;
+  /** Per-locale UI-string tables (`translations[locale][key]`). */
+  translations: Record<string, Record<string, string>>;
+  /** The tag vocabulary (used only when `settings.tagVocabulary` is on). */
+  tagVocabulary: readonly TagVocabularyEntry[];
+  /** Host color-scheme palette map, or `null` when the host passed none. */
+  colorSchemes: Record<string, ColorScheme> | null;
+  /**
+   * Resolved, enabled, ordered theme-pack registry. Optional for compatibility
+   * with hosts that constructed the payload before registry threading shipped;
+   * `createRouteContext` normalizes omission to `null` (feature inert).
+   */
+  themePackRegistry?: ThemePackRegistry | null;
+}

--- a/packages/zudo-doc/src/settings.ts
+++ b/packages/zudo-doc/src/settings.ts
@@ -22,23 +22,7 @@
  */
 export type TagGovernanceMode = "off" | "warn" | "strict";
 
-/**
- * A single entry in the tag vocabulary.
- *
- * - `id`         — canonical tag id. What content files should ideally use.
- * - `label`      — optional human-readable label (falls back to `id`).
- * - `description`— optional short description for tooling / tag index pages.
- * - `group`      — optional grouping key used by the grouped tag footer
- *                  (e.g. `"type"`, `"level"`, `"topic"`).
- * Content must use `id` exactly. Retired or misspelled ids are unknown tags;
- * the vocabulary intentionally has no alias or deprecation migration fields.
- */
-export interface TagVocabularyEntry {
-  id: string;
-  label?: string;
-  description?: string;
-  group?: string;
-}
+export type { TagVocabularyEntry } from "./route-context-payload/types.js";
 
 export interface HeaderNavChildItem {
   label: string;

--- a/packages/zudo-doc/src/theme-pack-switcher/__tests__/theme-pack-switcher-interaction.test.tsx
+++ b/packages/zudo-doc/src/theme-pack-switcher/__tests__/theme-pack-switcher-interaction.test.tsx
@@ -23,6 +23,7 @@
 
 import { afterEach, describe, expect, it } from "vitest";
 import { render } from "preact";
+import { render as renderToString } from "preact-render-to-string";
 import { act } from "preact/test-utils";
 import { ThemePackSwitcher, type ThemePackSwitcherProps } from "../index.js";
 import { THEME_PACK_ATTR } from "../theme-pack-sync.js";
@@ -41,14 +42,35 @@ const PROPS: ThemePackSwitcherProps = {
 // the current test's own launcher. Track + unmount/remove after every test.
 let mounted: HTMLDivElement | null = null;
 
-function mount(props: ThemePackSwitcherProps): HTMLDivElement {
+function mount(
+  props: ThemePackSwitcherProps,
+  beforeEffects?: (launcher: HTMLButtonElement) => void,
+): HTMLDivElement {
   const container = document.createElement("div");
   document.body.appendChild(container);
   act(() => {
     render(<ThemePackSwitcher {...props} />, container);
+    const launcher = container.querySelector<HTMLButtonElement>("[data-switcher-launcher]");
+    expect(launcher).not.toBeNull();
+    beforeEffects?.(launcher!);
   });
   mounted = container;
   return container;
+}
+
+function activate(
+  launcher: HTMLButtonElement,
+  path: "click" | "Enter" | " ",
+): void {
+  launcher.focus();
+  expect(document.activeElement).toBe(launcher);
+  if (path !== "click") {
+    launcher.dispatchEvent(new KeyboardEvent("keydown", { key: path, bubbles: true }));
+  }
+  launcher.click();
+  if (path !== "click") {
+    launcher.dispatchEvent(new KeyboardEvent("keyup", { key: path, bubbles: true }));
+  }
 }
 
 afterEach(() => {
@@ -66,6 +88,40 @@ afterEach(() => {
 });
 
 describe("ThemePackSwitcher — real-DOM interaction", () => {
+  it.each(["click", "Enter", " "] as const)(
+    "guards %s before the first effect, then enables it",
+    (path) => {
+      const container = mount(PROPS, (launcher) => {
+        const ssr = document.createElement("div");
+        ssr.innerHTML = renderToString(<ThemePackSwitcher {...PROPS} />);
+        expect(launcher.parentElement!.outerHTML).toBe(
+          ssr.querySelector("[data-theme-pack-switcher]")!.outerHTML,
+        );
+        expect(launcher.tabIndex).toBe(0);
+        expect(launcher.getAttribute("data-zd-pending")).toBe("");
+        expect(launcher.getAttribute("aria-disabled")).toBe("true");
+        activate(launcher, path);
+        expect(launcher.parentElement!.querySelector("[data-switcher-card]")).toBeNull();
+      });
+
+      const launcher = container.querySelector<HTMLButtonElement>("[data-switcher-launcher]")!;
+      expect(launcher.hasAttribute("data-zd-pending")).toBe(false);
+      expect(launcher.hasAttribute("aria-disabled")).toBe(false);
+      act(() => activate(launcher, path));
+      expect(container.querySelector("[data-switcher-card]")).not.toBeNull();
+    },
+  );
+
+  it("activates immediately when pendingUntilHydrated is false", () => {
+    const container = mount({ ...PROPS, pendingUntilHydrated: false }, (launcher) => {
+      expect(launcher.hasAttribute("data-zd-pending")).toBe(false);
+      expect(launcher.hasAttribute("aria-disabled")).toBe(false);
+      activate(launcher, "Enter");
+    });
+
+    expect(container.querySelector("[data-switcher-card]")).not.toBeNull();
+  });
+
   it("clicking the launcher opens the card and exposes data-switcher-card", () => {
     const container = mount(PROPS);
 

--- a/packages/zudo-doc/src/theme-pack-switcher/__tests__/theme-pack-switcher-ssr.test.tsx
+++ b/packages/zudo-doc/src/theme-pack-switcher/__tests__/theme-pack-switcher-ssr.test.tsx
@@ -29,6 +29,32 @@ const PROPS: ThemePackSwitcherProps = {
 describe("ThemePackSwitcher — SSR shape", () => {
   const html = render(<ThemePackSwitcher {...PROPS} />);
 
+  function launcherMarkup(output: string): string {
+    const match = output.match(/<button\b[^>]*data-switcher-launcher[^>]*>/);
+    expect(match).not.toBeNull();
+    return match![0];
+  }
+
+  it.each([undefined, true])("emits the launcher pending contract by default (%s)", (enabled) => {
+    const launcher = launcherMarkup(
+      render(<ThemePackSwitcher {...PROPS} pendingUntilHydrated={enabled} />),
+    );
+
+    expect(launcher).toMatch(/\sdata-zd-pending(?:=""|\s|>)/);
+    expect(launcher).toContain('aria-disabled="true"');
+    expect(launcher).not.toMatch(/\sdisabled(?:=|\s|>)/);
+    expect(launcher).not.toMatch(/\sinert(?:=|\s|>)/);
+  });
+
+  it("omits the launcher pending contract for the explicit opt-out", () => {
+    const launcher = launcherMarkup(
+      render(<ThemePackSwitcher {...PROPS} pendingUntilHydrated={false} />),
+    );
+
+    expect(launcher).not.toContain("data-zd-pending");
+    expect(launcher).not.toContain("aria-disabled");
+  });
+
   it("renders the launcher button, closed (aria-expanded=false, popup wiring)", () => {
     expect(html).toContain('aria-label="Theme pack switcher"');
     expect(html).toContain('aria-haspopup="dialog"');
@@ -69,6 +95,9 @@ describe("ThemePackSwitcher — SSR shape", () => {
 
   it("is a deterministic function of its serializable props (hydration-safe)", () => {
     expect(render(<ThemePackSwitcher {...PROPS} />)).toBe(html);
+    expect(render(<ThemePackSwitcher {...PROPS} pendingUntilHydrated />)).toBe(
+      render(<ThemePackSwitcher {...PROPS} pendingUntilHydrated />),
+    );
   });
 
   it("pins displayName for the island-scanner marker (#1446 contract)", () => {

--- a/packages/zudo-doc/src/theme-pack-switcher/index.tsx
+++ b/packages/zudo-doc/src/theme-pack-switcher/index.tsx
@@ -36,6 +36,7 @@
 import type { JSX, VNode } from "preact";
 import { useEffect, useRef, useState } from "preact/hooks";
 import { ChevronLeft, ChevronRight, Close } from "../icons/index.js";
+import { useHydrationPending } from "../hydration-pending.js";
 import { ThemePackDialog } from "../theme-pack-dialog/index.js";
 import { applyThemePack } from "./theme-pack-sync.js";
 import {
@@ -64,6 +65,8 @@ export interface ThemePackSwitcherProps {
   /** Base prefix WITH trailing slash (`ctx.withBase("/")`) — forwarded to
    *  the browse-all dialog for its `{base}theme-packs/index.json` fetch. */
   base: string;
+  /** Disable only when activation is useful before island hydration. */
+  pendingUntilHydrated?: boolean;
 }
 
 /** Props of the browse-all dialog mounted through {@link ThemePackDialogSlot}
@@ -159,7 +162,13 @@ const ICON_BUTTON_CLASS =
  * `Island({ when: "load" })` — see
  * `../doc-body-end-islands/theme-pack-switcher-island.tsx`.
  */
-export function ThemePackSwitcher({ active, order, base }: ThemePackSwitcherProps): JSX.Element {
+export function ThemePackSwitcher({
+  active,
+  order,
+  base,
+  pendingUntilHydrated = true,
+}: ThemePackSwitcherProps): JSX.Element {
+  const pending = useHydrationPending(pendingUntilHydrated);
   // Initial state must match the server render (hydration safety): card
   // closed, active = the SSR-configured slug. The user's stored pack is
   // synced from the DOM in the effect below.
@@ -290,9 +299,14 @@ export function ThemePackSwitcher({ active, order, base }: ThemePackSwitcherProp
         aria-haspopup="dialog"
         aria-expanded={open}
         aria-label="Theme pack switcher"
+        aria-disabled={pending ? "true" : undefined}
         title="Theme packs"
         data-switcher-launcher
-        onClick={() => setOpen(!open)}
+        data-zd-pending={pending ? "" : undefined}
+        onClick={() => {
+          if (pending) return;
+          setOpen(!open);
+        }}
         class="flex h-[2.5rem] w-[2.5rem] items-center justify-center rounded-full border border-muted bg-surface text-fg shadow-lg transition-colors hover:text-accent focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2"
       >
         <PaletteIcon className="h-icon-md w-icon-md" />

--- a/packages/zudo-doc/src/theme-pack-switcher/index.tsx
+++ b/packages/zudo-doc/src/theme-pack-switcher/index.tsx
@@ -65,7 +65,7 @@ export interface ThemePackSwitcherProps {
   /** Base prefix WITH trailing slash (`ctx.withBase("/")`) — forwarded to
    *  the browse-all dialog for its `{base}theme-packs/index.json` fetch. */
   base: string;
-  /** Disable only when activation is useful before island hydration. */
+  /** Keep launcher activation pending until the first successful mount. @default true */
   pendingUntilHydrated?: boolean;
 }
 

--- a/packages/zudo-doc/src/theme-packs-registry/load-registry.ts
+++ b/packages/zudo-doc/src/theme-packs-registry/load-registry.ts
@@ -13,22 +13,17 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 
-import type { ThemePackMeta } from "./meta-schema.js";
+import type {
+  ThemePackMeta,
+  ThemePackRegistry,
+  ThemePackRegistryEntry,
+} from "../route-context-payload/types.js";
 import { validateThemePack } from "./validator.js";
 
-/** One entry in the aggregated, canonically-ordered bundled registry. */
-export interface ThemePackRegistryEntry {
-  /** The pack's directory name (equals `meta.slug`). */
-  slug: string;
-  /** The pack's schema-validated `meta.json`. */
-  meta: ThemePackMeta;
-  /** Whether this pack ships a `pack.css` (always `false` for `"default"`). */
-  hasStylesheet: boolean;
-}
-
-/** The full bundled registry, or a subset of it (after `resolveEnabledPacks`)
- *  — an ordered array; order carries meaning (canonical / switcher order). */
-export type ThemePackRegistry = ThemePackRegistryEntry[];
+export type {
+  ThemePackRegistry,
+  ThemePackRegistryEntry,
+} from "../route-context-payload/types.js";
 
 function readFontFiles(fontsDir: string): string[] {
   if (!existsSync(fontsDir)) return [];

--- a/packages/zudo-doc/src/theme-packs-registry/meta-schema.ts
+++ b/packages/zudo-doc/src/theme-packs-registry/meta-schema.ts
@@ -10,6 +10,9 @@
 // dragging in filesystem access itself.
 
 import { z } from "zod";
+import type { ThemePackMeta, ThemePackSwatches } from "../route-context-payload/types.js";
+
+export type { ThemePackMeta, ThemePackSwatches } from "../route-context-payload/types.js";
 
 /** `[a-z0-9][a-z0-9-]*` — a pack's slug MUST equal its directory name
  *  (Decision 6.7 "slug regex + dir-name parity"). */
@@ -35,11 +38,7 @@ const themePackSwatchesSchema = z.object({
     comment: z.string().min(1),
     callable: z.string().min(1),
   }),
-});
-
-/** Preview swatches for the dialog grid — RESOLVED plain CSS colors, one set
- *  per mode. See {@link themePackMetaSchema}'s `preview` field. */
-export type ThemePackSwatches = z.infer<typeof themePackSwatchesSchema>;
+}) satisfies z.ZodType<ThemePackSwatches>;
 
 export const themePackMetaSchema = z.object({
   schemaVersion: z.literal(1),
@@ -58,11 +57,4 @@ export const themePackMetaSchema = z.object({
     light: themePackSwatchesSchema,
     dark: themePackSwatchesSchema,
   }),
-});
-
-/**
- * A pack's `meta.json`, schema-validated (ADR Decision 1). `mode` is a
- * designed-primary badge only — every pack still defines BOTH modes via
- * `light-dark()` in `pack.css`.
- */
-export type ThemePackMeta = z.infer<typeof themePackMetaSchema>;
+}) satisfies z.ZodType<ThemePackMeta>;

--- a/packages/zudo-doc/src/theme-toggle/__tests__/theme-toggle-interaction.test.tsx
+++ b/packages/zudo-doc/src/theme-toggle/__tests__/theme-toggle-interaction.test.tsx
@@ -1,0 +1,115 @@
+/** @vitest-environment happy-dom */
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { render } from "preact";
+import { render as renderToString } from "preact-render-to-string";
+import { act } from "preact/test-utils";
+import { ThemeToggle, type ThemeToggleProps } from "../index.js";
+
+let mounted: HTMLDivElement | null = null;
+
+function mount(
+  props: ThemeToggleProps = {},
+  beforeEffects?: (button: HTMLButtonElement) => void,
+): HTMLDivElement {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  mounted = container;
+  act(() => {
+    render(<ThemeToggle {...props} />, container);
+    const button = container.querySelector<HTMLButtonElement>("button");
+    expect(button).not.toBeNull();
+    beforeEffects?.(button!);
+  });
+  return container;
+}
+
+function activateWithKeyboard(button: HTMLButtonElement, key: "Enter" | " "): void {
+  button.focus();
+  expect(document.activeElement).toBe(button);
+  button.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+  // happy-dom does not synthesize the button click that a browser performs
+  // for keyboard activation, so reproduce that default action explicitly.
+  button.click();
+  button.dispatchEvent(new KeyboardEvent("keyup", { key, bubbles: true }));
+}
+
+afterEach(() => {
+  if (mounted) {
+    act(() => render(null, mounted!));
+    mounted.remove();
+    mounted = null;
+  }
+  document.documentElement.removeAttribute("data-theme");
+  document.documentElement.style.colorScheme = "";
+  localStorage.clear();
+});
+
+describe("ThemeToggle — hydration pending interaction", () => {
+  it("guards click, focused Enter, and focused Space before the first effect, then enables all three", () => {
+    const container = mount({}, (button) => {
+      const ssr = document.createElement("div");
+      ssr.innerHTML = renderToString(<ThemeToggle />);
+      expect(button.outerHTML).toBe(ssr.querySelector("button")!.outerHTML);
+      expect(button.tabIndex).toBe(0);
+      button.focus();
+      expect(document.activeElement).toBe(button);
+      expect(button.getAttribute("data-zd-pending")).toBe("");
+      expect(button.getAttribute("aria-disabled")).toBe("true");
+
+      button.click();
+      activateWithKeyboard(button, "Enter");
+      activateWithKeyboard(button, " ");
+      expect(button.getAttribute("aria-label")).toBe("Switch to light mode");
+      expect(document.documentElement.hasAttribute("data-theme")).toBe(false);
+    });
+
+    const button = container.querySelector<HTMLButtonElement>("button")!;
+    expect(button.hasAttribute("data-zd-pending")).toBe(false);
+    expect(button.hasAttribute("aria-disabled")).toBe(false);
+
+    act(() => button.click());
+    expect(button.getAttribute("aria-label")).toBe("Switch to dark mode");
+    act(() => activateWithKeyboard(button, "Enter"));
+    expect(button.getAttribute("aria-label")).toBe("Switch to light mode");
+    act(() => activateWithKeyboard(button, " "));
+    expect(button.getAttribute("aria-label")).toBe("Switch to dark mode");
+  });
+
+  it("activates immediately when pendingUntilHydrated is false", () => {
+    const container = mount({ pendingUntilHydrated: false }, (button) => {
+      expect(button.hasAttribute("data-zd-pending")).toBe(false);
+      expect(button.hasAttribute("aria-disabled")).toBe(false);
+      button.click();
+    });
+
+    expect(container.querySelector("button")!.getAttribute("aria-label")).toBe(
+      "Switch to dark mode",
+    );
+  });
+
+  it("re-enters the guarded pending state on a fresh remount", () => {
+    const container = mount();
+    const firstButton = container.querySelector<HTMLButtonElement>("button")!;
+    expect(firstButton.hasAttribute("data-zd-pending")).toBe(false);
+
+    act(() => render(null, container));
+    act(() => {
+      render(<ThemeToggle />, container);
+      const remountedButton = container.querySelector<HTMLButtonElement>("button")!;
+      expect(remountedButton.getAttribute("data-zd-pending")).toBe("");
+      expect(remountedButton.getAttribute("aria-disabled")).toBe("true");
+      remountedButton.click();
+      expect(remountedButton.getAttribute("aria-label")).toBe("Switch to light mode");
+      expect(document.documentElement.hasAttribute("data-theme")).toBe(false);
+    });
+
+    const remountedButton = container.querySelector<HTMLButtonElement>("button")!;
+    expect(remountedButton.hasAttribute("data-zd-pending")).toBe(false);
+    expect(remountedButton.hasAttribute("aria-disabled")).toBe(false);
+    act(() => remountedButton.click());
+    expect(remountedButton.getAttribute("aria-label")).toBe("Switch to dark mode");
+  });
+});

--- a/packages/zudo-doc/src/theme-toggle/__tests__/theme-toggle-ssr.test.tsx
+++ b/packages/zudo-doc/src/theme-toggle/__tests__/theme-toggle-ssr.test.tsx
@@ -1,0 +1,58 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+
+import { h } from "preact";
+import { render } from "preact-render-to-string";
+import { describe, expect, it } from "vitest";
+import ThemeToggleIsland from "../../theme/theme-toggle.js";
+import * as ThemeToggleModule from "../index.js";
+import { ThemeToggle } from "../index.js";
+
+function buttonMarkup(html: string): string {
+  const match = html.match(/<button\b[^>]*>/);
+  expect(match).not.toBeNull();
+  return match![0];
+}
+
+describe("ThemeToggle — SSR pending shape", () => {
+  it.each([undefined, true])("emits the pending contract by default (%s)", (enabled) => {
+    const html = render(h(ThemeToggle, { pendingUntilHydrated: enabled }));
+    const button = buttonMarkup(html);
+
+    expect(button).toMatch(/\sdata-zd-pending(?:=""|\s|>)/);
+    expect(button).toContain('aria-disabled="true"');
+    expect(button).not.toMatch(/\sdisabled(?:=|\s|>)/);
+    expect(button).not.toMatch(/\sinert(?:=|\s|>)/);
+  });
+
+  it("omits the pending contract for the explicit opt-out", () => {
+    const button = buttonMarkup(
+      render(<ThemeToggle pendingUntilHydrated={false} />),
+    );
+
+    expect(button).not.toContain("data-zd-pending");
+    expect(button).not.toContain("aria-disabled");
+  });
+
+  it("is deterministic across server rerenders", () => {
+    expect(render(<ThemeToggle />)).toBe(render(<ThemeToggle />));
+    expect(render(<ThemeToggle pendingUntilHydrated />)).toBe(
+      render(<ThemeToggle pendingUntilHydrated />),
+    );
+  });
+
+  it("keeps the island marker separate and read-only", () => {
+    const html = render(<ThemeToggleIsland />);
+    const button = buttonMarkup(html);
+
+    expect(html).toContain('data-zfb-island="ThemeToggle"');
+    expect(html).not.toContain("data-zfb-island-mounted");
+    expect(button).toMatch(/\sdata-zd-pending(?:=""|\s|>)/);
+    expect(button).toContain('aria-disabled="true"');
+  });
+
+  it("preserves the named export and displayName", () => {
+    expect(ThemeToggleModule.ThemeToggle).toBe(ThemeToggle);
+    expect(ThemeToggle.displayName).toBe("ThemeToggle");
+  });
+});

--- a/packages/zudo-doc/src/theme-toggle/index.tsx
+++ b/packages/zudo-doc/src/theme-toggle/index.tsx
@@ -70,6 +70,7 @@ function MoonIcon() {
 
 export interface ThemeToggleProps {
   defaultMode?: ColorSchemeMode;
+  /** Keep activation pending until the first successful mount. @default true */
   pendingUntilHydrated?: boolean;
 }
 

--- a/packages/zudo-doc/src/theme-toggle/index.tsx
+++ b/packages/zudo-doc/src/theme-toggle/index.tsx
@@ -14,6 +14,7 @@
 // not alias "react" to "preact/compat", so importing from "react" here
 // would fail to resolve.
 import { useState, useEffect } from "preact/hooks";
+import { useHydrationPending } from "../hydration-pending.js";
 import {
   applyColorScheme,
   readColorSchemeFromDom,
@@ -69,6 +70,7 @@ function MoonIcon() {
 
 export interface ThemeToggleProps {
   defaultMode?: ColorSchemeMode;
+  pendingUntilHydrated?: boolean;
 }
 
 // NAMED export (not default) on purpose: tsup compiles a default export
@@ -79,7 +81,9 @@ export interface ThemeToggleProps {
 // the package's MobileToc island).
 export function ThemeToggle({
   defaultMode = "dark",
+  pendingUntilHydrated = true,
 }: ThemeToggleProps) {
+  const pending = useHydrationPending(pendingUntilHydrated);
   // Initial state must match server render to avoid hydration mismatch.
   // Actual theme is synced from DOM in useEffect below.
   const [mode, setMode] = useState<ColorSchemeMode>(defaultMode);
@@ -94,6 +98,7 @@ export function ThemeToggle({
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   function toggle() {
+    if (pending) return;
     const next = mode === "dark" ? "light" : "dark";
     setMode(next);
     applyColorScheme(next);
@@ -105,6 +110,8 @@ export function ThemeToggle({
     <button
       onClick={toggle}
       aria-label={`Switch to ${nextMode} mode`}
+      aria-disabled={pending ? "true" : undefined}
+      data-zd-pending={pending ? "" : undefined}
       className="text-muted hover:text-fg transition-colors p-hsp-sm focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2"
     >
       {mode === "dark" ? <SunIcon /> : <MoonIcon />}


### PR DESCRIPTION
Parent: #3672

Closes #3677

## Summary

- renders a deterministic pre-hydration pending marker and accessibility state
- clears the temporary state during hydration without relying on `disabled` or `inert`

## Test plan

- package unit tests
- type checking

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/3690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790309416&installation_model_id=20910&pr_number=3690&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F3690&signature=722235cbd4523b87b91f49270dda52926eea0fc28f34e0e01a5f83f081536239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->