### PR TITLE
[Browser Embed][Sub] Pure, browser-safe theme-pack registry builder

### DIFF
--- a/packages/zudo-doc/package.json
+++ b/packages/zudo-doc/package.json
@@ -247,6 +247,10 @@
       "types": "./dist/site-schema/index.d.ts",
       "default": "./dist/site-schema/index.js"
     },
+    "./theme-packs-registry": {
+      "types": "./dist/theme-packs-registry/index.d.ts",
+      "default": "./dist/theme-packs-registry/index.js"
+    },
     "./theme.css": "./dist/theme.css",
     "./safelist.css": "./dist/safelist.css",
     "./content.css": "./dist/content.css",
@@ -632,7 +636,7 @@
     "dev:dts": "tsc -p tsconfig.build.json --watch --preserveWatchOutput",
     "prepare": "node scripts/gen-search-widget-script.mjs && node scripts/gen-nav-overflow-script.mjs && tsup --silent && tsc -p tsconfig.build.json",
     "// check:prepack-contract": "check:search-widget-drift and check:nav-overflow-drift run here (not just b4push/CI) because `prepare` regenerates BOTH frozen literals unconditionally — without a prepack gate, packing from a tree where a source changed but a literal was never re-committed would silently publish new script bytes and break every consumer's pinned CSP hash (#3534/#3535 for nav-overflow; #3540 extended the same gate to search-widget, the exact failure class the freezes exist to prevent).",
-    "check:prepack-contract": "pnpm --dir ../.. check:search-widget-drift && pnpm --dir ../.. check:nav-overflow-drift && pnpm --dir ../.. gen:changelog && node scripts/check-theme-css.mjs && node scripts/check-safelist.mjs && node scripts/check-content-css.mjs && node scripts/check-page-loading-css.mjs && node scripts/check-features-css.mjs && node scripts/check-theme-packs.mjs && node scripts/check-catalog.mjs && node scripts/check-site-schema.mjs && node scripts/check-plugins.mjs && node scripts/check-plugin-resolution.mjs && node scripts/check-eject-sources.mjs && node scripts/check-routes-src.mjs && node scripts/check-shim-artifacts.mjs && node scripts/check-virtual-modules.mjs && node bin/gen-component-tokens.mjs --check",
+    "check:prepack-contract": "pnpm --dir ../.. check:search-widget-drift && pnpm --dir ../.. check:nav-overflow-drift && pnpm --dir ../.. gen:changelog && node scripts/check-theme-css.mjs && node scripts/check-safelist.mjs && node scripts/check-content-css.mjs && node scripts/check-page-loading-css.mjs && node scripts/check-features-css.mjs && node scripts/check-theme-packs.mjs && node scripts/check-catalog.mjs && node scripts/check-site-schema.mjs && node scripts/check-theme-packs-registry.mjs && node scripts/check-plugins.mjs && node scripts/check-plugin-resolution.mjs && node scripts/check-eject-sources.mjs && node scripts/check-routes-src.mjs && node scripts/check-shim-artifacts.mjs && node scripts/check-virtual-modules.mjs && node bin/gen-component-tokens.mjs --check",
     "prepack": "pnpm check:prepack-contract",
     "test:plugin-resolution": "node scripts/check-plugin-resolution.mjs",
     "test": "vitest run --config vitest.config.ts",

--- a/packages/zudo-doc/scripts/check-catalog.mjs
+++ b/packages/zudo-doc/scripts/check-catalog.mjs
@@ -7,10 +7,12 @@
 // stale manifest for consumers (mirrors check-theme-packs.mjs).
 //
 // Asserts: dist/catalog.js and dist/catalog.d.ts exist, the manifest has
-// schemaVersion 1, exactly 31 packs (the current bundled pack count —
-// zudolab/zudo-doc#3349 acceptance criterion), and every pack carries the
-// full preview.{light,dark} swatch fields the catalog exists to serve
-// (bg/fg/accent/syntax).
+// schemaVersion 2, exactly 31 packs (the current bundled pack count —
+// zudolab/zudo-doc#3349 acceptance criterion), every entry carries the
+// registry-derived `hasStylesheet` boolean, and every pack carries the full
+// preview.{light,dark} swatch fields the catalog exists to serve
+// (bg/fg/accent/syntax). Catalog schemaVersion 2 is independent from each
+// pack's own meta.json schemaVersion 1.
 //
 // Exit 0 → dist/catalog.js is valid and complete.
 // Exit 1 → missing artifact or a shape violation (with a clear diagnostic).
@@ -37,7 +39,7 @@ if (!existsSync(DIST_JS) || !existsSync(DIST_DTS)) {
   process.exit(1);
 }
 
-const { default: catalog } = await import(DIST_JS);
+const { default: catalog, validateThemePackCatalog } = await import(DIST_JS);
 
 let allOk = true;
 function fail(message) {
@@ -45,8 +47,18 @@ function fail(message) {
   allOk = false;
 }
 
-if (catalog.schemaVersion !== 1) {
-  fail(`schemaVersion must be 1, got ${JSON.stringify(catalog.schemaVersion)}.`);
+if (typeof validateThemePackCatalog !== "function") {
+  fail("catalog must export validateThemePackCatalog(value).");
+} else {
+  try {
+    validateThemePackCatalog(catalog);
+  } catch (err) {
+    fail(`catalog validator rejected the generated manifest: ${err.message}`);
+  }
+}
+
+if (catalog.schemaVersion !== 2) {
+  fail(`schemaVersion must be 2, got ${JSON.stringify(catalog.schemaVersion)}.`);
 }
 if (!Array.isArray(catalog.packs)) {
   fail(`catalog.packs must be an array, got ${typeof catalog.packs}.`);
@@ -57,7 +69,14 @@ if (!Array.isArray(catalog.packs)) {
     );
   }
   for (const pack of catalog.packs) {
-    const preview = pack?.preview;
+    if (pack === null || typeof pack !== "object" || Array.isArray(pack)) {
+      fail("catalog entry must be an object.");
+      continue;
+    }
+    if (typeof pack.hasStylesheet !== "boolean") {
+      fail(`pack "${pack.slug}" is missing boolean hasStylesheet.`);
+    }
+    const preview = pack.meta?.preview;
     for (const mode of ["light", "dark"]) {
       const swatches = preview?.[mode];
       if (!swatches) {

--- a/packages/zudo-doc/scripts/check-theme-packs-registry.mjs
+++ b/packages/zudo-doc/scripts/check-theme-packs-registry.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// scripts/check-theme-packs-registry.mjs
+//
+// Publish-time browser-safety guard for the `./theme-packs-registry` subpath
+// (zudolab/zudo-doc#3679). The source test covers the same graph, but a
+// prepack check must inspect the actual emitted JS and declarations so a stale
+// or hand-edited dist/ cannot publish a Node-backed public entry by accident.
+// The filesystem loader is intentionally a separate internal artifact and is
+// not rooted by this check.
+
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { analyzeDeclarationGraph, analyzeSiteSchemaGraph } from "./site-schema-graph.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = resolve(__dirname, "..");
+const DIST_JS = resolve(PKG_ROOT, "dist/theme-packs-registry/index.js");
+const DIST_DTS = resolve(PKG_ROOT, "dist/theme-packs-registry/index.d.ts");
+
+if (!existsSync(DIST_JS) || !existsSync(DIST_DTS)) {
+  process.stderr.write(
+    `\n[check-theme-packs-registry] ERROR: dist/theme-packs-registry/index.js and/or index.d.ts is missing.\n` +
+      `  Run \`pnpm --filter @takazudo/zudo-doc build\` first, then retry.\n\n`,
+  );
+  process.exit(1);
+}
+
+const mod = await import(DIST_JS);
+if (typeof mod.schemaVersion !== "number") {
+  process.stderr.write(
+    `[check-theme-packs-registry] ERROR: dist/theme-packs-registry/index.js does not export a numeric schemaVersion (got ${JSON.stringify(mod.schemaVersion)}).\n`,
+  );
+  process.exit(1);
+}
+if (typeof mod.buildThemePackRegistry !== "function") {
+  process.stderr.write(
+    `[check-theme-packs-registry] ERROR: dist/theme-packs-registry/index.js does not export buildThemePackRegistry(catalog, settings).\n`,
+  );
+  process.exit(1);
+}
+if (typeof mod.loadThemePackRegistry === "function") {
+  process.stderr.write(
+    `[check-theme-packs-registry] ERROR: the browser-safe barrel must not export loadThemePackRegistry.\n`,
+  );
+  process.exit(1);
+}
+
+const { violations: jsViolations, specifiers } = await analyzeSiteSchemaGraph({
+  entry: DIST_JS,
+  resolveFrom: [PKG_ROOT, resolve(PKG_ROOT, "../..")],
+});
+const {
+  violations: dtsViolations,
+  files: declarationFiles,
+} = analyzeDeclarationGraph(DIST_DTS);
+
+if (jsViolations.length > 0 || dtsViolations.length > 0) {
+  process.stderr.write(
+    `\n[check-theme-packs-registry] ERROR: ./theme-packs-registry must stay browser-safe.\n`,
+  );
+  for (const violation of jsViolations) {
+    process.stderr.write(
+      `  JS: ${violation.specifier} (${violation.label}) imported by ${violation.importer}\n`,
+    );
+  }
+  for (const violation of dtsViolations) {
+    process.stderr.write(
+      `  DTS: ${violation.specifier} (${violation.label}) declared in ${violation.importer}\n`,
+    );
+  }
+  process.stderr.write("\n");
+  process.exit(1);
+}
+
+process.stdout.write(
+  `[check-theme-packs-registry] dist/theme-packs-registry/index.js OK ` +
+    `(schemaVersion ${mod.schemaVersion}, ${specifiers.length} resolved specifier(s), ` +
+    `${declarationFiles.length} declaration file(s), 0 forbidden)\n`,
+);

--- a/packages/zudo-doc/scripts/check-theme-packs.mjs
+++ b/packages/zudo-doc/scripts/check-theme-packs.mjs
@@ -41,7 +41,7 @@ if (!existsSync(DIST_THEME_PACKS)) {
 let registry;
 try {
   const { loadThemePackRegistry } = await import(
-    resolve(PKG_ROOT, "dist/theme-packs-registry/index.js")
+    resolve(PKG_ROOT, "dist/theme-packs-registry/load-registry.js")
   );
   registry = loadThemePackRegistry(DIST_THEME_PACKS);
 } catch (err) {

--- a/packages/zudo-doc/scripts/copy-theme-packs.mjs
+++ b/packages/zudo-doc/scripts/copy-theme-packs.mjs
@@ -14,13 +14,14 @@
 // Runs from the tsup `onSuccess` chain AFTER compilation (a one-shot build's
 // clean wipes dist/ first — `clean: !options.watch`, so a watch build does
 // not) — mirrors copy-theme-css.mjs's shape. Before copying, this
-// imports the ALREADY-COMPILED `dist/theme-packs-registry/index.js` (tsup
-// just finished compiling it) and calls `loadThemePackRegistry` against the
-// SOURCE directory — which validates every bundled pack (ADR Decision 6.7)
-// and throws loudly, naming the offending pack, on any failure. This is what
-// makes a broken pack fail the PACKAGE build, not a consumer's site build
+// imports the ALREADY-COMPILED `dist/theme-packs-registry/load-registry.js`
+// (tsup just finished compiling it) and calls `loadThemePackRegistry` against
+// the SOURCE directory — which validates every bundled pack (ADR Decision
+// 6.7) and throws loudly, naming the offending pack, on any failure. This is
+// what makes a broken pack fail the PACKAGE build, not a consumer's site build
 // (mirrors `copy-eject-sources.mjs`'s "import from dist/, already compiled"
-// precedent).
+// precedent). The public `index.js` barrel is intentionally browser-safe and
+// does not export the filesystem loader.
 
 import { cpSync, mkdirSync, rmSync, statSync } from "node:fs";
 import { resolve, dirname } from "node:path";
@@ -41,7 +42,7 @@ try {
 }
 
 const { loadThemePackRegistry } = await import(
-  resolve(PKG_ROOT, "dist/theme-packs-registry/index.js")
+  resolve(PKG_ROOT, "dist/theme-packs-registry/load-registry.js")
 );
 
 let registry;

--- a/packages/zudo-doc/scripts/gen-catalog.mjs
+++ b/packages/zudo-doc/scripts/gen-catalog.mjs
@@ -5,10 +5,12 @@
 // for the `@takazudo/zudo-doc/catalog` browser-safe data export (zudolab/
 // zudo-doc#3349, epic #3345 "theme catalog single-sourcing"). Aggregates
 // EVERY bundled theme pack's validated `meta.json` into one
-// `{ schemaVersion: 1, packs: ThemePackMeta[] }` manifest, `"default"` first
-// then alphabetical (the `resolveEnabledPacks` convention — this script calls
-// that same pure resolver with no settings so it resolves every pack, in that
-// canonical order).
+// `{ schemaVersion: 2, packs: ThemePackCatalogEntry[] }` manifest, `"default"`
+// first then alphabetical (the `resolveEnabledPacks` convention — this script
+// calls that same pure resolver with no settings so it resolves every pack, in
+// that canonical order). Catalog schema v2 is independent from the schema
+// version inside each pack's `meta.json` (currently v1); those two version
+// numbers must not be conflated.
 //
 // GENERATION SEQUENCING (binding, per the issue spec): this emits the
 // COMPLETE dist/ artifact pair directly, rather than generating a
@@ -57,15 +59,19 @@ try {
   process.exit(1);
 }
 const manifest = {
-  schemaVersion: 1,
-  packs: enabled.map((entry) => entry.meta),
+  schemaVersion: 2,
+  packs: enabled.map(({ slug, meta, hasStylesheet }) => ({
+    slug,
+    meta,
+    hasStylesheet,
+  })),
 };
 
-const banner = "// GENERATED FILE — do not edit by hand.\n// Produced by scripts/gen-catalog.mjs (zudolab/zudo-doc#3349) from the\n// validated src/theme-packs/<slug>/meta.json registry. Re-run `pnpm build`\n// to regenerate after adding, removing, or editing a theme pack.\n";
+const banner = "// GENERATED FILE — do not edit by hand.\n// Produced by scripts/gen-catalog.mjs (zudolab/zudo-doc#3349, #3675) from the\n// validated src/theme-packs/<slug>/meta.json registry. Re-run `pnpm build`\n// to regenerate after adding, removing, or editing a theme pack.\n// Catalog schemaVersion 2 is distinct from each pack's meta.json schemaVersion 1.\n";
 
 writeFileSync(
   DIST_JS,
-  `${banner}const catalog = ${JSON.stringify(manifest)};\n\nexport default catalog;\n`,
+  `${banner}const catalog = ${JSON.stringify(manifest)};\n\n/**\n * Validate the browser-facing catalog contract before consuming its entries.\n *\n * Catalog schemaVersion 2 is deliberately independent from the schemaVersion\n * in each pack's meta.json (currently 1). This validator checks the catalog\n * contract only; those per-pack metadata versions must not be conflated.\n */\nexport function validateThemePackCatalog(value) {\n  if (value === null || typeof value !== \"object\" || Array.isArray(value)) {\n    throw new TypeError(\n      \`@takazudo/zudo-doc/catalog: expected a catalog manifest object with schemaVersion 2; got \${describeCatalogValue(value)}.\`,\n    );\n  }\n\n  if (value.schemaVersion !== 2) {\n    throw new Error(\n      \`@takazudo/zudo-doc/catalog: unsupported catalog schemaVersion \${describeCatalogValue(value.schemaVersion)}; expected 2.\`,\n    );\n  }\n\n  if (!Array.isArray(value.packs)) {\n    throw new TypeError(\n      \`@takazudo/zudo-doc/catalog: catalog.packs must be an array; got \${describeCatalogValue(value.packs)}.\`,\n    );\n  }\n\n  for (const [index, entry] of value.packs.entries()) {\n    if (entry === null || typeof entry !== \"object\" || Array.isArray(entry)) {\n      throw new TypeError(\n        \`@takazudo/zudo-doc/catalog: catalog.packs[\${index}] must be an object; got \${describeCatalogValue(entry)}.\`,\n      );\n    }\n    if (typeof entry.slug !== \"string\") {\n      throw new TypeError(\n        \`@takazudo/zudo-doc/catalog: catalog.packs[\${index}].slug must be a string; got \${describeCatalogValue(entry.slug)}.\`,\n      );\n    }\n    if (entry.meta === null || typeof entry.meta !== \"object\" || Array.isArray(entry.meta)) {\n      throw new TypeError(\n        \`@takazudo/zudo-doc/catalog: catalog.packs[\${index}].meta must be an object; got \${describeCatalogValue(entry.meta)}.\`,\n      );\n    }\n    if (typeof entry.hasStylesheet !== \"boolean\") {\n      throw new TypeError(\n        \`@takazudo/zudo-doc/catalog: catalog.packs[\${index}].hasStylesheet must be a boolean; got \${describeCatalogValue(entry.hasStylesheet)}.\`,\n      );\n    }\n  }\n\n  return value;\n}\n\n/** @param {unknown} value */\nfunction describeCatalogValue(value) {\n  if (value === undefined) return \"undefined\";\n  try {\n    const json = JSON.stringify(value);\n    return json === undefined ? String(value) : json;\n  } catch {\n    return String(value);\n  }\n}\n\nexport default catalog;\n`,
 );
 
 writeFileSync(
@@ -74,17 +80,48 @@ writeFileSync(
 
 export type { ThemePackMeta };
 
-/** The aggregated theme-pack catalog manifest shape — mirrors the
- *  postBuild-time \`theme-packs/index.json\` registry manifest
- *  (\`ThemePacksIndexManifest\` in plugins/internal/theme-packs/types.ts),
- *  duplicated here rather than imported so this module stays free of any
- *  node-touching import chain. */
-export interface ThemePacksIndexManifest {
-  schemaVersion: 1;
-  packs: ThemePackMeta[];
+/** One entry in the browser-facing catalog (catalog schemaVersion 2). */
+export interface ThemePackCatalogEntry {
+  /** The pack directory slug. */
+  slug: string;
+  /** The pack's metadata; its own meta.json schemaVersion is currently 1. */
+  meta: ThemePackMeta;
+  /** Whether the pack ships a pack.css stylesheet, from the real registry. */
+  hasStylesheet: boolean;
 }
 
-declare const catalog: ThemePacksIndexManifest;
+/** The v2 catalog entry is structurally the same as a resolved registry entry. */
+export type ThemePackRegistryEntry = ThemePackCatalogEntry;
+
+/**
+ * The browser-facing theme-pack catalog manifest.
+ *
+ * This catalog schemaVersion 2 is distinct from each pack's meta.json
+ * schemaVersion 1. The two version numbers are unrelated and must not be
+ * conflated. The manifest is declared here instead of importing the
+ * postBuild-time theme-packs/index.json type so the browser export keeps its
+ * own contract and remains free of node-touching imports.
+ */
+export interface ThemePacksCatalogManifest {
+  schemaVersion: 2;
+  packs: ThemePackCatalogEntry[];
+}
+
+/**
+ * @deprecated Use ThemePacksCatalogManifest. This catalog-only legacy name is
+ * not the postBuild plugin's separate \`ThemePacksIndexManifest\` type.
+ */
+export type ThemePacksIndexManifest = ThemePacksCatalogManifest;
+
+/**
+ * Validate and return a browser-facing catalog manifest. Throws when the
+ * catalog is not schemaVersion 2 or has malformed v2 entries.
+ */
+export declare function validateThemePackCatalog(
+  value: unknown,
+): ThemePacksCatalogManifest;
+
+declare const catalog: ThemePacksCatalogManifest;
 export default catalog;
 `,
 );

--- a/packages/zudo-doc/scripts/gen-catalog.mjs
+++ b/packages/zudo-doc/scripts/gen-catalog.mjs
@@ -20,9 +20,10 @@
 // `copy-theme-packs.mjs` precedent: runs from the tsup `onSuccess` chain,
 // AFTER copy-theme-packs.mjs (so both read the same validated SRC packs
 // directory), and imports the ALREADY-COMPILED
-// `dist/theme-packs-registry/index.js` for `loadThemePackRegistry` +
-// `resolveEnabledPacks` — pure, browser-safe logic already proven against
-// this exact registry shape.
+// `dist/theme-packs-registry/load-registry.js` for the filesystem loader and
+// `dist/theme-packs-registry/index.js` for `resolveEnabledPacks` — the latter
+// is the pure, browser-safe logic already proven against this exact registry
+// shape.
 //
 // The generated `dist/catalog.js` embeds the manifest as a JSON literal —
 // no `node:fs` import, no filesystem access at import time, so a browser app
@@ -38,8 +39,11 @@ const SRC = resolve(PKG_ROOT, "src/theme-packs");
 const DIST_JS = resolve(PKG_ROOT, "dist/catalog.js");
 const DIST_DTS = resolve(PKG_ROOT, "dist/catalog.d.ts");
 
-const { loadThemePackRegistry, resolveEnabledPacks } = await import(
-  resolve(PKG_ROOT, "dist/theme-packs-registry/index.js")
+const { loadThemePackRegistry } = await import(
+  resolve(PKG_ROOT, "dist/theme-packs-registry/load-registry.js"),
+);
+const { resolveEnabledPacks } = await import(
+  resolve(PKG_ROOT, "dist/theme-packs-registry/index.js"),
 );
 
 let registry;

--- a/packages/zudo-doc/scripts/site-schema-graph.mjs
+++ b/packages/zudo-doc/scripts/site-schema-graph.mjs
@@ -15,6 +15,8 @@
 // fails to resolve, or gets inlined away.
 
 import { createRequire } from "node:module";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 
 /** Specifier classes that must never be reachable from `./site-schema`. */
 export const FORBIDDEN_SPECIFIERS = [
@@ -28,6 +30,56 @@ export const FORBIDDEN_SPECIFIERS = [
 /** The forbidden class a specifier belongs to, or `undefined` when it is fine. */
 export function forbiddenLabel(specifier) {
   return FORBIDDEN_SPECIFIERS.find((rule) => rule.pattern.test(specifier))?.label;
+}
+
+/** Every `from "..."` specifier in a declaration file. */
+export function declarationSpecifiers(source) {
+  return [...source.matchAll(/\bfrom\s*["']([^"']+)["']/g)].map((match) => match[1]);
+}
+
+/** Resolve a relative `.js`/extensionless specifier to its emitted `.d.ts`. */
+export function resolveDeclaration(fromFile, specifier) {
+  const base = resolve(dirname(fromFile), specifier);
+  for (const candidate of [
+    base.replace(/\.js$/, ".d.ts"),
+    `${base}.d.ts`,
+    resolve(base, "index.d.ts"),
+  ]) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+/**
+ * Walk the transitive emitted declaration graph rooted at `entry` and report
+ * forbidden package/specifier classes using the same rules as the JS guard.
+ *
+ * @param {string} entry - absolute path to an emitted `.d.ts` file.
+ * @returns {{ violations: Array<{ specifier: string, label: string, importer: string }>, files: string[] }}
+ */
+export function analyzeDeclarationGraph(entry) {
+  const seen = new Set();
+  const violations = [];
+  const queue = [entry];
+
+  while (queue.length > 0) {
+    const file = queue.pop();
+    if (seen.has(file)) continue;
+    seen.add(file);
+
+    for (const specifier of declarationSpecifiers(readFileSync(file, "utf8"))) {
+      const label = forbiddenLabel(specifier);
+      if (label) {
+        violations.push({ specifier, label, importer: file });
+        continue;
+      }
+      if (!specifier.startsWith(".")) continue;
+      const next = resolveDeclaration(file, specifier);
+      if (next) queue.push(next);
+    }
+  }
+
+  return { violations, files: [...seen].sort() };
 }
 
 /**

--- a/packages/zudo-doc/src/__tests__/catalog.test.ts
+++ b/packages/zudo-doc/src/__tests__/catalog.test.ts
@@ -13,12 +13,13 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PKG_ROOT = resolve(__dirname, "../..");
+const DIST_DTS = resolve(PKG_ROOT, "dist/catalog.d.ts");
 
 describe("@takazudo/zudo-doc/catalog", () => {
   it("aggregates every bundled theme pack, default first then alphabetical", async () => {
     const { default: catalog } = await import(resolve(PKG_ROOT, "dist/catalog.js"));
 
-    expect(catalog.schemaVersion).toBe(1);
+    expect(catalog.schemaVersion).toBe(2);
     expect(catalog.packs.length).toBe(31);
     expect(catalog.packs[0].slug).toBe("default");
 
@@ -30,8 +31,9 @@ describe("@takazudo/zudo-doc/catalog", () => {
     const { default: catalog } = await import(resolve(PKG_ROOT, "dist/catalog.js"));
 
     for (const pack of catalog.packs) {
+      expect(typeof pack.hasStylesheet, `${pack.slug}.hasStylesheet`).toBe("boolean");
       for (const mode of ["light", "dark"] as const) {
-        const swatches = pack.preview[mode];
+        const swatches = pack.meta.preview[mode];
         expect(swatches.bg, `${pack.slug}.preview.${mode}.bg`).toBeTruthy();
         expect(swatches.fg, `${pack.slug}.preview.${mode}.fg`).toBeTruthy();
         expect(swatches.accent, `${pack.slug}.preview.${mode}.accent`).toBeTruthy();
@@ -41,6 +43,52 @@ describe("@takazudo/zudo-doc/catalog", () => {
         expect(swatches.syntax.callable, `${pack.slug}.preview.${mode}.syntax.callable`).toBeTruthy();
       }
     }
+  });
+
+  it("carries hasStylesheet from the filesystem registry, not a slug heuristic", async () => {
+    const { default: catalog } = await import(resolve(PKG_ROOT, "dist/catalog.js"));
+    const { loadThemePackRegistry, resolveEnabledPacks } = await import(
+      resolve(PKG_ROOT, "dist/theme-packs-registry/index.js"),
+    );
+    const registry = loadThemePackRegistry(resolve(PKG_ROOT, "src/theme-packs"));
+    const enabled = resolveEnabledPacks(registry, {});
+
+    expect(
+      catalog.packs.map((pack: { slug: string; hasStylesheet: boolean }) => [
+        pack.slug,
+        pack.hasStylesheet,
+      ]),
+    ).toEqual(
+      enabled.map((entry: { slug: string; hasStylesheet: boolean }) => [
+        entry.slug,
+        entry.hasStylesheet,
+      ]),
+    );
+  });
+
+  it("exports a v2 validator that rejects a v1-shaped manifest", async () => {
+    const { default: catalog, validateThemePackCatalog } = await import(
+      resolve(PKG_ROOT, "dist/catalog.js"),
+    );
+
+    expect(validateThemePackCatalog(catalog)).toBe(catalog);
+    const v1Manifest = {
+      schemaVersion: 1,
+      packs: catalog.packs.map((pack: { meta: unknown }) => pack.meta),
+    };
+    expect(() => validateThemePackCatalog(v1Manifest)).toThrow(
+      /schemaVersion 1.*expected 2/,
+    );
+  });
+
+  it("declares the v2 manifest and entry types in the generated declaration", async () => {
+    const fs = await import("node:fs/promises");
+    const dts = await fs.readFile(DIST_DTS, "utf8");
+
+    expect(dts).toContain("interface ThemePackCatalogEntry");
+    expect(dts).toContain("interface ThemePacksCatalogManifest");
+    expect(dts).toContain("hasStylesheet: boolean");
+    expect(dts).toContain("validateThemePackCatalog");
   });
 
   it("exposes the ./catalog subpath export", async () => {

--- a/packages/zudo-doc/src/__tests__/catalog.test.ts
+++ b/packages/zudo-doc/src/__tests__/catalog.test.ts
@@ -47,7 +47,10 @@ describe("@takazudo/zudo-doc/catalog", () => {
 
   it("carries hasStylesheet from the filesystem registry, not a slug heuristic", async () => {
     const { default: catalog } = await import(resolve(PKG_ROOT, "dist/catalog.js"));
-    const { loadThemePackRegistry, resolveEnabledPacks } = await import(
+    const { loadThemePackRegistry } = await import(
+      resolve(PKG_ROOT, "dist/theme-packs-registry/load-registry.js"),
+    );
+    const { resolveEnabledPacks } = await import(
       resolve(PKG_ROOT, "dist/theme-packs-registry/index.js"),
     );
     const registry = loadThemePackRegistry(resolve(PKG_ROOT, "src/theme-packs"));

--- a/packages/zudo-doc/src/__tests__/public-api-snapshot.test.ts
+++ b/packages/zudo-doc/src/__tests__/public-api-snapshot.test.ts
@@ -177,6 +177,7 @@ describe("package.json exports keyset snapshot", () => {
         "./tags-audit",
         "./theme",
         "./theme-cli",
+        "./theme-packs-registry",
         "./theme-packs/*",
         "./theme-toggle",
         "./theme.css",

--- a/packages/zudo-doc/src/__tests__/route-context-payload-types.test.ts
+++ b/packages/zudo-doc/src/__tests__/route-context-payload-types.test.ts
@@ -1,0 +1,53 @@
+// Declaration-graph contract for the browser-safe route-context payload leaf.
+
+import { describe, expect, it } from "vitest";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = resolve(__dirname, "../..");
+const DIST_DTS = resolve(PKG_ROOT, "dist/route-context-payload/types.d.ts");
+const FACTORY_CONTEXT_DTS = resolve(PKG_ROOT, "dist/factory-context/index.d.ts");
+
+interface DeclarationGraph {
+  analyzeDeclarationGraph(entry: string): {
+    violations: Array<{ specifier: string; label: string; importer: string }>;
+    files: string[];
+  };
+}
+
+async function loadGraphHelper(): Promise<DeclarationGraph> {
+  const url = pathToFileURL(resolve(PKG_ROOT, "scripts/site-schema-graph.mjs")).href;
+  return (await import(/* @vite-ignore */ url)) as DeclarationGraph;
+}
+
+describe("route-context payload type leaf", () => {
+  it("has a transitively browser-clean emitted declaration graph", async () => {
+    expect(
+      existsSync(DIST_DTS),
+      `${DIST_DTS} missing — run \`pnpm --filter @takazudo/zudo-doc build\``,
+    ).toBe(true);
+
+    const { analyzeDeclarationGraph } = await loadGraphHelper();
+    const { violations, files } = analyzeDeclarationGraph(DIST_DTS);
+
+    expect(
+      violations,
+      violations.map((v) => `${v.specifier} (${v.label}) declared in ${v.importer}`).join("\n"),
+    ).toEqual([]);
+    // RouteContextPayload's default Settings generic makes this a real
+    // transitive walk rather than a single-file inspection.
+    expect(files.length).toBeGreaterThan(1);
+  });
+
+  it("keeps RouteContextPayload available from factory-context", () => {
+    expect(
+      existsSync(FACTORY_CONTEXT_DTS),
+      `${FACTORY_CONTEXT_DTS} missing — run \`pnpm --filter @takazudo/zudo-doc build\``,
+    ).toBe(true);
+    expect(readFileSync(FACTORY_CONTEXT_DTS, "utf8")).toContain(
+      'export type { RouteContextPayload } from "../route-context-payload/types.js";',
+    );
+  });
+});

--- a/packages/zudo-doc/src/__tests__/site-schema.test.ts
+++ b/packages/zudo-doc/src/__tests__/site-schema.test.ts
@@ -57,6 +57,10 @@ const DIST_DTS = resolve(PKG_ROOT, "dist/site-schema/index.d.ts");
 // vitest both resolve it, and TypeScript never has to.
 interface SiteSchemaGraph {
   forbiddenLabel(specifier: string): string | undefined;
+  analyzeDeclarationGraph(entry: string): {
+    violations: Array<{ specifier: string; label: string; importer: string }>;
+    files: string[];
+  };
   analyzeSiteSchemaGraph(args: { entry: string; resolveFrom: string[] }): Promise<{
     violations: Array<{ specifier: string; label: string; importer: string }>;
     specifiers: string[];
@@ -478,55 +482,20 @@ describe("site-schema stays browser-safe", () => {
 // (4b) Browser safety — TRANSITIVE declaration graph
 // ---------------------------------------------------------------------------
 
-/** Every `from "…"` specifier in a declaration file. */
-function declarationSpecifiers(source: string): string[] {
-  return [...source.matchAll(/\bfrom\s*["']([^"']+)["']/g)].map((m) => m[1] as string);
-}
-
-/** Resolve a relative `.js`/extensionless specifier to its emitted `.d.ts`. */
-function resolveDeclaration(fromFile: string, specifier: string): string | undefined {
-  const base = resolve(dirname(fromFile), specifier);
-  for (const candidate of [
-    base.replace(/\.js$/, ".d.ts"),
-    `${base}.d.ts`,
-    resolve(base, "index.d.ts"),
-  ]) {
-    if (existsSync(candidate)) return candidate;
-  }
-  return undefined;
-}
-
 describe("site-schema declaration graph", () => {
   it("never reaches @takazudo/zfb (or any other forbidden package) transitively", async () => {
-    const { forbiddenLabel } = await loadGraphHelper();
+    const { analyzeDeclarationGraph } = await loadGraphHelper();
     expect(
       existsSync(DIST_DTS),
       `${DIST_DTS} missing — run \`pnpm --filter @takazudo/zudo-doc build\``,
     ).toBe(true);
 
-    const seen = new Set<string>();
-    const violations: string[] = [];
-    const queue = [DIST_DTS];
-
-    while (queue.length > 0) {
-      const file = queue.pop() as string;
-      if (seen.has(file)) continue;
-      seen.add(file);
-
-      for (const specifier of declarationSpecifiers(readFileSync(file, "utf8"))) {
-        const label = forbiddenLabel(specifier);
-        if (label) {
-          violations.push(`${specifier} (${label}) declared in ${file}`);
-          continue;
-        }
-        if (!specifier.startsWith(".")) continue;
-        const next = resolveDeclaration(file, specifier);
-        if (next) queue.push(next);
-      }
-    }
-
-    expect(violations, violations.join("\n")).toEqual([]);
+    const { violations, files } = analyzeDeclarationGraph(DIST_DTS);
+    expect(
+      violations,
+      violations.map((v) => `${v.specifier} (${v.label}) declared in ${v.importer}`).join("\n"),
+    ).toEqual([]);
     // The walk must have covered more than the barrel itself.
-    expect(seen.size).toBeGreaterThan(1);
+    expect(files.length).toBeGreaterThan(1);
   });
 });

--- a/packages/zudo-doc/src/color-scheme-utils.ts
+++ b/packages/zudo-doc/src/color-scheme-utils.ts
@@ -22,60 +22,30 @@
  * scheme names, `colorMode` settings) stays project-side.
  */
 
-/** A color literal — an `oklch(…)` (or any valid CSS color) string. */
-export type OKLCH = string;
+import type {
+  ColorScheme,
+  ModeMap,
+  OKLCH,
+  RampRef,
+  Ramps,
+  SemanticKey,
+  StateRole,
+  SyntaxSemanticKey,
+} from "./route-context-payload/types.js";
 
-/** The four semantic state colors that live on their own ramp. */
-export type StateRole = "danger" | "success" | "warning" | "info";
+export type {
+  ColorScheme,
+  ModeMap,
+  OKLCH,
+  RampRef,
+  Ramps,
+  SemanticKey,
+  StateRole,
+  SyntaxSemanticKey,
+} from "./route-context-payload/types.js";
 
 /** Canonical order of the state ramp — used for `--palette-state-*` emit. */
 export const STATE_ROLES: readonly StateRole[] = ["danger", "success", "warning", "info"];
-
-/**
- * A reference into the shared ramps, resolved by `resolveRampRef`:
- *   - `{ base: n }`   → `ramps.base[n]`
- *   - `{ accent: n }` → `ramps.accent[n]`
- *   - `{ state: r }`  → `ramps.state[r]`
- *   - a bare string   → a literal OKLCH value, returned as-is
- */
-export type RampRef = { base: number } | { accent: number } | { state: StateRole } | OKLCH;
-
-/** The shared Tier-1 ramps. Values are identical across light/dark modes; the
- *  per-mode differences live in `ModeMap`, not here. */
-export interface Ramps {
-  /** Warm-neutral base ramp — 5 entries, index 0 = lightest. */
-  base: OKLCH[];
-  /** Accent ramp — 3 entries. */
-  accent: OKLCH[];
-  /** The four state colors. */
-  state: Record<StateRole, OKLCH>;
-}
-
-/** The 23 semantic roles that map onto `--zd-*` custom properties. */
-export type SemanticKey =
-  | "surface"
-  | "muted"
-  | "accent"
-  | "accentHover"
-  | "codeBg"
-  | "codeFg"
-  | "success"
-  | "danger"
-  | "warning"
-  | "info"
-  | "mermaidNodeBg"
-  | "mermaidText"
-  | "mermaidLine"
-  | "mermaidLabelBg"
-  | "mermaidNoteBg"
-  | "chatUserBg"
-  | "chatUserText"
-  | "chatAssistantBg"
-  | "chatAssistantText"
-  | "imageOverlayBg"
-  | "imageOverlayFg"
-  | "matchedKeywordBg"
-  | "matchedKeywordFg";
 
 /** Canonical order of the 23 semantic roles — used for `--zd-*` emit. */
 export const SEMANTIC_KEYS: readonly SemanticKey[] = [
@@ -121,8 +91,6 @@ export const SYNTAX_SEMANTIC_KEYS = [
   "syntaxDeleted",
 ] as const;
 
-export type SyntaxSemanticKey = (typeof SYNTAX_SEMANTIC_KEYS)[number];
-
 /** Existing semantic role inherited when a syntax role has no explicit map. */
 export const SYNTAX_SEMANTIC_ALIASES: Readonly<Record<SyntaxSemanticKey, SemanticKey>> = {
   syntaxComment: "muted",
@@ -147,27 +115,6 @@ export const SYNTAX_CSS_NAMES: Readonly<Record<SyntaxSemanticKey, string>> = {
   syntaxInserted: "--zd-syntax-inserted",
   syntaxDeleted: "--zd-syntax-deleted",
 };
-
-/** The per-mode wiring: each UI role points at a ramp stop (or literal OKLCH)
- *  via a `RampRef`. Two `ColorScheme`s (light + dark) share `ramps` but carry
- *  their own `ModeMap`. */
-export interface ModeMap {
-  bg: RampRef;
-  fg: RampRef;
-  selectionBg: RampRef;
-  selectionFg: RampRef;
-  semantic: Record<SemanticKey, RampRef>;
-  /** Optional syntax-specific overrides. An absent map and omitted roles
-   *  inherit the aliases in `SYNTAX_SEMANTIC_ALIASES`, preserving schemes
-   *  authored before syntax tokens existed. */
-  syntax?: Partial<Record<SyntaxSemanticKey, RampRef>>;
-}
-
-/** A complete color scheme — shared Tier-1 ramps + per-mode Tier-2 wiring. */
-export interface ColorScheme {
-  ramps: Ramps;
-  map: ModeMap;
-}
 
 /** Default per-mode semantic wiring (Default Dark reference — see epic #2584).
  *  Scheme authors spread this into `map.semantic` and override individual roles

--- a/packages/zudo-doc/src/factory-context/index.ts
+++ b/packages/zudo-doc/src/factory-context/index.ts
@@ -15,11 +15,14 @@
 // This module is **types only** — no runtime values, no node builtins — so it
 // stays importable from the config eval graph and from client islands alike.
 
-import type { Settings, TagVocabularyEntry } from "../settings.js";
+import type { Settings } from "../settings.js";
 // Type-only imports (erased at build — they never enter the runtime/eval graph,
 // so this module stays node-free; the foundation-eval-graph guard covers it).
-import type { ColorScheme } from "../color-scheme-utils.js";
-import type { ThemePackRegistry } from "../theme-packs-registry/index.js";
+import type {
+  ColorScheme,
+  RouteContextPayload,
+  ThemePackRegistry,
+} from "../route-context-payload/types.js";
 import type { UrlHelpers } from "../url-helpers/index.js";
 import type { NavSourceDocsAPI } from "../nav-source-docs/index.js";
 import type { DocRouteEntriesAPI } from "../doc-route-entries/index.js";
@@ -29,6 +32,8 @@ import type { DocNavNode, DocPageEntry } from "../doc-page-props/index.js";
 import type { HeadingItem } from "../extract-headings/index.js";
 import type { CategoryMeta } from "../sidebar-tree/index.js";
 import type { HeaderRightComponentRegistry } from "../header/types.js";
+
+export type { RouteContextPayload } from "../route-context-payload/types.js";
 
 /**
  * The i18n surface a factory may read. Parameterizes what `base.ts` used to read
@@ -130,39 +135,6 @@ export interface FactoryContext<S = Settings> {
 // (all imports above are `import type`, erased at build), so this module stays
 // importable from the config eval graph and client islands unchanged.
 // ===========================================================================
-
-/**
- * The serializable route-context payload carried by the
- * `virtual:zudo-doc-route-context` module (ADR `route-injection-seam.md`,
- * Decision 1) — DATA ONLY, no callables. `createRouteContext` rebuilds the full
- * runtime context from it by calling the importable package factories.
- */
-export interface RouteContextPayload<S = Settings> {
-  /** The host's resolved settings object. */
-  settings: S;
-  /** Per-locale UI-string tables (`translations[locale][key]`). */
-  translations: Record<string, Record<string, string>>;
-  /** The tag vocabulary (used only when `settings.tagVocabulary` is on). */
-  tagVocabulary: readonly TagVocabularyEntry[];
-  /** Host color-scheme palette map; `null` when the host passed none (chrome
-   *  then falls back to a neutral default scheme). */
-  colorSchemes: Record<string, ColorScheme> | null;
-  /**
-   * Resolved, enabled, ordered theme-pack registry (ADR
-   * `docs/adr/theme-packs.md`, Decision 2 "Registry threading to
-   * SSR/islands") — settings ∩ the bundled `theme-packs/` directories, in
-   * switcher order. `null` (or omitted) renders the whole feature inert (same
-   * accepted coupling class as {@link colorSchemes} for a
-   * `packageOwnedRoutes: false` host that builds its own payload without
-   * threading one).
-   *
-   * OPTIONAL on purpose: this field was added after the payload shape
-   * shipped, so an existing `packageOwnedRoutes: false` host that constructs
-   * its own payload predates it. `createRouteContext` normalizes an omitted
-   * value to `null` (→ inert) so upgrading such a host does not throw at SSR.
-   */
-  themePackRegistry?: ThemePackRegistry | null;
-}
 
 /** Aggregated `tag → docs` index entry built by `collectTags`. */
 export interface TagInfo {

--- a/packages/zudo-doc/src/plugins/internal/theme-packs/resolve.ts
+++ b/packages/zudo-doc/src/plugins/internal/theme-packs/resolve.ts
@@ -6,11 +6,9 @@
 // each hook call re-derives the resolved set from its own `ctx.options`,
 // mirroring `routes.ts`'s `setup()` shape.
 
-import {
-  loadThemePackRegistry,
-  resolveEnabledPacks,
-  type ThemePackRegistry,
-} from "../../../theme-packs-registry/index.js";
+import { loadThemePackRegistry } from "../../../theme-packs-registry/load-registry.js";
+import { resolveEnabledPacks } from "../../../theme-packs-registry/index.js";
+import type { ThemePackRegistry } from "../../../theme-packs-registry/index.js";
 import type { ThemePacksPluginOptions } from "./types.js";
 
 /**

--- a/packages/zudo-doc/src/plugins/routes.ts
+++ b/packages/zudo-doc/src/plugins/routes.ts
@@ -82,11 +82,9 @@ import { createRequire } from "node:module";
 import { existsSync, statSync, readFileSync, cpSync, rmSync, mkdirSync } from "node:fs";
 import { dirname, basename, join } from "node:path";
 import { definePlugin, type ZfbSetupContext } from "@takazudo/zfb/plugins";
-import {
-  loadThemePackRegistry,
-  resolveEnabledPacks,
-  type ThemePackRegistry,
-} from "../theme-packs-registry/index.js";
+import { loadThemePackRegistry } from "../theme-packs-registry/load-registry.js";
+import { resolveEnabledPacks } from "../theme-packs-registry/index.js";
+import type { ThemePackRegistry } from "../theme-packs-registry/index.js";
 import { derivePagesCandidates } from "./route-pages-candidates.js";
 
 // ---------------------------------------------------------------------------

--- a/packages/zudo-doc/src/route-context-payload/types.ts
+++ b/packages/zudo-doc/src/route-context-payload/types.ts
@@ -1,0 +1,161 @@
+// Browser-safe data contract for the serializable route-context payload.
+//
+// Keep this module types-only and deliberately narrow. Browser consumers use
+// its emitted declaration without traversing the broader factory-context or
+// the node-backed theme-pack registry barrel.
+
+import type { Settings } from "../settings.js";
+
+/** A color literal — an `oklch(...)` (or any valid CSS color) string. */
+export type OKLCH = string;
+
+/** The four semantic state colors that live on their own ramp. */
+export type StateRole = "danger" | "success" | "warning" | "info";
+
+/**
+ * A reference into the shared ramps:
+ * `{ base: n }`, `{ accent: n }`, `{ state: role }`, or a literal color.
+ */
+export type RampRef = { base: number } | { accent: number } | { state: StateRole } | OKLCH;
+
+/** The shared Tier-1 color ramps. */
+export interface Ramps {
+  base: OKLCH[];
+  accent: OKLCH[];
+  state: Record<StateRole, OKLCH>;
+}
+
+/** The semantic UI roles mapped by a color scheme. */
+export type SemanticKey =
+  | "surface"
+  | "muted"
+  | "accent"
+  | "accentHover"
+  | "codeBg"
+  | "codeFg"
+  | "success"
+  | "danger"
+  | "warning"
+  | "info"
+  | "mermaidNodeBg"
+  | "mermaidText"
+  | "mermaidLine"
+  | "mermaidLabelBg"
+  | "mermaidNoteBg"
+  | "chatUserBg"
+  | "chatUserText"
+  | "chatAssistantBg"
+  | "chatAssistantText"
+  | "imageOverlayBg"
+  | "imageOverlayFg"
+  | "matchedKeywordBg"
+  | "matchedKeywordFg";
+
+/** The syntax-specific semantic roles mapped by a color scheme. */
+export type SyntaxSemanticKey =
+  | "syntaxComment"
+  | "syntaxString"
+  | "syntaxNumber"
+  | "syntaxKeyword"
+  | "syntaxCallable"
+  | "syntaxType"
+  | "syntaxName"
+  | "syntaxInserted"
+  | "syntaxDeleted";
+
+/** The per-mode wiring from UI roles to ramp stops or literal colors. */
+export interface ModeMap {
+  bg: RampRef;
+  fg: RampRef;
+  selectionBg: RampRef;
+  selectionFg: RampRef;
+  semantic: Record<SemanticKey, RampRef>;
+  syntax?: Partial<Record<SyntaxSemanticKey, RampRef>>;
+}
+
+/** A complete color scheme — shared Tier-1 ramps + per-mode Tier-2 wiring. */
+export interface ColorScheme {
+  ramps: Ramps;
+  map: ModeMap;
+}
+
+/**
+ * A single tag-vocabulary entry. Content uses `id` exactly; the optional
+ * display metadata does not introduce alias or deprecation semantics.
+ */
+export interface TagVocabularyEntry {
+  id: string;
+  label?: string;
+  description?: string;
+  group?: string;
+}
+
+/** Resolved preview swatches for one theme-pack mode. */
+export interface ThemePackSwatches {
+  bg: string;
+  fg: string;
+  accent: string;
+  syntax: {
+    keyword: string;
+    string: string;
+    comment: string;
+    callable: string;
+  };
+}
+
+/**
+ * A theme pack's schema-validated metadata. `mode` is its designed-primary
+ * badge; each pack still supplies both light and dark preview swatches.
+ */
+export interface ThemePackMeta {
+  schemaVersion: 1;
+  slug: string;
+  name: string;
+  description: string;
+  mode: "light" | "dark";
+  version: string;
+  fonts: {
+    sans: string;
+    mono: string;
+    display?: string;
+    loaded: string[];
+  };
+  preview: {
+    light: ThemePackSwatches;
+    dark: ThemePackSwatches;
+  };
+}
+
+/** One entry in the aggregated, canonically ordered bundled registry. */
+export interface ThemePackRegistryEntry {
+  /** The pack directory name, equal to `meta.slug`. */
+  slug: string;
+  /** The pack's schema-validated metadata. */
+  meta: ThemePackMeta;
+  /** Whether the pack ships `pack.css` (`false` for the stock default pack). */
+  hasStylesheet: boolean;
+}
+
+/** The full bundled registry, or an enabled ordered subset of it. */
+export type ThemePackRegistry = ThemePackRegistryEntry[];
+
+/**
+ * Serializable data carried by `virtual:zudo-doc-route-context`.
+ * `createRouteContext` reconstructs all runtime callables from this payload.
+ */
+export interface RouteContextPayload<S = Settings> {
+  /** The host's resolved settings object. */
+  settings: S;
+  /** Per-locale UI-string tables (`translations[locale][key]`). */
+  translations: Record<string, Record<string, string>>;
+  /** The tag vocabulary (used only when `settings.tagVocabulary` is on). */
+  tagVocabulary: readonly TagVocabularyEntry[];
+  /** Host color-scheme palette map, or `null` when the host passed none. */
+  colorSchemes: Record<string, ColorScheme> | null;
+  /**
+   * Resolved, enabled, ordered theme-pack registry. Optional for compatibility
+   * with hosts that constructed the payload before registry threading shipped;
+   * `createRouteContext` normalizes omission to `null` (feature inert).
+   */
+  themePackRegistry?: ThemePackRegistry | null;
+}

--- a/packages/zudo-doc/src/settings.ts
+++ b/packages/zudo-doc/src/settings.ts
@@ -22,23 +22,7 @@
  */
 export type TagGovernanceMode = "off" | "warn" | "strict";
 
-/**
- * A single entry in the tag vocabulary.
- *
- * - `id`         — canonical tag id. What content files should ideally use.
- * - `label`      — optional human-readable label (falls back to `id`).
- * - `description`— optional short description for tooling / tag index pages.
- * - `group`      — optional grouping key used by the grouped tag footer
- *                  (e.g. `"type"`, `"level"`, `"topic"`).
- * Content must use `id` exactly. Retired or misspelled ids are unknown tags;
- * the vocabulary intentionally has no alias or deprecation migration fields.
- */
-export interface TagVocabularyEntry {
-  id: string;
-  label?: string;
-  description?: string;
-  group?: string;
-}
+export type { TagVocabularyEntry } from "./route-context-payload/types.js";
 
 export interface HeaderNavChildItem {
   label: string;

--- a/packages/zudo-doc/src/theme-cli/registry.ts
+++ b/packages/zudo-doc/src/theme-cli/registry.ts
@@ -14,11 +14,8 @@
 // the same relative shape `src/plugins/theme-packs.ts`'s `themePacksDir()`
 // uses for its own independent resolution.
 
-import {
-  loadThemePackRegistry,
-  type ThemePackRegistry,
-  type ThemePackRegistryEntry,
-} from "../theme-packs-registry/index.js";
+import { loadThemePackRegistry } from "../theme-packs-registry/load-registry.js";
+import type { ThemePackRegistry, ThemePackRegistryEntry } from "../theme-packs-registry/index.js";
 
 export type { ThemePackRegistry, ThemePackRegistryEntry };
 

--- a/packages/zudo-doc/src/theme-packs-registry/__tests__/build-registry.test.ts
+++ b/packages/zudo-doc/src/theme-packs-registry/__tests__/build-registry.test.ts
@@ -1,0 +1,161 @@
+// Contract suite for the browser-safe `./theme-packs-registry` surface
+// (zudolab/zudo-doc#3679).
+//
+// The source and emitted declaration graph checks intentionally reuse the
+// same detector as `site-schema`. The filesystem loader is tested separately
+// in `load-registry.test.ts`; it must not be reachable from this barrel.
+
+import { describe, expect, it } from "vitest";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import {
+  buildThemePackRegistry,
+  schemaVersion,
+  type ThemePacksCatalogManifest,
+} from "../index.js";
+import type { ThemePackMeta } from "../../route-context-payload/types.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = resolve(__dirname, "../../..");
+const REPO_ROOT = resolve(PKG_ROOT, "../..");
+const SRC_ENTRY = resolve(PKG_ROOT, "src/theme-packs-registry/index.ts");
+const DIST_DTS = resolve(PKG_ROOT, "dist/theme-packs-registry/index.d.ts");
+
+interface RegistryGraph {
+  analyzeDeclarationGraph(entry: string): {
+    violations: Array<{ specifier: string; label: string; importer: string }>;
+    files: string[];
+  };
+  analyzeSiteSchemaGraph(args: { entry: string; resolveFrom: string[] }): Promise<{
+    violations: Array<{ specifier: string; label: string; importer: string }>;
+    specifiers: string[];
+  }>;
+}
+
+async function loadGraphHelper(): Promise<RegistryGraph> {
+  const url = pathToFileURL(resolve(PKG_ROOT, "scripts/site-schema-graph.mjs")).href;
+  return (await import(/* @vite-ignore */ url)) as RegistryGraph;
+}
+
+function makeMeta(slug: string): ThemePackMeta {
+  return {
+    schemaVersion: 1,
+    slug,
+    name: slug,
+    description: `${slug} theme pack`,
+    mode: "light",
+    version: "1.0.0",
+    fonts: { sans: "System", mono: "System", loaded: [] },
+    preview: {
+      light: {
+        bg: "#fff",
+        fg: "#000",
+        accent: "#00f",
+        syntax: { keyword: "#00f", string: "#080", comment: "#888", callable: "#800" },
+      },
+      dark: {
+        bg: "#000",
+        fg: "#fff",
+        accent: "#0ff",
+        syntax: { keyword: "#0ff", string: "#8f8", comment: "#aaa", callable: "#f88" },
+      },
+    },
+  };
+}
+
+const CATALOG: ThemePacksCatalogManifest = {
+  schemaVersion: 2,
+  packs: [
+    { slug: "zeta", meta: makeMeta("zeta"), hasStylesheet: true },
+    { slug: "default", meta: makeMeta("default"), hasStylesheet: false },
+    { slug: "alpha", meta: makeMeta("alpha"), hasStylesheet: true },
+  ],
+};
+
+describe("buildThemePackRegistry", () => {
+  it("exposes its own numeric contract version", () => {
+    expect(schemaVersion).toBe(1);
+  });
+
+  it("accepts the whole catalog v2 manifest and resolves default first, then alphabetically", () => {
+    const registry = buildThemePackRegistry(CATALOG, {});
+
+    expect(registry.map((entry) => entry.slug)).toEqual(["default", "alpha", "zeta"]);
+    expect(registry.map((entry) => entry.hasStylesheet)).toEqual([false, true, true]);
+  });
+
+  it("passes the settings projection through to the existing resolver", () => {
+    const registry = buildThemePackRegistry(CATALOG, {
+      themePack: "zeta",
+      themePacks: ["zeta", "alpha"],
+    });
+
+    expect(registry.map((entry) => entry.slug)).toEqual(["zeta", "alpha"]);
+  });
+
+  it("rejects a v1 manifest before interpreting its packs", () => {
+    const v1Manifest = {
+      schemaVersion: 1,
+      packs: CATALOG.packs.map((entry) => entry.meta),
+    };
+
+    expect(() =>
+      buildThemePackRegistry(v1Manifest as unknown as ThemePacksCatalogManifest, {}),
+    ).toThrow(/schemaVersion 1.*expected 2/);
+  });
+
+  it("retains the resolver's loud duplicate and unknown slug errors", () => {
+    expect(() =>
+      buildThemePackRegistry(CATALOG, { themePacks: ["alpha", "alpha"], themePack: "alpha" }),
+    ).toThrow(/duplicate/i);
+    expect(() =>
+      buildThemePackRegistry(CATALOG, { themePacks: ["missing"], themePack: "missing" }),
+    ).toThrow(/missing/);
+  });
+});
+
+describe("./theme-packs-registry browser safety", () => {
+  it("reaches no forbidden source specifier", async () => {
+    const { analyzeSiteSchemaGraph } = await loadGraphHelper();
+    const { violations, specifiers } = await analyzeSiteSchemaGraph({
+      entry: SRC_ENTRY,
+      resolveFrom: [PKG_ROOT, REPO_ROOT, __dirname],
+    });
+
+    expect(
+      violations,
+      violations.map((v) => `${v.specifier} (${v.label}) via ${v.importer}`).join("\n"),
+    ).toEqual([]);
+    expect(specifiers.length).toBeGreaterThan(0);
+  });
+
+  it("keeps the emitted declaration graph free of forbidden specifiers", async () => {
+    const { analyzeDeclarationGraph } = await loadGraphHelper();
+    expect(
+      existsSync(DIST_DTS),
+      `${DIST_DTS} missing — run \`pnpm --filter @takazudo/zudo-doc build\``,
+    ).toBe(true);
+
+    const { violations, files } = analyzeDeclarationGraph(DIST_DTS);
+    expect(
+      violations,
+      violations.map((v) => `${v.specifier} (${v.label}) declared in ${v.importer}`).join("\n"),
+    ).toEqual([]);
+    expect(files.length).toBeGreaterThan(1);
+  });
+
+  it("does not expose the filesystem loader through the browser-safe barrel", async () => {
+    const mod = await import("../index.js");
+    expect(mod).not.toHaveProperty("loadThemePackRegistry");
+  });
+
+  it("declares the builder contract in the emitted declaration", () => {
+    expect(existsSync(DIST_DTS), `${DIST_DTS} missing — run package build`).toBe(true);
+    const dts = readFileSync(DIST_DTS, "utf8");
+    expect(dts).toContain("buildThemePackRegistry");
+    expect(dts).toContain("ThemePacksCatalogManifest");
+    expect(dts).toContain("ThemePackSettingsProjection");
+  });
+});

--- a/packages/zudo-doc/src/theme-packs-registry/__tests__/resolve-enabled-packs.test.ts
+++ b/packages/zudo-doc/src/theme-packs-registry/__tests__/resolve-enabled-packs.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { resolveEnabledPacks } from "../resolve-enabled-packs.js";
-import type { ThemePackRegistry, ThemePackRegistryEntry } from "../load-registry.js";
+import type { ThemePackRegistry, ThemePackRegistryEntry } from "../types.js";
 import type { ThemePackMeta } from "../meta-schema.js";
 
 function makeEntry(slug: string, mode: "light" | "dark" = "light"): ThemePackRegistryEntry {

--- a/packages/zudo-doc/src/theme-packs-registry/build-registry.ts
+++ b/packages/zudo-doc/src/theme-packs-registry/build-registry.ts
@@ -1,0 +1,129 @@
+// theme-packs-registry/build-registry — browser-safe catalog → registry
+// builder (zudolab/zudo-doc#3679).
+//
+// The filesystem-backed `loadThemePackRegistry` remains deliberately outside
+// this graph. Browser consumers already have the complete catalog v2 manifest
+// and only need the same settings projection + resolver that the Node build
+// uses. Keeping the manifest whole (rather than accepting `catalog.packs`)
+// lets this boundary fail closed when a consumer hands it an unsupported
+// catalog schema.
+
+import { resolveEnabledPacks, type ResolveEnabledPacksSettings } from "./resolve-enabled-packs.js";
+import type { ThemePackMeta, ThemePackRegistry } from "../route-context-payload/types.js";
+
+/** Contract version for the `./theme-packs-registry` public surface. */
+export const schemaVersion = 1;
+
+/** One entry in the browser-facing catalog v2 manifest. */
+export interface ThemePackCatalogEntry {
+  /** The pack directory slug. */
+  slug: string;
+  /** The schema-validated metadata for this pack. */
+  meta: ThemePackMeta;
+  /** Whether the pack ships a CSS stylesheet. */
+  hasStylesheet: boolean;
+}
+
+/**
+ * The complete catalog manifest accepted by {@link buildThemePackRegistry}.
+ *
+ * This is intentionally a whole-manifest parameter rather than a bare
+ * `packs` array: the catalog schema version is part of the input contract and
+ * must be checked before its entries are interpreted.
+ */
+export interface ThemePacksCatalogManifest {
+  /** Catalog schema version, distinct from each meta.json schema version. */
+  schemaVersion: 2;
+  packs: ThemePackCatalogEntry[];
+}
+
+/** The `{ themePack, themePacks }` settings projection used by the resolver. */
+export type ThemePackSettingsProjection = ResolveEnabledPacksSettings;
+
+/** Alias emphasizing that this is the registry builder's settings input. */
+export type ThemePackRegistrySettings = ThemePackSettingsProjection;
+
+function describeCatalogValue(value: unknown): string {
+  if (value === undefined) return "undefined";
+  try {
+    const json = JSON.stringify(value);
+    return json === undefined ? String(value) : json;
+  } catch {
+    return String(value);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Validate the runtime shape needed by the builder and return the typed
+ * catalog. The generated `./catalog` export performs the same fail-closed
+ * schema check; repeating the small boundary check here keeps this subpath
+ * independent from generated artifacts and makes arbitrary caller-provided
+ * manifests safe to pass in.
+ */
+function validateCatalogManifest(value: unknown): ThemePacksCatalogManifest {
+  if (!isRecord(value)) {
+    throw new TypeError(
+      `@takazudo/zudo-doc/theme-packs-registry: expected a catalog manifest object with schemaVersion 2; got ${describeCatalogValue(value)}.`,
+    );
+  }
+
+  if (value.schemaVersion !== 2) {
+    throw new Error(
+      `@takazudo/zudo-doc/theme-packs-registry: unsupported catalog schemaVersion ${describeCatalogValue(value.schemaVersion)}; expected 2.`,
+    );
+  }
+
+  if (!Array.isArray(value.packs)) {
+    throw new TypeError(
+      `@takazudo/zudo-doc/theme-packs-registry: catalog.packs must be an array; got ${describeCatalogValue(value.packs)}.`,
+    );
+  }
+
+  for (const [index, entry] of value.packs.entries()) {
+    if (!isRecord(entry)) {
+      throw new TypeError(
+        `@takazudo/zudo-doc/theme-packs-registry: catalog.packs[${index}] must be an object; got ${describeCatalogValue(entry)}.`,
+      );
+    }
+    if (typeof entry.slug !== "string") {
+      throw new TypeError(
+        `@takazudo/zudo-doc/theme-packs-registry: catalog.packs[${index}].slug must be a string; got ${describeCatalogValue(entry.slug)}.`,
+      );
+    }
+    if (!isRecord(entry.meta)) {
+      throw new TypeError(
+        `@takazudo/zudo-doc/theme-packs-registry: catalog.packs[${index}].meta must be an object; got ${describeCatalogValue(entry.meta)}.`,
+      );
+    }
+    if (typeof entry.hasStylesheet !== "boolean") {
+      throw new TypeError(
+        `@takazudo/zudo-doc/theme-packs-registry: catalog.packs[${index}].hasStylesheet must be a boolean; got ${describeCatalogValue(entry.hasStylesheet)}.`,
+      );
+    }
+  }
+
+  return value as unknown as ThemePacksCatalogManifest;
+}
+
+/**
+ * Build the resolved, enabled, ordered theme-pack registry for a browser
+ * consumer.
+ *
+ * The input is the complete catalog v2 manifest and the settings projection
+ * `{ themePack, themePacks }`. Catalog schema versions other than `2` are
+ * rejected with an error naming the received value. Once the boundary is
+ * validated, {@link resolveEnabledPacks} remains the single source of truth
+ * for default-first/alphabetical ordering and loud duplicate, unknown, and
+ * excluded-active-slug failures.
+ */
+export function buildThemePackRegistry(
+  catalog: ThemePacksCatalogManifest,
+  settings: ThemePackSettingsProjection,
+): ThemePackRegistry {
+  const manifest = validateCatalogManifest(catalog);
+  return resolveEnabledPacks(manifest.packs, settings);
+}

--- a/packages/zudo-doc/src/theme-packs-registry/index.ts
+++ b/packages/zudo-doc/src/theme-packs-registry/index.ts
@@ -1,18 +1,20 @@
 // theme-packs-registry — public barrel (ADR `docs/adr/theme-packs.md`).
 //
-// Three independent pieces, per the ADR:
-//   - `loadThemePackRegistry` — node-side fs scan of `theme-packs/<slug>/`
-//     directories (used by `src/plugins/routes.ts`'s `setup()`, and will be
-//     reused by `src/plugins/theme-packs.ts`, #2820).
+// This is the browser-safe half of the registry split, per the ADR:
+//   - `buildThemePackRegistry` — catalog-v2 + settings projection builder.
 //   - `resolveEnabledPacks` — PURE settings ∩ bundled-registry resolver.
 //   - `validateThemePack` — PURE, filesystem-free pack validator (also the
 //     build-time check `scripts/copy-theme-packs.mjs`, #2820, will run per
 //     pack before copying to `dist/`).
+//   - `meta-schema`, `token-manifest`, and registry types.
 //
-// `factory-context/index.ts` imports `ThemePackRegistry`/`ThemePackMeta` as
-// `import type` only (erased before bundling) so the node-side `node:fs`
-// import in `load-registry.ts` never reaches the node-free config eval graph
-// (`config.ts`/`preset.ts` — see their eval-graph guards).
+// The node-side `loadThemePackRegistry` filesystem scan intentionally does
+// NOT come through this barrel. Node callers import `./load-registry.js`
+// directly so this public subpath stays safe for browser and Worker bundles.
+//
+// Existing factory-context consumers import the registry shapes as types only
+// (the payload-types leaf owns those declarations), so this barrel can remain
+// in the node-free config/browser graph without pulling in the loader.
 
 export {
   THEME_PACK_SLUG_RE,
@@ -36,13 +38,18 @@ export {
   type ThemePackValidationSeverity,
 } from "./validator.js";
 
-export {
-  loadThemePackRegistry,
-  type ThemePackRegistry,
-  type ThemePackRegistryEntry,
-} from "./load-registry.js";
+export type { ThemePackRegistry, ThemePackRegistryEntry } from "./types.js";
 
 export {
   resolveEnabledPacks,
   type ResolveEnabledPacksSettings,
 } from "./resolve-enabled-packs.js";
+
+export {
+  buildThemePackRegistry,
+  schemaVersion,
+  type ThemePackCatalogEntry,
+  type ThemePackRegistrySettings,
+  type ThemePackSettingsProjection,
+  type ThemePacksCatalogManifest,
+} from "./build-registry.js";

--- a/packages/zudo-doc/src/theme-packs-registry/load-registry.ts
+++ b/packages/zudo-doc/src/theme-packs-registry/load-registry.ts
@@ -13,22 +13,17 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 
-import type { ThemePackMeta } from "./meta-schema.js";
+import type {
+  ThemePackMeta,
+  ThemePackRegistry,
+  ThemePackRegistryEntry,
+} from "../route-context-payload/types.js";
 import { validateThemePack } from "./validator.js";
 
-/** One entry in the aggregated, canonically-ordered bundled registry. */
-export interface ThemePackRegistryEntry {
-  /** The pack's directory name (equals `meta.slug`). */
-  slug: string;
-  /** The pack's schema-validated `meta.json`. */
-  meta: ThemePackMeta;
-  /** Whether this pack ships a `pack.css` (always `false` for `"default"`). */
-  hasStylesheet: boolean;
-}
-
-/** The full bundled registry, or a subset of it (after `resolveEnabledPacks`)
- *  — an ordered array; order carries meaning (canonical / switcher order). */
-export type ThemePackRegistry = ThemePackRegistryEntry[];
+export type {
+  ThemePackRegistry,
+  ThemePackRegistryEntry,
+} from "../route-context-payload/types.js";
 
 function readFontFiles(fontsDir: string): string[] {
   if (!existsSync(fontsDir)) return [];

--- a/packages/zudo-doc/src/theme-packs-registry/meta-schema.ts
+++ b/packages/zudo-doc/src/theme-packs-registry/meta-schema.ts
@@ -10,6 +10,9 @@
 // dragging in filesystem access itself.
 
 import { z } from "zod";
+import type { ThemePackMeta, ThemePackSwatches } from "../route-context-payload/types.js";
+
+export type { ThemePackMeta, ThemePackSwatches } from "../route-context-payload/types.js";
 
 /** `[a-z0-9][a-z0-9-]*` — a pack's slug MUST equal its directory name
  *  (Decision 6.7 "slug regex + dir-name parity"). */
@@ -35,11 +38,7 @@ const themePackSwatchesSchema = z.object({
     comment: z.string().min(1),
     callable: z.string().min(1),
   }),
-});
-
-/** Preview swatches for the dialog grid — RESOLVED plain CSS colors, one set
- *  per mode. See {@link themePackMetaSchema}'s `preview` field. */
-export type ThemePackSwatches = z.infer<typeof themePackSwatchesSchema>;
+}) satisfies z.ZodType<ThemePackSwatches>;
 
 export const themePackMetaSchema = z.object({
   schemaVersion: z.literal(1),
@@ -58,11 +57,4 @@ export const themePackMetaSchema = z.object({
     light: themePackSwatchesSchema,
     dark: themePackSwatchesSchema,
   }),
-});
-
-/**
- * A pack's `meta.json`, schema-validated (ADR Decision 1). `mode` is a
- * designed-primary badge only — every pack still defines BOTH modes via
- * `light-dark()` in `pack.css`.
- */
-export type ThemePackMeta = z.infer<typeof themePackMetaSchema>;
+}) satisfies z.ZodType<ThemePackMeta>;

--- a/packages/zudo-doc/src/theme-packs-registry/resolve-enabled-packs.ts
+++ b/packages/zudo-doc/src/theme-packs-registry/resolve-enabled-packs.ts
@@ -5,7 +5,7 @@
 // any future browser-side tooling.
 
 import { DEFAULT_THEME_PACK_SLUG } from "./meta-schema.js";
-import type { ThemePackRegistry } from "./load-registry.js";
+import type { ThemePackRegistry } from "./types.js";
 
 /** The subset of settings this resolver reads. */
 export interface ResolveEnabledPacksSettings {

--- a/packages/zudo-doc/src/theme-packs-registry/types.ts
+++ b/packages/zudo-doc/src/theme-packs-registry/types.ts
@@ -1,0 +1,11 @@
+// theme-packs-registry/types — the pure registry type surface.
+//
+// Keep these aliases on the browser-safe side of the registry split. The
+// filesystem loader has its own module (`load-registry.ts`) and must never be
+// reached by the public `./theme-packs-registry` barrel, including through an
+// emitted declaration import.
+
+export type {
+  ThemePackRegistry,
+  ThemePackRegistryEntry,
+} from "../route-context-payload/types.js";


### PR DESCRIPTION
Parent: #3672

Closes #3679

## Summary

- adds a pure browser-safe theme-pack registry builder
- maps catalog capabilities to stable asset URLs without importing server-only code

## Test plan

- registry unit tests
- browser dependency-graph and prepack-contract checks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-doc/pr/3692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790309423&installation_model_id=20910&pr_number=3692&repository=zudolab%2Fzudo-doc&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-doc%2Fpull%2F3692&signature=524b9f9c2970f7defb62dab833e5f0fb797980d4755c4a4d2374d7f9a2dcf300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->